### PR TITLE
CDAP-1268 Allow user-defined variables outside CDAP_HOME

### DIFF
--- a/cdap-common/bin/service
+++ b/cdap-common/bin/service
@@ -64,7 +64,7 @@ CDAP_CONF=${CDAP_CONF:-/etc/cdap/conf}
 COMPONENT_HOME="$CDAP_HOME"/"$PKGNAME"; export COMPONENT_HOME
 COMPONENT_BIN="$COMPONENT_HOME"/bin
 
-# Load component comman.sh 
+# Load component common.sh 
 source $COMPONENT_BIN/common.sh
 
 # Load component common environment file too
@@ -74,6 +74,11 @@ source $COMPONENT_BIN/common-env.sh
 SERVICE_ENVIRONMENT_FILE="$COMPONENT_HOME"/conf/"$APP"-env.sh
 if [ -f "$SERVICE_ENVIRONMENT_FILE" ]; then 
  . "$SERVICE_ENVIRONMENT_FILE"
+fi
+
+# Load user-modifiable configuration
+if [ -f "${CDAP_CONF}/cdap-env.sh" ]; then
+ . "${CDAP_CONF}/cdap-env.sh"
 fi
 
 # Set Log location


### PR DESCRIPTION
This allows the user to update settings for CDAP by editing `CDAP_CONF/cdap-env.sh` or `/etc/cdap/conf/cdap-env.sh` in most installations. Otherwise, users are required to edit files in CDAP_HOME, which will get replaced on package upgrades.

This is the same as #1126 for develop...