### PR TITLE
Metrics Collection API changed towards hierarchical context

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/metrics/MetricsCollectionService.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/metrics/MetricsCollectionService.java
@@ -17,6 +17,8 @@ package co.cask.cdap.common.metrics;
 
 import com.google.common.util.concurrent.Service;
 
+import java.util.Map;
+
 /**
  * Service for collects and publishes metrics.
  */
@@ -24,9 +26,8 @@ public interface MetricsCollectionService extends Service {
 
   /**
    * Returns the metric collector for the given context.
-   * @param context Name of the context that generating the metric.
-   * @param runId The Id fo the given run that generating the metric.
+   * @param tags The tags that define the metrics context.
    * @return A {@link MetricsCollector} for emitting metrics.
    */
-  MetricsCollector getCollector(MetricsScope scope, String context, String runId);
+  MetricsCollector getCollector(MetricsScope scope, Map<String, String> tags);
 }

--- a/cdap-common/src/main/java/co/cask/cdap/common/metrics/MetricsCollectionService.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/metrics/MetricsCollectionService.java
@@ -26,8 +26,8 @@ public interface MetricsCollectionService extends Service {
 
   /**
    * Returns the metric collector for the given context.
-   * @param tags The tags that define the metrics context.
+   * @param context The tags that define the metrics context.
    * @return A {@link MetricsCollector} for emitting metrics.
    */
-  MetricsCollector getCollector(MetricsScope scope, Map<String, String> tags);
+  MetricsCollector getCollector(MetricsScope scope, Map<String, String> context);
 }

--- a/cdap-common/src/main/java/co/cask/cdap/common/metrics/MetricsCollector.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/metrics/MetricsCollector.java
@@ -15,6 +15,8 @@
  */
 package co.cask.cdap.common.metrics;
 
+import java.util.Map;
+
 /**
  * A MetricCollector allows client publish counter metrics.
  */
@@ -24,15 +26,26 @@ public interface MetricsCollector {
    * Log a metric value at the current time.
    * @param metricName Name of the metric.
    * @param value value of the metric.
-   * @param tags Tags associated with the metric.
    */
-  void increment(String metricName, int value, String... tags);
+  void increment(String metricName, int value);
 
   /**
    * Gauge a metric value at the current time.
    * @param metricName Name of the metric.
    * @param value value of the metric.
-   * @param tags Tags associated with the metric.
    */
-  void gauge(String metricName, long value, String... tags);
+  void gauge(String metricName, long value);
+
+  /**
+   * Creates child {@link MetricsCollector} that inherits the metrics context from this one and adds extra context
+   * information.
+   * @param tags tags to add to the child metrics context
+   * @return child {@link MetricsCollector}
+   */
+  MetricsCollector childCollector(Map<String, String> tags);
+
+  /**
+   * Convenience method that acts as {@link #childCollector(java.util.Map)} by supplying single tag.
+   */
+  MetricsCollector childCollector(String tagName, String tagValue);
 }


### PR DESCRIPTION
As discussed previously (https://issues.cask.co/browse/CDAP-760), we want to collect "raw" metric values (on client), one time and pipe it to the metrics processor (metrics backend). To do that efficiently, the metrics context is changed from String to Map<String, String> tags on the client side. Metrics collector is changed to carry that context and allow creating child context with extra tags, where more information about context is available.

E.g. we construct MetricsCollector for Flowet instance using program details. When we instantiate a dataset client to be used in this flowlet we create a child MetricsCollector by inheriting the metrics context from the flowlet's and adding extra tag with dataset name.

I have full working changes based on this - just splitting the PR into multiple to provide nicer review experience :). Will not merge until all changes reviewed.