### PR TITLE
Set memory resources for Mapper, Reducer tasks

### DIFF
--- a/cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/WordCount.java
+++ b/cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/WordCount.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.examples.fileset;
 
+import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.mapreduce.AbstractMapReduce;
 import co.cask.cdap.api.mapreduce.MapReduceContext;
 import org.apache.hadoop.io.IntWritable;
@@ -41,6 +42,8 @@ public class WordCount extends AbstractMapReduce {
   public void configure() {
     setInputDataset("lines");
     setOutputDataset("counts");
+    setMapperResources(new Resources(1024));
+    setReducerResources(new Resources(1024));
   }
 
   @Override


### PR DESCRIPTION
MR fails due to unavailability of heap space otherwise. Defaults were not enough. 

Bamboo : https://builds.cask.co/browse/CDAP-RBT93