### PR TITLE
Remove redundant addition of action in workflow

### DIFF
--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/AppWithSchedule.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/AppWithSchedule.java
@@ -57,8 +57,7 @@ public class AppWithSchedule extends AbstractApplication {
       return WorkflowSpecification.Builder.with()
         .setName("SampleWorkflow")
         .setDescription("SampleWorkflow description")
-        .startWith(new DummyAction())
-        .last(new DummyAction())
+        .onlyWith(new DummyAction())
         .addSchedule(new Schedule("Schedule", "Run every second", "0/1 * * * * ?",
                                   Schedule.Action.START))
         .build();


### PR DESCRIPTION
I don't think the dummyAction needs to be added twice. 