### PR TITLE
Increase the test timeout for DFS concurrent writer test

### DIFF
--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/service/ConcurrentStreamWriterTestBase.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/service/ConcurrentStreamWriterTestBase.java
@@ -148,7 +148,7 @@ public abstract class ConcurrentStreamWriterTestBase {
     }
 
     startLatch.countDown();
-    Assert.assertTrue(completion.await(5, TimeUnit.SECONDS));
+    Assert.assertTrue(completion.await(60, TimeUnit.SECONDS));
 
     // Verify all events are written.
     // There should be only one partition


### PR DESCRIPTION
- It seems like it sometime takes longer than 5 seconds to finish on slow machine.