### PR TITLE
ts was taken out of record because it was redundant, but was not

### DIFF
--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/StreamInputFormatTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/StreamInputFormatTest.java
@@ -362,7 +362,6 @@ public class StreamInputFormatTest {
     // should only have read 1 record
     Assert.assertEquals(1, recordsRead.size());
     StructuredRecord record = recordsRead.get(0);
-    Assert.assertEquals(streamEvent.getTimestamp(), record.get("ts"));
     Assert.assertEquals(streamEvent.getHeaders(), record.get("headers"));
     Assert.assertEquals("hello world", record.get("body"));
   }


### PR DESCRIPTION
taken out of the unit test.