### PR TITLE
Updated schedule endpoints.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricHttpHandler.java
@@ -244,16 +244,16 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
   }
 
   /**
-   * Returns status of a runnable specified by the type{flows,workflows,mapreduce,spark,procedures,services}.
+   * Returns status of a type specified by {flows,workflows,mapreduce,spark,procedures,services,schedules}.
    */
   @GET
-  @Path("/apps/{app-id}/{runnable-type}/{runnable-id}/status")
+  @Path("/apps/{app-id}/{type}/{id}/status")
   public void getStatus(final HttpRequest request, final HttpResponder responder,
                         @PathParam("app-id") final String appId,
-                        @PathParam("runnable-type") final String runnableType,
-                        @PathParam("runnable-id") final String runnableId) {
+                        @PathParam("type") final String type,
+                        @PathParam("id") final String id) {
     programLifecycleHttpHandler.getStatus(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE, appId,
-                                          runnableType, runnableId);
+                                          type, id);
   }
 
   /**
@@ -323,39 +323,39 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
    * Starts a program.
    */
   @POST
-  @Path("/apps/{app-id}/{runnable-type}/{runnable-id}/start")
+  @Path("/apps/{app-id}/{type}/{id}/start")
   public void startProgram(HttpRequest request, HttpResponder responder,
                            @PathParam("app-id") final String appId,
-                           @PathParam("runnable-type") final String runnableType,
-                           @PathParam("runnable-id") final String runnableId) {
-    programLifecycleHttpHandler.takeActionOnProgram(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE,
-                                                      appId, runnableType, runnableId, "start");
+                           @PathParam("type") final String type,
+                           @PathParam("id") final String id) {
+    programLifecycleHttpHandler.performAction(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE,
+                                              appId, type, id, "start");
   }
 
   /**
    * Starts a program with debugging enabled.
    */
   @POST
-  @Path("/apps/{app-id}/{runnable-type}/{runnable-id}/debug")
+  @Path("/apps/{app-id}/{type}/{id}/debug")
   public void debugProgram(HttpRequest request, HttpResponder responder,
                            @PathParam("app-id") final String appId,
-                           @PathParam("runnable-type") final String runnableType,
-                           @PathParam("runnable-id") final String runnableId) {
-    programLifecycleHttpHandler.takeActionOnProgram(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE,
-                                                      appId, runnableType, runnableId, "debug");
+                           @PathParam("type") final String type,
+                           @PathParam("id") final String id) {
+    programLifecycleHttpHandler.performAction(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE,
+                                              appId, type, id, "debug");
   }
 
   /**
    * Stops a program.
    */
   @POST
-  @Path("/apps/{app-id}/{runnable-type}/{runnable-id}/stop")
+  @Path("/apps/{app-id}/{type}/{id}/stop")
   public void stopProgram(HttpRequest request, HttpResponder responder,
                           @PathParam("app-id") final String appId,
-                          @PathParam("runnable-type") final String runnableType,
-                          @PathParam("runnable-id") final String runnableId) {
-    programLifecycleHttpHandler.takeActionOnProgram(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE,
-                                                      appId, runnableType, runnableId, "stop");
+                          @PathParam("type") final String type,
+                          @PathParam("id") final String id) {
+    programLifecycleHttpHandler.performAction(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE,
+                                              appId, type, id, "stop");
   }
 
   /**
@@ -667,8 +667,8 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
   public void suspendSchedule(HttpRequest request, HttpResponder responder,
                                       @PathParam("app-id") String appId,
                                       @PathParam("schedule-name") String scheduleName) {
-    programLifecycleHttpHandler.takeActionOnProgram(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE,
-                                                        appId, "schedules", scheduleName, "suspend");
+    programLifecycleHttpHandler.performAction(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE,
+                                              appId, "schedules", scheduleName, "suspend");
   }
 
   /**
@@ -679,8 +679,8 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
   public void resumeSchedule(HttpRequest request, HttpResponder responder,
                                      @PathParam("app-id") String appId,
                                      @PathParam("schedule-name") String scheduleName) {
-    programLifecycleHttpHandler.takeActionOnProgram(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE,
-                                                       appId, "schedules", scheduleName, "resume");
+    programLifecycleHttpHandler.performAction(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE,
+                                              appId, "schedules", scheduleName, "resume");
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricHttpHandler.java
@@ -328,7 +328,7 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
                            @PathParam("app-id") final String appId,
                            @PathParam("runnable-type") final String runnableType,
                            @PathParam("runnable-id") final String runnableId) {
-    programLifecycleHttpHandler.startStopDebugProgram(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE,
+    programLifecycleHttpHandler.takeActionOnProgram(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE,
                                                       appId, runnableType, runnableId, "start");
   }
 
@@ -341,7 +341,7 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
                            @PathParam("app-id") final String appId,
                            @PathParam("runnable-type") final String runnableType,
                            @PathParam("runnable-id") final String runnableId) {
-    programLifecycleHttpHandler.startStopDebugProgram(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE,
+    programLifecycleHttpHandler.takeActionOnProgram(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE,
                                                       appId, runnableType, runnableId, "debug");
   }
 
@@ -354,7 +354,7 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
                           @PathParam("app-id") final String appId,
                           @PathParam("runnable-type") final String runnableType,
                           @PathParam("runnable-id") final String runnableId) {
-    programLifecycleHttpHandler.startStopDebugProgram(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE,
+    programLifecycleHttpHandler.takeActionOnProgram(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE,
                                                       appId, runnableType, runnableId, "stop");
   }
 
@@ -647,7 +647,6 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
                                                     appId, workflowId);
   }
 
-  //TODO [SAGAR]: CDAP-1155: Implement API to get ScheduleSpecification given schedule name
   /**
    * Returns the schedule ids for a given workflow.
    */
@@ -661,42 +660,27 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
   }
 
   /**
-   * Get schedule state.
-   */
-  @GET
-  @Path("/apps/{app-id}/workflows/{workflow-id}/schedules/{schedule-id}/status")
-  public void getScheduleState(HttpRequest request, HttpResponder responder,
-                               @PathParam("app-id") String appId,
-                               @PathParam("workflow-id") String workflowId,
-                               @PathParam("schedule-id") String scheduleId) {
-    programLifecycleHttpHandler.getScheduleState(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE,
-                                                 appId, workflowId, scheduleId);
-  }
-
-  /**
-   * Suspend a workflow schedule.
+   * Suspend a schedule.
    */
   @POST
-  @Path("/apps/{app-id}/workflows/{workflow-id}/schedules/{schedule-id}/suspend")
-  public void workflowScheduleSuspend(HttpRequest request, HttpResponder responder,
+  @Path("/apps/{app-id}/schedules/{schedule-name}/suspend")
+  public void suspendSchedule(HttpRequest request, HttpResponder responder,
                                       @PathParam("app-id") String appId,
-                                      @PathParam("workflow-id") String workflowId,
-                                      @PathParam("schedule-id") String scheduleId) {
-    programLifecycleHttpHandler.workflowScheduleSuspend(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE,
-                                                        appId, workflowId, scheduleId);
+                                      @PathParam("schedule-name") String scheduleName) {
+    programLifecycleHttpHandler.takeActionOnProgram(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE,
+                                                        appId, "schedules", scheduleName, "suspend");
   }
 
   /**
-   * Resume a workflow schedule.
+   * Resume a schedule.
    */
   @POST
-  @Path("/apps/{app-id}/workflows/{workflow-id}/schedules/{schedule-id}/resume")
-  public void workflowScheduleResume(HttpRequest request, HttpResponder responder,
+  @Path("/apps/{app-id}/schedules/{schedule-name}/resume")
+  public void resumeSchedule(HttpRequest request, HttpResponder responder,
                                      @PathParam("app-id") String appId,
-                                     @PathParam("workflow-id") String workflowId,
-                                     @PathParam("schedule-id") String scheduleId) {
-    programLifecycleHttpHandler.workflowScheduleResume(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE,
-                                                       appId, workflowId, scheduleId);
+                                     @PathParam("schedule-name") String scheduleName) {
+    programLifecycleHttpHandler.takeActionOnProgram(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE,
+                                                       appId, "schedules", scheduleName, "resume");
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/test/internal/AppFabricClient.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/test/internal/AppFabricClient.java
@@ -174,27 +174,27 @@ public class AppFabricClient {
     return responder.decodeResponseContent(new TypeToken<List<RunRecord>>() { });
   }
 
-  public void suspend(String appId, String wflowId, String schedId) {
+  public void suspend(String appId, String scheduleName) {
     MockResponder responder = new MockResponder();
-    String uri = String.format("/v2/apps/%s/workflows/%s/schedules/%s/suspend", appId, wflowId, schedId);
+    String uri = String.format("/v2/apps/%s/schedules/%s/suspend", appId, scheduleName);
     HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
-    httpHandler.workflowScheduleSuspend(request, responder, appId, wflowId, schedId);
+    httpHandler.suspendSchedule(request, responder, appId, scheduleName);
     verifyResponse(HttpResponseStatus.OK, responder.getStatus(), "Suspend workflow schedules failed");
   }
 
-  public void resume(String appId, String wflowId, String schedId) {
+  public void resume(String appId, String schedName) {
     MockResponder responder = new MockResponder();
-    String uri = String.format("/v2/apps/%s/workflows/%s/schedules/%s/resume", appId, wflowId, schedId);
+    String uri = String.format("/v2/apps/%s/schedules/%s/resume", appId, schedName);
     HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
-    httpHandler.workflowScheduleResume(request, responder, appId, wflowId, schedId);
+    httpHandler.resumeSchedule(request, responder, appId, schedName);
     verifyResponse(HttpResponseStatus.OK, responder.getStatus(), "Resume workflow schedules failed");
   }
 
-  public String scheduleStatus(String appId, String wflowId, String schedId) {
+  public String scheduleStatus(String appId, String schedId) {
     MockResponder responder = new MockResponder();
-    String uri = String.format("/v2/apps/%s/workflows/%s/schedules/%s/status", appId, wflowId, schedId);
+    String uri = String.format("/v2/apps/%s/schedules/%s/status", appId, schedId);
     HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
-    httpHandler.getScheduleState(request, responder, appId, wflowId, schedId);
+    httpHandler.getStatus(request, responder, appId, "schedules", schedId);
     verifyResponse(HttpResponseStatus.OK, responder.getStatus(), "Get workflow schedules status failed");
     Map<String, String> json = responder.decodeResponseContent(new TypeToken<Map<String, String>>() { });
     return json.get("status");

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/test/internal/AppFabricClient.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/test/internal/AppFabricClient.java
@@ -190,14 +190,19 @@ public class AppFabricClient {
     verifyResponse(HttpResponseStatus.OK, responder.getStatus(), "Resume workflow schedules failed");
   }
 
-  public String scheduleStatus(String appId, String schedId) {
+  public String scheduleStatus(String appId, String schedId, int expectedResponseCode) {
     MockResponder responder = new MockResponder();
     String uri = String.format("/v2/apps/%s/schedules/%s/status", appId, schedId);
     HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
     httpHandler.getStatus(request, responder, appId, "schedules", schedId);
-    verifyResponse(HttpResponseStatus.OK, responder.getStatus(), "Get workflow schedules status failed");
-    Map<String, String> json = responder.decodeResponseContent(new TypeToken<Map<String, String>>() { });
-    return json.get("status");
+    verifyResponse(HttpResponseStatus.valueOf(expectedResponseCode), responder.getStatus(),
+                   "Get schedules status failed");
+    if (HttpResponseStatus.NOT_FOUND.getCode() == expectedResponseCode) {
+      return "NOT_FOUND";
+    } else {
+      Map<String, String> json = responder.decodeResponseContent(new TypeToken<Map<String, String>>() { });
+      return json.get("status");
+    }
   }
 
   private void verifyResponse(HttpResponseStatus expected, HttpResponseStatus actual, String errorMsg) {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AppFabricTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AppFabricTestBase.java
@@ -419,6 +419,10 @@ public abstract class AppFabricTestBase {
     HttpResponse response;
     while (trial++ < retries) {
       response = doGet(url);
+      if (expected.equals("NOT_FOUND")) {
+        Assert.assertEquals(404, response.getStatusLine().getStatusCode());
+        return;
+      }
       Assert.assertEquals(200, response.getStatusLine().getStatusCode());
       json = EntityUtils.toString(response.getEntity());
       output = new Gson().fromJson(json, MAP_STRING_STRING_TYPE);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/AppFabricHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/AppFabricHttpHandlerTest.java
@@ -991,11 +991,11 @@ public class AppFabricHttpHandlerTest extends AppFabricTestBase {
     scheduleHistoryRuns(5, "/v2/apps/AppWithSchedule/workflows/SampleWorkflow/runs?status=completed", 0);
 
     //Check suspend status
-    String scheduleStatus = String.format("/v2/apps/AppWithSchedule/workflows/SampleWorkflow/schedules/%s/status",
+    String scheduleStatus = String.format("/v2/apps/AppWithSchedule/schedules/%s/status",
                                           scheduleName);
     scheduleStatusCheck(5, scheduleStatus, "SCHEDULED");
 
-    String scheduleSuspend = String.format("/v2/apps/AppWithSchedule/workflows/SampleWorkflow/schedules/%s/suspend",
+    String scheduleSuspend = String.format("/v2/apps/AppWithSchedule/schedules/%s/suspend",
                                            scheduleName);
 
     response = doPost(scheduleSuspend);
@@ -1022,21 +1022,20 @@ public class AppFabricHttpHandlerTest extends AppFabricTestBase {
     int workflowRunsAfterSuspend = history.size();
     Assert.assertEquals(workflowRuns, workflowRunsAfterSuspend);
 
-    String scheduleResume = String.format("/v2/apps/AppWithSchedule/workflows/SampleWorkflow/schedules/%s/resume",
+    String scheduleResume = String.format("/v2/apps/AppWithSchedule/schedules/%s/resume",
                                           scheduleName);
 
     response = doPost(scheduleResume);
     Assert.assertEquals(200, response.getStatusLine().getStatusCode());
 
     scheduleHistoryRuns(5, "/v2/apps/AppWithSchedule/workflows/SampleWorkflow/runs?status=completed",
-                         workflowRunsAfterSuspend);
+                        workflowRunsAfterSuspend);
 
     //check scheduled state
     scheduleStatusCheck(5, scheduleStatus, "SCHEDULED");
 
     //Check status of a non existing schedule
-    String notFoundSchedule = String.format("/v2/apps/AppWithSchedule/workflows/SampleWorkflow/schedules/%s/status",
-                                            "invalidId");
+    String notFoundSchedule = String.format("/v2/apps/AppWithSchedule/schedules/%s/status", "invalidId");
 
     scheduleStatusCheck(5, notFoundSchedule, "NOT_FOUND");
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/ProgramLifecycleHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/ProgramLifecycleHttpHandlerTest.java
@@ -677,7 +677,7 @@ public class ProgramLifecycleHttpHandlerTest extends AppFabricTestBase {
 
     for (ScheduleSpecification spec : schedules) {
       Assert.assertEquals(200, suspendSchedule(TEST_NAMESPACE2, APP_WITH_CONCURRENT_WORKFLOW,
-                                               CONCURRENT_WORKFLOW_NAME, spec.getSchedule().getName()));
+                                               spec.getSchedule().getName()));
     }
 
     // delete the application
@@ -732,12 +732,10 @@ public class ProgramLifecycleHttpHandlerTest extends AppFabricTestBase {
     scheduleHistoryRuns(5, runsUrl, 0);
 
     //Check schedule status
-    String statusUrl = getStatusUrl(TEST_NAMESPACE2, APP_WITH_SCHEDULE_APP_NAME, APP_WITH_SCHEDULE_WORKFLOW_NAME,
-                                    scheduleName);
+    String statusUrl = getStatusUrl(TEST_NAMESPACE2, APP_WITH_SCHEDULE_APP_NAME, scheduleName);
     scheduleStatusCheck(5, statusUrl, "SCHEDULED");
 
-    Assert.assertEquals(200, suspendSchedule(TEST_NAMESPACE2, APP_WITH_SCHEDULE_APP_NAME,
-                                             APP_WITH_SCHEDULE_WORKFLOW_NAME, scheduleName));
+    Assert.assertEquals(200, suspendSchedule(TEST_NAMESPACE2, APP_WITH_SCHEDULE_APP_NAME, scheduleName));
     //check paused state
     scheduleStatusCheck(5, statusUrl, "SUSPENDED");
 
@@ -751,8 +749,7 @@ public class ProgramLifecycleHttpHandlerTest extends AppFabricTestBase {
     int workflowRunsAfterSuspend = getRuns(runsUrl);
     Assert.assertEquals(workflowRuns, workflowRunsAfterSuspend);
 
-    Assert.assertEquals(200, resumeSchedule(TEST_NAMESPACE2, APP_WITH_SCHEDULE_APP_NAME,
-                                            APP_WITH_SCHEDULE_WORKFLOW_NAME, scheduleName));
+    Assert.assertEquals(200, resumeSchedule(TEST_NAMESPACE2, APP_WITH_SCHEDULE_APP_NAME, scheduleName));
 
     scheduleHistoryRuns(5, runsUrl, workflowRunsAfterSuspend);
 
@@ -760,15 +757,19 @@ public class ProgramLifecycleHttpHandlerTest extends AppFabricTestBase {
     scheduleStatusCheck(5, statusUrl, "SCHEDULED");
 
     //Check status of a non existing schedule
-    String invalid = getStatusUrl(TEST_NAMESPACE2, APP_WITH_SCHEDULE_APP_NAME, APP_WITH_SCHEDULE_WORKFLOW_NAME,
-                                  "invalid");
+    String invalid = getStatusUrl(TEST_NAMESPACE2, APP_WITH_SCHEDULE_APP_NAME, "invalid");
     scheduleStatusCheck(5, invalid, "NOT_FOUND");
 
-    Assert.assertEquals(200, suspendSchedule(TEST_NAMESPACE2, APP_WITH_SCHEDULE_APP_NAME,
-                                             APP_WITH_SCHEDULE_WORKFLOW_NAME, scheduleName));
+    Assert.assertEquals(200, suspendSchedule(TEST_NAMESPACE2, APP_WITH_SCHEDULE_APP_NAME, scheduleName));
 
     //check paused state
     scheduleStatusCheck(5, statusUrl, "SUSPENDED");
+
+    //Schedule operations using invalid namespace
+    String inValidNamespaceUrl = getStatusUrl(TEST_NAMESPACE1, APP_WITH_SCHEDULE_APP_NAME, scheduleName);
+    scheduleStatusCheck(5, inValidNamespaceUrl, "NOT_FOUND");
+    Assert.assertEquals(404, suspendSchedule(TEST_NAMESPACE1, APP_WITH_SCHEDULE_APP_NAME, scheduleName));
+    Assert.assertEquals(404, resumeSchedule(TEST_NAMESPACE1, APP_WITH_SCHEDULE_APP_NAME, scheduleName));
 
     TimeUnit.SECONDS.sleep(2); //wait till any running jobs just before suspend call completes.
   }
@@ -920,20 +921,20 @@ public class ProgramLifecycleHttpHandlerTest extends AppFabricTestBase {
     return time;
   }
 
-  private String getStatusUrl(String namespace, String appName, String workflow, String schedule) throws Exception {
-    String statusUrl = String.format("apps/%s/workflows/%s/schedules/%s/status", appName, workflow, schedule);
+  private String getStatusUrl(String namespace, String appName, String schedule) throws Exception {
+    String statusUrl = String.format("apps/%s/schedules/%s/status", appName, schedule);
     return getVersionedAPIPath(statusUrl, Constants.Gateway.API_VERSION_3_TOKEN, namespace);
   }
 
-  private int resumeSchedule(String namespace, String appName, String workflow, String schedule) throws Exception {
-    String scheduleResume = String.format("apps/%s/workflows/%s/schedules/%s/resume", appName, workflow, schedule);
+  private int resumeSchedule(String namespace, String appName, String schedule) throws Exception {
+    String scheduleResume = String.format("apps/%s/schedules/%s/resume", appName, schedule);
     HttpResponse response = doPost(getVersionedAPIPath(scheduleResume, Constants.Gateway.API_VERSION_3_TOKEN,
                                                        namespace));
     return response.getStatusLine().getStatusCode();
   }
 
-  private int suspendSchedule(String namespace, String appName, String workflow, String schedule) throws Exception {
-    String scheduleSuspend = String.format("apps/%s/workflows/%s/schedules/%s/suspend", appName, workflow, schedule);
+  private int suspendSchedule(String namespace, String appName, String schedule) throws Exception {
+    String scheduleSuspend = String.format("apps/%s/schedules/%s/suspend", appName, schedule);
     String versionedScheduledSuspend = getVersionedAPIPath(scheduleSuspend, Constants.Gateway.API_VERSION_3_TOKEN,
                                                            namespace);
     HttpResponse response = doPost(versionedScheduledSuspend);

--- a/cdap-docs/reference-manual/source/http-restful-api/lifecycle.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/lifecycle.rst
@@ -549,7 +549,7 @@ Schedules can be suspended or resumed:
 Example
 .......
 .. list-table::
-   :widths: 20 80
+   :widths: 10 90
    :stub-columns: 1
 
    * - HTTP Method

--- a/cdap-docs/reference-manual/source/http-restful-api/lifecycle.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/lifecycle.rst
@@ -566,7 +566,7 @@ Example
      - Retrieves the schedules of the Workflow *PurchaseHistoryWorkflow* of the Application *PurchaseHistory*
    * - Returns
      - ``[{"schedule":{"name":"DailySchedule","description":"DailySchedule with crontab 0 4 * * *","cronEntry":"0 4 * * *"},``
-              ``"program":{"programName":"PurchaseHistoryWorkflow","programType":"WORKFLOW"},"properties":{}}]``
+       ``"program":{"programName":"PurchaseHistoryWorkflow","programType":"WORKFLOW"},"properties":{}}]``
    * - 
      - 
    * - HTTP Method

--- a/cdap-docs/reference-manual/source/http-restful-api/lifecycle.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/lifecycle.rst
@@ -536,7 +536,7 @@ For Workflows, you can also retrieve:
 
     GET <base-url>/apps/<app-id>/workflows/<workflow-id>/nextruntime
 
-Schedule can be suspended or resumed:
+Schedules can be suspended or resumed:
 
 - to suspend a schedule::
 
@@ -565,7 +565,8 @@ Example
    * - Description
      - Retrieves the schedules of the Workflow *PurchaseHistoryWorkflow* of the Application *PurchaseHistory*
    * - Returns
-     - ``[{"schedule":{"name":"DailySchedule","description":"DailySchedule with crontab 0 4 * * *","cronEntry":"0 4 * * *"},"program":{"programName":"PurchaseHistoryWorkflow","programType":"WORKFLOW"},"properties":{}}]``
+     - ``[{"schedule":{"name":"DailySchedule","description":"DailySchedule with crontab 0 4 * * *","cronEntry":"0 4 * * *"},``
+              ``"program":{"programName":"PurchaseHistoryWorkflow","programType":"WORKFLOW"},"properties":{}}]``
    * - 
      - 
    * - HTTP Method

--- a/cdap-docs/reference-manual/source/http-restful-api/lifecycle.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/lifecycle.rst
@@ -536,6 +536,16 @@ For Workflows, you can also retrieve:
 
     GET <base-url>/apps/<app-id>/workflows/<workflow-id>/nextruntime
 
+Schedule can be suspended or resumed:
+
+- to suspend a schedule::
+
+    POST <base-url>/apps/<app-id>/schedules/<schedule-name>/suspend
+
+- to resume a schedule::
+
+    POST <base-url>/apps/<app-id>/schedules/<schedule-name>/resume
+
 Example
 .......
 .. list-table::
@@ -555,7 +565,7 @@ Example
    * - Description
      - Retrieves the schedules of the Workflow *PurchaseHistoryWorkflow* of the Application *PurchaseHistory*
    * - Returns
-     - ``["WORKFLOW:developer:PurchaseHistory:PurchaseHistoryWorkflow:0:DailySchedule"]``
+     - ``[{"schedule":{"name":"DailySchedule","description":"DailySchedule with crontab 0 4 * * *","cronEntry":"0 4 * * *"},"program":{"programName":"PurchaseHistoryWorkflow","programType":"WORKFLOW"},"properties":{}}]``
    * - 
      - 
    * - HTTP Method

--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteApplicationManager.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteApplicationManager.java
@@ -230,7 +230,7 @@ public class RemoteApplicationManager implements ApplicationManager {
           }
 
           @Override
-          public String status() {
+          public String status(int expectedCode) {
             throw new UnsupportedOperationException("TODO");
           }
         };

--- a/cdap-test/src/main/java/co/cask/cdap/test/ScheduleManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/ScheduleManager.java
@@ -33,5 +33,5 @@ public interface ScheduleManager {
   /**
    * returns the status of the workflow schedule
    */
-  public String status();
+  public String status(int expectedCode);
 }

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultApplicationManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultApplicationManager.java
@@ -298,17 +298,17 @@ public class DefaultApplicationManager implements ApplicationManager {
         return new ScheduleManager() {
           @Override
           public void suspend() {
-            appFabricClient.suspend(applicationId, workflowName, schedName);
+            appFabricClient.suspend(applicationId, schedName);
           }
 
           @Override
           public void resume() {
-            appFabricClient.resume(applicationId, workflowName, schedName);
+            appFabricClient.resume(applicationId, schedName);
           }
 
           @Override
           public String status() {
-            return appFabricClient.scheduleStatus(applicationId, workflowName, schedName);
+            return appFabricClient.scheduleStatus(applicationId, schedName);
           }
         };
       }

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultApplicationManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultApplicationManager.java
@@ -307,8 +307,8 @@ public class DefaultApplicationManager implements ApplicationManager {
           }
 
           @Override
-          public String status() {
-            return appFabricClient.scheduleStatus(applicationId, schedName);
+          public String status(int expectedCode) {
+            return appFabricClient.scheduleStatus(applicationId, schedName, expectedCode);
           }
         };
       }

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
@@ -116,7 +116,7 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     int workflowRuns;
     workFlowHistoryCheck(5, wfmanager, 0);
 
-    String status = wfmanager.getSchedule(scheduleName).status();
+    String status = wfmanager.getSchedule(scheduleName).status(200);
     Assert.assertEquals("SCHEDULED", status);
 
     wfmanager.getSchedule(scheduleName).suspend();
@@ -139,10 +139,10 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     workFlowHistoryCheck(5, wfmanager, workflowRunsAfterSuspend);
 
     //check scheduled state
-    Assert.assertEquals("SCHEDULED", wfmanager.getSchedule(scheduleName).status());
+    Assert.assertEquals("SCHEDULED", wfmanager.getSchedule(scheduleName).status(200));
 
     //check status of non-existent schedule
-    Assert.assertEquals("NOT_FOUND", wfmanager.getSchedule("doesnt exist").status());
+    Assert.assertEquals("NOT_FOUND", wfmanager.getSchedule("doesnt exist").status(404));
 
     //suspend the schedule
     wfmanager.getSchedule(scheduleName).suspend();
@@ -171,7 +171,7 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     int trial = 0;
     String status = null;
     while (trial++ < retries) {
-      status = wfmanager.getSchedule(scheduleId).status();
+      status = wfmanager.getSchedule(scheduleId).status(200);
       if (status.equals(expected)) {
         return;
       }


### PR DESCRIPTION
1. Updated following schedule endpoints:
a) Moved apps/{app-id}/workflows/{workflow-id}/schedules/{schedule-name}/status to apps/{app-id}/schedules/{schedule-name}/status
b) Moved apps/{app-id}/workflows/{workflow-id}/schedules/{schedule-name}/suspend to apps/{app-id}/schedules/{schedule-name}/suspend
c) Moved apps/{app-id}/workflows/{workflow-id}/schedules/{schedule-name}/resume to apps/{app-id}/schedules/{schedule-name}/resume 
2. Updated unit test cases to reflect the new end-points.
3. Added unit test case for accessing the schedules in another namespace which should give 404. 

Note that schedule status endpoint is handled by /apps/{app-id}/{runnable-type}/{runnable-id}/status and schedule suspend/resume endpoint is handled by /apps/{app-id}/{runnable-type}/{runnable-id}/{action}. This is because the issue mentioned in https://issues.cask.co/browse/NETTY-3 