### PR TITLE
[CDAP-1006] Replaced Id.Account with Id.Namespace

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/authorization/AuthorizationHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/authorization/AuthorizationHandler.java
@@ -22,5 +22,5 @@ import co.cask.cdap.proto.Id;
  *
  */
 public interface AuthorizationHandler {
-  boolean authroize(Id.Account account);
+  boolean authroize(Id.Namespace namespace);
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/deploy/Manager.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/deploy/Manager.java
@@ -37,5 +37,5 @@ public interface Manager<I, O> {
    * @param input the input to the deployment pipeline
    * @return A future of Application with Programs.
    */
-  ListenableFuture<O> deploy(Id.Account id, @Nullable String appId, I input) throws Exception;
+  ListenableFuture<O> deploy(Id.Namespace id, @Nullable String appId, I input) throws Exception;
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/program/DefaultProgram.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/program/DefaultProgram.java
@@ -124,7 +124,7 @@ public final class DefaultProgram implements Program {
 
   @Override
   public String getAccountId() {
-    return id.getAccountId();
+    return id.getNamespaceId();
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/program/Programs.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/program/Programs.java
@@ -70,7 +70,7 @@ public final class Programs {
                                          throws IOException {
     Location allAppsLocation = factory.create(filePath);
 
-    Location accountAppsLocation = allAppsLocation.append(id.getAccountId());
+    Location accountAppsLocation = allAppsLocation.append(id.getNamespaceId());
     String name = String.format(Locale.ENGLISH, "%s/%s", type.toString(), id.getApplicationId());
     Location applicationProgramsLocation = accountAppsLocation.append(name);
     if (!applicationProgramsLocation.exists()) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/Store.java
@@ -22,9 +22,7 @@ import co.cask.cdap.api.service.ServiceWorker;
 import co.cask.cdap.app.ApplicationSpecification;
 import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.runtime.ProgramController;
-import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.OperationException;
-import co.cask.cdap.gateway.handlers.AppFabricHttpHandler;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.ProgramRunStatus;
@@ -94,7 +92,7 @@ public interface Store {
    * @param stream the stream to create
    * @throws OperationException
    */
-  void addStream(Id.Account id, StreamSpecification stream) throws OperationException;
+  void addStream(Id.Namespace id, StreamSpecification stream) throws OperationException;
 
   /**
    * Get the spec of a named stream.
@@ -102,7 +100,7 @@ public interface Store {
    * @param name the name of the stream
    * @throws OperationException
    */
-  StreamSpecification getStream(Id.Account id, String name) throws OperationException;
+  StreamSpecification getStream(Id.Namespace id, String name) throws OperationException;
 
   /**
    * Get the specs of all streams for an account.
@@ -111,7 +109,7 @@ public interface Store {
    * @throws OperationException
    */
 
-  Collection<StreamSpecification> getAllStreams(Id.Account id) throws OperationException;
+  Collection<StreamSpecification> getAllStreams(Id.Namespace id) throws OperationException;
 
   /**
    * Creates new application if it doesn't exist. Updates existing one otherwise.
@@ -151,7 +149,7 @@ public interface Store {
   /**
    * Returns a collection of all application specs.
    */
-  Collection<ApplicationSpecification> getAllApplications(Id.Account id) throws OperationException;
+  Collection<ApplicationSpecification> getAllApplications(Id.Namespace id) throws OperationException;
 
   /**
    * Returns location of the application archive.
@@ -254,14 +252,14 @@ public interface Store {
    *
    * @param id account id whose applications to remove
    */
-  void removeAllApplications(Id.Account id) throws OperationException;
+  void removeAllApplications(Id.Namespace id) throws OperationException;
 
   /**
    * Remove all metadata associated with account.
    *
    * @param id account id whose items to remove
    */
-  void removeAll(Id.Account id) throws OperationException;
+  void removeAll(Id.Namespace id) throws OperationException;
 
   /**
    * Store the user arguments needed in the run-time.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricHttpHandler.java
@@ -30,6 +30,7 @@ import co.cask.cdap.app.store.Store;
 import co.cask.cdap.app.store.StoreFactory;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.data.Namespace;
 import co.cask.cdap.data2.OperationException;
 import co.cask.cdap.data2.datafabric.DefaultDatasetNamespace;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
@@ -152,8 +153,7 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
     this.queueAdmin = queueAdmin;
     this.txClient = txClient;
     this.dsFramework =
-      new NamespacedDatasetFramework(dsFramework,
-                                     new DefaultDatasetNamespace(configuration, co.cask.cdap.data.Namespace.USER));
+      new NamespacedDatasetFramework(dsFramework, new DefaultDatasetNamespace(configuration, Namespace.USER));
     this.appLifecycleHttpHandler = appLifecycleHttpHandler;
     this.programLifecycleHttpHandler = programLifecycleHttpHandler;
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricHttpHandler.java
@@ -30,7 +30,6 @@ import co.cask.cdap.app.store.Store;
 import co.cask.cdap.app.store.StoreFactory;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
-import co.cask.cdap.data.Namespace;
 import co.cask.cdap.data2.OperationException;
 import co.cask.cdap.data2.datafabric.DefaultDatasetNamespace;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
@@ -153,7 +152,8 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
     this.queueAdmin = queueAdmin;
     this.txClient = txClient;
     this.dsFramework =
-      new NamespacedDatasetFramework(dsFramework, new DefaultDatasetNamespace(configuration, Namespace.USER));
+      new NamespacedDatasetFramework(dsFramework,
+                                     new DefaultDatasetNamespace(configuration, co.cask.cdap.data.Namespace.USER));
     this.appLifecycleHttpHandler = appLifecycleHttpHandler;
     this.programLifecycleHttpHandler = programLifecycleHttpHandler;
   }
@@ -1065,7 +1065,7 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
 
   private String getDataEntity(Id.Program programId, Data type, String name) throws Exception {
     try {
-      Id.Account account = new Id.Account(programId.getAccountId());
+      Id.Namespace namespace = new Id.Namespace(programId.getNamespaceId());
       if (type == Data.DATASET) {
         DatasetSpecification dsSpec = getDatasetSpec(name);
         String typeName = null;
@@ -1074,7 +1074,7 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
         }
         return GSON.toJson(makeDataSetRecord(name, typeName));
       } else if (type == Data.STREAM) {
-        StreamSpecification spec = store.getStream(account, name);
+        StreamSpecification spec = store.getStream(namespace, name);
         return spec == null ? "" : GSON.toJson(makeStreamRecord(spec.getName(), spec));
       }
       return "";
@@ -1094,7 +1094,7 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
         }
         return GSON.toJson(result);
       } else if (type == Data.STREAM) {
-        Collection<StreamSpecification> specs = store.getAllStreams(new Id.Account(programId.getAccountId()));
+        Collection<StreamSpecification> specs = store.getAllStreams(new Id.Namespace(programId.getNamespaceId()));
         List<StreamRecord> result = Lists.newArrayListWithExpectedSize(specs.size());
         for (StreamSpecification spec : specs) {
           result.add(makeStreamRecord(spec.getName(), null));
@@ -1110,9 +1110,9 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
 
   private String listDataEntitiesByApp(Id.Program programId, Data type) throws Exception {
     try {
-      Id.Account account = new Id.Account(programId.getAccountId());
+      Id.Namespace namespace = new Id.Namespace(programId.getNamespaceId());
       ApplicationSpecification appSpec = store.getApplication(new Id.Application(
-        account, programId.getApplicationId()));
+        namespace, programId.getApplicationId()));
       if (type == Data.DATASET) {
         Set<String> dataSetsUsed = dataSetsUsedBy(appSpec);
         List<DatasetRecord> result = Lists.newArrayListWithExpectedSize(dataSetsUsed.size());
@@ -1241,7 +1241,7 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
     try {
       List<ProgramRecord> result = Lists.newArrayList();
       Collection<ApplicationSpecification> appSpecs = store.getAllApplications(
-        new Id.Account(programId.getAccountId()));
+        new Id.Namespace(programId.getNamespaceId()));
       if (appSpecs != null) {
         for (ApplicationSpecification appSpec : appSpecs) {
           if (type == ProgramType.FLOW) {
@@ -1316,13 +1316,13 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
         return;
       }
       String account = getAuthenticatedAccountId(request);
-      final Id.Account accountId = Id.Account.from(account);
+      final Id.Namespace namespaceId = Id.Namespace.from(account);
 
       // Check if any program is still running
       boolean appRunning = appLifecycleHttpHandler.checkAnyRunning(new Predicate<Id.Program>() {
         @Override
         public boolean apply(Id.Program programId) {
-          return programId.getAccountId().equals(accountId.getId());
+          return programId.getNamespaceId().equals(namespaceId.getId());
         }
       }, ProgramType.values());
 
@@ -1338,7 +1338,7 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
       // todo: do efficiently and also remove timeseries metrics as well: CDAP-1125
       appLifecycleHttpHandler.deleteMetrics(account, null);
       // delete all meta data
-      store.removeAll(accountId);
+      store.removeAll(namespaceId);
       // todo: delete only for specified account
       // delete queues and streams data
       queueAdmin.dropAll();
@@ -1369,13 +1369,13 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
         return;
       }
       String account = getAuthenticatedAccountId(request);
-      final Id.Account accountId = Id.Account.from(account);
+      final Id.Namespace namespaceId = Id.Namespace.from(account);
 
       // Check if any program is still running
       boolean appRunning = appLifecycleHttpHandler.checkAnyRunning(new Predicate<Id.Program>() {
         @Override
         public boolean apply(Id.Program programId) {
-          return programId.getAccountId().equals(accountId.getId());
+          return programId.getNamespaceId().equals(namespaceId.getId());
         }
       }, ProgramType.values());
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppLifecycleHttpHandler.java
@@ -268,7 +268,7 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   public void deleteAllApps(HttpRequest request, HttpResponder responder,
                             @PathParam("namespace-id") String namespaceId) {
     try {
-      Id.Account id = Id.Account.from(namespaceId);
+      Id.Namespace id = Id.Namespace.from(namespaceId);
       AppFabricServiceStatus status = removeAll(id);
       LOG.trace("Delete all call at AppFabricHttpHandler");
       responder.sendString(status.getCode(), status.getMessage());
@@ -344,11 +344,11 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   // deploy helper
   private void deploy(final String namespaceId, final String appId , Location archive) throws Exception {
     try {
-      Id.Account id = Id.Account.from(namespaceId);
+      Id.Namespace id = Id.Namespace.from(namespaceId);
       Location archiveLocation = archive;
       Manager<Location, ApplicationWithPrograms> manager = managerFactory.create(new ProgramTerminator() {
         @Override
-        public void stop(Id.Account id, Id.Program programId, ProgramType type) throws ExecutionException {
+        public void stop(Id.Namespace id, Id.Program programId, ProgramType type) throws ExecutionException {
           deleteHandler(programId, type);
         }
       });
@@ -433,7 +433,7 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
 
   private void stopProgramIfRunning(Id.Program programId, ProgramType type)
     throws InterruptedException, ExecutionException {
-    ProgramRuntimeService.RuntimeInfo programRunInfo = findRuntimeInfo(programId.getAccountId(),
+    ProgramRuntimeService.RuntimeInfo programRunInfo = findRuntimeInfo(programId.getNamespaceId(),
                                                                        programId.getApplicationId(),
                                                                        programId.getId(),
                                                                        type, runtimeService);
@@ -456,7 +456,7 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
     }
 
     try {
-      Id.Account accId = Id.Account.from(namespaceId);
+      Id.Namespace accId = Id.Namespace.from(namespaceId);
       List<ApplicationRecord> result = Lists.newArrayList();
       List<ApplicationSpecification> specList;
       if (appId == null) {
@@ -495,16 +495,16 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   /**
    * Protected only to support v2 APIs
    */
-  protected AppFabricServiceStatus removeAll(Id.Account identifier) throws Exception {
+  protected AppFabricServiceStatus removeAll(Id.Namespace identifier) throws Exception {
     List<ApplicationSpecification> allSpecs = new ArrayList<ApplicationSpecification>(
       store.getAllApplications(identifier));
 
     //Check if any App associated with this namespace is running
-    final Id.Account accId = Id.Account.from(identifier.getId());
+    final Id.Namespace accId = Id.Namespace.from(identifier.getId());
     boolean appRunning = checkAnyRunning(new Predicate<Id.Program>() {
       @Override
       public boolean apply(Id.Program programId) {
-        return programId.getApplication().getAccount().equals(accId);
+        return programId.getApplication().getNamespace().equals(accId);
       }
     }, ProgramType.values());
 
@@ -521,8 +521,8 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   }
 
   private AppFabricServiceStatus removeApplication(Id.Program identifier) throws Exception {
-    Id.Account accountId = Id.Account.from(identifier.getAccountId());
-    final Id.Application appId = Id.Application.from(accountId, identifier.getApplicationId());
+    Id.Namespace namespaceId = Id.Namespace.from(identifier.getNamespaceId());
+    final Id.Application appId = Id.Application.from(namespaceId, identifier.getApplicationId());
 
     //Check if all are stopped.
     boolean appRunning = checkAnyRunning(new Predicate<Id.Program>() {
@@ -550,7 +550,7 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
       }
     }
 
-    deleteMetrics(identifier.getAccountId(), identifier.getApplicationId());
+    deleteMetrics(identifier.getNamespaceId(), identifier.getApplicationId());
 
     // Delete all streams and queues state of each flow
     // TODO: This should be unified with the DeletedProgramHandlerStage
@@ -589,10 +589,10 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   protected void deleteMetrics(String namespaceId, String applicationId) throws IOException, OperationException {
     Collection<ApplicationSpecification> applications = Lists.newArrayList();
     if (applicationId == null) {
-      applications = this.store.getAllApplications(new Id.Account(namespaceId));
+      applications = this.store.getAllApplications(new Id.Namespace(namespaceId));
     } else {
       ApplicationSpecification spec = this.store.getApplication
-        (new Id.Application(new Id.Account(namespaceId), applicationId));
+        (new Id.Application(new Id.Namespace(namespaceId), applicationId));
       applications.add(spec);
     }
     Iterable<Discoverable> discoverables = this.discoveryServiceClient.discover(Constants.Service.METRICS);
@@ -667,7 +667,7 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
     // Delete webapp
     // TODO: this will go away once webapp gets a spec
     try {
-      Id.Program programId = Id.Program.from(appId.getAccountId(), appId.getId(),
+      Id.Program programId = Id.Program.from(appId.getNamespaceId(), appId.getId(),
                                              ProgramType.WEBAPP.name().toLowerCase());
       Location location = Programs.programLocation(locationFactory, appFabricDir, programId, ProgramType.WEBAPP);
       location.delete();

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
@@ -682,7 +682,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
         return;
       }
 
-      StreamSpecification stream = store.getStream(Id.Account.from(namespaceId), streamId);
+      StreamSpecification stream = store.getStream(Id.Namespace.from(namespaceId), streamId);
       if (stream == null) {
         responder.sendString(HttpResponseStatus.BAD_REQUEST, "Stream specified with streamId param does not exist");
         return;
@@ -997,7 +997,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
           store.setServiceWorkerInstances(programId, runnableName, instances);
         }
 
-        ProgramRuntimeService.RuntimeInfo runtimeInfo = findRuntimeInfo(programId.getAccountId(),
+        ProgramRuntimeService.RuntimeInfo runtimeInfo = findRuntimeInfo(programId.getNamespaceId(),
                                                                         programId.getApplicationId(),
                                                                         programId.getId(),
                                                                         ProgramType.SERVICE, runtimeService);
@@ -1140,7 +1140,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
 
       // MapReduce is part of a workflow. Query the status of the workflow instead
       final SettableFuture<StatusMap> statusFuture = SettableFuture.create();
-      workflowClient.getWorkflowStatus(id.getAccountId(), id.getApplicationId(),
+      workflowClient.getWorkflowStatus(id.getNamespaceId(), id.getApplicationId(),
                                        workflowName, new WorkflowClient.Callback() {
           @Override
           public void handle(WorkflowClient.Status status) {
@@ -1241,7 +1241,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   protected ProgramRuntimeService.RuntimeInfo findRuntimeInfo(Id.Program identifier, ProgramType type) {
     Collection<ProgramRuntimeService.RuntimeInfo> runtimeInfos = runtimeService.list(type).values();
     Preconditions.checkNotNull(runtimeInfos, UserMessages.getMessage(UserErrors.RUNTIME_INFO_NOT_FOUND),
-                               identifier.getAccountId(), identifier.getApplicationId());
+                               identifier.getNamespaceId(), identifier.getApplicationId());
     for (ProgramRuntimeService.RuntimeInfo info : runtimeInfos) {
       if (identifier.equals(info.getProgramId())) {
         return info;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/util/AbstractAppFabricHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/util/AbstractAppFabricHttpHandler.java
@@ -266,15 +266,15 @@ public abstract class AbstractAppFabricHttpHandler extends AuthenticatedHttpHand
     return new ProgramRecord(type, appId, spec.getName(), spec.getName(), spec.getDescription());
   }
 
-  protected ProgramRuntimeService.RuntimeInfo findRuntimeInfo(String accountId, String appId,
+  protected ProgramRuntimeService.RuntimeInfo findRuntimeInfo(String namespaceId, String appId,
                                                               String flowId, ProgramType typeId,
                                                               ProgramRuntimeService runtimeService) {
     ProgramType type = ProgramType.valueOf(typeId.name());
     Collection<ProgramRuntimeService.RuntimeInfo> runtimeInfos = runtimeService.list(type).values();
     Preconditions.checkNotNull(runtimeInfos, UserMessages.getMessage(UserErrors.RUNTIME_INFO_NOT_FOUND),
-                               accountId, flowId);
+                               namespaceId, flowId);
 
-    Id.Program programId = Id.Program.from(accountId, appId, flowId);
+    Id.Program programId = Id.Program.from(namespaceId, appId, flowId);
 
     for (ProgramRuntimeService.RuntimeInfo info : runtimeInfos) {
       if (programId.equals(info.getProgramId())) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/util/AbstractAppFabricHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/util/AbstractAppFabricHttpHandler.java
@@ -173,7 +173,7 @@ public abstract class AbstractAppFabricHttpHandler extends AuthenticatedHttpHand
     try {
       List<ProgramRecord> programRecords;
       if (applicationId == null) {
-        Id.Account accId = Id.Account.from(namespaceId);
+        Id.Namespace accId = Id.Namespace.from(namespaceId);
         programRecords = listPrograms(accId, type, store);
       } else {
         Id.Application appId = Id.Application.from(namespaceId, applicationId);
@@ -195,7 +195,7 @@ public abstract class AbstractAppFabricHttpHandler extends AuthenticatedHttpHand
     }
   }
 
-  protected final List<ProgramRecord> listPrograms(Id.Account accId, ProgramType type, Store store) throws Exception {
+  protected final List<ProgramRecord> listPrograms(Id.Namespace accId, ProgramType type, Store store) throws Exception {
     try {
       Collection<ApplicationSpecification> appSpecs = store.getAllApplications(accId);
       return listPrograms(appSpecs, type);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/InMemoryConfigurator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/InMemoryConfigurator.java
@@ -62,7 +62,7 @@ public final class InMemoryConfigurator implements Configurator {
    *
    * @param archive name of the archive file for which configure is invoked in-memory.
    */
-  public InMemoryConfigurator(Id.Account id, Location archive) {
+  public InMemoryConfigurator(Id.Namespace id, Location archive) {
     Preconditions.checkNotNull(id);
     Preconditions.checkNotNull(archive);
     this.archive = archive;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/LocalManager.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/LocalManager.java
@@ -21,6 +21,7 @@ import co.cask.cdap.app.store.Store;
 import co.cask.cdap.app.store.StoreFactory;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.data.Namespace;
 import co.cask.cdap.data2.datafabric.DefaultDatasetNamespace;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.NamespacedDatasetFramework;
@@ -90,7 +91,7 @@ public class LocalManager<I, O> implements Manager<I, O> {
     this.programTerminator = programTerminator;
     this.datasetFramework =
       new NamespacedDatasetFramework(datasetFramework,
-                                     new DefaultDatasetNamespace(configuration, co.cask.cdap.data.Namespace.USER));
+                                     new DefaultDatasetNamespace(configuration, Namespace.USER));
     this.streamAdmin = streamAdmin;
     this.exploreFacade = exploreFacade;
     this.exploreEnabled = configuration.getBoolean(Constants.Explore.EXPLORE_ENABLED);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/LocalManager.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/LocalManager.java
@@ -21,7 +21,6 @@ import co.cask.cdap.app.store.Store;
 import co.cask.cdap.app.store.StoreFactory;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
-import co.cask.cdap.data.Namespace;
 import co.cask.cdap.data2.datafabric.DefaultDatasetNamespace;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.NamespacedDatasetFramework;
@@ -91,14 +90,14 @@ public class LocalManager<I, O> implements Manager<I, O> {
     this.programTerminator = programTerminator;
     this.datasetFramework =
       new NamespacedDatasetFramework(datasetFramework,
-                                     new DefaultDatasetNamespace(configuration, Namespace.USER));
+                                     new DefaultDatasetNamespace(configuration, co.cask.cdap.data.Namespace.USER));
     this.streamAdmin = streamAdmin;
     this.exploreFacade = exploreFacade;
     this.exploreEnabled = configuration.getBoolean(Constants.Explore.EXPLORE_ENABLED);
   }
 
   @Override
-  public ListenableFuture<O> deploy(Id.Account id, @Nullable String appId, I input) throws Exception {
+  public ListenableFuture<O> deploy(Id.Namespace id, @Nullable String appId, I input) throws Exception {
     Pipeline<O> pipeline = pipelineFactory.getPipeline();
     pipeline.addLast(new LocalArchiveLoaderStage(configuration, id, appId));
     pipeline.addLast(new VerificationStage(datasetFramework));

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/ProgramTerminator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/ProgramTerminator.java
@@ -32,6 +32,6 @@ public interface ProgramTerminator {
    * @param programId  Program id.
    * @param type       Program Type.
    */
-  void stop (Id.Account id, Id.Program programId, ProgramType type) throws Exception;
+  void stop (Id.Namespace id, Id.Program programId, ProgramType type) throws Exception;
 
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/DeletedProgramHandlerStage.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/DeletedProgramHandlerStage.java
@@ -94,7 +94,7 @@ public class DeletedProgramHandlerStage extends AbstractStage<ApplicationDeploya
       //call the deleted spec
       ProgramType type = ProgramTypes.fromSpecification(spec);
       Id.Program programId = Id.Program.from(appSpec.getId(), spec.getName());
-      programTerminator.stop(Id.Account.from(appSpec.getId().getAccountId()),
+      programTerminator.stop(Id.Namespace.from(appSpec.getId().getNamespaceId()),
                                    programId, type);
 
       // TODO: Unify with AppFabricHttpHandler.removeApplication
@@ -121,7 +121,7 @@ public class DeletedProgramHandlerStage extends AbstractStage<ApplicationDeploya
       }
     }
     if (!deletedFlows.isEmpty()) {
-      deleteMetrics(appSpec.getId().getAccountId(), appSpec.getId().getId(), deletedFlows);
+      deleteMetrics(appSpec.getId().getNamespaceId(), appSpec.getId().getId(), deletedFlows);
     }
 
     emit(appSpec);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/LocalArchiveLoaderStage.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/LocalArchiveLoaderStage.java
@@ -42,13 +42,13 @@ import javax.annotation.Nullable;
 public class LocalArchiveLoaderStage extends AbstractStage<Location> {
   private final CConfiguration cConf;
   private final ApplicationSpecificationAdapter adapter;
-  private final Id.Account id;
+  private final Id.Namespace id;
   private final String appId;
 
   /**
    * Constructor with hit for handling type.
    */
-  public LocalArchiveLoaderStage(CConfiguration cConf, Id.Account id, @Nullable String appId) {
+  public LocalArchiveLoaderStage(CConfiguration cConf, Id.Namespace id, @Nullable String appId) {
     super(TypeToken.of(Location.class));
     this.cConf = cConf;
     this.id = id;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/ProgramGenerationStage.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/ProgramGenerationStage.java
@@ -72,7 +72,7 @@ public class ProgramGenerationStage extends AbstractStage<ApplicationDeployable>
 
     // Make sure we have a directory to store the original artifact.
     Location outputDir = locationFactory.create(configuration.get(Constants.AppFabric.OUTPUT_DIR));
-    final Location newOutputDir = outputDir.append(input.getId().getAccountId());
+    final Location newOutputDir = outputDir.append(input.getId().getNamespaceId());
 
     // Check exists, create, check exists again to avoid failure due to race condition.
     if (!newOutputDir.exists() && !newOutputDir.mkdirs() && !newOutputDir.exists()) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/program/ProgramBundle.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/program/ProgramBundle.java
@@ -82,7 +82,7 @@ public final class ProgramBundle {
     manifest.getMainAttributes().put(ManifestFields.MAIN_CLASS, className);
     manifest.getMainAttributes().put(ManifestFields.PROCESSOR_TYPE, type.toString());
     manifest.getMainAttributes().put(ManifestFields.SPEC_FILE, ManifestFields.MANIFEST_SPEC_FILE);
-    manifest.getMainAttributes().put(ManifestFields.ACCOUNT_ID, id.getAccountId());
+    manifest.getMainAttributes().put(ManifestFields.ACCOUNT_ID, id.getNamespaceId());
     manifest.getMainAttributes().put(ManifestFields.APPLICATION_ID, id.getId());
     manifest.getMainAttributes().put(ManifestFields.PROGRAM_NAME, programName);
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
@@ -578,7 +578,7 @@ final class MapReduceRuntimeService extends AbstractExecutionThreadService {
     Location jobJar =
       locationFactory.create(String.format("%s.%s.%s.%s.%s.jar",
                                            ProgramType.MAPREDUCE.name().toLowerCase(),
-                                           programId.getAccountId(), programId.getApplicationId(),
+                                           programId.getNamespaceId(), programId.getApplicationId(),
                                            programId.getId(), context.getRunId().getId()));
 
     LOG.debug("Creating Job jar: {}", jobJar.toURI());
@@ -744,7 +744,7 @@ final class MapReduceRuntimeService extends AbstractExecutionThreadService {
     Location programJarCopy = locationFactory.create(
       String.format("%s.%s.%s.%s.%s.program.jar",
                     ProgramType.MAPREDUCE.name().toLowerCase(),
-                    programId.getAccountId(), programId.getApplicationId(),
+                    programId.getNamespaceId(), programId.getApplicationId(),
                     programId.getId(), context.getRunId().getId()));
 
     ByteStreams.copy(Locations.newInputSupplier(programJarLocation), Locations.newOutputSupplier(programJarCopy));

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedProgramRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedProgramRuntimeService.java
@@ -297,7 +297,7 @@ public final class DistributedProgramRuntimeService extends AbstractProgramRunti
   @Override
   public ProgramLiveInfo getLiveInfo(Id.Program program, ProgramType type) {
     String twillAppName = String.format("%s.%s.%s.%s", type.name().toLowerCase(),
-                                      program.getAccountId(), program.getApplicationId(), program.getId());
+                                      program.getNamespaceId(), program.getApplicationId(), program.getId());
     Iterator<TwillController> controllers = twillRunner.lookup(twillAppName).iterator();
     JsonObject json = new JsonObject();
     // this will return an empty Json if there is no live instance

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowUtils.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowUtils.java
@@ -58,7 +58,7 @@ public final class FlowUtils {
    */
   public static long generateConsumerGroupId(Id.Program program, String flowletId) {
     return Hashing.md5().newHasher()
-                  .putString(program.getAccountId())
+                  .putString(program.getNamespaceId())
                   .putString(program.getApplicationId())
                   .putString(program.getId())
                   .putString(flowletId).hash().asLong();

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/AbstractSchedulerService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/AbstractSchedulerService.java
@@ -171,7 +171,7 @@ public abstract class AbstractSchedulerService extends AbstractIdleService imple
         String scheduleName = schedule.getName();
         String cronEntry = schedule.getCronEntry();
         String triggerKey = String.format("%s:%s:%s:%s:%d:%s",
-                                          programType.name(), programId.getAccountId(),
+                                          programType.name(), programId.getNamespaceId(),
                                           programId.getApplicationId(), programId.getId(), idx, schedule.getName());
 
         LOG.debug("Scheduling job {} with cron {}", scheduleName, cronEntry);
@@ -281,7 +281,7 @@ public abstract class AbstractSchedulerService extends AbstractIdleService imple
     }
 
     private String getJobKey(Id.Program program, ProgramType programType) {
-      return String.format("%s:%s:%s:%s", programType.name(), program.getAccountId(),
+      return String.format("%s:%s:%s:%s", programType.name(), program.getNamespaceId(),
                            program.getApplicationId(), program.getId());
     }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/ScheduleTaskRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/ScheduleTaskRunner.java
@@ -116,7 +116,7 @@ public final class ScheduleTaskRunner {
                       TimeUnit.SECONDS.convert(System.currentTimeMillis(), TimeUnit.MILLISECONDS),
                       ProgramController.State.STOPPED);
         LOG.debug("Program {} {} {} completed successfully.",
-                  programId.getAccountId(), programId.getApplicationId(), programId.getId());
+                  programId.getNamespaceId(), programId.getApplicationId(), programId.getId());
         latch.countDown();
       }
 
@@ -126,7 +126,7 @@ public final class ScheduleTaskRunner {
                       TimeUnit.SECONDS.convert(System.currentTimeMillis(), TimeUnit.MILLISECONDS),
                       ProgramController.State.STOPPED);
         LOG.debug("Program {} {} {} execution failed.",
-                  programId.getAccountId(), programId.getApplicationId(), programId.getId(),
+                  programId.getNamespaceId(), programId.getApplicationId(), programId.getId(),
                   cause);
 
         latch.countDown();

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkRuntimeService.java
@@ -334,7 +334,7 @@ final class SparkRuntimeService extends AbstractExecutionThreadService {
 
     Location jobJarLocation = locationFactory.create(String.format("%s.%s.%s.%s.%s.jar",
                                                                    ProgramType.SPARK.name().toLowerCase(),
-                                                                   programId.getAccountId(),
+                                                                   programId.getNamespaceId(),
                                                                    programId.getApplicationId(), programId.getId(),
                                                                    context.getRunId().getId()));
 
@@ -363,7 +363,7 @@ final class SparkRuntimeService extends AbstractExecutionThreadService {
     Id.Program programId = context.getProgram().getId();
     Location programJarCopy = locationFactory.create(String.format("%s.%s.%s.%s.%s.program.jar",
                                                                    ProgramType.SPARK.name().toLowerCase(),
-                                                                   programId.getAccountId(),
+                                                                   programId.getNamespaceId(),
                                                                    programId.getApplicationId(), programId.getId(),
                                                                    context.getRunId().getId()));
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ServiceHttpServer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ServiceHttpServer.java
@@ -128,7 +128,7 @@ public class ServiceHttpServer extends AbstractIdleService {
     // The service URI is always prefixed for routing purpose
     String pathPrefix = String.format("%s/namespaces/%s/apps/%s/services/%s/methods",
                                       Constants.Gateway.API_VERSION_3,
-                                      programId.getAccountId(),
+                                      programId.getNamespaceId(),
                                       programId.getApplicationId(),
                                       programId.getId());
 
@@ -185,7 +185,7 @@ public class ServiceHttpServer extends AbstractIdleService {
   private String getServiceName(Id.Program programId) {
     return String.format("%s.%s.%s.%s",
                          ProgramType.SERVICE.name().toLowerCase(),
-                         programId.getAccountId(), programId.getApplicationId(), programId.getId());
+                         programId.getNamespaceId(), programId.getApplicationId(), programId.getId());
   }
 
   private TimerTask createHandlerDestroyTask() {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
@@ -36,6 +36,7 @@ import co.cask.cdap.app.store.Store;
 import co.cask.cdap.archive.ArchiveBundler;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.data.Namespace;
 import co.cask.cdap.data2.OperationException;
 import co.cask.cdap.data2.datafabric.DefaultDatasetNamespace;
 import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
@@ -104,8 +105,7 @@ public class DefaultStore implements Store {
 
     this.locationFactory = locationFactory;
     this.configuration = conf;
-    this.dsFramework =
-      new NamespacedDatasetFramework(framework, new DefaultDatasetNamespace(conf, co.cask.cdap.data.Namespace.SYSTEM));
+    this.dsFramework = new NamespacedDatasetFramework(framework, new DefaultDatasetNamespace(conf, Namespace.SYSTEM));
 
     txnl =
       Transactional.of(

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
@@ -36,7 +36,6 @@ import co.cask.cdap.app.store.Store;
 import co.cask.cdap.archive.ArchiveBundler;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
-import co.cask.cdap.data.Namespace;
 import co.cask.cdap.data2.OperationException;
 import co.cask.cdap.data2.datafabric.DefaultDatasetNamespace;
 import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
@@ -106,7 +105,7 @@ public class DefaultStore implements Store {
     this.locationFactory = locationFactory;
     this.configuration = conf;
     this.dsFramework =
-      new NamespacedDatasetFramework(framework, new DefaultDatasetNamespace(conf, Namespace.SYSTEM));
+      new NamespacedDatasetFramework(framework, new DefaultDatasetNamespace(conf, co.cask.cdap.data.Namespace.SYSTEM));
 
     txnl =
       Transactional.of(
@@ -145,7 +144,7 @@ public class DefaultStore implements Store {
     ApplicationMeta appMeta = txnl.executeUnchecked(new TransactionExecutor.Function<AppMds, ApplicationMeta>() {
       @Override
       public ApplicationMeta apply(AppMds mds) throws Exception {
-        return mds.apps.getApplication(id.getAccountId(), id.getApplicationId());
+        return mds.apps.getApplication(id.getNamespaceId(), id.getApplicationId());
       }
     });
 
@@ -167,7 +166,7 @@ public class DefaultStore implements Store {
     txnl.executeUnchecked(new TransactionExecutor.Function<AppMds, Void>() {
       @Override
       public Void apply(AppMds mds) throws Exception {
-        mds.apps.recordProgramStart(id.getAccountId(), id.getApplicationId(), id.getId(), pid, startTime);
+        mds.apps.recordProgramStart(id.getNamespaceId(), id.getApplicationId(), id.getId(), pid, startTime);
         return null;
       }
     });
@@ -180,7 +179,7 @@ public class DefaultStore implements Store {
     txnl.executeUnchecked(new TransactionExecutor.Function<AppMds, Void>() {
       @Override
       public Void apply(AppMds mds) throws Exception {
-        mds.apps.recordProgramStop(id.getAccountId(), id.getApplicationId(), id.getId(), pid, endTime, state);
+        mds.apps.recordProgramStop(id.getNamespaceId(), id.getApplicationId(), id.getId(), pid, endTime, state);
         return null;
       }
     });
@@ -196,7 +195,7 @@ public class DefaultStore implements Store {
     return txnl.executeUnchecked(new TransactionExecutor.Function<AppMds, List<RunRecord>>() {
       @Override
       public List<RunRecord> apply(AppMds mds) throws Exception {
-        return mds.apps.getRuns(id.getAccountId(), id.getApplicationId(), id.getId(), status,
+        return mds.apps.getRuns(id.getNamespaceId(), id.getApplicationId(), id.getId(), status,
                                 startTime, endTime, limit);
       }
     });
@@ -209,10 +208,10 @@ public class DefaultStore implements Store {
     txnl.executeUnchecked(new TransactionExecutor.Function<AppMds, Void>() {
       @Override
       public Void apply(AppMds mds) throws Exception {
-        mds.apps.writeApplication(id.getAccountId(), id.getId(), spec, appArchiveLocation.toURI().toString());
+        mds.apps.writeApplication(id.getNamespaceId(), id.getId(), spec, appArchiveLocation.toURI().toString());
 
         for (StreamSpecification stream : spec.getStreams().values()) {
-          mds.apps.writeStream(id.getAccountId(), stream);
+          mds.apps.writeStream(id.getNamespaceId(), stream);
         }
 
         return null;
@@ -229,7 +228,7 @@ public class DefaultStore implements Store {
     ApplicationMeta existing = txnl.executeUnchecked(new TransactionExecutor.Function<AppMds, ApplicationMeta>() {
       @Override
       public ApplicationMeta apply(AppMds mds) throws Exception {
-        return mds.apps.getApplication(id.getAccountId(), id.getId());
+        return mds.apps.getApplication(id.getNamespaceId(), id.getId());
       }
     });
 
@@ -265,7 +264,7 @@ public class DefaultStore implements Store {
   }
 
   @Override
-  public void addStream(final Id.Account id, final StreamSpecification streamSpec) {
+  public void addStream(final Id.Namespace id, final StreamSpecification streamSpec) {
     txnl.executeUnchecked(new TransactionExecutor.Function<AppMds, Void>() {
       @Override
       public Void apply(AppMds mds) throws Exception {
@@ -276,7 +275,7 @@ public class DefaultStore implements Store {
   }
 
   @Override
-  public StreamSpecification getStream(final Id.Account id, final String name) throws OperationException {
+  public StreamSpecification getStream(final Id.Namespace id, final String name) throws OperationException {
     return txnl.executeUnchecked(new TransactionExecutor.Function<AppMds, StreamSpecification>() {
       @Override
       public StreamSpecification apply(AppMds mds) throws Exception {
@@ -286,7 +285,7 @@ public class DefaultStore implements Store {
   }
 
   @Override
-  public Collection<StreamSpecification> getAllStreams(final Id.Account id) throws OperationException {
+  public Collection<StreamSpecification> getAllStreams(final Id.Namespace id) throws OperationException {
     return txnl.executeUnchecked(new TransactionExecutor.Function<AppMds, Collection<StreamSpecification>>() {
       @Override
       public Collection<StreamSpecification> apply(AppMds mds) throws Exception {
@@ -300,7 +299,7 @@ public class DefaultStore implements Store {
     Preconditions.checkArgument(count > 0, "cannot change number of flowlet instances to negative number: " + count);
 
     LOG.trace("Setting flowlet instances: account: {}, application: {}, flow: {}, flowlet: {}, new instances count: {}",
-              id.getAccountId(), id.getApplicationId(), id.getId(), flowletId, count);
+              id.getNamespaceId(), id.getApplicationId(), id.getId(), flowletId, count);
 
     txnl.executeUnchecked(new TransactionExecutor.Function<AppMds, Void>() {
       @Override
@@ -309,13 +308,13 @@ public class DefaultStore implements Store {
         ApplicationSpecification newAppSpec = updateFlowletInstancesInAppSpec(appSpec, id, flowletId, count);
         replaceAppSpecInProgramJar(id, newAppSpec, ProgramType.FLOW);
 
-        mds.apps.updateAppSpec(id.getAccountId(), id.getApplicationId(), newAppSpec);
+        mds.apps.updateAppSpec(id.getNamespaceId(), id.getApplicationId(), newAppSpec);
         return null;
       }
     });
 
     LOG.trace("Set flowlet instances: account: {}, application: {}, flow: {}, flowlet: {}, instances now: {}",
-              id.getAccountId(), id.getApplicationId(), id.getId(), flowletId, count);
+              id.getNamespaceId(), id.getApplicationId(), id.getId(), flowletId, count);
   }
 
   @Override
@@ -365,13 +364,13 @@ public class DefaultStore implements Store {
         ApplicationSpecification newAppSpec = replaceProcedureInAppSpec(appSpec, id, newSpecification);
         replaceAppSpecInProgramJar(id, newAppSpec, ProgramType.PROCEDURE);
 
-        mds.apps.updateAppSpec(id.getAccountId(), id.getApplicationId(), newAppSpec);
+        mds.apps.updateAppSpec(id.getNamespaceId(), id.getApplicationId(), newAppSpec);
         return null;
       }
     });
 
     LOG.trace("Setting program instances: account: {}, application: {}, procedure: {}, new instances count: {}",
-              id.getAccountId(), id.getApplicationId(), id.getId(), count);
+              id.getNamespaceId(), id.getApplicationId(), id.getId(), count);
   }
 
   @Override
@@ -393,13 +392,13 @@ public class DefaultStore implements Store {
         ApplicationSpecification newAppSpec = replaceServiceSpec(appSpec, id.getId(), serviceSpec);
         replaceAppSpecInProgramJar(id, newAppSpec, ProgramType.SERVICE);
 
-        mds.apps.updateAppSpec(id.getAccountId(), id.getApplicationId(), newAppSpec);
+        mds.apps.updateAppSpec(id.getNamespaceId(), id.getApplicationId(), newAppSpec);
         return null;
       }
     });
 
     LOG.trace("Setting program instances: account: {}, application: {}, service: {}, new instances count: {}",
-              id.getAccountId(), id.getApplicationId(), id.getId(), instances);
+              id.getNamespaceId(), id.getApplicationId(), id.getId(), instances);
   }
 
   @Override
@@ -443,13 +442,13 @@ public class DefaultStore implements Store {
         ApplicationSpecification newAppSpec = replaceServiceSpec(appSpec, id.getId(), serviceSpec);
         replaceAppSpecInProgramJar(id, newAppSpec, ProgramType.SERVICE);
 
-        mds.apps.updateAppSpec(id.getAccountId(), id.getApplicationId(), newAppSpec);
+        mds.apps.updateAppSpec(id.getNamespaceId(), id.getApplicationId(), newAppSpec);
         return null;
       }
     });
 
     LOG.trace("Setting program instances: account: {}, application: {}, service: {}, new instances count: {}",
-              id.getAccountId(), id.getApplicationId(), id.getId(), instances);
+              id.getNamespaceId(), id.getApplicationId(), id.getId(), instances);
   }
 
   @Override
@@ -467,21 +466,21 @@ public class DefaultStore implements Store {
 
   @Override
   public void removeApplication(final Id.Application id) {
-    LOG.trace("Removing application: account: {}, application: {}", id.getAccountId(), id.getId());
+    LOG.trace("Removing application: account: {}, application: {}", id.getNamespaceId(), id.getId());
 
     txnl.executeUnchecked(new TransactionExecutor.Function<AppMds, Void>() {
       @Override
       public Void apply(AppMds mds) throws Exception {
-        mds.apps.deleteApplication(id.getAccountId(), id.getId());
-        mds.apps.deleteProgramArgs(id.getAccountId(), id.getId());
-        mds.apps.deleteProgramHistory(id.getAccountId(), id.getId());
+        mds.apps.deleteApplication(id.getNamespaceId(), id.getId());
+        mds.apps.deleteProgramArgs(id.getNamespaceId(), id.getId());
+        mds.apps.deleteProgramHistory(id.getNamespaceId(), id.getId());
         return null;
       }
     });
   }
 
   @Override
-  public void removeAllApplications(final Id.Account id) {
+  public void removeAllApplications(final Id.Namespace id) {
     LOG.trace("Removing all applications of account with id: {}", id.getId());
 
     txnl.executeUnchecked(new TransactionExecutor.Function<AppMds, Void>() {
@@ -496,7 +495,7 @@ public class DefaultStore implements Store {
   }
 
   @Override
-  public void removeAll(final Id.Account id) {
+  public void removeAll(final Id.Namespace id) {
     LOG.trace("Removing all applications of account with id: {}", id.getId());
 
     txnl.executeUnchecked(new TransactionExecutor.Function<AppMds, Void>() {
@@ -519,7 +518,7 @@ public class DefaultStore implements Store {
     txnl.executeUnchecked(new TransactionExecutor.Function<AppMds, Void>() {
       @Override
       public Void apply(AppMds mds) throws Exception {
-        mds.apps.writeProgramArgs(id.getAccountId(), id.getApplicationId(), id.getId(), arguments);
+        mds.apps.writeProgramArgs(id.getNamespaceId(), id.getApplicationId(), id.getId(), arguments);
         return null;
       }
     });
@@ -530,7 +529,7 @@ public class DefaultStore implements Store {
     return txnl.executeUnchecked(new TransactionExecutor.Function<AppMds, Map<String, String>>() {
       @Override
       public Map<String, String> apply(AppMds mds) throws Exception {
-        ProgramArgs programArgs = mds.apps.getProgramArgs(id.getAccountId(), id.getApplicationId(), id.getId());
+        ProgramArgs programArgs = mds.apps.getProgramArgs(id.getNamespaceId(), id.getApplicationId(), id.getId());
         return programArgs == null ? Maps.<String, String>newHashMap() : programArgs.getArgs();
       }
     });
@@ -548,7 +547,7 @@ public class DefaultStore implements Store {
   }
 
   @Override
-  public Collection<ApplicationSpecification> getAllApplications(final Id.Account id) {
+  public Collection<ApplicationSpecification> getAllApplications(final Id.Namespace id) {
     return txnl.executeUnchecked(new TransactionExecutor.Function<AppMds, Collection<ApplicationSpecification>>() {
       @Override
       public Collection<ApplicationSpecification> apply(AppMds mds) throws Exception {
@@ -569,7 +568,7 @@ public class DefaultStore implements Store {
     return txnl.executeUnchecked(new TransactionExecutor.Function<AppMds, Location>() {
       @Override
       public Location apply(AppMds mds) throws Exception {
-        ApplicationMeta meta = mds.apps.getApplication(id.getAccountId(), id.getId());
+        ApplicationMeta meta = mds.apps.getApplication(id.getNamespaceId(), id.getId());
         return meta == null ? null : locationFactory.create(URI.create(meta.getArchiveLocation()));
       }
     });
@@ -586,7 +585,7 @@ public class DefaultStore implements Store {
 
     LOG.trace("Changing flowlet stream connection: account: {}, application: {}, flow: {}, flowlet: {}," +
                 " old coonnected stream: {}, new connected stream: {}",
-              flow.getAccountId(), flow.getApplicationId(), flow.getId(), flowletId, oldValue, newValue);
+              flow.getNamespaceId(), flow.getApplicationId(), flow.getId(), flowletId, oldValue, newValue);
 
     txnl.executeUnchecked(new TransactionExecutor.Function<AppMds, Void>() {
       @Override
@@ -613,7 +612,7 @@ public class DefaultStore implements Store {
           throw new IllegalArgumentException(
             String.format("Cannot change stream connection to %s, the connection to be changed is not found," +
                             " account: %s, application: %s, flow: %s, flowlet: %s, source stream: %s",
-                          newValue, flow.getAccountId(), flow.getApplicationId(), flow.getId(), flowletId, oldValue));
+                          newValue, flow.getNamespaceId(), flow.getApplicationId(), flow.getId(), flowletId, oldValue));
         }
 
         FlowletDefinition flowletDef = getFlowletDefinitionOrFail(flowSpec, flowletId, flow);
@@ -623,7 +622,7 @@ public class DefaultStore implements Store {
         replaceAppSpecInProgramJar(flow, newAppSpec, ProgramType.FLOW);
 
         Id.Application app = flow.getApplication();
-        mds.apps.updateAppSpec(app.getAccountId(), app.getId(), newAppSpec);
+        mds.apps.updateAppSpec(app.getNamespaceId(), app.getId(), newAppSpec);
         return null;
       }
     });
@@ -631,7 +630,7 @@ public class DefaultStore implements Store {
 
     LOG.trace("Changed flowlet stream connection: account: {}, application: {}, flow: {}, flowlet: {}," +
                 " old coonnected stream: {}, new connected stream: {}",
-              flow.getAccountId(), flow.getApplicationId(), flow.getId(), flowletId, oldValue, newValue);
+              flow.getNamespaceId(), flow.getApplicationId(), flow.getId(), flowletId, oldValue, newValue);
 
     // todo: change stream "used by" flow mapping in metadata?
   }
@@ -746,7 +745,7 @@ public class DefaultStore implements Store {
   }
 
   private ApplicationSpecification getApplicationSpec(AppMds mds, Id.Application id) {
-    ApplicationMeta meta = mds.apps.getApplication(id.getAccountId(), id.getId());
+    ApplicationMeta meta = mds.apps.getApplication(id.getNamespaceId(), id.getId());
     return meta == null ? null : meta.getSpec();
   }
 
@@ -807,7 +806,7 @@ public class DefaultStore implements Store {
                                                                 String workerName) {
     ServiceWorkerSpecification workerSpec = serviceSpec.getWorkers().get(workerName);
     if (workerSpec == null) {
-      throw new NoSuchElementException("no such worker @ account id: " + id.getAccountId() +
+      throw new NoSuchElementException("no such worker @ account id: " + id.getNamespaceId() +
                                          ", app id: " + id.getApplication() +
                                          ", service id: " + id.getId() +
                                          ", worker id: " + workerName);
@@ -819,7 +818,7 @@ public class DefaultStore implements Store {
                                                               String flowletId, Id.Program id) {
     FlowletDefinition flowletDef = flowSpec.getFlowlets().get(flowletId);
     if (flowletDef == null) {
-      throw new NoSuchElementException("no such flowlet @ account id: " + id.getAccountId() +
+      throw new NoSuchElementException("no such flowlet @ account id: " + id.getNamespaceId() +
                                            ", app id: " + id.getApplication() +
                                            ", flow id: " + id.getId() +
                                            ", flowlet id: " + flowletId);
@@ -830,7 +829,7 @@ public class DefaultStore implements Store {
   private static FlowSpecification getFlowSpecOrFail(Id.Program id, ApplicationSpecification appSpec) {
     FlowSpecification flowSpec = appSpec.getFlows().get(id.getId());
     if (flowSpec == null) {
-      throw new NoSuchElementException("no such flow @ account id: " + id.getAccountId() +
+      throw new NoSuchElementException("no such flow @ account id: " + id.getNamespaceId() +
                                            ", app id: " + id.getApplication() +
                                            ", flow id: " + id.getId());
     }
@@ -840,7 +839,7 @@ public class DefaultStore implements Store {
   private static ServiceSpecification getServiceSpecOrFail(Id.Program id, ApplicationSpecification appSpec) {
     ServiceSpecification spec = appSpec.getServices().get(id.getId());
     if (spec == null) {
-      throw new NoSuchElementException("no such service @ account id: " + id.getAccountId() +
+      throw new NoSuchElementException("no such service @ account id: " + id.getNamespaceId() +
                                            ", app id: " + id.getApplication() +
                                            ", service id: " + id.getId());
     }
@@ -850,7 +849,7 @@ public class DefaultStore implements Store {
   private static ProcedureSpecification getProcedureSpecOrFail(Id.Program id, ApplicationSpecification appSpec) {
     ProcedureSpecification procedureSpecification = appSpec.getProcedures().get(id.getId());
     if (procedureSpecification == null) {
-      throw new NoSuchElementException("no such procedure @ account id: " + id.getAccountId() +
+      throw new NoSuchElementException("no such procedure @ account id: " + id.getNamespaceId() +
                                            ", app id: " + id.getApplication() +
                                            ", procedure id: " + id.getId());
     }
@@ -870,7 +869,7 @@ public class DefaultStore implements Store {
   private ApplicationSpecification getAppSpecOrFail(AppMds mds, Id.Program id) {
     ApplicationSpecification appSpec = getApplicationSpec(mds, id.getApplication());
     if (appSpec == null) {
-      throw new NoSuchElementException("no such application @ account id: " + id.getAccountId() +
+      throw new NoSuchElementException("no such application @ account id: " + id.getNamespaceId() +
                                            ", app id: " + id.getApplication().getId());
     }
     return appSpec;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/test/internal/AppFabricTestHelper.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/test/internal/AppFabricTestHelper.java
@@ -92,7 +92,7 @@ public class AppFabricTestHelper {
 
     return factory.create(new ProgramTerminator() {
       @Override
-      public void stop(Id.Account id, Id.Program programId, ProgramType type) throws Exception {
+      public void stop(Id.Namespace id, Id.Program programId, ProgramType type) throws Exception {
         //No-op
       }
     });
@@ -120,7 +120,7 @@ public class AppFabricTestHelper {
 
     Location deployedJar = createAppJar(appClass);
     try {
-      ApplicationWithPrograms appWithPrograms = getLocalManager().deploy(DefaultId.ACCOUNT, null, deployedJar).get();
+      ApplicationWithPrograms appWithPrograms = getLocalManager().deploy(DefaultId.NAMESPACE, null, deployedJar).get();
       // Transform program to get loadable, as the one created in deploy pipeline is not loadable.
 
       final List<Program> programs = ImmutableList.copyOf(Iterables.transform(appWithPrograms.getPrograms(),

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/test/internal/DefaultId.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/test/internal/DefaultId.java
@@ -26,7 +26,7 @@ public class DefaultId {
   private static final String DEFAULT_APPLICATION_ID = "myapp";
   private static final String DEFAULT_PROGRAM_ID = "pgm";
 
-  public static final Id.Account ACCOUNT = new Id.Account(Constants.DEFAULT_NAMESPACE);
-  public static final Id.Application APPLICATION = new Id.Application(ACCOUNT, DEFAULT_APPLICATION_ID);
+  public static final Id.Namespace NAMESPACE = new Id.Namespace(Constants.DEFAULT_NAMESPACE);
+  public static final Id.Application APPLICATION = new Id.Application(NAMESPACE, DEFAULT_APPLICATION_ID);
   public static final Id.Program PROGRAM = new Id.Program(APPLICATION, DEFAULT_PROGRAM_ID);
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/deploy/ConfiguratorTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/deploy/ConfiguratorTest.java
@@ -45,7 +45,7 @@ public class ConfiguratorTest {
     Location appJar = AppFabricTestHelper.createAppJar(WordCountApp.class);
 
     // Create a configurator that is testable. Provide it a application.
-    Configurator configurator = new InMemoryConfigurator(DefaultId.ACCOUNT, appJar);
+    Configurator configurator = new InMemoryConfigurator(DefaultId.NAMESPACE, appJar);
 
     // Extract response from the configurator.
     ListenableFuture<ConfigResponse> result = configurator.config();

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/deploy/LocalManagerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/deploy/LocalManagerTest.java
@@ -53,7 +53,7 @@ public class LocalManagerTest {
     String jar = JarFinder.getJar(WebCrawlApp.class, new Manifest());
     Location deployedJar = lf.create(jar);
     try {
-      AppFabricTestHelper.getLocalManager().deploy(DefaultId.ACCOUNT, null, deployedJar).get();
+      AppFabricTestHelper.getLocalManager().deploy(DefaultId.NAMESPACE, null, deployedJar).get();
     } finally {
       deployedJar.delete(true);
     }
@@ -68,7 +68,7 @@ public class LocalManagerTest {
       JarFinder.getJar(ToyApp.class, AppFabricClient.getManifestWithMainClass(ToyApp.class))
     );
 
-    ApplicationWithPrograms input = AppFabricTestHelper.getLocalManager().deploy(DefaultId.ACCOUNT,
+    ApplicationWithPrograms input = AppFabricTestHelper.getLocalManager().deploy(DefaultId.NAMESPACE,
                                                                                  null, deployedJar).get();
 
     Assert.assertEquals(input.getPrograms().iterator().next().getType(), ProgramType.FLOW);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/queue/SimpleQueueSpecificationGeneratorTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/queue/SimpleQueueSpecificationGeneratorTest.java
@@ -45,7 +45,7 @@ import java.util.Set;
  */
 public class SimpleQueueSpecificationGeneratorTest {
 
-  private static final Id.Account TEST_ACCOUNT_ID = DefaultId.ACCOUNT;
+  private static final Id.Namespace TEST_NAMESPACE_ID = DefaultId.NAMESPACE;
 
   private static Table<QueueSpecificationGenerator.Node, String, Set<QueueSpecification>> table
     = HashBasedTable.create();
@@ -76,7 +76,7 @@ public class SimpleQueueSpecificationGeneratorTest {
     ApplicationSpecification newSpec = adapter.fromJson(adapter.toJson(appSpec));
 
     QueueSpecificationGenerator generator =
-      new SimpleQueueSpecificationGenerator(Id.Application.from(TEST_ACCOUNT_ID, newSpec.getName()));
+      new SimpleQueueSpecificationGenerator(Id.Application.from(TEST_NAMESPACE_ID, newSpec.getName()));
     table = generator.create(newSpec.getFlows().values().iterator().next());
 
     dumpConnectionQueue(table);
@@ -113,7 +113,7 @@ public class SimpleQueueSpecificationGeneratorTest {
     ApplicationSpecification newSpec = adapter.fromJson(adapter.toJson(appSpec));
 
     QueueSpecificationGenerator generator =
-      new SimpleQueueSpecificationGenerator(Id.Application.from(TEST_ACCOUNT_ID, newSpec.getName()));
+      new SimpleQueueSpecificationGenerator(Id.Application.from(TEST_NAMESPACE_ID, newSpec.getName()));
     table = generator.create(newSpec.getFlows().values().iterator().next());
 
     Assert.assertEquals(get(FlowletConnection.Type.STREAM, "text", "StreamSource")

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/DefaultStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/DefaultStoreTest.java
@@ -87,7 +87,7 @@ public class DefaultStoreTest {
   @Test
   public void testLoadingProgram() throws Exception {
     AppFabricTestHelper.deployApplication(ToyApp.class);
-    Program program = store.loadProgram(Id.Program.from(DefaultId.ACCOUNT.getId(), "ToyApp", "ToyFlow"),
+    Program program = store.loadProgram(Id.Program.from(DefaultId.NAMESPACE.getId(), "ToyApp", "ToyFlow"),
                                         ProgramType.FLOW);
     Assert.assertNotNull(program);
   }
@@ -167,7 +167,7 @@ public class DefaultStoreTest {
   @Test
   public void testAddApplication() throws Exception {
     ApplicationSpecification spec = Specifications.from(new WordCountApp());
-    Id.Application id = new Id.Application(new Id.Account("account1"), "application1");
+    Id.Application id = new Id.Application(new Id.Namespace("account1"), "application1");
     store.addApplication(id, spec, new LocalLocationFactory().create("/foo/path/application1.jar"));
 
     ApplicationSpecification stored = store.getApplication(id);
@@ -179,7 +179,7 @@ public class DefaultStoreTest {
   @Test
   public void testUpdateSameApplication() throws Exception {
     ApplicationSpecification spec = Specifications.from(new WordCountApp());
-    Id.Application id = new Id.Application(new Id.Account("account1"), "application1");
+    Id.Application id = new Id.Application(new Id.Namespace("account1"), "application1");
     store.addApplication(id, spec, new LocalLocationFactory().create("/foo/path/application1.jar"));
     // update
     store.addApplication(id, spec, new LocalLocationFactory().create("/foo/path/application1_modified.jar"));
@@ -192,7 +192,7 @@ public class DefaultStoreTest {
 
   @Test
   public void testUpdateChangedApplication() throws Exception {
-    Id.Application id = new Id.Application(new Id.Account("account1"), "application1");
+    Id.Application id = new Id.Application(new Id.Namespace("account1"), "application1");
 
     store.addApplication(id, Specifications.from(new FooApp()), new LocalLocationFactory().create("/foo"));
     // update
@@ -332,7 +332,7 @@ public class DefaultStoreTest {
     AbstractApplication app = new AppWithServices();
 
     ApplicationSpecification appSpec = Specifications.from(app);
-    Id.Application appId = new Id.Application(new Id.Account(DefaultId.ACCOUNT.getId()), appSpec.getName());
+    Id.Application appId = new Id.Application(new Id.Namespace(DefaultId.NAMESPACE.getId()), appSpec.getName());
     store.addApplication(appId, appSpec, new LocalLocationFactory().create("/appwithservicestestdelete"));
 
     AbstractApplication newApp = new AppWithNoServices();
@@ -353,7 +353,7 @@ public class DefaultStoreTest {
     app.configure(appConfigurer, new ApplicationContext());
 
     ApplicationSpecification appSpec = appConfigurer.createSpecification();
-    Id.Application appId = new Id.Application(new Id.Account(DefaultId.ACCOUNT.getId()), appSpec.getName());
+    Id.Application appId = new Id.Application(new Id.Namespace(DefaultId.NAMESPACE.getId()), appSpec.getName());
     store.addApplication(appId, appSpec, new LocalLocationFactory().create("/appwithservices"));
 
     // Test setting of service instances
@@ -379,7 +379,7 @@ public class DefaultStoreTest {
 
     ApplicationSpecification spec = Specifications.from(new WordCountApp());
     int initialInstances = spec.getFlows().get("WordCountFlow").getFlowlets().get("StreamSource").getInstances();
-    Id.Application appId = new Id.Application(new Id.Account(DefaultId.ACCOUNT.getId()), spec.getName());
+    Id.Application appId = new Id.Application(new Id.Namespace(DefaultId.NAMESPACE.getId()), spec.getName());
     store.addApplication(appId, spec, new LocalLocationFactory().create("/foo"));
 
     Id.Program programId = new Id.Program(appId, "WordCountFlow");
@@ -403,7 +403,7 @@ public class DefaultStoreTest {
     AppFabricTestHelper.deployApplication(AllProgramsApp.class);
     ApplicationSpecification spec = Specifications.from(new AllProgramsApp());
 
-    Id.Application appId = new Id.Application(new Id.Account(DefaultId.ACCOUNT.getId()), spec.getName());
+    Id.Application appId = new Id.Application(new Id.Namespace(DefaultId.NAMESPACE.getId()), spec.getName());
     Id.Program programId = new Id.Program(appId, "NoOpProcedure");
 
     int instancesFromSpec = spec.getProcedures().get("NoOpProcedure").getInstances();
@@ -419,62 +419,62 @@ public class DefaultStoreTest {
   @Test
   public void testRemoveAllApplications() throws Exception {
     ApplicationSpecification spec = Specifications.from(new WordCountApp());
-    Id.Account accountId = new Id.Account("account1");
-    Id.Application appId = new Id.Application(accountId, spec.getName());
+    Id.Namespace namespaceId = new Id.Namespace("account1");
+    Id.Application appId = new Id.Application(namespaceId, spec.getName());
     store.addApplication(appId, spec, new LocalLocationFactory().create("/foo"));
 
     Assert.assertNotNull(store.getApplication(appId));
-    Assert.assertEquals(1, store.getAllStreams(new Id.Account("account1")).size());
+    Assert.assertEquals(1, store.getAllStreams(new Id.Namespace("account1")).size());
 
     // removing flow
-    store.removeAllApplications(accountId);
+    store.removeAllApplications(namespaceId);
 
     Assert.assertNull(store.getApplication(appId));
     // Streams and DataSets should survive deletion
-    Assert.assertEquals(1, store.getAllStreams(new Id.Account("account1")).size());
+    Assert.assertEquals(1, store.getAllStreams(new Id.Namespace("account1")).size());
   }
 
   @Test
   public void testRemoveAll() throws Exception {
     ApplicationSpecification spec = Specifications.from(new WordCountApp());
-    Id.Account accountId = new Id.Account("account1");
-    Id.Application appId = new Id.Application(accountId, "application1");
+    Id.Namespace namespaceId = new Id.Namespace("account1");
+    Id.Application appId = new Id.Application(namespaceId, "application1");
     store.addApplication(appId, spec, new LocalLocationFactory().create("/foo"));
 
     Assert.assertNotNull(store.getApplication(appId));
-    Assert.assertEquals(1, store.getAllStreams(new Id.Account("account1")).size());
+    Assert.assertEquals(1, store.getAllStreams(new Id.Namespace("account1")).size());
 
     // removing flow
-    store.removeAll(accountId);
+    store.removeAll(namespaceId);
 
     Assert.assertNull(store.getApplication(appId));
     // Streams and DataSets should not survive deletion
-    Assert.assertEquals(0, store.getAllStreams(new Id.Account("account1")).size());
+    Assert.assertEquals(0, store.getAllStreams(new Id.Namespace("account1")).size());
   }
 
   @Test
   public void testRemoveApplication() throws Exception {
     ApplicationSpecification spec = Specifications.from(new WordCountApp());
-    Id.Account accountId = new Id.Account("account1");
-    Id.Application appId = new Id.Application(accountId, spec.getName());
+    Id.Namespace namespaceId = new Id.Namespace("account1");
+    Id.Application appId = new Id.Application(namespaceId, spec.getName());
     store.addApplication(appId, spec, new LocalLocationFactory().create("/foo"));
 
     Assert.assertNotNull(store.getApplication(appId));
-    Assert.assertEquals(1, store.getAllStreams(new Id.Account("account1")).size());
+    Assert.assertEquals(1, store.getAllStreams(new Id.Namespace("account1")).size());
 
     // removing application
     store.removeApplication(appId);
 
     Assert.assertNull(store.getApplication(appId));
     // Streams and DataSets should survive deletion
-    Assert.assertEquals(1, store.getAllStreams(new Id.Account("account1")).size());
+    Assert.assertEquals(1, store.getAllStreams(new Id.Namespace("account1")).size());
   }
 
   @Test
   public void testRuntimeArgsDeletion() throws Exception {
     ApplicationSpecification spec = Specifications.from(new AllProgramsApp());
-    Id.Account accountId = new Id.Account("testDeleteRuntimeArgs");
-    Id.Application appId = new Id.Application(accountId, spec.getName());
+    Id.Namespace namespaceId = new Id.Namespace("testDeleteRuntimeArgs");
+    Id.Application appId = new Id.Application(namespaceId, spec.getName());
     store.addApplication(appId, spec, new LocalLocationFactory().create("/foo"));
 
     Assert.assertNotNull(store.getApplication(appId));
@@ -530,12 +530,12 @@ public class DefaultStoreTest {
     // Remove application using accountId, AppId and verify
     // Remove all from accountId and verify
     ApplicationSpecification spec = Specifications.from(new AllProgramsApp());
-    Id.Account accountId = new Id.Account("testDeleteAll");
-    Id.Application appId1 = new Id.Application(accountId, spec.getName());
+    Id.Namespace namespaceId = new Id.Namespace("testDeleteAll");
+    Id.Application appId1 = new Id.Application(namespaceId, spec.getName());
     store.addApplication(appId1, spec, new LocalLocationFactory().create("/allPrograms"));
 
     spec = Specifications.from(new WordCountApp());
-    Id.Application appId2 = new Id.Application(accountId, spec.getName());
+    Id.Application appId2 = new Id.Application(namespaceId, spec.getName());
     store.addApplication(appId2, spec, new LocalLocationFactory().create("/wordCount"));
 
     Id.Program flowProgramId1 = new Id.Program(appId1, "NoOpFlow");
@@ -586,7 +586,7 @@ public class DefaultStoreTest {
     verifyRunHistory(flowProgramId2, 1);
 
     // remove all
-    store.removeAll(accountId);
+    store.removeAll(namespaceId);
 
     verifyRunHistory(flowProgramId2, 0);
   }
@@ -612,7 +612,7 @@ public class DefaultStoreTest {
     //Verify if there are 4 program specs in AllProgramsApp
     Assert.assertEquals(4, specsToBeVerified.size());
 
-    Id.Application appId = Id.Application.from(DefaultId.ACCOUNT, "App");
+    Id.Application appId = Id.Application.from(DefaultId.NAMESPACE, "App");
     // Check the diff with the same app - re-deployement scenario where programs are not removed.
     List<ProgramSpecification> deletedSpecs = store.getDeletedProgramSpecifications(appId,  spec);
     Assert.assertEquals(0, deletedSpecs.size());
@@ -645,7 +645,7 @@ public class DefaultStoreTest {
 
     Assert.assertEquals(2, specsToBeDeleted.size());
 
-    Id.Application appId = Id.Application.from(DefaultId.ACCOUNT, "App");
+    Id.Application appId = Id.Application.from(DefaultId.NAMESPACE, "App");
 
     //Get the spec for app that contains only flow and mapreduce - removing procedures and workflows.
     spec = Specifications.from(new FlowMapReduceApp());

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/runtime/FlowTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/runtime/FlowTest.java
@@ -115,7 +115,7 @@ public class FlowTest {
                                                     getInstance(DiscoveryServiceClient.class);
     Discoverable discoverable = discoveryServiceClient.discover(
       String.format("procedure.%s.%s.%s",
-                    DefaultId.ACCOUNT.getId(), "ArgumentCheckApp", "SimpleProcedure")).iterator().next();
+                    DefaultId.NAMESPACE.getId(), "ArgumentCheckApp", "SimpleProcedure")).iterator().next();
 
     URL url = new URL(String.format("http://%s:%d/apps/%s/procedures/%s/methods/%s",
                                     discoverable.getSocketAddress().getHostName(),
@@ -180,7 +180,7 @@ public class FlowTest {
     DiscoveryServiceClient discoveryServiceClient = AppFabricTestHelper.getInjector().
       getInstance(DiscoveryServiceClient.class);
     ServiceDiscovered procedureDiscovered = discoveryServiceClient.discover(
-      String.format("procedure.%s.%s.%s", DefaultId.ACCOUNT.getId(), "WordCountApp", "WordFrequency"));
+      String.format("procedure.%s.%s.%s", DefaultId.NAMESPACE.getId(), "WordCountApp", "WordFrequency"));
     EndpointStrategy endpointStrategy = new TimeLimitEndpointStrategy(new RandomEndpointStrategy(procedureDiscovered),
                                                                       2L, TimeUnit.SECONDS);
     int trials = 0;

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/runtime/OpenCloseDataSetTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/runtime/OpenCloseDataSetTest.java
@@ -140,7 +140,7 @@ public class OpenCloseDataSetTest {
     DiscoveryServiceClient discoveryServiceClient = AppFabricTestHelper.getInjector().
       getInstance(DiscoveryServiceClient.class);
     Discoverable discoverable = discoveryServiceClient.discover(
-      String.format("procedure.%s.%s.%s", DefaultId.ACCOUNT.getId(), "dummy", "DummyProcedure")).iterator().next();
+      String.format("procedure.%s.%s.%s", DefaultId.NAMESPACE.getId(), "dummy", "DummyProcedure")).iterator().next();
 
     HttpClient client = new DefaultHttpClient();
     HttpPost post = new HttpPost(String.format("http://%s:%d/apps/%s/procedures/%s/methods/%s",

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/Id.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/Id.java
@@ -25,185 +25,7 @@ import com.google.common.base.Preconditions;
 public final class Id  {
 
   /**
-   * Represents ID of an account.
-   * TODO: This should be removed in favor of {@link Id.Namespace}
-   */
-  public static final class Account {
-    private final String id;
-
-    public Account(String id) {
-      Preconditions.checkNotNull(id, "Account cannot be null.");
-      this.id = id;
-    }
-
-    public String getId() {
-      return id;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-
-      return id.equals(((Account) o).id);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hashCode(id);
-    }
-
-    public static Account from(String account) {
-      return new Account(account);
-    }
-  }
-
-  /**
-   * Program Id identifies a given application.
-   * Application is global unique if used within context of account.
-   */
-  public static final class Application {
-    private final Account account;
-    private final String applicationId;
-
-    public Application(final Account account, final String applicationId) {
-      Preconditions.checkNotNull(account, "Account cannot be null.");
-      Preconditions.checkNotNull(applicationId, "Application cannot be null.");
-      this.account = account;
-      this.applicationId = applicationId;
-    }
-
-    public Account getAccount() {
-      return account;
-    }
-
-    public String getAccountId() {
-      return account.getId();
-    }
-
-    public String getId() {
-      return applicationId;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-
-      Application that = (Application) o;
-      return account.equals(that.account) && applicationId.equals(that.applicationId);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hashCode(account, applicationId);
-    }
-
-    public static Application from(Account id, String application) {
-      return new Application(id, application);
-    }
-
-    public static Application from(String accountId, String applicationId) {
-      return new Application(Id.Account.from(accountId), applicationId);
-    }
-  }
-
-  /**
-   * Program Id identifies a given program.
-   * Program is global unique if used within context of account and application.
-   */
-  public static class Program {
-    private final Application application;
-    private final String id;
-
-    public Program(Application application, final String id) {
-      Preconditions.checkNotNull(application, "Application cannot be null.");
-      Preconditions.checkNotNull(id, "Id cannot be null.");
-      this.application = application;
-      this.id = id;
-    }
-
-    public String getId() {
-      return id;
-    }
-
-    public String getApplicationId() {
-      return application.getId();
-    }
-
-    public String getAccountId() {
-      return application.getAccountId();
-    }
-
-    public Application getApplication() {
-      return application;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-
-      Program program = (Program) o;
-      return application.equals(program.application) && id.equals(program.id);
-    }
-
-    @Override
-    public int hashCode() {
-      int result = application.hashCode();
-      result = 31 * result + id.hashCode();
-      return result;
-    }
-
-    public static Program from(Application appId, String pgmId) {
-      return new Program(appId, pgmId);
-    }
-
-    public static Program from(String accountId, String appId, String pgmId) {
-      return new Program(new Application(new Account(accountId), appId), pgmId);
-    }
-
-    @Override
-    public String toString() {
-      StringBuilder sb = new StringBuilder("ProgramId(");
-
-      sb.append("accountId:");
-      if (this.application.getAccountId() == null) {
-        sb.append("null");
-      } else {
-        sb.append(this.application.getAccountId());
-      }
-      sb.append(", applicationId:");
-      if (this.application.getId() == null) {
-        sb.append("null");
-      } else {
-        sb.append(this.application.getId());
-      }
-      sb.append(", runnableId:");
-      if (this.id == null) {
-        sb.append("null");
-      } else {
-        sb.append(this.id);
-      }
-      sb.append(")");
-      return sb.toString();
-    }
-  }
-
-  /**
-   * Represents ID of a namespace.
+   * Represents ID of an namespace.
    */
   public static final class Namespace {
     private final String id;
@@ -236,6 +58,146 @@ public final class Id  {
 
     public static Namespace from(String namespace) {
       return new Namespace(namespace);
+    }
+  }
+
+  /**
+   * Program Id identifies a given application.
+   * Application is global unique if used within context of namespace.
+   */
+  public static final class Application {
+    private final Namespace namespace;
+    private final String applicationId;
+
+    public Application(final Namespace namespace, final String applicationId) {
+      Preconditions.checkNotNull(namespace, "Namespace cannot be null.");
+      Preconditions.checkNotNull(applicationId, "Application cannot be null.");
+      this.namespace = namespace;
+      this.applicationId = applicationId;
+    }
+
+    public Namespace getNamespace() {
+      return namespace;
+    }
+
+    public String getNamespaceId() {
+      return namespace.getId();
+    }
+
+    public String getId() {
+      return applicationId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+
+      Application that = (Application) o;
+      return namespace.equals(that.namespace) && applicationId.equals(that.applicationId);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(namespace, applicationId);
+    }
+
+    public static Application from(Namespace id, String application) {
+      return new Application(id, application);
+    }
+
+    public static Application from(String namespaceId, String applicationId) {
+      return new Application(Namespace.from(namespaceId), applicationId);
+    }
+  }
+
+  /**
+   * Program Id identifies a given program.
+   * Program is global unique if used within context of namespace and application.
+   */
+  public static class Program {
+    private final Application application;
+    private final String id;
+
+    public Program(Application application, final String id) {
+      Preconditions.checkNotNull(application, "Application cannot be null.");
+      Preconditions.checkNotNull(id, "Id cannot be null.");
+      this.application = application;
+      this.id = id;
+    }
+
+    public String getId() {
+      return id;
+    }
+
+    public String getApplicationId() {
+      return application.getId();
+    }
+
+    public String getNamespaceId() {
+      return application.getNamespaceId();
+    }
+
+    public Application getApplication() {
+      return application;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+
+      Program program = (Program) o;
+      return application.equals(program.application) && id.equals(program.id);
+    }
+
+    @Override
+    public int hashCode() {
+      int result = application.hashCode();
+      result = 31 * result + id.hashCode();
+      return result;
+    }
+
+    public static Program from(Application appId, String pgmId) {
+      return new Program(appId, pgmId);
+    }
+
+    public static Program from(String namespaceId, String appId, String pgmId) {
+      return new Program(new Application(new Namespace(namespaceId), appId), pgmId);
+    }
+
+    @Override
+    public String toString() {
+      StringBuilder sb = new StringBuilder("ProgramId(");
+
+      sb.append("namespaceId:");
+      if (this.application.getNamespaceId() == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.application.getNamespaceId());
+      }
+      sb.append(", applicationId:");
+      if (this.application.getId() == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.application.getId());
+      }
+      sb.append(", runnableId:");
+      if (this.id == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.id);
+      }
+      sb.append(")");
+      return sb.toString();
     }
   }
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/Id.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/Id.java
@@ -25,7 +25,7 @@ import com.google.common.base.Preconditions;
 public final class Id  {
 
   /**
-   * Represents ID of an namespace.
+   * Represents ID of a namespace.
    */
   public static final class Namespace {
     private final String id;

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
@@ -171,7 +171,7 @@ public class TestBase {
       Location deployedJar = appFabricClient.deployApplication(appSpec.getName(), applicationClz, bundleEmbeddedJars);
 
       return
-        injector.getInstance(ApplicationManagerFactory.class).create(DefaultId.ACCOUNT.getId(), appSpec.getName(),
+        injector.getInstance(ApplicationManagerFactory.class).create(DefaultId.NAMESPACE.getId(), appSpec.getName(),
                                                                      deployedJar, appSpec);
 
     } catch (Exception e) {


### PR DESCRIPTION
Part 1 of replacing ``accountId`` with ``namespaceId``.

Looks long, but essentially only replaces ``Id.Account`` with ``Id.Namespace`` in this PR.

Will handle other ``accountId`` -> ``namespaceId`` replacements in separate PRs.