### PR TITLE
[CDAP-1115] Fixed NPE in NamespaceHttpHandler

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/NamespaceHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/NamespaceHttpHandler.java
@@ -119,14 +119,19 @@ public class NamespaceHttpHandler extends AbstractAppFabricHttpHandler {
       return;
     }
 
-    // displayName and description could be null
-    String displayName = metadata.getDisplayName();
-    if (displayName == null || displayName.isEmpty()) {
-      displayName = namespaceId;
-    }
-    String description = metadata.getDescription();
-    if (description == null) {
-      description = "";
+    // Handle optional params
+    // displayName defaults to id
+    String displayName = namespaceId;
+    // description defaults to empty
+    String description = "";
+    // override optional params if they are provided in the request
+    if (metadata != null) {
+      if (metadata.getDisplayName() != null) {
+        displayName = metadata.getDisplayName();
+      }
+      if (metadata.getDescription() != null) {
+        description = metadata.getDescription();
+      }
     }
 
     NamespaceMeta.Builder builder = new NamespaceMeta.Builder();


### PR DESCRIPTION
Summary:
1. Fixed an NPE in ``NamespaceHttpHandler``
2. Combined two tests into one.

Build: https://builds.cask.co/browse/CDAP-RBT73-1/