### PR TITLE
find java executable via sourced common.sh

### DIFF
--- a/cdap-web-app/bin/config-tool
+++ b/cdap-web-app/bin/config-tool
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-web-app/bin/config-tool
+++ b/cdap-web-app/bin/config-tool
@@ -40,6 +40,12 @@ SAVED="`pwd`"
 cd "`dirname \"$PRG\"`/.."
 APP_HOME="`pwd -P`"
 
+# source common.sh
+source ${bin}/common.sh
+
+# find java and set $JAVA
+set_java
+
 # In other environment, the jars are expected to be in <HOME>/lib directory.
 # Load all the jar files. Not ideal, but we need to load only the things that
 # is needed by this script.
@@ -70,4 +76,4 @@ if [ $containsTokenFileArg -eq 0 ] && [ -f $auth_file ]; then
   set -- "$@" "--token-file" "$auth_file"
 fi
 
-java -cp ${CLASSPATH} -Dscript=$script co.cask.cdap.common.conf.ConfigurationJsonTool "$@"
+$JAVA -cp ${CLASSPATH} -Dscript=$script co.cask.cdap.common.conf.ConfigurationJsonTool "$@"

--- a/cdap-web-app/bin/config-tool
+++ b/cdap-web-app/bin/config-tool
@@ -40,10 +40,10 @@ SAVED="`pwd`"
 cd "`dirname \"$PRG\"`/.."
 APP_HOME="`pwd -P`"
 
-# source common.sh
+# Source common.sh
 source ${bin}/common.sh
 
-# find java and set $JAVA
+# Find java and set $JAVA
 set_java
 
 # In other environment, the jars are expected to be in <HOME>/lib directory.


### PR DESCRIPTION
fixes https://issues.cask.co/browse/CDAP-998

This appears to be only used in distributed mode packaged along with the init framework, hence the sourcing of common.sh
