### PR TITLE
CDAP-1156 adding documentation for exploration of streams and

### DIFF
--- a/cdap-docs/developers-manual/source/advanced/index.rst
+++ b/cdap-docs/developers-manual/source/advanced/index.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 :hide-toc: true
 

--- a/cdap-docs/developers-manual/source/advanced/index.rst
+++ b/cdap-docs/developers-manual/source/advanced/index.rst
@@ -11,23 +11,17 @@ Advanced Topics
 .. toctree::
    :maxdepth: 1
    
-    Data Exploration <data-exploration>
     Best Practices <best-practices>
     Adapters <adapters>
 
 This section of the documentation includes articles that cover advanced topics on CDAP that
 will be of interest to developers who want a deeper dive into CDAP:
 
-.. |data-exploration| replace:: **Data Exploration:**
-.. _data-exploration: data-exploration.html
-
 .. |best-practices| replace:: **Best Practices:**
 .. _best-practices: best-practices.html
 
 .. |adapters| replace:: **Adapters:**
 .. _adapters: adapters.html
-
-- |data-exploration|_ Exploration of CDAP Datasets using SQL.
 
 - |best-practices|_ Suggestions when developing a CDAP application.
 

--- a/cdap-docs/developers-manual/source/data-exploration/custom-datasets.rst
+++ b/cdap-docs/developers-manual/source/data-exploration/custom-datasets.rst
@@ -2,10 +2,10 @@
     :author: Cask Data, Inc.
     :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
-.. _data-exploration:
+.. _custom-dataset-exploration:
 
 ============================================
-Data Exploration
+Custom Dataset Exploration
 ============================================
 
 

--- a/cdap-docs/developers-manual/source/data-exploration/filesets.rst
+++ b/cdap-docs/developers-manual/source/data-exploration/filesets.rst
@@ -42,13 +42,12 @@ In fact, the create table statement that will be generated for the table above i
     user string,
     item_id int,
     price double)
-  ROW FORMAT SERDE org.apache.hadoop.hive.serde2.avro.AvroSerDe
-  STORED AS INPUTFORMAT org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat
-  OUTPUTFORMAT org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat
-  LOCATION hdfs://<namenode>/cdap/mylocation
+  ROW FORMAT SERDE "org.apache.hadoop.hive.serde2.avro.AvroSerDe"
+  STORED AS INPUTFORMAT "org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat"
+  OUTPUTFORMAT "org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat"
+  LOCATION "/cdap/mylocation"
   TBLPROPERTIES (
-    cdap.name=cdap.user.myfiles,
-    avro.schema.literal="{\"type\": \"record\", \"name\": \"stringBody\", \"fields\": [{ \"name\":\"ts\", \"type\":\"long\" }, { \"name\":\"body\", \"type\":\"string\" } ] }"
+    "avro.schema.literal"="{\"type\": \"record\", \"name\": \"stringBody\", \"fields\": [{ \"name\":\"ts\", \"type\":\"long\" }, { \"name\":\"body\", \"type\":\"string\" } ] }"
   );
 
 Please see the `Hive Language Manual

--- a/cdap-docs/developers-manual/source/data-exploration/filesets.rst
+++ b/cdap-docs/developers-manual/source/data-exploration/filesets.rst
@@ -8,14 +8,22 @@
 Fileset Exploration
 ============================================
 
-The ``FileSet`` and ``TimePartitionedFileSet`` datasets can be explored through ad-hoc SQL-like queries.
+The ``FileSet`` and ``TimePartitionedFileSet`` Datasets can be explored through ad-hoc SQL-like queries.
 To enable exploration, you must set several properties when creating the Dataset, and the files in 
-your dataset must fit certain constraints. These are described in more detail in the following sections. 
+your Dataset must meet certain requirements. These properties and requirements are described below. 
 
 Explore Properties
 ------------------
-A ``FileSet`` or ``TimePartitionedFileSet`` can be made explorable by setting several properties when
-creating the dataset. For example, in the configure method of your application::
+A ``FileSet`` or ``TimePartitionedFileSet`` is made explorable by setting several properties when
+creating the dataset. The ``FileSetProperties`` class should be used to set the following required properties:
+
+- EnableExploreOnCreate must be set to true to create a Hive table when the Dataset is created
+- SerDe class that Hive should use for serialization and deserialization
+- InputFormat that Hive should use for reading files
+- OutputFormat that Hive should use for writing files 
+
+Any other table properties that the SerDe may need must also be set. 
+For example, in the configure method of your application::
 
     Schema schema = Schema.recordOf(
       "purchase",
@@ -23,7 +31,7 @@ creating the dataset. For example, in the configure method of your application::
       Schema.Field.of("item_id", Schema.of(Schema.Type.INT)),
       Schema.Field.of("price", Schema.of(Schema.Type.DOUBLE))
     );
-    createDataset("my-files", "fileSet", FileSetProperties.builder()
+    createDataset("myfiles", "fileSet", FileSetProperties.builder()
       .setBasePath("mylocation")
       .setInputFormat(AvroKeyInputFormat.class)
       .setOutputFormat(AvroKeyOutputFormat.class)
@@ -36,7 +44,7 @@ creating the dataset. For example, in the configure method of your application::
       .build());
 
 These Dataset properties map directly to table properties in Hive. 
-In fact, the create table statement that will be generated for the table above is::
+For example, Dataset above would result in the following "create table" statement being generated::
 
   CREATE EXTERNAL TABLE cdap_user_myfiles(
     user string,
@@ -52,35 +60,35 @@ In fact, the create table statement that will be generated for the table above i
 
 Please see the `Hive Language Manual
 <https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-Create/Drop/TruncateTable>`__
-for more information.
+for more information about input formats, output format, SerDes, and table properties.
 
 Limitations
 -----------
-As exploration is tied directly to Hive, file exploration has several limitations that mirror limitations in Hive.
+As exploration is tied directly to Hive, file exploration has several limitations that mirror limitations in Hive:
 
 - All explorable files must be of the same format.
 - All explorable files must be in a format known to the version of Hive you are using.
 - Some versions of Hive may try to create a temporary staging directory at the table location when executing queries.
   If you are seeing permissions errors, try setting ``hive.exec.stagingdir`` in your Hive configuration to ``/tmp/hive-staging``.
 
-A ``FileSet`` has some additional limitations that the ``TimePartitionedFileSet`` does not have.
+A ``FileSet`` has some additional limitations that the ``TimePartitionedFileSet`` does not have:
 
-- Hive tables created are not partitioned. This means any query will perform a full table scan.
+- Hive tables created by a ``FileSet`` are not partitioned; this means all queries perform a full table scan.
 - Only files at the base location of the ``FileSet`` are visible to queries. Directories are not read.
-  Since Mapreduce writes output files to a directory, if you want Mapreduce output to be explorable you
-  must move all output files to the base location. 
+  Since MapReduce writes output files to a directory, you must move all output files to the base location for
+  MapReduce output to be explorable.
 
 If you wish to use Impala to explore a ``FileSet`` or ``TimePartitionedFileSet``, there are several
-additional restrictions you must keep in mind.
+additional restrictions you must keep in mind:
 
-- Impala only supports scalar types. See `Data Types <http://www.cloudera.com/content/cloudera/en/documentation/cloudera-impala/latest/topics/impala_avro.html#avro_data_types_unique_1>`__ for more detail.
+- Impala only supports scalar types. See `Data Type Considerations for Avro Tables <http://www.cloudera.com/content/cloudera/en/documentation/cloudera-impala/latest/topics/impala_avro.html#avro_data_types_unique_1>`__ for details.
 - If your underlying data contains non-scalars, you cannot tell Impala to use a different read schema of just scalars.
   For example, if you have Avro files that contain a map field, you cannot simply leave out the field when specifying the table schema.
 - Impala caches table metadata, which clients must invalidate when there are changes. 
-  You have to issue the INVALIDATE METADATA [tablename] command, whenever table metadata changes.
-  This means you must invalidate metadata if a new table is added or a table partition is added.
-  Impala caches the table metadata otherwise, preventing you from seeing changes.
-  If data is added to the table without changing metadata (adding a partition), then you have to issue 
-  a REFRESH [tablename] command to get Impala to see the changes. 
-  It caches info on the table files and blocks as well, but the REFRESH command will cause it to re-read these.
+  You have to issue an ``INVALIDATE METADATA [tablename]`` command whenever table metadata changes.
+  You'll need to invalidate metadata if a new table or table partition is added. Otherwise, Impala will use the
+  cached table metadata, preventing you from seeing the changes. If data is added to a table without changing the
+  metadata (such as when adding a partition), then you need to issue a ``REFRESH [tablename]`` command to force
+  Impala to see the changes. Though Impala also caches info on table files and blocks, any calls to the
+  ``REFRESH`` command will cause it to re-read the information.
 

--- a/cdap-docs/developers-manual/source/data-exploration/filesets.rst
+++ b/cdap-docs/developers-manual/source/data-exploration/filesets.rst
@@ -44,7 +44,7 @@ For example, in the configure method of your application::
       .build());
 
 These Dataset properties map directly to table properties in Hive. 
-For example, Dataset above would result in the following "create table" statement being generated::
+For example, the Dataset above would result in the following "create table" statement being generated::
 
   CREATE EXTERNAL TABLE cdap_user_myfiles(
     user string,

--- a/cdap-docs/developers-manual/source/data-exploration/filesets.rst
+++ b/cdap-docs/developers-manual/source/data-exploration/filesets.rst
@@ -1,0 +1,87 @@
+.. meta::
+    :author: Cask Data, Inc.
+    :copyright: Copyright © 2015 Cask Data, Inc.
+
+.. _fileset-exploration:
+
+============================================
+Fileset Exploration
+============================================
+
+The ``FileSet`` and ``TimePartitionedFileSet`` datasets can be explored through ad-hoc SQL-like queries.
+To enable exploration, you must set several properties when creating the Dataset, and the files in 
+your dataset must fit certain constraints. These are described in more detail in the following sections. 
+
+Explore Properties
+------------------
+A ``FileSet`` or ``TimePartitionedFileSet`` can be made explorable by setting several properties when
+creating the dataset. For example, in the configure method of your application::
+
+    Schema schema = Schema.recordOf(
+      "purchase",
+      Schema.Field.of("user", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("item_id", Schema.of(Schema.Type.INT)),
+      Schema.Field.of("price", Schema.of(Schema.Type.DOUBLE))
+    );
+    createDataset("my-files", "fileSet", FileSetProperties.builder()
+      .setBasePath("mylocation")
+      .setInputFormat(AvroKeyInputFormat.class)
+      .setOutputFormat(AvroKeyOutputFormat.class)
+      // everything past here is an explore property
+      .setEnableExploreOnCreate(true)
+      .setSerDe("org.apache.hadoop.hive.serde2.avro.AvroSerDe")
+      .setExploreInputFormat("org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat")
+      .setExploreOutputFormat("org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat")
+      .setTableProperty("avro.schema.literal", schema.toString())
+      .build());
+
+These Dataset properties map directly to table properties in Hive. 
+In fact, the create table statement that will be generated for the table above is::
+
+  CREATE EXTERNAL TABLE cdap_user_myfiles(
+    user string,
+    item_id int,
+    price double)
+  ROW FORMAT SERDE org.apache.hadoop.hive.serde2.avro.AvroSerDe
+  STORED AS INPUTFORMAT org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat
+  OUTPUTFORMAT org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat
+  LOCATION hdfs://<namenode>/cdap/mylocation
+  TBLPROPERTIES (
+    cdap.name=cdap.user.myfiles,
+    avro.schema.literal="{\"type\": \"record\", \"name\": \"stringBody\", \"fields\": [{ \"name\":\"ts\", \"type\":\"long\" }, { \"name\":\"body\", \"type\":\"string\" } ] }"
+  );
+
+Please see the `Hive Language Manual
+<https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-Create/Drop/TruncateTable>`__
+for more information.
+
+Limitations
+-----------
+As exploration is tied directly to Hive, file exploration has several limitations that mirror limitations in Hive.
+
+- All explorable files must be of the same format.
+- All explorable files must be in a format known to the version of Hive you are using.
+- Some versions of Hive may try to create a temporary staging directory at the table location when executing queries.
+  If you are seeing permissions errors, try setting ``hive.exec.stagingdir`` in your Hive configuration to ``/tmp/hive-staging``.
+
+A ``FileSet`` has some additional limitations that the ``TimePartitionedFileSet`` does not have.
+
+- Hive tables created are not partitioned. This means any query will perform a full table scan.
+- Only files at the base location of the ``FileSet`` are visible to queries. Directories are not read.
+  Since Mapreduce writes output files to a directory, if you want Mapreduce output to be explorable you
+  must move all output files to the base location. 
+
+If you wish to use Impala to explore a ``FileSet`` or ``TimePartitionedFileSet``, there are several
+additional restrictions you must keep in mind.
+
+- Impala only supports scalar types. See `Data Types <http://www.cloudera.com/content/cloudera/en/documentation/cloudera-impala/latest/topics/impala_avro.html#avro_data_types_unique_1>`__ for more detail.
+- If your underlying data contains non-scalars, you cannot tell Impala to use a different read schema of just scalars.
+  For example, if you have Avro files that contain a map field, you cannot simply leave out the field when specifying the table schema.
+- Impala caches table metadata, which clients must invalidate when there are changes. 
+  You have to issue the INVALIDATE METADATA [tablename] command, whenever table metadata changes.
+  This means you must invalidate metadata if a new table is added or a table partition is added.
+  Impala caches the table metadata otherwise, preventing you from seeing changes.
+  If data is added to the table without changing metadata (adding a partition), then you have to issue 
+  a REFRESH [tablename] command to get Impala to see the changes. 
+  It caches info on the table files and blocks as well, but the REFRESH command will cause it to re-read these.
+

--- a/cdap-docs/developers-manual/source/data-exploration/index.rst
+++ b/cdap-docs/developers-manual/source/data-exploration/index.rst
@@ -1,0 +1,42 @@
+.. meta::
+    :author: Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
+
+:hide-toc: true
+
+.. _data-exploration:
+
+============================================
+Data Exploration
+============================================
+
+.. toctree::
+   :maxdepth: 1
+   
+    Streams <streams>
+    Filesets <filesets>
+    Custom Datasets <custom-datasets>
+    Integration with external systems <integration>
+
+This section covers how you can explore data in CDAP through the use of ad-hoc SQL-style queries.
+Queries can be run over Streams and certain types of Datasets, with a jdbc driver
+provided for integration with external systems like various Business Intelligence (BI) tools.
+
+.. rubric:: Exploring Streams
+
+All streams can be explored, with support for attaching a read format and schema to enable
+more powerful queries. :ref:`stream-exploration` describes how you can attach schema to a stream.
+
+.. rubric:: Exploring FileSet Datasets
+
+:ref:`fileset-exploration` describes how you can make a ``FileSet`` or ``TimePartitionedFileSet`` explorable.
+
+.. rubric:: Exploring Custom Datasets
+
+:ref:`custom-dataset-exploration` describes how you can make your custom dataset explorable.
+
+.. rubric:: Integration with External Systems
+
+Through the use of a jdbc driver, CDAP can be integrated with a wide range of external systems. :ref:`exploration-integration`
+describes how to use the jdbc driver programmatically, as well as examples of integrating CDAP with a couple
+business intelligence tools.

--- a/cdap-docs/developers-manual/source/data-exploration/index.rst
+++ b/cdap-docs/developers-manual/source/data-exploration/index.rst
@@ -16,16 +16,16 @@ Data Exploration
     Streams <streams>
     Filesets <filesets>
     Custom Datasets <custom-datasets>
-    Integration with external systems <integration>
+    Integration with External Systems <integration>
 
-This section covers how you can explore data in CDAP through the use of ad-hoc SQL-style queries.
-Queries can be run over Streams and certain types of Datasets, with a jdbc driver
-provided for integration with external systems like various Business Intelligence (BI) tools.
+This section covers how you can explore data in CDAP through the use of ad-hoc SQL-like queries.
+Queries can be run over Streams and certain types of Datasets, with a JDBC driver
+providing integration with external systems such as Business Intelligence (BI) tools.
 
 .. rubric:: Exploring Streams
 
-All streams can be explored, with support for attaching a read format and schema to enable
-more powerful queries. :ref:`stream-exploration` describes how you can attach schema to a stream.
+All streams can be explored, with support for attaching read formats and schemas, enabling powerful queries.
+:ref:`stream-exploration` describes how you can attach a schema to a Stream.
 
 .. rubric:: Exploring FileSet Datasets
 
@@ -33,10 +33,10 @@ more powerful queries. :ref:`stream-exploration` describes how you can attach sc
 
 .. rubric:: Exploring Custom Datasets
 
-:ref:`custom-dataset-exploration` describes how you can make your custom dataset explorable.
+:ref:`custom-dataset-exploration` describes how you can make a custom dataset that is explorable.
 
 .. rubric:: Integration with External Systems
 
-Through the use of a jdbc driver, CDAP can be integrated with a wide range of external systems. :ref:`exploration-integration`
-describes how to use the jdbc driver programmatically, as well as examples of integrating CDAP with a couple
+Through the use of a JDBC driver, CDAP can be integrated with a wide range of external systems. :ref:`exploration-integration`
+describes how to use the JDBC driver programmatically, with two examples of integrating CDAP with
 business intelligence tools.

--- a/cdap-docs/developers-manual/source/data-exploration/integration.rst
+++ b/cdap-docs/developers-manual/source/data-exploration/integration.rst
@@ -1,0 +1,166 @@
+.. meta::
+    :author: Cask Data, Inc.
+    :copyright: Copyright © 2015 Cask Data, Inc.
+
+.. _exploration-integration:
+
+Integrating with External Systems
+-------------------------------------
+CDAP provides a JDBC driver to make integrations with external programs and third-party BI (business intelligence)
+tools easier.
+
+The JDBC driver is a JAR that is bundled with the CDAP SDK. You can find it in the ``lib``
+directory of your SDK installation at::
+
+  lib/co.cask.cdap.cdap-explore-jdbc-<version>.jar
+
+If you don't have a CDAP SDK and only want to connect to an existing instance of CDAP, 
+you can download the CDAP JDBC driver from `this link 
+<https://repository.continuuity.com/content/groups/public/co/cask/cdap/cdap-explore/>`__.
+Go to the directory matching the version of your running CDAP instance, and download the file 
+with the matching version number::
+
+  cdap-explore-jdbc-<version>.jar
+
+Using the CDAP JDBC driver in your Java code
+............................................
+
+To use CDAP JDBC driver in your code, place ``cdap-jdbc-driver.jar`` in the classpath of your application.
+If you are using Maven, you can simply add a dependency in your file ``pom.xml``::
+
+  <dependencies>
+    ...
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-explore-jdbc</artifactId>
+      <version><!-- Version of CDAP you want the JDBC driver to query --></version>
+    </dependency>
+    ...
+  </dependencies>
+
+Here is a snippet of Java code that uses the CDAP JDBC driver to connect to a running instance of CDAP,
+and executes a query::
+
+  // First, register the driver once in your application
+  Class.forName("co.cask.cdap.explore.jdbc.ExploreDriver");
+
+  // If your CDAP instance requires a authentication token for connection,
+  // you have to specify it here.
+  // Replace <cdap-host> and <authentication_token> as appropriate to your installation.
+  String connectionUrl = "jdbc:cdap://<cdap-host>:10000" +
+    "?auth.token=<authentication_token>";
+
+  // Connect to CDAP instance
+  Connection connection = DriverManager.getConnection(connectionUrl);
+
+  // Execute a query over CDAP Datasets and retrieve the results
+  ResultSet resultSet = connection.prepareStatement("select * from cdap_user_mydataset").executeQuery();
+  ...
+
+JDBC drivers are a standard in the Java ecosystem, with many `resources about them available
+<http://docs.oracle.com/javase/tutorial/jdbc/>`__.
+
+Accessing CDAP Datasets through Business Intelligence Tools
+-----------------------------------------------------------
+
+Most Business Intelligence tools can integrate with relational databases using JDBC drivers. They often include
+drivers to connect to standard databases such as MySQL or PostgreSQL.
+Most tools allow the addition of non-standard JDBC drivers.
+
+We'll look at two business intelligence tools — *SquirrelSQL* and *Pentaho Data Integration* —
+and see how to connect them to a running CDAP instance and interact with CDAP Datasets.
+
+SquirrelSQL
+...........
+
+*SquirrelSQL* is a simple JDBC client which executes SQL queries against many different relational databases.
+Here's how to add the CDAP JDBC driver inside *SquirrelSQL*.
+
+#. Open the ``Drivers`` pane, located on the far left corner of *SquirrelSQL*.
+#. Click the ``+`` icon of the ``Drivers`` pane.
+
+   .. image:: ../_images/jdbc/squirrel_drivers.png
+      :width: 4in
+
+#. Add a new Driver by entering a ``Name``, such as ``CDAP Driver``. The ``Example URL`` is of the form
+   ``jdbc:cdap://<host>:10000?auth.token=<token>``. The ``Website URL`` can be left blank. In the ``Class Name``
+   field, enter ``co.cask.cdap.explore.jdbc.ExploreDriver``.
+   Click on the ``Extra Class Path`` tab, then on ``Add``, and put the path to ``co.cask.cdap.cdap-explore-jdbc-<version>.jar``.
+
+   .. image:: ../_images/jdbc/squirrel_add_driver.png
+      :width: 6in
+
+#. Click on ``OK``. You should now see ``Cask CDAP Driver`` in the list of drivers from the ``Drivers`` pane of
+   *SquirrelSQL*.
+#. We can now create an alias to connect to a running instance of CDAP. Open the ``Aliases`` pane, and click on
+   the ``+`` icon to create a new alias.
+#. In this example, we are going to connect to a standalone CDAP from the SDK.
+   The name of our alias will be ``CDAP Standalone``. Select the ``CDAP Driver`` in
+   the list of available drivers. Our URL will be ``jdbc:cdap://localhost:10000``. Our standalone instance
+   does not require an authentication token, but if yours requires one, HTML-encode your token
+   and pass it as a parameter of the ``URL``. ``User Name`` and ``Password`` are left blank.
+
+   .. image:: ../_images/jdbc/squirrel_add_alias.png
+      :width: 6in
+
+#. Click on ``OK``. ``CDAP Standalone`` is now added to the list of aliases.
+#. A popup asks you to connect to your newly-added alias. Click on ``Connect``, and *SquirrelSQL* will retrieve
+   information about your running CDAP Datasets.
+#. To execute a SQL query on your CDAP Datasets, go to the ``SQL`` tab, enter a query in the center field, and click
+   on the "running man" icon on top of the tab. Your results will show in the bottom half of the *SquirrelSQL* main view.
+
+   .. image:: ../_images/jdbc/squirrel_sql_query.png
+      :width: 6in
+
+Pentaho Data Integration
+........................
+
+*Pentaho Data Integration* is an advanced, open source business intelligence tool that can execute
+transformations of data coming from various sources. Let's see how to connect it to
+CDAP Datasets using the CDAP JDBC driver.
+
+#. Before opening the *Pentaho Data Integration* application, copy the ``co.cask.cdap.cdap-explore-jdbc-<version>.jar``
+   file to the ``lib`` directory of *Pentaho Data Integration*, located at the root of the application's directory.
+#. Open *Pentaho Data Integration*.
+#. In the toolbar, select ``File -> New -> Database Connection...``.
+#. In the ``General`` section, select a ``Connection Name``, like ``CDAP Standalone``. For the ``Connection Type``, select
+   ``Generic database``. Select ``Native (JDBC)`` for the ``Access`` field. In this example, where we connect to
+   a standalone instance of CDAP, our ``Custom Connection URL`` will then be ``jdbc:cdap://localhost:10000``.
+   In the field ``Custom Driver Class Name``, enter ``co.cask.cdap.explore.jdbc.ExploreDriver``.
+
+   .. image:: ../_images/jdbc/pentaho_add_connection.png
+      :width: 6in
+
+#. Click on ``OK``.
+#. To use this connection, navigate to the ``Design`` tab on the left of the main view. In the ``Input`` menu,
+   double click on ``Table input``. It will create a new transformation containing this input.
+
+   .. image:: ../_images/jdbc/pentaho_table_input.png
+      :width: 6in
+
+#. Right-click on ``Table input`` in your transformation and select ``Edit step``. You can specify an appropriate name
+   for this input such as ``CDAP Datasets query``. Under ``Connection``, select the newly created database connection;
+   in this example, ``CDAP Standalone``. Enter a valid SQL query in the main ``SQL`` field. This will define the data
+   available to your transformation.
+
+   .. image:: ../_images/jdbc/pentaho_modify_input.png
+      :width: 6in
+
+#. Click on ``OK``. Your input is now ready to be used in your transformation, and it will contain data coming
+   from the results of the SQL query on the CDAP Datasets.
+#. For more information on how to add components to a transformation and link them together, see the
+   `Pentaho Data Integration page <http://community.pentaho.com/projects/data-integration/>`__.
+
+
+Formulating Queries
+-------------------
+When creating your queries, keep these limitations in mind:
+
+- The query syntax of CDAP is a subset of the variant of SQL that was first defined by Apache Hive.
+- The SQL commands ``UPDATE`` and ``DELETE`` are not allowed on CDAP Datasets.
+- When addressing your datasets in queries, you need to prefix the data set name with the CDAP
+  namespace ``cdap_user_``. For example, if your Dataset is named ``ProductCatalog``, then the corresponding table
+  name is ``cdap_user_productcatalog``. Note that the table name is lower-case.
+
+For more examples of queries, please refer to the `Hive language manual
+<https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DML#LanguageManualDML-InsertingdataintoHiveTablesfromqueries>`__.

--- a/cdap-docs/developers-manual/source/data-exploration/integration.rst
+++ b/cdap-docs/developers-manual/source/data-exploration/integration.rst
@@ -39,7 +39,7 @@ If you are using Maven, you can simply add a dependency in your file ``pom.xml``
   </dependencies>
 
 Here is a snippet of Java code that uses the CDAP JDBC driver to connect to a running instance of CDAP,
-and executes a query::
+and executes a query over a CDAP dataset ``mydataset``::
 
   // First, register the driver once in your application
   Class.forName("co.cask.cdap.explore.jdbc.ExploreDriver");

--- a/cdap-docs/developers-manual/source/data-exploration/streams.rst
+++ b/cdap-docs/developers-manual/source/data-exploration/streams.rst
@@ -1,0 +1,214 @@
+.. meta::
+    :author: Cask Data, Inc.
+    :copyright: Copyright © 2015 Cask Data, Inc.
+
+.. _stream-exploration:
+
+============================================
+Stream Exploration
+============================================
+
+Streams are the primary method of ingesting real-time data into CDAP.
+It is often useful to be able to examine data in a Stream in an ad-hoc manner through
+SQL-like queries 
+
+Each event in a Stream contains a timestamp, a map of headers, and a body. When a Stream
+is created, a corresponding Hive table is created that allows queries to be run over
+those three columns. Many times, stream event bodies are also structued and have
+a format and schema of their own. For example, event bodies may be comma delimited
+text or Avro encoded binary data. In these cases it is possible to set a format and schema
+on a Stream, enabling more powerful queries.
+
+Let's take a closer look at attaching format and schema on streams.
+
+Stream Format
+-------------
+
+A format defines how the bytes in an event body can be read as some higher level object.
+For example, the CSV (comma separated values) format can read each value in comma delimited text 
+as a separate column of some given type. Each format has 
+a schema that describes the structure of data the format can read. Some formats, like the avro format,
+require a schema to be explicitly given. Other formats, like the CSV format, have a default schema. 
+
+Format is a configuration setting that can be set on a stream. This can be done through the
+RESTful API, or by using the CLI::
+
+  set stream format <stream-id> <format-name> [<schema>] [<settings>]
+  set stream format mystream csv "f1 int, f2 string"
+
+As mentioned above, a format may support different schemas, which will be discussed in more detail
+in the next section.
+
+It is important to note that formats are applied at read time.
+When events are added to a stream, there are no checks performed to enforce that
+all events added to the stream are readable by the format you have set on a stream.
+If any stream event cannot be read by the format you have set, your query will not work.
+
+Schema
+------
+CDAP schemas are adopted from Avro schemas `<http://avro.apache.org/docs/1.7.3/spec.html#schemas>`__
+with a few differences:
+ 
+  * Map keys do not have to be strings, but can be any type.
+  * No "name" property for enum type. 
+  * No support of "doc" and "aliases" in record and enum types.
+  * No support of "doc" and "default" in record field.
+  * No "fixed" type.
+
+There are a few additional limitations on the types of schemas that can be used for exploration: 
+ 
+  * Schemas must be a record of at least one field.
+  * Enums are not supported.
+  * Unions are not supported, unless it is a union of a null and another type, representing a nullable type.
+  * Recursive types are not supported. This means you cannot have a record field that references itself in one of its fields.
+
+Data exploration using Impala has additional limitations:
+
+  * Fields must be a scalar type (no maps, arrays, or records)
+
+On top of these general limitations, each format has its own restrictions on the types
+of schemas they support. For example, the CSV format does not support maps or records as
+data types. Please see the javadocs for each format for more information about the types
+of schemas they support. 
+
+Schema Syntax
+-------------
+Schemas are represented as JSON Objects, following the same format as Avro schemas
+`<http://avro.apache.org/docs/1.7.3/spec.html#schemas>`__. 
+The JSON representation is used by the RESTful APIs.
+The CLI also supports a SQL-like syntax. 
+
+For example, the SQL-like schema::
+
+  f1 int, f2 string, f3 array<int> not null, f4 map<string, int> not null, f5 record<x:int, y:double> not null
+
+is equivalent to the Avro-like JSON schema::
+
+  {
+    "type": "record",
+    "name": "rec",
+    "fields": [
+      { 
+        "name": "f1",
+        "type": [ "int", "null" ]
+      },
+      { 
+        "name": "f2",
+        "type": [ "string", "null" ]
+      },
+      { 
+        "name": "f3",
+        "type": { "type": "array", "items": [ "int", "null" ] } 
+      },
+      { 
+        "name": "f4", 
+        "type": { 
+          "type": "map", "keys": [ "string", "null" ], "values": [ "int", "null" ] 
+        }
+      },
+      { 
+        "name": "f5",
+        "type": {
+          "type": "record",
+          "name": "rec1",
+          "fields": [
+            { "name": "x", "type": [ "int", "null" ] },
+            { "name": "y", "type": [ "double", "null" ] }
+          ]
+        }
+      }
+    ]
+  }
+
+Text Format
+-----------
+The ``text`` format simply interprets each event body as a string. The format supports a very limited
+schema, namely a record with just one field of type ``string``. The format supports a ``charset`` setting
+that allows you to specify the charset of the text. It defaults to ``utf-8``.
+
+For example::
+
+  set stream format mystream text "data string not null" "charset=ISO-8859-1"
+
+CSV and TSV Formats
+-------------------
+The ``csv`` and ``tsv`` formats read event bodies as delimited text.
+They have two settings, ``charset`` for the text charset, and ``delimiter`` for the delimiter.
+The ``charset`` setting defaults to ``utf-8``. The ``delimiter`` setting defaults to a comma
+for the ``csv`` format and to a tab for the ``tsv`` format.
+
+These formats only support scalars as column types, except for the very last column, which can be an array of strings.
+All types can be nullable. If no schema is given, the default schema is an array of strings. 
+
+For example::
+ 
+  set stream format mystream csv "col1 string, col2 int not null, col3 array<string>"
+
+Avro Format
+-----------
+The ``avro`` format reads event bodies as binary encoded Avro. The format requires a schema to be given,
+and has no settings.
+
+For example::
+
+  set stream format mystream avro "col1 string, col2 map<string,int> not null, col3 record<x:double, y:float>"
+
+End-to-end Example
+------------------
+
+In the following example, we will create a Stream, send data to it, attach a format
+and schema to the stream, then query the Stream.
+
+Suppose we want to create a Stream for stock trades. We first create the stream
+and send some data to it as comma separated text::
+
+  > create stream trades
+  > send stream trades "AAPL,50,112.98"
+  > send stream trades "AAPL,100,112.87"
+  > send stream trades "AAPL,8,113.02"
+  > send stream trades "NFLX,10,437.45"
+
+If we run a query over the Stream, we can see each event as text::
+
+  > execute "select * from cdap_stream_trades"
+  +==================================================================================================================+
+  | cdap_stream_trades.ts: BIGINT | cdap_stream_trades.headers: map<string,string> | cdap_stream_trades.body: STRING |
+  +==================================================================================================================+
+  | 1422493022983                 | {}                                             | AAPL,50,112.98                  |
+  | 1422493027358                 | {}                                             | AAPL,100,112.87                 |
+  | 1422493031802                 | {}                                             | AAPL,8,113.02                   |
+  | 1422493036080                 | {}                                             | NFLX,10,437.45                  |
+  +==================================================================================================================+
+
+Since we know the body of every event is comma separated text and that each event
+contains three fields, we can set a format and schema on the stream to allow us to run more
+complicated queries::
+
+  > set stream format trades csv "ticker string, num_traded int, price double"
+  > execute "select ticker, count(*) as transactions, sum(num_traded) as volume from cdap_stream_trades group by ticker order by volume desc" 
+  +========================================================+
+  | ticker: STRING | transactions: BIGINT | volume: BIGINT |
+  +========================================================+
+  | AAPL           | 3                    | 158            |
+  | NFLX           | 1                    | 10             |
+  +========================================================+
+
+Formulating Queries
+-------------------
+When creating your queries, keep these limitations in mind:
+
+- The query syntax of CDAP is a subset of the variant of SQL that was first defined by Apache Hive.
+- Writing into a Stream using SQL is not allowed.
+- The SQL command ``DELETE`` is not allowed.
+- When addressing your streams in queries, you need to prefix the stream name with the CDAP
+  namespace ``cdap_stream_``. For example, if your Stream is named ``Purchases``, then the corresponding table
+  name is ``cdap_user_purchases``. Note that the table name is lower-case.
+- CDAP uses a custom storage handler to read Streams through Hive. This means that queries must be run through
+  CDAP and not directly through Hive unless you place CDAP jars in your Hive classpath. This also means that
+  Streams cannot be queried directly by Impala. If you wish to use Impala to explore data in a Stream, you can
+  create an Adapter that converts Stream data into a ``TimePartitionedFileSet``, as described at :ref:`advanced-adapters`. 
+- Some versions of Hive may try to create a temporary staging directory at the table location when executing queries.
+  If you are seeing permissions errors, try setting ``hive.exec.stagingdir`` in your Hive configuration to ``/tmp/hive-staging``.
+
+For more examples of queries, please refer to the `Hive language manual
+<https://cwiki.apache.org/confluence/display/Hive/LanguageManual>`__.

--- a/cdap-docs/developers-manual/source/data-exploration/streams.rst
+++ b/cdap-docs/developers-manual/source/data-exploration/streams.rst
@@ -14,24 +14,24 @@ SQL-like queries
 
 Each event in a Stream contains a timestamp, a map of headers, and a body. When a Stream
 is created, a corresponding Hive table is created that allows queries to be run over
-those three columns. Many times, stream event bodies are also structued and have
-a format and schema of their own. For example, event bodies may be comma delimited
-text or Avro encoded binary data. In these cases it is possible to set a format and schema
+those three columns. Many times, stream event bodies are also structured and have
+a format and schema of their own. For example, event bodies may be comma-delimited
+text or Avro-encoded binary data. In those cases, it is possible to set a format and schema
 on a Stream, enabling more powerful queries.
 
-Let's take a closer look at attaching format and schema on streams.
+Let's take a closer look at attaching format and schema on Streams.
 
 Stream Format
 -------------
 
-A format defines how the bytes in an event body can be read as some higher level object.
-For example, the CSV (comma separated values) format can read each value in comma delimited text 
+A format defines how the bytes in an event body can be read as a higher level object.
+For example, the CSV (comma separated values) format can read each value in comma-delimited text 
 as a separate column of some given type. Each format has 
-a schema that describes the structure of data the format can read. Some formats, like the avro format,
-require a schema to be explicitly given. Other formats, like the CSV format, have a default schema. 
+a schema that describes the structure of data the format can read. Some formats, such as the Avro format,
+require a schema to be explicitly given. Other formats, such as the CSV format, have a default schema. 
 
-Format is a configuration setting that can be set on a stream. This can be done through the
-RESTful API, or by using the CLI::
+Format is a configuration setting that can be set on a stream. This can be done either through the
+HTTP RESTful API or by using the CDAP Command Line Interface (CLI)::
 
   set stream format <stream-id> <format-name> [<schema>] [<settings>]
   set stream format mystream csv "f1 int, f2 string"
@@ -42,17 +42,18 @@ in the next section.
 It is important to note that formats are applied at read time.
 When events are added to a stream, there are no checks performed to enforce that
 all events added to the stream are readable by the format you have set on a stream.
-If any stream event cannot be read by the format you have set, your query will not work.
+If any stream event cannot be read by the format you have set, your entire query will fail and you
+will not get any results.
 
 Schema
 ------
-CDAP schemas are adopted from Avro schemas `<http://avro.apache.org/docs/1.7.3/spec.html#schemas>`__
+CDAP schemas are adopted from the `Avro Schema Declaration `<http://avro.apache.org/docs/1.7.3/spec.html#schemas>`__
 with a few differences:
  
-  * Map keys do not have to be strings, but can be any type.
-  * No "name" property for enum type. 
+  * Map keys do not have to be strings, but can be of any type.
+  * No "name" property for the enum type. 
   * No support of "doc" and "aliases" in record and enum types.
-  * No support of "doc" and "default" in record field.
+  * No support of "doc" and "default" in record fields.
   * No "fixed" type.
 
 There are a few additional limitations on the types of schemas that can be used for exploration: 
@@ -64,19 +65,17 @@ There are a few additional limitations on the types of schemas that can be used 
 
 Data exploration using Impala has additional limitations:
 
-  * Fields must be a scalar type (no maps, arrays, or records)
+  * Fields must be a scalar type (no maps, arrays, or records).
 
 On top of these general limitations, each format has its own restrictions on the types
 of schemas they support. For example, the CSV format does not support maps or records as
-data types. Please see the javadocs for each format for more information about the types
-of schemas they support. 
+data types.
 
 Schema Syntax
 -------------
-Schemas are represented as JSON Objects, following the same format as Avro schemas
-`<http://avro.apache.org/docs/1.7.3/spec.html#schemas>`__. 
-The JSON representation is used by the RESTful APIs.
-The CLI also supports a SQL-like syntax. 
+Schemas are represented as JSON Objects, following the same format as `Avro schemas
+<http://avro.apache.org/docs/1.7.3/spec.html#schemas>`__. 
+The JSON representation is used by the HTTP RESTful APIs, while the CDAP CLI supports a SQL-like syntax.
 
 For example, the SQL-like schema::
 
@@ -132,7 +131,7 @@ For example::
 
 CSV and TSV Formats
 -------------------
-The ``csv`` and ``tsv`` formats read event bodies as delimited text.
+The ``csv`` (comma separated values) and ``tsv`` (tab separated values) formats read event bodies as delimited text.
 They have two settings, ``charset`` for the text charset, and ``delimiter`` for the delimiter.
 The ``charset`` setting defaults to ``utf-8``. The ``delimiter`` setting defaults to a comma
 for the ``csv`` format and to a tab for the ``tsv`` format.
@@ -157,10 +156,10 @@ End-to-end Example
 ------------------
 
 In the following example, we will create a Stream, send data to it, attach a format
-and schema to the stream, then query the Stream.
+and schema to the Stream, then query the Stream.
 
 Suppose we want to create a Stream for stock trades. We first create the stream
-and send some data to it as comma separated text::
+and send some data to it as comma-delimited text::
 
   > create stream trades
   > send stream trades "AAPL,50,112.98"
@@ -198,17 +197,17 @@ Formulating Queries
 When creating your queries, keep these limitations in mind:
 
 - The query syntax of CDAP is a subset of the variant of SQL that was first defined by Apache Hive.
-- Writing into a Stream using SQL is not allowed.
-- The SQL command ``DELETE`` is not allowed.
+- Writing into a Stream using SQL is not supported.
+- The SQL command ``DELETE`` is not supported.
 - When addressing your streams in queries, you need to prefix the stream name with the CDAP
   namespace ``cdap_stream_``. For example, if your Stream is named ``Purchases``, then the corresponding table
-  name is ``cdap_user_purchases``. Note that the table name is lower-case.
+  name is ``cdap_stream_purchases``. Note that the table name is all lower-case, regardless of how it was defined.
 - CDAP uses a custom storage handler to read Streams through Hive. This means that queries must be run through
   CDAP and not directly through Hive unless you place CDAP jars in your Hive classpath. This also means that
   Streams cannot be queried directly by Impala. If you wish to use Impala to explore data in a Stream, you can
-  create an Adapter that converts Stream data into a ``TimePartitionedFileSet``, as described at :ref:`advanced-adapters`. 
+  create an Adapter that converts Stream data into a ``TimePartitionedFileSet``, as described in :ref:`advanced-adapters`. 
 - Some versions of Hive may try to create a temporary staging directory at the table location when executing queries.
-  If you are seeing permissions errors, try setting ``hive.exec.stagingdir`` in your Hive configuration to ``/tmp/hive-staging``.
+  If you are seeing permission errors, try setting ``hive.exec.stagingdir`` in your Hive configuration to ``/tmp/hive-staging``.
 
 For more examples of queries, please refer to the `Hive language manual
 <https://cwiki.apache.org/confluence/display/Hive/LanguageManual>`__.

--- a/cdap-docs/developers-manual/source/index.rst
+++ b/cdap-docs/developers-manual/source/index.rst
@@ -57,12 +57,19 @@ CDAP Developers’ Manual
   a daemon to tail local files and an Apache Flume Sink implementation.
 
 
+.. |data-exploration| replace:: **Data Exploration:**
+.. _data-exploration: data-exploration/index.html
+
+- |data-exploration|_ Data in CDAP can be explored without writing any code through the use of ad-hoc SQL-like queries.
+  Exploration of Streams and Datasets, along with integration with business intelligence tools, are covered in this section.
+
+
 .. |advanced| replace:: **Advanced Topics:**
 .. _advanced: advanced/index.html
 
 - |advanced|_ Covers **advanced topics on CDAP** that will be of interest to
-  developers who want a deeper dive into CDAP, with presentations on the **Data Exploration
-  of Datasets**, **Best Practices for CDAP development**, and **Adapters**.
+  developers who want a deeper dive into CDAP, with presentations on 
+  **Best Practices for CDAP development**, and **Adapters**.
   
 
 .. |(TM)| unicode:: U+2122 .. trademark sign

--- a/cdap-docs/developers-manual/source/index.rst
+++ b/cdap-docs/developers-manual/source/index.rst
@@ -1,7 +1,7 @@
 .. meta::
     :author: Cask Data, Inc.
     :description: Introduction to the Cask Data Application Platform
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 .. _developer-index:
 
@@ -60,7 +60,7 @@ CDAP Developers’ Manual
 .. |data-exploration| replace:: **Data Exploration:**
 .. _data-exploration: data-exploration/index.html
 
-- |data-exploration|_ Data in CDAP can be explored without writing any code through the use of ad-hoc SQL-like queries.
+- |data-exploration|_ Data in CDAP can be *explored without writing any code* through the use of *ad-hoc SQL-like queries*.
   Exploration of Streams and Datasets, along with integration with business intelligence tools, are covered in this section.
 
 
@@ -69,7 +69,7 @@ CDAP Developers’ Manual
 
 - |advanced|_ Covers **advanced topics on CDAP** that will be of interest to
   developers who want a deeper dive into CDAP, with presentations on 
-  **Best Practices for CDAP development**, and **Adapters**.
+  **Best Practices for CDAP development** and **Adapters**.
   
 
 .. |(TM)| unicode:: U+2122 .. trademark sign

--- a/cdap-docs/developers-manual/source/table-of-contents.rst
+++ b/cdap-docs/developers-manual/source/table-of-contents.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 ============================================
 CDAP Developers’ Manual Table of Contents

--- a/cdap-docs/developers-manual/source/table-of-contents.rst
+++ b/cdap-docs/developers-manual/source/table-of-contents.rst
@@ -16,4 +16,5 @@ CDAP Developers’ Manual Table of Contents
     Security <security/index>
     Testing and Debugging <testing/index>
     Ingesting Data <ingesting-tools/index>
+    Data Exploration <data-exploration/index>
     Advanced Topics <advanced/index>

--- a/cdap-docs/reference-manual/source/http-restful-api/stream.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/stream.rst
@@ -1,7 +1,7 @@
 .. meta::
     :author: Cask Data, Inc.
     :description: HTTP RESTful Interface to the Cask Data Application Platform
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 .. _http-restful-api-stream:
 
@@ -296,13 +296,13 @@ Example
 
 Setting Stream Properties
 -------------------------
-There are a few Stream properties that can be changed.
+There are a number of Stream properties that can be specified.
 The Time-To-Live (TTL) property governs how long an event is valid for consumption since 
 it was written to the Stream.
 The default TTL for all Streams is infinite, meaning that events will never expire.
 The format property defines how Stream event bodies should be read for data exploration.
 Different formats support different types of schemas. Schemas are used to determine
-table schema for running ad-hoc SQL queries on the Stream.
+the table schema used for running ad-hoc SQL-like queries on the Stream.
 See :ref:`stream-exploration` for more information about formats and schemas. 
 
 Stream properties can be changed with an HTTP PUT method to the URL::
@@ -332,7 +332,7 @@ New properties are passed in the JSON request body.
      - JSON Object describing the format name, schema, and settings
 
 If a property is not given in the request body, no change will be made to the value.
-For example, setting format but not ttl will preserve the current value for ttl.
+For example, setting format but not TTL will preserve the current value for TTL.
 Changing the schema attached to a Stream will drop the Hive table associated with
 the Stream and re-create it with the new schema.
 
@@ -380,5 +380,5 @@ Example
      
    * - Description
      - Change the TTL property of the Stream named *mystream* to 1 day,
-       and the format to csv (comma separated values) with a three field schema
+       and the format to CSV (comma separated values) with a three field schema
        that uses a space delimiter instead of a comma delimiter. 

--- a/cdap-docs/reference-manual/source/http-restful-api/stream.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/stream.rst
@@ -294,12 +294,18 @@ Example
    * - Description
      - Delete all events in the Stream named *mystream*
 
-Setting Time-To-Live Property of a Stream
------------------------------------------
+Setting Stream Properties
+-------------------------
+There are a few Stream properties that can be changed.
 The Time-To-Live (TTL) property governs how long an event is valid for consumption since 
 it was written to the Stream.
 The default TTL for all Streams is infinite, meaning that events will never expire.
-The TTL property of a Stream can be changed with an HTTP PUT method to the URL::
+The format property defines how Stream event bodies should be read for data exploration.
+Different formats support different types of schemas. Schemas are used to determine
+table schema for running ad-hoc SQL queries on the Stream.
+See :ref:`stream-exploration` for more information about formats and schemas. 
+
+Stream properties can be changed with an HTTP PUT method to the URL::
 
   PUT <base-url>/streams/<stream-id>/config
 
@@ -312,9 +318,7 @@ The TTL property of a Stream can be changed with an HTTP PUT method to the URL::
    * - ``<stream-id>``
      - Name of an existing Stream
 
-The new TTL value is passed in the request body as::
-
-  { "ttl" : <ttl-in-seconds> }
+New properties are passed in the JSON request body.
 
 .. list-table::
    :widths: 20 80
@@ -322,8 +326,15 @@ The new TTL value is passed in the request body as::
 
    * - Parameter
      - Description
-   * - ``<ttl-in-seconds>``
+   * - ``ttl``
      - Number of seconds that an event will be valid for since ingested
+   * - ``format``
+     - JSON Object describing the format name, schema, and settings
+
+If a property is not given in the request body, no change will be made to the value.
+For example, setting format but not ttl will preserve the current value for ttl.
+Changing the schema attached to a Stream will drop the Hive table associated with
+the Stream and re-create it with the new schema.
 
 HTTP Responses
 ..............
@@ -334,9 +345,10 @@ HTTP Responses
    * - Status Codes
      - Description
    * - ``200 OK``
-     - The stream TTL was changed successfully
+     - Stream properties were changed successfully
    * - ``400 Bad Request``
-     - The TTL value is not a non-negative integer
+     - The TTL value is not a non-negative integer, the format was not known,
+       the schema was malformed, or the schema is not supported by the format
    * - ``404 Not Found``
      - The Stream does not exist
 
@@ -347,11 +359,26 @@ Example
    :stub-columns: 1
 
    * - HTTP Method
-     - ``PUT <base-url>/streams/mystream/config``
+     - ``PUT <base-url>/streams/mystream/config``::
 
-       with the new TTL value as a JSON string in the body::
-
-         { "ttl" : 86400 }
+         { 
+           "ttl" : 86400,
+           "format": {
+             "name": "csv",
+             "schema": {
+               "type": "record",
+               "name": "event",
+               "fields": [
+                 { "name": "f1", "type": "string" },
+                 { "name": "f2", "type": "int" },
+                 { "name": "f3", "type": "double" }
+               ]
+             },
+             "settings": { "delimiter": " " }
+           } 
+         }
      
    * - Description
-     - Change the TTL property of the Stream named *mystream* to 1 day
+     - Change the TTL property of the Stream named *mystream* to 1 day,
+       and the format to csv (comma separated values) with a three field schema
+       that uses a space delimiter instead of a comma delimiter. 

--- a/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseApp.java
+++ b/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseApp.java
@@ -17,10 +17,8 @@
 package co.cask.cdap.examples.purchase;
 
 import co.cask.cdap.api.app.AbstractApplication;
-import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.data.schema.UnsupportedTypeException;
 import co.cask.cdap.api.data.stream.Stream;
-import co.cask.cdap.api.dataset.lib.FileSetProperties;
 import co.cask.cdap.api.dataset.lib.KeyValueTable;
 import co.cask.cdap.api.dataset.lib.ObjectStores;
 
@@ -67,23 +65,6 @@ public class PurchaseApp extends AbstractApplication {
     // Schedule the workflow
     scheduleWorkflow("DailySchedule", "0 4 * * *", "PurchaseHistoryWorkflow");
 
-
-    Schema schema = Schema.recordOf(
-      "purchase",
-      Schema.Field.of("user", Schema.of(Schema.Type.STRING)),
-      Schema.Field.of("item_id", Schema.of(Schema.Type.INT)),
-      Schema.Field.of("price", Schema.of(Schema.Type.DOUBLE))
-    );
-    createDataset("myfiles", "fileSet", FileSetProperties.builder()
-      .setBasePath("mylocation")
-      .setInputFormat("org.apache.avro.mapreduce.AvroKeyInputFormat")
-      .setOutputFormat("org.apache.avro.mapreduce.AvroKeyOutputFormat")
-      .setEnableExploreOnCreate(true)
-      .setSerDe("org.apache.hadoop.hive.serde2.avro.AvroSerDe")
-      .setExploreInputFormat("org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat")
-      .setExploreOutputFormat("org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat")
-      .setTableProperty("avro.schema.literal", schema.toString())
-      .build());
     try {
       createDataset("history", PurchaseHistoryStore.class, PurchaseHistoryStore.properties());
       ObjectStores.createObjectStore(getConfigurer(), "purchases", Purchase.class);

--- a/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseApp.java
+++ b/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseApp.java
@@ -17,8 +17,10 @@
 package co.cask.cdap.examples.purchase;
 
 import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.data.schema.UnsupportedTypeException;
 import co.cask.cdap.api.data.stream.Stream;
+import co.cask.cdap.api.dataset.lib.FileSetProperties;
 import co.cask.cdap.api.dataset.lib.KeyValueTable;
 import co.cask.cdap.api.dataset.lib.ObjectStores;
 
@@ -65,6 +67,23 @@ public class PurchaseApp extends AbstractApplication {
     // Schedule the workflow
     scheduleWorkflow("DailySchedule", "0 4 * * *", "PurchaseHistoryWorkflow");
 
+
+    Schema schema = Schema.recordOf(
+      "purchase",
+      Schema.Field.of("user", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("item_id", Schema.of(Schema.Type.INT)),
+      Schema.Field.of("price", Schema.of(Schema.Type.DOUBLE))
+    );
+    createDataset("myfiles", "fileSet", FileSetProperties.builder()
+      .setBasePath("mylocation")
+      .setInputFormat("org.apache.avro.mapreduce.AvroKeyInputFormat")
+      .setOutputFormat("org.apache.avro.mapreduce.AvroKeyOutputFormat")
+      .setEnableExploreOnCreate(true)
+      .setSerDe("org.apache.hadoop.hive.serde2.avro.AvroSerDe")
+      .setExploreInputFormat("org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat")
+      .setExploreOutputFormat("org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat")
+      .setTableProperty("avro.schema.literal", schema.toString())
+      .build());
     try {
       createDataset("history", PurchaseHistoryStore.class, PurchaseHistoryStore.properties());
       ObjectStores.createObjectStore(getConfigurer(), "purchases", Purchase.class);


### PR DESCRIPTION
filesets. Moved data exploration out of the advanced section and
into its own section. This is because there is is now much more
content about exploration, and because we want exploration to be
one of the starting points for people and not advanced usage.