### PR TITLE
CDAP-951 create tables in hive for any Table dataset created.

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -502,6 +502,8 @@ public final class Constants {
 
     public static final String DATASET_NAME = "explore.dataset.name";
     public static final String DATASET_STORAGE_HANDLER_CLASS = "co.cask.cdap.hive.datasets.DatasetStorageHandler";
+    public static final String TABLE_DATASET_NAME = "explore.dataset.table.name";
+    public static final String TABLE_DATASET_STORAGE_HANDLER_CLASS = "co.cask.cdap.hive.table.TableStorageHandler";
     public static final String STREAM_NAME = "explore.stream.name";
     public static final String STREAM_STORAGE_HANDLER_CLASS = "co.cask.cdap.hive.stream.StreamStorageHandler";
     public static final String EXPLORE_CLASSPATH = "explore.classpath";

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/datasets/DatasetInputFormat.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/datasets/DatasetInputFormat.java
@@ -165,6 +165,10 @@ public class DatasetInputFormat implements InputFormat<Void, ObjectWritable> {
    * This class duplicates all the functionality of
    * {@link co.cask.cdap.internal.app.runtime.batch.dataset.DataSetInputSplit}, but implements
    * {@link org.apache.hadoop.mapred.InputSplit} instead of {@link org.apache.hadoop.mapreduce.InputSplit}.
+   * Any InputSplit used by Hive MUST be a FileInputSplit otherwise
+   * Hive will choke and die. Hive will pass this into HiveInputSplit, which happily returns an invalid path if this is
+   * not a FileSplit. The invalid path causes mapred to die, but not in a way where any sensible error message
+   * is logged.
    */
   public static class DatasetInputSplit extends FileSplit {
     private Split dataSetSplit;

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/stream/StreamInputSplit.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/stream/StreamInputSplit.java
@@ -27,7 +27,10 @@ import java.io.IOException;
 import javax.annotation.Nullable;
 
 /**
- * Represents a mapred InputSplit for stream.
+ * Represents a mapred InputSplit for stream. Any InputSplit used by Hive MUST be a FileInputSplit otherwise
+ * Hive will choke and die. Hive will pass this into HiveInputSplit, which happily returns an invalid path if this is
+ * not a FileSplit. The invalid path causes mapred to die, but not in a way where any sensible error message is logged.
+ * Luckily for us stream splits are file splits.
  */
 public final class StreamInputSplit extends FileSplit implements Writable {
 

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/table/HiveTableInputFormat.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/table/HiveTableInputFormat.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.hive.table;
+
+import co.cask.cdap.api.data.batch.Split;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.api.dataset.table.TableSplit;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.data2.dataset2.DatasetManagementException;
+import co.cask.cdap.hive.context.ConfigurationUtil;
+import co.cask.cdap.hive.context.ContextManager;
+import co.cask.cdap.hive.context.TxnCodec;
+import co.cask.tephra.Transaction;
+import co.cask.tephra.TransactionAware;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.shims.ShimLoader;
+import org.apache.hadoop.io.ObjectWritable;
+import org.apache.hadoop.mapred.InputFormat;
+import org.apache.hadoop.mapred.InputSplit;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.RecordReader;
+import org.apache.hadoop.mapred.Reporter;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Table input format for use in hive queries and only hive queries. Will not work outside of hive.
+ */
+public class HiveTableInputFormat implements InputFormat<Void, ObjectWritable> {
+  private static final Logger LOG = LoggerFactory.getLogger(HiveTableInputFormat.class);
+
+  @Override
+  public InputSplit[] getSplits(JobConf conf, int numSplits) throws IOException {
+    String tableName = conf.get(Constants.Explore.TABLE_DATASET_NAME);
+    Table table = getTable(conf, tableName);
+
+    try {
+      Job job = new Job(conf);
+      JobContext jobContext = ShimLoader.getHadoopShims().newJobContext(job);
+      Path[] tablePaths = FileInputFormat.getInputPaths(jobContext);
+
+      List<Split> dsSplits = table.getSplits();
+
+      InputSplit[] inputSplits = new InputSplit[dsSplits.size()];
+      for (int i = 0; i < dsSplits.size(); i++) {
+        TableSplit tableSplit = (TableSplit) dsSplits.get(i);
+        inputSplits[i] = new TableInputSplit(tableName, tableSplit.getStart(), tableSplit.getStop(), tablePaths[0]);
+      }
+      return inputSplits;
+    } finally {
+      table.close();
+    }
+  }
+
+  private Table getTable(Configuration conf, String tableName) throws IOException {
+    ContextManager.Context context = ContextManager.getContext(conf);
+    try {
+      Table table = context.getDatasetFramework().getDataset(tableName, Collections.<String, String>emptyMap(), null);
+      if (table instanceof TransactionAware) {
+        Transaction tx = ConfigurationUtil.get(conf, Constants.Explore.TX_QUERY_KEY, TxnCodec.INSTANCE);
+        ((TransactionAware) table).startTx(tx);
+      }
+      return table;
+    } catch (DatasetManagementException e) {
+      LOG.error("Unable to get TableType to instantiate table {}.", tableName, e);
+      throw new IOException(e);
+    }
+  }
+
+  @Override
+  public RecordReader<Void, ObjectWritable> getRecordReader(InputSplit split, JobConf conf, Reporter reporter)
+    throws IOException {
+    TableInputSplit tableInputSplit = (TableInputSplit) split;
+    return new TableRecordReader(tableInputSplit, getTable(conf, tableInputSplit.getTableName()));
+  }
+}

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/table/TableInputSplit.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/table/TableInputSplit.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.hive.table;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.dataset.table.Table;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapred.FileSplit;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+/**
+ * Input split for a {@link Table} for Hive queries. Any InputSplit used by Hive MUST be a FileInputSplit otherwise
+ * Hive will choke and die. Hive will pass this into HiveInputSplit, which happily returns an invalid path if this is
+ * not a FileSplit. The invalid path causes mapred to die, but not in a way where any sensible error message is logged.
+ */
+public class TableInputSplit extends FileSplit {
+  // name is needed here since it is not in the job conf by the time getRecordReader is called on the input format
+  private String tableName;
+  private byte[] start;
+  private byte[] stop;
+
+  // This is required for mapred
+  public TableInputSplit() {
+    this(null, null, null, null);
+  }
+
+  public TableInputSplit(String tableName, byte[] start, byte[] stop, Path dummyPath) {
+    super(dummyPath, 0, 0, (String[]) null);
+    this.tableName = tableName;
+    this.start = start;
+    this.stop = stop;
+  }
+
+  public String getTableName() {
+    return tableName;
+  }
+
+  public byte[] getStartKey() {
+    return start;
+  }
+
+  public byte[] getStopKey() {
+    return stop;
+  }
+
+  @Override
+  public String[] getLocations() throws IOException {
+    return new String[0];
+  }
+
+  @Override
+  public void write(final DataOutput out) throws IOException {
+    super.write(out);
+    writeBytes(out, Bytes.toBytes(tableName));
+    writeBytes(out, start);
+    writeBytes(out, stop);
+  }
+
+  private void writeBytes(DataOutput out, byte[] bytes) throws IOException {
+    if (bytes == null) {
+      out.writeInt(0);
+    } else {
+      out.writeInt(bytes.length);
+      out.write(bytes);
+    }
+  }
+
+  @Override
+  public void readFields(final DataInput in) throws IOException {
+    super.readFields(in);
+    byte[] nameBytes = readBytes(in);
+    tableName = Bytes.toString(nameBytes);
+    start = readBytes(in);
+    stop = readBytes(in);
+  }
+
+  private byte[] readBytes(DataInput in) throws IOException {
+    int length = in.readInt();
+    if (length == 0) {
+      return null;
+    }
+    byte[] bytes = new byte[length];
+    in.readFully(bytes);
+    return bytes;
+  }
+}

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/table/TableRecordReader.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/table/TableRecordReader.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.hive.table;
+
+import co.cask.cdap.api.dataset.table.Row;
+import co.cask.cdap.api.dataset.table.Scanner;
+import co.cask.cdap.api.dataset.table.Table;
+import org.apache.hadoop.io.ObjectWritable;
+import org.apache.hadoop.mapred.RecordReader;
+
+import java.io.IOException;
+
+/**
+ * Record reader for table splits.
+ */
+public class TableRecordReader implements RecordReader<Void, ObjectWritable> {
+  private final Scanner scanner;
+
+  public TableRecordReader(TableInputSplit split, Table table) {
+    this.scanner = table.scan(split.getStartKey(), split.getStopKey());
+  }
+
+  @Override
+  public boolean next(Void key, ObjectWritable value) throws IOException {
+    Row row = scanner.next();
+    if (row == null) {
+      return false;
+    }
+    value.set(row);
+    return true;
+  }
+
+  @Override
+  public Void createKey() {
+    return null;
+  }
+
+  @Override
+  public ObjectWritable createValue() {
+    return new ObjectWritable();
+  }
+
+  @Override
+  public long getPos() throws IOException {
+    return 0;
+  }
+
+  @Override
+  public void close() throws IOException {
+    scanner.close();
+  }
+
+  @Override
+  public float getProgress() throws IOException {
+    return 0;
+  }
+}

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/table/TableSerDe.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/table/TableSerDe.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.hive.table;
+
+import co.cask.cdap.api.dataset.table.Row;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.hive.objectinspector.ObjectInspectorFactory;
+import com.google.common.collect.Lists;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.serde.serdeConstants;
+import org.apache.hadoop.hive.serde2.SerDe;
+import org.apache.hadoop.hive.serde2.SerDeException;
+import org.apache.hadoop.hive.serde2.SerDeStats;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
+import org.apache.hadoop.io.ObjectWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.Writable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+/**
+ * SerDe to deserialize {@link Row Rows} from a {@link Table}. It MUST implement the deprecated SerDe interface instead
+ * of extending the abstract SerDe class, otherwise we get ClassNotFound exceptions on cdh4.x.
+ */
+public class TableSerDe implements SerDe {
+  private ObjectInspector inspector;
+
+  @Override
+  public void initialize(Configuration conf, Properties properties) throws SerDeException {
+    ArrayList<String> columnNames = Lists.newArrayList(properties.getProperty(serdeConstants.LIST_COLUMNS).split(","));
+    ArrayList<TypeInfo> columnTypes =
+      TypeInfoUtils.getTypeInfosFromTypeString(properties.getProperty(serdeConstants.LIST_COLUMN_TYPES));
+
+    int numCols = columnNames.size();
+
+    final List<ObjectInspector> columnOIs = new ArrayList<ObjectInspector>(numCols);
+
+    for (int i = 0; i < numCols; i++) {
+      columnOIs.add(TypeInfoUtils.getStandardJavaObjectInspectorFromTypeInfo(columnTypes.get(i)));
+    }
+
+    this.inspector = ObjectInspectorFactory.getStandardStructObjectInspector(columnNames, columnOIs);
+  }
+
+  @Override
+  public Class<? extends Writable> getSerializedClass() {
+    return Text.class;
+  }
+
+  @Override
+  public Writable serialize(Object o, ObjectInspector objectInspector) throws SerDeException {
+    // should not be writing to tables through this
+    throw new SerDeException("Table serialization through Hive is not supported.");
+  }
+
+  @Override
+  public SerDeStats getSerDeStats() {
+    return new SerDeStats();
+  }
+
+  @Override
+  public Object deserialize(Writable writable) throws SerDeException {
+    // this should always contain a Row object
+    ObjectWritable objectWritable = (ObjectWritable) writable;
+    Row row = (Row) objectWritable.get();
+    // This will be replaced with schema related logic soon.
+    return Lists.newArrayList(row.getRow(), row.getColumns());
+  }
+
+  @Override
+  public ObjectInspector getObjectInspector() throws SerDeException {
+    return inspector;
+  }
+}

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/table/TableStorageHandler.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/table/TableStorageHandler.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.hive.table;
+
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.common.conf.Constants;
+import org.apache.hadoop.hive.metastore.HiveMetaHook;
+import org.apache.hadoop.hive.ql.metadata.DefaultStorageHandler;
+import org.apache.hadoop.hive.ql.plan.TableDesc;
+import org.apache.hadoop.hive.serde2.SerDe;
+import org.apache.hadoop.mapred.InputFormat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+/**
+ * HiveStorageHandler to access a {@link Table}.
+ */
+public class TableStorageHandler extends DefaultStorageHandler {
+  private static final Logger LOG = LoggerFactory.getLogger(TableStorageHandler.class);
+
+  @Override
+  public Class<? extends InputFormat> getInputFormatClass() {
+    return HiveTableInputFormat.class;
+  }
+
+  @Override
+  public Class<? extends SerDe> getSerDeClass() {
+    return TableSerDe.class;
+  }
+
+  @Override
+  public void configureInputJobProperties(TableDesc tableDesc, Map<String, String> jobProperties) {
+    configureTableJobProperties(tableDesc, jobProperties);
+  }
+
+  @Override
+  public void configureTableJobProperties(TableDesc tableDesc,
+                                          Map<String, String> jobProperties) {
+    // NOTE: the jobProperties map will be put in the jobConf passed to the HiveTableInputFormat.
+    // Hive ensures that the properties of the right table will be passed at the right time to those classes.
+    String tableName = tableDesc.getProperties().getProperty(Constants.Explore.TABLE_DATASET_NAME);
+    jobProperties.put(Constants.Explore.TABLE_DATASET_NAME, tableName);
+    LOG.debug("Got CDAP table {} for external table {}", tableName, tableDesc.getTableName());
+  }
+
+  @Override
+  public void configureOutputJobProperties(TableDesc tableDesc,
+                                           Map<String, String> jobProperties) {
+    // throw the exception here instead of in getOutputFormatClass because that method is called on table creation.
+    throw new UnsupportedOperationException("Writing to CDAP core table datasets through Hive is not supported");
+  }
+
+  @Override
+  public HiveMetaHook getMetaHook() {
+    return null;
+  }
+}
+

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreServiceTestsSuite.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreServiceTestsSuite.java
@@ -30,6 +30,8 @@ import org.junit.runners.Suite;
   ExploreMetadataTestRun.class,
   HiveExploreServiceTestRun.class,
   WritableDatasetTestRun.class,
+  HiveExploreServiceTableTestRun.class,
+  // TODO: remove order dependency and make it so the stop test does not need to run last
   HiveExploreServiceStopTestRun.class
 })
 public class ExploreServiceTestsSuite {

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceTableTestRun.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceTableTestRun.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.explore.service;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.dataset.DatasetDefinition;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.explore.client.ExploreExecutionResult;
+import co.cask.cdap.proto.ColumnDesc;
+import co.cask.cdap.proto.QueryResult;
+import co.cask.cdap.test.SlowTests;
+import co.cask.tephra.Transaction;
+import co.cask.tephra.TransactionAware;
+import com.google.common.collect.Lists;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.List;
+
+/**
+ * Tests Hive13ExploreService.
+ */
+@Category(SlowTests.class)
+public class HiveExploreServiceTableTestRun extends BaseHiveExploreServiceTest {
+
+  @BeforeClass
+  public static void start() throws Exception {
+    startServices();
+
+    // Performing admin operations to create dataset instance
+    datasetFramework.addInstance("table", "my_table", DatasetProperties.EMPTY);
+
+    // Accessing dataset instance to perform data operations
+    Table table = datasetFramework.getDataset("my_table", DatasetDefinition.NO_ARGUMENTS, null);
+    Assert.assertNotNull(table);
+
+    Transaction tx1 = transactionManager.startShort(100);
+    // normally this is handled by the platform... but we have to do it manually here since Table interface
+    // is not transaction aware
+    TransactionAware txTable = (TransactionAware) table;
+    txTable.startTx(tx1);
+
+    table.put(Bytes.toBytes("userX"), Bytes.toBytes("age"), Bytes.toBytes(36));
+    table.put(Bytes.toBytes("userX"), Bytes.toBytes("gender"), Bytes.toBytes("male"));
+    table.put(Bytes.toBytes("userX"), Bytes.toBytes("name"), Bytes.toBytes("Jack"));
+    table.put(Bytes.toBytes("userY"), Bytes.toBytes("age"), Bytes.toBytes(27));
+    table.put(Bytes.toBytes("userY"), Bytes.toBytes("gender"), Bytes.toBytes("female"));
+    table.put(Bytes.toBytes("userY"), Bytes.toBytes("name"), Bytes.toBytes("Jill"));
+
+    Assert.assertTrue(txTable.commitTx());
+
+    transactionManager.canCommit(tx1, txTable.getTxChanges());
+    transactionManager.commit(tx1);
+
+    txTable.postTxCommit();
+  }
+
+  @AfterClass
+  public static void stop() throws Exception {
+    datasetFramework.deleteInstance("my_table");
+  }
+
+  @Test
+  public void testDefaultSchema() throws Exception {
+    runCommand("describe my_table",
+               true,
+               Lists.newArrayList(
+                 new ColumnDesc("col_name", "STRING", 1, "from deserializer"),
+                 new ColumnDesc("data_type", "STRING", 2, "from deserializer"),
+                 new ColumnDesc("comment", "STRING", 3, "from deserializer")
+               ),
+               Lists.newArrayList(
+                 new QueryResult(Lists.<Object>newArrayList("row", "binary", "from deserializer")),
+                 new QueryResult(Lists.<Object>newArrayList("columns", "map<binary,binary>", "from deserializer"))
+               )
+    );
+  }
+
+  @Test
+  public void testSelectStar() throws Exception {
+    ExploreExecutionResult results = exploreClient.submit("select * from my_table").get();
+    // check schema
+    List<ColumnDesc> expectedSchema = Lists.newArrayList(
+      new ColumnDesc("my_table.row", "BINARY", 1, null),
+      new ColumnDesc("my_table.columns", "map<binary,binary>", 2, null)
+    );
+    Assert.assertEquals(expectedSchema, results.getResultSchema());
+    // check each result, without checking timestamp since that changes for each test
+    // first result
+    List<Object> columns = results.next().getColumns();
+    Assert.assertEquals("userX", Bytes.toString((byte[]) columns.get(0)));
+    // second result
+    columns = results.next().getColumns();
+    Assert.assertEquals("userY", Bytes.toString((byte[]) columns.get(0)));
+    // should not be any more
+    Assert.assertFalse(results.hasNext());
+  }
+
+  @Test
+  public void testSimpleSelect() throws Exception {
+    runCommand("select row from my_table",
+               true,
+               Lists.newArrayList(new ColumnDesc("row", "BINARY", 1, null)),
+               Lists.newArrayList(
+                 new QueryResult(Lists.<Object>newArrayList(Bytes.toBytes("userX"))),
+                 new QueryResult(Lists.<Object>newArrayList(Bytes.toBytes("userY"))))
+    );
+  }
+}

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceTestRun.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceTestRun.java
@@ -18,7 +18,6 @@ package co.cask.cdap.explore.service;
 
 import co.cask.cdap.api.dataset.DatasetDefinition;
 import co.cask.cdap.api.dataset.DatasetProperties;
-import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.discovery.RandomEndpointStrategy;
 import co.cask.cdap.explore.client.ExploreExecutionResult;


### PR DESCRIPTION
Start off with a fixed schema with plans to allow setting schema
in the near future. Also, Tables embedded within other datasets
are not yet supported due to wide ranging changes that would be
required for tracking instances of embedded datasets.

Added a storage handler and friends for CDAP tables. Unfortunately
we cannot re-use the HBaseStorageHandler because Tables are not
always HBase tables, like in Standalone mode.