### PR TITLE
Revert incrementing changes that make release 2.7 fail

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -221,13 +221,8 @@
     </property>
 
     <property>
-        <name>stream.container.instance.id</name>
-        <value>0</value>
-    </property>
-
-    <property>
         <name>stream.file.prefix</name>
-        <value>file.${stream.container.instance.id}</value>
+        <value>file</value>
         <description>Prefix of file name for Stream file</description>
     </property>
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/LocationStreamFileWriterFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/LocationStreamFileWriterFactory.java
@@ -41,7 +41,9 @@ public final class LocationStreamFileWriterFactory implements StreamFileWriterFa
 
   @Inject
   public LocationStreamFileWriterFactory(CConfiguration cConf) {
-    this.filePrefix = cConf.get(Constants.Stream.FILE_PREFIX);
+    this.filePrefix = String.format("%s.%d",
+                                    cConf.get(Constants.Stream.FILE_PREFIX),
+                                    cConf.getInt(Constants.Stream.CONTAINER_INSTANCE_ID, 0));
   }
 
   @Override


### PR DESCRIPTION
Build is running at: https://builds.cask.co/browse/CDAP-RBT65-1
Reverting useless changes made in PR https://github.com/caskdata/cdap/pull/1061/files and merged in release.
If the build passes, feel free to merge this PR.