### PR TITLE
Remove OperationException from MDS

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/Store.java
@@ -23,7 +23,6 @@ import co.cask.cdap.api.service.ServiceWorker;
 import co.cask.cdap.app.ApplicationSpecification;
 import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.runtime.ProgramController;
-import co.cask.cdap.data2.OperationException;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.ProgramRunStatus;
@@ -82,35 +81,31 @@ public interface Store {
    * @param endTime   fetch run history that has started before the endTime.
    * @param limit     max number of entries to fetch for this history call.
    * @return          list of logged runs
-   * @throws          OperationException
    */
   List<RunRecord> getRuns(Id.Program id, ProgramRunStatus status,
-                          long startTime, long endTime, int limit) throws OperationException;
+                          long startTime, long endTime, int limit);
 
   /**
    * Creates a new stream if it does not exist.
    * @param id the namespace id
    * @param stream the stream to create
-   * @throws OperationException
    */
-  void addStream(Id.Namespace id, StreamSpecification stream) throws OperationException;
+  void addStream(Id.Namespace id, StreamSpecification stream);
 
   /**
    * Get the spec of a named stream.
    * @param id the namespace id
    * @param name the name of the stream
-   * @throws OperationException
    */
-  StreamSpecification getStream(Id.Namespace id, String name) throws OperationException;
+  StreamSpecification getStream(Id.Namespace id, String name);
 
   /**
    * Get the specs of all streams for a namespace.
    *
    * @param id the namespace id
-   * @throws OperationException
    */
 
-  Collection<StreamSpecification> getAllStreams(Id.Namespace id) throws OperationException;
+  Collection<StreamSpecification> getAllStreams(Id.Namespace id);
 
   /**
    * Creates new application if it doesn't exist. Updates existing one otherwise.
@@ -118,10 +113,9 @@ public interface Store {
    * @param id            application id
    * @param specification application specification to store
    * @param appArchiveLocation location of the deployed app archive
-   * @throws OperationException
    */
   void addApplication(Id.Application id,
-                      ApplicationSpecification specification, Location appArchiveLocation) throws OperationException;
+                      ApplicationSpecification specification, Location appArchiveLocation);
 
 
   /**
@@ -131,36 +125,32 @@ public interface Store {
    * @param id                   ApplicationId
    * @param specification        Application specification
    * @return                     List of ProgramSpecifications that are deleted
-   * @throws OperationException  on errors
    */
   List<ProgramSpecification> getDeletedProgramSpecifications (Id.Application id,
-                                                              ApplicationSpecification specification)
-                                                              throws OperationException;
+                                                              ApplicationSpecification specification);
 
   /**
    * Returns application specification by id.
    *
    * @param id application id
    * @return application specification
-   * @throws OperationException
    */
   @Nullable
-  ApplicationSpecification getApplication(Id.Application id) throws OperationException;
+  ApplicationSpecification getApplication(Id.Application id);
 
   /**
    * Returns a collection of all application specs.
    */
-  Collection<ApplicationSpecification> getAllApplications(Id.Namespace id) throws OperationException;
+  Collection<ApplicationSpecification> getAllApplications(Id.Namespace id);
 
   /**
    * Returns location of the application archive.
    *
    * @param id application id
    * @return application archive location
-   * @throws OperationException
    */
   @Nullable
-  Location getApplicationArchiveLocation(Id.Application id) throws OperationException;
+  Location getApplicationArchiveLocation(Id.Application id);
 
   /**
    * Sets number of instances of specific flowlet.
@@ -168,57 +158,51 @@ public interface Store {
    * @param id flow id
    * @param flowletId flowlet id
    * @param count new number of instances
-   * @throws OperationException
    */
-  void setFlowletInstances(Id.Program id, String flowletId, int count) throws OperationException;
+  void setFlowletInstances(Id.Program id, String flowletId, int count);
 
   /**
    * Gets number of instances of specific flowlet.
    *
    * @param id flow id
    * @param flowletId flowlet id
-   * @throws OperationException
    */
-  int getFlowletInstances(Id.Program id, String flowletId) throws OperationException;
+  int getFlowletInstances(Id.Program id, String flowletId);
 
   /**
    * Set the number of procedure instances.
    *
    * @param id     program id
    * @param count  new number of instances.
-   * @throws OperationException
    * @deprecated As of version 2.6.0, replaced by {@link co.cask.cdap.api.service.Service}
    */
   @Deprecated
-  void setProcedureInstances(Id.Program id, int count) throws OperationException;
+  void setProcedureInstances(Id.Program id, int count);
 
   /**
    * Gets the number of procedure instances.
    *
    * @param id  program id
    * @return    number of instances
-   * @throws OperationException
    * @deprecated As of version 2.6.0, replaced by {@link co.cask.cdap.api.service.Service}
    */
   @Deprecated
-  int getProcedureInstances(Id.Program id) throws OperationException;
+  int getProcedureInstances(Id.Program id);
 
   /**
    * Sets the number of instances of a service.
    *
    * @param id program id
    * @param instances number of instances
-   * @throws OperationException If failed to set the instances
    */
-  void setServiceInstances(Id.Program id, int instances) throws OperationException;
+  void setServiceInstances(Id.Program id, int instances);
 
   /**
    * Returns the number of instances of a service.
    * @param id program id
    * @return number of instances
-   * @throws OperationException
    */
-  int getServiceInstances(Id.Program id) throws OperationException;
+  int getServiceInstances(Id.Program id);
 
   /**
    * Sets the number of instances of a {@link ServiceWorker}.
@@ -226,9 +210,8 @@ public interface Store {
    * @param id program id
    * @param workerName name of the {@link ServiceWorker}
    * @param instances number of instances
-   * @throws OperationException
    */
-  void setServiceWorkerInstances(Id.Program id, String workerName, int instances) throws OperationException;
+  void setServiceWorkerInstances(Id.Program id, String workerName, int instances);
 
   /**
    * Returns the number of instances of a {@link ServiceWorker}.
@@ -236,49 +219,45 @@ public interface Store {
    * @param id program id
    * @param workerName name of the {@link ServiceWorker}.
    * @return number of instances
-   * @throws OperationException
    */
-  int getServiceWorkerInstances(Id.Program id, String workerName) throws OperationException;
+  int getServiceWorkerInstances(Id.Program id, String workerName);
 
   /**
    * Removes all program under the given application and also the application itself.
    *
    * @param id Application id
-   * @throws OperationException
    */
-  void removeApplication(Id.Application id) throws OperationException;
+  void removeApplication(Id.Application id);
 
   /**
    * Removes all applications (with programs) associated with the given namespace.
    *
    * @param id namespace id whose applications to remove
    */
-  void removeAllApplications(Id.Namespace id) throws OperationException;
+  void removeAllApplications(Id.Namespace id);
 
   /**
    * Remove all metadata associated with the given namespace.
    *
    * @param id namespace id whose items to remove
    */
-  void removeAll(Id.Namespace id) throws OperationException;
+  void removeAll(Id.Namespace id);
 
   /**
    * Store the user arguments needed in the run-time.
    *
    * @param programId id of program
    * @param arguments Map of key value arguments
-   * @throws OperationException
    */
-  void storeRunArguments(Id.Program programId, Map<String, String> arguments) throws OperationException;
+  void storeRunArguments(Id.Program programId, Map<String, String> arguments);
 
   /**
    * Get run time arguments for a program.
    *
    * @param programId id of the program.
    * @return Map of key, value pairs
-   * @throws OperationException
    */
-  Map<String, String> getRunArguments(Id.Program programId) throws OperationException;
+  Map<String, String> getRunArguments(Id.Program programId);
 
   /**
    * Changes input stream for a flowlet connection
@@ -286,18 +265,15 @@ public interface Store {
    * @param flowletId flowlet which connection to change
    * @param oldValue name of the stream in stream connection to change
    * @param newValue name of the new stream to connect to
-   * @throws OperationException
    */
-  void changeFlowletSteamConnection(Id.Program flow, String flowletId, String oldValue, String newValue)
-    throws OperationException;
-
+  void changeFlowletSteamConnection(Id.Program flow, String flowletId, String oldValue, String newValue);
   /**
    * Check if a program exists.
    * @param id id of program.
    * @param type type of program.
    * @return true if the program exists, false otherwise.
    */
-  boolean programExists(Id.Program id, ProgramType type) throws OperationException;
+  boolean programExists(Id.Program id, ProgramType type);
 
   /**
    * Creates a new namespace.
@@ -342,9 +318,8 @@ public interface Store {
    *
    * @param id Namespace id
    * @param adapterSpecification specification of the adapter
-   * @throws OperationException on errors.
    */
-  void addAdapter(Id.Namespace id, AdapterSpecification adapterSpecification) throws OperationException;
+  void addAdapter(Id.Namespace id, AdapterSpecification adapterSpecification);
 
   /**
    * Fetch the adapter identified by the name in a give namespace.
@@ -352,34 +327,30 @@ public interface Store {
    * @param id  Namespace id.
    * @param name Adapter name
    * @return an instance of {@link AdapterSpecification}.
-   * @throws OperationException on errors.
    */
-  AdapterSpecification getAdapter(Id.Namespace id, String name) throws OperationException;
+  AdapterSpecification getAdapter(Id.Namespace id, String name);
 
   /**
    * Fetch all the adapters in a given namespace.
    *
    * @param id Namespace id.
    * @return {@link Collection} of Adapter Specification.
-   * @throws OperationException on errors.
    */
-  Collection<AdapterSpecification> getAllAdapters(Id.Namespace id) throws OperationException;
+  Collection<AdapterSpecification> getAllAdapters(Id.Namespace id);
 
   /**
    * Remove the adapter specified by the name in a given namespace.
    *
    * @param id Namespace id.
    * @param name Adapter name.
-   * @throws OperationException on errors.
    */
-  void removeAdapter(Id.Namespace id, String name) throws OperationException;
+  void removeAdapter(Id.Namespace id, String name);
 
   /**
    * Remove all the adapters in a given namespace.
    *
    * @param id Namespace id.
-   * @throws OperationException on errors.
    */
-  void removeAllAdapters(Id.Namespace id) throws OperationException;
+  void removeAllAdapters(Id.Namespace id);
 
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricHttpHandler.java
@@ -32,9 +32,9 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.config.PreferencesStore;
 import co.cask.cdap.data.Namespace;
-import co.cask.cdap.data2.OperationException;
 import co.cask.cdap.data2.datafabric.DefaultDatasetNamespace;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.dataset2.DatasetManagementException;
 import co.cask.cdap.data2.dataset2.NamespacedDatasetFramework;
 import co.cask.cdap.data2.transaction.queue.QueueAdmin;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
@@ -169,7 +169,7 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/ping")
   @GET
   public void ping(HttpRequest request, HttpResponder responder) {
-      responder.sendStatus(HttpResponseStatus.OK);
+    responder.sendStatus(HttpResponseStatus.OK);
   }
 
   /**
@@ -640,8 +640,8 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
   public void getScheduledRunTime(HttpRequest request, HttpResponder responder,
                                   @PathParam("app-id") String appId,
                                   @PathParam("workflow-id") String workflowId) {
-   programLifecycleHttpHandler.getScheduledRunTime(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE,
-                                                   appId, workflowId);
+    programLifecycleHttpHandler.getScheduledRunTime(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE,
+                                                    appId, workflowId);
   }
 
   //TODO [SAGAR]: CDAP-1155: Implement API to get ScheduleSpecification given schedule name
@@ -651,10 +651,10 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
   @GET
   @Path("/apps/{app-id}/workflows/{workflow-id}/schedules")
   public void getWorkflowSchedules(HttpRequest request, HttpResponder responder,
-                                @PathParam("app-id") String appId,
-                                @PathParam("workflow-id") String workflowId) {
+                                   @PathParam("app-id") String appId,
+                                   @PathParam("workflow-id") String workflowId) {
     programLifecycleHttpHandler.getWorkflowSchedules(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE,
-                                                  appId, workflowId);
+                                                     appId, workflowId);
   }
 
   /**
@@ -663,9 +663,9 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
   @GET
   @Path("/apps/{app-id}/workflows/{workflow-id}/schedules/{schedule-id}/status")
   public void getScheduleState(HttpRequest request, HttpResponder responder,
-                              @PathParam("app-id") String appId,
-                              @PathParam("workflow-id") String workflowId,
-                              @PathParam("schedule-id") String scheduleId) {
+                               @PathParam("app-id") String appId,
+                               @PathParam("workflow-id") String workflowId,
+                               @PathParam("schedule-id") String scheduleId) {
     programLifecycleHttpHandler.getScheduleState(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE,
                                                  appId, workflowId, scheduleId);
   }
@@ -761,8 +761,8 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
   @GET
   @Path("/apps/{app-id}/spark/{spark-id}")
   public void sparkSpecification(HttpRequest request, HttpResponder responder,
-                                     @PathParam("app-id") final String appId,
-                                     @PathParam("spark-id")final String sparkId) {
+                                 @PathParam("app-id") final String appId,
+                                 @PathParam("spark-id")final String sparkId) {
     programLifecycleHttpHandler.runnableSpecification(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE,
                                                       appId, ProgramType.SPARK.getCategoryName(), sparkId);
   }
@@ -970,7 +970,7 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
   @GET
   @Path("/apps/{app-id}/spark")
   public void getSparkByApp(HttpRequest request, HttpResponder responder,
-                                @PathParam("app-id") String appId) {
+                            @PathParam("app-id") String appId) {
     programLifecycleHttpHandler.getProgramsByApp(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE, appId,
                                                  ProgramType.SPARK.getCategoryName());
   }
@@ -1069,82 +1069,68 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
     }
   }
 
-  private String getDataEntity(Id.Program programId, Data type, String name) throws Exception {
-    try {
-      Id.Namespace namespace = new Id.Namespace(programId.getNamespaceId());
-      if (type == Data.DATASET) {
-        DatasetSpecification dsSpec = getDatasetSpec(name);
-        String typeName = null;
-        if (dsSpec != null) {
-          typeName = dsSpec.getType();
-        }
-        return GSON.toJson(makeDataSetRecord(name, typeName));
-      } else if (type == Data.STREAM) {
-        StreamSpecification spec = store.getStream(namespace, name);
-        return spec == null ? "" : GSON.toJson(makeStreamRecord(spec.getName(), spec));
+  private String getDataEntity(Id.Program programId, Data type, String name) {
+    Id.Namespace namespace = new Id.Namespace(programId.getNamespaceId());
+    if (type == Data.DATASET) {
+      DatasetSpecification dsSpec = getDatasetSpec(name);
+      String typeName = null;
+      if (dsSpec != null) {
+        typeName = dsSpec.getType();
       }
-      return "";
-    } catch (OperationException e) {
-      LOG.warn(e.getMessage(), e);
-      throw new Exception("Could not retrieve data specs for " + programId.toString() + ", reason: " + e.getMessage());
+      return GSON.toJson(makeDataSetRecord(name, typeName));
+    } else if (type == Data.STREAM) {
+      StreamSpecification spec = store.getStream(namespace, name);
+      return spec == null ? "" : GSON.toJson(makeStreamRecord(spec.getName(), spec));
     }
+    return "";
   }
 
   private String listDataEntities(Id.Program programId, Data type) throws Exception {
-    try {
-      if (type == Data.DATASET) {
-        Collection<DatasetSpecification> instances = dsFramework.getInstances();
-        List<DatasetRecord> result = Lists.newArrayListWithExpectedSize(instances.size());
-        for (DatasetSpecification instance : instances) {
-          result.add(makeDataSetRecord(instance.getName(), instance.getType()));
-        }
-        return GSON.toJson(result);
-      } else if (type == Data.STREAM) {
-        Collection<StreamSpecification> specs = store.getAllStreams(new Id.Namespace(programId.getNamespaceId()));
-        List<StreamRecord> result = Lists.newArrayListWithExpectedSize(specs.size());
-        for (StreamSpecification spec : specs) {
-          result.add(makeStreamRecord(spec.getName(), null));
-        }
-        return GSON.toJson(result);
+    if (type == Data.DATASET) {
+      Collection<DatasetSpecification> instances = dsFramework.getInstances();
+      List<DatasetRecord> result = Lists.newArrayListWithExpectedSize(instances.size());
+      for (DatasetSpecification instance : instances) {
+        result.add(makeDataSetRecord(instance.getName(), instance.getType()));
       }
-      return "";
-    } catch (OperationException e) {
-      LOG.warn(e.getMessage(), e);
-      throw new Exception("Could not retrieve data specs for " + programId.toString() + ", reason: " + e.getMessage());
+      return GSON.toJson(result);
+    } else if (type == Data.STREAM) {
+      Collection<StreamSpecification> specs = store.getAllStreams(new Id.Namespace(programId.getNamespaceId()));
+      List<StreamRecord> result = Lists.newArrayListWithExpectedSize(specs.size());
+      for (StreamSpecification spec : specs) {
+        result.add(makeStreamRecord(spec.getName(), null));
+      }
+      return GSON.toJson(result);
     }
+    return "";
+
   }
 
   private String listDataEntitiesByApp(Id.Program programId, Data type) throws Exception {
-    try {
-      Id.Namespace namespace = new Id.Namespace(programId.getNamespaceId());
-      ApplicationSpecification appSpec = store.getApplication(new Id.Application(
-        namespace, programId.getApplicationId()));
-      if (type == Data.DATASET) {
-        Set<String> dataSetsUsed = dataSetsUsedBy(appSpec);
-        List<DatasetRecord> result = Lists.newArrayListWithExpectedSize(dataSetsUsed.size());
-        for (String dsName : dataSetsUsed) {
-          String typeName = null;
-          DatasetSpecification dsSpec = getDatasetSpec(dsName);
-          if (dsSpec != null) {
-            typeName = dsSpec.getType();
-          }
-          result.add(makeDataSetRecord(dsName, typeName));
+    Id.Namespace namespace = new Id.Namespace(programId.getNamespaceId());
+    ApplicationSpecification appSpec = store.getApplication(new Id.Application(
+      namespace, programId.getApplicationId()));
+    if (type == Data.DATASET) {
+      Set<String> dataSetsUsed = dataSetsUsedBy(appSpec);
+      List<DatasetRecord> result = Lists.newArrayListWithExpectedSize(dataSetsUsed.size());
+      for (String dsName : dataSetsUsed) {
+        String typeName = null;
+        DatasetSpecification dsSpec = getDatasetSpec(dsName);
+        if (dsSpec != null) {
+          typeName = dsSpec.getType();
         }
-        return GSON.toJson(result);
+        result.add(makeDataSetRecord(dsName, typeName));
       }
-      if (type == Data.STREAM) {
-        Set<String> streamsUsed = streamsUsedBy(appSpec);
-        List<StreamRecord> result = Lists.newArrayListWithExpectedSize(streamsUsed.size());
-        for (String streamName : streamsUsed) {
-          result.add(makeStreamRecord(streamName, null));
-        }
-        return GSON.toJson(result);
-      }
-      return "";
-    } catch (OperationException e) {
-      LOG.warn(e.getMessage(), e);
-      throw new Exception("Could not retrieve data specs for " + programId.toString() + ", reason: " + e.getMessage());
+      return GSON.toJson(result);
     }
+    if (type == Data.STREAM) {
+      Set<String> streamsUsed = streamsUsedBy(appSpec);
+      List<StreamRecord> result = Lists.newArrayListWithExpectedSize(streamsUsed.size());
+      for (String streamName : streamsUsed) {
+        result.add(makeStreamRecord(streamName, null));
+      }
+      return GSON.toJson(result);
+    }
+    return "";
   }
 
   @Nullable
@@ -1244,40 +1230,35 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
 
   private String listProgramsByDataAccess(Id.Program programId, ProgramType type, Data data,
                                           String name) throws Exception {
-    try {
-      List<ProgramRecord> result = Lists.newArrayList();
-      Collection<ApplicationSpecification> appSpecs = store.getAllApplications(
-        new Id.Namespace(programId.getNamespaceId()));
-      if (appSpecs != null) {
-        for (ApplicationSpecification appSpec : appSpecs) {
-          if (type == ProgramType.FLOW) {
-            for (FlowSpecification flowSpec : appSpec.getFlows().values()) {
-              if ((data == Data.DATASET && usesDataSet(flowSpec, name))
-                || (data == Data.STREAM && usesStream(flowSpec, name))) {
-                result.add(makeProgramRecord(appSpec.getName(), flowSpec, ProgramType.FLOW));
-              }
+    List<ProgramRecord> result = Lists.newArrayList();
+    Collection<ApplicationSpecification> appSpecs = store.getAllApplications(
+      new Id.Namespace(programId.getNamespaceId()));
+    if (appSpecs != null) {
+      for (ApplicationSpecification appSpec : appSpecs) {
+        if (type == ProgramType.FLOW) {
+          for (FlowSpecification flowSpec : appSpec.getFlows().values()) {
+            if ((data == Data.DATASET && usesDataSet(flowSpec, name))
+              || (data == Data.STREAM && usesStream(flowSpec, name))) {
+              result.add(makeProgramRecord(appSpec.getName(), flowSpec, ProgramType.FLOW));
             }
-          } else if (type == ProgramType.PROCEDURE) {
-            for (ProcedureSpecification procedureSpec : appSpec.getProcedures().values()) {
-              if (data == Data.DATASET && procedureSpec.getDataSets().contains(name)) {
-                result.add(makeProgramRecord(appSpec.getName(), procedureSpec, ProgramType.PROCEDURE));
-              }
+          }
+        } else if (type == ProgramType.PROCEDURE) {
+          for (ProcedureSpecification procedureSpec : appSpec.getProcedures().values()) {
+            if (data == Data.DATASET && procedureSpec.getDataSets().contains(name)) {
+              result.add(makeProgramRecord(appSpec.getName(), procedureSpec, ProgramType.PROCEDURE));
             }
-          } else if (type == ProgramType.MAPREDUCE) {
-            for (MapReduceSpecification mrSpec : appSpec.getMapReduce().values()) {
-              if (data == Data.DATASET && mrSpec.getDataSets().contains(name)) {
-                result.add(makeProgramRecord(appSpec.getName(), mrSpec, ProgramType.MAPREDUCE));
-              }
+          }
+        } else if (type == ProgramType.MAPREDUCE) {
+          for (MapReduceSpecification mrSpec : appSpec.getMapReduce().values()) {
+            if (data == Data.DATASET && mrSpec.getDataSets().contains(name)) {
+              result.add(makeProgramRecord(appSpec.getName(), mrSpec, ProgramType.MAPREDUCE));
             }
           }
         }
       }
-      return GSON.toJson(result);
-    } catch (OperationException e) {
-      LOG.warn(e.getMessage(), e);
-      throw new Exception("Could not retrieve application specs for " +
-                                             programId.toString() + ", reason: " + e.getMessage());
     }
+    return GSON.toJson(result);
+
   }
 
   private static boolean usesDataSet(FlowSpecification flowSpec, String dataset) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
@@ -37,7 +37,6 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.discovery.RandomEndpointStrategy;
 import co.cask.cdap.common.discovery.TimeLimitEndpointStrategy;
 import co.cask.cdap.config.PreferencesStore;
-import co.cask.cdap.data2.OperationException;
 import co.cask.cdap.data2.transaction.queue.QueueAdmin;
 import co.cask.cdap.gateway.auth.Authenticator;
 import co.cask.cdap.gateway.handlers.util.AbstractAppFabricHttpHandler;
@@ -265,7 +264,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
     }
     startStopProgram(request, responder, namespaceId, appId, programType, runnableId, action);
   }
-  
+
   /**
    * Returns program runs based on options it returns either currently running or completed or failed.
    * Default it returns all.
@@ -315,7 +314,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
         return;
       }
       Map<String, String> runtimeArgs = preferencesStore.getProperties(id.getNamespaceId(), appId,
-                                                                         runnableType, runnableId);
+                                                                       runnableType, runnableId);
       responder.sendJson(HttpResponseStatus.OK, runtimeArgs);
     } catch (Throwable e) {
       LOG.error("Error getting runtime args {}", e.getMessage(), e);
@@ -369,7 +368,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
                                                                                 runnableType));
       return;
     }
-    
+
     try {
       Id.Program id = Id.Program.from(namespaceId, appId, runnableId);
       String specification = programSpecificationToString(id, type);
@@ -578,7 +577,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   @GET
   @Path("/services")
   public void getAllServices(HttpRequest request, HttpResponder responder,
-                              @PathParam("namespace-id") String namespaceId) {
+                             @PathParam("namespace-id") String namespaceId) {
     programList(responder, namespaceId, ProgramType.SERVICE, null, store);
   }
 
@@ -828,26 +827,21 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
                                    @PathParam("namespace-id") String namespaceId,
                                    @PathParam("app-id") String appId,
                                    @PathParam("workflow-id") String workflowId) {
-    try {
-      ApplicationSpecification appSpec = store.getApplication(Id.Application.from(namespaceId, appId));
-      if (appSpec == null) {
-        responder.sendString(HttpResponseStatus.NOT_FOUND, "App:" + appId + " not found");
-        return;
-      }
-
-      List<ScheduleSpecification> specList = Lists.newArrayList();
-      for (Map.Entry<String, ScheduleSpecification> entry : appSpec.getSchedules().entrySet()) {
-        ScheduleSpecification spec = entry.getValue();
-        if (spec.getProgram().getProgramName().equals(workflowId) &&
-          spec.getProgram().getProgramType() == SchedulableProgramType.WORKFLOW) {
-          specList.add(entry.getValue());
-        }
-      }
-      responder.sendJson(HttpResponseStatus.OK, specList);
-    } catch (OperationException ex) {
-      LOG.warn("Error while getting schedule specifications for the workflow {}: {}", workflowId, ex.getMessage());
-      responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
+    ApplicationSpecification appSpec = store.getApplication(Id.Application.from(namespaceId, appId));
+    if (appSpec == null) {
+      responder.sendString(HttpResponseStatus.NOT_FOUND, "App:" + appId + " not found");
+      return;
     }
+
+    List<ScheduleSpecification> specList = Lists.newArrayList();
+    for (Map.Entry<String, ScheduleSpecification> entry : appSpec.getSchedules().entrySet()) {
+      ScheduleSpecification spec = entry.getValue();
+      if (spec.getProgram().getProgramName().equals(workflowId) &&
+        spec.getProgram().getProgramType() == SchedulableProgramType.WORKFLOW) {
+        specList.add(entry.getValue());
+      }
+    }
+    responder.sendJson(HttpResponseStatus.OK, specList);
   }
 
   /**
@@ -856,9 +850,9 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   @GET
   @Path("/apps/{app-id}/workflows/{workflow-id}/schedules/{schedule-name}/status")
   public void getScheduleState(HttpRequest request, HttpResponder responder,
-                              @PathParam("namespace-id") String namespaceId, @PathParam("app-id") String appId,
-                              @PathParam("workflow-id") String workflowId,
-                              @PathParam("schedule-name") String scheduleName) {
+                               @PathParam("namespace-id") String namespaceId, @PathParam("app-id") String appId,
+                               @PathParam("workflow-id") String workflowId,
+                               @PathParam("schedule-name") String scheduleName) {
     try {
       Id.Program programId = Id.Program.from(namespaceId, appId, workflowId);
       JsonObject json = new JsonObject();
@@ -943,10 +937,10 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   @GET
   @Path("/apps/{app-id}/services/{service-id}/runnables/{runnable-name}/instances")
   public void getServiceInstances(HttpRequest request, HttpResponder responder,
-                           @PathParam("namespace-id") String namespaceId,
-                           @PathParam("app-id") String appId,
-                           @PathParam("service-id") String serviceId,
-                           @PathParam("runnable-name") String runnableName) {
+                                  @PathParam("namespace-id") String namespaceId,
+                                  @PathParam("app-id") String appId,
+                                  @PathParam("service-id") String serviceId,
+                                  @PathParam("runnable-name") String runnableName) {
     try {
       Id.Program programId = Id.Program.from(namespaceId, appId, serviceId);
       if (!store.programExists(programId, ProgramType.SERVICE)) {
@@ -1052,7 +1046,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
    */
   private void populateRunnableInstances(BatchEndpointInstances requestedObj, String namespaceId, String appId,
                                          ApplicationSpecification spec, ProgramType programType,
-                                         String programId) throws OperationException {
+                                         String programId) {
     int requested;
     String runnableId;
     if (programType == ProgramType.PROCEDURE) {
@@ -1166,31 +1160,31 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
       final SettableFuture<StatusMap> statusFuture = SettableFuture.create();
       workflowClient.getWorkflowStatus(id.getNamespaceId(), id.getApplicationId(),
                                        workflowName, new WorkflowClient.Callback() {
-          @Override
-          public void handle(WorkflowClient.Status status) {
-            StatusMap result = new StatusMap();
+        @Override
+        public void handle(WorkflowClient.Status status) {
+          StatusMap result = new StatusMap();
 
-            if (status.getCode().equals(WorkflowClient.Status.Code.OK)) {
-              result.setStatus("RUNNING");
-              result.setStatusCode(HttpResponseStatus.OK.getCode());
-            } else {
-              //mapreduce name might follow the same format even when its not part of the workflow.
-              try {
-                // getProgramStatus returns program status or http response status NOT_FOUND
-                getProgramStatus(id, type, result);
-              } catch (Exception e) {
-                LOG.error("Exception raised when getting program status for {} {}", id, type, e);
-                // error occurred so say internal server error
-                result.setStatusCode(HttpResponseStatus.INTERNAL_SERVER_ERROR.getCode());
-                result.setError(e.getMessage());
-              }
+          if (status.getCode().equals(WorkflowClient.Status.Code.OK)) {
+            result.setStatus("RUNNING");
+            result.setStatusCode(HttpResponseStatus.OK.getCode());
+          } else {
+            //mapreduce name might follow the same format even when its not part of the workflow.
+            try {
+              // getProgramStatus returns program status or http response status NOT_FOUND
+              getProgramStatus(id, type, result);
+            } catch (Exception e) {
+              LOG.error("Exception raised when getting program status for {} {}", id, type, e);
+              // error occurred so say internal server error
+              result.setStatusCode(HttpResponseStatus.INTERNAL_SERVER_ERROR.getCode());
+              result.setError(e.getMessage());
             }
-
-            // This would make all changes in the result statusMap available to the other thread that doing
-            // the take() call.
-            statusFuture.set(result);
           }
+
+          // This would make all changes in the result statusMap available to the other thread that doing
+          // the take() call.
+          statusFuture.set(result);
         }
+      }
       );
       // wait for status to come back in case we are polling mapreduce status in workflow
       // status map contains either a status or an error
@@ -1511,10 +1505,6 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
       } catch (IllegalArgumentException e) {
         responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR,
                              "Supported options for status of runs are running/completed/failed");
-      } catch (OperationException e) {
-        LOG.warn(String.format(UserMessages.getMessage(UserErrors.PROGRAM_NOT_FOUND),
-                               programId.toString(), e.getMessage()), e);
-        responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
       }
     } catch (SecurityException e) {
       responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);
@@ -1737,7 +1727,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
    * @return
    */
   private int getRunnableCount(String namespaceId, String appId, ProgramType programType,
-                               String programId, String runnableId) throws OperationException {
+                               String programId, String runnableId) {
     Id.Program id = Id.Program.from(namespaceId, appId, programId);
     ProgramLiveInfo info = runtimeService.getLiveInfo(id, programType);
     int count = 0;
@@ -1764,7 +1754,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
     return 1;
   }
 
-  private int getRequestedServiceInstances(Id.Program serviceId, String runnableId) throws OperationException {
+  private int getRequestedServiceInstances(Id.Program serviceId, String runnableId) {
     // Not running on YARN, get it from store
     // If the runnable name is the same as the service name, get the instances from service spec.
     // Otherwise get it from worker spec.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
@@ -38,7 +38,6 @@ import co.cask.cdap.archive.ArchiveBundler;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data.Namespace;
-import co.cask.cdap.data2.OperationException;
 import co.cask.cdap.data2.datafabric.DefaultDatasetNamespace;
 import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
@@ -276,7 +275,7 @@ public class DefaultStore implements Store {
   }
 
   @Override
-  public StreamSpecification getStream(final Id.Namespace id, final String name) throws OperationException {
+  public StreamSpecification getStream(final Id.Namespace id, final String name) {
     return txnl.executeUnchecked(new TransactionExecutor.Function<AppMds, StreamSpecification>() {
       @Override
       public StreamSpecification apply(AppMds mds) throws Exception {
@@ -286,7 +285,7 @@ public class DefaultStore implements Store {
   }
 
   @Override
-  public Collection<StreamSpecification> getAllStreams(final Id.Namespace id) throws OperationException {
+  public Collection<StreamSpecification> getAllStreams(final Id.Namespace id) {
     return txnl.executeUnchecked(new TransactionExecutor.Function<AppMds, Collection<StreamSpecification>>() {
       @Override
       public Collection<StreamSpecification> apply(AppMds mds) throws Exception {
@@ -375,7 +374,7 @@ public class DefaultStore implements Store {
   }
 
   @Override
-  public void setServiceInstances(final Id.Program id, final int instances) throws OperationException {
+  public void setServiceInstances(final Id.Program id, final int instances) {
     Preconditions.checkArgument(instances > 0,
                                 "cannot change number of program instances to negative number: %s", instances);
 
@@ -403,7 +402,7 @@ public class DefaultStore implements Store {
   }
 
   @Override
-  public int getServiceInstances(final Id.Program id) throws OperationException {
+  public int getServiceInstances(final Id.Program id) {
     return txnl.executeUnchecked(new TransactionExecutor.Function<AppMds, Integer>() {
       @Override
       public Integer apply(AppMds mds) throws Exception {
@@ -416,7 +415,7 @@ public class DefaultStore implements Store {
 
   @Override
   public void setServiceWorkerInstances(final Id.Program id,
-                                        final String workerName, final int instances) throws OperationException {
+                                        final String workerName, final int instances) {
     Preconditions.checkArgument(instances > 0,
                                 "cannot change number of program instances to negative number: %s", instances);
 
@@ -453,7 +452,7 @@ public class DefaultStore implements Store {
   }
 
   @Override
-  public int getServiceWorkerInstances(final Id.Program id, final String workerName) throws OperationException {
+  public int getServiceWorkerInstances(final Id.Program id, final String workerName) {
     return txnl.executeUnchecked(new TransactionExecutor.Function<AppMds, Integer>() {
       @Override
       public Integer apply(AppMds mds) throws Exception {
@@ -740,7 +739,7 @@ public class DefaultStore implements Store {
   }
 
   @Override
-  public AdapterSpecification getAdapter(final Id.Namespace id, final String name) throws OperationException {
+  public AdapterSpecification getAdapter(final Id.Namespace id, final String name) {
     return txnl.executeUnchecked(new TransactionExecutor.Function<AppMds, AdapterSpecification>() {
       @Override
       public AdapterSpecification apply(AppMds mds) throws Exception {
@@ -750,7 +749,7 @@ public class DefaultStore implements Store {
   }
 
   @Override
-  public Collection<AdapterSpecification> getAllAdapters(final Id.Namespace id) throws OperationException {
+  public Collection<AdapterSpecification> getAllAdapters(final Id.Namespace id) {
     return txnl.executeUnchecked(new TransactionExecutor.Function<AppMds, Collection<AdapterSpecification>>() {
       @Override
       public Collection<AdapterSpecification> apply(AppMds mds) throws Exception {
@@ -760,7 +759,7 @@ public class DefaultStore implements Store {
   }
 
   @Override
-  public void removeAdapter(final Id.Namespace id, final String name) throws OperationException {
+  public void removeAdapter(final Id.Namespace id, final String name) {
     txnl.executeUnchecked(new TransactionExecutor.Function<AppMds, Void>() {
       @Override
       public Void apply(AppMds mds) throws Exception {
@@ -771,7 +770,7 @@ public class DefaultStore implements Store {
   }
 
   @Override
-  public void removeAllAdapters(final Id.Namespace id) throws OperationException {
+  public void removeAllAdapters(final Id.Namespace id) {
     txnl.executeUnchecked(new TransactionExecutor.Function<AppMds, Void>() {
       @Override
       public Void apply(AppMds mds) throws Exception {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/OperationException.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/OperationException.java
@@ -19,6 +19,7 @@ package co.cask.cdap.data2;
 /**
  * Defines OperationException.
  */
+@Deprecated
 public class OperationException extends Exception {
 
   int statusCode;


### PR DESCRIPTION
OperationException existed in legacy code. We don't need it anymore, the implementation doesn't throw OperationException. 

Removing it now so that the new code that is added doesn't need to follow the same. 