### PR TITLE
(CDAP-1153) Added support of batch write to Stream file writer

### DIFF
--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/StreamDataFileTestBase.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/StreamDataFileTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -27,12 +27,16 @@ import co.cask.cdap.test.SlowTests;
 import com.google.common.base.Charsets;
 import com.google.common.base.Stopwatch;
 import com.google.common.base.Throwables;
+import com.google.common.collect.AbstractIterator;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.google.common.io.Closeables;
+import com.google.common.io.Flushables;
+import com.google.common.util.concurrent.Uninterruptibles;
 import org.apache.hadoop.hbase.util.Strings;
 import org.apache.twill.filesystem.Location;
 import org.apache.twill.filesystem.LocationFactory;
@@ -69,6 +73,25 @@ public abstract class StreamDataFileTestBase {
   protected abstract LocationFactory getLocationFactory();
 
   protected abstract StreamAdmin getStreamAdmin();
+
+  @Test
+  public void testEmptyFile() throws Exception {
+    Location dir = StreamFileTestUtils.createTempDir(getLocationFactory());
+    Location eventFile = dir.getTempFile(".dat");
+    Location indexFile = dir.getTempFile(".idx");
+
+    // Creates a stream file that has no event inside
+    StreamDataFileWriter writer = new StreamDataFileWriter(Locations.newOutputSupplier(eventFile),
+                                                           Locations.newOutputSupplier(indexFile),
+                                                           10000L);
+    writer.close();
+
+    // Create a reader that starts from beginning.
+    StreamDataFileReader reader = StreamDataFileReader.create(Locations.newInputSupplier(eventFile));
+    List<StreamEvent> events = Lists.newArrayList();
+    Assert.assertEquals(-1, reader.read(events, 1, 0, TimeUnit.SECONDS));
+    reader.close();
+  }
 
   /**
    * Test for basic read write to verify data encode/decode correctly.
@@ -698,6 +721,143 @@ public abstract class StreamDataFileTestBase {
     }
   }
 
+  /**
+   * This test is to validate batch write with the same timestamp are written in the same data block.
+   */
+  @Test
+  public void testAppendAll() throws Exception {
+    Location dir = StreamFileTestUtils.createTempDir(getLocationFactory());
+    Location eventFile = dir.getTempFile(".dat");
+    Location indexFile = dir.getTempFile(".idx");
+
+    // Creates a stream file
+    final StreamDataFileWriter writer = new StreamDataFileWriter(Locations.newOutputSupplier(eventFile),
+                                                           Locations.newOutputSupplier(indexFile),
+                                                           10000L);
+    try {
+      final CountDownLatch writeCompleted = new CountDownLatch(1);
+      final CountDownLatch readAttempted = new CountDownLatch(1);
+
+      // Write 1000 events using appendAll from a separate thread
+      // It writes 1000 events of size 300 bytes of the same timestamp and wait for a signal before ending.
+      // This make sure the data block is not written (internal buffer size is 256K if the writer flush),
+      // hence the reader shouldn't be seeing it.
+      Thread t = new Thread() {
+        @Override
+        public void run() {
+          try {
+            writer.appendAll(new AbstractIterator<StreamEvent>() {
+              int count = 1000;
+              long timestamp = System.currentTimeMillis();
+              Map<String, String> headers = ImmutableMap.of();
+
+              @Override
+              protected StreamEvent computeNext() {
+                if (count-- > 0) {
+                  return new StreamEvent(headers, Charsets.UTF_8.encode(String.format("%0300d", count)), timestamp);
+                }
+                writeCompleted.countDown();
+                Uninterruptibles.awaitUninterruptibly(readAttempted);
+                Flushables.flushQuietly(writer);
+                return endOfData();
+              }
+            });
+          } catch (IOException e) {
+            throw Throwables.propagate(e);
+          }
+        }
+      };
+      t.start();
+
+      // Create a reader
+      StreamDataFileReader reader = StreamDataFileReader.create(Locations.newInputSupplier(eventFile));
+      try {
+        List<PositionStreamEvent> events = Lists.newArrayList();
+
+        // Wait for the writer completion
+        Assert.assertTrue(writeCompleted.await(20, TimeUnit.SECONDS));
+
+        // Try to read a event, nothing should be read
+        Assert.assertEquals(0, reader.read(events, 1, 0, TimeUnit.SECONDS));
+
+        // Now signal writer to flush
+        readAttempted.countDown();
+
+        // Now should be able to read 1000 events
+        t.join(10000);
+        Assert.assertEquals(1000, reader.read(events, 1000, 0, TimeUnit.SECONDS));
+
+        int size = events.size();
+        long lastStart = -1;
+        for (int i = 0; i < size; i++) {
+          PositionStreamEvent event = events.get(i);
+          Assert.assertEquals(String.format("%0300d", size - i - 1), Charsets.UTF_8.decode(event.getBody()).toString());
+
+          if (lastStart > 0) {
+            // The position differences between two consecutive events should be 303
+            // 2 bytes for body length, 300 bytes body, 1 byte header map (value == 0)
+            Assert.assertEquals(303L, event.getStart() - lastStart);
+          }
+          lastStart = event.getStart();
+        }
+      } finally {
+        reader.close();
+      }
+    } finally {
+      writer.close();
+    }
+  }
+
+  /**
+   * This is to test batch write with different timestamps will write to different data block correctly.
+   */
+  @Test
+  public void testAppendAllMultiBlocks() throws IOException, InterruptedException {
+    Location dir = StreamFileTestUtils.createTempDir(getLocationFactory());
+    Location eventFile = dir.getTempFile(".dat");
+    Location indexFile = dir.getTempFile(".idx");
+
+    // Creates a stream file
+    StreamDataFileWriter writer = new StreamDataFileWriter(Locations.newOutputSupplier(eventFile),
+                                                           Locations.newOutputSupplier(indexFile),
+                                                           10000L);
+
+    try {
+      // Writes with appendAll with events having 2 different timestamps
+      Map<String, String> headers = ImmutableMap.of();
+      writer.appendAll(ImmutableList.of(
+        new StreamEvent(headers, Charsets.UTF_8.encode("0"), 1000),
+        new StreamEvent(headers, Charsets.UTF_8.encode("0"), 1000),
+        new StreamEvent(headers, Charsets.UTF_8.encode("1"), 1001),
+        new StreamEvent(headers, Charsets.UTF_8.encode("1"), 1001)
+      ).iterator());
+    } finally {
+      writer.close();
+    }
+
+    // Reads all events and assert the event position to see if they are in two different blocks
+    StreamDataFileReader reader = StreamDataFileReader.create(Locations.newInputSupplier(eventFile));
+    try {
+      List<PositionStreamEvent> events = Lists.newArrayList();
+      Assert.assertEquals(4, reader.read(events, 4, 0, TimeUnit.SECONDS));
+
+      // Event is encoded as <var_int_body_length><body_bytes><var_int_map_size>
+      // Since we are writing single byte data,
+      // body_length is 1 byte, body_bytes is 1 byte and map_size is 1 byte (with value == 0)
+
+      // The position differences between the first two events should be 3 since they belongs to the same data block.
+      Assert.assertEquals(3L, events.get(1).getStart() - events.get(0).getStart());
+
+      // The position differences between the second and third events
+      // should be 3 (second event size) + 8 (timestamp) + 1 (block length) == 12
+      Assert.assertEquals(12L, events.get(2).getStart() - events.get(1).getStart());
+
+      // The position differences between the third and forth events should be 3 again since they are in the same block
+      Assert.assertEquals(3L, events.get(3).getStart() - events.get(2).getStart());
+    } finally {
+      reader.close();
+    }
+  }
 
   private FileWriter<StreamEvent> createWriter(StreamConfig config, String prefix) {
     return new TimePartitionedStreamFileWriter(config.getLocation(), config.getPartitionDuration(),

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/file/FileWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/file/FileWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -18,6 +18,7 @@ package co.cask.cdap.data.file;
 import java.io.Closeable;
 import java.io.Flushable;
 import java.io.IOException;
+import java.util.Iterator;
 
 /**
  * This interface represents classes that can write data to file.
@@ -26,5 +27,19 @@ import java.io.IOException;
  */
 public interface FileWriter<T> extends Closeable, Flushable {
 
+  /**
+   * Appends an event to the file.
+   *
+   * @param event event to append
+   * @throws IOException if fail to append
+   */
   void append(T event) throws IOException;
+
+  /**
+   * Appends multiple events to the file. This method will block until the iterator ends.
+   *
+   * @param events an {@link Iterator} that provides events to append
+   * @throws IOException if fail to append
+   */
+  void appendAll(Iterator<? extends T> events) throws IOException;
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/file/PartitionedFileWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/file/PartitionedFileWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,15 +16,22 @@
 package co.cask.cdap.data.file;
 
 import com.google.common.base.Objects;
+import com.google.common.base.Throwables;
+import com.google.common.collect.AbstractIterator;
+import com.google.common.collect.Iterators;
 import com.google.common.collect.Maps;
+import com.google.common.collect.PeekingIterator;
+import com.google.common.io.Closeables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Iterator;
 import java.util.Map;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
+ * An abstract base class for implementation partitioned {@link FileWriter}.
  *
  * @param <T> Type of event.
  * @param <P> Type of partition.
@@ -56,33 +63,24 @@ public abstract class PartitionedFileWriter<T, P> implements FileWriter<T> {
     }
 
     try {
-      P partition = getPartition(event);
-
-      // If the partition changed, get the file writer for the new partition.
-      if (!Objects.equal(currentPartition, partition)) {
-        // Notify that partition changed, so that children class can take action if necessary.
-        partitionChanged(currentPartition, partition);
-        currentWriter = writers.get(partition);
-        if (currentWriter == null) {
-          currentWriter = fileWriterFactory.create(partition);
-          writers.put(partition, currentWriter);
-        }
-        currentPartition = partition;
-      }
-
-      currentWriter.append(event);
-
+      getWriter(event).append(event);
     } catch (Throwable t) {
-      try {
-        LOG.error("Exception on append.", t);
-        if (t instanceof IOException) {
-          throw (IOException) t;
-        } else {
-          throw new IOException(t);
-        }
-      } finally {
-        close();
-      }
+      LOG.error("Exception on append.", t);
+      Closeables.closeQuietly(this);
+      Throwables.propagateIfInstanceOf(t, IOException.class);
+      throw Throwables.propagate(t);
+    }
+  }
+
+  @Override
+  public void appendAll(final Iterator<? extends T> events) throws IOException {
+    if (closed) {
+      throw new IOException("Attempts to write to a closed FileWriter.");
+    }
+
+    PeekingIterator<T> iterator = Iterators.peekingIterator(events);
+    while (iterator.hasNext()) {
+      getWriter(iterator.peek()).appendAll(new AppendIterator(iterator));
     }
   }
 
@@ -128,6 +126,27 @@ public abstract class PartitionedFileWriter<T, P> implements FileWriter<T> {
   }
 
   /**
+   * Gets a {@link FileWriter} for the given event.
+   */
+  private FileWriter<T> getWriter(T event) throws IOException {
+    P partition = getPartition(event);
+
+    // If the partition changed, get the file writer for the new partition.
+    if (!Objects.equal(currentPartition, partition)) {
+      // Notify that partition changed, so that children class can take action if necessary.
+      partitionChanged(currentPartition, partition);
+      currentWriter = writers.get(partition);
+      if (currentWriter == null) {
+        currentWriter = fileWriterFactory.create(partition);
+        writers.put(partition, currentWriter);
+      }
+      currentPartition = partition;
+    }
+
+    return currentWriter;
+  }
+
+  /**
    * Closes the {@link FileWriter} for the given partition.
    */
   protected final void closePartitionWriter(P partition) throws IOException {
@@ -167,5 +186,33 @@ public abstract class PartitionedFileWriter<T, P> implements FileWriter<T> {
      * @throws java.io.IOException If creation failed.
      */
     FileWriter<T> create(P partition) throws IOException;
+  }
+
+  /**
+   * An {@link Iterator} to support the {@link PartitionedFileWriter#appendAll(Iterator)} operation.
+   * It will write as many events as possible as long as the event partition stays the same.
+   */
+  private final class AppendIterator extends AbstractIterator<T> {
+
+    private final PeekingIterator<? extends T> events;
+
+    AppendIterator(PeekingIterator<? extends T> events) {
+      this.events = events;
+    }
+
+    @Override
+    protected T computeNext() {
+      if (!events.hasNext()) {
+        return endOfData();
+      }
+
+      T event = events.peek();
+      P partition = getPartition(event);
+      if (Objects.equal(currentPartition, partition)) {
+        events.next();
+        return event;
+      }
+      return endOfData();
+    }
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/InMemoryStreamFileWriterFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/InMemoryStreamFileWriterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -28,12 +28,14 @@ import co.cask.tephra.TransactionAware;
 import co.cask.tephra.TransactionExecutor;
 import co.cask.tephra.TransactionExecutorFactory;
 import co.cask.tephra.TransactionFailureException;
+import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InterruptedIOException;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -69,6 +71,11 @@ final class InMemoryStreamFileWriterFactory implements StreamFileWriterFactory {
       @Override
       public void append(StreamEvent event) throws IOException {
         events.add(event);
+      }
+
+      @Override
+      public void appendAll(Iterator<? extends StreamEvent> events) throws IOException {
+        Iterators.addAll(this.events, events);
       }
 
       @Override


### PR DESCRIPTION
- The batch write support also guarantees events from the same batch that have the same timestamp are written in the same data block. This is an essential part to support file upload for stream.