### PR TITLE
Fix dataset caching in contexts based on transaction timeout and runtime...

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DatasetCacheKey.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DatasetCacheKey.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.dataset2;
+
+import com.google.common.base.Objects;
+
+import java.util.Map;
+
+/**
+ * A key used by implementations of {@link DynamicDatasetContext} to cache Datasets. Includes the dataset name
+ * and it's arguments.
+ */
+public final class DatasetCacheKey {
+  private final String name;
+  private final Map<String, String> arguments;
+
+  public DatasetCacheKey(String name, Map<String, String> arguments) {
+    this.name = name;
+    this.arguments = arguments;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    DatasetCacheKey that = (DatasetCacheKey) o;
+
+    return Objects.equal(this.name, that.name) &&
+      Objects.equal(this.arguments, that.arguments);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(name, arguments);
+  }
+}

--- a/cdap-notifications/src/main/java/co/cask/cdap/notifications/service/BasicNotificationContext.java
+++ b/cdap-notifications/src/main/java/co/cask/cdap/notifications/service/BasicNotificationContext.java
@@ -18,6 +18,7 @@ package co.cask.cdap.notifications.service;
 
 import co.cask.cdap.api.TxRunnable;
 import co.cask.cdap.api.dataset.Dataset;
+import co.cask.cdap.data2.dataset2.DatasetCacheKey;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.DynamicDatasetContext;
 import co.cask.tephra.TransactionContext;
@@ -55,7 +56,7 @@ public final class BasicNotificationContext implements NotificationContext {
           runnable.run(new DynamicDatasetContext(context, dsFramework, context.getClass().getClassLoader()) {
             @Nullable
             @Override
-            protected LoadingCache<Long, Map<String, Dataset>> getDatasetsCache() {
+            protected LoadingCache<Long, Map<DatasetCacheKey, Dataset>> getDatasetsCache() {
               return null;
             }
           });

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/AppWithServices.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/AppWithServices.java
@@ -39,6 +39,7 @@ import co.cask.cdap.api.service.http.HttpServiceRequest;
 import co.cask.cdap.api.service.http.HttpServiceResponder;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMap;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
@@ -58,7 +59,9 @@ public class AppWithServices extends AbstractApplication {
   public static final String DATASET_TEST_KEY = "testKey";
   public static final String DATASET_TEST_VALUE = "testValue";
   public static final String DATASET_TEST_KEY_STOP = "testKeyStop";
+  public static final String DATASET_TEST_KEY_STOP_2 = "testKeyStop2";
   public static final String DATASET_TEST_VALUE_STOP = "testValueStop";
+  public static final String DATASET_TEST_VALUE_STOP_2 = "testValueStop2";
   public static final String PROCEDURE_DATASET_KEY = "key";
 
   private static final String DATASET_NAME = "AppWithServicesDataset";
@@ -243,6 +246,23 @@ public class AppWithServices extends AbstractApplication {
           public void run(DatasetContext context) throws Exception {
             KeyValueTable table = context.getDataset(DATASET_NAME);
             table.write(DATASET_TEST_KEY_STOP, valueToWriteOnStop);
+
+            // Test different cases of getting datasets - datasets with the same arguments should be the same instance
+            // while datasets with different arguments should be different instances
+            KeyValueTable table2 = context.getDataset(DATASET_NAME, ImmutableMap.of("arg", "value"));
+            KeyValueTable table3 = context.getDataset(DATASET_NAME, ImmutableMap.of("arg", "value"));
+            KeyValueTable table4 = context.getDataset(DATASET_NAME, ImmutableMap.of("arg", "value2"));
+
+            // table and table2 have different arguments and thus should be different instances
+            if (System.identityHashCode(table) != System.identityHashCode(table2)) {
+              // table2 and table3 have the same arguments and thus should be the same instance
+              if (System.identityHashCode(table2) == System.identityHashCode(table3)) {
+                // table2 and table4 have different arguments and thus should be different instances
+                if (System.identityHashCode(table2) != System.identityHashCode(table4)) {
+                  table2.write(DATASET_TEST_KEY_STOP_2, DATASET_TEST_VALUE_STOP_2);
+                }
+              }
+            }
           }
         });
         workerStopped = true;

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTest.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTest.java
@@ -128,7 +128,7 @@ public class TestFrameworkTest extends TestBase {
       Assert.assertFalse(scheduleName.isEmpty());
 
       List<RunRecord> history;
-      int workflowRuns = 0;
+      int workflowRuns;
       workFlowHistoryCheck(5, wfmanager, 0);
 
       String status = wfmanager.getSchedule(scheduleName).status();
@@ -445,7 +445,10 @@ public class TestFrameworkTest extends TestBase {
       decodedResult = new Gson().fromJson(result, String.class);
       Assert.assertEquals(AppWithServices.DATASET_TEST_VALUE_STOP, decodedResult);
 
-      procedureManager.stop();
+      result = procedureClient.query("ping", ImmutableMap.of(AppWithServices.PROCEDURE_DATASET_KEY,
+                                                             AppWithServices.DATASET_TEST_KEY_STOP_2));
+      decodedResult = new Gson().fromJson(result, String.class);
+      Assert.assertEquals(AppWithServices.DATASET_TEST_VALUE_STOP_2, decodedResult);
     } finally {
       applicationManager.stopAll();
     }


### PR DESCRIPTION
... args

Fixes for: https://issues.cask.co/browse/CDAP-1211 and https://issues.cask.co/browse/CDAP-1212

Add the hashcode of the arguments to the key used to cache datasets and extend the cache timeout to be greater than the transaction timeout.