### PR TITLE
Zookeeper Configuration documentation

### DIFF
--- a/cdap-docs/admin-manual/source/installation/installation.rst
+++ b/cdap-docs/admin-manual/source/installation/installation.rst
@@ -168,6 +168,10 @@ For a distributed enterprise, you must install these Hadoop components:
 **Note:** Certain CDAP components need to reference your *Hadoop*, *HBase*, *YARN* (and
 possibly *Hive*) cluster configurations by adding your configuration to their class paths.
 
+**Note:** Zookeeper's ``maxClientCnxns`` must be raised from its default.  We suggest setting it to zero
+(unlimited connections). As each YARN container launched by CDAP makes a connection to Zookeeper, 
+the number of connections required is a function of usage.
+
 .. _deployment-architectures:
 
 Deployment Architectures

--- a/cdap-docs/admin-manual/source/installation/quick-start.rst
+++ b/cdap-docs/admin-manual/source/installation/quick-start.rst
@@ -53,6 +53,11 @@ the packages, and prior to starting services.
 - The CDAP user should be able to write temp files; if not, see the instructions in 
   :ref:`the installation guide <install-tmp-files>`.
 
+- **Note:** Zookeeper's ``maxClientCnxns`` must be raised from its default.  We suggest setting it to zero
+  (unlimited connections). As each YARN container launched by CDAP makes a connection to Zookeeper, 
+  the number of connections required is a function of usage.
+
+
 Configuring Package Managers
 ----------------------------
 


### PR DESCRIPTION
Fix for [CDAP-1390](https://issues.cask.co/browse/CDAP-1390)

Staged at:

[Installation](http://stg-web101.sw.joyent.continuuity.net/cdap/2.7.0-SNAPSHOT-r2.7.0_zookeeper_docs/en/admin-manual/installation/installation.html) Second "Note" of "Hadoop/HBase Environment"

[Quick-start](http://stg-web101.sw.joyent.continuuity.net/cdap/2.7.0-SNAPSHOT-r2.7.0_zookeeper_docs/en/admin-manual/installation/quick-start.html) Last line under "Preparing the Cluster"