### PR TITLE
Wait for Service to start/stop

### DIFF
--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/PreferencesClientTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/PreferencesClientTestRun.java
@@ -41,6 +41,7 @@ import java.io.File;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 
@@ -83,6 +84,8 @@ public class PreferencesClientTestRun extends ClientTestBase {
                                                         AppReturnsArgs.SERVICE));
       programClient.start(AppReturnsArgs.NAME, ProgramType.SERVICE, AppReturnsArgs.SERVICE,
                           ImmutableMap.of("run", "value"));
+      programClient.waitForStatus(AppReturnsArgs.NAME, ProgramType.SERVICE, AppReturnsArgs.SERVICE, "RUNNING",
+                                  15, TimeUnit.SECONDS);
       propMap.put("run", "value");
       propMap.putAll(setMap);
       URL serviceURL = new URL(serviceClient.getServiceURL(AppReturnsArgs.NAME, AppReturnsArgs.SERVICE),
@@ -92,9 +95,13 @@ public class PreferencesClientTestRun extends ClientTestBase {
       assertEquals(HttpURLConnection.HTTP_OK, response.getResponseCode());
       assertEquals(GSON.toJson(propMap), response.getResponseBodyAsString());
       programClient.stop(AppReturnsArgs.NAME, ProgramType.SERVICE, AppReturnsArgs.SERVICE);
+      programClient.waitForStatus(AppReturnsArgs.NAME, ProgramType.SERVICE, AppReturnsArgs.SERVICE, "STOPPED",
+                                  15, TimeUnit.SECONDS);
 
       client.deleteInstancePreferences();
       programClient.start(AppReturnsArgs.NAME, ProgramType.SERVICE, AppReturnsArgs.SERVICE);
+      programClient.waitForStatus(AppReturnsArgs.NAME, ProgramType.SERVICE, AppReturnsArgs.SERVICE, "RUNNING",
+                                  15, TimeUnit.SECONDS);
       propMap.remove("key");
       propMap.remove("run");
       serviceURL = new URL(serviceClient.getServiceURL(AppReturnsArgs.NAME, AppReturnsArgs.SERVICE),
@@ -104,10 +111,14 @@ public class PreferencesClientTestRun extends ClientTestBase {
       assertEquals(HttpURLConnection.HTTP_OK, response.getResponseCode());
       assertEquals(GSON.toJson(propMap), response.getResponseBodyAsString());
       programClient.stop(AppReturnsArgs.NAME, ProgramType.SERVICE, AppReturnsArgs.SERVICE);
+      programClient.waitForStatus(AppReturnsArgs.NAME, ProgramType.SERVICE, AppReturnsArgs.SERVICE, "STOPPED",
+                                  15, TimeUnit.SECONDS);
 
       propMap.clear();
       programClient.setRuntimeArgs(AppReturnsArgs.NAME, ProgramType.SERVICE, AppReturnsArgs.SERVICE, propMap);
       programClient.start(AppReturnsArgs.NAME, ProgramType.SERVICE, AppReturnsArgs.SERVICE);
+      programClient.waitForStatus(AppReturnsArgs.NAME, ProgramType.SERVICE, AppReturnsArgs.SERVICE, "RUNNING",
+                                  15, TimeUnit.SECONDS);
       serviceURL = new URL(serviceClient.getServiceURL(AppReturnsArgs.NAME, AppReturnsArgs.SERVICE),
                            AppReturnsArgs.ENDPOINT);
       request = HttpRequest.builder(HttpMethod.GET, serviceURL).build();
@@ -116,6 +127,8 @@ public class PreferencesClientTestRun extends ClientTestBase {
       assertEquals(GSON.toJson(propMap), response.getResponseBodyAsString());
     } finally {
       programClient.stop(AppReturnsArgs.NAME, ProgramType.SERVICE, AppReturnsArgs.SERVICE);
+      programClient.waitForStatus(AppReturnsArgs.NAME, ProgramType.SERVICE, AppReturnsArgs.SERVICE, "STOPPED",
+                                  15, TimeUnit.SECONDS);
       appClient.delete(AppReturnsArgs.NAME);
     }
   }

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/PreferencesClientTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/PreferencesClientTestRun.java
@@ -41,7 +41,6 @@ import java.io.File;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 
@@ -84,8 +83,7 @@ public class PreferencesClientTestRun extends ClientTestBase {
                                                         AppReturnsArgs.SERVICE));
       programClient.start(AppReturnsArgs.NAME, ProgramType.SERVICE, AppReturnsArgs.SERVICE,
                           ImmutableMap.of("run", "value"));
-      programClient.waitForStatus(AppReturnsArgs.NAME, ProgramType.SERVICE, AppReturnsArgs.SERVICE, "RUNNING",
-                                  15, TimeUnit.SECONDS);
+      assertProgramRunning(programClient, AppReturnsArgs.NAME, ProgramType.SERVICE, AppReturnsArgs.SERVICE);
       propMap.put("run", "value");
       propMap.putAll(setMap);
       URL serviceURL = new URL(serviceClient.getServiceURL(AppReturnsArgs.NAME, AppReturnsArgs.SERVICE),
@@ -95,13 +93,11 @@ public class PreferencesClientTestRun extends ClientTestBase {
       assertEquals(HttpURLConnection.HTTP_OK, response.getResponseCode());
       assertEquals(GSON.toJson(propMap), response.getResponseBodyAsString());
       programClient.stop(AppReturnsArgs.NAME, ProgramType.SERVICE, AppReturnsArgs.SERVICE);
-      programClient.waitForStatus(AppReturnsArgs.NAME, ProgramType.SERVICE, AppReturnsArgs.SERVICE, "STOPPED",
-                                  15, TimeUnit.SECONDS);
+      assertProgramStopped(programClient, AppReturnsArgs.NAME, ProgramType.SERVICE, AppReturnsArgs.SERVICE);
 
       client.deleteInstancePreferences();
       programClient.start(AppReturnsArgs.NAME, ProgramType.SERVICE, AppReturnsArgs.SERVICE);
-      programClient.waitForStatus(AppReturnsArgs.NAME, ProgramType.SERVICE, AppReturnsArgs.SERVICE, "RUNNING",
-                                  15, TimeUnit.SECONDS);
+      assertProgramRunning(programClient, AppReturnsArgs.NAME, ProgramType.SERVICE, AppReturnsArgs.SERVICE);
       propMap.remove("key");
       propMap.remove("run");
       serviceURL = new URL(serviceClient.getServiceURL(AppReturnsArgs.NAME, AppReturnsArgs.SERVICE),
@@ -111,14 +107,12 @@ public class PreferencesClientTestRun extends ClientTestBase {
       assertEquals(HttpURLConnection.HTTP_OK, response.getResponseCode());
       assertEquals(GSON.toJson(propMap), response.getResponseBodyAsString());
       programClient.stop(AppReturnsArgs.NAME, ProgramType.SERVICE, AppReturnsArgs.SERVICE);
-      programClient.waitForStatus(AppReturnsArgs.NAME, ProgramType.SERVICE, AppReturnsArgs.SERVICE, "STOPPED",
-                                  15, TimeUnit.SECONDS);
+      assertProgramStopped(programClient, AppReturnsArgs.NAME, ProgramType.SERVICE, AppReturnsArgs.SERVICE);
 
       propMap.clear();
       programClient.setRuntimeArgs(AppReturnsArgs.NAME, ProgramType.SERVICE, AppReturnsArgs.SERVICE, propMap);
       programClient.start(AppReturnsArgs.NAME, ProgramType.SERVICE, AppReturnsArgs.SERVICE);
-      programClient.waitForStatus(AppReturnsArgs.NAME, ProgramType.SERVICE, AppReturnsArgs.SERVICE, "RUNNING",
-                                  15, TimeUnit.SECONDS);
+      assertProgramRunning(programClient, AppReturnsArgs.NAME, ProgramType.SERVICE, AppReturnsArgs.SERVICE);
       serviceURL = new URL(serviceClient.getServiceURL(AppReturnsArgs.NAME, AppReturnsArgs.SERVICE),
                            AppReturnsArgs.ENDPOINT);
       request = HttpRequest.builder(HttpMethod.GET, serviceURL).build();
@@ -127,8 +121,7 @@ public class PreferencesClientTestRun extends ClientTestBase {
       assertEquals(GSON.toJson(propMap), response.getResponseBodyAsString());
     } finally {
       programClient.stop(AppReturnsArgs.NAME, ProgramType.SERVICE, AppReturnsArgs.SERVICE);
-      programClient.waitForStatus(AppReturnsArgs.NAME, ProgramType.SERVICE, AppReturnsArgs.SERVICE, "STOPPED",
-                                  15, TimeUnit.SECONDS);
+      assertProgramStopped(programClient, AppReturnsArgs.NAME, ProgramType.SERVICE, AppReturnsArgs.SERVICE);
       appClient.delete(AppReturnsArgs.NAME);
     }
   }


### PR DESCRIPTION
Fixing a timing issue where we try to query the service before it is started. So wait until the service status turns to running.

Bamboo : https://builds.cask.co/browse/CDAP-RBT124