### PR TITLE
[CDAP-1261] Respond with 404 instead of 400 for stream not found in chan...

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
@@ -690,7 +690,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
 
       StreamSpecification stream = store.getStream(Id.Namespace.from(namespaceId), streamId);
       if (stream == null) {
-        responder.sendString(HttpResponseStatus.BAD_REQUEST, "Stream specified with streamId param does not exist");
+        responder.sendString(HttpResponseStatus.NOT_FOUND, "Stream specified with streamId param does not exist");
         return;
       }
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/AppFabricHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/AppFabricHttpHandlerTest.java
@@ -350,6 +350,10 @@ public class AppFabricHttpHandlerTest extends AppFabricTestBase {
   public void testChangeFlowletStreamInput() throws Exception {
     deploy(MultiStreamApp.class);
 
+    // non-existing stream
+    Assert.assertEquals(404,
+                        changeFlowletStreamInput("MultiStreamApp", "CounterFlow", "counter1", "stream1", "notfound"));
+
     Assert.assertEquals(200,
                         changeFlowletStreamInput("MultiStreamApp", "CounterFlow", "counter1", "stream1", "stream2"));
     // stream1 is no longer a connection

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/ProgramLifecycleHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/ProgramLifecycleHttpHandlerTest.java
@@ -617,8 +617,11 @@ public class ProgramLifecycleHttpHandlerTest extends AppFabricTestBase {
     Assert.assertEquals(200, response.getStatusLine().getStatusCode());
 
     // change stream input in the wrong namespace
-    Assert.assertEquals(400, changeFLowletStreamConnection(TEST_NAMESPACE2, appId, flowId, flowletId, "stream1",
+    Assert.assertEquals(404, changeFLowletStreamConnection(TEST_NAMESPACE2, appId, flowId, flowletId, "stream1",
                                                            "stream2"));
+    // change stream input to a non-existing stream in the right namespace
+    Assert.assertEquals(404, changeFLowletStreamConnection(TEST_NAMESPACE1, appId, flowId, flowletId, "stream1",
+                                                           "notfound"));
 
     Assert.assertEquals(200, changeFLowletStreamConnection(TEST_NAMESPACE1, appId, flowId, flowletId, "stream1",
                                                            "stream2"));


### PR DESCRIPTION
Changes the response code when stream is not found.

Related jira: https://issues.cask.co/browse/CDAP-1261

Build: https://builds.cask.co/browse/CDAP-RBT95-1