### PR TITLE
CDAP-1255 the explore service was not returning any results

### DIFF
--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/BaseHiveExploreService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/BaseHiveExploreService.java
@@ -44,7 +44,6 @@ import co.cask.tephra.TransactionSystemClient;
 import com.google.common.base.Charsets;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
-import com.google.common.base.Throwables;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableList;
@@ -73,9 +72,6 @@ import org.apache.hive.service.cli.HiveSQLException;
 import org.apache.hive.service.cli.OperationHandle;
 import org.apache.hive.service.cli.SessionHandle;
 import org.apache.hive.service.cli.TableSchema;
-import org.apache.hive.service.cli.thrift.TColumnValue;
-import org.apache.hive.service.cli.thrift.TRow;
-import org.apache.hive.service.cli.thrift.TRowSet;
 import org.apache.thrift.TException;
 import org.apache.twill.common.Threads;
 import org.slf4j.Logger;
@@ -89,8 +85,6 @@ import java.io.Reader;
 import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.sql.SQLException;
 import java.util.Collections;
 import java.util.List;
@@ -658,7 +652,8 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
     try {
       // Fetch results from Hive
       LOG.trace("Getting results for handle {}", handle);
-      List<QueryResult> results = fetchNextResults(getOperationHandle(handle), size);
+      OperationHandle opHandle = getOperationHandle(handle);
+      List<QueryResult> results = fetchNextResults(opHandle, size);
       QueryStatus status = getStatus(handle);
       if (results.isEmpty() && status.getStatus() == QueryStatus.OpStatus.FINISHED) {
         // Since operation has fetched all the results, handle can be timed out aggressively.
@@ -676,35 +671,19 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
     throws HiveSQLException, ExploreException, HandleNotFoundException {
     startAndWait();
 
-    try {
-      if (operationHandle.hasResultSet()) {
-        // Rowset is an interface in Hive 13, but a class in Hive 12, so we use reflection
-        // so that the compiler does not make assumption on the return type of fetchResults
-        Object rowSet = getCliService().fetchResults(operationHandle, FetchOrientation.FETCH_NEXT, size);
-        Class rowSetClass = Class.forName("org.apache.hive.service.cli.RowSet");
-        Method toTRowSetMethod = rowSetClass.getMethod("toTRowSet");
-        TRowSet tRowSet = (TRowSet) toTRowSetMethod.invoke(rowSet);
-
-        ImmutableList.Builder<QueryResult> rowsBuilder = ImmutableList.builder();
-        for (TRow tRow : tRowSet.getRows()) {
-          List<Object> cols = Lists.newArrayList();
-          for (TColumnValue tColumnValue : tRow.getColVals()) {
-            cols.add(tColumnToObject(tColumnValue));
-          }
-          rowsBuilder.add(new QueryResult(cols));
+    if (operationHandle.hasResultSet()) {
+      ImmutableList.Builder<QueryResult> rowsBuilder = ImmutableList.builder();
+      Iterable<Object[]> rowSet = getCliService().fetchResults(operationHandle, FetchOrientation.FETCH_NEXT, size);
+      for (Object[] row : rowSet) {
+        List<Object> cols = Lists.newArrayList();
+        for (int i = 0; i < row.length; i++) {
+          cols.add(row[i]);
         }
-        return rowsBuilder.build();
-      } else {
-        return Collections.emptyList();
+        rowsBuilder.add(new QueryResult(cols));
       }
-    } catch (ClassNotFoundException e) {
-      throw Throwables.propagate(e);
-    } catch (NoSuchMethodException e) {
-      throw Throwables.propagate(e);
-    } catch (InvocationTargetException e) {
-      throw Throwables.propagate(e);
-    } catch (IllegalAccessException e) {
-      throw Throwables.propagate(e);
+      return rowsBuilder.build();
+    } else {
+      return Collections.emptyList();
     }
   }
 
@@ -1018,25 +997,6 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
       throw e;
     }
     throw new ExploreException(e);
-  }
-
-  protected Object tColumnToObject(TColumnValue tColumnValue) throws ExploreException {
-    if (tColumnValue.isSetBoolVal()) {
-      return tColumnValue.getBoolVal().isValue();
-    } else if (tColumnValue.isSetByteVal()) {
-      return tColumnValue.getByteVal().getValue();
-    } else if (tColumnValue.isSetDoubleVal()) {
-      return tColumnValue.getDoubleVal().getValue();
-    } else if (tColumnValue.isSetI16Val()) {
-      return tColumnValue.getI16Val().getValue();
-    } else if (tColumnValue.isSetI32Val()) {
-      return tColumnValue.getI32Val().getValue();
-    } else if (tColumnValue.isSetI64Val()) {
-      return tColumnValue.getI64Val().getValue();
-    } else if (tColumnValue.isSetStringVal()) {
-      return tColumnValue.getStringVal().getValue();
-    }
-    throw new ExploreException("Unknown column value encountered: " + tColumnValue);
   }
 
   /**


### PR DESCRIPTION
because it was translating a RowSet to a TRowSet (thrift object),
and then getting the rows from that. But different versions of
the protocol get the rows differently, with older versions using
a RowBasedSet and newer versions using a ColumnBasedSet that
behave differently. Instead, we should just be using the RowSet
directly.