### PR TITLE
Replace references to 2.7.0.

### DIFF
--- a/cdap-docs/examples-manual/source/examples/stream-conversion.rst
+++ b/cdap-docs/examples-manual/source/examples/stream-conversion.rst
@@ -39,7 +39,7 @@ of the Application are tied together by the class ``StreamConversionApp``:
 
 The interesting part is the creation of the dataset ``converted``:
 
-- It is a ``TimePartitionedFileSet``. This is an experimental new dataset type, introduced in CDAP 2.7.0. This
+- It is a ``TimePartitionedFileSet``. This is an experimental new dataset type, introduced in CDAP 2.7.1. This
   dataset manages the files in a ``FileSet`` by associating each file with a time stamp.
 - The properties are divided in two sections:
 

--- a/cdap-docs/integrations/source/partners/cloudera/configuring.txt
+++ b/cdap-docs/integrations/source/partners/cloudera/configuring.txt
@@ -71,7 +71,7 @@ Prerequisites
 Download
 =======================================
 
-Download the CDAP CSD (Custom Service Descriptor): `download JAR file <http://repository.cask.co/downloads/co/cask/cdap/csd/2.7.0/CDAP-2.7.0-1.jar>`__.
+Download the CDAP CSD (Custom Service Descriptor): `download JAR file <http://cask.co/resources/#cdap-integrations>`__.
 
 Details on CSDs and Cloudera Manager Extensions are `available online 
 <https://github.com/cloudera/cm_ext/wiki>`__.

--- a/cdap-docs/reference-manual/source/release-notes.rst
+++ b/cdap-docs/reference-manual/source/release-notes.rst
@@ -24,7 +24,7 @@ Cask Data Application Platform Release Notes
    :depth: 2
 
 
-`Release 2.7.0 <http://docs.cask.co/cdap/2.7.0/index.html>`__
+`Release 2.7.1 <http://docs.cask.co/cdap/2.7.1/index.html>`__
 =============================================================
 
 API Changes
@@ -70,7 +70,7 @@ New Features
 Known Issues
 ------------
 - See also the *Known Issues* of `version 2.6.1. <#known-issues-261>`_
-- When upgrading an existing CDAP installation to 2.7.0, all metrics are reset.
+- When upgrading an existing CDAP installation to 2.7.1, all metrics are reset.
 
 
 `Release 2.6.1 <http://docs.cask.co/cdap/2.6.1/index.html>`__


### PR DESCRIPTION
Replaces references to "2.7.0" with either references to non-versioned links or to 2.7.1