### PR TITLE
Fix the condition of timeout checking from > to >= to timeout earlier

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/MultiLiveStreamFileReader.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/MultiLiveStreamFileReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -93,7 +93,7 @@ public final class MultiLiveStreamFileReader implements FileReader<StreamEventOf
       }
       eventsRead += read(events, readFilter);
 
-      if (eventSources.isEmpty() && stopwatch.elapsedTime(unit) > timeout) {
+      if (eventSources.isEmpty() && stopwatch.elapsedTime(unit) >= timeout) {
         break;
       }
     }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamDataFileReader.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamDataFileReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -210,13 +210,13 @@ public final class StreamDataFileReader implements FileReader<PositionStreamEven
             break;
           }
 
-          if (stopwatch.elapsedTime(unit) > timeout) {
+          if (stopwatch.elapsedTime(unit) >= timeout) {
             break;
           }
 
           TimeUnit.NANOSECONDS.sleep(sleepNano);
 
-          if (stopwatch.elapsedTime(unit) > timeout) {
+          if (stopwatch.elapsedTime(unit) >= timeout) {
             break;
           }
         }


### PR DESCRIPTION
This remove the need for waiting on an extra cycle unnecessarily.

E.g. Timeout = 0, unit = SECONDS

stopwatch.elapsedTime(SECONDS) > 0 will be false until 1 second is passed