### PR TITLE
Remove "New" badge from current (develop) docs build

### DIFF
--- a/cdap-docs/_common/common_conf.py
+++ b/cdap-docs/_common/common_conf.py
@@ -187,10 +187,12 @@ html_theme = 'cdap'
 # the inner-lists being the directory and a label
 #
 # manual_list is an ordered list of the manuals
+# Fields: directory, manual name, icon 
+# icon: "" for none, "new-icon" for the ico_new.png
 manuals_list = [
     ["developers-manual",   u"Developers’ Manual",             "",],
     ["admin-manual",        "Administration Manual",           "",],
-    ["integrations",        "Integrations",                    "new-icon",],
+    ["integrations",        "Integrations",                    "",],
     ["examples-manual",     "Examples, Guides, and Tutorials", "",],
     ["reference-manual",    "Reference Manual",                "",],
 ]


### PR DESCRIPTION
Remove "new" icon badge from the Integrations manual, and add docs about using icons.