### PR TITLE
Fix for CDAP-1112: No documentation for pre-splitting in table datasets

### DIFF
--- a/cdap-docs/developers-manual/source/building-blocks/datasets/system-custom.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/datasets/system-custom.rst
@@ -108,8 +108,7 @@ Dataset with multiple partitions, you can use::
     DatasetProperties.builder()
                      .add("conflict.level", "NONE")      
                      .add("hbase.splits", new Gson().toJson(new byte[][]{{1},{2},{3},{4},{5}})
-                     .build()
-  );
+                     .build());
 
 Application components can access a created Dataset via the ``@UseDataSet`` annotation::
 

--- a/cdap-docs/developers-manual/source/building-blocks/datasets/system-custom.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/datasets/system-custom.rst
@@ -106,7 +106,7 @@ Dataset with multiple partitions, you can use::
 
   createDataset("frequentCustomers", KeyValueTable.class,
     DatasetProperties.builder()
-                     .add("conflict.level", "NONE")      
+                     .add("ttl", "3600")      
                      .add("hbase.splits", new Gson().toJson(new byte[][]{{1},{2},{3},{4},{5}})
                      .build());
 

--- a/cdap-docs/developers-manual/source/building-blocks/datasets/system-custom.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/datasets/system-custom.rst
@@ -101,7 +101,15 @@ To create a Dataset of type ``UniqueCountTable``, add the following into the App
 
 You can also pass ``DatasetProperties`` as a third parameter to the ``createDataset`` method.
 These properties will be used by embedded Datasets during creation and will be available via the
-``DatasetSpecification`` passed to the Dataset constructor.
+``DatasetSpecification`` passed to the Dataset constructor. For example, to create a 
+Dataset with multiple partitions, you can use::
+
+  createDataset("frequentCustomers", KeyValueTable.class,
+    DatasetProperties.builder()
+                     .add("conflict.level", "NONE")      
+                     .add("hbase.splits", new Gson().toJson(new byte[][]{{1},{2},{3},{4},{5}})
+                     .build()
+  );
 
 Application components can access a created Dataset via the ``@UseDataSet`` annotation::
 

--- a/cdap-docs/developers-manual/source/building-blocks/datasets/system-custom.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/datasets/system-custom.rst
@@ -101,14 +101,17 @@ To create a Dataset of type ``UniqueCountTable``, add the following into the App
 
 You can also pass ``DatasetProperties`` as a third parameter to the ``createDataset`` method.
 These properties will be used by embedded Datasets during creation and will be available via the
-``DatasetSpecification`` passed to the Dataset constructor. For example, to create a 
-Dataset with multiple partitions, you can use::
+``DatasetSpecification`` passed to the Dataset constructor. For example, to create a Dataset with
+a TTL (time-to-live) property, you can use::
 
   createDataset("frequentCustomers", KeyValueTable.class,
     DatasetProperties.builder()
-                     .add("ttl", "3600")      
-                     .add("hbase.splits", new Gson().toJson(new byte[][]{{1},{2},{3},{4},{5}})
+                     .add(OrderedTable.PROPERTY_TTL, "3600")      
                      .build());
+
+You can pass other properties, such as for 
+:ref:`conflict detection <transaction-system-conflict-detection>` and for
+:ref:`pre-splitting into multiple regions <table-datasets-pre-splitting>`.
 
 Application components can access a created Dataset via the ``@UseDataSet`` annotation::
 

--- a/cdap-docs/developers-manual/source/building-blocks/datasets/table.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/datasets/table.rst
@@ -244,16 +244,8 @@ Application class' ``configure()`` you specify:
       DatasetProperties props = 
           DatasetProperties.builder().add("hbase.splits", "[[64],[128],[192]]").build();
       createDataset("myTable", KeyValueTable.class, props);
+      
       // init other components
+      
     }
   } 
-
-
-
-To create a Dataset pre-split into multiple regions, where the underlying storage is HBase,
-you can use::
-
-  createDataset("frequentCustomers", KeyValueTable.class,
-    DatasetProperties.builder()
-                     .add("hbase.splits", new Gson().toJson(new byte[][]{{1},{2},{3},{4},{5}})
-                     .build());

--- a/cdap-docs/developers-manual/source/building-blocks/datasets/table.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/datasets/table.rst
@@ -213,6 +213,47 @@ also delete the entire row, as the underlying implementation of a Table is a
 Pre-Splitting a Table into Multiple Regions
 ===========================================
 
+When the underlying storage for a Table Dataset (or any Dataset that uses a Table
+underneath, such as a ``KeyValueTable``) is HBase, CDAP allows you to 
+`configure pre-splitting <http://hbase.apache.org/book.html#manual_region_splitting_decisions>`__
+to gain a better distribution of data operations after the tables are created. This helps
+optimize for better performance, depending on your use case.
+
+To specify the splits for a Table-based Dataset, you use the ``hbase.splits`` dataset property. 
+The value must contain a JSON-formatted ``byte[][]`` of the split keys, such as::
+
+  { "hbase.splits": "[[64],[128],[192]]" }
+
+The above will create four regions; the first of which will receive all rows whose first
+byte is in the range 0…63; the second will receive the range 64…127, the third will
+receive the range 128…191 and the fourth will receive the range 192…255.
+
+You set Dataset properties when you create the Dataset, either during application
+deployment or via CDAP's HTTP RESTful APIs. The following is an example of the former; for
+an example of the latter, please refer to the 
+:ref:`Dataset section <http-restful-api-dataset-creating>` of the :ref:`RESTful API
+:Reference <restful-api>`.
+
+To configure pre-splitting for a Table created during application deployment, in your
+Application class' ``configure()`` you specify:
+
+  public class MyApp extends AbstractApplication {
+
+    @Override
+    public void configure() {
+      DatasetProperties props = 
+          DatasetProperties.builder().add("hbase.splits", "[[64],[128],[192]]").build();
+
+          DatasetProperties.builder().add("hbase.splits", new Gson().toJson(new byte[][]{{64},{128},{192}})).build();
+
+      createDataset("myTable", KeyValueTable.class, props);
+
+      // init other components
+    }
+  } 
+
+
+
 To create a Dataset pre-split into multiple regions, where the underlying storage is HBase,
 you can use::
 

--- a/cdap-docs/developers-manual/source/building-blocks/datasets/table.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/datasets/table.rst
@@ -207,3 +207,16 @@ When you want to delete all the columns of a row and you know all of them,
 passing all of them will make the deletion faster. Deleting all the columns of a row will
 also delete the entire row, as the underlying implementation of a Table is a 
 `columnar store. <http://en.wikipedia.org/wiki/Column-oriented_DBMS>`__
+
+.. _table-datasets-pre-splitting:
+
+Pre-Splitting a Table into Multiple Regions
+===========================================
+
+To create a Dataset pre-split into multiple regions, where the underlying storage is HBase,
+you can use::
+
+  createDataset("frequentCustomers", KeyValueTable.class,
+    DatasetProperties.builder()
+                     .add("hbase.splits", new Gson().toJson(new byte[][]{{1},{2},{3},{4},{5}})
+                     .build());

--- a/cdap-docs/developers-manual/source/building-blocks/datasets/table.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/datasets/table.rst
@@ -243,11 +243,7 @@ Application class' ``configure()`` you specify:
     public void configure() {
       DatasetProperties props = 
           DatasetProperties.builder().add("hbase.splits", "[[64],[128],[192]]").build();
-
-          DatasetProperties.builder().add("hbase.splits", new Gson().toJson(new byte[][]{{64},{128},{192}})).build();
-
       createDataset("myTable", KeyValueTable.class, props);
-
       // init other components
     }
   } 

--- a/cdap-docs/developers-manual/source/building-blocks/transaction-system.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/transaction-system.rst
@@ -81,6 +81,8 @@ Here are some rules to follow for Flows, Flowlets, Services, and Procedures:
 Keeping these guidelines in mind will help you write more efficient and faster-performing
 code.
 
+.. _transaction-system-conflict-detection:
+
 Levels of Conflict Detection
 ----------------------------
 

--- a/cdap-docs/reference-manual/source/http-restful-api/dataset.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/dataset.rst
@@ -37,6 +37,7 @@ The response body will contain a JSON-formatted list of the existing Datasets::
      }
    }
 
+.. _http-restful-api-dataset-creating:
 
 Creating a Dataset
 ------------------


### PR DESCRIPTION
Adds an example to the custom datasets documentation of using a DatasetSpecification to pre-split a table.

Fix for [CDAP-1112](https://issues.cask.co/browse/CDAP-1112).