### PR TITLE
[CDAP-1284] Fixed contains logic in metrics aggregation

### DIFF
--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/process/MetricRecordsWrapper.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/process/MetricRecordsWrapper.java
@@ -172,7 +172,9 @@ public class MetricRecordsWrapper implements Iterator<MetricsRecord> {
 
   private boolean contains(List<Rule> rules, Rule rule) {
     for (Rule candidate : rules) {
-      return contains(candidate, rule);
+      if (contains(candidate, rule)) {
+        return true;
+      }
     }
     return false;
   }


### PR DESCRIPTION
Corrects ``contains`` logic.

Fixes 9/25 failing audi tests. 

Build: https://builds.cask.co/browse/CDAP-RBT113-1