### PR TITLE
Descriptions for Security options for cdap-site.xml

### DIFF
--- a/cdap-docs/admin-manual/source/installation/security.rst
+++ b/cdap-docs/admin-manual/source/installation/security.rst
@@ -261,7 +261,7 @@ The simplest way to identity a client is to authenticate against a realm file.
 To configure basic authentication add the following properties to ``cdap-site.xml``:
 
 ========================================================== =========================== ======================================
-Property                                                   Default Value               Description
+Property                                                   Value                       Description
 ========================================================== =========================== ======================================
 ``security.authentication.handlerClassName``               ``co.cask.cdap.security.``\ Name of the class handling
                                                            ``server.``                 authentication
@@ -287,7 +287,7 @@ You can configure CDAP to authenticate against an LDAP instance by adding these
 properties to ``cdap-site.xml``:
 
 ========================================================== =========================== ======================================
-Property                                                   Default Value               Description
+Property                                                   Value                       Description
 ========================================================== =========================== ======================================
 ``security.authentication.handlerClassName``               ``co.cask.cdap.security.``\ Name of the class handling
                                                            ``server.``                 authentication
@@ -309,22 +309,22 @@ Property                                                   Default Value        
 In addition, you may configure these optional properties in ``cdap-site.xml``:
 
 ========================================================== =========================== ======================================
-Property                                                   Default Value               Description
+Property                                                   Value                       Description
 ========================================================== =========================== ======================================
-``security.authentication.handler.bindDn``                 ``<bindDn>``                The user on an external LDAP server 
-                                                                                       permitted to search the LDAP directory
-``security.authentication.handler.bindPassword``           ``<bindPassword>``          The password of the user on an
-                                                                                       external LDAP server permitted to 
-                                                                                       search the LDAP directory
+``security.authentication.handler.bindDn``                 ``<bindDn>``                The Distinguished Name used to bind to
+                                                                                       the LDAP server and search the
+                                                                                       directory
+``security.authentication.handler.bindPassword``           ``<bindPassword>``          The password used to bind to the LDAP
+                                                                                       server
 ``security.authentication.handler.userIdAttribute``        ``<userIdAttribute>``       The Unique User ID Attribute
 ``security.authentication.handler.userPasswordAttribute``  ``<userPasswordAttribute>`` Password of the ``userIdAttribute``
-``security.authentication.handler.roleBaseDn``             ``<roleBaseDn>``            Role Based: <to be confirmed>
-``security.authentication.handler.roleNameAttribute``      ``<roleNameAttribute>``     Name of attribute specifying the role 
-                                                                                       <to be confirmed>
-``security.authentication.handler.roleMemberAttribute``    ``<roleMemberAttribute>``   Name of attribute specifying the role 
-                                                                                       <to be confirmed>
-``security.authentication.handler.roleObjectClass``        ``<roleObjectClass>``       Name of attribute specifying the role 
-                                                                                       <to be confirmed>
+``security.authentication.handler.roleBaseDn``             ``<roleBaseDn>``            Role Based Distinguished Name
+``security.authentication.handler.roleNameAttribute``      ``<roleNameAttribute>``      
+                                                                                       
+``security.authentication.handler.roleMemberAttribute``    ``<roleMemberAttribute>``    
+                                                                                       
+``security.authentication.handler.roleObjectClass``        ``<roleObjectClass>``        
+                                                                                       
 ========================================================== =========================== ======================================
 
 To enable SSL between the authentication server and the LDAP instance, configure
@@ -347,7 +347,7 @@ To authenticate a user using JASPI (Java Authentication Service Provider Interfa
 the following properties to ``cdap-site.xml``:
 
 ========================================================== =========================== ======================================
-Property                                                   Default Value               Description
+Property                                                   Value                       Description
 ========================================================== =========================== ======================================
 ``security.authentication.handlerClassName``               ``co.cask.cdap.security.``\ Name of the class handling
                                                            ``server.``                 authentication

--- a/cdap-docs/admin-manual/source/installation/security.rst
+++ b/cdap-docs/admin-manual/source/installation/security.rst
@@ -261,9 +261,10 @@ To configure basic authentication add the following properties to ``cdap-site.xm
 ========================================================== =========================== ======================================
 Property                                                   Default Value               Description
 ========================================================== =========================== ======================================
-``security.authentication.handlerClassName``               ``co.cask.cdap.security.server.BasicAuthenticationHandler``
-                                                                                       Name of the class handling
-                                                                                       authentication
+``security.authentication.handlerClassName``               ``co.cask.cdap.security.``\ Name of the class handling
+                                                           ``server.``                 authentication
+                                                           ``BasicAuthentication``\
+                                                           ``Handler``
 ``security.authentication.basic.realmfile``                ``<path>``                  An absolute or relative path to the 
                                                                                        realm file
 ========================================================== =========================== ======================================
@@ -283,18 +284,23 @@ LDAP Authentication
 You can configure CDAP to authenticate against an LDAP instance by adding these
 properties to ``cdap-site.xml``:
 
-========================================================== ==================================================================
+========================================================== =========================== ======================================
 Property                                                   Default Value               Description
-========================================================== ==================================================================
-``security.authentication.handlerClassName``               ``co.cask.cdap.security.server.LDAPAuthenticationHandler``
-``security.authentication.loginmodule.className``          ``co.cask.cdap.security.server.LDAPLoginModule``
-``security.authentication.handler.debug``                  ``true/false``
+========================================================== =========================== ======================================
+``security.authentication.handlerClassName``               ``co.cask.cdap.security.``\ Name of the class handling
+                                                           ``server.``                 authentication
+                                                           ``LDAPAuthentication``\
+                                                           ``Handler``
+``security.authentication.loginmodule.className``          ``co.cask.cdap.security.``\
+                                                           ``server.``
+                                                           ``LDAPLoginModule``
+``security.authentication.handler.debug``                  ``false``                   Set to ``true`` to enable debugging
 ``security.authentication.handler.hostname``               ``<hostname>``
 ``security.authentication.handler.port``                   ``<port>``
 ``security.authentication.handler.userBaseDn``             ``<userBaseDn>``
 ``security.authentication.handler.userRdnAttribute``       ``<userRdnAttribute>``
 ``security.authentication.handler.userObjectClass``        ``<userObjectClass>``
-========================================================== ==================================================================
+========================================================== =========================== ======================================
 
 In addition, you may configure these optional properties in ``cdap-site.xml``:
 
@@ -308,14 +314,13 @@ Property                                                   Default Value        
                                                                                        search the LDAP directory
 ``security.authentication.handler.userIdAttribute``        ``<userIdAttribute>``       The Unique User ID Attribute
 ``security.authentication.handler.userPasswordAttribute``  ``<userPasswordAttribute>`` Password of the ``userIdAttribute``
-``security.authentication.handler.roleBaseDn``             ``<roleBaseDn>``            Role Based 
-                                                                                       ?????
+``security.authentication.handler.roleBaseDn``             ``<roleBaseDn>``            Role Based: <to be confirmed>
 ``security.authentication.handler.roleNameAttribute``      ``<roleNameAttribute>``     Name of attribute specifying the role 
-                                                                                       ?????
+                                                                                       <to be confirmed>
 ``security.authentication.handler.roleMemberAttribute``    ``<roleMemberAttribute>``   Name of attribute specifying the role 
-                                                                                       ?????
+                                                                                       <to be confirmed>
 ``security.authentication.handler.roleObjectClass``        ``<roleObjectClass>``       Name of attribute specifying the role 
-                                                                                       ?????
+                                                                                       <to be confirmed>
 ========================================================== =========================== ======================================
 
 To enable SSL between the authentication server and the LDAP instance, configure
@@ -337,12 +342,16 @@ JASPI Authentication
 To authenticate a user using JASPI (Java Authentication Service Provider Interface) add 
 the following properties to ``cdap-site.xml``:
 
-========================================================== ==================================================================
-Property                                                   Value
-========================================================== ==================================================================
-``security.authentication.handlerClassName``               ``co.cask.cdap.security.server.JASPIAuthenticationHandler``
-``security.authentication.loginmodule.className``          ``<custom-login-module>``
-========================================================== ==================================================================
+========================================================== =========================== ======================================
+Property                                                   Default Value               Description
+========================================================== =========================== ======================================
+``security.authentication.handlerClassName``               ``co.cask.cdap.security.``\ Name of the class handling
+                                                           ``server.``                 authentication
+                                                           ``JASPIAuthentication``\
+                                                           ``Handler``
+``security.authentication.loginmodule.className``          ``<custom-login-module>``   Name of the class of the login module
+                                                                                       handling authentication
+========================================================== =========================== ======================================
 
 In addition, any properties with the prefix ``security.authentication.handler.``,
 such as ``security.authentication.handler.hostname``, will be provided to the handler.

--- a/cdap-docs/admin-manual/source/installation/security.rst
+++ b/cdap-docs/admin-manual/source/installation/security.rst
@@ -304,7 +304,8 @@ Property                                                   Value                
                                                                                        directory
 ``security.authentication.handler.userRdnAttribute``       ``<userRdnAttribute>``      LDAP Object attribute for username 
                                                                                        when search by role DN
-``security.authentication.handler.userObjectClass``        ``<userObjectClass>``
+``security.authentication.handler.userObjectClass``        ``<userObjectClass>``       LDAP Object class used to store user  
+                                                                                       entries
 ========================================================== =========================== ======================================
 
 In addition, you may configure these optional properties in ``cdap-site.xml``:
@@ -317,15 +318,19 @@ Property                                                   Value                
                                                                                        directory
 ``security.authentication.handler.bindPassword``           ``<bindPassword>``          The password used to bind to the LDAP
                                                                                        server
-``security.authentication.handler.userIdAttribute``        ``<userIdAttribute>``       The Unique User ID Attribute
-``security.authentication.handler.userPasswordAttribute``  ``<userPasswordAttribute>`` Password of the ``userIdAttribute``
-``security.authentication.handler.roleBaseDn``             ``<roleBaseDn>``            Role Based Distinguished Name
-``security.authentication.handler.roleNameAttribute``      ``<roleNameAttribute>``      
-                                                                                       
-``security.authentication.handler.roleMemberAttribute``    ``<roleMemberAttribute>``    
-                                                                                       
-``security.authentication.handler.roleObjectClass``        ``<roleObjectClass>``        
-                                                                                       
+``security.authentication.handler.userIdAttribute``        ``<userIdAttribute>``       LDAP Object attribute containing the 
+                                                                                       username
+``security.authentication.handler.userPasswordAttribute``  ``<userPasswordAttribute>`` LDAP Object attribute containing the 
+                                                                                       user password
+``security.authentication.handler.roleBaseDn``             ``<roleBaseDn>``            Distinguished Name of the root of the 
+                                                                                       LDAP tree to search for group 
+                                                                                       memberships
+``security.authentication.handler.roleNameAttribute``      ``<roleNameAttribute>``     LDAP Object attribute specifying the 
+                                                                                       group name 
+``security.authentication.handler.roleMemberAttribute``    ``<roleMemberAttribute>``   LDAP Object attribute specifying the 
+                                                                                       group members
+``security.authentication.handler.roleObjectClass``        ``<roleObjectClass>``       LDAP Object class used to store group  
+                                                                                       entries
 ========================================================== =========================== ======================================
 
 To enable SSL between the authentication server and the LDAP instance, configure
@@ -337,7 +342,7 @@ Property                                                   Default Value     Val
 ``security.authentication.handler.useLdaps``               ``false``         ``true``  Set to ``true`` to enable use of LDAPS
 ``security.authentication.handler.ldapsVerifyCertificate`` ``true``          ``true``  Set to ``true`` to enable verification
                                                                                        of the SSL certificate used by the
-                                                                                        LDAP server
+                                                                                       LDAP server
 ========================================================== ================= ========= ======================================
 
 .. _installation-jaspi-authentication:

--- a/cdap-docs/admin-manual/source/installation/security.rst
+++ b/cdap-docs/admin-manual/source/installation/security.rst
@@ -40,10 +40,13 @@ Enabling Security (Standalone CDAP)
 To enable security in :term:`Standalone CDAP <standalone cdap>`, add these properties to ``cdap-site.xml``:
 
 ================================================= ===================== =====================================================
-Property                                          Value                 Notes
+Property                                          Default Value         Description
 ================================================= ===================== =====================================================
-``security.enabled``                              ``true``
-``security.auth.server.bind.address``             ``<hostname>``
+``security.enabled``                              ``false``             Enables authentication for CDAP. When set to ``true`` 
+                                                                        all requests to CDAP must provide a valid access 
+                                                                        token.
+``security.auth.server.bind.address``             ``<hostname>``        IP address that the CDAP Authentication Server should
+                                                                        bind to
 ================================================= ===================== =====================================================
 
 Client Authentication then needs to be configured, as described below under
@@ -56,11 +59,14 @@ Enabling Security (Distributed CDAP)
 To enable security in :term:`Distributed CDAP <distributed cdap>`, add these properties to ``cdap-site.xml``:
 
 ================================================= ===================== =====================================================
-Property                                          Value                 Notes
+Property                                          Default Value         Description
 ================================================= ===================== =====================================================
-``security.enabled``                              ``true``
+``security.enabled``                              ``false``             Enables authentication for CDAP. When set to ``true`` 
+                                                                        all requests to CDAP must provide a valid access 
+                                                                        token.
 ``security.auth.server.address``                  *Deprecated*          Use ``security.auth.server.bind.address`` instead
-``security.auth.server.bind.address``             ``<hostname>``
+``security.auth.server.bind.address``             ``<hostname>``        IP address that the CDAP Authentication Server should
+                                                                        bind to
 ================================================= ===================== =====================================================
 
 Configuring Kerberos (required)
@@ -112,34 +118,38 @@ Running Servers with SSL
 
 To enable running servers with SSL in CDAP, add this property to ``cdap-site.xml``:
 
-================================================= ===========================================================================
-Property                                          Value
-================================================= ===========================================================================
-``ssl.enabled``                                   ``true``
-================================================= ===========================================================================
+================================================= ==================== ======================================================
+Property                                          Default Value        Description
+================================================= ==================== ======================================================
+``ssl.enabled``                                   ``true``             ``true`` to enable servers running with SSL in CDAP
+================================================= ==================== ======================================================
 
 Default Ports
 .............
 
 Without SSL:
 
-================================================= ===========================================================================
-Property                                          Default Value
-================================================= ===========================================================================
-``router.bind.port``                              ``10000``
-``security.auth.server.bind.port``                ``10009``
-``dashboard.bind.port``                           ``9999``
-================================================= ===========================================================================
+================================================= ==================== ======================================================
+Property                                          Default Value        Description
+================================================= ==================== ======================================================
+``router.bind.port``                              ``10000``            Port number that the CDAP Router should bind to for 
+                                                                       HTTP Connections
+``security.auth.server.bind.port``                ``10009``            Port number that the CDAP Authentication Server should
+                                                                       bind to for HTTP
+``dashboard.bind.port``                           ``9999``             CDAP Console bind port
+================================================= ==================== ======================================================
 
 With SSL:
 
-================================================= ===========================================================================
-Property                                          Default Value
-================================================= ===========================================================================
-``router.ssl.bind.port``                          ``10443``
-``security.auth.server.ssl.bind.port``            ``10010``
-``dashboard.ssl.bind.port``                       ``9443``
-================================================= ===========================================================================
+================================================= ==================== ======================================================
+Property                                          Default Value        Description
+================================================= ==================== ======================================================
+``router.ssl.bind.port``                          ``10443``            Port number that the CDAP router should bind to for 
+                                                                       HTTPS Connections
+``security.auth.server.ssl.bind.port``            ``10010``            Port number that the CDAP Authentication Server should
+                                                                       bind to for HTTP
+``dashboard.ssl.bind.port``                       ``9443``             CDAP Console bind port
+================================================= ==================== ======================================================
 
 
 Configuring SSL for the Authentication Server
@@ -248,12 +258,15 @@ Basic Authentication
 The simplest way to identity a client is to authenticate against a realm file.
 To configure basic authentication add the following properties to ``cdap-site.xml``:
 
-========================================================== ==================================================================
-Property                                                   Value
-========================================================== ==================================================================
+========================================================== =========================== ======================================
+Property                                                   Default Value               Description
+========================================================== =========================== ======================================
 ``security.authentication.handlerClassName``               ``co.cask.cdap.security.server.BasicAuthenticationHandler``
-``security.authentication.basic.realmfile``                ``<path>`` *(either absolute or relative)*
-========================================================== ==================================================================
+                                                                                       Name of the class handling
+                                                                                       authentication
+``security.authentication.basic.realmfile``                ``<path>``                  An absolute or relative path to the 
+                                                                                       realm file
+========================================================== =========================== ======================================
 
 The realm file is of the following format::
 
@@ -271,7 +284,7 @@ You can configure CDAP to authenticate against an LDAP instance by adding these
 properties to ``cdap-site.xml``:
 
 ========================================================== ==================================================================
-Property                                                   Value
+Property                                                   Default Value               Description
 ========================================================== ==================================================================
 ``security.authentication.handlerClassName``               ``co.cask.cdap.security.server.LDAPAuthenticationHandler``
 ``security.authentication.loginmodule.className``          ``co.cask.cdap.security.server.LDAPLoginModule``
@@ -285,28 +298,37 @@ Property                                                   Value
 
 In addition, you may configure these optional properties in ``cdap-site.xml``:
 
-========================================================== ==================================================================
-Property                                                   Value
-========================================================== ==================================================================
-``security.authentication.handler.bindDn``                 ``<bindDn>``
-``security.authentication.handler.bindPassword``           ``<bindPassword>``
-``security.authentication.handler.userIdAttribute``        ``<userIdAttribute>``
-``security.authentication.handler.userPasswordAttribute``  ``<userPasswordAttribute>``
-``security.authentication.handler.roleBaseDn``             ``<roleBaseDn>``
-``security.authentication.handler.roleNameAttribute``      ``<roleNameAttribute>``
-``security.authentication.handler.roleMemberAttribute``    ``<roleMemberAttribute>``
-``security.authentication.handler.roleObjectClass``        ``<roleObjectClass>``
-========================================================== ==================================================================
+========================================================== =========================== ======================================
+Property                                                   Default Value               Description
+========================================================== =========================== ======================================
+``security.authentication.handler.bindDn``                 ``<bindDn>``                The user on an external LDAP server 
+                                                                                       permitted to search the LDAP directory
+``security.authentication.handler.bindPassword``           ``<bindPassword>``          The password of the user on an
+                                                                                       external LDAP server permitted to 
+                                                                                       search the LDAP directory
+``security.authentication.handler.userIdAttribute``        ``<userIdAttribute>``       The Unique User ID Attribute
+``security.authentication.handler.userPasswordAttribute``  ``<userPasswordAttribute>`` Password of the ``userIdAttribute``
+``security.authentication.handler.roleBaseDn``             ``<roleBaseDn>``            Role Based 
+                                                                                       ?????
+``security.authentication.handler.roleNameAttribute``      ``<roleNameAttribute>``     Name of attribute specifying the role 
+                                                                                       ?????
+``security.authentication.handler.roleMemberAttribute``    ``<roleMemberAttribute>``   Name of attribute specifying the role 
+                                                                                       ?????
+``security.authentication.handler.roleObjectClass``        ``<roleObjectClass>``       Name of attribute specifying the role 
+                                                                                       ?????
+========================================================== =========================== ======================================
 
 To enable SSL between the authentication server and the LDAP instance, configure
 these properties in ``cdap-site.xml``:
 
-========================================================== ================= ================================================
-Property                                                   Value             Default Value
-========================================================== ================= ================================================
-``security.authentication.handler.useLdaps``               ``true/false``    ``false``
-``security.authentication.handler.ldapsVerifyCertificate`` ``true/false``    ``true``
-========================================================== ================= ================================================
+========================================================== ================= ========= ======================================
+Property                                                   Default Value     Value     Description
+========================================================== ================= ========= ======================================
+``security.authentication.handler.useLdaps``               ``false``         ``true``  Set to ``true`` to enable use of LDAP
+``security.authentication.handler.ldapsVerifyCertificate`` ``true``          ``true``  Set to ``true`` to enable SSL between
+                                                                                       the authentication server and the LDAP 
+                                                                                       instance
+========================================================== ================= ========= ======================================
 
 .. _installation-jaspi-authentication:
 

--- a/cdap-docs/admin-manual/source/installation/security.rst
+++ b/cdap-docs/admin-manual/source/installation/security.rst
@@ -299,10 +299,11 @@ Property                                                   Value                
 ``security.authentication.handler.debug``                  ``false``                   Set to ``true`` to enable debugging
 ``security.authentication.handler.hostname``               ``<hostname>``              LDAP server host
 ``security.authentication.handler.port``                   ``<port>``                  LDAP server port
-``security.authentication.handler.userBaseDn``             ``<userBaseDn>``            LDAP base Distinguished Name to
-                                                                                       authenticate with
-``security.authentication.handler.userRdnAttribute``       ``<userRdnAttribute>``      LDAP attribute used as the relative 
-                                                                                       Distinguished Name
+``security.authentication.handler.userBaseDn``             ``<userBaseDn>``            Distinguished Name of the root for 
+                                                                                       user account entries in the LDAP
+                                                                                       directory
+``security.authentication.handler.userRdnAttribute``       ``<userRdnAttribute>``      LDAP Object attribute for username 
+                                                                                       when search by role DN
 ``security.authentication.handler.userObjectClass``        ``<userObjectClass>``
 ========================================================== =========================== ======================================
 
@@ -333,10 +334,10 @@ these properties in ``cdap-site.xml``:
 ========================================================== ================= ========= ======================================
 Property                                                   Default Value     Value     Description
 ========================================================== ================= ========= ======================================
-``security.authentication.handler.useLdaps``               ``false``         ``true``  Set to ``true`` to enable use of LDAP
-``security.authentication.handler.ldapsVerifyCertificate`` ``true``          ``true``  Set to ``true`` to enable SSL between
-                                                                                       the authentication server and the LDAP 
-                                                                                       instance
+``security.authentication.handler.useLdaps``               ``false``         ``true``  Set to ``true`` to enable use of LDAPS
+``security.authentication.handler.ldapsVerifyCertificate`` ``true``          ``true``  Set to ``true`` to enable verification
+                                                                                       of the SSL certificate used by the
+                                                                                        LDAP server
 ========================================================== ================= ========= ======================================
 
 .. _installation-jaspi-authentication:

--- a/cdap-docs/admin-manual/source/installation/security.rst
+++ b/cdap-docs/admin-manual/source/installation/security.rst
@@ -135,8 +135,9 @@ Property                                          Default Value        Descripti
 ``router.bind.port``                              ``10000``            Port number that the CDAP Router should bind to for 
                                                                        HTTP Connections
 ``security.auth.server.bind.port``                ``10009``            Port number that the CDAP Authentication Server should
-                                                                       bind to for HTTP
-``dashboard.bind.port``                           ``9999``             CDAP Console bind port
+                                                                       bind to for HTTP Connections
+``dashboard.bind.port``                           ``9999``             Port number that the CDAP Console should
+                                                                       bind to for HTTP Connections
 ================================================= ==================== ======================================================
 
 With SSL:
@@ -147,8 +148,9 @@ Property                                          Default Value        Descripti
 ``router.ssl.bind.port``                          ``10443``            Port number that the CDAP router should bind to for 
                                                                        HTTPS Connections
 ``security.auth.server.ssl.bind.port``            ``10010``            Port number that the CDAP Authentication Server should
-                                                                       bind to for HTTP
-``dashboard.ssl.bind.port``                       ``9443``             CDAP Console bind port
+                                                                       bind to for HTTPS Connections
+``dashboard.ssl.bind.port``                       ``9443``             Port number that the CDAP Console should bind to for 
+                                                                       HTTPS Connections
 ================================================= ==================== ======================================================
 
 
@@ -295,10 +297,12 @@ Property                                                   Default Value        
                                                            ``server.``
                                                            ``LDAPLoginModule``
 ``security.authentication.handler.debug``                  ``false``                   Set to ``true`` to enable debugging
-``security.authentication.handler.hostname``               ``<hostname>``
-``security.authentication.handler.port``                   ``<port>``
-``security.authentication.handler.userBaseDn``             ``<userBaseDn>``
-``security.authentication.handler.userRdnAttribute``       ``<userRdnAttribute>``
+``security.authentication.handler.hostname``               ``<hostname>``              LDAP server host
+``security.authentication.handler.port``                   ``<port>``                  LDAP server port
+``security.authentication.handler.userBaseDn``             ``<userBaseDn>``            LDAP base Distinguished Name to
+                                                                                       authenticate with
+``security.authentication.handler.userRdnAttribute``       ``<userRdnAttribute>``      LDAP attribute used as the relative 
+                                                                                       Distinguished Name
 ``security.authentication.handler.userObjectClass``        ``<userObjectClass>``
 ========================================================== =========================== ======================================
 


### PR DESCRIPTION
Preliminary Fix for [CDAP-1289](https://issues.cask.co/browse/CDAP-1289): adding descriptions to security options for cdap-site.xml

The security page tables have been adjusted, and I have added to them as I saw fit, but there are gaps missing that need fixing. CDAP-1289 is about adding descriptions for all the settings for security; however, it's not clear what they are for, and so require assistance in completing. **Please check and confirm that all descriptions are accurate!**

Staged Page: [Security Page](http://stg-web101.sw.joyent.continuuity.net/cdap/2.7.0-SNAPSHOT-r2.7.0_security/en/admin-manual/installation/security.html)