### PR TITLE
fix metrics collection in mapreduce

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/AbstractMapReduceContextBuilder.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/AbstractMapReduceContextBuilder.java
@@ -59,6 +59,7 @@ public abstract class AbstractMapReduceContextBuilder {
    */
   public BasicMapReduceContext build(MapReduceMetrics.TaskType type,
                                      String runId,
+                                     String taskId,
                                      long logicalStartTime,
                                      String workflowBatch,
                                      Arguments runtimeArguments,
@@ -95,7 +96,7 @@ public abstract class AbstractMapReduceContextBuilder {
     // Creating mapreduce job context
     MapReduceSpecification spec = program.getApplicationSpecification().getMapReduce().get(program.getName());
     BasicMapReduceContext context =
-      new BasicMapReduceContext(program, type, RunIds.fromString(runId),
+      new BasicMapReduceContext(program, type, RunIds.fromString(runId), taskId,
                                 runtimeArguments, programSpec.getDatasets().keySet(), spec, logicalStartTime,
                                 workflowBatch, discoveryServiceClient, metricsCollectionService,
                                 datasetFramework, configuration);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
@@ -53,14 +53,11 @@ import javax.annotation.Nullable;
  */
 public class BasicMapReduceContext extends AbstractContext implements MapReduceContext {
 
-  // TODO: InstanceId is not supported in MR jobs, see CDAP-2
   private final MapReduceSpecification spec;
   private final MapReduceLoggingContext loggingContext;
-  private final MetricsCollector mapperMetrics;
-  private final MetricsCollector reducerMetrics;
   private final long logicalStartTime;
   private final String workflowBatch;
-  private final Metrics mapredMetrics;
+  private final Metrics userMetrics;
   private final MetricsCollectionService metricsCollectionService;
 
   private String inputDatasetName;
@@ -75,7 +72,7 @@ public class BasicMapReduceContext extends AbstractContext implements MapReduceC
 
   public BasicMapReduceContext(Program program,
                                MapReduceMetrics.TaskType type,
-                               RunId runId,
+                               RunId runId, String taskId,
                                Arguments runtimeArguments,
                                Set<String> datasets,
                                MapReduceSpecification spec,
@@ -86,25 +83,16 @@ public class BasicMapReduceContext extends AbstractContext implements MapReduceC
                                DatasetFramework dsFramework,
                                CConfiguration conf) {
     super(program, runId, runtimeArguments, datasets,
-          getMetricCollector(metricsCollectionService, program, type, runId.getId()),
+          getMetricCollector(metricsCollectionService, program, type, runId.getId(), taskId),
           dsFramework, conf, discoveryServiceClient);
     this.logicalStartTime = logicalStartTime;
     this.workflowBatch = workflowBatch;
     this.metricsCollectionService = metricsCollectionService;
 
     if (metricsCollectionService != null) {
-      mapperMetrics =
-        getMetricCollector(metricsCollectionService, program, MapReduceMetrics.TaskType.Mapper, runId.getId());
-      reducerMetrics =
-        getMetricCollector(metricsCollectionService, program, MapReduceMetrics.TaskType.Reducer, runId.getId());
-      // for user metrics.  type can be null if its not in a map or reduce task, but in the yarn container that
-      // launches the mapred job.
-      this.mapredMetrics = (type == null) ?
-        null : new ProgramUserMetrics(getMetricCollector(metricsCollectionService, program, type, runId.getId()));
+      this.userMetrics = new ProgramUserMetrics(getProgramMetrics());
     } else {
-      this.mapperMetrics = null;
-      this.reducerMetrics = null;
-      this.mapredMetrics = null;
+      this.userMetrics = null;
     }
     this.loggingContext = new MapReduceLoggingContext(getNamespaceId(), getApplicationId(), getProgramName());
     this.spec = spec;
@@ -245,32 +233,33 @@ public class BasicMapReduceContext extends AbstractContext implements MapReduceC
   }
 
   private static MetricsCollector getMetricCollector(MetricsCollectionService service, Program program,
-                                                     MapReduceMetrics.TaskType type, String runId) {
+                                                     MapReduceMetrics.TaskType type, String runId, String taskId) {
     if (service == null) {
       return null;
     }
-    Map<String, String> tags = Maps.newHashMap(getMetricsContext(program, runId));
+    Map<String, String> tags = Maps.newHashMap();
+    // NOTE: Currently we report metrics thru mapreduce counters and to it in mapreduce program runner. It "knows" all
+    //       the details about program, run, etc. so no need to pollute counters with it. Also counter name has strict
+    //       limits by default (64 bytes), we simply can't risk overflowing it.
     if (type != null) {
+      // in a task: put only task info
       tags.put(Constants.Metrics.Tag.MR_TASK_TYPE, type.getId());
+      tags.put(Constants.Metrics.Tag.INSTANCE_ID, taskId);
+    } else {
+      // in a runner (container that submits the job): put program info
+      tags.putAll(getMetricsContext(program, runId));
     }
+
     return service.getCollector(tags);
   }
 
   @Override
   public Metrics getMetrics() {
-    return mapredMetrics;
+    return userMetrics;
   }
 
   public MetricsCollectionService getMetricsCollectionService() {
     return metricsCollectionService;
-  }
-
-  public MetricsCollector getMapperMetrics() {
-    return mapperMetrics;
-  }
-
-  public MetricsCollector getReducerMetrics() {
-    return reducerMetrics;
   }
 
   public LoggingContext getLoggingContext() {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
@@ -238,7 +238,7 @@ public class BasicMapReduceContext extends AbstractContext implements MapReduceC
       return null;
     }
     Map<String, String> tags = Maps.newHashMap();
-    // NOTE: Currently we report metrics thru mapreduce counters and to it in mapreduce program runner. It "knows" all
+    // NOTE: Currently we report metrics thru mapreduce counters and emit them in mapreduce program runner. It "knows" all
     //       the details about program, run, etc. so no need to pollute counters with it. Also counter name has strict
     //       limits by default (64 bytes), we simply can't risk overflowing it.
     if (type != null) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
@@ -238,9 +238,9 @@ public class BasicMapReduceContext extends AbstractContext implements MapReduceC
       return null;
     }
     Map<String, String> tags = Maps.newHashMap();
-    // NOTE: Currently we report metrics thru mapreduce counters and emit them in mapreduce program runner. It "knows" all
-    //       the details about program, run, etc. so no need to pollute counters with it. Also counter name has strict
-    //       limits by default (64 bytes), we simply can't risk overflowing it.
+    // NOTE: Currently we report metrics thru mapreduce counters and emit them in mapreduce program runner. It "knows"
+    //       all the details about program, run, etc. so no need to pollute counters with it. Also counter name has
+    //       strict limits by default (64 bytes), we simply can't risk overflowing it.
     if (type != null) {
       // in a task: put only task info
       tags.put(Constants.Metrics.Tag.MR_TASK_TYPE, type.getId());

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextProvider.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextProvider.java
@@ -67,6 +67,7 @@ public final class MapReduceContextProvider {
       context = getBuilder(conf)
         .build(type,
                contextConfig.getRunId(),
+               taskContext.getTaskAttemptID().getTaskID().toString(),
                contextConfig.getLogicalStartTime(),
                contextConfig.getWorkflowBatch(),
                contextConfig.getArguments(),

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceMetricsWriter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceMetricsWriter.java
@@ -16,9 +16,10 @@
 
 package co.cask.cdap.internal.app.runtime.batch;
 
+import co.cask.cdap.app.metrics.MapReduceMetrics;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.metrics.MetricsCollector;
-import co.cask.cdap.metrics.transport.MetricType;
-import com.google.common.collect.Maps;
+import co.cask.cdap.metrics.collect.MapReduceCounterCollectionService;
 import org.apache.hadoop.mapreduce.Counter;
 import org.apache.hadoop.mapreduce.Counters;
 import org.apache.hadoop.mapreduce.Job;
@@ -45,16 +46,16 @@ public class MapReduceMetricsWriter {
 
   private final Job jobConf;
   private final BasicMapReduceContext context;
-  private final Map<String, Integer> previousMapStats;
-  private final Map<String, Integer> previousReduceStats;
-  private final Map<String, Integer> previousDatasetStats;
+  private final MetricsCollector mapperMetrics;
+  private final MetricsCollector reducerMetrics;
 
   public MapReduceMetricsWriter(Job jobConf, BasicMapReduceContext context) {
     this.jobConf = jobConf;
     this.context = context;
-    this.previousMapStats = Maps.newHashMap();
-    this.previousReduceStats = Maps.newHashMap();
-    this.previousDatasetStats = Maps.newHashMap();
+    this.mapperMetrics = context.getProgramMetrics().childCollector(Constants.Metrics.Tag.MR_TASK_TYPE,
+                                                                    MapReduceMetrics.TaskType.Mapper.getId());
+    this.reducerMetrics = context.getProgramMetrics().childCollector(Constants.Metrics.Tag.MR_TASK_TYPE,
+                                                                    MapReduceMetrics.TaskType.Reducer.getId());
   }
 
   public void reportStats() throws IOException, InterruptedException {
@@ -77,19 +78,16 @@ public class MapReduceMetricsWriter {
     int memoryPerMapper = jobConf.getConfiguration().getInt(Job.MAP_MEMORY_MB, Job.DEFAULT_MAP_MEMORY_MB);
     int memoryPerReducer = jobConf.getConfiguration().getInt(Job.REDUCE_MEMORY_MB, Job.DEFAULT_REDUCE_MEMORY_MB);
 
-    // mapred counters are running counters whereas our metrics timeseries and aggregates make more
-    // sense as incremental numbers.  So we want to subtract the current counter value from the previous before
-    // emitting to the metrics system.
     long mapInputRecords = getTaskCounter(TaskCounter.MAP_INPUT_RECORDS);
     long mapOutputRecords = getTaskCounter(TaskCounter.MAP_OUTPUT_RECORDS);
     long mapOutputBytes = getTaskCounter(TaskCounter.MAP_OUTPUT_BYTES);
 
-    context.getMapperMetrics().gauge(METRIC_COMPLETION, (long) (mapProgress * 100));
-    context.getMapperMetrics().gauge(METRIC_INPUT_RECORDS, mapInputRecords);
-    context.getMapperMetrics().gauge(METRIC_OUTPUT_RECORDS, mapOutputRecords);
-    context.getMapperMetrics().gauge(METRIC_BYTES, mapOutputBytes);
-    context.getMapperMetrics().gauge(METRIC_USED_CONTAINERS, runningMappers);
-    context.getMapperMetrics().gauge(METRIC_USED_MEMORY, runningMappers * memoryPerMapper);
+    mapperMetrics.gauge(METRIC_COMPLETION, (long) (mapProgress * 100));
+    mapperMetrics.gauge(METRIC_INPUT_RECORDS, mapInputRecords);
+    mapperMetrics.gauge(METRIC_OUTPUT_RECORDS, mapOutputRecords);
+    mapperMetrics.gauge(METRIC_BYTES, mapOutputBytes);
+    mapperMetrics.gauge(METRIC_USED_CONTAINERS, runningMappers);
+    mapperMetrics.gauge(METRIC_USED_MEMORY, runningMappers * memoryPerMapper);
 
     LOG.trace("Reporting mapper stats: (completion, ins, outs, bytes, containers, memory) = ({}, {}, {}, {}, {}, {})",
               (int) (mapProgress * 100), mapInputRecords, mapOutputRecords, mapOutputBytes, runningMappers,
@@ -100,11 +98,11 @@ public class MapReduceMetricsWriter {
     long reduceInputRecords = getTaskCounter(TaskCounter.REDUCE_INPUT_RECORDS);
     long reduceOutputRecords = getTaskCounter(TaskCounter.REDUCE_OUTPUT_RECORDS);
 
-    context.getReducerMetrics().gauge(METRIC_COMPLETION, (long) (reduceProgress * 100));
-    context.getReducerMetrics().gauge(METRIC_INPUT_RECORDS, reduceInputRecords);
-    context.getReducerMetrics().gauge(METRIC_OUTPUT_RECORDS, reduceOutputRecords);
-    context.getReducerMetrics().gauge(METRIC_USED_CONTAINERS, runningReducers);
-    context.getReducerMetrics().gauge(METRIC_USED_MEMORY, runningReducers * memoryPerReducer);
+    reducerMetrics.gauge(METRIC_COMPLETION, (long) (reduceProgress * 100));
+    reducerMetrics.gauge(METRIC_INPUT_RECORDS, reduceInputRecords);
+    reducerMetrics.gauge(METRIC_OUTPUT_RECORDS, reduceOutputRecords);
+    reducerMetrics.gauge(METRIC_USED_CONTAINERS, runningReducers);
+    reducerMetrics.gauge(METRIC_USED_MEMORY, runningReducers * memoryPerReducer);
 
     LOG.trace("Reporting reducer stats: (completion, ins, outs, containers, memory) = ({}, {}, {}, {}, {})",
               (int) (reduceProgress * 100), reduceInputRecords, reduceOutputRecords, runningReducers,
@@ -116,80 +114,17 @@ public class MapReduceMetricsWriter {
     Counters counters = jobConf.getCounters();
     for (String group : counters.getGroupNames()) {
       if (group.startsWith("cdap.")) {
-        String[] parts = group.split("\\.");
-        MetricType metricType = MetricType.valueOf(parts[parts.length - 2]);
 
-        //TODO: Refactor to support any context
-        String programPart = parts[1];
-        if (programPart.equals("mapper")) {
-          reportSystemStats(counters.getGroup(group), context.getMapperMetrics(),
-                            previousMapStats, metricType);
-        } else if (programPart.equals("reducer")) {
-          reportSystemStats(counters.getGroup(group), context.getReducerMetrics(),
-                            previousReduceStats, metricType);
+        Map<String, String> tags = MapReduceCounterCollectionService.parseTags(group);
+        // todo: use some caching?
+        MetricsCollector collector = context.getProgramMetrics().childCollector(tags);
+
+        // Note: all mapreduce metrics are reported as gauges due to how mapreduce counters work;
+        //       we may later emit metrics right from the tasks into the metrics system to overcome this limitation
+        for (Counter counter : counters.getGroup(group)) {
+          collector.gauge(counter.getName(), counter.getValue());
         }
       }
-    }
-  }
-
-  // convenience function to set the table value to the given value and return the difference between the given value
-  // and the previous table value, where the previous value is 0 if there was no entry in the table to begin with.
-  private int calcDiffAndSetTableValue(Map<String, Integer> table, String key, long value) {
-    Integer previous = table.get(key);
-    previous = (previous == null) ? 0 : previous;
-    table.put(key, (int) value);
-    return (int) value - previous;
-  }
-
-  private void reportSystemStats(Iterable<Counter> counters, MetricsCollector collector,
-                                 Map<String, Integer> previousStats,  MetricType type) {
-    if (type == MetricType.GAUGE) {
-      reportGaugeSystemStats(counters, collector);
-    } else {
-      reportIncrementSystemStats(counters, collector, previousStats);
-    }
-  }
-
-
-  private void reportIncrementSystemStats(Iterable<Counter> counters, MetricsCollector collector,
-                                          Map<String, Integer> previousStats) {
-
-    // we don't want to overcount the untagged version of the metric.  For example.  If "metric":"store.bytes"
-    // comes in with "tag":"dataset1" and value 10, we will also have another counter for just the metric without the
-    // tag, also with value 10.  If we increment both of them with their values, the final count sent off to the metrics
-    // system for the untagged metric will be 20 instead of 10.  So we need to keep track of the sum of the tagged
-    // values so that we can adjust accordingly.
-    Map<String, Integer> metricTagValues = Maps.newHashMap();
-    Map<String, Integer> metricUntaggedValues = Maps.newHashMap();
-
-    for (Counter counter : counters) {
-
-      // mapred counters are running counters whereas our metrics timeseries and aggregates make more
-      // sense as incremental numbers.  So we want to subtract the current counter value from the previous before
-      // emitting to the metrics system.
-      int emitValue = calcDiffAndSetTableValue(previousStats, counter.getName(), counter.getValue());
-
-      // "<metric>" or "<metric>,<tag>" if tag is present
-      String[] parts = counter.getName().split(",", 2);
-      String metric = parts[0];
-      metricUntaggedValues.put(metric, emitValue);
-    }
-
-    // emit adjusted counts for the untagged metrics.
-    for (Map.Entry<String, Integer> untaggedEntry : metricUntaggedValues.entrySet()) {
-      String metric = untaggedEntry.getKey();
-      int tagValueSum = (metricTagValues.containsKey(metric)) ? metricTagValues.get(metric) : 0;
-      int adjustedValue = untaggedEntry.getValue() - tagValueSum;
-      collector.increment(metric, adjustedValue);
-    }
-  }
-
-  private void reportGaugeSystemStats(Iterable<Counter> counters, MetricsCollector collector) {
-    for (Counter counter : counters) {
-      // "<metric>" or "<metric>,<tag>" if tag is present
-      String[] parts = counter.getName().split(",", 2);
-      String metric = parts[0];
-      collector.gauge(metric, counter.getValue());
     }
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
@@ -35,6 +35,7 @@ import co.cask.cdap.common.metrics.MetricsCollectionService;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.internal.app.runtime.DataSetFieldSetter;
+import co.cask.cdap.internal.app.runtime.MetricsFieldSetter;
 import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
 import co.cask.cdap.internal.lang.Reflections;
 import co.cask.cdap.proto.ProgramType;
@@ -133,7 +134,7 @@ public class MapReduceProgramRunner implements ProgramRunner {
     }
 
     final BasicMapReduceContext context =
-      new BasicMapReduceContext(program, null, runId, options.getUserArguments(),
+      new BasicMapReduceContext(program, null, runId, null, options.getUserArguments(),
                                 program.getApplicationSpecification().getDatasets().keySet(), spec,
                                 logicalStartTime,
                                 workflowBatch, discoveryServiceClient, metricsCollectionService,
@@ -142,6 +143,7 @@ public class MapReduceProgramRunner implements ProgramRunner {
 
     Reflections.visit(mapReduce, TypeToken.of(mapReduce.getClass()),
                       new PropertyFieldSetter(context.getSpecification().getProperties()),
+                      new MetricsFieldSetter(context.getMetrics()),
                       new DataSetFieldSetter(context));
 
     // note: this sets logging context on the thread level

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/DataSetRecordReader.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/DataSetRecordReader.java
@@ -60,8 +60,8 @@ final class DataSetRecordReader<KEY, VALUE> extends RecordReader<KEY, VALUE> {
     boolean hasNext = splitReader.nextKeyValue();
     if (hasNext) {
       // splitreader doesn't increment these metrics, need to do it ourselves.
-      context.getMapperMetrics().increment("store.reads", 1);
-      context.getMapperMetrics().increment("store.ops", 1);
+      context.getProgramMetrics().increment("store.reads", 1);
+      context.getProgramMetrics().increment("store.ops", 1);
       dataSetMetrics.increment("dataset.store.reads", 1);
       dataSetMetrics.increment("dataset.store.ops", 1);
     }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithMapReduce.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithMapReduce.java
@@ -24,6 +24,7 @@ import co.cask.cdap.api.dataset.lib.TimeseriesTable;
 import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.api.mapreduce.AbstractMapReduce;
 import co.cask.cdap.api.mapreduce.MapReduceContext;
+import co.cask.cdap.api.metrics.Metrics;
 import org.apache.hadoop.mapreduce.Job;
 
 /**
@@ -75,6 +76,8 @@ public class AppWithMapReduce extends AbstractApplication {
     @UseDataSet("timeSeries")
     private TimeseriesTable table;
 
+    private Metrics metrics;
+
     @Override
     protected void configure() {
       setOutputDataset("timeSeries");
@@ -82,6 +85,7 @@ public class AppWithMapReduce extends AbstractApplication {
 
     @Override
     public void beforeSubmit(MapReduceContext context) throws Exception {
+      metrics.count("beforeSubmit", 1);
       Job hadoopJob = context.getHadoopJob();
       AggregateMetricsByTag.configureJob(hadoopJob);
       String metricName = context.getRuntimeArguments().get("metric");
@@ -96,12 +100,15 @@ public class AppWithMapReduce extends AbstractApplication {
         hadoopJob.getConfiguration().setInt("c.mapper.flush.freq", 1);
         hadoopJob.getConfiguration().setInt("c.reducer.flush.freq", 1);
       }
+      metrics.count("beforeSubmit", 1);
     }
 
     @Override
     public void onFinish(boolean succeeded, MapReduceContext context) throws Exception {
+      metrics.count("onFinish", 1);
       System.out.println("Action taken on MapReduce job " + (succeeded ? "" : "un") + "successful completion");
       onFinishTable.write(Bytes.toBytes("onFinish"), Bytes.toBytes("onFinish:done"));
+      metrics.count("onFinish", 1);
     }
   }
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunnerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunnerTest.java
@@ -411,6 +411,8 @@ public class MapReduceProgramRunnerTest {
           Assert.assertTrue(countersFromContext.get(new Get("reducer")).getLong("records", 0) > 0);
         }
       });
+
+    // todo: verify metrics. Will be possible after refactor for CDAP-765
   }
 
   @Test

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/metrics/MetricsDiscoveryQueryTestRun.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/metrics/MetricsDiscoveryQueryTestRun.java
@@ -139,11 +139,11 @@ public class MetricsDiscoveryQueryTestRun extends MetricsSuiteTestBase {
     collector.increment("reads", 1);
     collector = collectionService.getCollector(getMapReduceTaskContext(Constants.DEFAULT_NAMESPACE, "WCount",
                                                                        "ClassicWordCount",
-                                                                       MapReduceMetrics.TaskType.Mapper));
+                                                                       MapReduceMetrics.TaskType.Mapper, "run1", "t1"));
     collector.increment("reads", 1);
-    collector = collectionService.getCollector(getMapReduceTaskContext(Constants.DEFAULT_NAMESPACE, "WCount",
-                                                                       "ClassicWordCount",
-                                                                       MapReduceMetrics.TaskType.Reducer));
+    collector = collectionService.getCollector(
+      getMapReduceTaskContext(Constants.DEFAULT_NAMESPACE, "WCount", "ClassicWordCount",
+                              MapReduceMetrics.TaskType.Reducer, "run1", "t2"));
     collector.increment("reads", 1);
     collector = collectionService.getCollector(getFlowletContext(Constants.DEFAULT_NAMESPACE, "WordCount",
                                                                  "WordCounter", "splitter"));

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/metrics/MetricsHandlerTestRun.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/metrics/MetricsHandlerTestRun.java
@@ -64,10 +64,12 @@ public class MetricsHandlerTestRun extends MetricsSuiteTestBase {
     collector = collectionService.getCollector(getProcedureContext("yourspace", "WCount1", "RCounts"));
     collector.increment("reads", 1);
     collector = collectionService.getCollector(getMapReduceTaskContext("yourspace", "WCount1", "ClassicWordCount",
-                                                                       MapReduceMetrics.TaskType.Mapper));
+                                                                       MapReduceMetrics.TaskType.Mapper,
+                                                                       "run1", "task1"));
     collector.increment("reads", 1);
     collector = collectionService.getCollector(
-      getMapReduceTaskContext("yourspace", "WCount1", "ClassicWordCount", MapReduceMetrics.TaskType.Reducer));
+      getMapReduceTaskContext("yourspace", "WCount1", "ClassicWordCount",
+                              MapReduceMetrics.TaskType.Reducer, "run1", "task2"));
     collector.increment("reads", 1);
     collector = collectionService.getCollector(getFlowletContext("myspace", "WordCount1", "WordCounter", "splitter"));
     collector.increment("reads", 1);
@@ -111,6 +113,8 @@ public class MetricsHandlerTestRun extends MetricsSuiteTestBase {
     verifySearchResult("/v3/metrics/search?target=childContext&context=yourspace.WCount1.b.ClassicWordCount",
                        ImmutableList.<String>of("m", "r"));
     verifySearchResult("/v3/metrics/search?target=childContext&context=yourspace.WCount1.b.ClassicWordCount.m",
+                       ImmutableList.<String>of("task1"));
+    verifySearchResult("/v3/metrics/search?target=childContext&context=yourspace.WCount1.b.ClassicWordCount.m.task1",
                        ImmutableList.<String>of());
   }
 

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/metrics/MetricsQueryTestRun.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/metrics/MetricsQueryTestRun.java
@@ -180,12 +180,12 @@ public class MetricsQueryTestRun extends MetricsSuiteTestBase {
 
     MetricsCollector collector3 =
       collectionService.getCollector(getMapReduceTaskContext(Constants.DEFAULT_NAMESPACE, "WordCount", "CounterMapRed",
-                                                             MapReduceMetrics.TaskType.Mapper, runId3));
+                                                             MapReduceMetrics.TaskType.Mapper, runId3, "t1"));
     collector3.gauge("entries.out", 10);
 
     MetricsCollector collector4 =
       collectionService.getCollector(getMapReduceTaskContext(Constants.DEFAULT_NAMESPACE, "WordCount", "CounterMapRed",
-                                                             MapReduceMetrics.TaskType.Reducer, runId3));
+                                                             MapReduceMetrics.TaskType.Reducer, runId3, "t2"));
     collector4.gauge("entries.out", 10);
 
     // Wait for collection to happen

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/metrics/MetricsSuiteTestBase.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/metrics/MetricsSuiteTestBase.java
@@ -429,7 +429,7 @@ public abstract class MetricsSuiteTestBase {
 
   protected static Map<String, String> getFlowletQueueContext(String namespaceId, String appName, String flowName,
                                                               String flowletName, String queueName) {
-    ImmutableMap immutableMap = ImmutableMap.builder()
+    return ImmutableMap.<String, String>builder()
       .put(Constants.Metrics.Tag.NAMESPACE, namespaceId)
       .put(Constants.Metrics.Tag.APP, appName)
       .put(Constants.Metrics.Tag.PROGRAM_TYPE, TypeId.getMetricContextId(ProgramType.FLOW))
@@ -437,7 +437,6 @@ public abstract class MetricsSuiteTestBase {
       .put(Constants.Metrics.Tag.FLOWLET, flowletName)
       .put(Constants.Metrics.Tag.FLOWLET_QUEUE, queueName)
       .build();
-    return ImmutableMap.copyOf(immutableMap);
   }
 
   protected static Map<String, String> getStreamHandlerContext(String streamName, String instanceId) {
@@ -465,7 +464,7 @@ public abstract class MetricsSuiteTestBase {
 
   protected static Map<String, String> getUserServiceContext(String namespaceId, String appName, String serviceName,
                                                              String runnableName, String runId) {
-    ImmutableMap immutableMap = ImmutableMap.builder()
+    return ImmutableMap.<String, String>builder()
       .put(Constants.Metrics.Tag.NAMESPACE, namespaceId)
       .put(Constants.Metrics.Tag.APP, appName)
       .put(Constants.Metrics.Tag.PROGRAM_TYPE, TypeId.getMetricContextId(ProgramType.SERVICE))
@@ -473,28 +472,19 @@ public abstract class MetricsSuiteTestBase {
       .put(Constants.Metrics.Tag.SERVICE_RUNNABLE, runnableName)
       .put(Constants.Metrics.Tag.RUN_ID, runId)
       .build();
-    return ImmutableMap.copyOf(immutableMap);
   }
 
   protected static Map<String, String> getMapReduceTaskContext(String namespaceId, String appName, String jobName,
-                                                               MapReduceMetrics.TaskType type) {
-    return ImmutableMap.of(Constants.Metrics.Tag.NAMESPACE, namespaceId,
-                           Constants.Metrics.Tag.APP, appName,
-                           Constants.Metrics.Tag.PROGRAM_TYPE, TypeId.getMetricContextId(ProgramType.MAPREDUCE),
-                           Constants.Metrics.Tag.PROGRAM, jobName,
-                           Constants.Metrics.Tag.MR_TASK_TYPE, type.getId());
-  }
-
-  protected static Map<String, String> getMapReduceTaskContext(String namespaceId, String appName, String jobName,
-                                                               MapReduceMetrics.TaskType type, String runId) {
-    ImmutableMap immutableMap = ImmutableMap.builder()
+                                                               MapReduceMetrics.TaskType type,
+                                                               String runId, String instanceId) {
+    return ImmutableMap.<String, String>builder()
       .put(Constants.Metrics.Tag.NAMESPACE, namespaceId)
       .put(Constants.Metrics.Tag.APP, appName)
       .put(Constants.Metrics.Tag.PROGRAM_TYPE, TypeId.getMetricContextId(ProgramType.MAPREDUCE))
       .put(Constants.Metrics.Tag.PROGRAM, jobName)
       .put(Constants.Metrics.Tag.MR_TASK_TYPE, type.getId())
       .put(Constants.Metrics.Tag.RUN_ID, runId)
+      .put(Constants.Metrics.Tag.INSTANCE_ID, instanceId)
       .build();
-    return ImmutableMap.copyOf(immutableMap);
   }
 }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/collect/AggregatedMetricsCollectionService.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/collect/AggregatedMetricsCollectionService.java
@@ -24,6 +24,7 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.AbstractScheduledService;
 import org.apache.twill.common.Threads;
 import org.slf4j.Logger;
@@ -180,8 +181,13 @@ public abstract class AggregatedMetricsCollectionService extends AbstractSchedul
 
     @Override
     public MetricsCollector childCollector(Map<String, String> tags) {
-      ImmutableMap<String, String> allTags = ImmutableMap.<String, String>builder()
-        .putAll(tags).putAll(tags).build();
+      if (tags.isEmpty()) {
+        return this;
+      }
+      // todo: may be warn when duplicate tag is provided? for now ok
+      Map<String, String> allTags = Maps.newHashMap();
+      allTags.putAll(this.tags);
+      allTags.putAll(tags);
       return new MetricsCollectorImpl(allTags);
     }
   }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/collect/MapReduceCounterCollectionService.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/collect/MapReduceCounterCollectionService.java
@@ -17,6 +17,7 @@ package co.cask.cdap.metrics.collect;
 
 import co.cask.cdap.metrics.transport.MetricType;
 import co.cask.cdap.metrics.transport.MetricValue;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -72,9 +73,8 @@ public final class MapReduceCounterCollectionService extends AggregatedMetricsCo
   public static Map<String, String> parseTags(String counterGroupName) {
     // see publish method for format info
 
-    if (counterGroupName.startsWith("cdap.")) {
-      return Collections.emptyMap();
-    }
+    Preconditions.checkArgument(counterGroupName.startsWith("cdap."),
+                                "Counters group was not created by CDAP: " + counterGroupName);
     String[] parts = counterGroupName.split("\\.");
     Map<String, String> tags = Maps.newHashMap();
     // todo: assert that we have odd count of parts?


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-1238

Couple notes:
* all mapreduce metrics emitted as gauges, as this is how mr counters work that we use
* for that to work properly, we need to emit from tasks with task id in the context, so that for aggregate values all are summed (as expected)
* metrics collector's context in tasks now has only task type and id - since metrics reported by mr program runner, all other tags present in its context (like app id, etc.)
* added emitting custom metrics in mr tests which cought couple isuues by itself, no asserting results well - without refactoring that is coming later it is really hard