### PR TITLE
[CDAP-744] Updating netty-http version to pull in fix for CDAP-744.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
     <mockito.version>1.9.5</mockito.version>
     <mysql.version>5.1.21</mysql.version>
     <netty.version>3.6.6.Final</netty.version>
-    <netty.http.version>0.9.0</netty.http.version>
+    <netty.http.version>0.10.0</netty.http.version>
     <rs-api.version>2.0</rs-api.version>
     <quartz.version>2.2.0</quartz.version>
     <resteasy.version>3.0.8.Final</resteasy.version>


### PR DESCRIPTION
Updating ``netty-http`` version to pull in fix for [CDAP-744](https://issues.cask.co/browse/CDAP-744).

Build: https://builds.cask.co/browse/CDAP-RBT98-1