### PR TITLE
(CDAP-960) Collections of small stream changes

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/InMemoryStreamFileWriterFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/InMemoryStreamFileWriterFactory.java
@@ -55,6 +55,12 @@ public final class InMemoryStreamFileWriterFactory implements StreamFileWriterFa
   }
 
   @Override
+  public String getFileNamePrefix() {
+    // There is no file being created
+    return "";
+  }
+
+  @Override
   public FileWriter<StreamEvent> create(StreamConfig config, int generation) throws IOException {
     final QueueProducer producer = queueClientFactory.createProducer(QueueName.fromStream(config.getName()));
     final List<TransactionAware> txAwares = Lists.newArrayList();

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/LocationStreamFileWriterFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/LocationStreamFileWriterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -23,7 +23,6 @@ import co.cask.cdap.data.file.FileWriter;
 import co.cask.cdap.data.stream.StreamFileWriterFactory;
 import co.cask.cdap.data.stream.StreamUtils;
 import co.cask.cdap.data.stream.TimePartitionedStreamFileWriter;
-import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.data2.transaction.stream.StreamConfig;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
@@ -38,15 +37,18 @@ import java.io.IOException;
  */
 public final class LocationStreamFileWriterFactory implements StreamFileWriterFactory {
 
-  private final StreamAdmin streamAdmin;
   private final String filePrefix;
 
   @Inject
-  LocationStreamFileWriterFactory(CConfiguration cConf, StreamAdmin streamAdmin) {
-    this.streamAdmin = streamAdmin;
+  LocationStreamFileWriterFactory(CConfiguration cConf) {
     this.filePrefix = String.format("%s.%d",
                                     cConf.get(Constants.Stream.FILE_PREFIX),
                                     cConf.getInt(Constants.Stream.CONTAINER_INSTANCE_ID, 0));
+  }
+
+  @Override
+  public String getFileNamePrefix() {
+    return filePrefix;
   }
 
   @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamDataFileWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamDataFileWriter.java
@@ -24,6 +24,7 @@ import co.cask.cdap.common.io.Encoder;
 import co.cask.cdap.common.stream.StreamEventDataCodec;
 import co.cask.cdap.data.file.FileWriter;
 import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.io.Closeables;
@@ -75,7 +76,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  * </pre>
  */
 @NotThreadSafe
-public final class StreamDataFileWriter implements Closeable, Flushable, FileWriter<StreamEvent> {
+public final class StreamDataFileWriter implements TimestampCloseable, Flushable, FileWriter<StreamEvent> {
 
   private static final int BUFFER_SIZE = 256 * 1024;    // 256K
 
@@ -192,10 +193,9 @@ public final class StreamDataFileWriter implements Closeable, Flushable, FileWri
     }
   }
 
-  /**
-   * Returns the timestamp when this writer was closed or {@code -1} if this writer is not yet closed.
-   */
+  @Override
   public long getCloseTimestamp() {
+    Preconditions.checkState(closed, "Writer not closed");
     return closeTimestamp;
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/TimePartitionedStreamFileWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/TimePartitionedStreamFileWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -146,33 +146,8 @@ public class TimePartitionedStreamFileWriter extends PartitionedFileWriter<Strea
       // Always try to create the directory
       partitionDirectory.mkdirs();
 
-      // Try to find the file of this bucket with the highest sequence number.
-      int maxSequence = -1;
-      for (Location location : partitionDirectory.list()) {
-        String fileName = location.getName();
-        if (fileName.startsWith(fileNamePrefix)) {
-          StreamUtils.getSequenceId(fileName);
-
-          int idx = fileName.lastIndexOf('.');
-          if (idx < fileNamePrefix.length()) {
-            LOG.warn("Ignore file with invalid stream file name {}", location.toURI());
-            continue;
-          }
-
-          try {
-            // File name format is [prefix].[sequenceId].[dat|idx]
-            int seq = StreamUtils.getSequenceId(fileName);
-            if (seq > maxSequence) {
-              maxSequence = seq;
-            }
-          } catch (NumberFormatException e) {
-            LOG.warn("Ignore stream file with invalid sequence id {}", location.toURI());
-          }
-        }
-      }
-
-      // Create the event and index file with the max sequence + 1
-      int fileSequence = maxSequence + 1;
+      // Create the event and index file with the next sequence id
+      int fileSequence = StreamUtils.getNextSequenceId(partitionDirectory, fileNamePrefix);
       Location eventFile = StreamUtils.createStreamLocation(partitionDirectory, fileNamePrefix,
                                                             fileSequence, StreamFileType.EVENT);
       Location indexFile = StreamUtils.createStreamLocation(partitionDirectory, fileNamePrefix,

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/TimestampCloseable.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/TimestampCloseable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -13,23 +13,20 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package co.cask.cdap.data.stream;
 
-import co.cask.cdap.api.flow.flowlet.StreamEvent;
-import co.cask.cdap.data.file.FileWriter;
-import co.cask.cdap.data2.transaction.stream.StreamConfig;
-
-import java.io.IOException;
+import java.io.Closeable;
 
 /**
- *
+ * A {@link Closeable} that also provides timestamp when the actual close operation happened.
  */
-public interface StreamFileWriterFactory {
+public interface TimestampCloseable extends Closeable {
 
   /**
-   * Returns the file name prefix of all stream files created through this factory.
+   * Returns timestamp in milliseconds when the close operation happened.
+   *
+   * @throws IllegalStateException if close operation hasn't been performed
    */
-  String getFileNamePrefix();
-
-  FileWriter<StreamEvent> create(StreamConfig config, int generation) throws IOException;
+  long getCloseTimestamp();
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/MutableStreamEvent.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/MutableStreamEvent.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data.stream.service;
+
+import co.cask.cdap.api.flow.flowlet.StreamEvent;
+import co.cask.cdap.api.stream.StreamEventData;
+
+import java.nio.ByteBuffer;
+import java.util.Map;
+import javax.annotation.concurrent.NotThreadSafe;
+
+/**
+ * A mutable {@link StreamEvent} that allows setting the data and timestamp.
+ */
+@NotThreadSafe
+public final class MutableStreamEvent extends StreamEvent {
+
+  private StreamEventData data;
+  private long timestamp;
+
+  /**
+   * Sets the event data and timestamp.
+
+   * @return this instance
+   */
+  public MutableStreamEvent set(StreamEventData data, long timestamp) {
+    return setData(data).setTimestamp(timestamp);
+  }
+
+  /**
+   * Sets the event data.
+   *
+   * @param data the data to set
+   * @return this instance
+   */
+  public MutableStreamEvent setData(StreamEventData data) {
+    this.data = data;
+    return this;
+  }
+
+  /**
+   * Sets the event timestamp.
+   *
+   * @param timestamp the timestamp to set
+   * @return this instance
+   */
+  public MutableStreamEvent setTimestamp(long timestamp) {
+    this.timestamp = timestamp;
+    return this;
+  }
+
+  @Override
+  public long getTimestamp() {
+    return timestamp;
+  }
+
+  @Override
+  public ByteBuffer getBody() {
+    return data.getBody();
+  }
+
+  @Override
+  public Map<String, String> getHeaders() {
+    return data.getHeaders();
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/MutableStreamEventData.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/MutableStreamEventData.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data.stream.service;
+
+import co.cask.cdap.api.stream.StreamEventData;
+import co.cask.cdap.common.io.ByteBuffers;
+import com.google.common.collect.ImmutableMap;
+
+import java.nio.ByteBuffer;
+import java.util.Map;
+import javax.annotation.concurrent.NotThreadSafe;
+
+/**
+ * A mutable {@link StreamEventData} that allows setting header and body.
+ */
+@NotThreadSafe
+public final class MutableStreamEventData extends StreamEventData {
+
+  private ByteBuffer body;
+  private Map<String, String> headers;
+
+  public MutableStreamEventData() {
+    super(ImmutableMap.<String, String>of(), ByteBuffers.EMPTY_BUFFER);
+    body = ByteBuffers.EMPTY_BUFFER;
+    headers = ImmutableMap.of();
+  }
+
+  @Override
+  public ByteBuffer getBody() {
+    return body;
+  }
+
+  @Override
+  public Map<String, String> getHeaders() {
+    return headers;
+  }
+
+  public MutableStreamEventData setBody(ByteBuffer body) {
+    this.body = body;
+    return this;
+  }
+
+  public MutableStreamEventData setHeaders(Map<String, String> headers) {
+    this.headers = headers;
+    return this;
+  }
+}


### PR DESCRIPTION
1. Expose the stream file prefix from the StreamFileWriterFactory
2. Introduce interface TimestampCloseable interface and have StreamDataFileWriter implements it to expose close timestamp
3. Add new classes MutableStreamEventData and MutableStreamEvent
4. Refactor TimePartitionStreamFileWriter