### PR TITLE
Fix for CDAP-1097 (Missing Services Scaling Documentation)

### DIFF
--- a/cdap-docs/admin-manual/source/operations/scaling-instances.rst
+++ b/cdap-docs/admin-manual/source/operations/scaling-instances.rst
@@ -6,6 +6,17 @@
 Scaling Instances
 ============================================
 
+You can scale CDAP components using:
+
+- the :ref:`Scaling<http-restful-api-lifecycle-scale>` methods of the 
+  :ref:`Lifecycle HTTP RESTful API<http-restful-api-lifecycle>`;
+- the :ref:`ProgramClient API<program-client>` of the 
+  :ref:`Java Client API<java-client-api>`; or
+- the :ref:`Get/Set Commands<cli-available-commands>` of the 
+  :ref:`Command Line Interface<cli>`.
+
+The examples given below use the :ref:`HTTP RESTful API<http-restful-api-lifecycle-scale>`.
+
 .. highlight:: console
 
 Scaling Flowlets
@@ -74,3 +85,45 @@ in the Flow *WhoFlow* of the application *HelloWorld*::
 with the arguments as a JSON string in the body::
 
   { "instances" : 2 }
+  
+
+Scaling Services
+------------------
+
+In a similar way to `Scaling Flowlets`_, you can query or change the number of handler instances of a Service
+by using the ``instances`` parameter with HTTP GET and PUT methods::
+
+  GET /v2/apps/<app-id>/services/<service-id>/runnables/<runnable-id>/instances
+  PUT /v2/apps/<app-id>/services/<service-id>/runnables/<runnable-id>/instances
+
+with the arguments as a JSON string in the body::
+
+  { "instances" : <quantity> }
+
+Where:
+  :<app-id>: Name of the application
+  :<service-id>: Name of the Service
+  :<runnable-id>: Name of the Service
+  :<quantity>: Number of handler instances requested
+  
+**Note:** In this release, the ``runnable-id`` is the same as the ``service-id``.
+
+Example: Find out the number of handler instances of the Service *RetrieveCounts*
+of the application *WordCount*::
+
+  GET /v2/apps/WordCount/services/RetrieveCounts/runnables/RetrieveCounts/instances
+
+Example: Change the number of handler instances of the Service *RetrieveCounts*
+of the application *WordCount*::
+
+  PUT /v2/apps/WordCount/services/RetrieveCounts/runnables/RetrieveCounts/instances
+
+with the arguments as a JSON string in the body::
+
+  { "instances" : 2 }
+  
+Example using the CDAP Standalone SDK and ``curl`` (reformatted to fit)::
+
+  curl -w '\n' -XPUT -v 'http://localhost:10000/v2/apps/WordCount/services/RetrieveCounts/runnables/RetrieveCounts/instances' \
+    -d '{ "instances" : 2 }'
+

--- a/cdap-docs/admin-manual/source/operations/scaling-instances.rst
+++ b/cdap-docs/admin-manual/source/operations/scaling-instances.rst
@@ -122,7 +122,7 @@ with the arguments as a JSON string in the body::
 
   { "instances" : 2 }
   
-Example using the CDAP Standalone SDK and ``curl`` (reformatted to fit)::
+Example using the :ref:`CDAP Standalone SDK<standalone-index>` and ``curl`` (reformatted to fit)::
 
   curl -w '\n' -XPUT -v 'http://localhost:10000/v2/apps/WordCount/services/RetrieveCounts/runnables/RetrieveCounts/instances' \
     -d '{ "instances" : 2 }'

--- a/cdap-docs/reference-manual/source/cli-api.rst
+++ b/cdap-docs/reference-manual/source/cli-api.rst
@@ -67,6 +67,8 @@ you for the required credentials to acquire an access token from the CDAP instan
 the CLI will save it to ~/.cdap.accesstoken.<hostname> for later use and use it for the rest of
 the current CLI session.
 
+.. _cli-available-commands:
+
 Available Commands
 ==================
 

--- a/cdap-docs/reference-manual/source/http-restful-api/lifecycle.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/lifecycle.rst
@@ -250,8 +250,10 @@ The response is formatted in JSON; an example of this is shown in
 :ref:`CDAP Testing and Debugging. <developers:debugging-distributed>`
 
 
-Scale
------
+.. _http-restful-api-lifecycle-scale:
+
+Scaling
+-------
 
 You can retrieve the instance count executing different components from various applications and
 different program types using an HTTP POST method::


### PR DESCRIPTION
The documentation was there, just hard to find. Fixes [CDAP-1097](https://issues.cask.co/browse/CDAP-1097).

Added documentation on the scaling of services. 
Added links and references to the three different ways that components can be scaled.

Staged at:
http://stg-web101.sw.joyent.continuuity.net/cdap/2.6.0-SNAPSHOT-r2.6.0_fix_services/en/index.html

In particular, look at:
- [Scaling Instances, first section](http://stg-web101.sw.joyent.continuuity.net/cdap/2.6.0-SNAPSHOT-r2.6.0_fix_services/en/admin-manual/operations/scaling-instances.html)
- [Scaling Instances, Scaling Services section](http://stg-web101.sw.joyent.continuuity.net/cdap/2.6.0-SNAPSHOT-r2.6.0_fix_services/en/admin-manual/operations/scaling-instances.html#scaling-services)