### PR TITLE
Fixes workflow ui with changes in backend API

### DIFF
--- a/cdap-web-app/client/core/controllers/workflow-status.js
+++ b/cdap-web-app/client/core/controllers/workflow-status.js
@@ -24,10 +24,11 @@ define(['helpers/plumber'], function (Plumber) {
         model.actions[i].running = false;
 
         model.actions[i].appId = self.get('model').app;
-        model.actions[i].divId = model.actions[i].name.replace(' ', '');
+        model.actions[i].divId = model.actions[i].programName.replace(' ', '');
 
-        if (model.actions[i].properties && 'mapReduceName' in model.actions[i].properties) {
+        if (model.actions[i].programType === 'MAPREDUCE') {
           var transformedModel = C.Mapreduce.transformModel(model.actions[i]);
+          transformedModel.name = model.actions[i].programName;
           var mrModel = C.Mapreduce.create(transformedModel);
           this.get('elements.Action.content').push(mrModel);
         } else {
@@ -37,9 +38,7 @@ define(['helpers/plumber'], function (Plumber) {
       }
 
       this.HTTP.rest(model.get('context') + '/schedules', function (all) {
-
         self.get('elements.Schedule').clear();
-
         var i = all.length, schedules = [];
         while (i--) {
           schedules.unshift(Em.Object.create({ id: all[i] }));
@@ -196,7 +195,7 @@ define(['helpers/plumber'], function (Plumber) {
       var context = this.get('model.context');
 
       this.get('elements.Schedule').forEach(function (schedule, index) {
-        self.HTTP.rest(context, 'schedules', schedule.id, 'status', function (status) {
+        self.HTTP.rest(context, 'schedules', schedule.id.program.programName, 'status', function (status) {
 
           if (status.status === 'SUSPENDED') {
             self.set('suspended', true);

--- a/cdap-web-app/client/core/models/mapreduce.js
+++ b/cdap-web-app/client/core/models/mapreduce.js
@@ -25,7 +25,7 @@ define(['core/lib/date', 'core/models/program'],
 
   var EXPECTED_FIELDS = [
     'divId',
-    'name',
+    'programName',
     'description',
     'datasets',
     'inputDataSet',

--- a/cdap-web-app/client/index.html
+++ b/cdap-web-app/client/index.html
@@ -1085,13 +1085,14 @@
             {{#each elements.Action}}
             <div class="batch-item" {{bindAttr id="divId"}} {{action loadAction this}} style="cursor: pointer;">
               <div class="batch-icon batch-map">
+                {{programType}}
                 <div class="info-window">
                   {{#if running}}
                     <div class="window-icon running"></div>
                   {{else}}
                     <div class="window-icon"></div>
                   {{/if}}
-                  <div class="batch-phase">{{name}}</div>
+                  <div class="batch-phase">{{programName}}</div>
                 </div>
               </div>
             </div>
@@ -1154,7 +1155,7 @@
       </ul>
       <h1>
         <span>Mapreduce</span>
-        <span class="breadcrumb-app-name"><a {{bindAttr href="model.appHref"}}>{{model.app}}</a> : {{model.name}}
+        <span class="breadcrumb-app-name"><a {{bindAttr href="model.appHref"}}>{{model.app}}</a> : {{model.programName}}
         </span>
       </h1>
     </div>


### PR DESCRIPTION
Fixes the workflow UI based on changes in the backend API.

Existing API returned everything (schedules, mapreduces etc.,) in the same API call (apps/PurchaseHistory/workflows/PurchaseHistoryWorkflow)

Right now this has been split up into separate calls for schedules and mapreduce. 

The structure of actions in a workflow and structure of schedules object are the ones changed. The UI changes are related to changing the property names to appropriate changes in the API.