### PR TITLE
Increasing timeout to 1hour from 30secs

### DIFF
--- a/cdap-cli/src/main/java/co/cask/cdap/cli/ArgumentName.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/ArgumentName.java
@@ -48,6 +48,7 @@ public enum ArgumentName {
   NUM_INSTANCES("num-instances"),
   START_TIME("start-time"),
   END_TIME("end-time"),
+  TIMEOUT("timeout"),
   LIMIT("limit"),
   RUN_STATUS("status"),
   APP_JAR_FILE("app-jar-file"),

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/ExecuteQueryCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/ExecuteQueryCommand.java
@@ -47,7 +47,7 @@ import java.util.concurrent.TimeoutException;
  */
 public class ExecuteQueryCommand extends AbstractAuthCommand {
 
-  private static final long TIMEOUT_MS = 30000;
+  private static final long TIMEOUT_SEC = 3600;
   private final QueryClient queryClient;
 
   @Inject
@@ -62,7 +62,7 @@ public class ExecuteQueryCommand extends AbstractAuthCommand {
 
     ListenableFuture<ExploreExecutionResult> future = queryClient.execute(query);
     try {
-      ExploreExecutionResult executionResult = future.get(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+      ExploreExecutionResult executionResult = future.get(TIMEOUT_SEC, TimeUnit.SECONDS);
       if (!executionResult.canContainResults()) {
         output.println("SQL statement does not output any result.");
         executionResult.close();
@@ -101,7 +101,7 @@ public class ExecuteQueryCommand extends AbstractAuthCommand {
     } catch (CancellationException e) {
       throw new RuntimeException("Query has been cancelled on ListenableFuture object.");
     } catch (TimeoutException e) {
-      output.println("Couldn't obtain results after " + TIMEOUT_MS + "ms.");
+      output.println("Couldn't obtain results after " + TIMEOUT_SEC + "ms.");
     }
 
   }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/ExecuteQueryCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/ExecuteQueryCommand.java
@@ -59,7 +59,7 @@ public class ExecuteQueryCommand extends AbstractAuthCommand {
   @Override
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     String query = arguments.get(ArgumentName.QUERY.toString());
-    long timeOutMins = arguments.getLong(ArgumentName.END_TIME.toString(), TIMEOUT_MINS);
+    long timeOutMins = arguments.getLong(ArgumentName.TIMEOUT.toString(), TIMEOUT_MINS);
 
     ListenableFuture<ExploreExecutionResult> future = queryClient.execute(query);
     try {
@@ -109,7 +109,7 @@ public class ExecuteQueryCommand extends AbstractAuthCommand {
 
   @Override
   public String getPattern() {
-    return String.format("execute <%s> [<%s>]", ArgumentName.QUERY, ArgumentName.END_TIME);
+    return String.format("execute <%s> [<%s>]", ArgumentName.QUERY, ArgumentName.TIMEOUT);
   }
 
   @Override


### PR DESCRIPTION
Temporary Fix for https://issues.cask.co/browse/CDAP-1281
We need to have a better fix - returning a QueryHandle and a separate command to fetch results using that QueryHandle.

Bamboo : https://builds.cask.co/browse/CDAP-RBT106-1