### PR TITLE
[CDAP-1369] Create/delete namespace directories on namespace create/dele...

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/program/Programs.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/program/Programs.java
@@ -60,22 +60,26 @@ public final class Programs {
    * Get program location
    *
    * @param factory  location factory
-   * @param filePath app fabric output directory path
+   * @param appFabricDir app fabric output directory path
    * @param id       program id
    * @param type     type of the program
    * @return         Location corresponding to the program id
    * @throws IOException incase of errors
    */
-  public static Location programLocation(LocationFactory factory, String filePath, Id.Program id, ProgramType type)
+  public static Location programLocation(LocationFactory factory, String appFabricDir, Id.Program id, ProgramType type)
                                          throws IOException {
-    Location allAppsLocation = factory.create(filePath);
+    Location namespaceHome = factory.create(id.getNamespaceId());
+    if (!namespaceHome.exists()) {
+      throw new FileNotFoundException("Unable to locate the Program, namespace location doesn't exist: " +
+                                        namespaceHome.toURI().getPath());
+    }
+    Location appFabricLocation = namespaceHome.append(appFabricDir);
 
-    Location accountAppsLocation = allAppsLocation.append(id.getNamespaceId());
-    String name = String.format(Locale.ENGLISH, "%s/%s", type.toString(), id.getApplicationId());
-    Location applicationProgramsLocation = accountAppsLocation.append(name);
+    String name = String.format(Locale.ENGLISH, "%s/%s", id.getApplicationId(), type.toString());
+    Location applicationProgramsLocation = appFabricLocation.append(name);
     if (!applicationProgramsLocation.exists()) {
-      throw new FileNotFoundException("Unable to locate the Program,  location doesn't exist: "
-                                   + applicationProgramsLocation.toURI().getPath());
+      throw new FileNotFoundException("Unable to locate the Program,  location doesn't exist: " +
+                                        applicationProgramsLocation.toURI().getPath());
     }
     Location programLocation = applicationProgramsLocation.append(String.format("%s.jar", id.getId()));
     if (!programLocation.exists()) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/ProgramGenerationStage.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/ProgramGenerationStage.java
@@ -30,6 +30,7 @@ import co.cask.cdap.internal.app.runtime.webapp.WebappProgramRunner;
 import co.cask.cdap.pipeline.AbstractStage;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.ProgramTypes;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -70,13 +71,17 @@ public class ProgramGenerationStage extends AbstractStage<ApplicationDeployable>
 
     final ArchiveBundler bundler = new ArchiveBundler(input.getLocation());
 
+    // Make sure the namespace directory exists
+    String namespace = input.getId().getNamespaceId();
+    Location namespaceDir = locationFactory.create(namespace);
+    // Note: deployApplication/deployAdapters have already checked for namespaceDir existence, so not checking again
     // Make sure we have a directory to store the original artifact.
-    Location outputDir = locationFactory.create(configuration.get(Constants.AppFabric.OUTPUT_DIR));
-    final Location newOutputDir = outputDir.append(input.getId().getNamespaceId());
+    Location appFabricDir = namespaceDir.append(configuration.get(Constants.AppFabric.OUTPUT_DIR));
+    final Location newOutputDir = appFabricDir;
 
     // Check exists, create, check exists again to avoid failure due to race condition.
     if (!newOutputDir.exists() && !newOutputDir.mkdirs() && !newOutputDir.exists()) {
-      throw new IOException("Failed to create directory");
+      throw new IOException(String.format("Failed to create directory %s", newOutputDir.toURI().getPath()));
     }
 
     // Now, we iterate through all ProgramSpecification and generate programs
@@ -109,7 +114,7 @@ public class ProgramGenerationStage extends AbstractStage<ApplicationDeployable>
           @Override
           public Location call() throws Exception {
             ProgramType type = ProgramTypes.fromSpecification(spec);
-            String name = String.format(Locale.ENGLISH, "%s/%s", type, applicationName);
+            String name = String.format(Locale.ENGLISH, "%s/%s", applicationName, type);
             Location programDir = newOutputDir.append(name);
             if (!programDir.exists()) {
               programDir.mkdirs();
@@ -129,8 +134,37 @@ public class ProgramGenerationStage extends AbstractStage<ApplicationDeployable>
       executorService.shutdown();
     }
 
+    // moves the <appfabricdir>/archive/<app-name>.jar to <appfabricdir>/<app-name>/archive/<app-name>.jar
+    // Cannot do this before starting the deploy pipeline because appId could be null at that time.
+    // However, it is guaranteed to be non-null from VerificationsStage onwards
+    moveAppArchiveUnderAppDirectory(input.getLocation(), applicationName);
+
     // Emits the received specification with programs.
     emit(new ApplicationWithPrograms(input, programs.build()));
+  }
+
+  private void moveAppArchiveUnderAppDirectory(Location origArchiveLocation, String appName) throws IOException {
+    // Move archive directory under application directory.
+    Location oldArchiveDir = Locations.getParent(origArchiveLocation);
+    Preconditions.checkState(oldArchiveDir != null, "Application archive is not expected to be in the root directory.");
+    String archiveParentDirName = oldArchiveDir.getName();
+    Location appFabricOutputLocation = Locations.getParent(oldArchiveDir);
+    Preconditions.checkState(appFabricOutputLocation != null,
+                             "App Fabric output directory is not expected to be filesystem root");
+    Location applicationArchiveDir = appFabricOutputLocation.append(appName);
+    // This directory should already be created by now.
+    // However, it may not be present during unit tests that do not go through the create namespace -> deploy app path
+    Locations.mkdirsIfNotExists(applicationArchiveDir);
+    Location newArchiveLocation = applicationArchiveDir.append(archiveParentDirName);
+    if (newArchiveLocation.exists()) {
+      // this is from an older deployment
+      newArchiveLocation.delete(true);
+    }
+    if (oldArchiveDir.renameTo(newArchiveLocation) == null) {
+      throw new IOException(String.format("Could not move archive from location: %s, to location: %s",
+                                          oldArchiveDir.toURI(), newArchiveLocation.toURI()));
+    }
+
   }
 
   private WebappSpecification createWebappSpec(final String name) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/NamespaceAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/NamespaceAdmin.java
@@ -21,6 +21,7 @@ import co.cask.cdap.common.exception.NotFoundException;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 
+import java.io.IOException;
 import java.util.List;
 
 /**
@@ -58,7 +59,7 @@ public interface NamespaceAdmin {
    * @param metadata the {@link NamespaceMeta} for the new namespace to be created
    * @throws AlreadyExistsException if the specified namespace already exists
    */
-  public void createNamespace(NamespaceMeta metadata) throws AlreadyExistsException;
+  public void createNamespace(NamespaceMeta metadata) throws AlreadyExistsException, IOException;
 
   /**
    * Deletes the specified namespace
@@ -66,5 +67,5 @@ public interface NamespaceAdmin {
    * @param namespaceId the {@link Id.Namespace} of the specified namespace
    * @throws NotFoundException if the specified namespace does not exist
    */
-  public void deleteNamespace(Id.Namespace namespaceId) throws NotFoundException;
+  public void deleteNamespace(Id.Namespace namespaceId) throws NotFoundException, IOException;
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdminTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdminTest.java
@@ -24,6 +24,8 @@ import co.cask.cdap.proto.NamespaceMeta;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.IOException;
+
 /**
  * Tests for {@link DefaultNamespaceAdmin}
  */
@@ -31,7 +33,7 @@ public class DefaultNamespaceAdminTest extends AppFabricTestBase {
   private static final NamespaceAdmin namespaceAdmin = getInjector().getInstance(NamespaceAdmin.class);
 
   @Test
-  public void testNamespaces() throws AlreadyExistsException {
+  public void testNamespaces() throws AlreadyExistsException, IOException {
     String namespace = "namespace";
     Id.Namespace namespaceId = Id.Namespace.from(namespace);
     NamespaceMeta.Builder builder = new NamespaceMeta.Builder();

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/adapter/AdapterServiceTests.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/adapter/AdapterServiceTests.java
@@ -65,9 +65,6 @@ public class AdapterServiceTests extends AppFabricTestBase {
 
   @Test
   public void testAdapters() throws Exception {
-    //Basic adapter service tests.
-    String namespaceId = Constants.DEFAULT_NAMESPACE;
-
     ImmutableMap<String, String> properties = ImmutableMap.of("frequency", "1m");
     ImmutableMap<String, String> sourceProperties = ImmutableMap.of();
     ImmutableMap<String, String> sinkProperties = ImmutableMap.of("dataset.class", FileSet.class.getName());
@@ -79,35 +76,35 @@ public class AdapterServiceTests extends AppFabricTestBase {
                                ImmutableSet.of(new Sink("mySink", Sink.Type.DATASET, sinkProperties)));
 
     // Create Adapter
-    adapterService.createAdapter(namespaceId, adapterSpecification);
+    adapterService.createAdapter(TEST_NAMESPACE1, adapterSpecification);
     PreferencesStore preferencesStore = getInjector().getInstance(PreferencesStore.class);
-    Map<String, String> prop = preferencesStore.getResolvedProperties(namespaceId, adapterSpecification.getType());
+    Map<String, String> prop = preferencesStore.getResolvedProperties(TEST_NAMESPACE1, adapterSpecification.getType());
     Assert.assertTrue(Boolean.parseBoolean(prop.get(ProgramOptionConstants.CONCURRENT_RUNS_ENABLED)));
     try {
       // Expect another call to create Adapter with the same adapterName to throw an AdapterAlreadyExistsException.
-      adapterService.createAdapter(namespaceId, adapterSpecification);
+      adapterService.createAdapter(TEST_NAMESPACE1, adapterSpecification);
       Assert.fail("Second call to create adapter with same adapterName did not throw AdapterAlreadyExistsException.");
     } catch (AdapterAlreadyExistsException expected) {
     }
 
-    AdapterSpecification actualAdapterSpec = adapterService.getAdapter(namespaceId, adapterName);
+    AdapterSpecification actualAdapterSpec = adapterService.getAdapter(TEST_NAMESPACE1, adapterName);
     Assert.assertNotNull(actualAdapterSpec);
     Assert.assertEquals(adapterSpecification, actualAdapterSpec);
 
     // list all adapters
-    Collection<AdapterSpecification> adapters = adapterService.getAdapters(namespaceId);
+    Collection<AdapterSpecification> adapters = adapterService.getAdapters(TEST_NAMESPACE1);
     Assert.assertArrayEquals(new AdapterSpecification[] {adapterSpecification}, adapters.toArray());
 
     // Delete Adapter
-    adapterService.removeAdapter(namespaceId, "myAdapter");
+    adapterService.removeAdapter(TEST_NAMESPACE1, "myAdapter");
     // verify that the adapter is deleted
     try {
-      adapterService.getAdapter(namespaceId, adapterName);
+      adapterService.getAdapter(TEST_NAMESPACE1, adapterName);
       Assert.fail(String.format("Found adapterSpec with name %s; it should be deleted.", adapterName));
     } catch (AdapterNotFoundException expected) {
     }
 
-    adapters = adapterService.getAdapters(namespaceId);
+    adapters = adapterService.getAdapters(TEST_NAMESPACE1);
     Assert.assertTrue(adapters.isEmpty());
   }
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AppFabricTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AppFabricTestBase.java
@@ -27,7 +27,6 @@ import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetOpExecutor;
 import co.cask.cdap.internal.app.services.AppFabricServer;
 import co.cask.cdap.metrics.query.MetricsQueryService;
 import co.cask.cdap.proto.NamespaceMeta;
-import co.cask.cdap.test.internal.TempFolder;
 import co.cask.cdap.test.internal.guice.AppFabricTestModule;
 import co.cask.tephra.TransactionManager;
 import co.cask.tephra.TransactionSystemClient;
@@ -63,6 +62,8 @@ import org.jboss.netty.handler.codec.http.HttpHeaders;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -115,16 +116,19 @@ public abstract class AppFabricTestBase {
   private static DatasetService datasetService;
   private static TransactionSystemClient txClient;
   private static StreamCoordinatorClient streamCoordinatorClient;
-  private static final TempFolder TEMP_FOLDER = new TempFolder();
   private static final String adapterFolder = "adapter";
+
+  @ClassRule
+  public static TemporaryFolder tmpFolder = new TemporaryFolder();
 
   @BeforeClass
   public static void beforeClass() throws Throwable {
-    File adapterDir = TEMP_FOLDER.newFolder(adapterFolder);
+    File adapterDir = tmpFolder.newFolder(adapterFolder);
 
     CConfiguration conf = CConfiguration.create();
 
     conf.set(Constants.AppFabric.SERVER_ADDRESS, hostname);
+    conf.set(Constants.CFG_LOCAL_DATA_DIR, tmpFolder.newFolder("data").getAbsolutePath());
     conf.set(Constants.AppFabric.OUTPUT_DIR, System.getProperty("java.io.tmpdir"));
     conf.set(Constants.AppFabric.TEMP_DIR, System.getProperty("java.io.tmpdir"));
 
@@ -163,7 +167,6 @@ public abstract class AppFabricTestBase {
     datasetService.stopAndWait();
     dsOpService.stopAndWait();
     txManager.stopAndWait();
-    TEMP_FOLDER.delete();
   }
 
   protected static Injector getInjector() {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/AppLifecycleHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/AppLifecycleHttpHandlerTest.java
@@ -41,7 +41,7 @@ public class AppLifecycleHttpHandlerTest extends AppFabricTestBase {
   public void testDeployNonExistingNamespace() throws Exception {
     HttpResponse response = deploy(WordCountApp.class, Constants.Gateway.API_VERSION_3_TOKEN, "random");
     Assert.assertEquals(404, response.getStatusLine().getStatusCode());
-    Assert.assertEquals("Deploy failed - namespace 'random' does not exist.", readResponse(response));
+    Assert.assertEquals("Deploy failed - namespace 'random' not found.", readResponse(response));
   }
 
   /**

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/DefaultStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/DefaultStoreTest.java
@@ -68,6 +68,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import com.google.inject.Injector;
 import org.apache.twill.filesystem.LocalLocationFactory;
+import org.apache.twill.filesystem.LocationFactory;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -93,6 +94,8 @@ public class DefaultStoreTest {
   @Before
   public void before() throws Exception {
     store.clear();
+    LocationFactory locationFactory = AppFabricTestHelper.getInjector().getInstance(LocationFactory.class);
+    locationFactory.create(Constants.DEFAULT_NAMESPACE).delete(true);
   }
 
   @Test

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -120,6 +120,8 @@ public final class Constants {
     public static final int DEFAULT_HISTORY_RESULTS_LIMIT = 100;
 
     public static final String SERVICE_DESCRIPTION = "Service for managing application lifecycle.";
+
+    public static final String ARCHIVE_DIR = "archive";
   }
 
   /**


### PR DESCRIPTION
...te. Re-org CDAP directory structure

Summary:
1. Creates ``<cdap_root>/<namespace-id>`` directory on namespace create
2. Deletes ``<cdap_root>/<namespace-id>`` directory on namespace delete
3. Underlying directory structure:
```
<cdap_root>/<namespace-id>
<cdap_root>/<namespace-id>/${app.output.dir}
<cdap_root>/<namespace-id>/${app.output.dir}/PurchaseHistory
<cdap_root>/<namespace-id>/${app.output.dir}/PurchaseHistory/Flow/PurchaseFlow.jar
<cdap_root>/<namespace-id>/${app.output.dir}/PurchaseHistory/Mapreduce/PurchaseHistoryBuilder.jar
<cdap_root>/<namespace-id>/${app.output.dir}/PurchaseHistory/Service/CatalogLookup.jar
<cdap_root>/<namespace-id>/${app.output.dir}/PurchaseHistory/Workflow/PurchaseHistoryWorkflow.jar
<cdap_root>/<namespace-id>/${app.output.dir}/PurchaseHistory/archive/Purchase-2.8.0-SNAPSHOT.jar
<cdap_root>/<namespace-id>/tmp:
```

There will be follow up PRs for similar directory structure changes for logs, datasets, streams and system lib directories.