### PR TITLE
CDAP-1185 Assign unique timestamps for non-transactional readless increments

### DIFF
--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseOrderedTableTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseOrderedTableTest.java
@@ -26,6 +26,7 @@ import co.cask.cdap.data.hbase.HBaseTestBase;
 import co.cask.cdap.data.hbase.HBaseTestFactory;
 import co.cask.cdap.data2.dataset2.lib.table.ordered.BufferingOrderedTable;
 import co.cask.cdap.data2.dataset2.lib.table.ordered.BufferingOrderedTableTest;
+import co.cask.cdap.data2.increment.hbase.IncrementHandlerState;
 import co.cask.cdap.data2.increment.hbase96.IncrementHandler;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
@@ -214,7 +215,7 @@ public class HBaseOrderedTableTest extends BufferingOrderedTableTest<BufferingOr
       table.increment(row, col, 10);
       table.commitTx();
       // verify that value was written as a delta value
-      final byte[] expectedValue = Bytes.add(IncrementHandler.DELTA_MAGIC_PREFIX, Bytes.toBytes(10L));
+      final byte[] expectedValue = Bytes.add(IncrementHandlerState.DELTA_MAGIC_PREFIX, Bytes.toBytes(10L));
       final AtomicBoolean foundValue = new AtomicBoolean();
       testHBase.forEachRegion(Bytes.toBytes(enabledTableName), new Function<HRegion, Object>() {
         @Nullable

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseMetricsTableDefinition.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseMetricsTableDefinition.java
@@ -25,6 +25,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.data2.dataset2.lib.hbase.AbstractHBaseDataSetAdmin;
 import co.cask.cdap.data2.dataset2.lib.table.MetricsTable;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
+import co.cask.tephra.TxConstants;
 import com.google.inject.Inject;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -87,7 +88,8 @@ public class HBaseMetricsTableDefinition extends AbstractDatasetDefinition<Metri
 
     long ttlMillis = spec.getLongProperty(OrderedTable.PROPERTY_TTL, -1);
     if (ttlMillis > 0) {
-      columnDescriptor.setTimeToLive((int) TimeUnit.MILLISECONDS.toSeconds(ttlMillis));
+      // the IncrementHandler coprocessor reads this value and performs TTL
+      columnDescriptor.setValue(TxConstants.PROPERTY_TTL, Long.toString(ttlMillis));
     }
 
     final HTableDescriptor tableDescriptor = new HTableDescriptor(tableName);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/increment/hbase/IncrementHandlerState.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/increment/hbase/IncrementHandlerState.java
@@ -73,6 +73,8 @@ public class IncrementHandlerState {
   }
 
   protected Supplier<TransactionStateCache> getTransactionStateCacheSupplier(String tableName, Configuration conf) {
+    // Table name is in the format "prefix.(system|user).tablename"
+    // We need the prefix in order to find the ConfigurationTable to read CDAP configuration
     String[] parts = tableName.split("\\.", 2);
     String tableNamespace = "";
     if (parts.length > 0) {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/increment/hbase/IncrementHandlerState.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/increment/hbase/IncrementHandlerState.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.increment.hbase;
+
+import co.cask.cdap.data2.transaction.coprocessor.DefaultTransactionStateCacheSupplier;
+import co.cask.tephra.TxConstants;
+import co.cask.tephra.coprocessor.TransactionStateCache;
+import co.cask.tephra.persist.TransactionSnapshot;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Supplier;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Common state and utilities shared by the HBase version-specific {@code IncrementHandler} coprocessor
+ * implementations.  This common implementation cannot go into a shared base class, as each coprocessor needs
+ * to derive from the HBase version's {@code BaseRegionObserver} class, in order to avoid being broken by
+ * API changes.
+ */
+public class IncrementHandlerState {
+  /**
+   * Property set for {@link HColumnDescriptor} to indicate if increment is transactional. Default: "true", i.e.
+   * transactional.
+   */
+  public static final String PROPERTY_TRANSACTIONAL = "dataset.table.readless.increment.transactional";
+  public static final long MAX_TS_PER_MS = 1000000;
+  // prefix bytes used to mark values that are deltas vs. full sums
+  public static final byte[] DELTA_MAGIC_PREFIX = new byte[] { 'X', 'D' };
+  // expected length for values storing deltas (prefix + increment value)
+  public static final int DELTA_FULL_LENGTH = DELTA_MAGIC_PREFIX.length + Bytes.SIZEOF_LONG;
+  public static final int BATCH_UNLIMITED = -1;
+
+  public static final Log LOG = LogFactory.getLog(IncrementHandlerState.class);
+
+  private TransactionStateCache cache;
+  private TimestampOracle timeOracle = new TimestampOracle();
+  private final String tableName;
+  private final Configuration conf;
+  protected final Set<byte[]> txnlFamilies = Sets.newTreeSet(Bytes.BYTES_COMPARATOR);
+  protected Map<byte[], Long> ttlByFamily = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
+
+  public IncrementHandlerState(Configuration conf, String tableName) {
+    this.conf = conf;
+    this.tableName = tableName;
+  }
+
+  @VisibleForTesting
+  public void setTimestampOracle(TimestampOracle timeOracle) {
+    this.timeOracle = timeOracle;
+  }
+
+  protected Supplier<TransactionStateCache> getTransactionStateCacheSupplier(String tableName, Configuration conf) {
+    String[] parts = tableName.split("\\.", 2);
+    String tableNamespace = "";
+    if (parts.length > 0) {
+      tableNamespace = parts[0];
+    }
+    return new DefaultTransactionStateCacheSupplier(tableNamespace, conf);
+  }
+
+  public void initFamily(byte[] familyName, Map<byte[], byte[]> familyValues) {
+    String familyAsString = Bytes.toString(familyName);
+    byte[] transactionalConfig = familyValues.get(Bytes.toBytes(IncrementHandlerState.PROPERTY_TRANSACTIONAL));
+    boolean txnl = transactionalConfig == null || !"false".equals(Bytes.toString(transactionalConfig));
+    LOG.info("Family " + familyAsString + " is transactional: " + txnl);
+    if (txnl) {
+      txnlFamilies.add(familyName);
+    }
+
+    // check for TTL configuration
+    byte[] columnTTL = familyValues.get(Bytes.toBytes(TxConstants.PROPERTY_TTL));
+    long ttl = 0;
+    if (columnTTL != null) {
+      try {
+        String stringTTL = Bytes.toString(columnTTL);
+        ttl = Long.parseLong(stringTTL);
+        LOG.info("Family " + familyAsString + " has TTL of " + ttl);
+      } catch (NumberFormatException nfe) {
+        LOG.warn("Invalid TTL value configured for column family " + familyAsString +
+            ", value = " + Bytes.toStringBinary(columnTTL));
+      }
+    }
+    ttlByFamily.put(familyName, ttl);
+
+    // get the transaction state cache as soon as we have a transactional family
+    if (!txnlFamilies.isEmpty() && cache == null) {
+      Supplier<TransactionStateCache> cacheSupplier = getTransactionStateCacheSupplier(tableName, conf);
+      this.cache = cacheSupplier.get();
+    }
+  }
+
+  public boolean containsTransactionalFamily(Set<byte[]> familyNames) {
+    // we assume that if any of the column families written to are transactional, the entire write is transactional
+    for (byte[] key : familyNames) {
+      if (txnlFamilies.contains(key)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Returns a unique timestamp for the current operation.
+   *
+   * @return a new timestamp guaranteed to be unique within the scope of usage
+   */
+  public synchronized long getUniqueTimestamp() {
+    return timeOracle.getUniqueTimestamp();
+  }
+
+  /**
+   * Returns the upper bound beyond which we can compact any increment deltas into a new sum.
+   * @param columnFamily the column family name
+   * @return the newest timestamp beyond which can compact delta increments
+   */
+  public long getCompactionBound(byte[] columnFamily) {
+    if (txnlFamilies.contains(columnFamily)) {
+      TransactionSnapshot snapshot = cache.getLatestState();
+      // if tx snapshot is not available, used "0" as upper bound to avoid trashing in-progress tx
+      return snapshot != null ? snapshot.getVisibilityUpperBound() : 0;
+    } else {
+      return Long.MAX_VALUE;
+    }
+  }
+
+  /**
+   * Returns the time-to-live (in milliseconds) for the given column family, transformed into the same precision
+   * used in assigning unique timestamps.
+   *
+   * @param familyName the column family name
+   * @return the time-to-live value
+   */
+  public long getFamilyTTL(byte[] familyName) {
+    Long configuredTTL = ttlByFamily.get(familyName);
+    return configuredTTL == null ? -1 : configuredTTL * TxConstants.MAX_TX_PER_MS;
+  }
+
+  /**
+   * Returns the oldest timestamp that will be visible for a given column family, after the column family's
+   * configured time-to-live is applied.
+   * @param familyName the name of the column family
+   * @return the oldest timestamp value that will be visible
+   */
+  public long getOldestVisibleTimestamp(byte[] familyName) {
+    long familyTTL = getFamilyTTL(familyName);
+    return familyTTL > 0 ? timeOracle.currentTime() - familyTTL : 0;
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/increment/hbase/SettableTimestampOracle.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/increment/hbase/SettableTimestampOracle.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.increment.hbase;
+
+/**
+ * Implementation of {@link TimestampOracle} that allows setting the current time.  This is useful
+ * to allow deterministic behavior during testing.
+ */
+public class SettableTimestampOracle extends TimestampOracle {
+  private long currentTime;
+
+  @Override
+  public long currentTime() {
+    return currentTime;
+  }
+
+  public void setCurrentTime(long time) {
+    this.currentTime = time;
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/increment/hbase/TimestampOracle.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/increment/hbase/TimestampOracle.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.increment.hbase;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Utility class that allows HBase coprocessors to interact with unique timestamps.
+ */
+public class TimestampOracle {
+  private AtomicLong lastTimestamp = new AtomicLong();
+
+  /**
+   * Returns the current wall clock time in milliseconds, multiplied by the required precision.
+   */
+  public long currentTime() {
+    // We want to align tx ids with current time. We assume that tx ids are sequential, but not less than
+    // System.currentTimeMillis() * MAX_TX_PER_MS.
+    return System.currentTimeMillis() * IncrementHandlerState.MAX_TS_PER_MS;
+  }
+
+
+  /**
+   * Returns a timestamp value unique within the scope of this {@code TimestampOracle} instance.  For usage
+   * by HBase {@code RegionObserver} coprocessors, this normally means unique within a given region.
+   */
+  public long getUniqueTimestamp() {
+    long lastTs;
+    long nextTs;
+    do {
+      lastTs = lastTimestamp.get();
+      nextTs = Math.max(lastTs + 1, currentTime());
+    } while (!lastTimestamp.compareAndSet(lastTs, nextTs));
+    return nextTs;
+  }
+}

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/increment/hbase/AbstractIncrementHandlerTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/increment/hbase/AbstractIncrementHandlerTest.java
@@ -1,0 +1,553 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.increment.hbase;
+
+import co.cask.cdap.data.hbase.HBaseTestBase;
+import co.cask.cdap.data.hbase.HBaseTestFactory;
+import co.cask.cdap.data2.dataset2.lib.table.hbase.HBaseOrderedTable;
+import co.cask.tephra.TxConstants;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.HTable;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Common test cases for HBase version-specific {@code IncrementHandlerTest} implementations.
+ */
+public abstract class AbstractIncrementHandlerTest {
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractIncrementHandlerTest.class);
+
+  protected static final byte[] EMPTY_BYTES = new byte[0];
+  protected static final byte[] FAMILY = Bytes.toBytes("i");
+
+  protected static HBaseTestBase testUtil;
+  protected static Configuration conf;
+
+  protected long ts = 1;
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    testUtil = new HBaseTestFactory().get();
+    testUtil.startHBase();
+    conf = testUtil.getConfiguration();
+  }
+
+  @AfterClass
+  public static void tearDown() throws Exception {
+    testUtil.stopHBase();
+  }
+
+  @Test
+  public void testIncrements() throws Exception {
+    String tableName = "incrementTest";
+    createTable("incrementTest");
+
+    HTable table = new HTable(conf, tableName);
+    try {
+      byte[] colA = Bytes.toBytes("a");
+      byte[] row1 = Bytes.toBytes("row1");
+
+      // test column containing only increments
+      table.put(newIncrement(row1, colA, 1));
+      table.put(newIncrement(row1, colA, 1));
+      table.put(newIncrement(row1, colA, 1));
+
+      assertColumn(table, row1, colA, 3);
+
+      // test intermixed increments and puts
+      Put putA = new Put(row1);
+      putA.add(FAMILY, colA, ts++, Bytes.toBytes(5L));
+      table.put(putA);
+
+      assertColumn(table, row1, colA, 5);
+
+      table.put(newIncrement(row1, colA, 1));
+      table.put(newIncrement(row1, colA, 1));
+
+      assertColumn(table, row1, colA, 7);
+
+      // test multiple increment columns
+      byte[] row2 = Bytes.toBytes("row2");
+      byte[] colB = Bytes.toBytes("b");
+
+      // increment A and B twice at the same timestamp
+      table.put(newIncrement(row2, colA, 1, 1));
+      table.put(newIncrement(row2, colB, 1, 1));
+      table.put(newIncrement(row2, colA, 2, 1));
+      table.put(newIncrement(row2, colB, 2, 1));
+      // increment A once more
+      table.put(newIncrement(row2, colA, 1));
+
+      assertColumns(table, row2, new byte[][]{ colA, colB }, new long[]{ 3, 2 });
+
+      // overwrite B with a new put
+      Put p = new Put(row2);
+      p.add(FAMILY, colB, ts++, Bytes.toBytes(10L));
+      table.put(p);
+
+      assertColumns(table, row2, new byte[][]{ colA, colB }, new long[]{ 3, 10 });
+    } finally {
+      table.close();
+    }
+  }
+
+  @Test
+  public void testIncrementsCompaction() throws Exception {
+    // In this test we verify that squashing delta-increments during flush or compaction works as designed.
+
+    String tableName = "incrementCompactTest";
+    byte[] tableBytes = Bytes.toBytes(tableName);
+    createTable(tableName);
+
+    HTable table = new HTable(conf, tableName);
+    try {
+      byte[] colA = Bytes.toBytes("a");
+      byte[] row1 = Bytes.toBytes("row1");
+
+      // do some increments
+      table.put(newIncrement(row1, colA, 1));
+      table.put(newIncrement(row1, colA, 1));
+      table.put(newIncrement(row1, colA, 1));
+
+      assertColumn(table, row1, colA, 3);
+
+      testUtil.forceRegionFlush(tableBytes);
+
+      // verify increments after flush
+      assertColumn(table, row1, colA, 3);
+
+      // do some more increments
+      table.put(newIncrement(row1, colA, 1));
+      table.put(newIncrement(row1, colA, 1));
+      table.put(newIncrement(row1, colA, 1));
+
+      // verify increments merged well from hstore and memstore
+      assertColumn(table, row1, colA, 6);
+
+      testUtil.forceRegionFlush(tableBytes);
+
+      // verify increments merged well into hstores
+      assertColumn(table, row1, colA, 6);
+
+      // do another iteration to verify that multiple "squashed" increments merged well at scan and at flush
+      table.put(newIncrement(row1, colA, 1));
+      table.put(newIncrement(row1, colA, 1));
+      table.put(newIncrement(row1, colA, 1));
+
+      assertColumn(table, row1, colA, 9);
+      testUtil.forceRegionFlush(tableBytes);
+      assertColumn(table, row1, colA, 9);
+
+      // verify increments merged well on minor compaction
+      testUtil.forceRegionCompact(tableBytes, false);
+      assertColumn(table, row1, colA, 9);
+
+      // another round of increments to verify that merged on compaction merges well with memstore and with new hstores
+      table.put(newIncrement(row1, colA, 1));
+      table.put(newIncrement(row1, colA, 1));
+      table.put(newIncrement(row1, colA, 1));
+
+      assertColumn(table, row1, colA, 12);
+      testUtil.forceRegionFlush(tableBytes);
+      assertColumn(table, row1, colA, 12);
+
+      // do same, but with major compaction
+      // verify increments merged well on minor compaction
+      testUtil.forceRegionCompact(tableBytes, true);
+      assertColumn(table, row1, colA, 12);
+
+      // another round of increments to verify that merged on compaction merges well with memstore and with new hstores
+      table.put(newIncrement(row1, colA, 1));
+      table.put(newIncrement(row1, colA, 1));
+      table.put(newIncrement(row1, colA, 1));
+
+      assertColumn(table, row1, colA, 15);
+      testUtil.forceRegionFlush(tableBytes);
+      assertColumn(table, row1, colA, 15);
+
+    } finally {
+      table.close();
+    }
+  }
+
+  @Test
+  public void testIncrementsCompactionUnlimBound() throws Exception {
+    RegionWrapper region = createRegion("testIncrementsCompactionsUnlimBound", ImmutableMap.<String, String>builder()
+        .put(IncrementHandlerState.PROPERTY_TRANSACTIONAL, "false").build());
+
+    try {
+      region.initialize();
+
+      byte[] colA = Bytes.toBytes("a");
+      byte[] row1 = Bytes.toBytes("row1");
+
+      // do some increments
+      region.put(newIncrement(row1, colA, 1));
+      region.put(newIncrement(row1, colA, 1));
+      region.put(newIncrement(row1, colA, 1));
+
+      region.flush();
+
+      // verify increments merged after flush
+      assertSingleVersionColumn(region, row1, colA, 3);
+
+      // do some more increments
+      region.put(newIncrement(row1, colA, 1));
+      region.put(newIncrement(row1, colA, 1));
+      region.put(newIncrement(row1, colA, 1));
+
+      region.flush();
+      region.compact(true);
+
+      // verify increments merged well into hstores
+      assertSingleVersionColumn(region, row1, colA, 6);
+    } finally {
+      region.close();
+    }
+  }
+
+  @Test
+  public void testNonTransactionalMixed() throws Exception {
+    // test mix of increment, put and delete operations
+
+    String tableName = "testNonTransactionalMixed";
+    createTable(tableName);
+
+    byte[] row1 = Bytes.toBytes("r1");
+    byte[] col = Bytes.toBytes("c");
+    HTable table = new HTable(conf, tableName);
+    try {
+      // perform 100 increments on a column
+      for (int i = 0; i < 100; i++) {
+        table.put(newIncrement(row1, col, 1));
+      }
+
+      assertColumn(table, row1, col, 100);
+
+      // do a new put on the column
+      Put put = new Put(row1);
+      put.add(FAMILY, col, Bytes.toBytes(11L));
+      table.put(put);
+
+      assertColumn(table, row1, col, 11);
+
+      // perform a delete on the column
+      Delete delete = new Delete(row1);
+      delete.deleteColumns(FAMILY, col);
+      // use batch to work around a bug in delete coprocessor hooks on HBase 0.94
+      table.batch(Lists.newArrayList(delete));
+
+      Get get = new Get(row1);
+      Result result = table.get(get);
+      LOG.info("Get after delete returned " + result);
+      assertTrue(result.isEmpty());
+
+      // perform 100 increments on a column
+      for (int i = 0; i < 100; i++) {
+        table.put(newIncrement(row1, col, 1));
+      }
+
+      assertColumn(table, row1, col, 100);
+
+      // perform a family delete
+      delete = new Delete(row1);
+      delete.deleteFamily(FAMILY);
+      // use batch to work around a bug in delete coprocessor hooks on HBase 0.94
+      table.batch(Lists.newArrayList(delete));
+
+      get = new Get(row1);
+      result = table.get(get);
+      LOG.info("Get after delete returned " + result);
+      assertTrue(result.isEmpty());
+
+      // do 100 more increments
+      for (int i = 0; i < 100; i++) {
+        table.put(newIncrement(row1, col, 1));
+      }
+
+      assertColumn(table, row1, col, 100);
+
+      // perform a row delete
+      delete = new Delete(row1);
+      // use batch to work around a bug in delete coprocessor hooks on HBase 0.94
+      table.batch(Lists.newArrayList(delete));
+
+      get = new Get(row1);
+      result = table.get(get);
+      LOG.info("Get after delete returned " + result);
+      assertTrue(result.isEmpty());
+
+      // do 100 more increments
+      for (int i = 0; i < 100; i++) {
+        table.put(newIncrement(row1, col, 1));
+      }
+
+      assertColumn(table, row1, col, 100);
+    } finally {
+      table.close();
+    }
+  }
+
+  /**
+   * Verifies that time-to-live based expiration of data is applied correctly when the {@code IncrementHandler}
+   * coprocessor is generating timestamps, ie. for non-transactional writes.  TTL-based expiration of increment
+   * values follows a couple of rule:
+   * <ol>
+   *   <li>delta writes (increments) are never TTL'd</li>
+   *   <li>a normal put is only TTL'd if not preceeded by newer increments in the same column</li>
+   * </ol>
+   */
+  @Test
+  public void testNonTransactionalTTL() throws Exception {
+    RegionWrapper region = createRegion("testNonTransactionalTTL", ImmutableMap.<String, String>builder()
+        .put(IncrementHandlerState.PROPERTY_TRANSACTIONAL, "false")
+        .put(TxConstants.PROPERTY_TTL, "50").build());
+
+    byte[] row = Bytes.toBytes("r1");
+    byte[] col = Bytes.toBytes("c");
+    try {
+      region.initialize();
+
+      SettableTimestampOracle timeOracle = new SettableTimestampOracle();
+      region.setCoprocessorTimestampOracle(timeOracle);
+
+      // test that we do not apply TTL in the middle of a set of increments
+      long now = System.currentTimeMillis();
+
+      for (int i = 100; i > 0; i--) {
+        timeOracle.setCurrentTime((now - i) * IncrementHandlerState.MAX_TS_PER_MS);
+        // timestamp will be overridden by IncrementHandler coprocessor
+        region.put(newIncrement(row, col, Integer.MAX_VALUE, 1));
+      }
+      // reset "current time"
+      timeOracle.setCurrentTime(now * IncrementHandlerState.MAX_TS_PER_MS);
+
+      List<ColumnCell> results = Lists.newArrayList();
+      assertFalse(region.scanRegion(results, row));
+      // verify we have 100 individual cells, one per increment
+      assertEquals(100, results.size());
+      for (int i = 0; i < results.size(); i++) {
+        ColumnCell cell = results.get(i);
+        assertEquals(1L, Bytes.toLong(cell.getValue(), 2));
+        Assert.assertEquals((now - i - 1) * IncrementHandlerState.MAX_TS_PER_MS, cell.getTimestamp());
+      }
+
+      // verify that when summing we return the correct sum
+
+      // run a flush, verify that all cells are included in the summed value
+      region.flush();
+
+      results.clear();
+      assertFalse(region.scanRegion(results, row));
+      // verify 1 increment cell now exists
+      assertEquals(1, results.size());
+      assertEquals(100L, Bytes.toLong(results.get(0).getValue(), 2));
+      // should have the timestamp from the most recent increment
+      Assert.assertEquals((now - 1) * IncrementHandlerState.MAX_TS_PER_MS, results.get(0).getTimestamp());
+
+      // test that we do not apply TTL to a put terminating a set of increments
+      byte[] row2 = Bytes.toBytes("r2");
+      // first add a full put
+      Put p = new Put(row2);
+      p.add(FAMILY, col, Bytes.toBytes(50L));
+      region.put(p);
+
+      // move 51 msec into the future, so that the previous put is behind the TTL
+      now = now + 51;
+
+      // add some increments
+      for (int i = 10; i > 0; i--) {
+        timeOracle.setCurrentTime((now - i) * IncrementHandlerState.MAX_TS_PER_MS);
+        // timestamp will be overridden by IncrementHandler coprocessor
+        region.put(newIncrement(row2, col, Integer.MAX_VALUE, 1));
+      }
+      // reset "current time"
+      timeOracle.setCurrentTime(now * IncrementHandlerState.MAX_TS_PER_MS);
+
+      results.clear();
+      assertFalse(region.scanRegion(results, row2));
+      assertEquals(11, results.size());
+      // first 10 cells should be the increments
+      for (int i = 0; i < 10; i++) {
+        ColumnCell cell = results.get(i);
+        Assert.assertEquals((now - i - 1) * IncrementHandlerState.MAX_TS_PER_MS, cell.getTimestamp());
+        assertEquals(1L, Bytes.toLong(cell.getValue(), 2));
+      }
+
+      // last should be the full put
+      ColumnCell cell = results.get(10);
+      Assert.assertEquals((now - 51) * IncrementHandlerState.MAX_TS_PER_MS, cell.getTimestamp());
+      assertEquals(50L, Bytes.toLong(cell.getValue()));
+
+      // do a compaction
+      region.flush();
+      region.compact(true);
+
+      // verify that the 10 increments and 1 put are summed to 1 cell (as a normal put)
+      results.clear();
+      assertFalse(region.scanRegion(results, row2));
+      assertEquals(1, results.size());
+      assertEquals(60L, Bytes.toLong(results.get(0).getValue()));
+      Assert.assertEquals((now - 1) * IncrementHandlerState.MAX_TS_PER_MS, results.get(0).getTimestamp());
+
+      // test that we apply TTL to a put preceeded by a non-TTL'd put
+      // go 50 msec into the future
+      now = now + 50;
+      timeOracle.setCurrentTime(now * IncrementHandlerState.MAX_TS_PER_MS);
+
+      // do another full put
+      p = new Put(row2);
+      p.add(FAMILY, col, Bytes.toBytes(99L));
+      region.put(p);
+
+      // run a compaction to apply TTL
+      region.compact(true);
+      // the previously summed value should now be gone
+      results.clear();
+      assertFalse(region.scanRegion(results, row2));
+      assertEquals(1, results.size());
+      assertEquals(99L, Bytes.toLong(results.get(0).getValue()));
+      Assert.assertEquals(now * IncrementHandlerState.MAX_TS_PER_MS, results.get(0).getTimestamp());
+
+      // test that we apply TTL to a standalone put
+      byte[] row3 = Bytes.toBytes("r3");
+      p = new Put(row3);
+      p.add(FAMILY, col, Bytes.toBytes(11L));
+      region.put(p);
+
+      results.clear();
+      assertFalse(region.scanRegion(results, row3));
+      assertEquals(1, results.size());
+      assertEquals(11L, Bytes.toLong(results.get(0).getValue()));
+
+      // advance 51 msec into the future
+      now = now + 51;
+      timeOracle.setCurrentTime(now * IncrementHandlerState.MAX_TS_PER_MS);
+
+      region.flush();
+      region.compact(true);
+      // the stand alone put should be gone
+      results.clear();
+      assertFalse(region.scanRegion(results, row3));
+      assertEquals(0, results.size());
+    } finally {
+      region.close();
+    }
+  }
+
+  public Put newIncrement(byte[] row, byte[] column, long value) {
+      return newIncrement(row, column, ts++, value);
+  }
+
+  public Put newIncrement(byte[] row, byte[] column, long timestamp, long value) {
+    Put p = new Put(row);
+    p.add(FAMILY, column, timestamp, Bytes.toBytes(value));
+    p.setAttribute(HBaseOrderedTable.DELTA_WRITE, EMPTY_BYTES);
+    return p;
+  }
+
+  public abstract void assertColumn(HTable table, byte[] row, byte[] col, long expected) throws Exception;
+
+  public void assertSingleVersionColumn(RegionWrapper region, byte[] row, byte[] col, long expected) throws Exception {
+    List<ColumnCell> results = Lists.newArrayList();
+    Assert.assertFalse(region.scanRegion(results, row, new byte[][]{col}));
+    Assert.assertEquals(1, results.size());
+    byte[] value = results.get(0).getValue();
+    // note: it may be stored as increment delta even after merge on flush/compact
+    long longValue =
+        Bytes.toLong(value, value.length > Bytes.SIZEOF_LONG ? IncrementHandlerState.DELTA_MAGIC_PREFIX.length : 0);
+    Assert.assertEquals(expected, longValue);
+  }
+
+  public abstract void assertColumns(HTable table, byte[] row, byte[][] cols, long[] expected) throws Exception;
+
+  public abstract RegionWrapper createRegion(String tableName, Map<String, String> familyProperties) throws Exception;
+
+  public abstract void createTable(String tableName) throws Exception;
+
+  public static class ColumnCell {
+    private final byte[] row;
+    private final byte[] family;
+    private final byte[] qualifier;
+    private final long timestamp;
+    private final byte[] value;
+
+    public ColumnCell(byte[] row, byte[] family, byte[] qualifier, long timestamp, byte[] value) {
+      this.row = row;
+      this.family = family;
+      this.qualifier = qualifier;
+      this.timestamp = timestamp;
+      this.value = value;
+    }
+
+    public byte[] getRow() {
+      return row;
+    }
+
+    public byte[] getFamily() {
+      return family;
+    }
+
+    public byte[] getQualifier() {
+      return qualifier;
+    }
+
+    public long getTimestamp() {
+      return timestamp;
+    }
+
+    public byte[] getValue() {
+      return value;
+    }
+  }
+
+  public interface RegionWrapper extends Closeable {
+    void initialize() throws IOException;
+
+    void put(Put put) throws IOException;
+
+    boolean scanRegion(List<ColumnCell> results, byte[] startRow) throws IOException;
+
+    boolean scanRegion(List<ColumnCell> results, byte[] startRow, byte[][] column) throws IOException;
+
+    boolean flush() throws IOException;
+
+    void compact(boolean majorCompact) throws IOException;
+
+    void setCoprocessorTimestampOracle(TimestampOracle timeOracle);
+  }
+}

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/increment/hbase/AbstractIncrementHandlerTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/increment/hbase/AbstractIncrementHandlerTest.java
@@ -366,7 +366,7 @@ public abstract class AbstractIncrementHandlerTest {
         Assert.assertEquals((now - i - 1) * IncrementHandlerState.MAX_TS_PER_MS, cell.getTimestamp());
       }
 
-      // verify that when summing we return the correct sum
+      // verify that when summing during flush we return the correct sum
 
       // run a flush, verify that all cells are included in the summed value
       region.flush();

--- a/cdap-hbase-compat-0.94/src/test/java/co/cask/cdap/data2/increment/hbase94/IncrementHandlerTest.java
+++ b/cdap-hbase-compat-0.94/src/test/java/co/cask/cdap/data2/increment/hbase94/IncrementHandlerTest.java
@@ -16,16 +16,17 @@
 
 package co.cask.cdap.data2.increment.hbase94;
 
-import co.cask.cdap.data2.dataset2.lib.table.hbase.HBaseOrderedTable;
+import co.cask.cdap.data2.increment.hbase.AbstractIncrementHandlerTest;
+import co.cask.cdap.data2.increment.hbase.IncrementHandlerState;
+import co.cask.cdap.data2.increment.hbase.TimestampOracle;
 import co.cask.cdap.test.SlowTests;
-import com.google.common.collect.Lists;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hbase.HBaseTestingUtility;
+import org.apache.hadoop.hbase.Coprocessor;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.HTable;
+import org.apache.hadoop.hbase.client.Mutation;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
@@ -33,13 +34,13 @@ import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.hadoop.hbase.regionserver.RegionScanner;
 import org.apache.hadoop.hbase.util.Bytes;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.apache.hadoop.hbase.util.Pair;
 import org.junit.experimental.categories.Category;
 
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -50,233 +51,10 @@ import static org.junit.Assert.assertNotNull;
  * Tests for the HBase 0.94 version of the {@link IncrementHandler} coprocessor.
  */
 @Category(SlowTests.class)
-public class IncrementHandlerTest {
-  private static final byte[] EMPTY_BYTES = new byte[0];
-  private static final byte[] FAMILY = Bytes.toBytes("i");
+public class IncrementHandlerTest extends AbstractIncrementHandlerTest {
 
-  private static HBaseTestingUtility testUtil;
-  private static Configuration conf;
-
-  private long ts = 1;
-
-  @BeforeClass
-  public static void setup() throws Exception {
-    testUtil = new HBaseTestingUtility();
-    testUtil.startMiniCluster();
-    conf = testUtil.getConfiguration();
-  }
-
-  @AfterClass
-  public static void tearDown() throws Exception {
-    testUtil.shutdownMiniCluster();
-  }
-
-  @Test
-  public void testIncrements() throws Exception {
-    byte[] tableName = Bytes.toBytes("incrementTest");
-    HTableDescriptor tableDesc = new HTableDescriptor(tableName);
-    HColumnDescriptor columnDesc = new HColumnDescriptor(FAMILY);
-    columnDesc.setMaxVersions(Integer.MAX_VALUE);
-    tableDesc.addFamily(columnDesc);
-    tableDesc.addCoprocessor(IncrementHandler.class.getName());
-    testUtil.getHBaseAdmin().createTable(tableDesc);
-    testUtil.waitTableAvailable(tableName, 5000);
-
-    HTable table = new HTable(conf, tableName);
-    try {
-      byte[] colA = Bytes.toBytes("a");
-      byte[] row1 = Bytes.toBytes("row1");
-
-      // test column containing only increments
-      table.put(newIncrement(row1, colA, 1));
-      table.put(newIncrement(row1, colA, 1));
-      table.put(newIncrement(row1, colA, 1));
-
-      assertColumn(table, row1, colA, 3);
-
-      // test intermixed increments and puts
-      Put putA = new Put(row1);
-      putA.add(FAMILY, colA, ts++, Bytes.toBytes(5L));
-      table.put(putA);
-
-      assertColumn(table, row1, colA, 5);
-
-      table.put(newIncrement(row1, colA, 1));
-      table.put(newIncrement(row1, colA, 1));
-
-      assertColumn(table, row1, colA, 7);
-
-      // test multiple increment columns
-      byte[] row2 = Bytes.toBytes("row2");
-      byte[] colB = Bytes.toBytes("b");
-
-      // increment A and B twice at the same timestamp
-      table.put(newIncrement(row2, colA, 1, 1));
-      table.put(newIncrement(row2, colB, 1, 1));
-      table.put(newIncrement(row2, colA, 2, 1));
-      table.put(newIncrement(row2, colB, 2, 1));
-      // increment A once more
-      table.put(newIncrement(row2, colA, 1));
-
-      assertColumns(table, row2, new byte[][]{ colA, colB }, new long[]{ 3, 2 });
-
-      // overwrite B with a new put
-      Put p = new Put(row2);
-      p.add(FAMILY, colB, ts++, Bytes.toBytes(10L));
-      table.put(p);
-
-      assertColumns(table, row2, new byte[][]{ colA, colB }, new long[]{ 3, 10 });
-
-      // check a full scan
-      Scan scan = new Scan();
-      ResultScanner scanner = table.getScanner(scan);
-      // row1
-      Result scanRes = scanner.next();
-      assertNotNull(scanRes);
-      assertFalse(scanRes.isEmpty());
-      KeyValue scanResCell = scanRes.getColumnLatest(FAMILY, colA);
-      assertArrayEquals(row1, scanResCell.getRow());
-      assertEquals(7L, Bytes.toLong(scanResCell.getValue()));
-
-      // row2
-      scanRes = scanner.next();
-      assertNotNull(scanRes);
-      assertFalse(scanRes.isEmpty());
-      scanResCell = scanRes.getColumnLatest(FAMILY, colA);
-      assertArrayEquals(row2, scanResCell.getRow());
-      assertEquals(3L, Bytes.toLong(scanResCell.getValue()));
-      scanResCell = scanRes.getColumnLatest(FAMILY, colB);
-      assertArrayEquals(row2, scanResCell.getRow());
-      assertEquals(10L, Bytes.toLong(scanResCell.getValue()));
-    } finally {
-      table.close();
-    }
-  }
-
-  @Test
-  public void testIncrementsCompaction() throws Exception {
-    // In this test we verify that squashing delta-increments during flush or compaction works as designed.
-
-    byte[] tableName = Bytes.toBytes("incrementCompactTest");
-    HTableDescriptor tableDesc = new HTableDescriptor(tableName);
-    HColumnDescriptor columnDesc = new HColumnDescriptor(FAMILY);
-    columnDesc.setMaxVersions(Integer.MAX_VALUE);
-    tableDesc.addFamily(columnDesc);
-    tableDesc.addCoprocessor(IncrementHandler.class.getName());
-    testUtil.getHBaseAdmin().createTable(tableDesc);
-    testUtil.waitTableAvailable(tableName, 5000);
-
-    HTable table = new HTable(conf, tableName);
-    try {
-      byte[] colA = Bytes.toBytes("a");
-      byte[] row1 = Bytes.toBytes("row1");
-
-      // do some increments
-      table.put(newIncrement(row1, colA, 1));
-      table.put(newIncrement(row1, colA, 1));
-      table.put(newIncrement(row1, colA, 1));
-
-      assertColumn(table, row1, colA, 3);
-
-      testUtil.flush(tableName);
-
-      // verify increments after flush
-      assertColumn(table, row1, colA, 3);
-
-      // do some more increments
-      table.put(newIncrement(row1, colA, 1));
-      table.put(newIncrement(row1, colA, 1));
-      table.put(newIncrement(row1, colA, 1));
-
-      // verify increments merged well from hstore and memstore
-      assertColumn(table, row1, colA, 6);
-
-      testUtil.flush(tableName);
-
-      // verify increments merged well into hstores
-      assertColumn(table, row1, colA, 6);
-
-      // do another iteration to verify that multiple "squashed" increments merged well at scan and at flush
-      table.put(newIncrement(row1, colA, 1));
-      table.put(newIncrement(row1, colA, 1));
-      table.put(newIncrement(row1, colA, 1));
-
-      assertColumn(table, row1, colA, 9);
-      testUtil.flush(tableName);
-      assertColumn(table, row1, colA, 9);
-
-      // verify increments merged well on minor compaction
-      testUtil.compact(tableName, false);
-      assertColumn(table, row1, colA, 9);
-
-      // another round of increments to verify that merged on compaction merges well with memstore and with new hstores
-      table.put(newIncrement(row1, colA, 1));
-      table.put(newIncrement(row1, colA, 1));
-      table.put(newIncrement(row1, colA, 1));
-
-      assertColumn(table, row1, colA, 12);
-      testUtil.flush(tableName);
-      assertColumn(table, row1, colA, 12);
-
-      // do same, but with major compaction
-      // verify increments merged well on minor compaction
-      testUtil.compact(tableName, true);
-      assertColumn(table, row1, colA, 12);
-
-      // another round of increments to verify that merged on compaction merges well with memstore and with new hstores
-      table.put(newIncrement(row1, colA, 1));
-      table.put(newIncrement(row1, colA, 1));
-      table.put(newIncrement(row1, colA, 1));
-
-      assertColumn(table, row1, colA, 15);
-      testUtil.flush(tableName);
-      assertColumn(table, row1, colA, 15);
-
-    } finally {
-      table.close();
-    }
-  }
-
-  @Test
-  public void testIncrementsCompactionUnlimBound() throws Exception {
-    // In this test we verify that having compaction bound unlim merges increments and leaves single version of a cell.
-    // It is important because in cases where we don't use tx nobody else will cleanup redundant (merged) keyvalues.
-    HColumnDescriptor columnDesc = new HColumnDescriptor(FAMILY);
-    columnDesc.setValue(IncrementHandler.PROPERTY_TRANSACTIONAL, "false");
-    HRegion region = IncrementSummingScannerTest.createRegion(conf, "incrementCompactUnlimBoundTest", columnDesc);
-
-    try {
-      region.initialize();
-
-      byte[] colA = Bytes.toBytes("a");
-      byte[] row1 = Bytes.toBytes("row1");
-
-      // do some increments
-      IncrementSummingScannerTest.doPut(region, newIncrement(row1, colA, 1));
-      IncrementSummingScannerTest.doPut(region, newIncrement(row1, colA, 1));
-      IncrementSummingScannerTest.doPut(region, newIncrement(row1, colA, 1));
-
-      region.flushcache();
-
-      // verify increments merged after flush
-      assertSingleVersionColumn(region, row1, colA, 3);
-
-      // do some more increments
-      IncrementSummingScannerTest.doPut(region, newIncrement(row1, colA, 1));
-      IncrementSummingScannerTest.doPut(region, newIncrement(row1, colA, 1));
-      IncrementSummingScannerTest.doPut(region, newIncrement(row1, colA, 1));
-
-      region.flushcache();
-      region.compactStores(true);
-
-      // verify increments merged well into hstores
-      assertSingleVersionColumn(region, row1, colA, 6);
-    } finally {
-      region.close();
-    }
-  }
-
-  private void assertColumn(HTable table, byte[] row, byte[] col, long expected) throws Exception {
+  @Override
+  public void assertColumn(HTable table, byte[] row, byte[] col, long expected) throws Exception {
     Result res = table.get(new Get(row));
     KeyValue resA = res.getColumnLatest(FAMILY, col);
     assertFalse(res.isEmpty());
@@ -294,22 +72,8 @@ public class IncrementHandlerTest {
     assertEquals(expected, Bytes.toLong(scanResA.getValue()));
   }
 
-  private void assertSingleVersionColumn(HRegion region, byte[] row, byte[] col, long expected) throws Exception {
-    Scan scan = new Scan(row);
-    scan.addColumn(FAMILY, col);
-    scan.setMaxVersions();
-    RegionScanner scanner = region.getScanner(scan);
-    List<KeyValue> results = Lists.newArrayList();
-    Assert.assertFalse(scanner.nextRaw(results, "foo"));
-    Assert.assertEquals(1, results.size());
-    byte[] value = results.get(0).getValue();
-    // note: it may be stored as increment delta even after merge on flush/compact
-    long longValue =
-      Bytes.toLong(value, value.length > Bytes.SIZEOF_LONG ? IncrementHandler.DELTA_MAGIC_PREFIX.length : 0);
-    Assert.assertEquals(expected, longValue);
-  }
-
-  private void assertColumns(HTable table, byte[] row, byte[][] cols, long[] expected) throws Exception {
+  @Override
+  public void assertColumns(HTable table, byte[] row, byte[][] cols, long[] expected) throws Exception {
     assertEquals(cols.length, expected.length);
 
     Get get = new Get(row);
@@ -340,14 +104,100 @@ public class IncrementHandlerTest {
     }
   }
 
-  public Put newIncrement(byte[] row, byte[] column, long value) {
-      return newIncrement(row, column, ts++, value);
+  @Override
+  public RegionWrapper createRegion(String tableName, Map<String, String> familyProperties) throws Exception {
+    HColumnDescriptor columnDesc = new HColumnDescriptor(FAMILY);
+    columnDesc.setMaxVersions(Integer.MAX_VALUE);
+    for (Map.Entry<String, String> prop : familyProperties.entrySet()) {
+      columnDesc.setValue(prop.getKey(), prop.getValue());
+    }
+    return new HBase94RegionWrapper(
+        IncrementSummingScannerTest.createRegion(testUtil.getConfiguration(), tableName, columnDesc));
   }
 
-  public Put newIncrement(byte[] row, byte[] column, long timestamp, long value) {
-    Put p = new Put(row);
-    p.add(FAMILY, column, timestamp, Bytes.toBytes(value));
-    p.setAttribute(HBaseOrderedTable.DELTA_WRITE, EMPTY_BYTES);
-    return p;
+  @Override
+  public void createTable(String tableName) throws Exception {
+    HTableDescriptor tableDesc = new HTableDescriptor(tableName);
+    HColumnDescriptor columnDesc = new HColumnDescriptor(FAMILY);
+    columnDesc.setMaxVersions(Integer.MAX_VALUE);
+    columnDesc.setValue(IncrementHandlerState.PROPERTY_TRANSACTIONAL, "false");
+    tableDesc.addFamily(columnDesc);
+    tableDesc.addCoprocessor(IncrementHandler.class.getName());
+    testUtil.getHBaseAdmin().createTable(tableDesc);
+    testUtil.waitUntilTableAvailable(Bytes.toBytes(tableName), 5000);
+  }
+
+  public static ColumnCell convertCell(KeyValue cell) {
+    return new ColumnCell(cell.getRow(), cell.getFamily(), cell.getQualifier(),
+        cell.getTimestamp(), cell.getValue());
+  }
+
+  public class HBase94RegionWrapper implements RegionWrapper {
+    private final HRegion region;
+
+    public HBase94RegionWrapper(HRegion region) {
+      this.region = region;
+    }
+
+    @Override
+    public void initialize() throws IOException {
+      region.initialize();
+    }
+
+    /**
+     * Work around a bug in HRegion.internalPut(), where RegionObserver.prePut() modifications are not applied.
+     */
+    @Override
+    public void put(Put put) throws IOException {
+      region.batchMutate(new Pair[]{ new Pair<Mutation, Integer>(put, null) });
+    }
+
+    @Override
+    public boolean scanRegion(List<ColumnCell> results, byte[] startRow) throws IOException {
+      return scanRegion(results, startRow, null);
+    }
+
+    @Override
+    public boolean scanRegion(List<ColumnCell> results, byte[] startRow, byte[][] columns) throws IOException {
+      Scan scan = new Scan().setMaxVersions().setStartRow(startRow);
+      if (columns != null) {
+        for (int i = 0; i < columns.length; i++) {
+          scan.addColumn(FAMILY, columns[i]);
+        }
+      }
+      RegionScanner rs = region.getScanner(scan);
+      try {
+        List<KeyValue> tmpResults = new ArrayList<KeyValue>();
+        boolean hasMore = rs.next(tmpResults);
+        for (KeyValue cell : tmpResults) {
+          results.add(convertCell(cell));
+        }
+        return hasMore;
+      } finally {
+        rs.close();
+      }
+    }
+
+    @Override
+    public boolean flush() throws IOException {
+      return region.flushcache();
+    }
+
+    @Override
+    public void compact(boolean majorCompact) throws IOException {
+      region.compactStores(majorCompact);
+    }
+
+    @Override
+    public void setCoprocessorTimestampOracle(TimestampOracle timeOracle) {
+      Coprocessor cp = region.getCoprocessorHost().findCoprocessor(IncrementHandler.class.getName());
+      assertNotNull(cp);
+      ((IncrementHandler) cp).setTimestampOracle(timeOracle);
+    }
+
+    @Override
+    public void close() throws IOException {
+      region.close();
+    }
   }
 }

--- a/cdap-hbase-compat-0.94/src/test/java/co/cask/cdap/data2/increment/hbase94/IncrementSummingScannerTest.java
+++ b/cdap-hbase-compat-0.94/src/test/java/co/cask/cdap/data2/increment/hbase94/IncrementSummingScannerTest.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.data2.increment.hbase94;
 
 import co.cask.cdap.data2.dataset2.lib.table.hbase.HBaseOrderedTable;
+import co.cask.cdap.data2.increment.hbase.IncrementHandlerState;
 import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -200,7 +201,7 @@ public class IncrementSummingScannerTest {
       assertEquals(2, results.size());
       cell = results.get(0);
       assertNotNull(cell);
-      assertEquals(3L, Bytes.toLong(cell.getValue(), IncrementHandler.DELTA_MAGIC_PREFIX.length, 8));
+      assertEquals(3L, Bytes.toLong(cell.getValue(), IncrementHandlerState.DELTA_MAGIC_PREFIX.length, 8));
       // next cell should be the delete
       cell = results.get(1);
       assertTrue(KeyValue.isDelete(cell.getType()));
@@ -400,7 +401,7 @@ public class IncrementSummingScannerTest {
 
     for (int i = 0; i < upperVisBound.length; i++) {
       scanner = new IncrementSummingScanner(region, batch, scanner,
-          ScanType.MINOR_COMPACT, upperVisBound[i]);
+          ScanType.MINOR_COMPACT, upperVisBound[i], -1);
     }
     scanner = new IncrementSummingScanner(region, batch, scanner, ScanType.USER_SCAN);
     // init with false if loop will execute zero times

--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/increment/hbase96/IncrementHandler.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/increment/hbase96/IncrementHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,20 +17,19 @@
 package co.cask.cdap.data2.increment.hbase96;
 
 import co.cask.cdap.data2.dataset2.lib.table.hbase.HBaseOrderedTable;
-import co.cask.cdap.data2.transaction.coprocessor.DefaultTransactionStateCacheSupplier;
-import co.cask.tephra.coprocessor.TransactionStateCache;
+import co.cask.cdap.data2.increment.hbase.IncrementHandlerState;
+import co.cask.cdap.data2.increment.hbase.TimestampOracle;
 import co.cask.tephra.hbase96.Filters;
-import co.cask.tephra.persist.TransactionSnapshot;
-import com.google.common.base.Supplier;
-import com.google.common.collect.Sets;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Maps;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.CoprocessorEnvironment;
 import org.apache.hadoop.hbase.HColumnDescriptor;
-import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.Durability;
 import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.Put;
@@ -38,6 +37,7 @@ import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.coprocessor.BaseRegionObserver;
 import org.apache.hadoop.hbase.coprocessor.ObserverContext;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
+import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.hadoop.hbase.regionserver.InternalScanner;
 import org.apache.hadoop.hbase.regionserver.RegionScanner;
@@ -52,7 +52,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
-import java.util.Set;
 import java.util.TreeMap;
 
 /**
@@ -71,54 +70,38 @@ import java.util.TreeMap;
  * all the successfully committed delta values.</p>
  */
 public class IncrementHandler extends BaseRegionObserver {
-  /**
-   * Property set for {@link HColumnDescriptor} to indicate if increment is transactional. Default: "true", i.e.
-   * transactional.
-   */
-  public static final String PROPERTY_TRANSACTIONAL = "dataset.table.readless.increment.transactional";
-
-  // prefix bytes used to mark values that are deltas vs. full sums
-  public static final byte[] DELTA_MAGIC_PREFIX = new byte[] { 'X', 'D' };
-  // expected length for values storing deltas (prefix + increment value)
-  public static final int DELTA_FULL_LENGTH = DELTA_MAGIC_PREFIX.length + Bytes.SIZEOF_LONG;
-  public static final int BATCH_UNLIMITED = -1;
 
   private static final Log LOG = LogFactory.getLog(IncrementHandler.class);
 
   private HRegion region;
-  private TransactionStateCache cache;
-
-  protected Set<byte[]> txnlFamilies = Sets.newTreeSet(Bytes.BYTES_COMPARATOR);
+  private IncrementHandlerState state;
 
   @Override
   public void start(CoprocessorEnvironment e) throws IOException {
     if (e instanceof RegionCoprocessorEnvironment) {
       RegionCoprocessorEnvironment env = (RegionCoprocessorEnvironment) e;
       this.region = ((RegionCoprocessorEnvironment) e).getRegion();
+      this.state = new IncrementHandlerState(env.getConfiguration(),
+          env.getRegion().getTableDesc().getNameAsString());
+
       HTableDescriptor tableDesc = env.getRegion().getTableDesc();
       for (HColumnDescriptor columnDesc : tableDesc.getFamilies()) {
-        boolean txnl = !"false".equals(columnDesc.getValue(PROPERTY_TRANSACTIONAL));
-        LOG.info("Family " + columnDesc.getNameAsString() + " is transactional: " + txnl);
-        if (txnl) {
-          txnlFamilies.add(columnDesc.getName());
-        }
-      }
-
-      if (!txnlFamilies.isEmpty()) {
-        Supplier<TransactionStateCache> cacheSupplier = getTransactionStateCacheSupplier(env);
-        this.cache = cacheSupplier.get();
+        state.initFamily(columnDesc.getName(), convertFamilyValues(columnDesc.getValues()));
       }
     }
   }
 
-  protected Supplier<TransactionStateCache> getTransactionStateCacheSupplier(RegionCoprocessorEnvironment env) {
-    String tableName = env.getRegion().getTableDesc().getNameAsString();
-    String[] parts = tableName.split("\\.", 2);
-    String tableNamespace = "";
-    if (parts.length > 0) {
-      tableNamespace = parts[0];
+  @VisibleForTesting
+  public void setTimestampOracle(TimestampOracle timeOracle) {
+    state.setTimestampOracle(timeOracle);
+  }
+
+  private Map<byte[], byte[]> convertFamilyValues(Map<ImmutableBytesWritable, ImmutableBytesWritable> writableValues) {
+    Map<byte[], byte[]> converted = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
+    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> e : writableValues.entrySet()) {
+      converted.put(e.getKey().get(), e.getValue().get());
     }
-    return new DefaultTransactionStateCacheSupplier(tableNamespace, env.getConfiguration());
+    return converted;
   }
 
   @Override
@@ -142,24 +125,62 @@ public class IncrementHandler extends BaseRegionObserver {
   @Override
   public void prePut(ObserverContext<RegionCoprocessorEnvironment> ctx, Put put, WALEdit edit, Durability durability)
     throws IOException {
-    if (put.getAttribute(HBaseOrderedTable.DELTA_WRITE) != null) {
+    // we assume that if any of the column families written to are transactional, the entire write is transactional
+    boolean transactional = state.containsTransactionalFamily(put.getFamilyCellMap().keySet());
+    boolean isIncrement = put.getAttribute(HBaseOrderedTable.DELTA_WRITE) != null;
+
+    if (isIncrement || !transactional) {
       // incremental write
       NavigableMap<byte[], List<Cell>> newFamilyMap = new TreeMap<byte[], List<Cell>>(Bytes.BYTES_COMPARATOR);
+
+      long tsToAssign = 0;
+      if (!transactional) {
+        tsToAssign = state.getUniqueTimestamp();
+      }
       for (Map.Entry<byte[], List<Cell>> entry : put.getFamilyCellMap().entrySet()) {
         List<Cell> newCells = new ArrayList<Cell>(entry.getValue().size());
         for (Cell cell : entry.getValue()) {
           // rewrite the cell value with a special prefix to identify it as a delta
           // for 0.98 we can update this to use cell tags
-          byte[] newValue = Bytes.add(DELTA_MAGIC_PREFIX, CellUtil.cloneValue(cell));
+          byte[] newValue = isIncrement ?
+              Bytes.add(IncrementHandlerState.DELTA_MAGIC_PREFIX, CellUtil.cloneValue(cell)) :
+              CellUtil.cloneValue(cell);
           newCells.add(CellUtil.createCell(CellUtil.cloneRow(cell), CellUtil.cloneFamily(cell),
-                                           CellUtil.cloneQualifier(cell), cell.getTimestamp(), cell.getTypeByte(),
-                                           newValue));
+                                           CellUtil.cloneQualifier(cell),
+                                           transactional ? cell.getTimestamp() : tsToAssign,
+                                           cell.getTypeByte(), newValue));
         }
         newFamilyMap.put(entry.getKey(), newCells);
       }
       put.setFamilyCellMap(newFamilyMap);
     }
     // put completes normally with value prefix marker
+  }
+
+  @Override
+  public void preDelete(ObserverContext<RegionCoprocessorEnvironment> e, Delete delete, WALEdit edit,
+                        Durability durability) throws IOException {
+    boolean transactional = state.containsTransactionalFamily(delete.getFamilyMap().keySet());
+    if (!transactional) {
+      long tsToAssign = state.getUniqueTimestamp();
+      delete.setTimestamp(tsToAssign);
+      // new key values
+      NavigableMap<byte[], List<Cell>> newFamilyMap = new TreeMap<byte[], List<Cell>>(Bytes.BYTES_COMPARATOR);
+      for (Map.Entry<byte[], List<Cell>> entry : delete.getFamilyCellMap().entrySet()) {
+        List<Cell> newCells = new ArrayList<Cell>(entry.getValue().size());
+        for (Cell kv : entry.getValue()) {
+          //LOG.info("Replacing delete cell: " + kv);
+          // replace the timestamp
+          newCells.add(CellUtil.createCell(CellUtil.cloneRow(kv),
+              CellUtil.cloneFamily(kv),
+              CellUtil.cloneQualifier(kv),
+              tsToAssign, kv.getTypeByte(),
+              CellUtil.cloneValue(kv)));
+        }
+        newFamilyMap.put(entry.getKey(), newCells);
+      }
+      delete.setFamilyCellMap(newFamilyMap);
+    }
   }
 
   @Override
@@ -181,36 +202,31 @@ public class IncrementHandler extends BaseRegionObserver {
   @Override
   public InternalScanner preFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store,
                                   InternalScanner scanner) throws IOException {
-    return new IncrementSummingScanner(region, BATCH_UNLIMITED, scanner,
-                                       ScanType.COMPACT_RETAIN_DELETES, getCompactionBound(store));
+    byte[] family = store.getFamily().getName();
+    return new IncrementSummingScanner(region, IncrementHandlerState.BATCH_UNLIMITED, scanner,
+        ScanType.COMPACT_RETAIN_DELETES, state.getCompactionBound(family), state.getOldestVisibleTimestamp(family));
   }
 
   public static boolean isIncrement(Cell cell) {
-    return !CellUtil.isDelete(cell) && cell.getValueLength() == IncrementHandler.DELTA_FULL_LENGTH &&
-      Bytes.equals(cell.getValueArray(), cell.getValueOffset(), IncrementHandler.DELTA_MAGIC_PREFIX.length,
-                   IncrementHandler.DELTA_MAGIC_PREFIX, 0, IncrementHandler.DELTA_MAGIC_PREFIX.length);
+    return !CellUtil.isDelete(cell) && cell.getValueLength() == IncrementHandlerState.DELTA_FULL_LENGTH &&
+      Bytes.equals(cell.getValueArray(), cell.getValueOffset(), IncrementHandlerState.DELTA_MAGIC_PREFIX.length,
+                   IncrementHandlerState.DELTA_MAGIC_PREFIX, 0, IncrementHandlerState.DELTA_MAGIC_PREFIX.length);
   }
 
   @Override
   public InternalScanner preCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store,
                                     InternalScanner scanner, ScanType scanType) throws IOException {
-    return new IncrementSummingScanner(region, BATCH_UNLIMITED, scanner, scanType, getCompactionBound(store));
+    byte[] family = store.getFamily().getName();
+    return new IncrementSummingScanner(region, IncrementHandlerState.BATCH_UNLIMITED, scanner, scanType,
+        state.getCompactionBound(family), state.getOldestVisibleTimestamp(family));
   }
 
   @Override
   public InternalScanner preCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store,
                                     InternalScanner scanner, ScanType scanType, CompactionRequest request)
     throws IOException {
-    return new IncrementSummingScanner(region, BATCH_UNLIMITED, scanner, scanType, getCompactionBound(store));
-  }
-
-  private long getCompactionBound(Store store) {
-    if (txnlFamilies.contains(store.getFamily().getName())) {
-      TransactionSnapshot snapshot = cache.getLatestState();
-      // if tx snapshot is not available, used "0" as upper bound to avoid trashing in-progress tx
-      return snapshot != null ? snapshot.getVisibilityUpperBound() : 0;
-    } else {
-      return HConstants.LATEST_TIMESTAMP;
-    }
+    byte[] family = store.getFamily().getName();
+    return new IncrementSummingScanner(region, IncrementHandlerState.BATCH_UNLIMITED, scanner, scanType,
+        state.getCompactionBound(family), state.getOldestVisibleTimestamp(family));
   }
 }

--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/increment/hbase96/IncrementSummingScanner.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/increment/hbase96/IncrementSummingScanner.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.data2.increment.hbase96;
 
+import co.cask.cdap.data2.increment.hbase.IncrementHandlerState;
 import com.google.common.base.Preconditions;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -48,13 +49,15 @@ class IncrementSummingScanner implements RegionScanner {
   // Highest timestamp, beyond which we cannot aggregate increments during flush and compaction.
   // Increments newer than this may still be visible to running transactions
   private final long compactionUpperBound;
+  // scan start time to use in computing TTL
+  private final long oldestTsByTTL;
 
   IncrementSummingScanner(HRegion region, int batchSize, InternalScanner internalScanner, ScanType scanType) {
-    this(region, batchSize, internalScanner, scanType, Long.MAX_VALUE);
+    this(region, batchSize, internalScanner, scanType, Long.MAX_VALUE, -1);
   }
 
   IncrementSummingScanner(HRegion region, int batchSize, InternalScanner internalScanner, ScanType scanType,
-                          long compationUpperBound) {
+                          long compationUpperBound, long oldestTsByTTL) {
     this.region = region;
     this.batchSize = batchSize;
     this.baseScanner = new WrappedScanner(internalScanner);
@@ -63,6 +66,7 @@ class IncrementSummingScanner implements RegionScanner {
     }
     this.scanType = scanType;
     this.compactionUpperBound = compationUpperBound;
+    this.oldestTsByTTL = oldestTsByTTL;
   }
 
   @Override
@@ -177,7 +181,7 @@ class IncrementSummingScanner implements RegionScanner {
         }
         // add this increment to the tally
         runningSum += Bytes.toLong(cell.getValueArray(),
-            cell.getValueOffset() + IncrementHandler.DELTA_MAGIC_PREFIX.length);
+            cell.getValueOffset() + IncrementHandlerState.DELTA_MAGIC_PREFIX.length);
       } else {
         // otherwise (not an increment)
         if (previousIncrement != null) {
@@ -205,8 +209,11 @@ class IncrementSummingScanner implements RegionScanner {
           LOG.trace("Including raw cell: " + cell);
         }
 
-        cells.add(cell);
-        addedCnt++;
+        // apply any configured TTL
+        if (cell.getTimestamp() > oldestTsByTTL) {
+          cells.add(cell);
+          addedCnt++;
+        }
       }
       // if we made it this far, consume the current cell
       baseScanner.nextCell(limit);
@@ -239,7 +246,7 @@ class IncrementSummingScanner implements RegionScanner {
   private Cell newCell(Cell toCopy, long value) {
     byte[] newValue = Bytes.toBytes(value);
     if (scanType == ScanType.COMPACT_RETAIN_DELETES) {
-      newValue = Bytes.add(IncrementHandler.DELTA_MAGIC_PREFIX, newValue);
+      newValue = Bytes.add(IncrementHandlerState.DELTA_MAGIC_PREFIX, newValue);
     }
     return CellUtil.createCell(CellUtil.cloneRow(toCopy), CellUtil.cloneFamily(toCopy),
                                CellUtil.cloneQualifier(toCopy), toCopy.getTimestamp(),

--- a/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data/hbase/HBase96Test.java
+++ b/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data/hbase/HBase96Test.java
@@ -20,10 +20,12 @@ import com.google.common.base.Function;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HBaseTestingUtility;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.HRegionInfo;
 import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.MiniHBaseCluster;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.hadoop.hbase.util.Bytes;
@@ -41,6 +43,33 @@ import java.util.TreeMap;
  */
 public class HBase96Test extends HBaseTestBase {
   private static final Logger LOG = LoggerFactory.getLogger(HBase96Test.class);
+
+  private HBaseTestingUtility testUtil = new HBaseTestingUtility();
+
+  @Override
+  public Configuration getConfiguration() {
+    return testUtil.getConfiguration();
+  }
+
+  @Override
+  public int getZKClientPort() {
+    return testUtil.getZkCluster().getClientPort();
+  }
+
+  @Override
+  public void startHBase() throws Exception {
+    testUtil.startMiniCluster();
+  }
+
+  @Override
+  public void stopHBase() throws Exception {
+    testUtil.shutdownMiniCluster();
+  }
+
+  @Override
+  public MiniHBaseCluster getHBaseCluster() {
+    return testUtil.getHBaseCluster();
+  }
 
   @Override
   public HRegion createHRegion(byte[] tableName, byte[] startKey,
@@ -67,6 +96,7 @@ public class HBase96Test extends HBaseTestBase {
 
   @Override
   public void forceRegionFlush(byte[] tableName) throws IOException {
+    MiniHBaseCluster hbaseCluster = getHBaseCluster();
     if (hbaseCluster != null) {
       TableName qualifiedTableName = TableName.valueOf(tableName);
       for (JVMClusterUtil.RegionServerThread t : hbaseCluster.getRegionServerThreads()) {
@@ -84,6 +114,7 @@ public class HBase96Test extends HBaseTestBase {
 
   @Override
   public void forceRegionCompact(byte[] tableName, boolean majorCompact) throws IOException {
+    MiniHBaseCluster hbaseCluster = getHBaseCluster();
     if (hbaseCluster != null) {
       TableName qualifiedTableName = TableName.valueOf(tableName);
       for (JVMClusterUtil.RegionServerThread t : hbaseCluster.getRegionServerThreads()) {
@@ -101,6 +132,7 @@ public class HBase96Test extends HBaseTestBase {
 
   @Override
   public <T> Map<byte[], T> forEachRegion(byte[] tableName, Function<HRegion, T> function) {
+    MiniHBaseCluster hbaseCluster = getHBaseCluster();
     Map<byte[], T> results = new TreeMap<byte[], T>(Bytes.BYTES_COMPARATOR);
     // make sure consumer config cache is updated
     for (JVMClusterUtil.RegionServerThread t : hbaseCluster.getRegionServerThreads()) {
@@ -110,5 +142,12 @@ public class HBase96Test extends HBaseTestBase {
       }
     }
     return results;
+  }
+
+  @Override
+  public void waitUntilTableAvailable(byte[] tableName, long timeoutInMillis)
+      throws IOException, InterruptedException {
+    testUtil.waitTableAvailable(tableName, timeoutInMillis);
+    testUtil.waitUntilAllRegionsAssigned(TableName.valueOf(tableName), timeoutInMillis);
   }
 }

--- a/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data2/increment/hbase96/IncrementHandlerTest.java
+++ b/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data2/increment/hbase96/IncrementHandlerTest.java
@@ -16,12 +16,13 @@
 
 package co.cask.cdap.data2.increment.hbase96;
 
-import co.cask.cdap.data2.dataset2.lib.table.hbase.HBaseOrderedTable;
+import co.cask.cdap.data2.increment.hbase.AbstractIncrementHandlerTest;
+import co.cask.cdap.data2.increment.hbase.IncrementHandlerState;
+import co.cask.cdap.data2.increment.hbase.TimestampOracle;
 import co.cask.cdap.test.SlowTests;
-import com.google.common.collect.Lists;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.Cell;
-import org.apache.hadoop.hbase.HBaseTestingUtility;
+import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.Coprocessor;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.TableName;
@@ -34,13 +35,14 @@ import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.hadoop.hbase.regionserver.RegionScanner;
 import org.apache.hadoop.hbase.util.Bytes;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -51,234 +53,11 @@ import static org.junit.Assert.assertNotNull;
  * Tests for the HBase 0.96+ version of the {@link IncrementHandler} coprocessor.
  */
 @Category(SlowTests.class)
-public class IncrementHandlerTest {
-  private static final byte[] EMPTY_BYTES = new byte[0];
-  private static final byte[] FAMILY = Bytes.toBytes("i");
+public class IncrementHandlerTest extends AbstractIncrementHandlerTest {
+  private static final Logger LOG = LoggerFactory.getLogger(IncrementHandlerTest.class);
 
-  private static HBaseTestingUtility testUtil;
-  private static Configuration conf;
-
-  private long ts = 1;
-
-  @BeforeClass
-  public static void setup() throws Exception {
-    testUtil = new HBaseTestingUtility();
-    testUtil.startMiniCluster();
-    conf = testUtil.getConfiguration();
-  }
-
-  @AfterClass
-  public static void tearDown() throws Exception {
-    testUtil.shutdownMiniCluster();
-  }
-
-  @Test
-  public void testIncrements() throws Exception {
-    TableName tableName = TableName.valueOf("incrementTest");
-    HTableDescriptor tableDesc = new HTableDescriptor(tableName);
-    HColumnDescriptor columnDesc = new HColumnDescriptor(FAMILY);
-    columnDesc.setMaxVersions(Integer.MAX_VALUE);
-    tableDesc.addFamily(columnDesc);
-    tableDesc.addCoprocessor(IncrementHandler.class.getName());
-    testUtil.getHBaseAdmin().createTable(tableDesc);
-    testUtil.waitUntilAllRegionsAssigned(tableName, 5000);
-
-    HTable table = new HTable(conf, tableName);
-    try {
-      byte[] colA = Bytes.toBytes("a");
-      byte[] row1 = Bytes.toBytes("row1");
-
-      // test column containing only increments
-      table.put(newIncrement(row1, colA, 1));
-      table.put(newIncrement(row1, colA, 1));
-      table.put(newIncrement(row1, colA, 1));
-
-      assertColumn(table, row1, colA, 3);
-
-      // test intermixed increments and puts
-      Put putA = new Put(row1);
-      putA.add(FAMILY, colA, ts++, Bytes.toBytes(5L));
-      table.put(putA);
-
-      assertColumn(table, row1, colA, 5);
-
-      table.put(newIncrement(row1, colA, 1));
-      table.put(newIncrement(row1, colA, 1));
-
-      assertColumn(table, row1, colA, 7);
-
-      // test multiple increment columns
-      byte[] row2 = Bytes.toBytes("row2");
-      byte[] colB = Bytes.toBytes("b");
-
-      // increment A and B twice at the same timestamp
-      table.put(newIncrement(row2, colA, 1, 1));
-      table.put(newIncrement(row2, colB, 1, 1));
-      table.put(newIncrement(row2, colA, 2, 1));
-      table.put(newIncrement(row2, colB, 2, 1));
-      // increment A once more
-      table.put(newIncrement(row2, colA, 1));
-
-      assertColumns(table, row2, new byte[][]{ colA, colB }, new long[]{ 3, 2 });
-
-      // overwrite B with a new put
-      Put p = new Put(row2);
-      p.add(FAMILY, colB, ts++, Bytes.toBytes(10L));
-      table.put(p);
-
-      assertColumns(table, row2, new byte[][]{ colA, colB }, new long[]{ 3, 10 });
-
-      // check a full scan
-      Scan scan = new Scan();
-      ResultScanner scanner = table.getScanner(scan);
-      // row1
-      Result scanRes = scanner.next();
-      assertNotNull(scanRes);
-      assertFalse(scanRes.isEmpty());
-      Cell scanResCell = scanRes.getColumnLatestCell(FAMILY, colA);
-      assertArrayEquals(row1, scanResCell.getRow());
-      assertEquals(7L, Bytes.toLong(scanResCell.getValue()));
-
-      // row2
-      scanRes = scanner.next();
-      assertNotNull(scanRes);
-      assertFalse(scanRes.isEmpty());
-      scanResCell = scanRes.getColumnLatestCell(FAMILY, colA);
-      assertArrayEquals(row2, scanResCell.getRow());
-      assertEquals(3L, Bytes.toLong(scanResCell.getValue()));
-      scanResCell = scanRes.getColumnLatestCell(FAMILY, colB);
-      assertArrayEquals(row2, scanResCell.getRow());
-      assertEquals(10L, Bytes.toLong(scanResCell.getValue()));
-    } finally {
-      table.close();
-    }
-  }
-
-  @Test
-  public void testIncrementsCompaction() throws Exception {
-    // In this test we verify that squashing delta-increments during flush or compaction works as designed.
-
-    TableName tableName = TableName.valueOf("incrementCompactTest");
-    HTableDescriptor tableDesc = new HTableDescriptor(tableName);
-    HColumnDescriptor columnDesc = new HColumnDescriptor(FAMILY);
-    columnDesc.setMaxVersions(Integer.MAX_VALUE);
-    tableDesc.addFamily(columnDesc);
-    tableDesc.addCoprocessor(IncrementHandler.class.getName());
-    testUtil.getHBaseAdmin().createTable(tableDesc);
-    testUtil.waitUntilAllRegionsAssigned(tableName, 5000);
-
-    HTable table = new HTable(conf, tableName);
-    try {
-      byte[] colA = Bytes.toBytes("a");
-      byte[] row1 = Bytes.toBytes("row1");
-
-      // do some increments
-      table.put(newIncrement(row1, colA, 1));
-      table.put(newIncrement(row1, colA, 1));
-      table.put(newIncrement(row1, colA, 1));
-
-      assertColumn(table, row1, colA, 3);
-
-      testUtil.flush(tableName);
-
-      // verify increments after flush
-      assertColumn(table, row1, colA, 3);
-
-      // do some more increments
-      table.put(newIncrement(row1, colA, 1));
-      table.put(newIncrement(row1, colA, 1));
-      table.put(newIncrement(row1, colA, 1));
-
-      // verify increments merged well from hstore and memstore
-      assertColumn(table, row1, colA, 6);
-
-      testUtil.flush(tableName);
-
-      // verify increments merged well into hstores
-      assertColumn(table, row1, colA, 6);
-
-      // do another iteration to verify that multiple "squashed" increments merged well at scan and at flush
-      table.put(newIncrement(row1, colA, 1));
-      table.put(newIncrement(row1, colA, 1));
-      table.put(newIncrement(row1, colA, 1));
-
-      assertColumn(table, row1, colA, 9);
-      testUtil.flush(tableName);
-      assertColumn(table, row1, colA, 9);
-
-      // verify increments merged well on minor compaction
-      testUtil.compact(tableName, false);
-      assertColumn(table, row1, colA, 9);
-
-      // another round of increments to verify that merged on compaction merges well with memstore and with new hstores
-      table.put(newIncrement(row1, colA, 1));
-      table.put(newIncrement(row1, colA, 1));
-      table.put(newIncrement(row1, colA, 1));
-
-      assertColumn(table, row1, colA, 12);
-      testUtil.flush(tableName);
-      assertColumn(table, row1, colA, 12);
-
-      // do same, but with major compaction
-      // verify increments merged well on minor compaction
-      testUtil.compact(tableName, true);
-      assertColumn(table, row1, colA, 12);
-
-      // another round of increments to verify that merged on compaction merges well with memstore and with new hstores
-      table.put(newIncrement(row1, colA, 1));
-      table.put(newIncrement(row1, colA, 1));
-      table.put(newIncrement(row1, colA, 1));
-
-      assertColumn(table, row1, colA, 15);
-      testUtil.flush(tableName);
-      assertColumn(table, row1, colA, 15);
-
-    } finally {
-      table.close();
-    }
-  }
-
-  @Test
-  public void testIncrementsCompactionUnlimBound() throws Exception {
-    // In this test we verify that having compaction bound unlim merges increments and leaves single version of a cell.
-    // It is important because in cases where we don't use tx nobody else will cleanup redundant (merged) keyvalues.
-    TableName tableName = TableName.valueOf("incrementCompactUnlimBoundTest");
-    HColumnDescriptor columnDesc = new HColumnDescriptor(FAMILY);
-    columnDesc.setValue(IncrementHandler.PROPERTY_TRANSACTIONAL, "false");
-    HRegion region = IncrementSummingScannerTest.createRegion(conf, tableName, columnDesc);
-
-    try {
-      region.initialize();
-
-      byte[] colA = Bytes.toBytes("a");
-      byte[] row1 = Bytes.toBytes("row1");
-
-      // do some increments
-      region.put(newIncrement(row1, colA, 1));
-      region.put(newIncrement(row1, colA, 1));
-      region.put(newIncrement(row1, colA, 1));
-
-      region.flushcache();
-
-      // verify increments merged after flush
-      assertSingleVersionColumn(region, row1, colA, 3);
-
-      // do some more increments
-      region.put(newIncrement(row1, colA, 1));
-      region.put(newIncrement(row1, colA, 1));
-      region.put(newIncrement(row1, colA, 1));
-
-      region.flushcache();
-      region.compactStores(true);
-
-      // verify increments merged well into hstores
-      assertSingleVersionColumn(region, row1, colA, 6);
-    } finally {
-      region.close();
-    }
-  }
-
-  private void assertColumn(HTable table, byte[] row, byte[] col, long expected) throws Exception {
+  @Override
+  public void assertColumn(HTable table, byte[] row, byte[] col, long expected) throws Exception {
     Result res = table.get(new Get(row));
     Cell resA = res.getColumnLatestCell(FAMILY, col);
     assertFalse(res.isEmpty());
@@ -296,22 +75,8 @@ public class IncrementHandlerTest {
     assertEquals(expected, Bytes.toLong(scanResA.getValue()));
   }
 
-  private void assertSingleVersionColumn(HRegion region, byte[] row, byte[] col, long expected) throws Exception {
-    Scan scan = new Scan(row);
-    scan.addColumn(FAMILY, col);
-    scan.setMaxVersions();
-    RegionScanner scanner = region.getScanner(scan);
-    List<Cell> results = Lists.newArrayList();
-    Assert.assertFalse(scanner.nextRaw(results));
-    Assert.assertEquals(1, results.size());
-    byte[] value = results.get(0).getValue();
-    // note: it may be stored as increment delta even after merge on flush/compact
-    long longValue =
-      Bytes.toLong(value, value.length > Bytes.SIZEOF_LONG ? IncrementHandler.DELTA_MAGIC_PREFIX.length : 0);
-    Assert.assertEquals(expected, longValue);
-  }
-
-  private void assertColumns(HTable table, byte[] row, byte[][] cols, long[] expected) throws Exception {
+  @Override
+  public void assertColumns(HTable table, byte[] row, byte[][] cols, long[] expected) throws Exception {
     assertEquals(cols.length, expected.length);
 
     Get get = new Get(row);
@@ -342,14 +107,99 @@ public class IncrementHandlerTest {
     }
   }
 
-  public Put newIncrement(byte[] row, byte[] column, long value) {
-      return newIncrement(row, column, ts++, value);
+  @Override
+  public void createTable(String tableName) throws Exception {
+    TableName table = TableName.valueOf(tableName);
+    HTableDescriptor tableDesc = new HTableDescriptor(table);
+    HColumnDescriptor columnDesc = new HColumnDescriptor(FAMILY);
+    columnDesc.setMaxVersions(Integer.MAX_VALUE);
+    columnDesc.setValue(IncrementHandlerState.PROPERTY_TRANSACTIONAL, "false");
+    tableDesc.addFamily(columnDesc);
+    tableDesc.addCoprocessor(IncrementHandler.class.getName());
+    testUtil.getHBaseAdmin().createTable(tableDesc);
+    testUtil.waitUntilTableAvailable(Bytes.toBytes(tableName), 5000);
   }
 
-  public Put newIncrement(byte[] row, byte[] column, long timestamp, long value) {
-    Put p = new Put(row);
-    p.add(FAMILY, column, timestamp, Bytes.toBytes(value));
-    p.setAttribute(HBaseOrderedTable.DELTA_WRITE, EMPTY_BYTES);
-    return p;
+  @Override
+  public RegionWrapper createRegion(String tableName, Map<String, String> familyProperties) throws Exception {
+    TableName table = TableName.valueOf(tableName);
+    HColumnDescriptor columnDesc = new HColumnDescriptor(FAMILY);
+    columnDesc.setMaxVersions(Integer.MAX_VALUE);
+    for (Map.Entry<String, String> prop : familyProperties.entrySet()) {
+      columnDesc.setValue(prop.getKey(), prop.getValue());
+    }
+    return new HBase96RegionWrapper(
+        IncrementSummingScannerTest.createRegion(testUtil.getConfiguration(), table, columnDesc));
+  }
+
+  public static ColumnCell convertCell(Cell cell) {
+    return new ColumnCell(CellUtil.cloneRow(cell), CellUtil.cloneFamily(cell), CellUtil.cloneQualifier(cell),
+        cell.getTimestamp(), CellUtil.cloneValue(cell));
+  }
+
+  public class HBase96RegionWrapper implements RegionWrapper {
+    private final HRegion region;
+
+    public HBase96RegionWrapper(HRegion region) {
+      this.region = region;
+    }
+
+    @Override
+    public void initialize() throws IOException {
+      region.initialize();
+    }
+
+    @Override
+    public void put(Put put) throws IOException {
+      region.put(put);
+    }
+
+    @Override
+    public boolean scanRegion(List<ColumnCell> results, byte[] startRow) throws IOException {
+      return scanRegion(results, startRow, null);
+    }
+
+    @Override
+    public boolean scanRegion(List<ColumnCell> results, byte[] startRow, byte[][] columns) throws IOException {
+      Scan scan = new Scan().setMaxVersions().setStartRow(startRow);
+      if (columns != null) {
+        for (int i = 0; i < columns.length; i++) {
+          scan.addColumn(FAMILY, columns[i]);
+        }
+      }
+      RegionScanner rs = region.getScanner(scan);
+      try {
+        List<Cell> tmpResults = new ArrayList<Cell>();
+        boolean hasMore = rs.next(tmpResults);
+        for (Cell cell : tmpResults) {
+          results.add(convertCell(cell));
+        }
+        return hasMore;
+      } finally {
+        rs.close();
+      }
+    }
+
+    @Override
+    public boolean flush() throws IOException {
+      return region.flushcache();
+    }
+
+    @Override
+    public void compact(boolean majorCompact) throws IOException {
+      region.compactStores(majorCompact);
+    }
+
+    @Override
+    public void setCoprocessorTimestampOracle(TimestampOracle timeOracle) {
+      Coprocessor cp = region.getCoprocessorHost().findCoprocessor(IncrementHandler.class.getName());
+      assertNotNull(cp);
+      ((IncrementHandler) cp).setTimestampOracle(timeOracle);
+    }
+
+    @Override
+    public void close() throws IOException {
+      region.close();
+    }
   }
 }

--- a/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data2/increment/hbase96/IncrementSummingScannerTest.java
+++ b/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data2/increment/hbase96/IncrementSummingScannerTest.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.data2.increment.hbase96;
 
 import co.cask.cdap.data2.dataset2.lib.table.hbase.HBaseOrderedTable;
+import co.cask.cdap.data2.increment.hbase.IncrementHandlerState;
 import co.cask.cdap.data2.util.hbase.MockRegionServerServices;
 import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
@@ -202,7 +203,7 @@ public class IncrementSummingScannerTest {
       assertEquals(2, results.size());
       cell = results.get(0);
       assertNotNull(cell);
-      assertEquals(3L, Bytes.toLong(cell.getValue(), IncrementHandler.DELTA_MAGIC_PREFIX.length, 8));
+      assertEquals(3L, Bytes.toLong(cell.getValue(), IncrementHandlerState.DELTA_MAGIC_PREFIX.length, 8));
       // next cell should be the delete
       cell = results.get(1);
       assertTrue(CellUtil.isDelete(cell));
@@ -403,7 +404,7 @@ public class IncrementSummingScannerTest {
 
     for (int i = 0; i < upperVisBound.length; i++) {
       scanner = new IncrementSummingScanner(region, batch, scanner,
-          ScanType.COMPACT_RETAIN_DELETES, upperVisBound[i]);
+          ScanType.COMPACT_RETAIN_DELETES, upperVisBound[i], -1);
     }
     scanner = new IncrementSummingScanner(region, batch, scanner, ScanType.USER_SCAN);
     // init with false if loop will execute zero times

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/increment/hbase98/IncrementHandler.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/increment/hbase98/IncrementHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,20 +17,19 @@
 package co.cask.cdap.data2.increment.hbase98;
 
 import co.cask.cdap.data2.dataset2.lib.table.hbase.HBaseOrderedTable;
-import co.cask.cdap.data2.transaction.coprocessor.DefaultTransactionStateCacheSupplier;
-import co.cask.tephra.coprocessor.TransactionStateCache;
+import co.cask.cdap.data2.increment.hbase.IncrementHandlerState;
+import co.cask.cdap.data2.increment.hbase.TimestampOracle;
 import co.cask.tephra.hbase98.Filters;
-import co.cask.tephra.persist.TransactionSnapshot;
-import com.google.common.base.Supplier;
-import com.google.common.collect.Sets;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Maps;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.CoprocessorEnvironment;
 import org.apache.hadoop.hbase.HColumnDescriptor;
-import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.Durability;
 import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.Put;
@@ -38,6 +37,7 @@ import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.coprocessor.BaseRegionObserver;
 import org.apache.hadoop.hbase.coprocessor.ObserverContext;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
+import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.hadoop.hbase.regionserver.InternalScanner;
 import org.apache.hadoop.hbase.regionserver.RegionScanner;
@@ -52,7 +52,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
-import java.util.Set;
 import java.util.TreeMap;
 
 /**
@@ -71,54 +70,38 @@ import java.util.TreeMap;
  * all the successfully committed delta values.</p>
  */
 public class IncrementHandler extends BaseRegionObserver {
-  /**
-   * Property set for {@link HColumnDescriptor} to indicate if increment is transactional. Default: "true", i.e.
-   * transactional.
-   */
-  public static final String PROPERTY_TRANSACTIONAL = "dataset.table.readless.increment.transactional";
-
-  // prefix bytes used to mark values that are deltas vs. full sums
-  public static final byte[] DELTA_MAGIC_PREFIX = new byte[] { 'X', 'D' };
-  // expected length for values storing deltas (prefix + increment value)
-  public static final int DELTA_FULL_LENGTH = DELTA_MAGIC_PREFIX.length + Bytes.SIZEOF_LONG;
-  public static final int BATCH_UNLIMITED = -1;
-
   private static final Log LOG = LogFactory.getLog(IncrementHandler.class);
 
   private HRegion region;
-  private TransactionStateCache cache;
+  private IncrementHandlerState state;
 
-  protected Set<byte[]> txnlFamilies = Sets.newTreeSet(Bytes.BYTES_COMPARATOR);
 
   @Override
   public void start(CoprocessorEnvironment e) throws IOException {
     if (e instanceof RegionCoprocessorEnvironment) {
       RegionCoprocessorEnvironment env = (RegionCoprocessorEnvironment) e;
       this.region = ((RegionCoprocessorEnvironment) e).getRegion();
+      this.state = new IncrementHandlerState(env.getConfiguration(),
+          env.getRegion().getTableDesc().getNameAsString());
+
       HTableDescriptor tableDesc = env.getRegion().getTableDesc();
       for (HColumnDescriptor columnDesc : tableDesc.getFamilies()) {
-        boolean txnl = !"false".equals(columnDesc.getValue(PROPERTY_TRANSACTIONAL));
-        LOG.info("Family " + columnDesc.getNameAsString() + " is transactional: " + txnl);
-        if (txnl) {
-          txnlFamilies.add(columnDesc.getName());
-        }
-      }
-
-      if (!txnlFamilies.isEmpty()) {
-        Supplier<TransactionStateCache> cacheSupplier = getTransactionStateCacheSupplier(env);
-        this.cache = cacheSupplier.get();
+        state.initFamily(columnDesc.getName(), convertFamilyValues(columnDesc.getValues()));
       }
     }
   }
 
-  protected Supplier<TransactionStateCache> getTransactionStateCacheSupplier(RegionCoprocessorEnvironment env) {
-    String tableName = env.getRegion().getTableDesc().getNameAsString();
-    String[] parts = tableName.split("\\.", 2);
-    String tableNamespace = "";
-    if (parts.length > 0) {
-      tableNamespace = parts[0];
+  @VisibleForTesting
+  public void setTimestampOracle(TimestampOracle timeOracle) {
+    state.setTimestampOracle(timeOracle);
+  }
+
+  private Map<byte[], byte[]> convertFamilyValues(Map<ImmutableBytesWritable, ImmutableBytesWritable> writableValues) {
+    Map<byte[], byte[]> converted = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
+    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> e : writableValues.entrySet()) {
+      converted.put(e.getKey().get(), e.getValue().get());
     }
-    return new DefaultTransactionStateCacheSupplier(tableNamespace, env.getConfiguration());
+    return converted;
   }
 
   @Override
@@ -142,24 +125,61 @@ public class IncrementHandler extends BaseRegionObserver {
   @Override
   public void prePut(ObserverContext<RegionCoprocessorEnvironment> ctx, Put put, WALEdit edit, Durability durability)
     throws IOException {
-    if (put.getAttribute(HBaseOrderedTable.DELTA_WRITE) != null) {
+    // we assume that if any of the column families written to are transactional, the entire write is transactional
+    boolean transactional = state.containsTransactionalFamily(put.getFamilyCellMap().keySet());
+    boolean isIncrement = put.getAttribute(HBaseOrderedTable.DELTA_WRITE) != null;
+
+    if (isIncrement || !transactional) {
       // incremental write
       NavigableMap<byte[], List<Cell>> newFamilyMap = new TreeMap<byte[], List<Cell>>(Bytes.BYTES_COMPARATOR);
+
+      long tsToAssign = 0;
+      if (!transactional) {
+        tsToAssign = state.getUniqueTimestamp();
+      }
       for (Map.Entry<byte[], List<Cell>> entry : put.getFamilyCellMap().entrySet()) {
         List<Cell> newCells = new ArrayList<Cell>(entry.getValue().size());
         for (Cell cell : entry.getValue()) {
           // rewrite the cell value with a special prefix to identify it as a delta
           // for 0.98 we can update this to use cell tags
-          byte[] newValue = Bytes.add(DELTA_MAGIC_PREFIX, CellUtil.cloneValue(cell));
+          byte[] newValue = isIncrement ?
+              Bytes.add(IncrementHandlerState.DELTA_MAGIC_PREFIX, CellUtil.cloneValue(cell)) :
+              CellUtil.cloneValue(cell);
           newCells.add(CellUtil.createCell(CellUtil.cloneRow(cell), CellUtil.cloneFamily(cell),
-                                           CellUtil.cloneQualifier(cell), cell.getTimestamp(), cell.getTypeByte(),
-                                           newValue));
+                                           CellUtil.cloneQualifier(cell),
+                                           transactional ? cell.getTimestamp() : tsToAssign,
+                                           cell.getTypeByte(), newValue));
         }
         newFamilyMap.put(entry.getKey(), newCells);
       }
       put.setFamilyCellMap(newFamilyMap);
     }
     // put completes normally with value prefix marker
+  }
+
+  @Override
+  public void preDelete(ObserverContext<RegionCoprocessorEnvironment> e, Delete delete, WALEdit edit,
+                        Durability durability) throws IOException {
+    boolean transactional = state.containsTransactionalFamily(delete.getFamilyMap().keySet());
+    if (!transactional) {
+      long tsToAssign = state.getUniqueTimestamp();
+      delete.setTimestamp(tsToAssign);
+      // new key values
+      NavigableMap<byte[], List<Cell>> newFamilyMap = new TreeMap<byte[], List<Cell>>(Bytes.BYTES_COMPARATOR);
+      for (Map.Entry<byte[], List<Cell>> entry : delete.getFamilyCellMap().entrySet()) {
+        List<Cell> newCells = new ArrayList<Cell>(entry.getValue().size());
+        for (Cell kv : entry.getValue()) {
+          // replace the timestamp
+          newCells.add(CellUtil.createCell(CellUtil.cloneRow(kv),
+              CellUtil.cloneFamily(kv),
+              CellUtil.cloneQualifier(kv),
+              tsToAssign, kv.getTypeByte(),
+              CellUtil.cloneValue(kv)));
+        }
+        newFamilyMap.put(entry.getKey(), newCells);
+      }
+      delete.setFamilyCellMap(newFamilyMap);
+    }
   }
 
   @Override
@@ -181,36 +201,31 @@ public class IncrementHandler extends BaseRegionObserver {
   @Override
   public InternalScanner preFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store,
                                   InternalScanner scanner) throws IOException {
-    return new IncrementSummingScanner(region, BATCH_UNLIMITED, scanner,
-                                       ScanType.COMPACT_RETAIN_DELETES, getCompactionBound(store));
+    byte[] family = store.getFamily().getName();
+    return new IncrementSummingScanner(region, IncrementHandlerState.BATCH_UNLIMITED, scanner,
+        ScanType.COMPACT_RETAIN_DELETES, state.getCompactionBound(family), state.getOldestVisibleTimestamp(family));
   }
 
   public static boolean isIncrement(Cell cell) {
-    return !CellUtil.isDelete(cell) && cell.getValueLength() == IncrementHandler.DELTA_FULL_LENGTH &&
-      Bytes.equals(cell.getValueArray(), cell.getValueOffset(), IncrementHandler.DELTA_MAGIC_PREFIX.length,
-                   IncrementHandler.DELTA_MAGIC_PREFIX, 0, IncrementHandler.DELTA_MAGIC_PREFIX.length);
+    return !CellUtil.isDelete(cell) && cell.getValueLength() == IncrementHandlerState.DELTA_FULL_LENGTH &&
+      Bytes.equals(cell.getValueArray(), cell.getValueOffset(), IncrementHandlerState.DELTA_MAGIC_PREFIX.length,
+                   IncrementHandlerState.DELTA_MAGIC_PREFIX, 0, IncrementHandlerState.DELTA_MAGIC_PREFIX.length);
   }
 
   @Override
   public InternalScanner preCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store,
                                     InternalScanner scanner, ScanType scanType) throws IOException {
-    return new IncrementSummingScanner(region, BATCH_UNLIMITED, scanner, scanType, getCompactionBound(store));
+    byte[] family = store.getFamily().getName();
+    return new IncrementSummingScanner(region, IncrementHandlerState.BATCH_UNLIMITED, scanner, scanType,
+        state.getCompactionBound(family), state.getOldestVisibleTimestamp(family));
   }
 
   @Override
   public InternalScanner preCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store,
                                     InternalScanner scanner, ScanType scanType, CompactionRequest request)
     throws IOException {
-    return new IncrementSummingScanner(region, BATCH_UNLIMITED, scanner, scanType, getCompactionBound(store));
-  }
-
-  private long getCompactionBound(Store store) {
-    if (txnlFamilies.contains(store.getFamily().getName())) {
-      TransactionSnapshot snapshot = cache.getLatestState();
-      // if tx snapshot is not available, used "0" as upper bound to avoid trashing in-progress tx
-      return snapshot != null ? snapshot.getVisibilityUpperBound() : 0;
-    } else {
-      return HConstants.LATEST_TIMESTAMP;
-    }
+    byte[] family = store.getFamily().getName();
+    return new IncrementSummingScanner(region, IncrementHandlerState.BATCH_UNLIMITED, scanner, scanType,
+        state.getCompactionBound(family), state.getOldestVisibleTimestamp(family));
   }
 }

--- a/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data/hbase/HBase98Test.java
+++ b/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data/hbase/HBase98Test.java
@@ -20,10 +20,12 @@ import com.google.common.base.Function;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HBaseTestingUtility;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.HRegionInfo;
 import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.MiniHBaseCluster;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.hadoop.hbase.util.Bytes;
@@ -41,6 +43,33 @@ import java.util.TreeMap;
  */
 public class HBase98Test extends HBaseTestBase {
   private static final Logger LOG = LoggerFactory.getLogger(HBase98Test.class);
+
+  protected HBaseTestingUtility testUtil = new HBaseTestingUtility();
+
+  @Override
+  public Configuration getConfiguration() {
+    return testUtil.getConfiguration();
+  }
+
+  @Override
+  public int getZKClientPort() {
+    return testUtil.getZkCluster().getClientPort();
+  }
+
+  @Override
+  public void startHBase() throws Exception {
+    testUtil.startMiniCluster();
+  }
+
+  @Override
+  public void stopHBase() throws Exception {
+    testUtil.shutdownMiniCluster();
+  }
+
+  @Override
+  public MiniHBaseCluster getHBaseCluster() {
+    return testUtil.getHBaseCluster();
+  }
 
   @Override
   public HRegion createHRegion(byte[] tableName, byte[] startKey,
@@ -67,6 +96,7 @@ public class HBase98Test extends HBaseTestBase {
 
   @Override
   public void forceRegionFlush(byte[] tableName) throws IOException {
+    MiniHBaseCluster hbaseCluster = getHBaseCluster();
     if (hbaseCluster != null) {
       TableName qualifiedTableName = TableName.valueOf(tableName);
       for (JVMClusterUtil.RegionServerThread t : hbaseCluster.getRegionServerThreads()) {
@@ -84,6 +114,7 @@ public class HBase98Test extends HBaseTestBase {
 
   @Override
   public void forceRegionCompact(byte[] tableName, boolean majorCompact) throws IOException {
+    MiniHBaseCluster hbaseCluster = getHBaseCluster();
     if (hbaseCluster != null) {
       TableName qualifiedTableName = TableName.valueOf(tableName);
       for (JVMClusterUtil.RegionServerThread t : hbaseCluster.getRegionServerThreads()) {
@@ -101,6 +132,7 @@ public class HBase98Test extends HBaseTestBase {
 
   @Override
   public <T> Map<byte[], T> forEachRegion(byte[] tableName, Function<HRegion, T> function) {
+    MiniHBaseCluster hbaseCluster = getHBaseCluster();
     Map<byte[], T> results = new TreeMap<byte[], T>(Bytes.BYTES_COMPARATOR);
     // make sure consumer config cache is updated
     for (JVMClusterUtil.RegionServerThread t : hbaseCluster.getRegionServerThreads()) {
@@ -110,5 +142,12 @@ public class HBase98Test extends HBaseTestBase {
       }
     }
     return results;
+  }
+
+  @Override
+  public void waitUntilTableAvailable(byte[] tableName, long timeoutInMillis)
+      throws IOException, InterruptedException {
+    testUtil.waitTableAvailable(tableName, timeoutInMillis);
+    testUtil.waitUntilAllRegionsAssigned(TableName.valueOf(tableName), timeoutInMillis);
   }
 }

--- a/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data2/increment/hbase98/IncrementSummingScannerTest.java
+++ b/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data2/increment/hbase98/IncrementSummingScannerTest.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.data2.increment.hbase98;
 
 import co.cask.cdap.data2.dataset2.lib.table.hbase.HBaseOrderedTable;
+import co.cask.cdap.data2.increment.hbase.IncrementHandlerState;
 import co.cask.cdap.data2.util.hbase.MockRegionServerServices;
 import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
@@ -202,7 +203,7 @@ public class IncrementSummingScannerTest {
       assertEquals(2, results.size());
       cell = results.get(0);
       assertNotNull(cell);
-      assertEquals(3L, Bytes.toLong(cell.getValue(), IncrementHandler.DELTA_MAGIC_PREFIX.length, 8));
+      assertEquals(3L, Bytes.toLong(cell.getValue(), IncrementHandlerState.DELTA_MAGIC_PREFIX.length, 8));
       // next cell should be the delete
       cell = results.get(1);
       assertTrue(CellUtil.isDelete(cell));
@@ -403,7 +404,7 @@ public class IncrementSummingScannerTest {
 
     for (int i = 0; i < upperVisBound.length; i++) {
       scanner = new IncrementSummingScanner(region, batch, scanner,
-          ScanType.COMPACT_RETAIN_DELETES, upperVisBound[i]);
+          ScanType.COMPACT_RETAIN_DELETES, upperVisBound[i], -1);
     }
     scanner = new IncrementSummingScanner(region, batch, scanner, ScanType.USER_SCAN);
     // init with false if loop will execute zero times


### PR DESCRIPTION
This change makes readless increments safe to use in a non-transactional context by assigning a region-unique timestamp to all writes, similar to how the Tephra TransactionManager assigns timestamp based transaction IDs.

The change breaks down into a few parts:
* IncrementHandlerState factored out to reduce code duplication between IncrementHandler implementations
* IncrementHandler implementations updated to assign timestamps in non-transactional case
* AbstractIncrementHandler pulled out to provide a single set of test cases for IncrementHandlerTest implementations.  Also added test cases for mixed increment, put, delete and TTL handling.
* HBaseTestBase, HBaseTest94, HBaseTest96 HBaseTest98 refactored to reduce code duplication (supports shared test cases in AbstractIncrementHandlerTest)
