### PR TITLE
(CDAP-1098) Use sendJson instead of explicitly setting header type

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppLifecycleHttpHandler.java
@@ -59,7 +59,6 @@ import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.ProgramTypes;
 import co.cask.http.BodyConsumer;
 import co.cask.http.HttpResponder;
-import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.base.Throwables;
@@ -471,7 +470,7 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
 
     try {
       Id.Namespace accId = Id.Namespace.from(namespaceId);
-      List<ApplicationRecord> result = Lists.newArrayList();
+      List<ApplicationRecord> appRecords = Lists.newArrayList();
       List<ApplicationSpecification> specList;
       if (appId == null) {
         specList = new ArrayList<ApplicationSpecification>(store.getAllApplications(accId));
@@ -485,18 +484,14 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
       }
 
       for (ApplicationSpecification appSpec : specList) {
-        result.add(makeAppRecord(appSpec));
+        appRecords.add(makeAppRecord(appSpec));
       }
 
-      String json;
       if (appId == null) {
-        json = GSON.toJson(result);
+        responder.sendJson(HttpResponseStatus.OK, appRecords);
       } else {
-        json = GSON.toJson(result.get(0));
+        responder.sendJson(HttpResponseStatus.OK, appRecords.get(0));
       }
-
-      responder.sendByteArray(HttpResponseStatus.OK, json.getBytes(Charsets.UTF_8),
-                              ImmutableMultimap.of(HttpHeaders.Names.CONTENT_TYPE, "application/json"));
     } catch (SecurityException e) {
       LOG.debug("Security Exception while retrieving app details: ", e);
       responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
@@ -371,12 +371,11 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
 
     try {
       Id.Program id = Id.Program.from(namespaceId, appId, runnableId);
-      String specification = programSpecificationToString(id, type);
-      if (specification == null || specification.isEmpty()) {
+      ProgramSpecification specification = getProgramSpecification(id, type);
+      if (specification == null) {
         responder.sendStatus(HttpResponseStatus.NOT_FOUND);
       } else {
-        responder.sendByteArray(HttpResponseStatus.OK, specification.getBytes(Charsets.UTF_8),
-                                ImmutableMultimap.of(HttpHeaders.Names.CONTENT_TYPE, "application/json"));
+        responder.sendJson(HttpResponseStatus.OK, specification);
       }
     } catch (SecurityException e) {
       responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);
@@ -1218,8 +1217,8 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
       if (runtimeInfo == null) {
         if (type != ProgramType.WEBAPP) {
           //Runtime info not found. Check to see if the program exists.
-          String spec = programSpecificationToString(id, type);
-          if (spec == null || spec.isEmpty()) {
+          ProgramSpecification spec = getProgramSpecification(id, type);
+          if (spec == null) {
             // program doesn't exist
             return new ProgramStatus(id.getApplicationId(), id.getId(), HttpResponseStatus.NOT_FOUND.toString());
           } else {
@@ -1282,18 +1281,6 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
     } else {
       return null;
     }
-  }
-
-  /**
-   * Returns {@link ProgramSpecification} as a JSON string if the program exists.
-   * If the program does not exist, it returns an empty string.
-   */
-  private String programSpecificationToString(Id.Program id, ProgramType type) throws Exception {
-    ProgramSpecification programSpec = getProgramSpecification(id, type);
-    if (programSpec == null) {
-      return "";
-    }
-    return GSON.toJson(programSpec);
   }
 
   @Nullable

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/util/AbstractAppFabricHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/util/AbstractAppFabricHttpHandler.java
@@ -34,14 +34,12 @@ import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Lists;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
 import org.jboss.netty.buffer.ChannelBuffer;
 import org.jboss.netty.buffer.ChannelBufferInputStream;
-import org.jboss.netty.handler.codec.http.HttpHeaders;
 import org.jboss.netty.handler.codec.http.HttpRequest;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.slf4j.Logger;
@@ -183,9 +181,7 @@ public abstract class AbstractAppFabricHttpHandler extends AuthenticatedHttpHand
       if (programRecords == null) {
         responder.sendStatus(HttpResponseStatus.NOT_FOUND);
       } else {
-        String result = GSON.toJson(programRecords);
-        responder.sendByteArray(HttpResponseStatus.OK, result.getBytes(Charsets.UTF_8),
-                                ImmutableMultimap.of(HttpHeaders.Names.CONTENT_TYPE, "application/json"));
+        responder.sendJson(HttpResponseStatus.OK, programRecords);
       }
     } catch (SecurityException e) {
       responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/AppLifecycleHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/AppLifecycleHttpHandlerTest.java
@@ -27,6 +27,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
 import org.apache.http.HttpResponse;
+import org.jboss.netty.handler.codec.http.HttpHeaders;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -152,6 +153,7 @@ public class AppLifecycleHttpHandlerTest extends AppFabricTestBase {
     HttpResponse response = doGet(getVersionedAPIPath(String.format("apps/%s", appName),
                                                       Constants.Gateway.API_VERSION_3_TOKEN, namespace));
     Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+    Assert.assertEquals("application/json", response.getFirstHeader(HttpHeaders.Names.CONTENT_TYPE).getValue());
     Type typeToken = new TypeToken<JsonObject>() { }.getType();
     return readResponse(response, typeToken);
   }

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/metrics/MetricsQueryTestRun.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/metrics/MetricsQueryTestRun.java
@@ -30,6 +30,7 @@ import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
+import org.jboss.netty.handler.codec.http.HttpHeaders;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.junit.Assert;
 import org.junit.Test;
@@ -74,7 +75,7 @@ public class MetricsQueryTestRun extends MetricsSuiteTestBase {
 
     // Query for queue length
     HttpPost post = getPost("/v2/metrics");
-    post.setHeader("Content-type", "application/json");
+    post.setHeader(HttpHeaders.Names.CONTENT_TYPE, "application/json");
     post.setEntity(new StringEntity(
       "[\"/system/apps/WordCount/flows/WordCounter/flowlets/unique/process.events.pending?aggregate=true\"]"));
     HttpResponse response = doPost(post);
@@ -293,7 +294,7 @@ public class MetricsQueryTestRun extends MetricsSuiteTestBase {
 
   private static void testSingleMetricWithPost(String resource, int value) throws Exception {
     HttpPost post = getPost("/v2/metrics");
-    post.setHeader("Content-type", "application/json");
+    post.setHeader(HttpHeaders.Names.CONTENT_TYPE, "application/json");
     post.setEntity(new StringEntity("[\"" + resource + "\"]"));
     HttpResponse response = doPost(post);
     Assert.assertEquals("POST " + resource + " did not return 200 status.",
@@ -375,7 +376,7 @@ public class MetricsQueryTestRun extends MetricsSuiteTestBase {
                           HttpStatus.SC_NOT_FOUND, response.getStatusLine().getStatusCode());
       // test POST also fails, but with 400
       HttpPost post = getPost("/v2/metrics");
-      post.setHeader("Content-type", "application/json");
+      post.setHeader(HttpHeaders.Names.CONTENT_TYPE, "application/json");
       post.setEntity(new StringEntity("[\"" + resource + "\"]"));
       response = doPost(post);
       Assert.assertEquals("POST for " + resource + " did not return 400 as expected.",

--- a/cdap-security/src/main/java/co/cask/cdap/security/server/GrantAccessToken.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/server/GrantAccessToken.java
@@ -26,6 +26,7 @@ import com.google.common.base.Charsets;
 import com.google.gson.JsonObject;
 import com.google.inject.Inject;
 import org.apache.commons.codec.binary.Base64;
+import org.jboss.netty.handler.codec.http.HttpHeaders;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -129,8 +130,8 @@ public class GrantAccessToken {
 
     // Set response headers
     response.setContentType("application/json;charset=UTF-8");
-    response.addHeader("Cache-Control", "no-store");
-    response.addHeader("Pragma", "no-cache");
+    response.addHeader(HttpHeaders.Names.CACHE_CONTROL, "no-store");
+    response.addHeader(HttpHeaders.Names.PRAGMA, "no-cache");
 
     // Set response body
     JsonObject json = new JsonObject();

--- a/cdap-security/src/test/java/co/cask/cdap/security/server/ExternalAuthenticationServerTestBase.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/server/ExternalAuthenticationServerTestBase.java
@@ -49,6 +49,7 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.twill.discovery.Discoverable;
 import org.apache.twill.discovery.DiscoveryServiceClient;
+import org.jboss.netty.handler.codec.http.HttpHeaders;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Test;
@@ -208,9 +209,9 @@ public abstract class ExternalAuthenticationServerTestBase {
     verify(TEST_AUDIT_LOGGER, timeout(10000).atLeastOnce()).trace(contains("admin"));
 
     // Test correct headers being returned
-    String cacheControlHeader = response.getFirstHeader("Cache-Control").getValue();
-    String pragmaHeader = response.getFirstHeader("Pragma").getValue();
-    String contentType = response.getFirstHeader("Content-Type").getValue();
+    String cacheControlHeader = response.getFirstHeader(HttpHeaders.Names.CACHE_CONTROL).getValue();
+    String pragmaHeader = response.getFirstHeader(HttpHeaders.Names.PRAGMA).getValue();
+    String contentType = response.getFirstHeader(HttpHeaders.Names.CONTENT_TYPE).getValue();
 
     assertEquals("no-store", cacheControlHeader);
     assertEquals("no-cache", pragmaHeader);


### PR DESCRIPTION
Even when given an explicit header value, `netty-http` overrides the `Content-Type` header value to `octet-stream` when using the `sendByteArray` or `sendBytes` methods (which is probably the right thing to do). Instead I've replaced the calls with `sendJson`, which also cleans up the implementation. 

Some minor unrelated cleanups as well.

Build: https://builds.cask.co/browse/CDAP-DUT553-2/