### PR TITLE
delete only aggregated metrics on delete app

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricHttpHandler.java
@@ -2962,6 +2962,7 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
       dsFramework.deleteAllInstances();
       dsFramework.deleteAllModules();
 
+      // todo: do efficiently and also remove timeseries metrics as well: CDAP-1125
       deleteMetrics(account, null);
       // delete all meta data
       store.removeAll(accountId);


### PR DESCRIPTION
deleting timeseries metrics is incredibly inefficient and causes app deletion timeout at the moment.