### PR TITLE
Allowing hbase classes into application's bundled jar in unit tests.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/test/internal/AppFabricClient.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/test/internal/AppFabricClient.java
@@ -266,9 +266,9 @@ public class AppFabricClient {
 
     ApplicationBundler bundler = new ApplicationBundler(ImmutableList.of("co.cask.cdap.api",
                                                                          "org.apache.hadoop",
-                                                                         "org.apache.hbase",
                                                                          "org.apache.hive",
-                                                                         "org.apache.spark"));
+                                                                         "org.apache.spark"),
+                                                        ImmutableList.of("org.apache.hadoop.hbase"));
     Location jarLocation = locationFactory.create(clz.getName()).getTempFile(".jar");
     bundler.createBundle(jarLocation, clz);
 


### PR DESCRIPTION
This is necessary in case a flowlet wishes to use hbase classes (which are not exposed by cdap).
For instance, the test cases in cdap-etl-pack fail due to ClassNotFoundException, because it tries to use hbase classes.

https://builds.cask.co/browse/CDAP-RBT120-2