### PR TITLE
clean up the mapreduce api around stream format to allow formats

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/data/stream/StreamBatchReadable.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/data/stream/StreamBatchReadable.java
@@ -24,6 +24,7 @@ import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.flow.flowlet.StreamEvent;
 import co.cask.cdap.api.mapreduce.MapReduceContext;
+import co.cask.cdap.api.stream.GenericStreamEventData;
 import co.cask.cdap.api.stream.StreamEventDecoder;
 import co.cask.cdap.internal.io.SchemaTypeAdapter;
 import com.google.common.base.Charsets;
@@ -122,7 +123,7 @@ public class StreamBatchReadable implements BatchReadable<Long, String> {
   /**
    * Specifies to use the given stream as input of a MapReduce job, using the given {@link FormatSpecification}
    * describing how to read the body of a stream. Using this method means your mapper must use a
-   * mapreduce LongWritable as the map key and a {@link StructuredRecord} as the map value.
+   * mapreduce LongWritable as the map key and {@link GenericStreamEventData} as the map value.
    *
    * @param context The context of the MapReduce job
    * @param streamName Name of the stream

--- a/cdap-api/src/main/java/co/cask/cdap/api/stream/GenericStreamEventData.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/stream/GenericStreamEventData.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.api.stream;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+import javax.annotation.Nonnull;
+
+/**
+ * Represents data in one stream event with the body as a specific type.
+ *
+ * @param <T> Type of the stream body.
+ */
+@Nonnull
+public class GenericStreamEventData<T> {
+
+  private final T body;
+  private final Map<String, String> headers;
+
+  /**
+   * Constructs a {@link GenericStreamEventData} instance. The given body and headers are taken as-is.
+   *
+   * @param headers Map of key/value pairs of the event data
+   * @param body body of the event data
+   */
+  public GenericStreamEventData(Map<String, String> headers, T body) {
+    this.body = body;
+    this.headers = ImmutableMap.copyOf(headers);
+  }
+
+  /**
+   * @return An immutable map of all headers included in this event.
+   */
+  public Map<String, String> getHeaders() {
+    return headers;
+  }
+
+  /**
+   * @return The payload of the event.
+   */
+  public T getBody() {
+    return body;
+  }
+}

--- a/cdap-api/src/main/java/co/cask/cdap/api/stream/StreamEventData.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/stream/StreamEventData.java
@@ -23,10 +23,7 @@ import javax.annotation.Nonnull;
  * Represents data in one stream event.
  */
 @Nonnull
-public class StreamEventData {
-
-  private final ByteBuffer body;
-  private final Map<String, String> headers;
+public class StreamEventData extends GenericStreamEventData<ByteBuffer> {
 
   /**
    * Constructs a {@link StreamEventData} instance. The given body and headers are taken as-is.
@@ -35,21 +32,6 @@ public class StreamEventData {
    * @param body body of the event data
    */
   public StreamEventData(Map<String, String> headers, ByteBuffer body) {
-    this.body = body;
-    this.headers = headers;
-  }
-
-  /**
-   * @return An immutable map of all headers included in this event.
-   */
-  public Map<String, String> getHeaders() {
-    return headers;
-  }
-
-  /**
-   * @return A {@link java.nio.ByteBuffer} that is the payload of the event.
-   */
-  public ByteBuffer getBody() {
-    return body;
+    super(headers, body);
   }
 }

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/StreamInputFormatTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/StreamInputFormatTest.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.data.format.FormatSpecification;
 import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.flow.flowlet.StreamEvent;
+import co.cask.cdap.api.stream.GenericStreamEventData;
 import co.cask.cdap.api.stream.StreamEventData;
 import co.cask.cdap.api.stream.StreamEventDecoder;
 import co.cask.cdap.data.format.SingleStringRecordFormat;
@@ -349,10 +350,11 @@ public class StreamInputFormatTest {
     StreamInputFormat format = new StreamInputFormat();
 
     // read all splits and store the results in the list
-    List<StructuredRecord> recordsRead = Lists.newArrayList();
+    List<GenericStreamEventData<StructuredRecord>> recordsRead = Lists.newArrayList();
     List<InputSplit> inputSplits = format.getSplits(context);
     for (InputSplit split : inputSplits) {
-      RecordReader<LongWritable, StructuredRecord> recordReader = format.createRecordReader(split, context);
+      RecordReader<LongWritable, GenericStreamEventData<StructuredRecord>> recordReader =
+        format.createRecordReader(split, context);
       recordReader.initialize(split, context);
       while (recordReader.nextKeyValue()) {
         recordsRead.add(recordReader.getCurrentValue());
@@ -361,9 +363,9 @@ public class StreamInputFormatTest {
 
     // should only have read 1 record
     Assert.assertEquals(1, recordsRead.size());
-    StructuredRecord record = recordsRead.get(0);
-    Assert.assertEquals(streamEvent.getHeaders(), record.get("headers"));
-    Assert.assertEquals("hello world", record.get("body"));
+    GenericStreamEventData<StructuredRecord> eventData = recordsRead.get(0);
+    Assert.assertEquals(streamEvent.getHeaders(), eventData.getHeaders());
+    Assert.assertEquals("hello world", eventData.getBody().get("body"));
   }
 
   private void generateEvents(File inputDir, int numEvents, long startTime, long timeIncrement,

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamInputFormat.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamInputFormat.java
@@ -17,7 +17,6 @@ package co.cask.cdap.data.stream;
 
 import co.cask.cdap.api.data.format.FormatSpecification;
 import co.cask.cdap.api.data.format.RecordFormat;
-import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.data.schema.UnsupportedTypeException;
 import co.cask.cdap.api.flow.flowlet.StreamEvent;
@@ -329,7 +328,7 @@ public class StreamInputFormat<K, V> extends InputFormat<K, V> {
       // to format the stream body.
       if (decoderClass.isAssignableFrom(FormatStreamEventDecoder.class)) {
         try {
-          RecordFormat<ByteBuffer, StructuredRecord> bodyFormat = getInitializedFormat(conf);
+          RecordFormat<ByteBuffer, V> bodyFormat = getInitializedFormat(conf);
           return (StreamEventDecoder<K, V>) new FormatStreamEventDecoder(bodyFormat);
         } catch (Exception e) {
           throw new IllegalArgumentException("Unable to get the stream body format.");
@@ -342,7 +341,7 @@ public class StreamInputFormat<K, V> extends InputFormat<K, V> {
     }
   }
 
-  private RecordFormat<ByteBuffer, StructuredRecord> getInitializedFormat(Configuration conf)
+  private RecordFormat<ByteBuffer, V> getInitializedFormat(Configuration conf)
     throws UnsupportedTypeException, IllegalAccessException, ClassNotFoundException, InstantiationException {
     String formatSpecStr = conf.get(BODY_FORMAT);
     if (formatSpecStr == null || formatSpecStr.isEmpty()) {
@@ -350,7 +349,7 @@ public class StreamInputFormat<K, V> extends InputFormat<K, V> {
         BODY_FORMAT + " must be set in the configuration in order to use a format for the stream body.");
     }
     FormatSpecification formatSpec = GSON.fromJson(formatSpecStr, FormatSpecification.class);
-    RecordFormat<ByteBuffer, StructuredRecord> recordFormat = RecordFormats.create(formatSpec.getName());
+    RecordFormat<ByteBuffer, V> recordFormat = RecordFormats.create(formatSpec.getName());
     recordFormat.initialize(formatSpec);
     return recordFormat;
   }

--- a/cdap-unit-test/src/test/java/co/cask/cdap/mapreduce/AppWithMapReduceUsingStream.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/mapreduce/AppWithMapReduceUsingStream.java
@@ -27,6 +27,7 @@ import co.cask.cdap.api.dataset.lib.FileSetProperties;
 import co.cask.cdap.api.dataset.lib.KeyValueTable;
 import co.cask.cdap.api.mapreduce.AbstractMapReduce;
 import co.cask.cdap.api.mapreduce.MapReduceContext;
+import co.cask.cdap.api.stream.GenericStreamEventData;
 import co.cask.cdap.data.format.RecordFormats;
 import co.cask.cdap.data.format.SingleStringRecordFormat;
 import com.google.common.base.Throwables;
@@ -79,12 +80,13 @@ public class AppWithMapReduceUsingStream extends AbstractApplication {
   }
 
   // reads input from the stream and records the last timestamp that the body was seen
-  public static class StreamMapper extends Mapper<LongWritable, StructuredRecord, byte[], byte[]> {
+  public static class StreamMapper extends
+    Mapper<LongWritable, GenericStreamEventData<StructuredRecord>, byte[], byte[]> {
 
     @Override
-    public void map(LongWritable key, StructuredRecord streamEvent, Context context)
+    public void map(LongWritable key, GenericStreamEventData<StructuredRecord> eventData, Context context)
       throws IOException, InterruptedException {
-      context.write(Bytes.toBytes((String) streamEvent.get("body")), Bytes.toBytes(key.get()));
+      context.write(Bytes.toBytes((String) eventData.getBody().get("body")), Bytes.toBytes(key.get()));
     }
   }
 


### PR DESCRIPTION
that read the stream body as something other than a
StructuredRecord.