### PR TITLE
Revised 404 and Search documentation pages

### DIFF
--- a/cdap-docs/_common/_source/404.rst
+++ b/cdap-docs/_common/_source/404.rst
@@ -63,15 +63,14 @@ The **main page for the documentation:** :ref:`CDAP Documentation <documentation
 
 .. rubric:: Search
 
-The site has a **Quick Search**, located in the left sidebar.
+The site has a **Quick Search**, located in the left sidebar and on the 
+`Search page <search.html>`__.
 
 *Quick Search* is a local keyword search; not as comprehensive as an external search
 engine, but fast and often sufficiently accurate. Note that the Search function will
 automatically search for all of the words. Pages containing fewer words won't appear in
 the result list.
 
-You can search—using Google—the site for either **this documentation
-release** or **all documentation releases** from the `Search page <search.html>`__.
 
 .. rubric:: Contact Us
 

--- a/cdap-docs/_common/_themes/cdap/search.html
+++ b/cdap-docs/_common/_themes/cdap/search.html
@@ -38,7 +38,7 @@
   From here you can search the documentation. 
   </p>
   <p>
-  To perform a local <strong>Quick Search</strong>, enter your search word(s) into the box below and
+  To perform a <strong>Quick Search</strong>, enter your search word(s) into the box below and
   click <strong>"Search"</strong>: 
   </p>
   <form name="searchQ" action="" method="get">
@@ -51,6 +51,7 @@
   an external search engine, but fast and often sufficiently accurate. Note that the Search function will automatically search for all of the
   words. Pages containing fewer words won't appear in the result list.
   </p>
+<!-- 
   <p>
   You can search—using Google—the site for either <strong>this documentation release</strong> or <strong>all documentation releases</strong>:
   </p>
@@ -78,6 +79,7 @@
   </tr>
   </table>
   </p>
+ -->
   {% if search_performed %}
     <h2>{{ _('Search Results') }}</h2>
     {% if not search_results %}


### PR DESCRIPTION
After some more testing and discussion, it has been decided to remove Google Search from the Search page and the 404 page, as it is not ready for release. Certain terms were not finding any results, even when they should or could.

See CDAP-1039 (https://issues.cask.co/browse/CDAP-1039)

Staged at:
- [Search](http://stg-web101.sw.joyent.continuuity.net/cdap/2.7.0-SNAPSHOT-r2.7.0_404_search_pages/en/search.html)
- [404](http://stg-web101.sw.joyent.continuuity.net/cdap/2.7.0-SNAPSHOT-r2.7.0_404_search_pages/en/404.html)