### PR TITLE
[CDAP-1161] move metrics scope to metric name - part2

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/metrics/ProgramUserMetrics.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/metrics/ProgramUserMetrics.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.app.metrics;
 
 import co.cask.cdap.api.metrics.Metrics;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.metrics.MetricsCollectionService;
 import co.cask.cdap.common.metrics.MetricsCollector;
 
@@ -41,7 +42,7 @@ public class ProgramUserMetrics implements Metrics, Externalizable {
   }
 
   public ProgramUserMetrics(MetricsCollector metricsCollector) {
-    this.metricsCollector = metricsCollector;
+    this.metricsCollector = metricsCollector.childCollector(Constants.Metrics.Tag.SCOPE, "user");
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppLifecycleHttpHandler.java
@@ -34,7 +34,6 @@ import co.cask.cdap.common.discovery.RandomEndpointStrategy;
 import co.cask.cdap.common.discovery.TimeLimitEndpointStrategy;
 import co.cask.cdap.common.http.AbstractBodyConsumer;
 import co.cask.cdap.common.io.Locations;
-import co.cask.cdap.common.metrics.MetricsScope;
 import co.cask.cdap.common.queue.QueueName;
 import co.cask.cdap.common.utils.DirUtils;
 import co.cask.cdap.config.PreferencesStore;
@@ -605,16 +604,14 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
       throw new IOException("Can't find Metrics endpoint");
     }
 
-    for (MetricsScope scope : MetricsScope.values()) {
-      for (ApplicationSpecification application : applications) {
-        String url = String.format("http://%s:%d%s/metrics/%s/apps/%s",
-                                   discoverable.getSocketAddress().getHostName(),
-                                   discoverable.getSocketAddress().getPort(),
-                                   Constants.Gateway.API_VERSION_2,
-                                   scope.name().toLowerCase(),
-                                   application.getName());
-        sendMetricsDelete(url);
-      }
+    for (ApplicationSpecification application : applications) {
+      String url = String.format("http://%s:%d%s/metrics/%s/apps/%s",
+                                 discoverable.getSocketAddress().getHostName(),
+                                 discoverable.getSocketAddress().getPort(),
+                                 Constants.Gateway.API_VERSION_2,
+                                 "ignored",
+                                 application.getName());
+      sendMetricsDelete(url);
     }
 
     if (applicationId == null) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/DeletedProgramHandlerStage.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/DeletedProgramHandlerStage.java
@@ -23,7 +23,6 @@ import co.cask.cdap.app.store.Store;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.discovery.RandomEndpointStrategy;
 import co.cask.cdap.common.discovery.TimeLimitEndpointStrategy;
-import co.cask.cdap.common.metrics.MetricsScope;
 import co.cask.cdap.common.queue.QueueName;
 import co.cask.cdap.data2.transaction.queue.QueueAdmin;
 import co.cask.cdap.data2.transaction.stream.StreamConsumerFactory;
@@ -138,28 +137,26 @@ public class DeletedProgramHandlerStage extends AbstractStage<ApplicationDeploya
     }
 
     LOG.debug("Deleting metrics for application {}", application);
-    for (MetricsScope scope : MetricsScope.values()) {
-      for (String flow : flows) {
-        String url = String.format("http://%s:%d%s/metrics/%s/apps/%s/flows/%s",
-                                   discoverable.getSocketAddress().getHostName(),
-                                   discoverable.getSocketAddress().getPort(),
-                                   Constants.Gateway.API_VERSION_2,
-                                   scope.name().toLowerCase(),
-                                   application, flow);
+    for (String flow : flows) {
+      String url = String.format("http://%s:%d%s/metrics/%s/apps/%s/flows/%s",
+                                 discoverable.getSocketAddress().getHostName(),
+                                 discoverable.getSocketAddress().getPort(),
+                                 Constants.Gateway.API_VERSION_2,
+                                 "ignored",
+                                 application, flow);
 
-        SimpleAsyncHttpClient client = new SimpleAsyncHttpClient.Builder()
-          .setUrl(url)
-          .setRequestTimeoutInMs((int) METRICS_SERVER_RESPONSE_TIMEOUT)
-          .build();
+      SimpleAsyncHttpClient client = new SimpleAsyncHttpClient.Builder()
+        .setUrl(url)
+        .setRequestTimeoutInMs((int) METRICS_SERVER_RESPONSE_TIMEOUT)
+        .build();
 
-        try {
-          client.delete().get(METRICS_SERVER_RESPONSE_TIMEOUT, TimeUnit.MILLISECONDS);
-        } catch (Exception e) {
-          LOG.error("exception making metrics delete call", e);
-          Throwables.propagate(e);
-        } finally {
-          client.close();
-        }
+      try {
+        client.delete().get(METRICS_SERVER_RESPONSE_TIMEOUT, TimeUnit.MILLISECONDS);
+      } catch (Exception e) {
+        LOG.error("exception making metrics delete call", e);
+        Throwables.propagate(e);
+      } finally {
+        client.close();
       }
     }
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
@@ -30,7 +30,6 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.logging.LoggingContext;
 import co.cask.cdap.common.metrics.MetricsCollectionService;
 import co.cask.cdap.common.metrics.MetricsCollector;
-import co.cask.cdap.common.metrics.MetricsScope;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.internal.app.runtime.AbstractContext;
 import co.cask.cdap.logging.context.MapReduceLoggingContext;
@@ -53,8 +52,8 @@ public class BasicMapReduceContext extends AbstractContext implements MapReduceC
   // TODO: InstanceId is not supported in MR jobs, see CDAP-2
   private final MapReduceSpecification spec;
   private final MapReduceLoggingContext loggingContext;
-  private final Map<MetricsScope, MetricsCollector> systemMapperMetrics;
-  private final Map<MetricsScope, MetricsCollector> systemReducerMetrics;
+  private final MetricsCollector mapperMetrics;
+  private final MetricsCollector reducerMetrics;
   private final long logicalStartTime;
   private final String workflowBatch;
   private final Metrics mapredMetrics;
@@ -88,24 +87,17 @@ public class BasicMapReduceContext extends AbstractContext implements MapReduceC
     this.metricsCollectionService = metricsCollectionService;
 
     if (metricsCollectionService != null) {
-      this.systemMapperMetrics = Maps.newHashMap();
-      this.systemReducerMetrics = Maps.newHashMap();
-      Map<MetricsScope, MetricsCollector> systemMetrics = Maps.newHashMap();
-      for (MetricsScope scope : MetricsScope.values()) {
-        this.systemMapperMetrics.put(scope, getMetricCollector(metricsCollectionService, program,
-                                                               MapReduceMetrics.TaskType.Mapper, runId.getId()));
-        this.systemReducerMetrics.put(scope, getMetricCollector(metricsCollectionService, program,
-                                                                MapReduceMetrics.TaskType.Reducer, runId.getId()));
-        systemMetrics.put(scope, getMetricCollector(metricsCollectionService, program, null, runId.getId()));
-      }
+      mapperMetrics =
+        getMetricCollector(metricsCollectionService, program, MapReduceMetrics.TaskType.Mapper, runId.getId());
+      reducerMetrics =
+        getMetricCollector(metricsCollectionService, program, MapReduceMetrics.TaskType.Reducer, runId.getId());
       // for user metrics.  type can be null if its not in a map or reduce task, but in the yarn container that
       // launches the mapred job.
       this.mapredMetrics = (type == null) ?
-        null : new ProgramUserMetrics(getMetricCollector(metricsCollectionService,
-                                                         program, type, runId.getId()));
+        null : new ProgramUserMetrics(getMetricCollector(metricsCollectionService, program, type, runId.getId()));
     } else {
-      this.systemMapperMetrics = null;
-      this.systemReducerMetrics = null;
+      this.mapperMetrics = null;
+      this.reducerMetrics = null;
       this.mapredMetrics = null;
     }
     this.loggingContext = new MapReduceLoggingContext(getNamespaceId(), getApplicationId(), getProgramName());
@@ -189,20 +181,12 @@ public class BasicMapReduceContext extends AbstractContext implements MapReduceC
     return metricsCollectionService;
   }
 
-  public MetricsCollector getSystemMapperMetrics() {
-    return systemMapperMetrics.get(MetricsScope.SYSTEM);
+  public MetricsCollector getMapperMetrics() {
+    return mapperMetrics;
   }
 
-  public MetricsCollector getSystemReducerMetrics() {
-    return systemReducerMetrics.get(MetricsScope.SYSTEM);
-  }
-
-  public MetricsCollector getSystemMapperMetrics(MetricsScope scope) {
-    return systemMapperMetrics.get(scope);
-  }
-
-  public MetricsCollector getSystemReducerMetrics(MetricsScope scope) {
-    return systemReducerMetrics.get(scope);
+  public MetricsCollector getReducerMetrics() {
+    return reducerMetrics;
   }
 
   public LoggingContext getLoggingContext() {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/DataSetRecordReader.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/DataSetRecordReader.java
@@ -60,8 +60,8 @@ final class DataSetRecordReader<KEY, VALUE> extends RecordReader<KEY, VALUE> {
     boolean hasNext = splitReader.nextKeyValue();
     if (hasNext) {
       // splitreader doesn't increment these metrics, need to do it ourselves.
-      context.getSystemMapperMetrics().increment("store.reads", 1);
-      context.getSystemMapperMetrics().increment("store.ops", 1);
+      context.getMapperMetrics().increment("store.reads", 1);
+      context.getMapperMetrics().increment("store.ops", 1);
       dataSetMetrics.increment("dataset.store.reads", 1);
       dataSetMetrics.increment("dataset.store.ops", 1);
     }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/BasicFlowletContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/BasicFlowletContext.java
@@ -27,7 +27,6 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.logging.LoggingContext;
 import co.cask.cdap.common.metrics.MetricsCollectionService;
 import co.cask.cdap.common.metrics.MetricsCollector;
-import co.cask.cdap.common.metrics.MetricsScope;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.internal.app.runtime.AbstractContext;
 import co.cask.cdap.logging.context.FlowletLoggingContext;
@@ -66,8 +65,7 @@ final class BasicFlowletContext extends AbstractContext implements FlowletContex
                       DatasetFramework dsFramework,
                       CConfiguration conf) {
     super(program, runId, runtimeArguments, datasets,
-          getMetricCollector(metricsCollectionService, MetricsScope.SYSTEM,
-                             program, flowletId, runId.getId(), instanceId),
+          getMetricCollector(metricsCollectionService, program, flowletId, runId.getId(), instanceId),
           dsFramework, conf, discoveryServiceClient);
     this.namespaceId = program.getNamespaceId();
     this.flowId = program.getName();
@@ -76,8 +74,8 @@ final class BasicFlowletContext extends AbstractContext implements FlowletContex
     this.instanceId = instanceId;
     this.instanceCount = instanceCount;
     this.flowletSpec = flowletSpec;
-    this.userMetrics = new ProgramUserMetrics(getMetricCollector(metricsCollectionService, MetricsScope.USER,
-                                                                 program, flowletId, runId.getId(), instanceId));
+    this.userMetrics = new ProgramUserMetrics(getMetricCollector(metricsCollectionService, program,
+                                                                 flowletId, runId.getId(), instanceId));
     this.queueMetrics = CacheBuilder.newBuilder()
       .expireAfterAccess(1, TimeUnit.HOURS)
       .build(new CacheLoader<String, MetricsCollector>() {
@@ -144,10 +142,8 @@ final class BasicFlowletContext extends AbstractContext implements FlowletContex
     return groupId;
   }
 
-  private static MetricsCollector getMetricCollector(MetricsCollectionService service,
-                                                     MetricsScope scope, Program program,
-                                                     String flowletName,
-                                                     String runId, int instanceId) {
+  private static MetricsCollector getMetricCollector(MetricsCollectionService service, Program program,
+                                                     String flowletName, String runId, int instanceId) {
     if (service == null) {
       return null;
     }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/BasicServiceWorkerContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/BasicServiceWorkerContext.java
@@ -29,7 +29,6 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.logging.LoggingContext;
 import co.cask.cdap.common.metrics.MetricsCollectionService;
 import co.cask.cdap.common.metrics.MetricsCollector;
-import co.cask.cdap.common.metrics.MetricsScope;
 import co.cask.cdap.data.Namespace;
 import co.cask.cdap.data2.datafabric.DefaultDatasetNamespace;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
@@ -82,7 +81,7 @@ public class BasicServiceWorkerContext extends AbstractContext implements Servic
                                    TransactionSystemClient transactionSystemClient,
                                    DiscoveryServiceClient discoveryServiceClient) {
     super(program, runId, runtimeArgs, spec.getDatasets(),
-          getMetricCollector(metricsSerice, MetricsScope.SYSTEM, program, spec.getName(), runId.getId(), instanceId),
+          getMetricCollector(metricsSerice, program, spec.getName(), runId.getId(), instanceId),
           datasetFramework, cConf, discoveryServiceClient);
     this.program = program;
     this.specification = spec;
@@ -92,7 +91,7 @@ public class BasicServiceWorkerContext extends AbstractContext implements Servic
     this.transactionSystemClient = transactionSystemClient;
     this.datasetFramework = new NamespacedDatasetFramework(datasetFramework,
                                                            new DefaultDatasetNamespace(cConf, Namespace.USER));
-    this.userMetrics = new ProgramUserMetrics(getMetricCollector(metricsSerice, MetricsScope.USER, program,
+    this.userMetrics = new ProgramUserMetrics(getMetricCollector(metricsSerice, program,
                                                                  spec.getName(), runId.getId(), instanceId));
     // A cache of datasets by threadId. Repeated requests for a dataset from the same thread returns the same
     // instance, thus avoiding the overhead of creating a new instance for every request.
@@ -132,9 +131,8 @@ public class BasicServiceWorkerContext extends AbstractContext implements Servic
                                          program.getId().getId(), specification.getName());
   }
 
-  private static MetricsCollector getMetricCollector(MetricsCollectionService service,
-                                                     MetricsScope scope, Program program, String runnableName,
-                                                     String runId, int instanceId) {
+  private static MetricsCollector getMetricCollector(MetricsCollectionService service, Program program,
+                                                     String runnableName, String runId, int instanceId) {
     if (service == null) {
       return null;
     }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/metrics/SparkMetricsReporter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/metrics/SparkMetricsReporter.java
@@ -63,7 +63,7 @@ class SparkMetricsReporter extends ScheduledReporter {
       for (Map.Entry<String, Gauge> entry : gauges.entrySet()) {
         // for some cases the gauge value is Integer so a typical casting fails. Hence, first cast to Number and then
         // get the value as a long
-        SparkProgramWrapper.getBasicSparkContext().getMetricsCollector(MetricsScope.SYSTEM).gauge(
+        SparkProgramWrapper.getBasicSparkContext().getProgramMetrics().gauge(
           entry.getKey(), ((Number) entry.getValue().getValue()).longValue());
       }
     }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/test/RuntimeStats.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/test/RuntimeStats.java
@@ -50,27 +50,27 @@ public final class RuntimeStats {
 
   public static RuntimeMetrics getFlowletMetrics(String applicationId, String flowId, String flowletId) {
     String prefix = String.format("%s.f.%s.%s", applicationId, flowId, flowletId);
-    String inputName = String.format("%s.process.tuples.read", prefix);
-    String processedName = String.format("%s.process.events.processed", prefix);
-    String exceptionName = String.format("%s.process.errors", prefix);
+    String inputName = String.format("%s.system.process.tuples.read", prefix);
+    String processedName = String.format("%s.system.process.events.processed", prefix);
+    String exceptionName = String.format("%s.system.process.errors", prefix);
 
     return getMetrics(prefix, inputName, processedName, exceptionName);
   }
 
   public static RuntimeMetrics getProcedureMetrics(String applicationId, String procedureId) {
     String prefix = String.format("%s.p.%s", applicationId, procedureId);
-    String inputName = String.format("%s.query.requests", prefix);
-    String processedName = String.format("%s.query.processed", prefix);
-    String exceptionName = String.format("%s.query.failures", prefix);
+    String inputName = String.format("%s.system.query.requests", prefix);
+    String processedName = String.format("%s.system.query.processed", prefix);
+    String exceptionName = String.format("%s.system.query.failures", prefix);
 
     return getMetrics(prefix, inputName, processedName, exceptionName);
   }
 
   public static RuntimeMetrics getServiceMetrics(String applicationId, String serviceId) {
     String prefix = String.format("%s.%s.%s", applicationId, TypeId.getMetricContextId(ProgramType.SERVICE), serviceId);
-    String inputName = String.format("%s.requests.count", prefix);
-    String processedName = String.format("%s.response.successful.count", prefix);
-    String exceptionName = String.format("%s.response.server.error.count", prefix);
+    String inputName = String.format("%s.system.requests.count", prefix);
+    String processedName = String.format("%s.system.response.successful.count", prefix);
+    String exceptionName = String.format("%s.system.response.server.error.count", prefix);
 
     return getMetrics(prefix, inputName, processedName, exceptionName);
   }

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -381,6 +381,8 @@ public final class Constants {
       public static final String FLOWLET = "flt";
       public static final String FLOWLET_QUEUE = "flq";
       public static final String CLUSTER_METRICS = "cls";
+      // who emitted: user vs system (scope is historical name)
+      public static final String SCOPE = "scp";
     }
   }
 

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/metrics/MetricsDiscoveryQueryTestRun.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/metrics/MetricsDiscoveryQueryTestRun.java
@@ -25,7 +25,7 @@ import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.junit.Assert;
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.InputStreamReader;
@@ -37,8 +37,8 @@ import java.util.concurrent.TimeUnit;
  */
 public class MetricsDiscoveryQueryTestRun extends MetricsSuiteTestBase {
 
-  @BeforeClass
-  public static void setup() throws Exception {
+  @Before
+  public void setup() throws Exception {
     setupMetrics();
   }
 
@@ -60,7 +60,7 @@ public class MetricsDiscoveryQueryTestRun extends MetricsSuiteTestBase {
           node("procedure", "RCounts"))));
 
     JsonObject reads = new JsonObject();
-    reads.addProperty("metric", "reads");
+    reads.addProperty("metric", "system.reads");
     reads.add("contexts", readContexts);
     expected.add(reads);
 
@@ -85,7 +85,7 @@ public class MetricsDiscoveryQueryTestRun extends MetricsSuiteTestBase {
           node("flow", "WordCounter", children(
             node("flowlet", "splitter"))))));
     JsonObject expectedReads = new JsonObject();
-    expectedReads.addProperty("metric", "reads");
+    expectedReads.addProperty("metric", "system.reads");
     expectedReads.add("contexts", contexts);
     expected.add(expectedReads);
     expected.add(expectedWrites());
@@ -159,7 +159,7 @@ public class MetricsDiscoveryQueryTestRun extends MetricsSuiteTestBase {
             node("flowlet", "splitter"))))));
 
     JsonObject writes = new JsonObject();
-    writes.addProperty("metric", "writes");
+    writes.addProperty("metric", "system.writes");
     writes.add("contexts", writeContexts);
     return writes;
   }

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/metrics/MetricsQueryTestRun.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/metrics/MetricsQueryTestRun.java
@@ -151,10 +151,10 @@ public class MetricsQueryTestRun extends MetricsSuiteTestBase {
     TimeUnit.SECONDS.sleep(2);
 
     String runnableRequest =
-      "/user/apps/WordCount/services/CounterService/runnables/CountRunnable/reads?aggregate=true";
+      "/system/apps/WordCount/services/CounterService/runnables/CountRunnable/reads?aggregate=true";
 
     String serviceRequest =
-      "/user/apps/WordCount/services/CounterService/reads?aggregate=true";
+      "/system/apps/WordCount/services/CounterService/reads?aggregate=true";
     testSingleMetric(runnableRequest, 1);
     testSingleMetric(serviceRequest, 1);
   }
@@ -187,24 +187,24 @@ public class MetricsQueryTestRun extends MetricsSuiteTestBase {
     TimeUnit.SECONDS.sleep(2);
 
     String serviceRequest =
-      "/user/apps/WordCount/services/CounterService/runs/" + runId2 + "/rid_metric?aggregate=true";
+      "/system/apps/WordCount/services/CounterService/runs/" + runId2 + "/rid_metric?aggregate=true";
 
     //service metric request with invliad runId
     String serviceRequestInvalidId =
-      "/user/apps/WordCount/services/CounterService/runs/fff/rid_metric?aggregate=true";
+      "/system/apps/WordCount/services/CounterService/runs/fff/rid_metric?aggregate=true";
 
     //service metric request without specifying the runId and aggregate will run the sum of these two runIds
     String serviceRequestTotal =
-      "/user/apps/WordCount/services/CounterService/rid_metric?aggregate=true";
+      "/system/apps/WordCount/services/CounterService/rid_metric?aggregate=true";
 
     String mappersMetric =
-      "/user/apps/WordCount/mapreduce/CounterMapRed/runs/" + runId3 + "/mappers/entries.out?aggregate=true";
+      "/system/apps/WordCount/mapreduce/CounterMapRed/runs/" + runId3 + "/mappers/entries.out?aggregate=true";
 
     String reducersMetric =
-      "/user/apps/WordCount/mapreduce/CounterMapRed/runs/" + runId3 + "/reducers/entries.out?aggregate=true";
+      "/system/apps/WordCount/mapreduce/CounterMapRed/runs/" + runId3 + "/reducers/entries.out?aggregate=true";
 
     String mapredMetric =
-      "/user/apps/WordCount/mapreduce/CounterMapRed/runs/" + runId3 + "/entries.out?aggregate=true";
+      "/system/apps/WordCount/mapreduce/CounterMapRed/runs/" + runId3 + "/entries.out?aggregate=true";
 
 
     testSingleMetric(serviceRequest, 2);
@@ -246,10 +246,10 @@ public class MetricsQueryTestRun extends MetricsSuiteTestBase {
     TimeUnit.SECONDS.sleep(2);
 
     String runnableRequest =
-      "/user/apps/WordCount/services/CounterService/runnables/CountRunnable/gmetric?aggregate=true";
+      "/system/apps/WordCount/services/CounterService/runnables/CountRunnable/gmetric?aggregate=true";
 
     String serviceRequest =
-      "/user/apps/WordCount/services/CounterService/gmetric?aggregate=true";
+      "/system/apps/WordCount/services/CounterService/gmetric?aggregate=true";
     testSingleMetric(runnableRequest, 10);
     testSingleMetric(serviceRequest, 10);
   }

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/metrics/MetricsSuiteTestBase.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/metrics/MetricsSuiteTestBase.java
@@ -65,6 +65,7 @@ import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.message.BasicHeader;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.apache.twill.filesystem.LocationFactory;
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.rules.TemporaryFolder;
@@ -151,6 +152,11 @@ public abstract class MetricsSuiteTestBase {
     } finally {
       tmpFolder.delete();
     }
+  }
+
+  @After
+  public void after() throws Exception {
+    doDelete("/v2/metrics/");
   }
 
   public static void initialize() throws IOException, OperationException {

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/TestMetricsCollectionService.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/TestMetricsCollectionService.java
@@ -15,7 +15,6 @@
  */
 package co.cask.cdap.test.internal;
 
-import co.cask.cdap.common.metrics.MetricsScope;
 import co.cask.cdap.metrics.collect.AggregatedMetricsCollectionService;
 import co.cask.cdap.metrics.process.MetricRecordsWrapper;
 import co.cask.cdap.metrics.transport.MetricValue;
@@ -30,12 +29,7 @@ import java.util.Iterator;
 public final class TestMetricsCollectionService extends AggregatedMetricsCollectionService {
 
   @Override
-  protected void publish(MetricsScope scope, Iterator<MetricValue> metrics) throws Exception {
-    // Currently the test framework only supports system metrics.
-    if (scope != MetricsScope.SYSTEM) {
-      return;
-    }
-
+  protected void publish(Iterator<MetricValue> metrics) throws Exception {
     Iterator<MetricsRecord> records = new MetricRecordsWrapper(metrics);
     while (records.hasNext()) {
       MetricsRecord metricsRecord = records.next();

--- a/cdap-unit-test/src/test/java/co/cask/cdap/spark/metrics/TestSparkMetricsIntegration.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/spark/metrics/TestSparkMetricsIntegration.java
@@ -33,7 +33,7 @@ import java.util.concurrent.TimeUnit;
 @Category(XSlowTests.class)
 public class TestSparkMetricsIntegration extends TestBase {
 
-  public static final String METRICS_KEY = ".BlockManager.memory.remainingMem_MB";
+  public static final String METRICS_KEY = ".system.BlockManager.memory.remainingMem_MB";
 
   @Test
   public void testSparkMetrics() throws Exception {

--- a/cdap-unit-test/src/test/java/co/cask/cdap/spark/metrics/TestSparkMetricsIntegration.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/spark/metrics/TestSparkMetricsIntegration.java
@@ -33,7 +33,7 @@ import java.util.concurrent.TimeUnit;
 @Category(XSlowTests.class)
 public class TestSparkMetricsIntegration extends TestBase {
 
-  public static final String METRICS_KEY = ".system.BlockManager.memory.remainingMem_MB";
+  public static final String METRICS_KEY = ".BlockManager.memory.remainingMem_MB";
 
   @Test
   public void testSparkMetrics() throws Exception {

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTest.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTest.java
@@ -612,12 +612,12 @@ public class TestFrameworkTest extends TestBase {
                                                                        "BatchSinkFlowlet");
 
       // Generator generators 99 events + 99 batched events
-      sinkMetrics.waitFor("process.events.in", 198, 5, TimeUnit.SECONDS);
+      sinkMetrics.waitFor("system.process.events.in", 198, 5, TimeUnit.SECONDS);
       sinkMetrics.waitForProcessed(198, 5, TimeUnit.SECONDS);
       Assert.assertEquals(0L, sinkMetrics.getException());
 
       // Batch sink only get the 99 batch events
-      batchSinkMetrics.waitFor("process.events.in", 99, 5, TimeUnit.SECONDS);
+      batchSinkMetrics.waitFor("system.process.events.in", 99, 5, TimeUnit.SECONDS);
       batchSinkMetrics.waitForProcessed(99, 5, TimeUnit.SECONDS);
       Assert.assertEquals(0L, batchSinkMetrics.getException());
 

--- a/cdap-watchdog-tests/src/test/java/co/cask/cdap/metrics/data/AggregatesTableTestBase.java
+++ b/cdap-watchdog-tests/src/test/java/co/cask/cdap/metrics/data/AggregatesTableTestBase.java
@@ -39,7 +39,7 @@ public abstract class AggregatesTableTestBase {
 
   @Test
   public void testSimpleAggregates() throws OperationException {
-    AggregatesTable aggregatesTable = getTableFactory().createAggregates("agg");
+    AggregatesTable aggregatesTable = getTableFactory().createAggregates();
 
     try {
       // Insert 10 metrics.
@@ -77,7 +77,7 @@ public abstract class AggregatesTableTestBase {
 
   @Test
   public void testIntOverflow() throws OperationException {
-    AggregatesTable aggregatesTable = getTableFactory().createAggregates("intOverflow");
+    AggregatesTable aggregatesTable = getTableFactory().createAggregates();
 
     // 2012-10-01T12:00:00
     final long time = 1317470400;
@@ -98,7 +98,7 @@ public abstract class AggregatesTableTestBase {
 
   @Test
   public void testGaugeValues() throws OperationException {
-    AggregatesTable aggregatesTable = getTableFactory().createAggregates("testGauge");
+    AggregatesTable aggregatesTable = getTableFactory().createAggregates();
 
     // 2012-10-01T12:00:00
     final long time = 1317470400;
@@ -125,7 +125,7 @@ public abstract class AggregatesTableTestBase {
 
   @Test
   public void testScanAllTags() throws OperationException {
-    AggregatesTable aggregatesTable = getTableFactory().createAggregates("aggScanAllTags");
+    AggregatesTable aggregatesTable = getTableFactory().createAggregates();
     try {
       aggregatesTable.update(ImmutableList.of(
         new MetricsRecord("app1.f.flow1.flowlet1", "0", "metric", ImmutableList.of(
@@ -156,7 +156,7 @@ public abstract class AggregatesTableTestBase {
 
   @Test
   public void testScanTagPrefix() throws OperationException {
-    AggregatesTable aggregatesTable = getTableFactory().createAggregates("aggScanTagPrefix");
+    AggregatesTable aggregatesTable = getTableFactory().createAggregates();
     try {
       aggregatesTable.update(ImmutableList.of(
         new MetricsRecord("app1.f.flow1.flowlet1", "0", "metric", ImmutableList.of(
@@ -196,7 +196,7 @@ public abstract class AggregatesTableTestBase {
 
   @Test
   public void testClear() throws OperationException {
-    AggregatesTable aggregatesTable = getTableFactory().createAggregates("aggDelete");
+    AggregatesTable aggregatesTable = getTableFactory().createAggregates();
 
     for (int i = 1; i <= 10; i++) {
       MetricsRecord metric = new MetricsRecord("simple." + i, "runId", "metric",
@@ -232,7 +232,7 @@ public abstract class AggregatesTableTestBase {
 
   @Test
   public void testRowFilter() throws OperationException {
-    AggregatesTable aggregatesTable = getTableFactory().createAggregates("agg");
+    AggregatesTable aggregatesTable = getTableFactory().createAggregates();
 
     try {
       // Insert 20 different metrics from the same context.
@@ -261,7 +261,7 @@ public abstract class AggregatesTableTestBase {
 
   @Test
   public void testTags() throws OperationException {
-    AggregatesTable aggregatesTable = getTableFactory().createAggregates("agg");
+    AggregatesTable aggregatesTable = getTableFactory().createAggregates();
 
     try {
       // Insert 10 metrics, each with 20 tags.
@@ -293,7 +293,7 @@ public abstract class AggregatesTableTestBase {
 
   @Test
   public void testDeleteContext() throws OperationException {
-    AggregatesTable aggregatesTable = getTableFactory().createAggregates("agg");
+    AggregatesTable aggregatesTable = getTableFactory().createAggregates();
 
     try {
       List<TagMetric> tags = Lists.newArrayList();
@@ -344,7 +344,7 @@ public abstract class AggregatesTableTestBase {
 
   @Test
   public void testDeleteContextAndMetric() throws OperationException {
-    AggregatesTable aggregatesTable = getTableFactory().createAggregates("agg");
+    AggregatesTable aggregatesTable = getTableFactory().createAggregates();
 
     try {
       List<TagMetric> tags = Lists.newArrayList();
@@ -413,7 +413,7 @@ public abstract class AggregatesTableTestBase {
 
   @Test
   public void testDeletes() throws OperationException {
-    AggregatesTable aggregatesTable = getTableFactory().createAggregates("agg");
+    AggregatesTable aggregatesTable = getTableFactory().createAggregates();
 
     try {
       String metric = "metric";
@@ -472,7 +472,7 @@ public abstract class AggregatesTableTestBase {
 
   @Test
   public void testSwap() throws OperationException {
-    AggregatesTable aggregatesTable = getTableFactory().createAggregates("aggSave");
+    AggregatesTable aggregatesTable = getTableFactory().createAggregates();
     try {
       checkSwapForTag(aggregatesTable, null);
       checkSwapForTag(aggregatesTable, "tag");

--- a/cdap-watchdog-tests/src/test/java/co/cask/cdap/metrics/data/TimeSeriesTableTestBase.java
+++ b/cdap-watchdog-tests/src/test/java/co/cask/cdap/metrics/data/TimeSeriesTableTestBase.java
@@ -128,11 +128,11 @@ public abstract class TimeSeriesTableTestBase {
     final long time = 1317470400;
 
     // Insert metrics for flow
-    String context = "app.f.flow.flowlet";
+    String context = "app.f.flow2.flowlet";
     String metric = "input";
     insertMetrics(timeSeriesTable, context, "runId", metric, ImmutableList.of("test"), time, 0, 7200, 100);
 
-    MetricsScanQuery query = new MetricsScanQueryBuilder().setContext("app.f.flow.flowlet")
+    MetricsScanQuery query = new MetricsScanQueryBuilder().setContext("app.f.flow2.flowlet")
       .setMetric("input")
       .build(time, time + 7200);
 
@@ -143,6 +143,7 @@ public abstract class TimeSeriesTableTestBase {
       }
     });
   }
+
   @Test
   public void testTimeSeriesMinuteResolution() throws OperationException {
     TimeSeriesTable timeSeriesTable = getTableFactory().createTimeSeries(60);
@@ -151,7 +152,7 @@ public abstract class TimeSeriesTableTestBase {
     final long time = 1317470400;
 
     // Insert metrics for flow
-    String context = "app.f.flow.flowlet";
+    String context = "app.f.flow3.flowlet";
     String metric = "input";
 
     insertMetricsEachMinute(timeSeriesTable, context, "runId", metric, ImmutableList.of("test"), time, 0, 1440,
@@ -159,7 +160,7 @@ public abstract class TimeSeriesTableTestBase {
     insertMetricsEachMinute(timeSeriesTable, context, "runId", metric, ImmutableList.of("test"), time, 0, 1440,
                             MetricType.COUNTER);
 
-    MetricsScanQuery query = new MetricsScanQueryBuilder().setContext("app.f.flow.flowlet")
+    MetricsScanQuery query = new MetricsScanQueryBuilder().setContext("app.f.flow3.flowlet")
       .setMetric("input")
       .build(time, time + 86400);
 
@@ -563,14 +564,14 @@ public abstract class TimeSeriesTableTestBase {
 
     try {
       timeSeriesTable.save(ImmutableList.of(
-        new MetricsRecord("app.f.flow.flowlet", "0", "store.bytes", ImmutableList.of(
+        new MetricsRecord("app.f.flow4.flowlet", "0", "store.bytes", ImmutableList.of(
           new TagMetric("tag1", 1), new TagMetric("tag2", 2), new TagMetric("tag3", 3)), 1234567890, 6,
                           MetricType.COUNTER)
       ));
 
       Map<String, Long> tagValues = Maps.newHashMap();
       MetricsScanQuery query = new MetricsScanQueryBuilder()
-        .setContext("app.f.flow.flowlet")
+        .setContext("app.f.flow4.flowlet")
         .setMetric("store.bytes")
         .setRunId("0")
         .build(1234567890, 1234567891);

--- a/cdap-watchdog-tests/src/test/java/co/cask/cdap/metrics/data/TimeSeriesTableTestBase.java
+++ b/cdap-watchdog-tests/src/test/java/co/cask/cdap/metrics/data/TimeSeriesTableTestBase.java
@@ -38,7 +38,7 @@ public abstract class TimeSeriesTableTestBase {
 
   @Test
   public void testAggregate() throws OperationException {
-    TimeSeriesTable timeSeriesTable = getTableFactory().createTimeSeries("test", 1);
+    TimeSeriesTable timeSeriesTable = getTableFactory().createTimeSeries(1);
 
     // 2012-10-01T12:00:00
     final long time = 1317470400;
@@ -122,7 +122,7 @@ public abstract class TimeSeriesTableTestBase {
 
   @Test
   public void testTimeSeriesMinuteResolutionAggregation() throws OperationException {
-    TimeSeriesTable timeSeriesTable = getTableFactory().createTimeSeries("minute-agg", 60);
+    TimeSeriesTable timeSeriesTable = getTableFactory().createTimeSeries(60);
 
     // 2012-10-01T12:00:00
     final long time = 1317470400;
@@ -145,7 +145,7 @@ public abstract class TimeSeriesTableTestBase {
   }
   @Test
   public void testTimeSeriesMinuteResolution() throws OperationException {
-    TimeSeriesTable timeSeriesTable = getTableFactory().createTimeSeries("minutes", 60);
+    TimeSeriesTable timeSeriesTable = getTableFactory().createTimeSeries(60);
 
     // 2012-10-01T12:00:00
     final long time = 1317470400;
@@ -218,7 +218,7 @@ public abstract class TimeSeriesTableTestBase {
 
   @Test
   public void testClear() throws OperationException {
-    TimeSeriesTable timeSeriesTable = getTableFactory().createTimeSeries("testDeleteAll", 1);
+    TimeSeriesTable timeSeriesTable = getTableFactory().createTimeSeries(1);
     // 2012-10-01T12:00:00
     final long time = 1317470400;
 
@@ -249,7 +249,7 @@ public abstract class TimeSeriesTableTestBase {
 
   @Test
   public void testIntOverflow() throws OperationException {
-    TimeSeriesTable timeSeriesTable = getTableFactory().createTimeSeries("intOverflow", 1);
+    TimeSeriesTable timeSeriesTable = getTableFactory().createTimeSeries(1);
     // 2012-10-01T12:00:00
     final long time = 1317470400;
 
@@ -271,7 +271,7 @@ public abstract class TimeSeriesTableTestBase {
 
   @Test
   public void testGauge() throws OperationException {
-    TimeSeriesTable timeSeriesTable = getTableFactory().createTimeSeries("testGauge", 1);
+    TimeSeriesTable timeSeriesTable = getTableFactory().createTimeSeries(1);
     // 2012-10-01T12:00:00
     final long time = 1317470400;
 
@@ -298,7 +298,7 @@ public abstract class TimeSeriesTableTestBase {
   @Test
   public void testDelete() throws OperationException {
 
-    TimeSeriesTable timeSeriesTable = getTableFactory().createTimeSeries("testDelete", 1);
+    TimeSeriesTable timeSeriesTable = getTableFactory().createTimeSeries(1);
 
     // 2012-10-01T12:00:00
     final long time = 1317470400;
@@ -360,7 +360,7 @@ public abstract class TimeSeriesTableTestBase {
   @Test
   public void testDeleteContextAndMetric() throws OperationException {
 
-    TimeSeriesTable timeSeriesTable = getTableFactory().createTimeSeries("testContextAndMetricDelete", 1);
+    TimeSeriesTable timeSeriesTable = getTableFactory().createTimeSeries(1);
 
     // 2012-10-01T12:00:00
     final long time = 1317470400;
@@ -447,7 +447,7 @@ public abstract class TimeSeriesTableTestBase {
   @Test
   public void testRangeDelete() throws OperationException {
 
-    TimeSeriesTable timeSeriesTable = getTableFactory().createTimeSeries("testRangeDelete", 1);
+    TimeSeriesTable timeSeriesTable = getTableFactory().createTimeSeries(1);
 
     // 2012-10-01T12:00:00
     final long time = 1317470400;
@@ -559,7 +559,7 @@ public abstract class TimeSeriesTableTestBase {
   @Test
   public void testScanAllTags() throws OperationException {
 
-    TimeSeriesTable timeSeriesTable = getTableFactory().createTimeSeries("testScanAllTags", 1);
+    TimeSeriesTable timeSeriesTable = getTableFactory().createTimeSeries(1);
 
     try {
       timeSeriesTable.save(ImmutableList.of(

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/collect/AggregatedMetricsCollectionService.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/collect/AggregatedMetricsCollectionService.java
@@ -46,7 +46,7 @@ public abstract class AggregatedMetricsCollectionService extends AbstractSchedul
   private static final long CACHE_EXPIRE_MINUTES = 1;
   private static final long DEFAULT_FREQUENCY_SECONDS = 1;
 
-   private final LoadingCache<Map<String, String>, MetricsCollector> collectors;
+  private final LoadingCache<Map<String, String>, MetricsCollector> collectors;
   private final LoadingCache<EmitterKey, AggregatedMetricsEmitter> emitters;
 
   public AggregatedMetricsCollectionService() {

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/collect/KafkaMetricsCollectionService.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/collect/KafkaMetricsCollectionService.java
@@ -17,7 +17,6 @@ package co.cask.cdap.metrics.collect;
 
 import co.cask.cdap.common.io.BinaryEncoder;
 import co.cask.cdap.common.io.Encoder;
-import co.cask.cdap.common.metrics.MetricsScope;
 import co.cask.cdap.internal.io.DatumWriter;
 import co.cask.cdap.metrics.MetricsConstants;
 import co.cask.cdap.metrics.transport.MetricValue;
@@ -76,7 +75,7 @@ public final class KafkaMetricsCollectionService extends AggregatedMetricsCollec
   }
 
   @Override
-  protected void publish(MetricsScope scope, Iterator<MetricValue> metrics) throws Exception {
+  protected void publish(Iterator<MetricValue> metrics) throws Exception {
     KafkaPublisher publisher = getPublisher();
     if (publisher == null) {
       LOG.warn("Unable to get kafka publisher, will not be able to publish metrics.");
@@ -84,7 +83,7 @@ public final class KafkaMetricsCollectionService extends AggregatedMetricsCollec
     }
     encoderOutputStream.reset();
 
-    KafkaPublisher.Preparer preparer = publisher.prepare(topicPrefix + "." + scope.name().toLowerCase());
+    KafkaPublisher.Preparer preparer = publisher.prepare(topicPrefix);
     while (metrics.hasNext()) {
       // Encode each MetricRecord into bytes and make it an individual kafka message in a message set.
       MetricValue value = metrics.next();

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/collect/LocalMetricsCollectionService.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/collect/LocalMetricsCollectionService.java
@@ -16,7 +16,6 @@
 package co.cask.cdap.metrics.collect;
 
 import co.cask.cdap.common.conf.CConfiguration;
-import co.cask.cdap.common.metrics.MetricsScope;
 import co.cask.cdap.metrics.MetricsConstants;
 import co.cask.cdap.metrics.data.MetricsTableFactory;
 import co.cask.cdap.metrics.data.TimeSeriesTables;
@@ -62,10 +61,10 @@ public final class LocalMetricsCollectionService extends AggregatedMetricsCollec
   }
 
   @Override
-  protected void publish(MetricsScope scope, Iterator<MetricValue> metrics) throws Exception {
+  protected void publish(Iterator<MetricValue> metrics) throws Exception {
     List<MetricValue> records = ImmutableList.copyOf(metrics);
     for (MetricsProcessor processor : processors) {
-      processor.process(scope, new MetricRecordsWrapper(records.iterator()));
+      processor.process(new MetricRecordsWrapper(records.iterator()));
     }
   }
 
@@ -112,9 +111,7 @@ public final class LocalMetricsCollectionService extends AggregatedMetricsCollec
         long currentTime = TimeUnit.SECONDS.convert(System.currentTimeMillis(), TimeUnit.MILLISECONDS);
         long deleteBefore = currentTime - retention;
 
-        for (MetricsScope scope : MetricsScope.values()) {
-          timeSeriesTables.deleteBefore(scope, deleteBefore);
-        }
+        timeSeriesTables.deleteBefore(deleteBefore);
         scheduler.schedule(this, 1, TimeUnit.HOURS);
       }
     };

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/collect/MapReduceCounterCollectionService.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/collect/MapReduceCounterCollectionService.java
@@ -15,7 +15,6 @@
  */
 package co.cask.cdap.metrics.collect;
 
-import co.cask.cdap.common.metrics.MetricsScope;
 import co.cask.cdap.metrics.transport.MetricType;
 import co.cask.cdap.metrics.transport.MetricValue;
 import com.google.inject.Inject;
@@ -45,13 +44,11 @@ public final class MapReduceCounterCollectionService extends AggregatedMetricsCo
 
 
   @Override
-  protected void publish(MetricsScope scope, Iterator<MetricValue> metrics) throws Exception {
+  protected void publish(Iterator<MetricValue> metrics) throws Exception {
     while (metrics.hasNext()) {
       MetricValue record = metrics.next();
 
-      StringBuilder counterGroup = new StringBuilder("cdap.")
-        .append(scope).append(".")
-        .append(record.getType());
+      StringBuilder counterGroup = new StringBuilder("cdap.").append(record.getType());
 
       // flatten tags
       for (Map.Entry<String, String> tag : record.getTags().entrySet()) {

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/data/MetricsTableFactory.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/data/MetricsTableFactory.java
@@ -24,25 +24,23 @@ public interface MetricsTableFactory {
 
   /**
    * Creates a new instance of {@link TimeSeriesTable} with the given resolution.
-   * @param namespace Name prefix of the table name
+   *
    * @param resolution The resolution that the table represents.
    * @return A new instance of {@link TimeSeriesTable}.
    */
-  TimeSeriesTable createTimeSeries(String namespace, int resolution);
+  TimeSeriesTable createTimeSeries(int resolution);
 
   /**
    * Creates a new instance of {@link AggregatesTable}.
-   * @param namespace Name prefix of the table name
    * @return A new instance of {@link AggregatesTable}.
    */
-  AggregatesTable createAggregates(String namespace);
+  AggregatesTable createAggregates();
 
   /**
    * Creates a new instance of {@link KafkaConsumerMetaTable}.
-   * @param namespace Name prefix of the table name
    * @return A new instance of {@link KafkaConsumerMetaTable}.
    */
-  KafkaConsumerMetaTable createKafkaConsumerMeta(String namespace);
+  KafkaConsumerMetaTable createKafkaConsumerMeta();
 
   /**
    * Returns whether the underlying table supports TTL.

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/data/TimeSeriesTables.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/data/TimeSeriesTables.java
@@ -16,7 +16,6 @@
 
 package co.cask.cdap.metrics.data;
 
-import co.cask.cdap.common.metrics.MetricsScope;
 import co.cask.cdap.data2.OperationException;
 import co.cask.cdap.metrics.collect.LocalMetricsCollectionService;
 import co.cask.cdap.metrics.transport.MetricsRecord;
@@ -24,72 +23,64 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Maps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Creates Multiple Time Resolution tables and time-series table operations are performed on all the tables.
  */
 public class TimeSeriesTables {
 
-  private final Map<MetricsScope, LoadingCache<Integer, TimeSeriesTable>> metricsTableCaches;
+  private final LoadingCache<Integer, TimeSeriesTable> metricsTableCaches;
   private final List<Integer> timeSeriesResolutions = ImmutableList.of(1, 60, 3600);
   private static final Logger LOG = LoggerFactory.getLogger(LocalMetricsCollectionService.class);
 
   public TimeSeriesTables(final MetricsTableFactory metricsTableFactory) {
-    this.metricsTableCaches = Maps.newHashMap();
-    for (final MetricsScope scope : MetricsScope.values()) {
-      LoadingCache<Integer, TimeSeriesTable> cache =
-        CacheBuilder.newBuilder().build(new CacheLoader<Integer, TimeSeriesTable>() {
-          @Override
-          public TimeSeriesTable load(Integer key) throws Exception {
-            return metricsTableFactory.createTimeSeries(scope.name(), key);
-          }
-        });
-      this.metricsTableCaches.put(scope, cache);
-    }
+    this.metricsTableCaches = CacheBuilder.newBuilder().build(new CacheLoader<Integer, TimeSeriesTable>() {
+        @Override
+        public TimeSeriesTable load(Integer key) throws Exception {
+          return metricsTableFactory.createTimeSeries(key);
+        }
+      });
   }
 
-  public void clear(MetricsScope scope) throws OperationException {
+  public void clear() throws OperationException {
     for (int resolution : timeSeriesResolutions) {
-      metricsTableCaches.get(scope).getUnchecked(resolution).clear();
+      metricsTableCaches.getUnchecked(resolution).clear();
     }
   }
 
-  public void delete(MetricsScope scope, String contextPrefix, String metricPrefix) throws OperationException {
+  public void delete(String contextPrefix, String metricPrefix) throws OperationException {
     for (int resolution : timeSeriesResolutions) {
-      metricsTableCaches.get(scope).getUnchecked(resolution).delete(contextPrefix, metricPrefix);
+      metricsTableCaches.getUnchecked(resolution).delete(contextPrefix, metricPrefix);
     }
   }
 
-  public void delete(MetricsScope scope, MetricsScanQuery scanQuery) throws OperationException {
+  public void delete(MetricsScanQuery scanQuery) throws OperationException {
     for (int resolution : timeSeriesResolutions) {
-      metricsTableCaches.get(scope).getUnchecked(resolution).delete(scanQuery);
+      metricsTableCaches.getUnchecked(resolution).delete(scanQuery);
     }
   }
 
-  public void deleteBefore(MetricsScope scope, long deleteBefore) {
+  public void deleteBefore(long deleteBefore) {
     for (int resolution : timeSeriesResolutions) {
       try {
-        metricsTableCaches.get(scope).getUnchecked(resolution).deleteBefore(deleteBefore);
+        metricsTableCaches.getUnchecked(resolution).deleteBefore(deleteBefore);
       } catch (OperationException e) {
         LOG.error("Failed in cleaning up metrics table: {}", e.getMessage(), e);
       }
     }
   }
 
-  public void save(MetricsScope scope, List<MetricsRecord> records) throws OperationException {
+  public void save(List<MetricsRecord> records) throws OperationException {
     for (int resolution : timeSeriesResolutions) {
-      metricsTableCaches.get(scope).getUnchecked(resolution).save(records.iterator());
+      metricsTableCaches.getUnchecked(resolution).save(records.iterator());
     }
   }
 
-  public MetricsScanner scan(MetricsScope scope, int resolution, MetricsScanQuery scanQuery) throws OperationException {
-    return metricsTableCaches.get(scope).getUnchecked(resolution).scan(scanQuery);
+  public MetricsScanner scan(int resolution, MetricsScanQuery scanQuery) throws OperationException {
+    return metricsTableCaches.getUnchecked(resolution).scan(scanQuery);
   }
 }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/guice/MetricsClientRuntimeModule.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/guice/MetricsClientRuntimeModule.java
@@ -16,7 +16,6 @@
 package co.cask.cdap.metrics.guice;
 
 import co.cask.cdap.common.metrics.MetricsCollectionService;
-import co.cask.cdap.common.metrics.MetricsScope;
 import co.cask.cdap.common.runtime.RuntimeModule;
 import co.cask.cdap.metrics.collect.AggregatedMetricsCollectionService;
 import co.cask.cdap.metrics.collect.LocalMetricsCollectionService;
@@ -88,7 +87,7 @@ public final class MetricsClientRuntimeModule extends RuntimeModule {
       protected void configure() {
         bind(MetricsCollectionService.class).toInstance(new AggregatedMetricsCollectionService() {
           @Override
-          protected void publish(MetricsScope scope, Iterator<MetricValue> metrics) throws Exception {
+          protected void publish(Iterator<MetricValue> metrics) throws Exception {
             // No-op
           }
         });

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/process/KafkaMetricsProcessorService.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/process/KafkaMetricsProcessorService.java
@@ -16,7 +16,6 @@
 
 package co.cask.cdap.metrics.process;
 
-import co.cask.cdap.common.metrics.MetricsScope;
 import co.cask.cdap.data2.OperationException;
 import co.cask.cdap.metrics.MetricsConstants.ConfigKeys;
 import co.cask.cdap.metrics.data.MetricsTableFactory;
@@ -114,7 +113,7 @@ public final class KafkaMetricsProcessorService extends AbstractExecutionThreadS
         break;
       }
       try {
-        metaTable = metricsTableFactory.createKafkaConsumerMeta("default");
+        metaTable = metricsTableFactory.createKafkaConsumerMeta();
       } catch (Exception e) {
         LOG.warn("Cannot access kafka consumer metaTable, will retry in 1 sec.");
         try {
@@ -131,24 +130,21 @@ public final class KafkaMetricsProcessorService extends AbstractExecutionThreadS
 
   private void subscribe() {
     List<Cancellable> cancels = Lists.newArrayList();
-    for (MetricsScope scope : MetricsScope.values()) {
-      // Assuming there is only one process that pulling in all metrics.
-      KafkaConsumer.Preparer preparer = kafkaClient.getConsumer().prepare();
+    // Assuming there is only one process that pulling in all metrics.
+    KafkaConsumer.Preparer preparer = kafkaClient.getConsumer().prepare();
 
-      String topic = topicPrefix + "." + scope.name().toLowerCase();
-      for (int i : partitions) {
-        long offset = getOffset(topic, i);
-        if (offset >= 0) {
-          preparer.add(topic, i, offset);
-        } else {
-          preparer.addFromBeginning(topic, i);
-        }
+    String topic = topicPrefix;
+    for (int i : partitions) {
+      long offset = getOffset(topic, i);
+      if (offset >= 0) {
+        preparer.add(topic, i, offset);
+      } else {
+        preparer.addFromBeginning(topic, i);
       }
-
-      cancels.add(preparer.consume(callbackFactory.create(getMetaTable(), scope)));
-      LOG.info("Consumer created for topic {}, partitions {}", topic, partitions);
     }
-    unsubscribe = createCancelAll(cancels);
+
+    unsubscribe = preparer.consume(callbackFactory.create(getMetaTable()));
+    LOG.info("Consumer created for topic {}, partitions {}", topic, partitions);
   }
 
   private long getOffset(String topic, int partition) {
@@ -166,16 +162,5 @@ public final class KafkaMetricsProcessorService extends AbstractExecutionThreadS
       LOG.error("Failed to get offset from meta table. Defaulting to beginning. {}", e.getMessage(), e);
     }
     return -1L;
-  }
-
-  private Cancellable createCancelAll(final Iterable<? extends Cancellable> cancels) {
-    return new Cancellable() {
-      @Override
-      public void cancel() {
-        for (Cancellable cancel : cancels) {
-          cancel.cancel();
-        }
-      }
-    };
   }
 }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/process/MessageCallbackFactory.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/process/MessageCallbackFactory.java
@@ -24,5 +24,5 @@ import org.apache.twill.kafka.client.KafkaConsumer;
  */
 public interface MessageCallbackFactory {
 
-  KafkaConsumer.MessageCallback create(KafkaConsumerMetaTable metaTable, MetricsScope scope);
+  KafkaConsumer.MessageCallback create(KafkaConsumerMetaTable metaTable);
 }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/process/MetricsMessageCallback.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/process/MetricsMessageCallback.java
@@ -17,7 +17,6 @@ package co.cask.cdap.metrics.process;
 
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.common.io.BinaryDecoder;
-import co.cask.cdap.common.metrics.MetricsScope;
 import co.cask.cdap.internal.io.DatumReader;
 import co.cask.cdap.metrics.transport.MetricValue;
 import co.cask.common.io.ByteBufferInputStream;
@@ -43,17 +42,14 @@ public final class MetricsMessageCallback implements KafkaConsumer.MessageCallba
 
   private static final Logger LOG = LoggerFactory.getLogger(MetricsMessageCallback.class);
 
-  private final MetricsScope scope;
   private final DatumReader<MetricValue> recordReader;
   private final Schema recordSchema;
   private final Set<MetricsProcessor> processors;
   private long recordProcessed;
 
-  public MetricsMessageCallback(MetricsScope scope,
-                                Set<MetricsProcessor> processors,
+  public MetricsMessageCallback(Set<MetricsProcessor> processors,
                                 DatumReader<MetricValue> recordReader,
                                 Schema recordSchema) {
-    this.scope = scope;
     this.processors = processors;
     this.recordReader = recordReader;
     this.recordSchema = recordSchema;
@@ -82,12 +78,12 @@ public final class MetricsMessageCallback implements KafkaConsumer.MessageCallba
     }
     // Invoke processors one by one.
     for (MetricsProcessor processor : processors) {
-      processor.process(scope, new MetricRecordsWrapper(records.iterator()));
+      processor.process(new MetricRecordsWrapper(records.iterator()));
     }
 
     recordProcessed += records.size();
     if (recordProcessed % 1000 == 0) {
-      LOG.info("{} metrics of {} records processed", scope, recordProcessed);
+      LOG.info("{} metrics records processed", recordProcessed);
       LOG.info("Last record time: {}", records.get(records.size() - 1).getTimestamp());
     }
   }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/process/MetricsMessageCallbackFactory.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/process/MetricsMessageCallbackFactory.java
@@ -17,7 +17,6 @@ package co.cask.cdap.metrics.process;
 
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.data.schema.UnsupportedTypeException;
-import co.cask.cdap.common.metrics.MetricsScope;
 import co.cask.cdap.internal.io.DatumReader;
 import co.cask.cdap.internal.io.DatumReaderFactory;
 import co.cask.cdap.internal.io.SchemaGenerator;
@@ -59,8 +58,8 @@ public final class MetricsMessageCallbackFactory implements MessageCallbackFacto
   }
 
   @Override
-  public KafkaConsumer.MessageCallback create(KafkaConsumerMetaTable metaTable, MetricsScope scope) {
+  public KafkaConsumer.MessageCallback create(KafkaConsumerMetaTable metaTable) {
     return new PersistedMessageCallback(
-      new MetricsMessageCallback(scope, processors, datumReader, recordSchema), metaTable, persistThreshold);
+      new MetricsMessageCallback(processors, datumReader, recordSchema), metaTable, persistThreshold);
   }
 }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/process/MetricsProcessor.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/process/MetricsProcessor.java
@@ -16,7 +16,6 @@
 
 package co.cask.cdap.metrics.process;
 
-import co.cask.cdap.common.metrics.MetricsScope;
 import co.cask.cdap.metrics.transport.MetricsRecord;
 
 import java.util.Iterator;
@@ -26,5 +25,5 @@ import java.util.Iterator;
  */
 public interface MetricsProcessor {
 
-  void process(MetricsScope scope, Iterator<MetricsRecord> records);
+  void process(Iterator<MetricsRecord> records);
 }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/process/TimeSeriesMetricsProcessor.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/process/TimeSeriesMetricsProcessor.java
@@ -16,7 +16,6 @@
 
 package co.cask.cdap.metrics.process;
 
-import co.cask.cdap.common.metrics.MetricsScope;
 import co.cask.cdap.data2.OperationException;
 import co.cask.cdap.metrics.data.MetricsTableFactory;
 import co.cask.cdap.metrics.data.TimeSeriesTables;
@@ -47,13 +46,13 @@ public final class TimeSeriesMetricsProcessor implements MetricsProcessor {
   }
 
   @Override
-  public void process(MetricsScope scope, Iterator<MetricsRecord> records) {
+  public void process(Iterator<MetricsRecord> records) {
     try {
       List<MetricsRecord> metricsRecords = Lists.newArrayList();
       while (records.hasNext()) {
         metricsRecords.add(records.next());
         if (metricsRecords.size() == MAX_RECORDLIST_SIZE || !records.hasNext()) {
-          timeSeriesTables.save(scope, metricsRecords);
+          timeSeriesTables.save(metricsRecords);
           metricsRecords.clear();
         }
       }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/MetricsDiscoveryHandler.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/MetricsDiscoveryHandler.java
@@ -16,7 +16,6 @@
 package co.cask.cdap.metrics.query;
 
 import co.cask.cdap.common.conf.Constants;
-import co.cask.cdap.common.metrics.MetricsScope;
 import co.cask.cdap.common.service.ServerException;
 import co.cask.cdap.gateway.auth.Authenticator;
 import co.cask.cdap.metrics.data.AggregatesScanResult;
@@ -48,8 +47,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
 
 /**
- * Class for handling requests for aggregate application metrics of the
- * {@link co.cask.cdap.common.metrics.MetricsScope#USER} scope.
+ * Class for handling requests for aggregate application metrics.
  */
 @Path(Constants.Gateway.API_VERSION_2 + "/metrics/available")
 //todo : clean up the /apps/ endpoints after deprecating old-UI (CDAP-1111)
@@ -57,12 +55,8 @@ public final class MetricsDiscoveryHandler extends BaseMetricsHandler {
 
   private static final Logger LOG = LoggerFactory.getLogger(MetricsDiscoveryHandler.class);
 
-  private final Supplier<Map<MetricsScope, AggregatesTable>> aggregatesTables;
+  private final Supplier<AggregatesTable> aggregatesTable;
 
-  // just user metrics for now.  Can add system metrics when there is a unified way to query for them
-  // currently you query differently depending on the metric, and some metrics you can query for in the
-  // BatchMetricsHandler are computed in the handler and are not stored in the table.
-  private final MetricsScope[] scopesToDiscover = {MetricsScope.USER};
   // known 'program types' in a metric context (app.programType.programId.componentId)
   private enum ProgramType {
     PROCEDURES("p"),
@@ -130,14 +124,10 @@ public final class MetricsDiscoveryHandler extends BaseMetricsHandler {
   public MetricsDiscoveryHandler(Authenticator authenticator, final MetricsTableFactory metricsTableFactory) {
     super(authenticator);
 
-    this.aggregatesTables = Suppliers.memoize(new Supplier<Map<MetricsScope, AggregatesTable>>() {
+    this.aggregatesTable = Suppliers.memoize(new Supplier<AggregatesTable>() {
       @Override
-      public Map<MetricsScope, AggregatesTable> get() {
-        Map<MetricsScope, AggregatesTable> map = Maps.newHashMap();
-        for (MetricsScope scope : MetricsScope.values()) {
-          map.put(scope, metricsTableFactory.createAggregates(scope.name()));
-        }
-        return map;
+      public AggregatesTable get() {
+        return metricsTableFactory.createAggregates();
       }
     });
   }
@@ -222,16 +212,15 @@ public final class MetricsDiscoveryHandler extends BaseMetricsHandler {
     }
 
     Map<String, ContextNode> metricContextsMap = Maps.newHashMap();
-    for (AggregatesTable table : aggregatesTables.get().values()) {
-      AggregatesScanner scanner = table.scanRowsOnly(contextPrefix, metricPrefix);
+    AggregatesTable table = aggregatesTable.get();
+    AggregatesScanner scanner = table.scanRowsOnly(contextPrefix, metricPrefix);
 
-      // scanning through all metric rows in the aggregates table
-      // row has context plus metric info
-      // each metric can show up in multiple contexts
-      while (scanner.hasNext()) {
-        AggregatesScanResult result = scanner.next();
-        addContext(result.getContext(), result.getMetric(), metricContextsMap);
-      }
+    // scanning through all metric rows in the aggregates table
+    // row has context plus metric info
+    // each metric can show up in multiple contexts
+    while (scanner.hasNext()) {
+      AggregatesScanResult result = scanner.next();
+      addContext(result.getContext(), result.getMetric(), metricContextsMap);
     }
 
     // return the metrics sorted by metric name so it can directly be displayed to the user.

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/MetricsRequest.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/MetricsRequest.java
@@ -15,7 +15,6 @@
  */
 package co.cask.cdap.metrics.query;
 
-import co.cask.cdap.common.metrics.MetricsScope;
 import co.cask.cdap.metrics.data.Interpolator;
 
 import java.net.URI;
@@ -70,6 +69,4 @@ interface MetricsRequest {
   int getCount();
 
   Interpolator getInterpolator();
-
-  MetricsScope getScope();
 }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/MetricsRequestBuilder.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/MetricsRequestBuilder.java
@@ -17,7 +17,6 @@ package co.cask.cdap.metrics.query;
 
 import co.cask.cdap.common.metrics.MetricsScope;
 import co.cask.cdap.metrics.data.Interpolator;
-import com.google.common.base.Preconditions;
 
 import java.net.URI;
 
@@ -98,8 +97,11 @@ final class MetricsRequestBuilder {
   }
 
   MetricsRequest build() {
-    return new MetricsRequestImpl(requestURI, contextPrefix, runId, metricPrefix,
-                                  tagPrefix, startTime, endTime, type, resolution, count, scope, interpolator);
+    String metricNamePrefix =
+      scope == null || metricPrefix == null ? metricPrefix : scope.name().toLowerCase() + "." + metricPrefix;
+
+    return new MetricsRequestImpl(requestURI, contextPrefix, runId, metricNamePrefix,
+                                  tagPrefix, startTime, endTime, type, resolution, count, interpolator);
   }
 
   private static class MetricsRequestImpl implements MetricsRequest {
@@ -113,13 +115,11 @@ final class MetricsRequestBuilder {
     private final Type type;
     private final int resolution;
     private final int count;
-    private MetricsScope scope;
     private Interpolator interpolator;
 
     public MetricsRequestImpl(URI requestURI, String contextPrefix, String runId, String metricPrefix, String tagPrefix,
                               long startTime, long endTime, Type type, int resolution,
-                              int count, MetricsScope scope, Interpolator interpolator) {
-      Preconditions.checkNotNull(scope);
+                              int count, Interpolator interpolator) {
       this.contextPrefix = contextPrefix;
       this.requestURI = requestURI;
       this.runId = runId;
@@ -129,7 +129,6 @@ final class MetricsRequestBuilder {
       this.endTime = endTime;
       this.type = type;
       this.count = count;
-      this.scope = scope;
       this.interpolator = interpolator;
       this.resolution = resolution;
     }
@@ -187,11 +186,6 @@ final class MetricsRequestBuilder {
     @Override
     public Interpolator getInterpolator() {
       return interpolator;
-    }
-
-    @Override
-    public MetricsScope getScope() {
-      return scope;
     }
   }
 }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/MetricsRequestExecutor.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/MetricsRequestExecutor.java
@@ -17,7 +17,6 @@
 package co.cask.cdap.metrics.query;
 
 import co.cask.cdap.common.conf.Constants;
-import co.cask.cdap.common.metrics.MetricsScope;
 import co.cask.cdap.common.queue.QueueName;
 import co.cask.cdap.common.utils.ImmutablePair;
 import co.cask.cdap.data2.OperationException;
@@ -61,19 +60,15 @@ public class MetricsRequestExecutor {
   private static final Logger LOG = LoggerFactory.getLogger(MetricsRequestExecutor.class);
   private static final Gson GSON = new Gson();
 
-  private final Supplier<Map<MetricsScope, AggregatesTable>> aggregatesTables;
+  private final Supplier<AggregatesTable> aggregatesTables;
   private final TimeSeriesTables timeSeriesTables;
 
   public MetricsRequestExecutor(final MetricsTableFactory metricsTableFactory) {
     this.timeSeriesTables = new TimeSeriesTables(metricsTableFactory);
-    this.aggregatesTables = Suppliers.memoize(new Supplier<Map<MetricsScope, AggregatesTable>>() {
+    this.aggregatesTables = Suppliers.memoize(new Supplier<AggregatesTable>() {
       @Override
-      public Map<MetricsScope, AggregatesTable> get() {
-        Map<MetricsScope, AggregatesTable> map = Maps.newHashMap();
-        for (final MetricsScope scope : MetricsScope.values()) {
-          map.put(scope, metricsTableFactory.createAggregates(scope.name()));
-        }
-        return map;
+      public AggregatesTable get() {
+        return metricsTableFactory.createAggregates();
       }
     });
   }
@@ -86,14 +81,13 @@ public class MetricsRequestExecutor {
       TimeSeriesResponse.Builder builder = TimeSeriesResponse.builder(metricsRequest.getStartTime(),
                                                                       metricsRequest.getEndTime());
       // Special metrics handle that requires computation from multiple time series.
-      if ("process.busyness".equals(metricsRequest.getMetricPrefix())) {
+      if ("system.process.busyness".equals(metricsRequest.getMetricPrefix())) {
         computeProcessBusyness(metricsRequest, builder);
       } else {
         MetricsScanQuery scanQuery = createScanQuery(metricsRequest);
 
         PeekingIterator<TimeValue> timeValueItor = Iterators.peekingIterator(
-          queryTimeSeries(metricsRequest.getScope(),
-                          scanQuery,
+          queryTimeSeries(scanQuery,
                           metricsRequest.getInterpolator(),
                           metricsRequest.getTimeSeriesResolution()));
 
@@ -123,7 +117,7 @@ public class MetricsRequestExecutor {
 
     } else if (metricsRequest.getType() == MetricsRequest.Type.AGGREGATE) {
       // Special metrics handle that requires computation from multiple aggregates results.
-      if ("process.events.pending".equals(metricsRequest.getMetricPrefix())) {
+      if ("system.process.events.pending".equals(metricsRequest.getMetricPrefix())) {
         resultObj = computeQueueLength(metricsRequest);
       } else {
         resultObj = getAggregates(metricsRequest);
@@ -140,21 +134,20 @@ public class MetricsRequestExecutor {
     long end = (metricsRequest.getEndTime() / resolution) * resolution;
     MetricsScanQuery scanQuery = new MetricsScanQueryBuilder()
       .setContext(metricsRequest.getContextPrefix())
-      .setMetric("process.tuples.read")
+      .setMetric("system.process.tuples.read")
       .build(start, end);
-    MetricsScope scope = metricsRequest.getScope();
 
     PeekingIterator<TimeValue> tuplesReadItor =
-      Iterators.peekingIterator(queryTimeSeries(scope, scanQuery, metricsRequest.getInterpolator(),
+      Iterators.peekingIterator(queryTimeSeries(scanQuery, metricsRequest.getInterpolator(),
                                                 metricsRequest.getTimeSeriesResolution()));
 
     scanQuery = new MetricsScanQueryBuilder()
       .setContext(metricsRequest.getContextPrefix())
-      .setMetric("process.events.processed")
+      .setMetric("system.process.events.processed")
       .build(metricsRequest.getStartTime(), metricsRequest.getEndTime());
 
     PeekingIterator<TimeValue> eventsProcessedItor =
-      Iterators.peekingIterator(queryTimeSeries(scope, scanQuery, metricsRequest.getInterpolator(),
+      Iterators.peekingIterator(queryTimeSeries(scanQuery, metricsRequest.getInterpolator(),
                                                 metricsRequest.getTimeSeriesResolution()));
     long resultTimeStamp = start;
 
@@ -179,14 +172,14 @@ public class MetricsRequestExecutor {
   }
 
   private Object computeQueueLength(MetricsRequest metricsRequest) {
-    AggregatesTable aggregatesTable = aggregatesTables.get().get(metricsRequest.getScope());
+    AggregatesTable aggregatesTable = aggregatesTables.get();
 
     // process.events.processed will have a tag like "input.queue://PurchaseFlow/reader/queue" which indicates
     // where the processed event came from.  So first get the aggregate count for events processed and all the
     // queues they came from. Next, for all those queues, get the aggregate count for events they wrote,
     // and subtract the two to get queue length.
     AggregatesScanner scanner = aggregatesTable.scan(metricsRequest.getContextPrefix(),
-                                                     "process.events.processed",
+                                                     "system.process.events.processed",
                                                      metricsRequest.getRunId(),
                                                      "input");
 
@@ -217,21 +210,22 @@ public class MetricsRequestExecutor {
     long enqueue = 0;
     for (ImmutablePair<String, String> pair : queueNameContexts) {
       // The paths would be /flowId/flowletId/queueSimpleName
-      enqueue += sumAll(aggregatesTable.scan(pair.getSecond(), "process.events.out", "0", pair.getFirst()));
+      enqueue += sumAll(aggregatesTable.scan(pair.getSecond(), "system.process.events.out", "0", pair.getFirst()));
     }
     for (String streamName : streamNames) {
       String ctx = Constants.Gateway.METRICS_CONTEXT + "." + Constants.Gateway.STREAM_HANDLER_NAME;
-      enqueue += sumAll(aggregatesTable.scan(ctx, "collect.events", "0", streamName));
+      enqueue += sumAll(aggregatesTable.scan(ctx, "system.collect.events", "0", streamName));
     }
 
     long len = enqueue - processed;
     return new AggregateResponse(len >= 0 ? len : 0);
   }
 
-  private Iterator<TimeValue> queryTimeSeries(MetricsScope scope, MetricsScanQuery scanQuery,
-                                              Interpolator interpolator, int resolution) throws OperationException {
+  private Iterator<TimeValue> queryTimeSeries(MetricsScanQuery scanQuery, Interpolator interpolator, int resolution)
+    throws OperationException {
+
     Map<TimeseriesId, Iterable<TimeValue>> timeValues = Maps.newHashMap();
-    MetricsScanner scanner = timeSeriesTables.scan(scope, resolution, scanQuery);
+    MetricsScanner scanner = timeSeriesTables.scan(resolution, scanQuery);
     while (scanner.hasNext()) {
       MetricsScanResult res = scanner.next();
       // if we get multiple scan results for the same logical timeseries, concatenate them together.
@@ -249,7 +243,7 @@ public class MetricsRequestExecutor {
   }
 
   private AggregateResponse getAggregates(MetricsRequest request) {
-    AggregatesTable aggregatesTable = aggregatesTables.get().get(request.getScope());
+    AggregatesTable aggregatesTable = aggregatesTables.get();
     AggregatesScanner scanner = aggregatesTable.scan(request.getContextPrefix(), request.getMetricPrefix(),
                                                      request.getRunId(), request.getTagPrefix());
     return new AggregateResponse(sumAll(scanner));

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/MetricsRequestParser.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/MetricsRequestParser.java
@@ -158,6 +158,11 @@ final class MetricsRequestParser {
     Iterator<String> pathParts = Splitter.on('/').omitEmptyStrings().split(path).iterator();
     MetricsRequestContext.Builder contextBuilder = new MetricsRequestContext.Builder();
 
+    // everything
+    if (!pathParts.hasNext()) {
+      return contextBuilder.build();
+    }
+
     // scope is the first part of the path
     String scopeStr = pathParts.next();
     try {

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/MetricsSearchHandler.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/MetricsSearchHandler.java
@@ -27,7 +27,6 @@ import co.cask.cdap.metrics.data.TimeSeriesTable;
 import co.cask.http.HttpResponder;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import org.jboss.netty.handler.codec.http.HttpRequest;
@@ -37,7 +36,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
 import javax.ws.rs.GET;
@@ -54,7 +52,7 @@ import javax.ws.rs.QueryParam;
 @Path(Constants.Gateway.API_VERSION_3 + "/namespaces/{namespace-id}/metrics")
 public class MetricsSearchHandler extends  BaseMetricsHandler {
   private static final Logger LOG = LoggerFactory.getLogger(MetricsDiscoveryHandler.class);
-  private final Supplier<Map<MetricsScope, TimeSeriesTable>> timeSeriesTables;
+  private final Supplier<TimeSeriesTable> timeSeriesTables;
 
   // NOTE: Hour is the lowest resolution and also has the highest TTL compared to minute and second resolutions.
   // highest TTL ensures, this is good for querying all available metrics and also has fewer rows of data points.
@@ -64,14 +62,10 @@ public class MetricsSearchHandler extends  BaseMetricsHandler {
   public MetricsSearchHandler(Authenticator authenticator, final MetricsTableFactory metricsTableFactory) {
     super(authenticator);
 
-    this.timeSeriesTables = Suppliers.memoize(new Supplier<Map<MetricsScope, TimeSeriesTable>>() {
+    this.timeSeriesTables = Suppliers.memoize(new Supplier<TimeSeriesTable>() {
       @Override
-      public Map<MetricsScope, TimeSeriesTable> get() {
-        Map<MetricsScope, TimeSeriesTable> map = Maps.newHashMap();
-        for (MetricsScope scope : MetricsScope.values()) {
-          map.put(scope, metricsTableFactory.createTimeSeries(scope.name(), LOWEST_RESOLUTION));
-        }
-        return map;
+      public TimeSeriesTable get() {
+        return metricsTableFactory.createTimeSeries(LOWEST_RESOLUTION);
       }
     });
   }
@@ -81,9 +75,8 @@ public class MetricsSearchHandler extends  BaseMetricsHandler {
    * Returns all the unique elements available in the first context
    */
   @GET
-  @Path("/{scope}")
+  @Path("/")
   public void listFirstContexts(HttpRequest request, HttpResponder responder,
-                                @PathParam("scope") final String scope,
                                 @QueryParam("search") String search) throws IOException {
     try {
       if (search == null || !search.equals("childContext")) {
@@ -91,8 +84,7 @@ public class MetricsSearchHandler extends  BaseMetricsHandler {
                            "please provide queryparam search for childContext for getting contexts at next level");
         return;
       }
-      MetricsScope metricsScope = MetricsScope.valueOf(scope.toUpperCase());
-      responder.sendJson(HttpResponseStatus.OK, getNextContext(metricsScope, null));
+      responder.sendJson(HttpResponseStatus.OK, getNextContext(null));
     } catch (IllegalArgumentException exception) {
       responder.sendJson(HttpResponseStatus.BAD_REQUEST, "Available scopes are : " + MetricsScope.SYSTEM + " and " +
         MetricsScope.USER);
@@ -106,9 +98,8 @@ public class MetricsSearchHandler extends  BaseMetricsHandler {
    * Returns all the unique elements available in the context after the given context prefix
    */
   @GET
-  @Path("/{scope}/{context}")
+  @Path("/{context}")
   public void listContextsByPrefix(HttpRequest request, HttpResponder responder,
-                                   @PathParam("scope") final String scope,
                                    @PathParam("context") final String context,
                                    @QueryParam("search") String search) throws IOException {
     try {
@@ -117,8 +108,7 @@ public class MetricsSearchHandler extends  BaseMetricsHandler {
                            "please provide queryparam search for childContext for getting contexts at next level");
         return;
       }
-      MetricsScope metricsScope = MetricsScope.valueOf(scope.toUpperCase());
-      responder.sendJson(HttpResponseStatus.OK, getNextContext(metricsScope, context));
+      responder.sendJson(HttpResponseStatus.OK, getNextContext(context));
     } catch (IllegalArgumentException exception) {
       responder.sendJson(HttpResponseStatus.BAD_REQUEST, "Available scopes are : " + MetricsScope.SYSTEM + " and " +
         MetricsScope.USER);
@@ -132,13 +122,11 @@ public class MetricsSearchHandler extends  BaseMetricsHandler {
    * Returns all the unique metrics in the given context
    */
   @GET
-  @Path("/{scope}/{context}/metrics")
+  @Path("/{context}/metrics")
   public void listContextMetrics(HttpRequest request, HttpResponder responder,
-                                 @PathParam("scope") final String scope,
                                  @PathParam("context") final String context) throws IOException {
     try {
-      MetricsScope metricsScope = MetricsScope.valueOf(scope.toUpperCase());
-      responder.sendJson(HttpResponseStatus.OK, getAvailableMetricNames(metricsScope, context));
+      responder.sendJson(HttpResponseStatus.OK, getAvailableMetricNames(context));
     } catch (IllegalArgumentException exception) {
       responder.sendJson(HttpResponseStatus.BAD_REQUEST, "Available scopes are : " + MetricsScope.SYSTEM + " and " +
         MetricsScope.USER);
@@ -148,21 +136,21 @@ public class MetricsSearchHandler extends  BaseMetricsHandler {
     }
   }
 
-  private Set<String> getNextContext(MetricsScope scope, String contextPrefix) throws OperationException {
+  private Set<String> getNextContext(String contextPrefix) throws OperationException {
     SortedSet<String> nextLevelContexts = Sets.newTreeSet();
-    TimeSeriesTable table = timeSeriesTables.get().get(scope);
+    TimeSeriesTable table = timeSeriesTables.get();
     MetricsScanQuery query = new MetricsScanQueryBuilder().setContext(contextPrefix).
       allowEmptyMetric().build(-1, -1);
 
     List<String> results = table.getNextLevelContexts(query);
     for (String nextContext : results) {
       nextContext = (contextPrefix == null) ? nextContext : nextContext.substring(contextPrefix.length() + 1);
-      nextLevelContexts.add(getNextContext(nextContext));
+      nextLevelContexts.add(getNextPart(nextContext));
     }
     return nextLevelContexts;
   }
 
-  private String getNextContext(String context) {
+  private String getNextPart(String context) {
     int index = context.indexOf(".");
     if (index == -1) {
       return context;
@@ -171,9 +159,9 @@ public class MetricsSearchHandler extends  BaseMetricsHandler {
     }
   }
 
-  private Set<String> getAvailableMetricNames(MetricsScope scope, String contextPrefix) throws OperationException {
+  private Set<String> getAvailableMetricNames(String contextPrefix) throws OperationException {
     SortedSet<String> metrics = Sets.newTreeSet();
-    TimeSeriesTable table = timeSeriesTables.get().get(scope);
+    TimeSeriesTable table = timeSeriesTables.get();
     MetricsScanQuery query = new MetricsScanQueryBuilder().setContext(contextPrefix).
       allowEmptyMetric().build(-1, -1);
     metrics.addAll(table.getAllMetrics(query));

--- a/cdap-watchdog/src/test/java/co/cask/cdap/metrics/collect/AggregatedMetricsCollectionServiceTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/metrics/collect/AggregatedMetricsCollectionServiceTest.java
@@ -15,7 +15,6 @@
  */
 package co.cask.cdap.metrics.collect;
 
-import co.cask.cdap.common.metrics.MetricsScope;
 import co.cask.cdap.metrics.transport.MetricValue;
 import co.cask.cdap.test.SlowTests;
 import com.google.common.collect.Iterators;
@@ -43,7 +42,7 @@ public class AggregatedMetricsCollectionServiceTest {
 
     AggregatedMetricsCollectionService service = new AggregatedMetricsCollectionService() {
       @Override
-      protected void publish(MetricsScope scope, Iterator<MetricValue> metrics) {
+      protected void publish(Iterator<MetricValue> metrics) {
         Iterators.addAll(published, metrics);
       }
 

--- a/cdap-watchdog/src/test/java/co/cask/cdap/metrics/collect/KafkaMetricsCollectionServiceTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/metrics/collect/KafkaMetricsCollectionServiceTest.java
@@ -19,7 +19,6 @@ import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.data.schema.UnsupportedTypeException;
 import co.cask.cdap.common.io.BinaryDecoder;
 import co.cask.cdap.common.metrics.MetricsCollectionService;
-import co.cask.cdap.common.metrics.MetricsScope;
 import co.cask.cdap.internal.io.ASMDatumWriterFactory;
 import co.cask.cdap.internal.io.ASMFieldAccessorFactory;
 import co.cask.cdap.internal.io.DatumWriter;
@@ -158,7 +157,7 @@ public class KafkaMetricsCollectionServiceTest {
     // Consume from kafka
     final Map<String, MetricValue> metrics = Maps.newHashMap();
     final Semaphore semaphore = new Semaphore(0);
-    kafkaClient.getConsumer().prepare().addFromBeginning("metrics." + MetricsScope.USER.name().toLowerCase(), 0)
+    kafkaClient.getConsumer().prepare().addFromBeginning("metrics", 0)
                                        .consume(new KafkaConsumer.MessageCallback() {
 
       ReflectionDatumReader<MetricValue> reader = new ReflectionDatumReader<MetricValue>(schema, metricRecordType);

--- a/cdap-watchdog/src/test/java/co/cask/cdap/metrics/data/LevelDBFilterableOVCTableTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/metrics/data/LevelDBFilterableOVCTableTest.java
@@ -60,7 +60,7 @@ public class LevelDBFilterableOVCTableTest {
 
   @Test
   public void testAggregatesQuery() throws OperationException {
-    AggregatesTable table = tableFactory.createAggregates("test");
+    AggregatesTable table = tableFactory.createAggregates();
     List<MetricsRecord> records = Lists.newLinkedList();
     List<TagMetric> tags = Lists.newArrayList();
     long ts = 1317470400;
@@ -112,7 +112,7 @@ public class LevelDBFilterableOVCTableTest {
 
   @Test
   public void testTimeseriesQuery() throws OperationException {
-    TimeSeriesTable tsTable = tableFactory.createTimeSeries("test", 1);
+    TimeSeriesTable tsTable = tableFactory.createTimeSeries(1);
 
     // one below the 1317470400 timebase
     long ts = 1317470399;

--- a/cdap-watchdog/src/test/java/co/cask/cdap/metrics/data/TimeSeriesCleanupTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/metrics/data/TimeSeriesCleanupTest.java
@@ -58,7 +58,7 @@ public class TimeSeriesCleanupTest {
 
   @Test
   public void testDeleteBefore() throws OperationException {
-    TimeSeriesTable timeSeriesTable = tableFactory.createTimeSeries("deleteTimeRange", 1);
+    TimeSeriesTable timeSeriesTable = tableFactory.createTimeSeries(1);
 
     // 2012-10-01T12:00:00
     final long time = 1317470400;

--- a/cdap-watchdog/src/test/java/co/cask/cdap/metrics/query/MetricsRequestParserTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/metrics/query/MetricsRequestParserTest.java
@@ -16,7 +16,6 @@
 package co.cask.cdap.metrics.query;
 
 import co.cask.cdap.common.conf.Constants;
-import co.cask.cdap.common.metrics.MetricsScope;
 import co.cask.cdap.metrics.data.Interpolators;
 import org.junit.Assert;
 import org.junit.Test;
@@ -139,26 +138,17 @@ public class MetricsRequestParserTest {
   }
 
   @Test
-  public void testScope() throws MetricsPathException {
-    MetricsRequest request = MetricsRequestParser.parse(URI.create("/system/apps/app1/reads?summary=true"));
-    Assert.assertEquals(MetricsScope.SYSTEM, request.getScope());
-
-    request = MetricsRequestParser.parse(URI.create("/user/apps/app1/reads?summary=true"));
-    Assert.assertEquals(MetricsScope.USER, request.getScope());
-  }
-
-  @Test
   public void testOverview() throws MetricsPathException  {
     MetricsRequest request = MetricsRequestParser.parse(URI.create("/system/reads?aggregate=true"));
     Assert.assertNull(request.getContextPrefix());
-    Assert.assertEquals("reads", request.getMetricPrefix());
+    Assert.assertEquals("system.reads", request.getMetricPrefix());
   }
 
   @Test
   public void testApps() throws MetricsPathException  {
     MetricsRequest request = MetricsRequestParser.parse(URI.create("/system/apps/app1/reads?aggregate=true"));
     Assert.assertEquals("app1", request.getContextPrefix());
-    Assert.assertEquals("reads", request.getMetricPrefix());
+    Assert.assertEquals("system.reads", request.getMetricPrefix());
   }
 
   @Test
@@ -166,30 +156,30 @@ public class MetricsRequestParserTest {
     MetricsRequest request = MetricsRequestParser.parse(
       URI.create("/system/apps/app1/flows/flow1/flowlets/flowlet1/process.bytes?count=60&start=1&end=61"));
     Assert.assertEquals("app1.f.flow1.flowlet1", request.getContextPrefix());
-    Assert.assertEquals("process.bytes", request.getMetricPrefix());
+    Assert.assertEquals("system.process.bytes", request.getMetricPrefix());
 
     request = MetricsRequestParser.parse(
       URI.create("/system/apps/app1/flows/flow1/some.metric?summary=true"));
     Assert.assertEquals("app1.f.flow1", request.getContextPrefix());
-    Assert.assertEquals("some.metric", request.getMetricPrefix());
+    Assert.assertEquals("system.some.metric", request.getMetricPrefix());
 
     request = MetricsRequestParser.parse(
       URI.create("/system/apps/app1/flows/loads?aggregate=true"));
     Assert.assertEquals("app1.f", request.getContextPrefix());
-    Assert.assertEquals("loads", request.getMetricPrefix());
+    Assert.assertEquals("system.loads", request.getMetricPrefix());
 
     //flow with runId
     request = MetricsRequestParser.parse(
       URI.create("/system/apps/app1/flows/flow1/runs/1234/some.metric?summary=true"));
     Assert.assertEquals("app1.f.flow1", request.getContextPrefix());
-    Assert.assertEquals("some.metric", request.getMetricPrefix());
+    Assert.assertEquals("system.some.metric", request.getMetricPrefix());
     Assert.assertEquals("1234", request.getRunId());
 
     //flowlet with runId
     request = MetricsRequestParser.parse(
       URI.create("/system/apps/app1/flows/flow1/runs/1234/flowlets/flowlet1/some.metric?summary=true"));
     Assert.assertEquals("app1.f.flow1.flowlet1", request.getContextPrefix());
-    Assert.assertEquals("some.metric", request.getMetricPrefix());
+    Assert.assertEquals("system.some.metric", request.getMetricPrefix());
     Assert.assertEquals("1234", request.getRunId());
   }
 
@@ -205,32 +195,32 @@ public class MetricsRequestParserTest {
     MetricsRequest request = MetricsRequestParser.parse(
       URI.create("/system/apps/app1/flows/flow1/flowlets/flowlet1/queues/queue1/process.bytes.in?aggregate=true"));
     Assert.assertEquals("app1.f.flow1.flowlet1", request.getContextPrefix());
-    Assert.assertEquals("process.bytes.in", request.getMetricPrefix());
+    Assert.assertEquals("system.process.bytes.in", request.getMetricPrefix());
     Assert.assertEquals("queue1", request.getTagPrefix());
 
     request = MetricsRequestParser.parse(
       URI.create("/system/apps/app1/flows/flow1/flowlets/flowlet1/queues/queue1/process.bytes.out?aggregate=true"));
     Assert.assertEquals("app1.f.flow1.flowlet1", request.getContextPrefix());
-    Assert.assertEquals("process.bytes.out", request.getMetricPrefix());
+    Assert.assertEquals("system.process.bytes.out", request.getMetricPrefix());
     Assert.assertEquals("queue1", request.getTagPrefix());
 
     request = MetricsRequestParser.parse(
       URI.create("/system/apps/app1/flows/flow1/flowlets/flowlet1/queues/queue1/process.events.in?aggregate=true"));
     Assert.assertEquals("app1.f.flow1.flowlet1", request.getContextPrefix());
-    Assert.assertEquals("process.events.in", request.getMetricPrefix());
+    Assert.assertEquals("system.process.events.in", request.getMetricPrefix());
     Assert.assertEquals("queue1", request.getTagPrefix());
 
     request = MetricsRequestParser.parse(
       URI.create("/system/apps/app1/flows/flow1/flowlets/flowlet1/queues/queue1/process.events.out?aggregate=true"));
     Assert.assertEquals("app1.f.flow1.flowlet1", request.getContextPrefix());
-    Assert.assertEquals("process.events.out", request.getMetricPrefix());
+    Assert.assertEquals("system.process.events.out", request.getMetricPrefix());
     Assert.assertEquals("queue1", request.getTagPrefix());
 
     request = MetricsRequestParser.parse(
       URI.create("/system/apps/app1/flows/flow1/runs/run123/flowlets/flowlet1/queues/queue1/" +
                    "process.events.out?aggregate=true"));
     Assert.assertEquals("app1.f.flow1.flowlet1", request.getContextPrefix());
-    Assert.assertEquals("process.events.out", request.getMetricPrefix());
+    Assert.assertEquals("system.process.events.out", request.getMetricPrefix());
     Assert.assertEquals("queue1", request.getTagPrefix());
     Assert.assertEquals("run123", request.getRunId());
   }
@@ -240,33 +230,33 @@ public class MetricsRequestParserTest {
     MetricsRequest request = MetricsRequestParser.parse(
       URI.create("/system/apps/app1/mapreduce/mapred1/mappers/reads?summary=true"));
     Assert.assertEquals("app1.b.mapred1.m", request.getContextPrefix());
-    Assert.assertEquals("reads", request.getMetricPrefix());
+    Assert.assertEquals("system.reads", request.getMetricPrefix());
 
     request = MetricsRequestParser.parse(
       URI.create("/system/apps/app1/mapreduce/mapred1/reducers/reads?summary=true"));
     Assert.assertEquals("app1.b.mapred1.r", request.getContextPrefix());
-    Assert.assertEquals("reads", request.getMetricPrefix());
+    Assert.assertEquals("system.reads", request.getMetricPrefix());
 
     request = MetricsRequestParser.parse(
       URI.create("/system/apps/app1/mapreduce/mapred1/reads?summary=true"));
     Assert.assertEquals("app1.b.mapred1", request.getContextPrefix());
-    Assert.assertEquals("reads", request.getMetricPrefix());
+    Assert.assertEquals("system.reads", request.getMetricPrefix());
 
     request = MetricsRequestParser.parse(
       URI.create("/system/apps/app1/mapreduce/reads?summary=true"));
     Assert.assertEquals("app1.b", request.getContextPrefix());
-    Assert.assertEquals("reads", request.getMetricPrefix());
+    Assert.assertEquals("system.reads", request.getMetricPrefix());
 
     request = MetricsRequestParser.parse(
       URI.create("/system/apps/app1/mapreduce/mapred1/runs/run123/reads?summary=true"));
     Assert.assertEquals("app1.b.mapred1", request.getContextPrefix());
-    Assert.assertEquals("reads", request.getMetricPrefix());
+    Assert.assertEquals("system.reads", request.getMetricPrefix());
     Assert.assertEquals("run123", request.getRunId());
 
     request = MetricsRequestParser.parse(
       URI.create("/system/apps/app1/mapreduce/mapred1/runs/run123/mappers/reads?summary=true"));
     Assert.assertEquals("app1.b.mapred1.m", request.getContextPrefix());
-    Assert.assertEquals("reads", request.getMetricPrefix());
+    Assert.assertEquals("system.reads", request.getMetricPrefix());
     Assert.assertEquals("run123", request.getRunId());
   }
 
@@ -275,17 +265,17 @@ public class MetricsRequestParserTest {
     MetricsRequest request = MetricsRequestParser.parse(
       URI.create("/system/apps/app1/procedures/proc1/reads?summary=true"));
     Assert.assertEquals("app1.p.proc1", request.getContextPrefix());
-    Assert.assertEquals("reads", request.getMetricPrefix());
+    Assert.assertEquals("system.reads", request.getMetricPrefix());
 
     request = MetricsRequestParser.parse(
       URI.create("/system/apps/app1/procedures/reads?summary=true"));
     Assert.assertEquals("app1.p", request.getContextPrefix());
-    Assert.assertEquals("reads", request.getMetricPrefix());
+    Assert.assertEquals("system.reads", request.getMetricPrefix());
 
     request = MetricsRequestParser.parse(
       URI.create("/system/apps/app1/procedures/proc1/runs/run123/reads?summary=true"));
     Assert.assertEquals("app1.p.proc1", request.getContextPrefix());
-    Assert.assertEquals("reads", request.getMetricPrefix());
+    Assert.assertEquals("system.reads", request.getMetricPrefix());
     Assert.assertEquals("run123", request.getRunId());
   }
 
@@ -294,17 +284,17 @@ public class MetricsRequestParserTest {
     MetricsRequest request = MetricsRequestParser.parse(
       URI.create("/system/apps/app1/services/serve1/reads?summary=true"));
     Assert.assertEquals("app1.u.serve1", request.getContextPrefix());
-    Assert.assertEquals("reads", request.getMetricPrefix());
+    Assert.assertEquals("system.reads", request.getMetricPrefix());
 
     request = MetricsRequestParser.parse(
       URI.create("/system/apps/app1/services/serve1/runnables/run1/reads?summary=true"));
     Assert.assertEquals("app1.u.serve1.run1", request.getContextPrefix());
-    Assert.assertEquals("reads", request.getMetricPrefix());
+    Assert.assertEquals("system.reads", request.getMetricPrefix());
 
     request = MetricsRequestParser.parse(
       URI.create("/system/apps/app1/services/serve1/runs/runid123/runnables/run1/reads?summary=true"));
     Assert.assertEquals("app1.u.serve1.run1", request.getContextPrefix());
-    Assert.assertEquals("reads", request.getMetricPrefix());
+    Assert.assertEquals("system.reads", request.getMetricPrefix());
     Assert.assertEquals("runid123", request.getRunId());
   }
 
@@ -313,12 +303,12 @@ public class MetricsRequestParserTest {
     MetricsRequest request = MetricsRequestParser.parse(
       URI.create("/system/apps/app1/spark/fakespark/sparkmetric?aggregate=true"));
     Assert.assertEquals("app1.s.fakespark", request.getContextPrefix());
-    Assert.assertEquals("sparkmetric", request.getMetricPrefix());
+    Assert.assertEquals("system.sparkmetric", request.getMetricPrefix());
 
     request = MetricsRequestParser.parse(
       URI.create("/system/apps/app1/spark/fakespark/runs/runid123/sparkmetric?aggregate=true"));
     Assert.assertEquals("app1.s.fakespark", request.getContextPrefix());
-    Assert.assertEquals("sparkmetric", request.getMetricPrefix());
+    Assert.assertEquals("system.sparkmetric", request.getMetricPrefix());
     Assert.assertEquals("runid123", request.getRunId());
   }
 
@@ -341,39 +331,39 @@ public class MetricsRequestParserTest {
       URI.create("/system/datasets/dataset1/apps/app1/flows/flow1/runs/run1/" +
                    "flowlets/flowlet1/store.reads?summary=true"));
     Assert.assertEquals("app1.f.flow1.flowlet1", request.getContextPrefix());
-    Assert.assertEquals("store.reads", request.getMetricPrefix());
+    Assert.assertEquals("system.store.reads", request.getMetricPrefix());
     Assert.assertEquals("dataset1", request.getTagPrefix());
     Assert.assertEquals("run1", request.getRunId());
 
     request = MetricsRequestParser.parse(
       URI.create("/system/datasets/dataset1/apps/app1/flows/flow1/store.reads?summary=true"));
     Assert.assertEquals("app1.f.flow1", request.getContextPrefix());
-    Assert.assertEquals("store.reads", request.getMetricPrefix());
+    Assert.assertEquals("system.store.reads", request.getMetricPrefix());
     Assert.assertEquals("dataset1", request.getTagPrefix());
 
     request = MetricsRequestParser.parse(
       URI.create("/system/datasets/dataset1/apps/app1/flows/flow1/runs/123/store.reads?summary=true"));
     Assert.assertEquals("app1.f.flow1", request.getContextPrefix());
-    Assert.assertEquals("store.reads", request.getMetricPrefix());
+    Assert.assertEquals("system.store.reads", request.getMetricPrefix());
     Assert.assertEquals("dataset1", request.getTagPrefix());
     Assert.assertEquals("123", request.getRunId());
 
     request = MetricsRequestParser.parse(
       URI.create("/system/datasets/dataset1/apps/app1/flows/store.reads?summary=true"));
     Assert.assertEquals("app1.f", request.getContextPrefix());
-    Assert.assertEquals("store.reads", request.getMetricPrefix());
+    Assert.assertEquals("system.store.reads", request.getMetricPrefix());
     Assert.assertEquals("dataset1", request.getTagPrefix());
 
     request = MetricsRequestParser.parse(
       URI.create("/system/datasets/dataset1/apps/app1/store.reads?summary=true"));
     Assert.assertEquals("app1", request.getContextPrefix());
-    Assert.assertEquals("store.reads", request.getMetricPrefix());
+    Assert.assertEquals("system.store.reads", request.getMetricPrefix());
     Assert.assertEquals("dataset1", request.getTagPrefix());
 
     request = MetricsRequestParser.parse(
       URI.create("/system/datasets/dataset1/store.reads?summary=true"));
     Assert.assertNull(request.getContextPrefix());
-    Assert.assertEquals("store.reads", request.getMetricPrefix());
+    Assert.assertEquals("system.store.reads", request.getMetricPrefix());
     Assert.assertEquals("dataset1", request.getTagPrefix());
   }
 
@@ -382,7 +372,7 @@ public class MetricsRequestParserTest {
     MetricsRequest request = MetricsRequestParser.parse(
       URI.create("/system/streams/stream1/collect.events?summary=true"));
     Assert.assertNull(request.getContextPrefix());
-    Assert.assertEquals("collect.events", request.getMetricPrefix());
+    Assert.assertEquals("system.collect.events", request.getMetricPrefix());
     Assert.assertEquals("stream1", request.getTagPrefix());
   }
 
@@ -392,7 +382,7 @@ public class MetricsRequestParserTest {
     MetricsRequest request = MetricsRequestParser.parse(
       URI.create("/system/services/appfabric/request.received?aggregate=true"));
     Assert.assertEquals("appfabric", request.getContextPrefix());
-    Assert.assertEquals("request.received", request.getMetricPrefix());
+    Assert.assertEquals("system.request.received", request.getMetricPrefix());
   }
 
 
@@ -402,7 +392,7 @@ public class MetricsRequestParserTest {
       URI.create("/system/services/appfabric/handlers/AppFabricHttpHandler/runs/123/" +
                    "response.server-error?aggregate=true"));
     Assert.assertEquals("appfabric.AppFabricHttpHandler", request.getContextPrefix());
-    Assert.assertEquals("response.server-error", request.getMetricPrefix());
+    Assert.assertEquals("system.response.server-error", request.getMetricPrefix());
     Assert.assertEquals("123", request.getRunId());
   }
 
@@ -412,7 +402,7 @@ public class MetricsRequestParserTest {
       URI.create("/system/services/metrics/handlers/MetricsQueryHandler/methods/handleComponent/" +
                    "response.successful?aggregate=true"));
     Assert.assertEquals("metrics.MetricsQueryHandler.handleComponent", request.getContextPrefix());
-    Assert.assertEquals("response.successful", request.getMetricPrefix());
+    Assert.assertEquals("system.response.successful", request.getMetricPrefix());
   }
 
   @Test(expected = MetricsPathException.class)
@@ -428,7 +418,7 @@ public class MetricsRequestParserTest {
     MetricsRequest request = MetricsRequestParser.parse(
       URI.create("/system/cluster/resources.total.storage?count=1&start=12345678&interpolate=step"));
     Assert.assertEquals("-.cluster", request.getContextPrefix());
-    Assert.assertEquals("resources.total.storage", request.getMetricPrefix());
+    Assert.assertEquals("system.resources.total.storage", request.getMetricPrefix());
   }
 
 
@@ -437,7 +427,7 @@ public class MetricsRequestParserTest {
     MetricsRequest request = MetricsRequestParser.parse(
       URI.create("/system/transactions/invalid?count=1&start=12345678&interpolate=step"));
     Assert.assertEquals("transactions", request.getContextPrefix());
-    Assert.assertEquals("invalid", request.getMetricPrefix());
+    Assert.assertEquals("system.invalid", request.getMetricPrefix());
   }
 
   @Test
@@ -448,14 +438,12 @@ public class MetricsRequestParserTest {
     MetricsRequest request = MetricsRequestParser.parse(
       URI.create("/user/apps/app1/flows/" + encodedWeirdMetric + "?aggregate=true"));
     Assert.assertEquals("app1.f", request.getContextPrefix());
-    Assert.assertEquals(weirdMetric, request.getMetricPrefix());
-    Assert.assertEquals(MetricsScope.USER, request.getScope());
+    Assert.assertEquals("user." + weirdMetric, request.getMetricPrefix());
 
     request = MetricsRequestParser.parse(
       URI.create("/user/apps/app1/" + encodedWeirdMetric + "?aggregate=true"));
     Assert.assertEquals("app1", request.getContextPrefix());
-    Assert.assertEquals(weirdMetric, request.getMetricPrefix());
-    Assert.assertEquals(MetricsScope.USER, request.getScope());
+    Assert.assertEquals("user." + weirdMetric, request.getMetricPrefix());
   }
 
 


### PR DESCRIPTION
Second step, after https://github.com/caskdata/cdap/pull/990. Again, mostly mechanical change. MetricsScope is left only in v2 api handlers, in parsing & building metrics request. Will go away completely after v2 is replaced with v3.

The idea is to move metrics scope (user/system) to a metric prefix. At emit time - it is a tag for user metrics, and absent for all other cases. At processing time it is moved to metric name prefix.