### PR TITLE
Update Dockerfile to match new modules in CDAP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ RUN mkdir /Build /Software
 
 # copy the minimum needed software (to build it) to the container
 COPY *xml /Build/
+COPY cdap-adapters /Build/cdap-adapters
 COPY cdap-api /Build/cdap-api
 COPY cdap-app-fabric /Build/cdap-app-fabric
 COPY cdap-archetypes /Build/cdap-archetypes
@@ -56,12 +57,16 @@ COPY cdap-gateway /Build/cdap-gateway
 COPY cdap-hbase-compat-0.94 /Build/cdap-hbase-compat-0.94
 COPY cdap-hbase-compat-0.96 /Build/cdap-hbase-compat-0.96
 COPY cdap-hbase-compat-0.98 /Build/cdap-hbase-compat-0.98
+COPY cdap-integration-test /Build/cdap-integration-test
 COPY cdap-kafka /Build/cdap-kafka
 COPY cdap-master /Build/cdap-master
+COPY cdap-notifications /Build/cdap-notifications
+COPY cdap-notifications-api /Build/cdap-notifications-api
 COPY cdap-proto /Build/cdap-proto
 COPY cdap-security /Build/cdap-security
 COPY cdap-security-service /Build/cdap-security-service
 COPY cdap-standalone /Build/cdap-standalone
+COPY cdap-test /Build/cdap-test
 COPY cdap-unit-test /Build/cdap-unit-test
 COPY cdap-unit-test-standalone /Build/cdap-unit-test-standalone
 COPY cdap-watchdog /Build/cdap-watchdog


### PR DESCRIPTION
When modules are added to CDAP, they need to be added to the Docker build context.