### PR TITLE
(CDAP-616) Send error string in response upon transaction failure

### DIFF
--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTest.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTest.java
@@ -391,6 +391,7 @@ public class TestFrameworkTest extends TestBase {
       request = HttpRequest.get(url).build();
       response = HttpRequests.execute(request);
       Assert.assertEquals(500, response.getResponseCode());
+      Assert.assertTrue(response.getResponseBodyAsString().contains("Transaction failure"));
 
       // Call the verify ClassLoader endpoint
       url = new URL(serviceURL, "verifyClassLoader");


### PR DESCRIPTION
Along with a 500 response code, send back a response message saying a transaction failure occurred.

https://builds.cask.co/browse/CDAP-DUT560-1/