### PR TITLE
(CDAP-960) Added method to filter valid stream partition directory (Stream upload Part 1)

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/file/FileWriters.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/file/FileWriters.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data.file;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Iterators;
+
+import java.io.IOException;
+import java.util.Iterator;
+
+/**
+ * Provides utility methods for interacting with {@link FileWriter}.
+ */
+public final class FileWriters {
+
+  /**
+   * Creates a {@link FileWriter} that writes to the given {@link FileWriter} with each event transformed by the
+   * given transformation function.
+   *
+   * @param writer the {@link FileWriter} to write to
+   * @param transform the transformation function for each individual event
+   * @param <U> source type
+   * @param <V> target type
+   * @return a new instance of {@link FileWriter}
+   */
+  public static <U, V> FileWriter<U> transform(final FileWriter<V> writer, final Function<U, V> transform) {
+    return new FileWriter<U>() {
+      @Override
+      public void append(U event) throws IOException {
+        writer.append(transform.apply(event));
+      }
+
+      @Override
+      public void appendAll(Iterator<? extends U> events) throws IOException {
+        writer.appendAll(Iterators.transform(events, transform));
+      }
+
+      @Override
+      public void close() throws IOException {
+        writer.close();
+      }
+
+      @Override
+      public void flush() throws IOException {
+        writer.flush();
+      }
+    };
+  }
+
+  private FileWriters() {
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamInputSplitFinder.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamInputSplitFinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -74,13 +74,14 @@ public class StreamInputSplitFinder<T> {
     for (FileStatus partitionStatus : fs.listStatus(path)) {
 
       // partition should be directory
-      if (!partitionStatus.isDirectory()) {
+      String pathName = partitionStatus.getPath().getName();
+      if (!partitionStatus.isDirectory() || !StreamUtils.isPartition(pathName)) {
         continue;
       }
 
       // Match the time range
-      long partitionStartTime = StreamUtils.getPartitionStartTime(partitionStatus.getPath().getName());
-      long partitionEndTime = StreamUtils.getPartitionEndTime(partitionStatus.getPath().getName());
+      long partitionStartTime = StreamUtils.getPartitionStartTime(pathName);
+      long partitionEndTime = StreamUtils.getPartitionEndTime(pathName);
       if (partitionStartTime > endTime || partitionEndTime <= startTime) {
         continue;
       }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamUtils.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -144,10 +144,34 @@ public final class StreamUtils {
    */
   public static long getPartitionStartTime(String partitionName) {
     int idx = partitionName.indexOf('.');
-    Preconditions.checkArgument(idx >= 0,
+    Preconditions.checkArgument(idx > 0,
                                 "Invalid partition name %s. Partition name should be of format %s",
                                 partitionName, "[startTimestamp].[duration]");
     return TimeUnit.MILLISECONDS.convert(Long.parseLong(partitionName.substring(0, idx)), TimeUnit.SECONDS);
+  }
+
+  /**
+   * Returns true if it is valid partition name, false other. The partition name must be
+   * {@code [0-9]+.[0-9]+}
+   */
+  public static boolean isPartition(String partitionName) {
+    int dotPos = -1;
+    for (int i = 0; i < partitionName.length(); i++) {
+      char c = partitionName.charAt(i);
+      if (c == '.') {
+        // Make sure there is only one '.'
+        if (dotPos >= 0) {
+          return false;
+        }
+        dotPos = i;
+        continue;
+      }
+      if (c < '0' || c > '9') {
+        return false;
+      }
+    }
+    // Must sure '.' is not the first character and not the last
+    return dotPos > 0 && dotPos < partitionName.length() - 1;
   }
 
   /**

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamFetchHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamFetchHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -236,7 +236,7 @@ public final class StreamFetchHandler extends AuthenticatedHttpHandler {
 
     for (Location location : baseLocation.list()) {
       // Partition must be a directory
-      if (!location.isDirectory()) {
+      if (!location.isDirectory() || !StreamUtils.isPartition(location.getName())) {
         continue;
       }
       long partitionStartTime = StreamUtils.getPartitionStartTime(location.getName());

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/AbstractStreamFileConsumerFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/AbstractStreamFileConsumerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -224,7 +224,7 @@ public abstract class AbstractStreamFileConsumerFactory implements StreamConsume
                                                                     streamConfig.getPartitionDuration());
 
     for (Location partitionLocation : streamLocation.list()) {
-      if (!partitionLocation.isDirectory()) {
+      if (!partitionLocation.isDirectory() || !StreamUtils.isPartition(partitionLocation.getName())) {
         // Partition should be a directory
         continue;
       }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data/stream/StreamUtilsTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data/stream/StreamUtilsTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data.stream;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link StreamUtils}.
+ */
+public class StreamUtilsTest {
+
+  @Test
+  public void testValidPartition() {
+    Assert.assertTrue(StreamUtils.isPartition("00012345.00345"));
+    Assert.assertTrue(StreamUtils.isPartition("1.1"));
+
+    Assert.assertFalse(StreamUtils.isPartition(".1"));
+    Assert.assertFalse(StreamUtils.isPartition("123."));
+
+    Assert.assertFalse(StreamUtils.isPartition("12345"));
+    Assert.assertFalse(StreamUtils.isPartition("abc.123"));
+  }
+}


### PR DESCRIPTION
This is a preparation step to support file upload REST endpoint. When the REST endpoint is added, there will be temp directory created under the stream directory, which could affect logic that scans the stream directory for set of partitions.

Also, piggy-back an addition of `FileWriters` util class, which is a pretty straightforward class right now.