### PR TITLE
cdap-cli doesnt resolve its location correctly

### DIFF
--- a/cdap-cli/bin/cdap-cli.sh
+++ b/cdap-cli/bin/cdap-cli.sh
@@ -19,12 +19,6 @@
 # Attempt to set APP_HOME
 # Resolve links: $0 may be a link
 PRG="$0"
-bin=`dirname "${BASH_SOURCE-$0}"`
-bin=`cd "$bin"; pwd`
-lib="$bin"/../lib
-conf="$bin"/../conf
-CDAP_CONF=${CDAP_CONF:-/etc/cdap/conf}
-script=`basename $0`
 
 # Need this for relative symlinks.
 while [ -h "$PRG" ] ; do
@@ -36,6 +30,13 @@ while [ -h "$PRG" ] ; do
         PRG=`dirname "$PRG"`"/$link"
     fi
 done
+
+bin=`dirname "${PRG}"`
+bin=`cd "$bin"; pwd`
+lib="$bin"/../lib
+conf="$bin"/../conf
+CDAP_CONF=${CDAP_CONF:-/etc/cdap/conf}
+script=`basename $0`
 
 if [ "$CLASSPATH" = "" ]; then
   CLASSPATH=${lib}/co.cask.cdap.cdap-cli-@@project.version@@.jar


### PR DESCRIPTION
fixes the case when cdap-cli.sh invoked via an alternatives link and does not resolve its location properly, resulting in an empty classpath

this would be needed in order to include the cli into the CDAP parcel.