### PR TITLE
[CDAP-1006] Replaced accountId with namespaceId in Store classes, comment...

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/deploy/Manager.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/deploy/Manager.java
@@ -32,7 +32,7 @@ public interface Manager<I, O> {
   /**
    * Executes a pipeline for deploying an input.
    *
-   * @param id account id to which the archive is deployed.
+   * @param id namespace id to which the archive is deployed.
    * @param appId application id to be used to override app name provided by app spec. If null, name of app spec is used
    * @param input the input to the deployment pipeline
    * @return A future of Application with Programs.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/Store.java
@@ -89,7 +89,7 @@ public interface Store {
 
   /**
    * Creates a new stream if it does not exist.
-   * @param id the account id
+   * @param id the namespace id
    * @param stream the stream to create
    * @throws OperationException
    */
@@ -97,16 +97,16 @@ public interface Store {
 
   /**
    * Get the spec of a named stream.
-   * @param id the account id
+   * @param id the namespace id
    * @param name the name of the stream
    * @throws OperationException
    */
   StreamSpecification getStream(Id.Namespace id, String name) throws OperationException;
 
   /**
-   * Get the specs of all streams for an account.
+   * Get the specs of all streams for a namespace.
    *
-   * @param id the account id
+   * @param id the namespace id
    * @throws OperationException
    */
 
@@ -249,16 +249,16 @@ public interface Store {
   void removeApplication(Id.Application id) throws OperationException;
 
   /**
-   * Removes all applications (with programs) of the given account.
+   * Removes all applications (with programs) associated with the given namespace.
    *
-   * @param id account id whose applications to remove
+   * @param id namespace id whose applications to remove
    */
   void removeAllApplications(Id.Namespace id) throws OperationException;
 
   /**
-   * Remove all metadata associated with account.
+   * Remove all metadata associated with the given namespace.
    *
-   * @param id account id whose items to remove
+   * @param id namespace id whose items to remove
    */
   void removeAll(Id.Namespace id) throws OperationException;
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/AppMetadataStore.java
@@ -78,40 +78,41 @@ public class AppMetadataStore extends MetadataStoreDataset {
   }
 
   @Nullable
-  public ApplicationMeta getApplication(String accountId, String appId) {
-    return get(new Key.Builder().add(TYPE_APP_META, accountId, appId).build(), ApplicationMeta.class);
+  public ApplicationMeta getApplication(String namespaceId, String appId) {
+    return get(new Key.Builder().add(TYPE_APP_META, namespaceId, appId).build(), ApplicationMeta.class);
   }
 
-  public List<ApplicationMeta> getAllApplications(String accountId) {
-    return list(new Key.Builder().add(TYPE_APP_META, accountId).build(), ApplicationMeta.class);
+  public List<ApplicationMeta> getAllApplications(String namespaceId) {
+    return list(new Key.Builder().add(TYPE_APP_META, namespaceId).build(), ApplicationMeta.class);
   }
 
-  public void writeApplication(String accountId, String appId, ApplicationSpecification spec, String archiveLocation) {
+  public void writeApplication(String namespaceId, String appId, ApplicationSpecification spec,
+                               String archiveLocation) {
     // NOTE: we use Gson underneath to do serde, as it doesn't serialize inner classes (which we use everywhere for
     //       specs - see forwarding specs), we want to wrap spec with DefaultApplicationSpecification
     spec = DefaultApplicationSpecification.from(spec);
-    write(new Key.Builder().add(TYPE_APP_META, accountId, appId).build(),
+    write(new Key.Builder().add(TYPE_APP_META, namespaceId, appId).build(),
           new ApplicationMeta(appId, spec, archiveLocation));
   }
 
-  public void deleteApplication(String accountId, String appId) {
-    deleteAll(new Key.Builder().add(TYPE_APP_META, accountId, appId).build());
+  public void deleteApplication(String namespaceId, String appId) {
+    deleteAll(new Key.Builder().add(TYPE_APP_META, namespaceId, appId).build());
   }
 
-  public void deleteApplications(String accountId) {
-    deleteAll(new Key.Builder().add(TYPE_APP_META, accountId).build());
+  public void deleteApplications(String namespaceId) {
+    deleteAll(new Key.Builder().add(TYPE_APP_META, namespaceId).build());
   }
 
   // todo: do we need appId? may be use from appSpec?
-  public void updateAppSpec(String accountId, String appId, ApplicationSpecification spec) {
+  public void updateAppSpec(String namespaceId, String appId, ApplicationSpecification spec) {
     // NOTE: we use Gson underneath to do serde, as it doesn't serialize inner classes (which we use everywhere for
     //       specs - see forwarding specs), we want to wrap spec with DefaultApplicationSpecification
     spec = DefaultApplicationSpecification.from(spec);
     LOG.trace("App spec to be updated: id: {}: spec: {}", appId, GSON.toJson(spec));
-    Key key = new Key.Builder().add(TYPE_APP_META, accountId, appId).build();
+    Key key = new Key.Builder().add(TYPE_APP_META, namespaceId, appId).build();
     ApplicationMeta existing = get(key, ApplicationMeta.class);
     if (existing == null) {
-      String msg = String.format("No meta for account %s app %s exists", accountId, appId);
+      String msg = String.format("No meta for namespace %s app %s exists", namespaceId, appId);
       LOG.error(msg);
       throw new IllegalArgumentException(msg);
     }
@@ -121,22 +122,22 @@ public class AppMetadataStore extends MetadataStoreDataset {
     write(key, updated);
 
     for (StreamSpecification stream : spec.getStreams().values()) {
-      writeStream(accountId, stream);
+      writeStream(namespaceId, stream);
     }
   }
 
-  public void recordProgramStart(String accountId, String appId, String programId, String pid, long startTs) {
-      write(new Key.Builder().add(TYPE_RUN_RECORD_STARTED, accountId, appId, programId, pid).build(),
+  public void recordProgramStart(String namespaceId, String appId, String programId, String pid, long startTs) {
+      write(new Key.Builder().add(TYPE_RUN_RECORD_STARTED, namespaceId, appId, programId, pid).build(),
             new RunRecord(pid, startTs, null, ProgramRunStatus.RUNNING));
   }
 
-  public void recordProgramStop(String accountId, String appId, String programId,
+  public void recordProgramStop(String namespaceId, String appId, String programId,
                                 String pid, long stopTs, ProgramController.State endStatus) {
-    Key key = new Key.Builder().add(TYPE_RUN_RECORD_STARTED, accountId, appId, programId, pid).build();
+    Key key = new Key.Builder().add(TYPE_RUN_RECORD_STARTED, namespaceId, appId, programId, pid).build();
     RunRecord started = get(key, RunRecord.class);
     if (started == null) {
-      String msg = String.format("No meta for started run record for account %s app %s program %s pid %s exists",
-                                 accountId, appId, programId, pid);
+      String msg = String.format("No meta for started run record for namespace %s app %s program %s pid %s exists",
+                                 namespaceId, appId, programId, pid);
       LOG.error(msg);
       throw new IllegalArgumentException(msg);
     }
@@ -144,39 +145,39 @@ public class AppMetadataStore extends MetadataStoreDataset {
     deleteAll(key);
 
     key = new Key.Builder()
-      .add(TYPE_RUN_RECORD_COMPLETED, accountId, appId, programId)
+      .add(TYPE_RUN_RECORD_COMPLETED, namespaceId, appId, programId)
       .add(getInvertedTsKeyPart(started.getStartTs()))
       .add(pid).build();
     write(key, new RunRecord(started, stopTs, endStatus.getRunStatus()));
   }
 
-  public List<RunRecord> getRuns(String accountId, String appId, String programId,
+  public List<RunRecord> getRuns(String namespaceId, String appId, String programId,
                                  ProgramRunStatus status,
                                  long startTime, long endTime, int limit) {
     if (status.equals(ProgramRunStatus.ALL)) {
       List<RunRecord> resultRecords = Lists.newArrayList();
-      resultRecords.addAll(getActiveRuns(accountId, appId, programId, startTime, endTime, limit));
-      resultRecords.addAll(getHistoricalRuns(accountId, appId, programId, status, startTime, endTime, limit));
+      resultRecords.addAll(getActiveRuns(namespaceId, appId, programId, startTime, endTime, limit));
+      resultRecords.addAll(getHistoricalRuns(namespaceId, appId, programId, status, startTime, endTime, limit));
       return resultRecords;
     } else if (status.equals(ProgramRunStatus.RUNNING)) {
-      return getActiveRuns(accountId, appId, programId, startTime, endTime, limit);
+      return getActiveRuns(namespaceId, appId, programId, startTime, endTime, limit);
     } else {
-      return getHistoricalRuns(accountId, appId, programId, status, startTime, endTime, limit);
+      return getHistoricalRuns(namespaceId, appId, programId, status, startTime, endTime, limit);
     }
   }
 
-  private List<RunRecord> getActiveRuns(String accountId, String appId, String programId,
+  private List<RunRecord> getActiveRuns(String namespaceId, String appId, String programId,
                                         final long startTime, final long endTime, int limit) {
-    Key activeKey = new Key.Builder().add(TYPE_RUN_RECORD_STARTED, accountId, appId, programId).build();
+    Key activeKey = new Key.Builder().add(TYPE_RUN_RECORD_STARTED, namespaceId, appId, programId).build();
     Key start = new Key.Builder(activeKey).add(getInvertedTsKeyPart(endTime)).build();
     Key stop = new Key.Builder(activeKey).add(getInvertedTsKeyPart(startTime)).build();
     return list(start, stop, RunRecord.class, limit, Predicates.<RunRecord>alwaysTrue());
   }
 
-  private List<RunRecord> getHistoricalRuns(String accountId, String appId, String programId,
+  private List<RunRecord> getHistoricalRuns(String namespaceId, String appId, String programId,
                                             ProgramRunStatus status,
                                             final long startTime, final long endTime, int limit) {
-    Key historyKey = new Key.Builder().add(TYPE_RUN_RECORD_COMPLETED, accountId, appId, programId).build();
+    Key historyKey = new Key.Builder().add(TYPE_RUN_RECORD_COMPLETED, namespaceId, appId, programId).build();
     Key start = new Key.Builder(historyKey).add(getInvertedTsKeyPart(endTime)).build();
     Key stop = new Key.Builder(historyKey).add(getInvertedTsKeyPart(startTime)).build();
     if (status.equals(ProgramRunStatus.ALL)) {
@@ -202,54 +203,54 @@ public class AppMetadataStore extends MetadataStoreDataset {
     return Long.MAX_VALUE - endTime;
   }
 
-  public void writeStream(String accountId, StreamSpecification spec) {
-    write(new Key.Builder().add(TYPE_STREAM, accountId, spec.getName()).build(), spec);
+  public void writeStream(String namespaceId, StreamSpecification spec) {
+    write(new Key.Builder().add(TYPE_STREAM, namespaceId, spec.getName()).build(), spec);
   }
 
-  public StreamSpecification getStream(String accountId, String name) {
-    return get(new Key.Builder().add(TYPE_STREAM, accountId, name).build(), StreamSpecification.class);
+  public StreamSpecification getStream(String namespaceId, String name) {
+    return get(new Key.Builder().add(TYPE_STREAM, namespaceId, name).build(), StreamSpecification.class);
   }
 
-  public List<StreamSpecification> getAllStreams(String accountId) {
-    return list(new Key.Builder().add(TYPE_STREAM, accountId).build(), StreamSpecification.class);
+  public List<StreamSpecification> getAllStreams(String namespaceId) {
+    return list(new Key.Builder().add(TYPE_STREAM, namespaceId).build(), StreamSpecification.class);
   }
 
-  public void deleteAllStreams(String accountId) {
-    deleteAll(new Key.Builder().add(TYPE_STREAM, accountId).build());
+  public void deleteAllStreams(String namespaceId) {
+    deleteAll(new Key.Builder().add(TYPE_STREAM, namespaceId).build());
   }
 
-  public void deleteStream(String accountId, String name) {
-    deleteAll(new Key.Builder().add(TYPE_STREAM, accountId, name).build());
+  public void deleteStream(String namespaceId, String name) {
+    deleteAll(new Key.Builder().add(TYPE_STREAM, namespaceId, name).build());
   }
 
-  public void writeProgramArgs(String accountId, String appId, String programName, Map<String, String> args) {
-    write(new Key.Builder().add(TYPE_PROGRAM_ARGS, accountId, appId, programName).build(), new ProgramArgs(args));
+  public void writeProgramArgs(String namespaceId, String appId, String programName, Map<String, String> args) {
+    write(new Key.Builder().add(TYPE_PROGRAM_ARGS, namespaceId, appId, programName).build(), new ProgramArgs(args));
   }
 
-  public ProgramArgs getProgramArgs(String accountId, String appId, String programName) {
-    return get(new Key.Builder().add(TYPE_PROGRAM_ARGS, accountId, appId, programName).build(), ProgramArgs.class);
+  public ProgramArgs getProgramArgs(String namespaceId, String appId, String programName) {
+    return get(new Key.Builder().add(TYPE_PROGRAM_ARGS, namespaceId, appId, programName).build(), ProgramArgs.class);
   }
 
-  public void deleteProgramArgs(String accountId, String appId, String programName) {
-    deleteAll(new Key.Builder().add(TYPE_PROGRAM_ARGS, accountId, appId, programName).build());
+  public void deleteProgramArgs(String namespaceId, String appId, String programName) {
+    deleteAll(new Key.Builder().add(TYPE_PROGRAM_ARGS, namespaceId, appId, programName).build());
   }
 
-  public void deleteProgramArgs(String accountId, String appId) {
-    deleteAll(new Key.Builder().add(TYPE_PROGRAM_ARGS, accountId, appId).build());
+  public void deleteProgramArgs(String namespaceId, String appId) {
+    deleteAll(new Key.Builder().add(TYPE_PROGRAM_ARGS, namespaceId, appId).build());
   }
 
-  public void deleteProgramArgs(String accountId) {
-    deleteAll(new Key.Builder().add(TYPE_PROGRAM_ARGS, accountId).build());
+  public void deleteProgramArgs(String namespaceId) {
+    deleteAll(new Key.Builder().add(TYPE_PROGRAM_ARGS, namespaceId).build());
   }
 
-  public void deleteProgramHistory(String accountId, String appId) {
-    deleteAll(new Key.Builder().add(TYPE_RUN_RECORD_STARTED, accountId, appId).build());
-    deleteAll(new Key.Builder().add(TYPE_RUN_RECORD_COMPLETED, accountId, appId).build());
+  public void deleteProgramHistory(String namespaceId, String appId) {
+    deleteAll(new Key.Builder().add(TYPE_RUN_RECORD_STARTED, namespaceId, appId).build());
+    deleteAll(new Key.Builder().add(TYPE_RUN_RECORD_COMPLETED, namespaceId, appId).build());
   }
 
-  public void deleteProgramHistory(String accountId) {
-    deleteAll(new Key.Builder().add(TYPE_RUN_RECORD_STARTED, accountId).build());
-    deleteAll(new Key.Builder().add(TYPE_RUN_RECORD_COMPLETED, accountId).build());
+  public void deleteProgramHistory(String namespaceId) {
+    deleteAll(new Key.Builder().add(TYPE_RUN_RECORD_STARTED, namespaceId).build());
+    deleteAll(new Key.Builder().add(TYPE_RUN_RECORD_COMPLETED, namespaceId).build());
   }
 
   public void createNamespace(NamespaceMeta metadata) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
@@ -299,8 +299,8 @@ public class DefaultStore implements Store {
   public void setFlowletInstances(final Id.Program id, final String flowletId, final int count) {
     Preconditions.checkArgument(count > 0, "cannot change number of flowlet instances to negative number: " + count);
 
-    LOG.trace("Setting flowlet instances: account: {}, application: {}, flow: {}, flowlet: {}, new instances count: {}",
-              id.getNamespaceId(), id.getApplicationId(), id.getId(), flowletId, count);
+    LOG.trace("Setting flowlet instances: namespace: {}, application: {}, flow: {}, flowlet: {}, " +
+                "new instances count: {}", id.getNamespaceId(), id.getApplicationId(), id.getId(), flowletId, count);
 
     txnl.executeUnchecked(new TransactionExecutor.Function<AppMds, Void>() {
       @Override
@@ -314,7 +314,7 @@ public class DefaultStore implements Store {
       }
     });
 
-    LOG.trace("Set flowlet instances: account: {}, application: {}, flow: {}, flowlet: {}, instances now: {}",
+    LOG.trace("Set flowlet instances: namespace: {}, application: {}, flow: {}, flowlet: {}, instances now: {}",
               id.getNamespaceId(), id.getApplicationId(), id.getId(), flowletId, count);
   }
 
@@ -370,7 +370,7 @@ public class DefaultStore implements Store {
       }
     });
 
-    LOG.trace("Setting program instances: account: {}, application: {}, procedure: {}, new instances count: {}",
+    LOG.trace("Setting program instances: namespace: {}, application: {}, procedure: {}, new instances count: {}",
               id.getNamespaceId(), id.getApplicationId(), id.getId(), count);
   }
 
@@ -398,7 +398,7 @@ public class DefaultStore implements Store {
       }
     });
 
-    LOG.trace("Setting program instances: account: {}, application: {}, service: {}, new instances count: {}",
+    LOG.trace("Setting program instances: namespace: {}, application: {}, service: {}, new instances count: {}",
               id.getNamespaceId(), id.getApplicationId(), id.getId(), instances);
   }
 
@@ -448,7 +448,7 @@ public class DefaultStore implements Store {
       }
     });
 
-    LOG.trace("Setting program instances: account: {}, application: {}, service: {}, new instances count: {}",
+    LOG.trace("Setting program instances: namespace: {}, application: {}, service: {}, new instances count: {}",
               id.getNamespaceId(), id.getApplicationId(), id.getId(), instances);
   }
 
@@ -467,7 +467,7 @@ public class DefaultStore implements Store {
 
   @Override
   public void removeApplication(final Id.Application id) {
-    LOG.trace("Removing application: account: {}, application: {}", id.getNamespaceId(), id.getId());
+    LOG.trace("Removing application: namespace: {}, application: {}", id.getNamespaceId(), id.getId());
 
     txnl.executeUnchecked(new TransactionExecutor.Function<AppMds, Void>() {
       @Override
@@ -482,7 +482,7 @@ public class DefaultStore implements Store {
 
   @Override
   public void removeAllApplications(final Id.Namespace id) {
-    LOG.trace("Removing all applications of account with id: {}", id.getId());
+    LOG.trace("Removing all applications of namespace with id: {}", id.getId());
 
     txnl.executeUnchecked(new TransactionExecutor.Function<AppMds, Void>() {
       @Override
@@ -497,7 +497,7 @@ public class DefaultStore implements Store {
 
   @Override
   public void removeAll(final Id.Namespace id) {
-    LOG.trace("Removing all applications of account with id: {}", id.getId());
+    LOG.trace("Removing all applications of namespace with id: {}", id.getId());
 
     txnl.executeUnchecked(new TransactionExecutor.Function<AppMds, Void>() {
       @Override
@@ -584,7 +584,7 @@ public class DefaultStore implements Store {
     Preconditions.checkArgument(oldValue != null, "oldValue cannot be null");
     Preconditions.checkArgument(newValue != null, "newValue cannot be null");
 
-    LOG.trace("Changing flowlet stream connection: account: {}, application: {}, flow: {}, flowlet: {}," +
+    LOG.trace("Changing flowlet stream connection: namespace: {}, application: {}, flow: {}, flowlet: {}," +
                 " old coonnected stream: {}, new connected stream: {}",
               flow.getNamespaceId(), flow.getApplicationId(), flow.getId(), flowletId, oldValue, newValue);
 
@@ -612,7 +612,7 @@ public class DefaultStore implements Store {
         if (!adjusted) {
           throw new IllegalArgumentException(
             String.format("Cannot change stream connection to %s, the connection to be changed is not found," +
-                            " account: %s, application: %s, flow: %s, flowlet: %s, source stream: %s",
+                            " namespace: %s, application: %s, flow: %s, flowlet: %s, source stream: %s",
                           newValue, flow.getNamespaceId(), flow.getApplicationId(), flow.getId(), flowletId, oldValue));
         }
 
@@ -629,7 +629,7 @@ public class DefaultStore implements Store {
     });
 
 
-    LOG.trace("Changed flowlet stream connection: account: {}, application: {}, flow: {}, flowlet: {}," +
+    LOG.trace("Changed flowlet stream connection: namespace: {}, application: {}, flow: {}, flowlet: {}," +
                 " old coonnected stream: {}, new connected stream: {}",
               flow.getNamespaceId(), flow.getApplicationId(), flow.getId(), flowletId, oldValue, newValue);
 
@@ -861,7 +861,7 @@ public class DefaultStore implements Store {
                                                                 String workerName) {
     ServiceWorkerSpecification workerSpec = serviceSpec.getWorkers().get(workerName);
     if (workerSpec == null) {
-      throw new NoSuchElementException("no such worker @ account id: " + id.getNamespaceId() +
+      throw new NoSuchElementException("no such worker @ namespace id: " + id.getNamespaceId() +
                                          ", app id: " + id.getApplication() +
                                          ", service id: " + id.getId() +
                                          ", worker id: " + workerName);
@@ -873,7 +873,7 @@ public class DefaultStore implements Store {
                                                               String flowletId, Id.Program id) {
     FlowletDefinition flowletDef = flowSpec.getFlowlets().get(flowletId);
     if (flowletDef == null) {
-      throw new NoSuchElementException("no such flowlet @ account id: " + id.getNamespaceId() +
+      throw new NoSuchElementException("no such flowlet @ namespace id: " + id.getNamespaceId() +
                                            ", app id: " + id.getApplication() +
                                            ", flow id: " + id.getId() +
                                            ", flowlet id: " + flowletId);
@@ -884,7 +884,7 @@ public class DefaultStore implements Store {
   private static FlowSpecification getFlowSpecOrFail(Id.Program id, ApplicationSpecification appSpec) {
     FlowSpecification flowSpec = appSpec.getFlows().get(id.getId());
     if (flowSpec == null) {
-      throw new NoSuchElementException("no such flow @ account id: " + id.getNamespaceId() +
+      throw new NoSuchElementException("no such flow @ namespace id: " + id.getNamespaceId() +
                                            ", app id: " + id.getApplication() +
                                            ", flow id: " + id.getId());
     }
@@ -894,7 +894,7 @@ public class DefaultStore implements Store {
   private static ServiceSpecification getServiceSpecOrFail(Id.Program id, ApplicationSpecification appSpec) {
     ServiceSpecification spec = appSpec.getServices().get(id.getId());
     if (spec == null) {
-      throw new NoSuchElementException("no such service @ account id: " + id.getNamespaceId() +
+      throw new NoSuchElementException("no such service @ namespace id: " + id.getNamespaceId() +
                                            ", app id: " + id.getApplication() +
                                            ", service id: " + id.getId());
     }
@@ -904,7 +904,7 @@ public class DefaultStore implements Store {
   private static ProcedureSpecification getProcedureSpecOrFail(Id.Program id, ApplicationSpecification appSpec) {
     ProcedureSpecification procedureSpecification = appSpec.getProcedures().get(id.getId());
     if (procedureSpecification == null) {
-      throw new NoSuchElementException("no such procedure @ account id: " + id.getNamespaceId() +
+      throw new NoSuchElementException("no such procedure @ namespace id: " + id.getNamespaceId() +
                                            ", app id: " + id.getApplication() +
                                            ", procedure id: " + id.getId());
     }
@@ -924,7 +924,7 @@ public class DefaultStore implements Store {
   private ApplicationSpecification getAppSpecOrFail(AppMds mds, Id.Program id) {
     ApplicationSpecification appSpec = getApplicationSpec(mds, id.getApplication());
     if (appSpec == null) {
-      throw new NoSuchElementException("no such application @ account id: " + id.getNamespaceId() +
+      throw new NoSuchElementException("no such application @ namespace id: " + id.getNamespaceId() +
                                            ", app id: " + id.getApplication().getId());
     }
     return appSpec;

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/LoggingContextHelper.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/LoggingContextHelper.java
@@ -49,10 +49,10 @@ public final class LoggingContextHelper {
     String systemId = tags.get(SystemLoggingContext.TAG_SYSTEM_ID);
     String componentId = tags.get(ComponentLoggingContext.TAG_COMPONENT_ID);
 
-    // No account id or application id present.
+    // No namespace id or application id present.
     if (namespaceId == null || applicationId == null) {
       if (systemId == null || componentId == null) {
-        throw new IllegalArgumentException("No account/application or system/component id present");
+        throw new IllegalArgumentException("No namespace/application or system/component id present");
       }
     }
 


### PR DESCRIPTION
...s and log statements

Part 4 of replacing ``accountId`` with ``namespaceId``. Last one for 2.7.0, does the replacement in ``Store`` classes, log statements and comments. Remaining traces of accountId in the code now are:
1. where it actually would stand for ``accountId`` or its equivalent in future; or
2. in methods/APIs that will be deprecated soon; or
3. In ``Streams`` and ``Datasets`` which are out of scope for 2.7.0 for namespaces conoid. Will change them later.

Build - https://builds.cask.co/browse/CDAP-DUT503