### PR TITLE
[CDAP-1376] Introduced HBase namespaces in compat modules

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseTableUtil.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseTableUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -19,6 +19,7 @@ package co.cask.cdap.data2.util.hbase;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.data2.transaction.queue.hbase.HBaseQueueAdmin;
 import co.cask.cdap.hbase.wd.AbstractRowKeyDistributor;
+import co.cask.cdap.proto.Id;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
 import com.google.common.base.Throwables;
@@ -36,6 +37,7 @@ import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.TableExistsException;
 import org.apache.hadoop.hbase.client.HBaseAdmin;
+import org.apache.hadoop.hbase.client.HTable;
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 import org.apache.twill.filesystem.Location;
 import org.apache.twill.internal.utils.Dependencies;
@@ -384,6 +386,71 @@ public abstract class HBaseTableUtil {
 
     return info;
   }
+
+  protected String toHBaseNamespace(Id.Namespace namespace) {
+    return "cdap_" + namespace.getId();
+  }
+
+  /**
+   * Returns if the current version of HBase supports namespaces
+   *
+   * @return true if namespaces are supported, false otherwise
+   */
+  public abstract boolean namespacesSupported();
+
+  /**
+   * Creates a new {@link HTable} which may contain an HBase namespace depending on the HBase version
+   *
+   * @param conf the hadoop configuration
+   * @param tableId the {@link TableId} to create an {@link HTable} for
+   * @return an {@link HTable} for the tableName in the namespace
+   */
+  public abstract HTable getHTable(Configuration conf, TableId tableId) throws IOException;
+
+  /**
+   * Creates a new {@link HTableDescriptor} which may contain an HBase namespace depending on the HBase version
+   *
+   * @param tableId the {@link TableId} to create an {@link HTableDescriptor} for
+   * @return an {@link HTableDescriptor} for the tableName in the namespace
+   */
+  public abstract HTableDescriptor getHTableDescriptor(TableId tableId);
+
+  /**
+   * Checks if an HBase namespace already exists
+   *
+   * @param admin the {@link HBaseAdmin} to use to communicate with HBase
+   * @param namespace the {@link Id.Namespace} to check for existence
+   * @throws IOException if an I/O error occurs during the operation
+   */
+  public abstract boolean hasNamespace(HBaseAdmin admin, Id.Namespace namespace) throws IOException;
+
+  /**
+   * Creates an HBase namespace, if it does not already exist
+   * This method uses {@link Id.Namespace} here to cover for a future case when CDAP namespaces may push down namespace
+   * properties to HBase
+   *
+   * @param admin the {@link HBaseAdmin} to use to communicate with HBase
+   * @param namespace the {@link Id.Namespace} to create
+   * @throws IOException if an I/O error occurs during the operation
+   */
+  public abstract void createNamespaceIfNotExists(HBaseAdmin admin, Id.Namespace namespace) throws IOException;
+
+  /**
+   * Creates an HBase namespace, if it exists
+   *
+   * @param admin the {@link HBaseAdmin} to use to communicate with HBase
+   * @param namespace the {@link Id.Namespace} to delete
+   * @throws IOException if an I/O error occurs during the operation
+   */
+  public abstract void deleteNamespaceIfExists(HBaseAdmin admin, Id.Namespace namespace) throws IOException;
+
+  /**
+   * Returns the fully qualified table name containing namespace
+   *
+   * @param tableId the identifier for the table containing namespace and table name
+   * @return the fully qualified table name containing namespace
+   */
+  public abstract String getTableNameWithNamespace(TableId tableId);
 
   public abstract void setCompression(HColumnDescriptor columnDescriptor, CompressionType type);
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/TableId.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/TableId.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import co.cask.cdap.proto.Id;
+import com.google.common.base.Objects;
+import com.google.common.base.Preconditions;
+
+/**
+ * Identifier for an HBase tables that contains namespace and a table name
+ */
+public class TableId {
+  private final Id.Namespace namespace;
+  private final String tableName;
+
+  private TableId(Id.Namespace namespace, String tableName) {
+    this.namespace = namespace;
+    this.tableName = tableName;
+  }
+
+  public Id.Namespace getNamespace() {
+    return namespace;
+  }
+
+  public String getTableName() {
+    return tableName;
+  }
+
+  public static TableId from(String namespace, String tableName) {
+    Preconditions.checkArgument(tableName != null, "Table name should not be null.");
+    // Id.Namespace already checks for non-null namespace
+    return new TableId(Id.Namespace.from(namespace), tableName);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof TableId)) {
+      return false;
+    }
+
+    TableId that = (TableId) o;
+    return Objects.equal(namespace, that.getNamespace()) &&
+      Objects.equal(tableName, that.getTableName());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(namespace, tableName);
+  }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(this)
+      .add("namespace", namespace)
+      .add("tableName", tableName)
+      .toString();
+  }
+}

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/util/hbase/AbstractHBaseTableUtilTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/util/hbase/AbstractHBaseTableUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -19,11 +19,13 @@ package co.cask.cdap.data2.util.hbase;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.data.hbase.HBaseTestBase;
 import co.cask.cdap.data.hbase.HBaseTestFactory;
+import co.cask.cdap.proto.Id;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.client.HBaseAdmin;
 import org.apache.hadoop.hbase.client.HTable;
 import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.constraint.ConstraintException;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -65,39 +67,67 @@ public abstract class AbstractHBaseTableUtilTest {
 
   @Test
   public void testTableSizeMetrics() throws Exception {
-    Assert.assertNull(getTableStats("table1"));
-    Assert.assertNull(getTableStats("table2"));
-    Assert.assertNull(getTableStats("table3"));
+    HBaseTableUtil tableUtil = getTableUtil();
+    // namespace should not exist
+    if (tableUtil.namespacesSupported()) {
+      Assert.assertFalse(tableUtil.hasNamespace(hAdmin, Id.Namespace.from("namespace")));
+    }
 
-    create("table1");
-    create("table2");
-    create("table3");
+    Assert.assertNull(getTableStats("namespace", "table1"));
+    Assert.assertNull(getTableStats("namespace", "table2"));
+    Assert.assertNull(getTableStats("namespace", "table3"));
 
-    waitForMetricsToUpdate();
+    if (tableUtil.namespacesSupported()) {
+      createNamespace("namespace");
+      Assert.assertTrue(tableUtil.hasNamespace(hAdmin, Id.Namespace.from("namespace")));
+    }
 
-    Assert.assertEquals(0, getTableStats("table1").getTotalSizeMB());
-    Assert.assertEquals(0, getTableStats("table2").getTotalSizeMB());
-    Assert.assertEquals(0, getTableStats("table3").getTotalSizeMB());
-
-    writeSome("table2");
-    writeSome("table3");
-
-    waitForMetricsToUpdate();
-
-    Assert.assertEquals(0, getTableStats("table1").getTotalSizeMB());
-    Assert.assertTrue(getTableStats("table2").getTotalSizeMB() > 0);
-    Assert.assertTrue(getTableStats("table3").getTotalSizeMB() > 0);
-
-    drop("table1");
-    testHBase.forceRegionFlush(Bytes.toBytes("table2"));
-    truncate("table3");
+    create("namespace", "table1");
+    create("namespace", "table2");
+    create("namespace", "table3");
 
     waitForMetricsToUpdate();
 
-    Assert.assertNull(getTableStats("table1"));
-    Assert.assertTrue(getTableStats("table2").getTotalSizeMB() > 0);
-    Assert.assertTrue(getTableStats("table2").getStoreFileSizeMB() > 0);
-    Assert.assertEquals(0, getTableStats("table3").getTotalSizeMB());
+    Assert.assertEquals(0, getTableStats("namespace", "table1").getTotalSizeMB());
+    Assert.assertEquals(0, getTableStats("namespace", "table2").getTotalSizeMB());
+    Assert.assertEquals(0, getTableStats("namespace", "table3").getTotalSizeMB());
+
+    writeSome("namespace", "table2");
+    writeSome("namespace", "table3");
+
+    waitForMetricsToUpdate();
+
+    Assert.assertEquals(0, getTableStats("namespace", "table1").getTotalSizeMB());
+    Assert.assertTrue(getTableStats("namespace", "table2").getTotalSizeMB() > 0);
+    Assert.assertTrue(getTableStats("namespace", "table3").getTotalSizeMB() > 0);
+
+    drop("namespace", "table1");
+    //TODO: TestHBase methods should eventually accept namespace as a param, but will add them incrementally
+    testHBase.forceRegionFlush(Bytes.toBytes(tableUtil.getTableNameWithNamespace(TableId.from("namespace", "table2"))));
+    truncate("namespace", "table3");
+
+    waitForMetricsToUpdate();
+
+    Assert.assertNull(getTableStats("namespace", "table1"));
+    Assert.assertTrue(getTableStats("namespace", "table2").getTotalSizeMB() > 0);
+    Assert.assertTrue(getTableStats("namespace", "table2").getStoreFileSizeMB() > 0);
+    Assert.assertEquals(0, getTableStats("namespace", "table3").getTotalSizeMB());
+
+    if (tableUtil.namespacesSupported()) {
+      try {
+        deleteNamespace("namespace");
+        Assert.fail("Should not be able to delete a non-empty namespace.");
+      } catch (ConstraintException e) {
+      }
+    }
+
+    drop("namespace", "table2");
+    drop("namespace", "table3");
+
+    if (tableUtil.namespacesSupported()) {
+      deleteNamespace("namespace");
+      Assert.assertFalse(tableUtil.hasNamespace(hAdmin, Id.Namespace.from("namespace")));
+    }
   }
 
   private void waitForMetricsToUpdate() throws InterruptedException {
@@ -107,8 +137,8 @@ public abstract class AbstractHBaseTableUtilTest {
     TimeUnit.SECONDS.sleep(4);
   }
 
-  private void writeSome(String tableName) throws IOException {
-    HTable table = new HTable(testHBase.getConfiguration(), tableName);
+  private void writeSome(String namespace, String tableName) throws IOException {
+    HTable table = getTableUtil().getHTable(testHBase.getConfiguration(), TableId.from(namespace, tableName));
     try {
       // writing at least couple megs to reflect in "megabyte"-based metrics
       for (int i = 0; i < 8; i++) {
@@ -121,25 +151,40 @@ public abstract class AbstractHBaseTableUtilTest {
     }
   }
 
-  private void create(String tableName) throws IOException {
-    HTableDescriptor desc = new HTableDescriptor(tableName);
-    desc.addFamily(new HColumnDescriptor("d"));
-    getTableUtil().createTableIfNotExists(hAdmin, tableName, desc);
+  private void createNamespace(String namespace) throws IOException {
+    getTableUtil().createNamespaceIfNotExists(hAdmin, Id.Namespace.from(namespace));
   }
 
-  private void truncate(String tableName) throws IOException {
-    HTableDescriptor tableDescriptor = hAdmin.getTableDescriptor(Bytes.toBytes(tableName));
-    hAdmin.disableTable(tableName);
-    hAdmin.deleteTable(tableName);
+  private void deleteNamespace(String namespace) throws IOException {
+    getTableUtil().deleteNamespaceIfExists(hAdmin, Id.Namespace.from(namespace));
+  }
+
+  private void create(String namespace, String tableName) throws IOException {
+    HBaseTableUtil tableUtil = getTableUtil();
+    HTableDescriptor desc = tableUtil.getHTableDescriptor(TableId.from(namespace, tableName));
+    desc.addFamily(new HColumnDescriptor("d"));
+    tableUtil.createTableIfNotExists(hAdmin, tableName, desc);
+  }
+
+  private void truncate(String namespace, String tableName) throws IOException {
+    HBaseTableUtil tableUtil = getTableUtil();
+    HTableDescriptor tableDescriptor = tableUtil.getHTableDescriptor(TableId.from(namespace, tableName));
+    TableId tableId = TableId.from(namespace, tableName);
+    hAdmin.disableTable(tableUtil.getTableNameWithNamespace(tableId));
+    hAdmin.deleteTable(tableUtil.getTableNameWithNamespace(tableId));
     hAdmin.createTable(tableDescriptor);
   }
 
-  private void drop(String tableName) throws IOException {
-    hAdmin.disableTable(tableName);
-    hAdmin.deleteTable(tableName);
+  private void drop(String namespace, String tableName) throws IOException {
+    HBaseTableUtil tableUtil = getTableUtil();
+    TableId tableId = TableId.from(namespace, tableName);
+    hAdmin.disableTable(tableUtil.getTableNameWithNamespace(tableId));
+    hAdmin.deleteTable(tableUtil.getTableNameWithNamespace(tableId));
   }
 
-  private HBaseTableUtil.TableStats getTableStats(String tableName) throws IOException {
-    return getTableUtil().getTableStats(hAdmin).get(tableName);
+  private HBaseTableUtil.TableStats getTableStats(String namespace, String tableName) throws IOException {
+    HBaseTableUtil tableUtil = getTableUtil();
+    TableId tableId = TableId.from(namespace, tableName);
+    return tableUtil.getTableStats(hAdmin).get(tableUtil.getTableNameWithNamespace(tableId));
   }
 }

--- a/cdap-hbase-compat-0.94/src/main/java/co/cask/cdap/data2/util/hbase/HBase94TableUtil.java
+++ b/cdap-hbase-compat-0.94/src/main/java/co/cask/cdap/data2/util/hbase/HBase94TableUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -21,14 +21,20 @@ import co.cask.cdap.data2.increment.hbase94.IncrementHandler;
 import co.cask.cdap.data2.transaction.coprocessor.hbase94.DefaultTransactionProcessor;
 import co.cask.cdap.data2.transaction.queue.coprocessor.hbase94.DequeueScanObserver;
 import co.cask.cdap.data2.transaction.queue.coprocessor.hbase94.HBaseQueueRegionObserver;
+import co.cask.cdap.proto.Id;
+import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.ClusterStatus;
 import org.apache.hadoop.hbase.Coprocessor;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HRegionInfo;
 import org.apache.hadoop.hbase.HServerLoad;
+import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.ServerName;
 import org.apache.hadoop.hbase.client.HBaseAdmin;
+import org.apache.hadoop.hbase.client.HTable;
 import org.apache.hadoop.hbase.io.hfile.Compression;
 import org.apache.hadoop.hbase.regionserver.StoreFile;
 
@@ -39,6 +45,45 @@ import java.util.Map;
  *
  */
 public class HBase94TableUtil extends HBaseTableUtil {
+
+  @Override
+  public boolean namespacesSupported() {
+    return false;
+  }
+
+  @Override
+  public HTable getHTable(Configuration conf, TableId tableId) throws IOException {
+    Preconditions.checkArgument(tableId != null, "Table id should not be null");
+    return new HTable(conf, getTableNameWithNamespace(tableId));
+  }
+
+  @Override
+  public HTableDescriptor getHTableDescriptor(TableId tableId) {
+    Preconditions.checkArgument(tableId != null, "Table id should not be null");
+    return new HTableDescriptor(getTableNameWithNamespace(tableId));
+  }
+
+  @Override
+  public boolean hasNamespace(HBaseAdmin admin, Id.Namespace namespace) throws IOException {
+    return true;
+  }
+
+  @Override
+  public void createNamespaceIfNotExists(HBaseAdmin admin, Id.Namespace namespace) throws IOException {
+    // No-op.
+  }
+
+  @Override
+  public void deleteNamespaceIfExists(HBaseAdmin admin, Id.Namespace namespace) throws IOException {
+    // No-op
+  }
+
+  @Override
+  public String getTableNameWithNamespace(TableId tableId) {
+    Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
+    return Joiner.on(".").join(toHBaseNamespace(tableId.getNamespace()), tableId.getTableName());
+  }
+
   @Override
   public void setCompression(HColumnDescriptor columnDescriptor, CompressionType type) {
     switch (type) {

--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/util/hbase/HBase96TableUtil.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/util/hbase/HBase96TableUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -21,14 +21,23 @@ import co.cask.cdap.data2.increment.hbase96.IncrementHandler;
 import co.cask.cdap.data2.transaction.coprocessor.hbase96.DefaultTransactionProcessor;
 import co.cask.cdap.data2.transaction.queue.coprocessor.hbase96.DequeueScanObserver;
 import co.cask.cdap.data2.transaction.queue.coprocessor.hbase96.HBaseQueueRegionObserver;
+import co.cask.cdap.proto.Id;
+import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.ClusterStatus;
 import org.apache.hadoop.hbase.Coprocessor;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HRegionInfo;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.NamespaceDescriptor;
+import org.apache.hadoop.hbase.NamespaceNotFoundException;
 import org.apache.hadoop.hbase.RegionLoad;
 import org.apache.hadoop.hbase.ServerName;
+import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.HBaseAdmin;
+import org.apache.hadoop.hbase.client.HTable;
 import org.apache.hadoop.hbase.io.compress.Compression;
 
 import java.io.IOException;
@@ -38,6 +47,62 @@ import java.util.Map;
  *
  */
 public class HBase96TableUtil extends HBaseTableUtil {
+
+  @Override
+  public boolean namespacesSupported() {
+    return true;
+  }
+
+  @Override
+  public HTable getHTable(Configuration conf, TableId tableId) throws IOException {
+    Preconditions.checkArgument(tableId != null, "Table id should not be null");
+    return new HTable(conf, TableName.valueOf(toHBaseNamespace(tableId.getNamespace()), tableId.getTableName()));
+  }
+
+  @Override
+  public HTableDescriptor getHTableDescriptor(TableId tableId) {
+    Preconditions.checkArgument(tableId != null, "Table id should not be null");
+    return new HTableDescriptor(TableName.valueOf(toHBaseNamespace(tableId.getNamespace()), tableId.getTableName()));
+  }
+
+  @Override
+  public boolean hasNamespace(HBaseAdmin admin, Id.Namespace namespace) throws IOException {
+    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
+    Preconditions.checkArgument(namespace != null, "Namespace should not be null.");
+    try {
+      admin.getNamespaceDescriptor(toHBaseNamespace(namespace));
+      return true;
+    } catch (NamespaceNotFoundException e) {
+      return false;
+    }
+  }
+
+  @Override
+  public void createNamespaceIfNotExists(HBaseAdmin admin, Id.Namespace namespace) throws IOException {
+    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
+    Preconditions.checkArgument(namespace != null, "Namespace should not be null.");
+    if (!hasNamespace(admin, namespace)) {
+      NamespaceDescriptor namespaceDescriptor =
+        NamespaceDescriptor.create(toHBaseNamespace(namespace)).build();
+      admin.createNamespace(namespaceDescriptor);
+    }
+  }
+
+  @Override
+  public void deleteNamespaceIfExists(HBaseAdmin admin, Id.Namespace namespace) throws IOException {
+    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
+    Preconditions.checkArgument(namespace != null, "Namespace should not be null.");
+    if (hasNamespace(admin, namespace)) {
+      admin.deleteNamespace(toHBaseNamespace(namespace));
+    }
+  }
+
+  @Override
+  public String getTableNameWithNamespace(TableId tableId) {
+    Preconditions.checkArgument(tableId != null, "Table id should not be null.");
+    return Joiner.on(':').join(toHBaseNamespace(tableId.getNamespace()), tableId.getTableName());
+  }
+
   @Override
   public void setCompression(HColumnDescriptor columnDescriptor, CompressionType type) {
     switch (type) {


### PR DESCRIPTION
# Summary
Adds preliminary APIs in ``HBaseTableUtil`` to use HBase namespaces. Updated unit test to use APIs.

Currently tested on a .98 cluster to ensure that the *configuration* table gets created in the *cdap_system* HBase namespace. (Those changes are not included in this PR, this PR only contains new APIs in compat modules).

These APIs will evolve till we complete the namespaces work in datasets. To summarize, the APIs manage HBase namespaces, as well as help construct ``HTableDescriptor`` and ``HTable`` objects using ``TableName`` objects if they are available in specific HBase versions. Otherwise, the ``HTableDescriptor`` and ``HTable`` objects are created using String prefixes.

# New APIs in ``HBaseTableUtil``
```
boolean namespacesSupported()
HTableDescriptor getHTableDescriptor(TableId tableId)
HTable getHTable(Configuration conf, TableId tableId)
void createNamespace(Id.Namespace namespace)
void deleteNamespace(Id.Namespace namespace)
boolean hasNamespace(HBaseAdmin admin, Id.Namespace namespace)
String getTableNameWithNamespace(TableId tableId)
```


Build: https://builds.cask.co/browse/CDAP-DUT721-1