### PR TITLE
TWILL-110 Known Issue of CDAP

### DIFF
--- a/cdap-docs/reference-manual/source/release-notes.rst
+++ b/cdap-docs/reference-manual/source/release-notes.rst
@@ -135,10 +135,16 @@ Known Issues
   running with OpenJDK or JDK7, though not with Oracle JDK6. It is caused by a change in the
   ``ThreadPoolExecutor`` implementation between Oracle JDK6 and OpenJDK/JDK7. Until Twill is
   updated in a future version of CDAP, a work-around is to kill the errant process. The Yarn
-  dashboard at port 8080 will provide the application id of the process; the command ``yarn
-  application kill <app-id>`` will kill the process. All versions of CDAP running Twill
-  version 0.4.0 with this configuration can exhibit this problem (`TWILL-110
-  <https://issues.apache.org/jira/browse/TWILL-110>`__).
+  command to list all running applications and their ``app-id``\s is::
+  
+    yarn application -list -appStates RUNNING
+
+  The command to kill a process is::
+  
+    yarn application -kill <app-id>
+    
+  All versions of CDAP running Twill version 0.4.0 with this configuration can exhibit this
+  problem (`TWILL-110 <https://issues.apache.org/jira/browse/TWILL-110>`__).
 
 
 Release 2.5.2

--- a/cdap-docs/reference-manual/source/release-notes.rst
+++ b/cdap-docs/reference-manual/source/release-notes.rst
@@ -126,10 +126,20 @@ Known Issues
   the master log indicating that in-transit (emitted, but not yet processed) metrics
   system messages could not be decoded (*Failed to decode message to MetricsRecord*). This
   is because of a change in the format of emitted metrics, and can result in a small
-  amount of metrics data points being lost. (`CDAP-745
+  amount of metrics data points being lost (`CDAP-745
   <https://issues.cask.co/browse/CDAP-745>`__).
 - Writing to datasets through Hive is not supported in CDH4.x
   (`CDAP-988 <https://issues.cask.co/browse/CDAP-988>`__).
+- A race condition resulting in a deadlock can occur when a TwillRunnable container
+  shutdowns while it still has Zookeeper events to process. This occasionally surfaces when
+  running with OpenJDK or JDK7, though not with Oracle JDK6. It is caused by a change in the
+  ``ThreadPoolExecutor`` implementation between Oracle JDK6 and OpenJDK/JDK7. Until Twill is
+  updated in a future version of CDAP, a work-around is to kill the errant process. The Yarn
+  dashboard at port 8080 will provide the application id of the process; the command ``yarn
+  application kill <app-id>`` will kill the process. All versions of CDAP running Twill
+  version 0.4.0 with this configuration can exhibit this problem (`TWILL-110
+  <https://issues.apache.org/jira/browse/TWILL-110>`__).
+
 
 Release 2.5.2
 =============
@@ -175,7 +185,7 @@ Known Issues
   fail with a class loading error. Spark or Scala classes should not be used outside of the
   Spark program. (`CDAP-599 <https://issues.cask.co/browse/CDAP-599>`__)
 - See also the *Known Issues* of `version 2.5.0. <#known-issues-250>`_
-
+- See also the *TWILL-110 Known Issue* of `version 2.6.0. <#known-issues-260>`_
 
 Release 2.5.1
 =============
@@ -207,7 +217,8 @@ Other Changes
 
 Known Issues
 ------------
-See *Known Issues* of `the previous version. <#known-issues-250>`_
+- See *Known Issues* of `the previous version. <#known-issues-250>`_
+- See also the *TWILL-110 Known Issue* of `version 2.6.0. <#known-issues-260>`_
 
 
 Release 2.5.0
@@ -282,3 +293,4 @@ Known Issues
 - Metrics for MapReduce jobs aren't populated on secure Hadoop clusters
 - The metric for the number of cores shown in the Resources view of the CDAP Console will be zero
   unless YARN has been configured to enable virtual cores
+- See also the *TWILL-110 Known Issue* of `version 2.6.0. <#known-issues-260>`_


### PR DESCRIPTION
Adds a Known Issue to the release notes for all versions of CDAP for [TWILL-110](https://issues.apache.org/jira/browse/TWILL-110).

Staged at: [2.6.0 Release Notes](http://stg-web101.sw.joyent.continuuity.net/cdap/2.6.0-SNAPSHOT-r2.6.0_twill_issue/en/reference-manual/release-notes.html#known-issues)

Last item of the *2.6.0 Known Issues*; references added to the other versions. Will be added to 2.5.2 docs once approved.