### PR TITLE
Fix a few bugs for Notifications in Streams to work

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/DistributedStreamCoordinatorClient.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/DistributedStreamCoordinatorClient.java
@@ -32,6 +32,8 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import org.apache.twill.zookeeper.ZKClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -42,6 +44,7 @@ import javax.annotation.Nullable;
  */
 @Singleton
 public final class DistributedStreamCoordinatorClient extends AbstractStreamCoordinatorClient {
+  private static final Logger LOG = LoggerFactory.getLogger(DistributedStreamCoordinatorClient.class);
 
   private final ResourceCoordinatorClient resourceCoordinatorClient;
   private final ZKClient zkClient;
@@ -78,6 +81,7 @@ public final class DistributedStreamCoordinatorClient extends AbstractStreamCoor
         @Nullable
         @Override
         public ResourceRequirement apply(@Nullable ResourceRequirement existingRequirement) {
+          LOG.debug("Modifying requirement to add stream {} as a resource", streamName);
           Set<ResourceRequirement.Partition> partitions;
           if (existingRequirement != null) {
             partitions = existingRequirement.getPartitions();

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/BasicStreamWriterSizeCollector.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/BasicStreamWriterSizeCollector.java
@@ -84,6 +84,7 @@ public class BasicStreamWriterSizeCollector extends AbstractIdleService implemen
     if (value != null) {
       value.addAndGet(dataSize);
     }
-    LOG.trace("Received data for stream {}: {}B. Total size is now {}", streamName, dataSize, value.get());
+    LOG.trace("Received data for stream {}: {}B. Total size is now {}", streamName, dataSize,
+              value == null ? dataSize : value.get());
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/BasicStreamWriterSizeCollector.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/BasicStreamWriterSizeCollector.java
@@ -23,6 +23,8 @@ import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.AbstractIdleService;
 import com.google.inject.Inject;
 import org.apache.twill.common.Cancellable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.concurrent.ConcurrentMap;
@@ -32,6 +34,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * Basic implementation of a {@link StreamWriterSizeCollector}.
  */
 public class BasicStreamWriterSizeCollector extends AbstractIdleService implements StreamWriterSizeCollector {
+  private static final Logger LOG = LoggerFactory.getLogger(BasicStreamWriterSizeCollector.class);
 
   private final StreamCoordinatorClient streamCoordinatorClient;
   private final ConcurrentMap<String, AtomicLong> streamSizes;
@@ -81,5 +84,6 @@ public class BasicStreamWriterSizeCollector extends AbstractIdleService implemen
     if (value != null) {
       value.addAndGet(dataSize);
     }
+    LOG.trace("Received data for stream {}: {}B. Total size is now {}", streamName, dataSize, value.get());
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/DistributedStreamService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/DistributedStreamService.java
@@ -98,7 +98,6 @@ public class DistributedStreamService extends AbstractStreamService {
 
   private final ConcurrentMap<String, StreamSizeAggregator> aggregators;
   private Cancellable heartbeatsSubscription;
-  private boolean isInit;
 
   private Supplier<Discoverable> discoverableSupplier;
 
@@ -133,7 +132,6 @@ public class DistributedStreamService extends AbstractStreamService {
     this.leaderListeners = Sets.newHashSet();
     this.instanceId = cConf.getInt(Constants.Stream.CONTAINER_INSTANCE_ID);
     this.aggregators = Maps.newConcurrentMap();
-    this.isInit = true;
   }
 
   @Override
@@ -191,7 +189,9 @@ public class DistributedStreamService extends AbstractStreamService {
     for (StreamSpecification streamSpec : streamMetaStore.listStreams()) {
       sizes.put(streamSpec.getName(), streamWriterSizeCollector.getTotalCollected(streamSpec.getName()));
     }
-    heartbeatPublisher.sendHeartbeat(new StreamWriterHeartbeat(System.currentTimeMillis(), instanceId, sizes.build()));
+    StreamWriterHeartbeat heartbeat = new StreamWriterHeartbeat(System.currentTimeMillis(), instanceId, sizes.build());
+    LOG.trace("Publishing heartbeat {}", heartbeat);
+    heartbeatPublisher.sendHeartbeat(heartbeat);
   }
 
   /**
@@ -210,6 +210,7 @@ public class DistributedStreamService extends AbstractStreamService {
       try {
         StreamConfig config = streamAdmin.getConfig(streamName);
         long filesSize = StreamUtils.fetchStreamFilesSize(config);
+        LOG.debug("Size of the files already present for stream {}: {}", streamName, filesSize);
         createSizeAggregator(streamName, filesSize, config.getNotificationThresholdMB());
       } catch (IOException e) {
         LOG.error("Could not compute sizes of files for stream {}", streamName);
@@ -237,7 +238,7 @@ public class DistributedStreamService extends AbstractStreamService {
    * @return the created {@link StreamSizeAggregator}
    */
   private StreamSizeAggregator createSizeAggregator(String streamName, long baseCount, final int threshold) {
-
+    LOG.debug("Creating size aggregator for stream {}", streamName);
     // Handle threshold changes
     final Cancellable thresholdSubscription =
       getStreamCoordinatorClient().addListener(streamName, new StreamPropertyListener() {
@@ -258,8 +259,13 @@ public class DistributedStreamService extends AbstractStreamService {
       getStreamCoordinatorClient().addListener(streamName, new StreamPropertyListener() {
         @Override
         public void generationChanged(String streamName, int generation) {
-          Cancellable previousAggregator = aggregators.replace(streamName, createSizeAggregator(streamName, 0,
-                                                                                                threshold));
+          int currentThresold = threshold;
+          StreamSizeAggregator currentAggregator = aggregators.get(streamName);
+          if (currentAggregator != null) {
+            currentThresold = currentAggregator.getStreamThresholdMB();
+          }
+          Cancellable previousAggregator =
+            aggregators.replace(streamName, createSizeAggregator(streamName, 0, currentThresold));
           if (previousAggregator != null) {
             previousAggregator.cancel();
           }
@@ -291,6 +297,7 @@ public class DistributedStreamService extends AbstractStreamService {
       .setCategory(Constants.Notification.Stream.STREAM_INTERNAL_FEED_CATEGORY)
       .setName(Constants.Notification.Stream.STREAM_HEARTBEAT_FEED_NAME)
       .build();
+    LOG.trace("Subscribing to stream heartbeats notification feed");
     return notificationService.subscribe(heartbeatsFeed, new NotificationHandler<StreamWriterHeartbeat>() {
       @Override
       public Type getNotificationFeedType() {
@@ -299,9 +306,11 @@ public class DistributedStreamService extends AbstractStreamService {
 
       @Override
       public void received(StreamWriterHeartbeat heartbeat, NotificationContext notificationContext) {
+        LOG.trace("Received heartbeat {}", heartbeat);
         for (Map.Entry<String, Long> entry : heartbeat.getStreamsSizes().entrySet()) {
           StreamSizeAggregator streamSizeAggregator = aggregators.get(entry.getKey());
           if (streamSizeAggregator == null) {
+            LOG.trace("Aggregator for stream {} is null", entry.getKey());
             continue;
           }
           streamSizeAggregator.bytesReceived(heartbeat.getInstanceId(), entry.getValue());
@@ -397,14 +406,16 @@ public class DistributedStreamService extends AbstractStreamService {
         }
       }
     });
+    leaderElection.start();
   }
 
   /**
-   * Call all the listeners that are interested in knowing that this coordinator is the leader of a set of Streams.
+   * Call all the listeners that are interested in knowing that this Stream writer is the leader of a set of Streams.
    *
    * @param streamNames set of Streams that this coordinator is the leader of
    */
   private void invokeLeaderListeners(Set<String> streamNames) {
+    LOG.debug("Stream writer is the leader of streams: {}", streamNames);
     Set<StreamLeaderListener> listeners;
     synchronized (this) {
       listeners = ImmutableSet.copyOf(leaderListeners);
@@ -425,6 +436,7 @@ public class DistributedStreamService extends AbstractStreamService {
 
     @Override
     public void onChange(Collection<PartitionReplica> partitionReplicas) {
+      LOG.debug("Stream leader requirement has changed");
       Set<String> streamNames =
         ImmutableSet.copyOf(Iterables.transform(partitionReplicas, new Function<PartitionReplica, String>() {
           @Nullable
@@ -454,15 +466,19 @@ public class DistributedStreamService extends AbstractStreamService {
     private final Map<Integer, Long> streamWriterSizes;
     private final NotificationFeed streamFeed;
     private final AtomicLong streamBaseCount;
+    private final AtomicLong countFromFiles;
     private final AtomicInteger streamThresholdMB;
     private final Cancellable cancellable;
+    private boolean isInit;
 
     protected StreamSizeAggregator(String streamName, long baseCount, int streamThresholdMB,
                                    Cancellable cancellable) {
       this.streamWriterSizes = Maps.newHashMap();
       this.streamBaseCount = new AtomicLong(baseCount);
+      this.countFromFiles = new AtomicLong(baseCount);
       this.streamThresholdMB = new AtomicInteger(streamThresholdMB);
       this.cancellable = cancellable;
+      this.isInit = true;
       this.streamFeed = new NotificationFeed.Builder()
         .setNamespace(Constants.DEFAULT_NAMESPACE)
         .setCategory(Constants.Notification.Stream.STREAM_FEED_CATEGORY)
@@ -485,6 +501,13 @@ public class DistributedStreamService extends AbstractStreamService {
     }
 
     /**
+     * @return the current notification threshold for the stream that this {@link StreamSizeAggregator} is linked to
+     */
+    public int getStreamThresholdMB() {
+      return streamThresholdMB.get();
+    }
+
+    /**
      * Notify this aggregator that a certain number of bytes have been received from the stream writer with instance
      * {@code instanceId}.
      *
@@ -492,12 +515,8 @@ public class DistributedStreamService extends AbstractStreamService {
      * @param nbBytes number of bytes of data received
      */
     public void bytesReceived(int instanceId, long nbBytes) {
-      Long lastSize = streamWriterSizes.get(instanceId);
-      if (lastSize == null) {
-        streamWriterSizes.put(instanceId, nbBytes);
-        return;
-      }
-      streamWriterSizes.put(instanceId, lastSize + nbBytes);
+      LOG.trace("Bytes received from instanceId {}: {}B", instanceId, nbBytes);
+      streamWriterSizes.put(instanceId, nbBytes);
       checkSendNotification();
     }
 
@@ -505,7 +524,7 @@ public class DistributedStreamService extends AbstractStreamService {
      * Check if the current size of data is enough to trigger a notification.
      */
     private void checkSendNotification() {
-      long sum = 0;
+      long sum = countFromFiles.get();
       for (Long size : streamWriterSizes.values()) {
         sum += size;
       }
@@ -515,8 +534,10 @@ public class DistributedStreamService extends AbstractStreamService {
           publishNotification(sum);
         } finally {
           streamBaseCount.set(sum);
+          countFromFiles.set(0);
         }
       }
+      isInit = false;
     }
 
     private void publishNotification(long absoluteSize) {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/LocalStreamService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/LocalStreamService.java
@@ -71,7 +71,7 @@ public class LocalStreamService extends AbstractStreamService {
     for (StreamSpecification streamSpec : streamMetaStore.listStreams()) {
       StreamConfig config = streamAdmin.getConfig(streamSpec.getName());
       long filesSize = StreamUtils.fetchStreamFilesSize(config);
-      createSizeAggregator(streamSpec.getName(), filesSize, new AtomicInteger(config.getNotificationThresholdMB()));
+      createSizeAggregator(streamSpec.getName(), filesSize, config.getNotificationThresholdMB());
     }
   }
 
@@ -90,8 +90,7 @@ public class LocalStreamService extends AbstractStreamService {
       if (streamSizeAggregator == null) {
         // First time that we see this Stream here
         StreamConfig config = streamAdmin.getConfig(streamSpec.getName());
-        streamSizeAggregator = createSizeAggregator(streamSpec.getName(), 0,
-                                                    new AtomicInteger(config.getNotificationThresholdMB()));
+        streamSizeAggregator = createSizeAggregator(streamSpec.getName(), 0, config.getNotificationThresholdMB());
       }
       streamSizeAggregator.checkAggregatedSize();
     }
@@ -107,7 +106,7 @@ public class LocalStreamService extends AbstractStreamService {
    * @param baseCount stream size from which to start aggregating
    * @return the created {@link StreamSizeAggregator}
    */
-  private StreamSizeAggregator createSizeAggregator(String streamName, long baseCount, final AtomicInteger threshold) {
+  private StreamSizeAggregator createSizeAggregator(String streamName, long baseCount, int threshold) {
 
     // Handle threshold changes
     final Cancellable thresholdSubscription =
@@ -115,9 +114,9 @@ public class LocalStreamService extends AbstractStreamService {
         @Override
         public void thresholdChanged(String streamName, int threshold) {
           StreamSizeAggregator aggregator = aggregators.get(streamName);
-          if (aggregator == null) {
-            LOG.warn("StreamSizeAggregator should not be null for stream {}", streamName);
-            return;
+          while (aggregator == null) {
+            Thread.yield();
+            aggregator = aggregators.get(streamName);
           }
           aggregator.setStreamThresholdMB(threshold);
         }
@@ -129,16 +128,12 @@ public class LocalStreamService extends AbstractStreamService {
       getStreamCoordinatorClient().addListener(streamName, new StreamPropertyListener() {
         @Override
         public void generationChanged(String streamName, int generation) {
-          AtomicInteger currentThresold = threshold;
-          StreamSizeAggregator currentAggregator = aggregators.get(streamName);
-          if (currentAggregator != null) {
-            currentThresold = currentAggregator.getStreamThresholdMB();
+          StreamSizeAggregator aggregator = aggregators.get(streamName);
+          while (aggregator == null) {
+            Thread.yield();
+            aggregator = aggregators.get(streamName);
           }
-          Cancellable previousAggregator = aggregators.replace(streamName, createSizeAggregator(streamName, 0,
-                                                                                                currentThresold));
-          if (previousAggregator != null) {
-            previousAggregator.cancel();
-          }
+          aggregator.resetCount();
         }
       });
 
@@ -165,8 +160,7 @@ public class LocalStreamService extends AbstractStreamService {
     private final AtomicInteger streamThresholdMB;
     private final Cancellable cancellable;
 
-    protected StreamSizeAggregator(String streamName, long baseCount, AtomicInteger streamThresholdMB,
-                                   Cancellable cancellable) {
+    protected StreamSizeAggregator(String streamName, long baseCount, int streamThresholdMB, Cancellable cancellable) {
       this.streamName = streamName;
       this.streamInitSize = new AtomicLong(baseCount);
       this.streamBaseCount = new AtomicLong(baseCount);
@@ -176,12 +170,20 @@ public class LocalStreamService extends AbstractStreamService {
         .setCategory(Constants.Notification.Stream.STREAM_FEED_CATEGORY)
         .setName(streamName)
         .build();
-      this.streamThresholdMB = streamThresholdMB;
+      this.streamThresholdMB = new AtomicInteger(streamThresholdMB);
     }
 
     @Override
     public void cancel() {
       cancellable.cancel();
+    }
+
+    /**
+     * Reset the counts of this {@link StreamSizeAggregator} to zero.
+     */
+    public void resetCount() {
+      streamBaseCount.set(0);
+      streamInitSize.set(0);
     }
 
     /**
@@ -191,13 +193,6 @@ public class LocalStreamService extends AbstractStreamService {
      */
     public void setStreamThresholdMB(int newThreshold) {
       streamThresholdMB.set(newThreshold);
-    }
-
-    /**
-     * @return the current notification threshold for the stream that this {@link StreamSizeAggregator} is linked to
-     */
-    public AtomicInteger getStreamThresholdMB() {
-      return streamThresholdMB;
     }
 
     /**

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamServiceRuntimeModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamServiceRuntimeModule.java
@@ -18,7 +18,7 @@ package co.cask.cdap.data.stream.service;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.runtime.RuntimeModule;
 import co.cask.cdap.data.stream.service.heartbeat.HeartbeatPublisher;
-import co.cask.cdap.data.stream.service.heartbeat.NoOpHeartbeatPublisher;
+import co.cask.cdap.data.stream.service.heartbeat.NotificationHeartbeatPublisher;
 import co.cask.cdap.gateway.handlers.PingHandler;
 import co.cask.http.HttpHandler;
 import com.google.common.base.Supplier;
@@ -76,7 +76,7 @@ public final class StreamServiceRuntimeModule extends RuntimeModule {
         handlerBinder.addBinding().to(StreamFetchHandler.class);
         handlerBinder.addBinding().to(PingHandler.class);
 
-        bind(HeartbeatPublisher.class).to(NoOpHeartbeatPublisher.class).in(Scopes.SINGLETON);
+        bind(HeartbeatPublisher.class).to(NotificationHeartbeatPublisher.class).in(Scopes.SINGLETON);
 
         bind(StreamHttpService.class).in(Scopes.SINGLETON);
         bind(Key.get(new TypeLiteral<Supplier<Discoverable>>() { })).to(StreamHttpService.class);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/heartbeat/HeartbeatPublisher.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/heartbeat/HeartbeatPublisher.java
@@ -19,8 +19,6 @@ package co.cask.cdap.data.stream.service.heartbeat;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.Service;
 
-import java.io.IOException;
-
 /**
  * Publishes {@link StreamWriterHeartbeat}s.
  */
@@ -32,7 +30,6 @@ public interface HeartbeatPublisher extends Service {
    * @param heartbeat heartbeat to publish
    * @return a {@link ListenableFuture} describing the state of publishing. The {@link ListenableFuture#get} method
    * will return the published heartbeat.
-   * @throws IOException when the {@code heartbeat}
    */
-  ListenableFuture<StreamWriterHeartbeat> sendHeartbeat(StreamWriterHeartbeat heartbeat) throws IOException;
+  ListenableFuture<StreamWriterHeartbeat> sendHeartbeat(StreamWriterHeartbeat heartbeat);
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/heartbeat/HeartbeatPublisher.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/heartbeat/HeartbeatPublisher.java
@@ -19,6 +19,8 @@ package co.cask.cdap.data.stream.service.heartbeat;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.Service;
 
+import java.io.IOException;
+
 /**
  * Publishes {@link StreamWriterHeartbeat}s.
  */
@@ -30,6 +32,7 @@ public interface HeartbeatPublisher extends Service {
    * @param heartbeat heartbeat to publish
    * @return a {@link ListenableFuture} describing the state of publishing. The {@link ListenableFuture#get} method
    * will return the published heartbeat.
+   * @throws IOException when the {@code heartbeat}
    */
-  ListenableFuture<StreamWriterHeartbeat> sendHeartbeat(StreamWriterHeartbeat heartbeat);
+  ListenableFuture<StreamWriterHeartbeat> sendHeartbeat(StreamWriterHeartbeat heartbeat) throws IOException;
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/heartbeat/NotificationHeartbeatPublisher.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/heartbeat/NotificationHeartbeatPublisher.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data.stream.service.heartbeat;
+
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.notifications.feeds.NotificationFeed;
+import co.cask.cdap.notifications.service.NotificationException;
+import co.cask.cdap.notifications.service.NotificationService;
+import com.google.common.util.concurrent.AbstractIdleService;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.inject.Inject;
+
+import java.io.IOException;
+
+/**
+ * Implementation of {@link HeartbeatPublisher} that publishes {@link StreamWriterHeartbeat} as notification using
+ * the {@link NotificationService}.
+ */
+public class NotificationHeartbeatPublisher extends AbstractIdleService implements HeartbeatPublisher {
+
+  private final NotificationService notificationService;
+  private final NotificationFeed heartbeatFeed;
+
+  @Inject
+  public NotificationHeartbeatPublisher(NotificationService notificationService) {
+    this.notificationService = notificationService;
+    this.heartbeatFeed = new NotificationFeed.Builder()
+      .setNamespace(Constants.DEFAULT_NAMESPACE)
+      .setCategory(Constants.Notification.Stream.STREAM_INTERNAL_FEED_CATEGORY)
+      .setName(Constants.Notification.Stream.STREAM_HEARTBEAT_FEED_NAME)
+      .build();
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    notificationService.startAndWait();
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    notificationService.stopAndWait();
+  }
+
+  @Override
+  public ListenableFuture<StreamWriterHeartbeat> sendHeartbeat(StreamWriterHeartbeat heartbeat) throws IOException {
+    try {
+      return notificationService.publish(heartbeatFeed, heartbeat);
+    } catch (NotificationException e) {
+      throw new IOException(e);
+    }
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/heartbeat/NotificationHeartbeatPublisher.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/heartbeat/NotificationHeartbeatPublisher.java
@@ -24,8 +24,6 @@ import com.google.common.util.concurrent.AbstractIdleService;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.inject.Inject;
 
-import java.io.IOException;
-
 /**
  * Implementation of {@link HeartbeatPublisher} that publishes {@link StreamWriterHeartbeat} as notification using
  * the {@link NotificationService}.
@@ -56,11 +54,11 @@ public class NotificationHeartbeatPublisher extends AbstractIdleService implemen
   }
 
   @Override
-  public ListenableFuture<StreamWriterHeartbeat> sendHeartbeat(StreamWriterHeartbeat heartbeat) throws IOException {
+  public ListenableFuture<StreamWriterHeartbeat> sendHeartbeat(StreamWriterHeartbeat heartbeat) {
     try {
       return notificationService.publish(heartbeatFeed, heartbeat);
     } catch (NotificationException e) {
-      throw new IOException(e);
+      throw new IllegalArgumentException("Streams' heartbeat notification feed has not been created", e);
     }
   }
 }

--- a/cdap-notifications/src/main/java/co/cask/cdap/notifications/service/AbstractNotificationService.java
+++ b/cdap-notifications/src/main/java/co/cask/cdap/notifications/service/AbstractNotificationService.java
@@ -68,6 +68,7 @@ public abstract class AbstractNotificationService extends AbstractIdleService im
    * @param notificationJson notification as a json object
    */
   protected void notificationReceived(NotificationFeed feed, JsonElement notificationJson) {
+    LOG.trace("Notification received on feed {}: {}", feed, notificationJson);
     Collection<NotificationCaller<?>> callers = subscribers.get(feed);
     synchronized (subscribers) {
       callers = ImmutableList.copyOf(callers);

--- a/cdap-notifications/src/main/java/co/cask/cdap/notifications/service/kafka/KafkaMessage.java
+++ b/cdap-notifications/src/main/java/co/cask/cdap/notifications/service/kafka/KafkaMessage.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.notifications.service.kafka;
 
+import com.google.common.base.Objects;
 import com.google.gson.JsonElement;
 
 /**
@@ -36,5 +37,13 @@ class KafkaMessage {
 
   public JsonElement getNotificationJson() {
     return notificationJson;
+  }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(this)
+      .add("messageKey", messageKey)
+      .add("notificationJson", notificationJson)
+      .toString();
   }
 }


### PR DESCRIPTION
- It was assumed that only one partition would be created for each notification feed in Kafka, but ``kafka.num.partitions`` are actually created. For now, the subscriber to a feed will subscribe to all the partitions for the topic in which the notifications for the feed will be stored.
- Leader election was not started in the ``DistributedStreamService``
- The counting logic was wrong in the aggregation of heartbeats in the ``DistributedStreamService``
- Truncating the stream meant creating an aggregator based on the initial threshold of the stream, and not the updated one, if it had been updated.

Build: https://builds.cask.co/browse/CDAP-RBT102