### PR TITLE
Fixes broken link.

### DIFF
--- a/cdap-docs/examples-manual/source/examples/count-random.rst
+++ b/cdap-docs/examples-manual/source/examples/count-random.rst
@@ -59,7 +59,7 @@ Building and Starting
 Running CDAP Applications
 ============================================
 
-.. include:: /../../developers-manual/source/getting-started/building-apps.rst
+.. include:: /../../developers-manual/build/_includes/building-apps-versioned.rst
    :start-line: 9
 
 Running the Example

--- a/cdap-docs/examples-manual/source/examples/fileset.rst
+++ b/cdap-docs/examples-manual/source/examples/fileset.rst
@@ -89,7 +89,7 @@ Building and Starting
 Running CDAP Applications
 ============================================
 
-.. include:: /../../developers-manual/source/getting-started/building-apps.rst
+.. include:: /../../developers-manual/build/_includes/building-apps-versioned.rst
     :start-line: 9
 
 Running the Example

--- a/cdap-docs/examples-manual/source/examples/hello-world.rst
+++ b/cdap-docs/examples-manual/source/examples/hello-world.rst
@@ -80,7 +80,7 @@ Building and Starting
 Running CDAP Applications
 ============================================
 
-.. include:: /../../developers-manual/source/getting-started/building-apps.rst
+.. include:: /../../developers-manual/build/_includes/building-apps-versioned.rst
    :start-line: 9
 
 Running the Example

--- a/cdap-docs/examples-manual/source/examples/purchase.rst
+++ b/cdap-docs/examples-manual/source/examples/purchase.rst
@@ -114,7 +114,7 @@ Building and Starting
 Running CDAP Applications
 ============================================
 
-.. include:: /../../developers-manual/source/getting-started/building-apps.rst
+.. include:: /../../developers-manual/build/_includes/building-apps-versioned.rst
    :start-line: 9
 
 Running the Example

--- a/cdap-docs/examples-manual/source/examples/spark-k-means.rst
+++ b/cdap-docs/examples-manual/source/examples/spark-k-means.rst
@@ -63,7 +63,7 @@ Building and Starting
 Running CDAP Applications
 ============================================
 
-.. include:: /../../developers-manual/source/getting-started/building-apps.rst
+.. include:: /../../developers-manual/build/_includes/building-apps-versioned.rst
    :start-line: 9
 
 Running the Example

--- a/cdap-docs/examples-manual/source/examples/spark-page-rank.rst
+++ b/cdap-docs/examples-manual/source/examples/spark-page-rank.rst
@@ -62,7 +62,7 @@ Building and Starting
 Running CDAP Applications
 ============================================
 
-.. include:: /../../developers-manual/source/getting-started/building-apps.rst
+.. include:: /../../developers-manual/build/_includes/building-apps-versioned.rst
    :start-line: 9
 
 Running the Example

--- a/cdap-docs/examples-manual/source/examples/web-analytics.rst
+++ b/cdap-docs/examples-manual/source/examples/web-analytics.rst
@@ -110,7 +110,7 @@ Building and Starting
 Running CDAP Applications
 ============================================
 
-.. include:: /../../developers-manual/source/getting-started/building-apps.rst
+.. include:: /../../developers-manual/build/_includes/building-apps-versioned.rst
    :start-line: 9
 
 

--- a/cdap-docs/examples-manual/source/examples/word-count.rst
+++ b/cdap-docs/examples-manual/source/examples/word-count.rst
@@ -74,7 +74,7 @@ Building and Starting
 Running CDAP Applications
 ============================================
 
-.. include:: /../../developers-manual/source/getting-started/building-apps.rst
+.. include:: /../../developers-manual/build/_includes/building-apps-versioned.rst
    :start-line: 9
 
 Running the Example


### PR DESCRIPTION
Fixes a broken link in the source files for examples, such a file to be included wasn't included.

Bad link: http://stg-web101.sw.joyent.continuuity.net/cdap/2.7.0-SNAPSHOT/en/examples-manual/examples/hello-world.html#running-cdap-applications ("Running CDAP Examples" is empty)

Fixed link: http://stg-web101.sw.joyent.continuuity.net/cdap/2.7.0-SNAPSHOT-r2.7.0_examples_fix/en/examples-manual/examples/hello-world.html#running-cdap-applications ("Running CDAP Examples" is included and versioned: see first bullet under "Deploying an Application")