### PR TITLE
allow configure unlim compaction bound for table with readless incs

### DIFF
--- a/cdap-hbase-compat-0.94/src/main/java/co/cask/cdap/data2/increment/hbase94/IncrementHandler.java
+++ b/cdap-hbase-compat-0.94/src/main/java/co/cask/cdap/data2/increment/hbase94/IncrementHandler.java
@@ -95,7 +95,7 @@ public class IncrementHandler extends BaseRegionObserver {
       this.region = ((RegionCoprocessorEnvironment) e).getRegion();
       HTableDescriptor tableDesc = env.getRegion().getTableDesc();
       for (HColumnDescriptor columnDesc : tableDesc.getFamilies()) {
-        boolean txnl = Boolean.parseBoolean(columnDesc.getValue(PROPERTY_TRANSACTIONAL));
+        boolean txnl = "true".equals(columnDesc.getValue(PROPERTY_TRANSACTIONAL));
         LOG.info("Family " + columnDesc.getNameAsString() + " is transactional: " + txnl);
         if (txnl) {
           txnlFamilies.add(columnDesc.getName());

--- a/cdap-hbase-compat-0.94/src/main/java/co/cask/cdap/data2/increment/hbase94/IncrementHandler.java
+++ b/cdap-hbase-compat-0.94/src/main/java/co/cask/cdap/data2/increment/hbase94/IncrementHandler.java
@@ -70,8 +70,8 @@ import java.util.TreeMap;
 public class IncrementHandler extends BaseRegionObserver {
   /**
    * Property set for {@link org.apache.hadoop.hbase.HColumnDescriptor} to configure how compaction bound is
-   * defined. Possible values are defined by {@link co.cask.cdap.data2.increment.hbase94.IncrementHandler.CompactionBound} with
-   * {@link co.cask.cdap.data2.increment.hbase94.IncrementHandler.CompactionBound#TX_UPPER_VISIBILITY_BOUND} being default.
+   * defined. Possible values are defined by {@link CompactionBound} with
+   * {@link CompactionBound#TX_UPPER_VISIBILITY_BOUND} being default.
    */
   public static final String PROPERTY_COMPACTION_BOUND = "increment.readless.compaction.bound";
 
@@ -90,6 +90,9 @@ public class IncrementHandler extends BaseRegionObserver {
 
   protected Map<byte[], CompactionBound> compactionBoundByFamily = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
 
+  /**
+   * Defines compaction boundary for merging delta increments
+   */
   public static enum CompactionBound {
     TX_UPPER_VISIBILITY_BOUND,
     UNLIMITED

--- a/cdap-hbase-compat-0.94/src/main/java/co/cask/cdap/data2/increment/hbase94/IncrementHandler.java
+++ b/cdap-hbase-compat-0.94/src/main/java/co/cask/cdap/data2/increment/hbase94/IncrementHandler.java
@@ -22,7 +22,7 @@ import co.cask.tephra.coprocessor.TransactionStateCache;
 import co.cask.tephra.hbase94.Filters;
 import co.cask.tephra.persist.TransactionSnapshot;
 import com.google.common.base.Supplier;
-import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.hbase.CoprocessorEnvironment;
@@ -50,6 +50,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
+import java.util.Set;
 import java.util.TreeMap;
 
 /**
@@ -69,11 +70,10 @@ import java.util.TreeMap;
  */
 public class IncrementHandler extends BaseRegionObserver {
   /**
-   * Property set for {@link org.apache.hadoop.hbase.HColumnDescriptor} to configure how compaction bound is
-   * defined. Possible values are defined by {@link CompactionBound} with
-   * {@link CompactionBound#TX_UPPER_VISIBILITY_BOUND} being default.
+   * Property set for {@link HColumnDescriptor} to indicate if increment is transactional. Default: "true", i.e.
+   * transactional.
    */
-  public static final String PROPERTY_COMPACTION_BOUND = "increment.readless.compaction.bound";
+  public static final String PROPERTY_TRANSACTIONAL = "dataset.table.readless.increment.transactional";
 
   // prefix bytes used to mark values that are deltas vs. full sums
   public static final byte[] DELTA_MAGIC_PREFIX = new byte[] { 'X', 'D' };
@@ -83,20 +83,10 @@ public class IncrementHandler extends BaseRegionObserver {
 
   private static final Log LOG = LogFactory.getLog(IncrementHandler.class);
 
-  private static final CompactionBound COMPACTION_BOUND_DEFAULT = CompactionBound.TX_UPPER_VISIBILITY_BOUND;
-
   private HRegion region;
   private TransactionStateCache cache;
 
-  protected Map<byte[], CompactionBound> compactionBoundByFamily = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
-
-  /**
-   * Defines compaction boundary for merging delta increments
-   */
-  public static enum CompactionBound {
-    TX_UPPER_VISIBILITY_BOUND,
-    UNLIMITED
-  }
+  protected Set<byte[]> txnlFamilies = Sets.newTreeSet(Bytes.BYTES_COMPARATOR);
 
   @Override
   public void start(CoprocessorEnvironment e) throws IOException {
@@ -104,26 +94,15 @@ public class IncrementHandler extends BaseRegionObserver {
       RegionCoprocessorEnvironment env = (RegionCoprocessorEnvironment) e;
       this.region = ((RegionCoprocessorEnvironment) e).getRegion();
       HTableDescriptor tableDesc = env.getRegion().getTableDesc();
-      boolean txIsUsed = false;
       for (HColumnDescriptor columnDesc : tableDesc.getFamilies()) {
-        String propValue = columnDesc.getValue(PROPERTY_COMPACTION_BOUND);
-        try {
-          CompactionBound bound =
-            propValue == null ? COMPACTION_BOUND_DEFAULT : CompactionBound.valueOf(propValue);
-          LOG.info("Family " + columnDesc.getNameAsString() + " compaction bound of " + bound);
-          compactionBoundByFamily.put(columnDesc.getName(), bound);
-
-          if (CompactionBound.TX_UPPER_VISIBILITY_BOUND == bound) {
-            txIsUsed = true;
-          }
-
-        } catch (IllegalArgumentException th) {
-          LOG.warn("Invalid compact bound value configured for column family " + columnDesc.getNameAsString() +
-                     ", value = " + propValue);
+        boolean txnl = Boolean.parseBoolean(columnDesc.getValue(PROPERTY_TRANSACTIONAL));
+        LOG.info("Family " + columnDesc.getNameAsString() + " is transactional: " + txnl);
+        if (txnl) {
+          txnlFamilies.add(columnDesc.getName());
         }
       }
 
-      if (txIsUsed) {
+      if (!txnlFamilies.isEmpty()) {
         Supplier<TransactionStateCache> cacheSupplier = getTransactionStateCacheSupplier(env);
         this.cache = cacheSupplier.get();
       }
@@ -225,18 +204,12 @@ public class IncrementHandler extends BaseRegionObserver {
   }
 
   private long getCompactionBound(Store store) {
-    long compationBound;
-    CompactionBound bound = compactionBoundByFamily.get(store.getFamily().getName());
-    if (CompactionBound.UNLIMITED == bound) {
-      compationBound = HConstants.LATEST_TIMESTAMP;
-    } else if (CompactionBound.TX_UPPER_VISIBILITY_BOUND == bound) {
+    if (txnlFamilies.contains(store.getFamily().getName())) {
       TransactionSnapshot snapshot = cache.getLatestState();
       // if tx snapshot is not available, used "0" as upper bound to avoid trashing in-progress tx
-      compationBound = snapshot != null ? snapshot.getVisibilityUpperBound() : 0;
+      return snapshot != null ? snapshot.getVisibilityUpperBound() : 0;
     } else {
-      // do not compact anything, if it is not clear what to do (safest approach)
-      compationBound = 0;
+      return HConstants.LATEST_TIMESTAMP;
     }
-    return compationBound;
   }
 }

--- a/cdap-hbase-compat-0.94/src/main/java/co/cask/cdap/data2/increment/hbase94/IncrementHandler.java
+++ b/cdap-hbase-compat-0.94/src/main/java/co/cask/cdap/data2/increment/hbase94/IncrementHandler.java
@@ -95,7 +95,7 @@ public class IncrementHandler extends BaseRegionObserver {
       this.region = ((RegionCoprocessorEnvironment) e).getRegion();
       HTableDescriptor tableDesc = env.getRegion().getTableDesc();
       for (HColumnDescriptor columnDesc : tableDesc.getFamilies()) {
-        boolean txnl = "true".equals(columnDesc.getValue(PROPERTY_TRANSACTIONAL));
+        boolean txnl = !"false".equals(columnDesc.getValue(PROPERTY_TRANSACTIONAL));
         LOG.info("Family " + columnDesc.getNameAsString() + " is transactional: " + txnl);
         if (txnl) {
           txnlFamilies.add(columnDesc.getName());

--- a/cdap-hbase-compat-0.94/src/test/java/co/cask/cdap/data2/increment/hbase94/IncrementHandlerTest.java
+++ b/cdap-hbase-compat-0.94/src/test/java/co/cask/cdap/data2/increment/hbase94/IncrementHandlerTest.java
@@ -242,7 +242,7 @@ public class IncrementHandlerTest {
     // In this test we verify that having compaction bound unlim merges increments and leaves single version of a cell.
     // It is important because in cases where we don't use tx nobody else will cleanup redundant (merged) keyvalues.
     HColumnDescriptor columnDesc = new HColumnDescriptor(FAMILY);
-    columnDesc.setValue(IncrementHandler.PROPERTY_COMPACTION_BOUND, IncrementHandler.CompactionBound.UNLIMITED.name());
+    columnDesc.setValue(IncrementHandler.PROPERTY_TRANSACTIONAL, "false");
     HRegion region = IncrementSummingScannerTest.createRegion(conf, "incrementCompactUnlimBoundTest", columnDesc);
 
     try {

--- a/cdap-hbase-compat-0.94/src/test/java/co/cask/cdap/data2/increment/hbase94/IncrementSummingScannerTest.java
+++ b/cdap-hbase-compat-0.94/src/test/java/co/cask/cdap/data2/increment/hbase94/IncrementSummingScannerTest.java
@@ -417,8 +417,11 @@ public class IncrementSummingScannerTest {
   }
 
   private HRegion createRegion(String tableName, byte[] family) throws Exception {
+    return createRegion(conf, tableName, new HColumnDescriptor(family));
+  }
+
+  static HRegion createRegion(Configuration hConf, String tableName, HColumnDescriptor cfd) throws Exception {
     HTableDescriptor htd = new HTableDescriptor(tableName);
-    HColumnDescriptor cfd = new HColumnDescriptor(family);
     cfd.setMaxVersions(Integer.MAX_VALUE);
     cfd.setKeepDeletedCells(true);
     htd.addFamily(cfd);
@@ -426,7 +429,6 @@ public class IncrementSummingScannerTest {
     Path tablePath = new Path("/tmp/" + tableName);
     Path hlogPath = new Path("/tmp/hlog-" + tableName);
     Path oldPath = new Path("/tmp/.oldLogs-" + tableName);
-    Configuration hConf = conf;
     FileSystem fs = FileSystem.get(hConf);
     assertTrue(fs.mkdirs(tablePath));
     HLog hlog = new HLog(fs, hlogPath, oldPath, hConf);
@@ -437,7 +439,7 @@ public class IncrementSummingScannerTest {
   /**
    * Work around a bug in HRegion.internalPut(), where RegionObserver.prePut() modifications are not applied.
    */
-  private void doPut(HRegion region, Put p) throws Exception {
+  static void doPut(HRegion region, Put p) throws Exception {
     region.batchMutate(new Pair[]{ new Pair<Mutation, Integer>(p, null) });
   }
 }

--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/increment/hbase96/IncrementHandler.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/increment/hbase96/IncrementHandler.java
@@ -97,7 +97,7 @@ public class IncrementHandler extends BaseRegionObserver {
       this.region = ((RegionCoprocessorEnvironment) e).getRegion();
       HTableDescriptor tableDesc = env.getRegion().getTableDesc();
       for (HColumnDescriptor columnDesc : tableDesc.getFamilies()) {
-        boolean txnl = Boolean.parseBoolean(columnDesc.getValue(PROPERTY_TRANSACTIONAL));
+        boolean txnl = "true".equals(columnDesc.getValue(PROPERTY_TRANSACTIONAL));
         LOG.info("Family " + columnDesc.getNameAsString() + " is transactional: " + txnl);
         if (txnl) {
           txnlFamilies.add(columnDesc.getName());

--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/increment/hbase96/IncrementHandler.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/increment/hbase96/IncrementHandler.java
@@ -22,7 +22,7 @@ import co.cask.tephra.coprocessor.TransactionStateCache;
 import co.cask.tephra.hbase96.Filters;
 import co.cask.tephra.persist.TransactionSnapshot;
 import com.google.common.base.Supplier;
-import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.hbase.Cell;
@@ -52,6 +52,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
+import java.util.Set;
 import java.util.TreeMap;
 
 /**
@@ -71,11 +72,10 @@ import java.util.TreeMap;
  */
 public class IncrementHandler extends BaseRegionObserver {
   /**
-   * Property set for {@link org.apache.hadoop.hbase.HColumnDescriptor} to configure how compaction bound is
-   * defined. Possible values are defined by {@link CompactionBound} with
-   * {@link CompactionBound#TX_UPPER_VISIBILITY_BOUND} being default.
+   * Property set for {@link HColumnDescriptor} to indicate if increment is transactional. Default: "true", i.e.
+   * transactional.
    */
-  public static final String PROPERTY_COMPACTION_BOUND = "increment.readless.compaction.bound";
+  public static final String PROPERTY_TRANSACTIONAL = "dataset.table.readless.increment.transactional";
 
   // prefix bytes used to mark values that are deltas vs. full sums
   public static final byte[] DELTA_MAGIC_PREFIX = new byte[] { 'X', 'D' };
@@ -85,20 +85,10 @@ public class IncrementHandler extends BaseRegionObserver {
 
   private static final Log LOG = LogFactory.getLog(IncrementHandler.class);
 
-  private static final CompactionBound COMPACTION_BOUND_DEFAULT = CompactionBound.TX_UPPER_VISIBILITY_BOUND;
-
   private HRegion region;
   private TransactionStateCache cache;
 
-  protected Map<byte[], CompactionBound> compactionBoundByFamily = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
-
-  /**
-   * Defines compaction boundary for merging delta increments
-   */
-  public static enum CompactionBound {
-    TX_UPPER_VISIBILITY_BOUND,
-    UNLIMITED
-  }
+  protected Set<byte[]> txnlFamilies = Sets.newTreeSet(Bytes.BYTES_COMPARATOR);
 
   @Override
   public void start(CoprocessorEnvironment e) throws IOException {
@@ -106,26 +96,15 @@ public class IncrementHandler extends BaseRegionObserver {
       RegionCoprocessorEnvironment env = (RegionCoprocessorEnvironment) e;
       this.region = ((RegionCoprocessorEnvironment) e).getRegion();
       HTableDescriptor tableDesc = env.getRegion().getTableDesc();
-      boolean txIsUsed = false;
       for (HColumnDescriptor columnDesc : tableDesc.getFamilies()) {
-        String propValue = columnDesc.getValue(PROPERTY_COMPACTION_BOUND);
-        try {
-          CompactionBound bound =
-            propValue == null ? COMPACTION_BOUND_DEFAULT : CompactionBound.valueOf(propValue);
-          LOG.info("Family " + columnDesc.getNameAsString() + " compaction bound of " + bound);
-          compactionBoundByFamily.put(columnDesc.getName(), bound);
-
-          if (CompactionBound.TX_UPPER_VISIBILITY_BOUND == bound) {
-            txIsUsed = true;
-          }
-
-        } catch (IllegalArgumentException th) {
-          LOG.warn("Invalid compact bound value configured for column family " + columnDesc.getNameAsString() +
-                     ", value = " + propValue);
+        boolean txnl = Boolean.parseBoolean(columnDesc.getValue(PROPERTY_TRANSACTIONAL));
+        LOG.info("Family " + columnDesc.getNameAsString() + " is transactional: " + txnl);
+        if (txnl) {
+          txnlFamilies.add(columnDesc.getName());
         }
       }
 
-      if (txIsUsed) {
+      if (!txnlFamilies.isEmpty()) {
         Supplier<TransactionStateCache> cacheSupplier = getTransactionStateCacheSupplier(env);
         this.cache = cacheSupplier.get();
       }
@@ -226,18 +205,12 @@ public class IncrementHandler extends BaseRegionObserver {
   }
 
   private long getCompactionBound(Store store) {
-    long compationBound;
-    CompactionBound bound = compactionBoundByFamily.get(store.getFamily().getName());
-    if (CompactionBound.UNLIMITED == bound) {
-      compationBound = HConstants.LATEST_TIMESTAMP;
-    } else if (CompactionBound.TX_UPPER_VISIBILITY_BOUND == bound) {
+    if (txnlFamilies.contains(store.getFamily().getName())) {
       TransactionSnapshot snapshot = cache.getLatestState();
       // if tx snapshot is not available, used "0" as upper bound to avoid trashing in-progress tx
-      compationBound = snapshot != null ? snapshot.getVisibilityUpperBound() : 0;
+      return snapshot != null ? snapshot.getVisibilityUpperBound() : 0;
     } else {
-      // do not compact anything, if it is not clear what to do (safest approach)
-      compationBound = 0;
+      return HConstants.LATEST_TIMESTAMP;
     }
-    return compationBound;
   }
 }

--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/increment/hbase96/IncrementHandler.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/increment/hbase96/IncrementHandler.java
@@ -92,6 +92,9 @@ public class IncrementHandler extends BaseRegionObserver {
 
   protected Map<byte[], CompactionBound> compactionBoundByFamily = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
 
+  /**
+   * Defines compaction boundary for merging delta increments
+   */
   public static enum CompactionBound {
     TX_UPPER_VISIBILITY_BOUND,
     UNLIMITED

--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/increment/hbase96/IncrementHandler.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/increment/hbase96/IncrementHandler.java
@@ -97,7 +97,7 @@ public class IncrementHandler extends BaseRegionObserver {
       this.region = ((RegionCoprocessorEnvironment) e).getRegion();
       HTableDescriptor tableDesc = env.getRegion().getTableDesc();
       for (HColumnDescriptor columnDesc : tableDesc.getFamilies()) {
-        boolean txnl = "true".equals(columnDesc.getValue(PROPERTY_TRANSACTIONAL));
+        boolean txnl = !"false".equals(columnDesc.getValue(PROPERTY_TRANSACTIONAL));
         LOG.info("Family " + columnDesc.getNameAsString() + " is transactional: " + txnl);
         if (txnl) {
           txnlFamilies.add(columnDesc.getName());

--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/increment/hbase96/IncrementHandler.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/increment/hbase96/IncrementHandler.java
@@ -22,11 +22,15 @@ import co.cask.tephra.coprocessor.TransactionStateCache;
 import co.cask.tephra.hbase96.Filters;
 import co.cask.tephra.persist.TransactionSnapshot;
 import com.google.common.base.Supplier;
+import com.google.common.collect.Maps;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.CoprocessorEnvironment;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.client.Durability;
 import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.Put;
@@ -66,6 +70,13 @@ import java.util.TreeMap;
  * all the successfully committed delta values.</p>
  */
 public class IncrementHandler extends BaseRegionObserver {
+  /**
+   * Property set for {@link org.apache.hadoop.hbase.HColumnDescriptor} to configure how compaction bound is
+   * defined. Possible values are defined by {@link CompactionBound} with
+   * {@link CompactionBound#TX_UPPER_VISIBILITY_BOUND} being default.
+   */
+  public static final String PROPERTY_COMPACTION_BOUND = "increment.readless.compaction.bound";
+
   // prefix bytes used to mark values that are deltas vs. full sums
   public static final byte[] DELTA_MAGIC_PREFIX = new byte[] { 'X', 'D' };
   // expected length for values storing deltas (prefix + increment value)
@@ -74,16 +85,47 @@ public class IncrementHandler extends BaseRegionObserver {
 
   private static final Log LOG = LogFactory.getLog(IncrementHandler.class);
 
+  private static final CompactionBound COMPACTION_BOUND_DEFAULT = CompactionBound.TX_UPPER_VISIBILITY_BOUND;
+
   private HRegion region;
   private TransactionStateCache cache;
+
+  protected Map<byte[], CompactionBound> compactionBoundByFamily = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
+
+  public static enum CompactionBound {
+    TX_UPPER_VISIBILITY_BOUND,
+    UNLIMITED
+  }
 
   @Override
   public void start(CoprocessorEnvironment e) throws IOException {
     if (e instanceof RegionCoprocessorEnvironment) {
       RegionCoprocessorEnvironment env = (RegionCoprocessorEnvironment) e;
       this.region = ((RegionCoprocessorEnvironment) e).getRegion();
-      Supplier<TransactionStateCache> cacheSupplier = getTransactionStateCacheSupplier(env);
-      this.cache = cacheSupplier.get();
+      HTableDescriptor tableDesc = env.getRegion().getTableDesc();
+      boolean txIsUsed = false;
+      for (HColumnDescriptor columnDesc : tableDesc.getFamilies()) {
+        String propValue = columnDesc.getValue(PROPERTY_COMPACTION_BOUND);
+        try {
+          CompactionBound bound =
+            propValue == null ? COMPACTION_BOUND_DEFAULT : CompactionBound.valueOf(propValue);
+          LOG.info("Family " + columnDesc.getNameAsString() + " compaction bound of " + bound);
+          compactionBoundByFamily.put(columnDesc.getName(), bound);
+
+          if (CompactionBound.TX_UPPER_VISIBILITY_BOUND == bound) {
+            txIsUsed = true;
+          }
+
+        } catch (IllegalArgumentException th) {
+          LOG.warn("Invalid compact bound value configured for column family " + columnDesc.getNameAsString() +
+                     ", value = " + propValue);
+        }
+      }
+
+      if (txIsUsed) {
+        Supplier<TransactionStateCache> cacheSupplier = getTransactionStateCacheSupplier(env);
+        this.cache = cacheSupplier.get();
+      }
     }
   }
 
@@ -157,10 +199,8 @@ public class IncrementHandler extends BaseRegionObserver {
   @Override
   public InternalScanner preFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store,
                                   InternalScanner scanner) throws IOException {
-    TransactionSnapshot snapshot = cache.getLatestState();
-    return new IncrementSummingScanner(region, BATCH_UNLIMITED, scanner, ScanType.COMPACT_RETAIN_DELETES,
-        // if tx snapshot is not available, used "0" as upper bound to avoid trashing in-progress tx
-        snapshot != null ? snapshot.getVisibilityUpperBound() : 0);
+    return new IncrementSummingScanner(region, BATCH_UNLIMITED, scanner,
+                                       ScanType.COMPACT_RETAIN_DELETES, getCompactionBound(store));
   }
 
   public static boolean isIncrement(Cell cell) {
@@ -172,20 +212,29 @@ public class IncrementHandler extends BaseRegionObserver {
   @Override
   public InternalScanner preCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store,
                                     InternalScanner scanner, ScanType scanType) throws IOException {
-    TransactionSnapshot snapshot = cache.getLatestState();
-    return new IncrementSummingScanner(region, BATCH_UNLIMITED, scanner, scanType,
-        // if tx snapshot is not available, used "0" as upper bound to avoid trashing in-progress tx
-        snapshot != null ? snapshot.getVisibilityUpperBound() : 0);
+    return new IncrementSummingScanner(region, BATCH_UNLIMITED, scanner, scanType, getCompactionBound(store));
   }
 
   @Override
   public InternalScanner preCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store,
                                     InternalScanner scanner, ScanType scanType, CompactionRequest request)
     throws IOException {
-    TransactionSnapshot snapshot = cache.getLatestState();
-    return new IncrementSummingScanner(region, BATCH_UNLIMITED, scanner, scanType,
-        // if tx snapshot is not available, used "0" as upper bound to avoid trashing in-progress tx
-        snapshot != null ? snapshot.getVisibilityUpperBound() : 0);
+    return new IncrementSummingScanner(region, BATCH_UNLIMITED, scanner, scanType, getCompactionBound(store));
   }
 
+  private long getCompactionBound(Store store) {
+    long compationBound;
+    CompactionBound bound = compactionBoundByFamily.get(store.getFamily().getName());
+    if (CompactionBound.UNLIMITED == bound) {
+      compationBound = HConstants.LATEST_TIMESTAMP;
+    } else if (CompactionBound.TX_UPPER_VISIBILITY_BOUND == bound) {
+      TransactionSnapshot snapshot = cache.getLatestState();
+      // if tx snapshot is not available, used "0" as upper bound to avoid trashing in-progress tx
+      compationBound = snapshot != null ? snapshot.getVisibilityUpperBound() : 0;
+    } else {
+      // do not compact anything, if it is not clear what to do (safest approach)
+      compationBound = 0;
+    }
+    return compationBound;
+  }
 }

--- a/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data2/increment/hbase96/IncrementHandlerTest.java
+++ b/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data2/increment/hbase96/IncrementHandlerTest.java
@@ -244,7 +244,7 @@ public class IncrementHandlerTest {
     // It is important because in cases where we don't use tx nobody else will cleanup redundant (merged) keyvalues.
     TableName tableName = TableName.valueOf("incrementCompactUnlimBoundTest");
     HColumnDescriptor columnDesc = new HColumnDescriptor(FAMILY);
-    columnDesc.setValue(IncrementHandler.PROPERTY_COMPACTION_BOUND, IncrementHandler.CompactionBound.UNLIMITED.name());
+    columnDesc.setValue(IncrementHandler.PROPERTY_TRANSACTIONAL, "false");
     HRegion region = IncrementSummingScannerTest.createRegion(conf, tableName, columnDesc);
 
     try {

--- a/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data2/increment/hbase96/IncrementSummingScannerTest.java
+++ b/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data2/increment/hbase96/IncrementSummingScannerTest.java
@@ -420,15 +420,17 @@ public class IncrementSummingScannerTest {
   }
 
   private HRegion createRegion(TableName tableName, byte[] family) throws Exception {
+    return createRegion(conf, tableName, new HColumnDescriptor(family));
+  }
+
+  static HRegion createRegion(Configuration hConf, TableName tableName, HColumnDescriptor cfd) throws Exception {
     HTableDescriptor htd = new HTableDescriptor(tableName);
-    HColumnDescriptor cfd = new HColumnDescriptor(family);
     cfd.setMaxVersions(Integer.MAX_VALUE);
     cfd.setKeepDeletedCells(true);
     htd.addFamily(cfd);
     htd.addCoprocessor(IncrementHandler.class.getName());
     Path tablePath = new Path("/tmp/" + tableName.getNameAsString());
     Path hlogPath = new Path("/tmp/hlog-" + tableName.getNameAsString());
-    Configuration hConf = conf;
     FileSystem fs = FileSystem.get(hConf);
     assertTrue(fs.mkdirs(tablePath));
     HLog hLog = HLogFactory.createHLog(fs, hlogPath, tableName.getNameAsString(), hConf);

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/increment/hbase98/IncrementHandler.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/increment/hbase98/IncrementHandler.java
@@ -22,11 +22,15 @@ import co.cask.tephra.coprocessor.TransactionStateCache;
 import co.cask.tephra.hbase98.Filters;
 import co.cask.tephra.persist.TransactionSnapshot;
 import com.google.common.base.Supplier;
+import com.google.common.collect.Maps;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.CoprocessorEnvironment;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.client.Durability;
 import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.Put;
@@ -66,6 +70,13 @@ import java.util.TreeMap;
  * all the successfully committed delta values.</p>
  */
 public class IncrementHandler extends BaseRegionObserver {
+  /**
+   * Property set for {@link org.apache.hadoop.hbase.HColumnDescriptor} to configure how compaction bound is
+   * defined. Possible values are defined by {@link CompactionBound} with
+   * {@link CompactionBound#TX_UPPER_VISIBILITY_BOUND} being default.
+   */
+  public static final String PROPERTY_COMPACTION_BOUND = "increment.readless.compaction.bound";
+
   // prefix bytes used to mark values that are deltas vs. full sums
   public static final byte[] DELTA_MAGIC_PREFIX = new byte[] { 'X', 'D' };
   // expected length for values storing deltas (prefix + increment value)
@@ -74,16 +85,47 @@ public class IncrementHandler extends BaseRegionObserver {
 
   private static final Log LOG = LogFactory.getLog(IncrementHandler.class);
 
+  private static final CompactionBound COMPACTION_BOUND_DEFAULT = CompactionBound.TX_UPPER_VISIBILITY_BOUND;
+
   private HRegion region;
   private TransactionStateCache cache;
+
+  protected Map<byte[], CompactionBound> compactionBoundByFamily = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
+
+  public static enum CompactionBound {
+    TX_UPPER_VISIBILITY_BOUND,
+    UNLIMITED
+  }
 
   @Override
   public void start(CoprocessorEnvironment e) throws IOException {
     if (e instanceof RegionCoprocessorEnvironment) {
       RegionCoprocessorEnvironment env = (RegionCoprocessorEnvironment) e;
       this.region = ((RegionCoprocessorEnvironment) e).getRegion();
-      Supplier<TransactionStateCache> cacheSupplier = getTransactionStateCacheSupplier(env);
-      this.cache = cacheSupplier.get();
+      HTableDescriptor tableDesc = env.getRegion().getTableDesc();
+      boolean txIsUsed = false;
+      for (HColumnDescriptor columnDesc : tableDesc.getFamilies()) {
+        String propValue = columnDesc.getValue(PROPERTY_COMPACTION_BOUND);
+        try {
+          CompactionBound bound =
+            propValue == null ? COMPACTION_BOUND_DEFAULT : CompactionBound.valueOf(propValue);
+          LOG.info("Family " + columnDesc.getNameAsString() + " compaction bound of " + bound);
+          compactionBoundByFamily.put(columnDesc.getName(), bound);
+
+          if (CompactionBound.TX_UPPER_VISIBILITY_BOUND == bound) {
+            txIsUsed = true;
+          }
+
+        } catch (IllegalArgumentException th) {
+          LOG.warn("Invalid compact bound value configured for column family " + columnDesc.getNameAsString() +
+                     ", value = " + propValue);
+        }
+      }
+
+      if (txIsUsed) {
+        Supplier<TransactionStateCache> cacheSupplier = getTransactionStateCacheSupplier(env);
+        this.cache = cacheSupplier.get();
+      }
     }
   }
 
@@ -157,10 +199,8 @@ public class IncrementHandler extends BaseRegionObserver {
   @Override
   public InternalScanner preFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store,
                                   InternalScanner scanner) throws IOException {
-    TransactionSnapshot snapshot = cache.getLatestState();
-    return new IncrementSummingScanner(region, BATCH_UNLIMITED, scanner, ScanType.COMPACT_RETAIN_DELETES,
-        // if tx snapshot is not available, used "0" as upper bound to avoid trashing in-progress tx
-        snapshot != null ? snapshot.getVisibilityUpperBound() : 0);
+    return new IncrementSummingScanner(region, BATCH_UNLIMITED, scanner,
+                                       ScanType.COMPACT_RETAIN_DELETES, getCompactionBound(store));
   }
 
   public static boolean isIncrement(Cell cell) {
@@ -172,20 +212,29 @@ public class IncrementHandler extends BaseRegionObserver {
   @Override
   public InternalScanner preCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store,
                                     InternalScanner scanner, ScanType scanType) throws IOException {
-    TransactionSnapshot snapshot = cache.getLatestState();
-    return new IncrementSummingScanner(region, BATCH_UNLIMITED, scanner, scanType,
-        // if tx snapshot is not available, used "0" as upper bound to avoid trashing in-progress tx
-        snapshot != null ? snapshot.getVisibilityUpperBound() : 0);
+    return new IncrementSummingScanner(region, BATCH_UNLIMITED, scanner, scanType, getCompactionBound(store));
   }
 
   @Override
   public InternalScanner preCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store,
                                     InternalScanner scanner, ScanType scanType, CompactionRequest request)
     throws IOException {
-    TransactionSnapshot snapshot = cache.getLatestState();
-    return new IncrementSummingScanner(region, BATCH_UNLIMITED, scanner, scanType,
-        // if tx snapshot is not available, used "0" as upper bound to avoid trashing in-progress tx
-        snapshot != null ? snapshot.getVisibilityUpperBound() : 0);
+    return new IncrementSummingScanner(region, BATCH_UNLIMITED, scanner, scanType, getCompactionBound(store));
   }
 
+  private long getCompactionBound(Store store) {
+    long compationBound;
+    CompactionBound bound = compactionBoundByFamily.get(store.getFamily().getName());
+    if (CompactionBound.UNLIMITED == bound) {
+      compationBound = HConstants.LATEST_TIMESTAMP;
+    } else if (CompactionBound.TX_UPPER_VISIBILITY_BOUND == bound) {
+      TransactionSnapshot snapshot = cache.getLatestState();
+      // if tx snapshot is not available, used "0" as upper bound to avoid trashing in-progress tx
+      compationBound = snapshot != null ? snapshot.getVisibilityUpperBound() : 0;
+    } else {
+      // do not compact anything, if it is not clear what to do (safest approach)
+      compationBound = 0;
+    }
+    return compationBound;
+  }
 }

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/increment/hbase98/IncrementHandler.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/increment/hbase98/IncrementHandler.java
@@ -97,7 +97,7 @@ public class IncrementHandler extends BaseRegionObserver {
       this.region = ((RegionCoprocessorEnvironment) e).getRegion();
       HTableDescriptor tableDesc = env.getRegion().getTableDesc();
       for (HColumnDescriptor columnDesc : tableDesc.getFamilies()) {
-        boolean txnl = Boolean.parseBoolean(columnDesc.getValue(PROPERTY_TRANSACTIONAL));
+        boolean txnl = "true".equals(columnDesc.getValue(PROPERTY_TRANSACTIONAL));
         LOG.info("Family " + columnDesc.getNameAsString() + " is transactional: " + txnl);
         if (txnl) {
           txnlFamilies.add(columnDesc.getName());

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/increment/hbase98/IncrementHandler.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/increment/hbase98/IncrementHandler.java
@@ -92,6 +92,9 @@ public class IncrementHandler extends BaseRegionObserver {
 
   protected Map<byte[], CompactionBound> compactionBoundByFamily = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
 
+  /**
+   * Defines compaction boundary for merging delta increments
+   */
   public static enum CompactionBound {
     TX_UPPER_VISIBILITY_BOUND,
     UNLIMITED

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/increment/hbase98/IncrementHandler.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/increment/hbase98/IncrementHandler.java
@@ -97,7 +97,7 @@ public class IncrementHandler extends BaseRegionObserver {
       this.region = ((RegionCoprocessorEnvironment) e).getRegion();
       HTableDescriptor tableDesc = env.getRegion().getTableDesc();
       for (HColumnDescriptor columnDesc : tableDesc.getFamilies()) {
-        boolean txnl = "true".equals(columnDesc.getValue(PROPERTY_TRANSACTIONAL));
+        boolean txnl = !"false".equals(columnDesc.getValue(PROPERTY_TRANSACTIONAL));
         LOG.info("Family " + columnDesc.getNameAsString() + " is transactional: " + txnl);
         if (txnl) {
           txnlFamilies.add(columnDesc.getName());

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/increment/hbase98/IncrementHandler.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/increment/hbase98/IncrementHandler.java
@@ -22,7 +22,7 @@ import co.cask.tephra.coprocessor.TransactionStateCache;
 import co.cask.tephra.hbase98.Filters;
 import co.cask.tephra.persist.TransactionSnapshot;
 import com.google.common.base.Supplier;
-import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.hbase.Cell;
@@ -52,6 +52,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
+import java.util.Set;
 import java.util.TreeMap;
 
 /**
@@ -71,11 +72,10 @@ import java.util.TreeMap;
  */
 public class IncrementHandler extends BaseRegionObserver {
   /**
-   * Property set for {@link org.apache.hadoop.hbase.HColumnDescriptor} to configure how compaction bound is
-   * defined. Possible values are defined by {@link CompactionBound} with
-   * {@link CompactionBound#TX_UPPER_VISIBILITY_BOUND} being default.
+   * Property set for {@link HColumnDescriptor} to indicate if increment is transactional. Default: "true", i.e.
+   * transactional.
    */
-  public static final String PROPERTY_COMPACTION_BOUND = "increment.readless.compaction.bound";
+  public static final String PROPERTY_TRANSACTIONAL = "dataset.table.readless.increment.transactional";
 
   // prefix bytes used to mark values that are deltas vs. full sums
   public static final byte[] DELTA_MAGIC_PREFIX = new byte[] { 'X', 'D' };
@@ -85,20 +85,10 @@ public class IncrementHandler extends BaseRegionObserver {
 
   private static final Log LOG = LogFactory.getLog(IncrementHandler.class);
 
-  private static final CompactionBound COMPACTION_BOUND_DEFAULT = CompactionBound.TX_UPPER_VISIBILITY_BOUND;
-
   private HRegion region;
   private TransactionStateCache cache;
 
-  protected Map<byte[], CompactionBound> compactionBoundByFamily = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
-
-  /**
-   * Defines compaction boundary for merging delta increments
-   */
-  public static enum CompactionBound {
-    TX_UPPER_VISIBILITY_BOUND,
-    UNLIMITED
-  }
+  protected Set<byte[]> txnlFamilies = Sets.newTreeSet(Bytes.BYTES_COMPARATOR);
 
   @Override
   public void start(CoprocessorEnvironment e) throws IOException {
@@ -106,26 +96,15 @@ public class IncrementHandler extends BaseRegionObserver {
       RegionCoprocessorEnvironment env = (RegionCoprocessorEnvironment) e;
       this.region = ((RegionCoprocessorEnvironment) e).getRegion();
       HTableDescriptor tableDesc = env.getRegion().getTableDesc();
-      boolean txIsUsed = false;
       for (HColumnDescriptor columnDesc : tableDesc.getFamilies()) {
-        String propValue = columnDesc.getValue(PROPERTY_COMPACTION_BOUND);
-        try {
-          CompactionBound bound =
-            propValue == null ? COMPACTION_BOUND_DEFAULT : CompactionBound.valueOf(propValue);
-          LOG.info("Family " + columnDesc.getNameAsString() + " compaction bound of " + bound);
-          compactionBoundByFamily.put(columnDesc.getName(), bound);
-
-          if (CompactionBound.TX_UPPER_VISIBILITY_BOUND == bound) {
-            txIsUsed = true;
-          }
-
-        } catch (IllegalArgumentException th) {
-          LOG.warn("Invalid compact bound value configured for column family " + columnDesc.getNameAsString() +
-                     ", value = " + propValue);
+        boolean txnl = Boolean.parseBoolean(columnDesc.getValue(PROPERTY_TRANSACTIONAL));
+        LOG.info("Family " + columnDesc.getNameAsString() + " is transactional: " + txnl);
+        if (txnl) {
+          txnlFamilies.add(columnDesc.getName());
         }
       }
 
-      if (txIsUsed) {
+      if (!txnlFamilies.isEmpty()) {
         Supplier<TransactionStateCache> cacheSupplier = getTransactionStateCacheSupplier(env);
         this.cache = cacheSupplier.get();
       }
@@ -226,18 +205,12 @@ public class IncrementHandler extends BaseRegionObserver {
   }
 
   private long getCompactionBound(Store store) {
-    long compationBound;
-    CompactionBound bound = compactionBoundByFamily.get(store.getFamily().getName());
-    if (CompactionBound.UNLIMITED == bound) {
-      compationBound = HConstants.LATEST_TIMESTAMP;
-    } else if (CompactionBound.TX_UPPER_VISIBILITY_BOUND == bound) {
+    if (txnlFamilies.contains(store.getFamily().getName())) {
       TransactionSnapshot snapshot = cache.getLatestState();
       // if tx snapshot is not available, used "0" as upper bound to avoid trashing in-progress tx
-      compationBound = snapshot != null ? snapshot.getVisibilityUpperBound() : 0;
+      return snapshot != null ? snapshot.getVisibilityUpperBound() : 0;
     } else {
-      // do not compact anything, if it is not clear what to do (safest approach)
-      compationBound = 0;
+      return HConstants.LATEST_TIMESTAMP;
     }
-    return compationBound;
   }
 }

--- a/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data2/increment/hbase98/IncrementHandlerTest.java
+++ b/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data2/increment/hbase98/IncrementHandlerTest.java
@@ -18,6 +18,7 @@ package co.cask.cdap.data2.increment.hbase98;
 
 import co.cask.cdap.data2.dataset2.lib.table.hbase.HBaseOrderedTable;
 import co.cask.cdap.test.SlowTests;
+import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.HBaseTestingUtility;
@@ -30,11 +31,16 @@ import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
 import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.regionserver.HRegion;
+import org.apache.hadoop.hbase.regionserver.RegionScanner;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+
+import java.util.List;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -232,6 +238,46 @@ public class IncrementHandlerTest {
     }
   }
 
+  @Test
+  public void testIncrementsCompactionUnlimBound() throws Exception {
+    // In this test we verify that having compaction bound unlim merges increments and leaves single version of a cell.
+    // It is important because in cases where we don't use tx nobody else will cleanup redundant (merged) keyvalues.
+    TableName tableName = TableName.valueOf("incrementCompactUnlimBoundTest");
+    HColumnDescriptor columnDesc = new HColumnDescriptor(FAMILY);
+    columnDesc.setValue(IncrementHandler.PROPERTY_COMPACTION_BOUND, IncrementHandler.CompactionBound.UNLIMITED.name());
+    HRegion region = IncrementSummingScannerTest.createRegion(conf, tableName, columnDesc);
+
+    try {
+      region.initialize();
+
+      byte[] colA = Bytes.toBytes("a");
+      byte[] row1 = Bytes.toBytes("row1");
+
+      // do some increments
+      region.put(newIncrement(row1, colA, 1));
+      region.put(newIncrement(row1, colA, 1));
+      region.put(newIncrement(row1, colA, 1));
+
+      region.flushcache();
+
+      // verify increments merged after flush
+      assertSingleVersionColumn(region, row1, colA, 3);
+
+      // do some more increments
+      region.put(newIncrement(row1, colA, 1));
+      region.put(newIncrement(row1, colA, 1));
+      region.put(newIncrement(row1, colA, 1));
+
+      region.flushcache();
+      region.compactStores(true);
+
+      // verify increments merged well into hstores
+      assertSingleVersionColumn(region, row1, colA, 6);
+    } finally {
+      region.close();
+    }
+  }
+
   private void assertColumn(HTable table, byte[] row, byte[] col, long expected) throws Exception {
     Result res = table.get(new Get(row));
     Cell resA = res.getColumnLatestCell(FAMILY, col);
@@ -248,6 +294,21 @@ public class IncrementHandlerTest {
     Cell scanResA = scanRes.getColumnLatestCell(FAMILY, col);
     assertArrayEquals(row, scanResA.getRow());
     assertEquals(expected, Bytes.toLong(scanResA.getValue()));
+  }
+
+  private void assertSingleVersionColumn(HRegion region, byte[] row, byte[] col, long expected) throws Exception {
+    Scan scan = new Scan(row);
+    scan.addColumn(FAMILY, col);
+    scan.setMaxVersions();
+    RegionScanner scanner = region.getScanner(scan);
+    List<Cell> results = Lists.newArrayList();
+    Assert.assertFalse(scanner.nextRaw(results));
+    Assert.assertEquals(1, results.size());
+    byte[] value = results.get(0).getValue();
+    // note: it may be stored as increment delta even after merge on flush/compact
+    long longValue =
+      Bytes.toLong(value, value.length > Bytes.SIZEOF_LONG ? IncrementHandler.DELTA_MAGIC_PREFIX.length : 0);
+    Assert.assertEquals(expected, longValue);
   }
 
   private void assertColumns(HTable table, byte[] row, byte[][] cols, long[] expected) throws Exception {
@@ -282,7 +343,7 @@ public class IncrementHandlerTest {
   }
 
   public Put newIncrement(byte[] row, byte[] column, long value) {
-    return newIncrement(row, column, ts++, value);
+      return newIncrement(row, column, ts++, value);
   }
 
   public Put newIncrement(byte[] row, byte[] column, long timestamp, long value) {

--- a/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data2/increment/hbase98/IncrementHandlerTest.java
+++ b/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data2/increment/hbase98/IncrementHandlerTest.java
@@ -244,7 +244,7 @@ public class IncrementHandlerTest {
     // It is important because in cases where we don't use tx nobody else will cleanup redundant (merged) keyvalues.
     TableName tableName = TableName.valueOf("incrementCompactUnlimBoundTest");
     HColumnDescriptor columnDesc = new HColumnDescriptor(FAMILY);
-    columnDesc.setValue(IncrementHandler.PROPERTY_COMPACTION_BOUND, IncrementHandler.CompactionBound.UNLIMITED.name());
+    columnDesc.setValue(IncrementHandler.PROPERTY_TRANSACTIONAL, "false");
     HRegion region = IncrementSummingScannerTest.createRegion(conf, tableName, columnDesc);
 
     try {

--- a/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data2/increment/hbase98/IncrementSummingScannerTest.java
+++ b/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data2/increment/hbase98/IncrementSummingScannerTest.java
@@ -420,15 +420,17 @@ public class IncrementSummingScannerTest {
   }
 
   private HRegion createRegion(TableName tableName, byte[] family) throws Exception {
+    return createRegion(conf, tableName, new HColumnDescriptor(family));
+  }
+
+  static HRegion createRegion(Configuration hConf, TableName tableName, HColumnDescriptor cfd) throws Exception {
     HTableDescriptor htd = new HTableDescriptor(tableName);
-    HColumnDescriptor cfd = new HColumnDescriptor(family);
     cfd.setMaxVersions(Integer.MAX_VALUE);
     cfd.setKeepDeletedCells(true);
     htd.addFamily(cfd);
     htd.addCoprocessor(IncrementHandler.class.getName());
     Path tablePath = new Path("/tmp/" + tableName.getNameAsString());
     Path hlogPath = new Path("/tmp/hlog-" + tableName.getNameAsString());
-    Configuration hConf = conf;
     FileSystem fs = FileSystem.get(hConf);
     assertTrue(fs.mkdirs(tablePath));
     HLog hLog = HLogFactory.createHLog(fs, hlogPath, tableName.getNameAsString(), hConf);


### PR DESCRIPTION
We need that for tables that are non-transactional, but want to use readless increments. E.g. metrics table.