### PR TITLE
Use empty namespace instead of default namespace for ConsoleSettings and...

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/config/PreferencesStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/config/PreferencesStore.java
@@ -17,7 +17,6 @@
 package co.cask.cdap.config;
 
 import co.cask.cdap.api.common.Bytes;
-import co.cask.cdap.common.conf.Constants;
 import com.google.common.collect.Maps;
 import com.google.inject.Inject;
 
@@ -32,7 +31,7 @@ public class PreferencesStore {
   // Id for Properties config stored at the instance level
   private static final String INSTANCE_PROPERTIES = "instance";
   // Namespace where instance level properties are stored
-  private static final String DEFAULT_NAMESPACE = Constants.DEFAULT_NAMESPACE;
+  private static final String EMPTY_NAMESPACE = "";
 
   private final ConfigStore configStore;
 
@@ -66,7 +65,7 @@ public class PreferencesStore {
   }
 
   public Map<String, String> getProperties() {
-    return getConfigProperties(DEFAULT_NAMESPACE, getMultipartKey(INSTANCE_PROPERTIES));
+    return getConfigProperties(EMPTY_NAMESPACE, getMultipartKey(INSTANCE_PROPERTIES));
   }
 
   public Map<String, String> getProperties(String namespace) {
@@ -105,7 +104,7 @@ public class PreferencesStore {
   }
 
   public void setProperties(Map<String, String> propMap) {
-    setConfig(DEFAULT_NAMESPACE, getMultipartKey(INSTANCE_PROPERTIES), propMap);
+    setConfig(EMPTY_NAMESPACE, getMultipartKey(INSTANCE_PROPERTIES), propMap);
   }
 
   public void setProperties(String namespace, Map<String, String> propMap) {
@@ -122,7 +121,7 @@ public class PreferencesStore {
   }
 
   public void deleteProperties() {
-    deleteConfig(DEFAULT_NAMESPACE, getMultipartKey(INSTANCE_PROPERTIES));
+    deleteConfig(EMPTY_NAMESPACE, getMultipartKey(INSTANCE_PROPERTIES));
   }
 
   public void deleteProperties(String namespace) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ConsoleSettingsHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ConsoleSettingsHttpHandler.java
@@ -46,7 +46,7 @@ import javax.ws.rs.Path;
 public class ConsoleSettingsHttpHandler extends AuthenticatedHttpHandler {
   private static final Logger LOG = LoggerFactory.getLogger(ConsoleSettingsHttpHandler.class);
   private static final JsonParser JSON_PARSER = new JsonParser();
-  private static final String NAMESPACE = Constants.DEFAULT_NAMESPACE;
+  private static final String NAMESPACE = "";
   private static final String CONFIG_TYPE = "usersettings";
   private static final String CONFIG_PROPERTY = "property";
   private static final String ID = "id";
@@ -103,7 +103,7 @@ public class ConsoleSettingsHttpHandler extends AuthenticatedHttpHandler {
     //Configuration Layout for UserSettings:
     //Config ID : userId
     //Config Properties : Map (Key = CONFIG_PROPERTY, Value = Serialized JSON string of properties)
-    //User Settings configurations are stored under default NAMESPACE.
+    //User Settings configurations are stored under empty NAMESPACE.
     Map<String, String> propMap = ImmutableMap.of(CONFIG_PROPERTY, data);
     String userId = getAuthenticatedAccountId(request);
     Config userConfig = new Config(userId, propMap);


### PR DESCRIPTION
... Instance Properties which fall outside of a Namespace scope

Bamboo: https://builds.cask.co/browse/CDAP-DUT478