### PR TITLE
CDAP-1411 refactor reflection writer/reader classes so that they

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionDatumReader.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionDatumReader.java
@@ -18,23 +18,16 @@ package co.cask.cdap.internal.io;
 
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.common.io.Decoder;
-import co.cask.cdap.common.lang.Instantiator;
-import co.cask.cdap.common.lang.InstantiatorFactory;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Maps;
-import com.google.common.primitives.Longs;
 import com.google.common.reflect.TypeToken;
 
 import java.io.IOException;
 import java.lang.reflect.Array;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.net.URI;
-import java.net.URL;
 import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Map;
-import java.util.UUID;
 
 /**
  * Reflection based Datnum Reader.
@@ -45,384 +38,256 @@ public final class ReflectionDatumReader<T> implements DatumReader<T> {
 
   private final Schema schema;
   private final TypeToken<T> type;
-  private final Map<Class<?>, Instantiator<?>> creators;
-  private final InstantiatorFactory creatorFactory;
-  private final FieldAccessorFactory fieldAccessorFactory;
 
-  @SuppressWarnings("unchecked")
   public ReflectionDatumReader(Schema schema, TypeToken<T> type) {
     this.schema = schema;
     this.type = type;
-    this.creatorFactory = new InstantiatorFactory(true);
-    this.creators = Maps.newIdentityHashMap();
-    this.fieldAccessorFactory = new ReflectionFieldAccessorFactory();
   }
 
   @SuppressWarnings("unchecked")
   @Override
   public T read(Decoder decoder, Schema sourceSchema) throws IOException {
-    return (T) read(decoder, sourceSchema, schema, type);
+    return new DecoderReflectionReader<T>(decoder).read(sourceSchema, schema, type);
   }
 
-  private Object read(Decoder decoder, Schema sourceSchema,
-                      Schema targetSchema, TypeToken<?> targetTypeToken) throws IOException {
+  private static class DecoderReflectionReader<T> extends ReflectionReader<T> {
+    private final Decoder decoder;
 
-    if (sourceSchema.getType() != Schema.Type.UNION && targetSchema.getType() == Schema.Type.UNION) {
-      // Try every target schemas
-      for (Schema schema : targetSchema.getUnionSchemas()) {
-        try {
-          return doRead(decoder, sourceSchema, schema, targetTypeToken);
-        } catch (IOException e) {
-          // Continue;
-        }
-      }
-      throw new IOException(String.format("No matching schema to resolve %s to %s", sourceSchema, targetSchema));
-    }
-    return doRead(decoder, sourceSchema, targetSchema, targetTypeToken);
-  }
-
-  private Object doRead(Decoder decoder, Schema sourceSchema,
-                        Schema targetSchema, TypeToken<?> targetTypeToken) throws IOException {
-
-    Schema.Type sourceType = sourceSchema.getType();
-    Schema.Type targetType = targetSchema.getType();
-
-    switch(sourceType) {
-      case NULL:
-        check(sourceType == targetType, "Fails to resolve %s to %s", sourceType, targetType);
-        return decoder.readNull();
-      case BYTES:
-        check(sourceType == targetType, "Fails to resolve %s to %s", sourceType, targetType);
-        return readBytes(decoder, targetTypeToken);
-      case ENUM:
-        String enumValue = sourceSchema.getEnumValue(decoder.readInt());
-        check(targetSchema.getEnumValues().contains(enumValue), "Enum value '%s' missing in target.", enumValue);
-        try {
-          return targetTypeToken.getRawType().getMethod("valueOf", String.class).invoke(null, enumValue);
-        } catch (Exception e) {
-          throw new IOException(e);
-        }
-      case ARRAY:
-        check(sourceType == targetType, "Fails to resolve %s to %s", sourceType, targetType);
-        return readArray(decoder, sourceSchema, targetSchema, targetTypeToken);
-      case MAP:
-        check(sourceType == targetType, "Fails to resolve %s to %s", sourceType, targetType);
-        return readMap(decoder, sourceSchema, targetSchema, targetTypeToken);
-      case RECORD:
-        check(sourceType == targetType, "Fails to resolve %s to %s", sourceType, targetType);
-        return readRecord(decoder, sourceSchema, targetSchema, targetTypeToken);
-      case UNION:
-        return readUnion(decoder, sourceSchema, targetSchema, targetTypeToken);
-    }
-    // For simple type other than NULL and BYTES
-    if (sourceType.isSimpleType()) {
-      return resolveType(decoder, sourceType, targetType, targetTypeToken);
-    }
-    throw new IOException(String.format("Fails to resolve %s to %s", sourceSchema, targetSchema));
-  }
-
-  private Object readBytes(Decoder decoder, TypeToken<?> targetTypeToken) throws IOException {
-    ByteBuffer buffer = decoder.readBytes();
-
-    if (targetTypeToken.getRawType().equals(byte[].class)) {
-      if (buffer.hasArray()) {
-        byte[] array = buffer.array();
-        if (buffer.remaining() == array.length) {
-          return array;
-        }
-        byte[] bytes = new byte[buffer.remaining()];
-        System.arraycopy(array, buffer.arrayOffset() + buffer.position(), bytes, 0, buffer.remaining());
-        return bytes;
-      } else {
-        byte[] bytes = new byte[buffer.remaining()];
-        buffer.get(bytes);
-        return bytes;
-      }
-    } else if (targetTypeToken.getRawType().equals(UUID.class) && buffer.remaining() == Longs.BYTES * 2) {
-      return new UUID(buffer.getLong(), buffer.getLong());
-    }
-    return buffer;
-  }
-
-  @SuppressWarnings("unchecked")
-  private Object readArray(Decoder decoder, Schema sourceSchema,
-                           Schema targetSchema, TypeToken<?> targetTypeToken) throws IOException {
-
-    TypeToken<?> componentType = null;
-    if (targetTypeToken.isArray()) {
-      componentType = targetTypeToken.getComponentType();
-    } else if (Collection.class.isAssignableFrom(targetTypeToken.getRawType())) {
-      Type type = targetTypeToken.getType();
-      check(type instanceof ParameterizedType, "Only parameterized type is supported for collection.");
-      componentType = TypeToken.of(((ParameterizedType) type).getActualTypeArguments()[0]);
-    }
-    check(componentType != null, "Only array or collection type is support for array value.");
-
-    int len = decoder.readInt();
-    Collection<Object> collection = (Collection<Object>) create(targetTypeToken);
-    while (len != 0) {
-      for (int i = 0; i < len; i++) {
-        collection.add(read(decoder, sourceSchema.getComponentSchema(),
-                            targetSchema.getComponentSchema(), componentType)
-        );
-      }
-      len = decoder.readInt();
+    private DecoderReflectionReader(Decoder decoder) {
+      this.decoder = decoder;
     }
 
-    if (targetTypeToken.isArray()) {
-      Object array = Array.newInstance(targetTypeToken.getComponentType().getRawType(), collection.size());
-      int idx = 0;
-      for (Object obj : collection) {
-        Array.set(array, idx++, obj);
-      }
-      return array;
-    }
-    return collection;
-  }
-
-  @SuppressWarnings("unchecked")
-  private Map<Object, Object> readMap(Decoder decoder, Schema sourceSchema,
-                                      Schema targetSchema, TypeToken<?> targetTypeToken) throws IOException {
-    check(Map.class.isAssignableFrom(targetTypeToken.getRawType()), "Only map type is supported for map data.");
-    Type type = targetTypeToken.getType();
-    Preconditions.checkArgument(type instanceof ParameterizedType, "Only parameterized map is supported.");
-    Type[] typeArgs = ((ParameterizedType) type).getActualTypeArguments();
-
-    int len = decoder.readInt();
-    Map<Object, Object> map = (Map<Object, Object>) create(targetTypeToken);
-    while (len != 0) {
-      for (int i = 0; i < len; i++) {
-        Map.Entry<Schema, Schema> sourceEntry = sourceSchema.getMapSchema();
-        Map.Entry<Schema, Schema> targetEntry = targetSchema.getMapSchema();
-
-        map.put(read(decoder, sourceEntry.getKey(), targetEntry.getKey(), TypeToken.of(typeArgs[0])),
-                read(decoder, sourceEntry.getValue(), targetEntry.getValue(), TypeToken.of(typeArgs[1])));
-      }
-      len = decoder.readInt();
+    @Override
+    protected Object readNull(String name) throws IOException {
+      return decoder.readNull();
     }
 
-    return map;
-  }
-
-  private Object readRecord(Decoder decoder, Schema sourceSchema,
-                            Schema targetSchema, TypeToken<?> targetTypeToken) throws IOException {
-    try {
-      Object record = create(targetTypeToken);
-      for (Schema.Field sourceField : sourceSchema.getFields()) {
-        Schema.Field targetField = targetSchema.getField(sourceField.getName());
-        if (targetField == null) {
-          skip(decoder, sourceField.getSchema());
-          continue;
-        }
-        FieldAccessor fieldAccessor = fieldAccessorFactory.getFieldAccessor(targetTypeToken, sourceField.getName());
-        fieldAccessor.set(record,
-                          read(decoder, sourceField.getSchema(), targetField.getSchema(), fieldAccessor.getType()));
-      }
-      return record;
-    } catch (Exception e) {
-      throw propagate(e);
+    @Override
+    protected boolean readBool(String name) throws IOException {
+      return decoder.readBool();
     }
-  }
 
-  private Object readUnion(Decoder decoder, Schema sourceSchema,
-                           Schema targetSchema, TypeToken<?> targetTypeToken) throws IOException {
-    int idx = decoder.readInt();
-    Schema sourceValueSchema = sourceSchema.getUnionSchemas().get(idx);
+    @Override
+    protected int readInt(String name) throws IOException {
+      return decoder.readInt();
+    }
 
+    @Override
+    protected long readLong(String name) throws IOException {
+      return decoder.readLong();
+    }
 
-    if (targetSchema.getType() == Schema.Type.UNION) {
+    @Override
+    protected float readFloat(String name) throws IOException {
+      return decoder.readFloat();
+    }
+
+    @Override
+    protected double readDouble(String name) throws IOException {
+      return decoder.readDouble();
+    }
+
+    @Override
+    protected String readString(String name) throws IOException {
+      return decoder.readString();
+    }
+
+    @Override
+    protected ByteBuffer readBytes(String name) throws IOException {
+      return decoder.readBytes();
+    }
+
+    @Override
+    protected Object readEnum(String name, Schema sourceSchema, Schema targetSchema,
+                              TypeToken<?> targetTypeToken) throws IOException {
+      String enumValue = sourceSchema.getEnumValue(decoder.readInt());
+      check(targetSchema.getEnumValues().contains(enumValue), "Enum value '%s' missing in target.", enumValue);
       try {
-        // A simple optimization to try resolve before resorting to linearly try the union schema.
-        Schema targetValueSchema = targetSchema.getUnionSchema(idx);
-        if (targetValueSchema != null && targetValueSchema.getType() == sourceValueSchema.getType()) {
-          return read(decoder, sourceValueSchema, targetValueSchema, targetTypeToken);
-        }
-      } catch (IOException e) {
-        // OK to ignore it, as we'll do union schema resolution
+        return targetTypeToken.getRawType().getMethod("valueOf", String.class).invoke(null, enumValue);
+      } catch (Exception e) {
+        throw new IOException(e);
       }
-      for (Schema targetValueSchema : targetSchema.getUnionSchemas()) {
+    }
+
+    @SuppressWarnings({"unchecked", "ConstantConditions"})
+    @Override
+    protected Object readArray(String name, Schema sourceSchema, Schema targetSchema,
+                               TypeToken<?> targetTypeToken) throws IOException {
+      TypeToken<?> componentType = null;
+      if (targetTypeToken.isArray()) {
+        componentType = targetTypeToken.getComponentType();
+      } else if (Collection.class.isAssignableFrom(targetTypeToken.getRawType())) {
+        Type type = targetTypeToken.getType();
+        check(type instanceof ParameterizedType, "Only parameterized type is supported for collection.");
+        componentType = TypeToken.of(((ParameterizedType) type).getActualTypeArguments()[0]);
+      }
+      check(componentType != null, "Only array or collection type is support for array value.");
+
+      int len = decoder.readInt();
+      Collection<Object> collection = (Collection<Object>) create(targetTypeToken);
+      while (len != 0) {
+        for (int i = 0; i < len; i++) {
+          collection.add(read(name, sourceSchema.getComponentSchema(),
+                              targetSchema.getComponentSchema(), componentType)
+          );
+        }
+        len = decoder.readInt();
+      }
+
+      if (targetTypeToken.isArray()) {
+        Object array = Array.newInstance(targetTypeToken.getComponentType().getRawType(), collection.size());
+        int idx = 0;
+        for (Object obj : collection) {
+          Array.set(array, idx++, obj);
+        }
+        return array;
+      }
+      return collection;
+    }
+
+    @Override
+    protected Object readMap(String name, Schema sourceSchema, Schema targetSchema,
+                             TypeToken<?> targetTypeToken) throws IOException {
+      check(Map.class.isAssignableFrom(targetTypeToken.getRawType()), "Only map type is supported for map data.");
+      Type type = targetTypeToken.getType();
+      Preconditions.checkArgument(type instanceof ParameterizedType, "Only parameterized map is supported.");
+      // suppressing warning because we know type is not null
+      @SuppressWarnings("ConstantConditions")
+      Type[] typeArgs = ((ParameterizedType) type).getActualTypeArguments();
+
+      int len = decoder.readInt();
+      // unchecked cast is ok, we're assuming the type token is correct
+      @SuppressWarnings("unchecked")
+      Map<Object, Object> map = (Map<Object, Object>) create(targetTypeToken);
+      while (len != 0) {
+        for (int i = 0; i < len; i++) {
+          Map.Entry<Schema, Schema> sourceEntry = sourceSchema.getMapSchema();
+          Map.Entry<Schema, Schema> targetEntry = targetSchema.getMapSchema();
+
+          map.put(read(name, sourceEntry.getKey(), targetEntry.getKey(), TypeToken.of(typeArgs[0])),
+                  read(name, sourceEntry.getValue(), targetEntry.getValue(), TypeToken.of(typeArgs[1])));
+        }
+        len = decoder.readInt();
+      }
+
+      return map;
+    }
+
+    @Override
+    protected Object readUnion(String name, Schema sourceSchema, Schema targetSchema,
+                               TypeToken<?> targetTypeToken) throws IOException {
+      int idx = decoder.readInt();
+      Schema sourceValueSchema = sourceSchema.getUnionSchemas().get(idx);
+
+
+      if (targetSchema.getType() == Schema.Type.UNION) {
         try {
-          return read(decoder, sourceValueSchema, targetValueSchema, targetTypeToken);
+          // A simple optimization to try resolve before resorting to linearly try the union schema.
+          Schema targetValueSchema = targetSchema.getUnionSchema(idx);
+          if (targetValueSchema != null && targetValueSchema.getType() == sourceValueSchema.getType()) {
+            return read(name, sourceValueSchema, targetValueSchema, targetTypeToken);
+          }
         } catch (IOException e) {
-          // It's ok to have exception here, as we'll keep trying until exhausted the target union.
+          // OK to ignore it, as we'll do union schema resolution
         }
+        for (Schema targetValueSchema : targetSchema.getUnionSchemas()) {
+          try {
+            return read(name, sourceValueSchema, targetValueSchema, targetTypeToken);
+          } catch (IOException e) {
+            // It's ok to have exception here, as we'll keep trying until exhausted the target union.
+          }
+        }
+        throw new IOException(String.format("Fail to resolve %s to %s", sourceSchema, targetSchema));
+      } else {
+        return read(name, sourceValueSchema, targetSchema, targetTypeToken);
       }
-      throw new IOException(String.format("Fail to resolve %s to %s", sourceSchema, targetSchema));
-    } else {
-      return read(decoder, sourceValueSchema, targetSchema, targetTypeToken);
     }
-  }
 
-  private void skip(Decoder decoder, Schema schema) throws IOException {
-    switch (schema.getType()) {
-      case NULL:
-        break;
-      case BOOLEAN:
-        decoder.readBool();
-        break;
-      case INT:
-        decoder.readInt();
-        break;
-      case LONG:
-        decoder.readLong();
-        break;
-      case FLOAT:
-        decoder.skipFloat();
-        break;
-      case DOUBLE:
-        decoder.skipDouble();
-        break;
-      case BYTES:
-        decoder.skipBytes();
-        break;
-      case STRING:
-        decoder.skipString();
-        break;
-      case ENUM:
-        decoder.readInt();
-        break;
-      case ARRAY:
-        skipArray(decoder, schema.getComponentSchema());
-        break;
-      case MAP:
-        skipMap(decoder, schema.getMapSchema());
-        break;
-      case RECORD:
-        skipRecord(decoder, schema);
-        break;
-      case UNION:
-        skip(decoder, schema.getUnionSchema(decoder.readInt()));
-        break;
-    }
-  }
-
-  private void skipArray(Decoder decoder, Schema componentSchema) throws IOException {
-    int len = decoder.readInt();
-    while (len != 0) {
-      skip(decoder, componentSchema);
-      len = decoder.readInt();
-    }
-  }
-
-  private void skipMap(Decoder decoder, Map.Entry<Schema, Schema> mapSchema) throws IOException {
-    int len = decoder.readInt();
-    while (len != 0) {
-      skip(decoder, mapSchema.getKey());
-      skip(decoder, mapSchema.getValue());
-      len = decoder.readInt();
-    }
-  }
-
-  private void skipRecord(Decoder decoder, Schema recordSchema) throws IOException {
-    for (Schema.Field field : recordSchema.getFields()) {
-      skip(decoder, field.getSchema());
-    }
-  }
-
-  private Object resolveType(Decoder decoder, Schema.Type sourceType,
-                             Schema.Type targetType, TypeToken<?> targetTypeToken) throws IOException {
-    switch(sourceType) {
-      case BOOLEAN:
-        switch(targetType) {
-          case BOOLEAN:
-            return decoder.readBool();
-          case STRING:
-            return String.valueOf(decoder.readBool());
+    @Override
+    protected Object readRecord(String name, Schema sourceSchema, Schema targetSchema,
+                                TypeToken<?> targetTypeToken) throws IOException {
+      try {
+        Object record = create(targetTypeToken);
+        for (Schema.Field sourceField : sourceSchema.getFields()) {
+          Schema.Field targetField = targetSchema.getField(sourceField.getName());
+          if (targetField == null) {
+            skip(decoder, sourceField.getSchema());
+            continue;
+          }
+          FieldAccessor fieldAccessor = getFieldAccessor(targetTypeToken, sourceField.getName());
+          fieldAccessor.set(record,
+                            read(name, sourceField.getSchema(), targetField.getSchema(), fieldAccessor.getType()));
         }
-        break;
-      case INT:
-        switch(targetType) {
-          case INT:
-            Class<?> targetClass = targetTypeToken.getRawType();
-            int value = decoder.readInt();
-            if (targetClass.equals(byte.class) || targetClass.equals(Byte.class)) {
-              return (byte) value;
-            }
-            if (targetClass.equals(char.class) || targetClass.equals(Character.class)) {
-              return (char) value;
-            }
-            if (targetClass.equals(short.class) || targetClass.equals(Short.class)) {
-              return (short) value;
-            }
-            return value;
-          case LONG:
-            return (long) decoder.readInt();
-          case FLOAT:
-            return (float) decoder.readInt();
-          case DOUBLE:
-            return (double) decoder.readInt();
-          case STRING:
-            return String.valueOf(decoder.readInt());
-        }
-        break;
-      case LONG:
-        switch(targetType) {
-          case LONG:
-            return decoder.readLong();
-          case FLOAT:
-            return (float) decoder.readLong();
-          case DOUBLE:
-            return (double) decoder.readLong();
-          case STRING:
-            return String.valueOf(decoder.readLong());
-        }
-        break;
-      case FLOAT:
-        switch(targetType) {
-          case FLOAT:
-            return decoder.readFloat();
-          case DOUBLE:
-            return (double) decoder.readFloat();
-          case STRING:
-            return String.valueOf(decoder.readFloat());
-        }
-        break;
-      case DOUBLE:
-        switch(targetType) {
-          case DOUBLE:
-            return decoder.readDouble();
-          case STRING:
-            return String.valueOf(decoder.readDouble());
-        }
-        break;
-      case STRING:
-        switch(targetType) {
-          case STRING:
-            String str = decoder.readString();
-            Class<?> targetClass = targetTypeToken.getRawType();
-            if (targetClass.equals(URI.class)) {
-              return URI.create(str);
-            } else if (targetClass.equals(URL.class)) {
-              return new URL(str);
-            }
-            return str;
-        }
-        break;
+        return record;
+      } catch (Exception e) {
+        throw propagate(e);
+      }
     }
 
-    throw new IOException("Fail to resolve type " + sourceType + " to type " + targetType);
-  }
-
-  private void check(boolean condition, String message, Object... objs) throws IOException {
-    if (!condition) {
-      throw new IOException(String.format(message, objs));
+    private void skip(Decoder decoder, Schema schema) throws IOException {
+      switch (schema.getType()) {
+        case NULL:
+          break;
+        case BOOLEAN:
+          decoder.readBool();
+          break;
+        case INT:
+          decoder.readInt();
+          break;
+        case LONG:
+          decoder.readLong();
+          break;
+        case FLOAT:
+          decoder.skipFloat();
+          break;
+        case DOUBLE:
+          decoder.skipDouble();
+          break;
+        case BYTES:
+          decoder.skipBytes();
+          break;
+        case STRING:
+          decoder.skipString();
+          break;
+        case ENUM:
+          decoder.readInt();
+          break;
+        case ARRAY:
+          skipArray(decoder, schema.getComponentSchema());
+          break;
+        case MAP:
+          skipMap(decoder, schema.getMapSchema());
+          break;
+        case RECORD:
+          skipRecord(decoder, schema);
+          break;
+        case UNION:
+          skip(decoder, schema.getUnionSchema(decoder.readInt()));
+          break;
+      }
     }
-  }
 
-  private IOException propagate(Throwable t) throws IOException {
-    if (t instanceof IOException) {
-      throw (IOException) t;
+    private void skipArray(Decoder decoder, Schema componentSchema) throws IOException {
+      int len = decoder.readInt();
+      while (len != 0) {
+        skip(decoder, componentSchema);
+        len = decoder.readInt();
+      }
     }
-    throw new IOException(t);
-  }
 
-  private Object create(TypeToken<?> type) {
-    Class<?> rawType = type.getRawType();
-    Instantiator<?> creator = creators.get(rawType);
-    if (creator == null) {
-      creator = creatorFactory.get(type);
-      creators.put(rawType, creator);
+    private void skipMap(Decoder decoder, Map.Entry<Schema, Schema> mapSchema) throws IOException {
+      int len = decoder.readInt();
+      while (len != 0) {
+        skip(decoder, mapSchema.getKey());
+        skip(decoder, mapSchema.getValue());
+        len = decoder.readInt();
+      }
     }
-    return creator.create();
+
+    private void skipRecord(Decoder decoder, Schema recordSchema) throws IOException {
+      for (Schema.Field field : recordSchema.getFields()) {
+        skip(decoder, field.getSchema());
+      }
+    }
   }
 }

--- a/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionDatumWriter.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionDatumWriter.java
@@ -18,26 +18,17 @@ package co.cask.cdap.internal.io;
 
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.common.io.Encoder;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
-import com.google.common.primitives.Longs;
-import com.google.common.reflect.TypeToken;
 
 import java.io.IOException;
 import java.lang.reflect.Array;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
 
 /**
  * A {@link DatumWriter} that uses java reflection to encode data. The encoding schema it uses is
- * the same as the binary encoding as specified in Avro, with the enhancement of support non-string
- * map key.
+ * the same as the binary encoding as specified in Avro, with the enhancement of support for non-string
+ * map keys.
  *
  * @param <T> Type T to be written.
  */
@@ -55,204 +46,125 @@ public final class ReflectionDatumWriter<T> implements DatumWriter<T> {
 
   @Override
   public void encode(T data, Encoder encoder) throws IOException {
-    Set<Object> seenRefs = Sets.newIdentityHashSet();
-    write(data, encoder, schema, seenRefs);
+    ReflectionWriter writer = new EncoderReflectionWriter(encoder);
+    writer.write(data, schema);
   }
 
-  private void write(Object object, Encoder encoder, Schema objSchema, Set<Object> seenRefs) throws IOException {
-    if (object != null) {
-      if (seenRefs.contains(object)) {
-        throw new IOException("Circular reference not supported.");
+  /**
+   * Uses an {@link Encoder} to write an object as binary encoded Avro, with the enhancement of support for
+   * non-string map keys.
+   */
+  private static class EncoderReflectionWriter extends ReflectionWriter {
+    private final Encoder encoder;
+
+    private EncoderReflectionWriter(Encoder encoder) {
+      this.encoder = encoder;
+    }
+
+    @Override
+    protected void writeNull(String name) throws IOException {
+      encoder.writeNull();
+    }
+
+    @Override
+    protected void writeBool(String name, Boolean val) throws IOException {
+      encoder.writeBool(val);
+    }
+
+    @Override
+    protected void writeInt(String name, int val) throws IOException {
+      encoder.writeInt(val);
+    }
+
+    @Override
+    protected void writeLong(String name, long val) throws IOException {
+      encoder.writeLong(val);
+    }
+
+    @Override
+    protected void writeFloat(String name, Float val) throws IOException {
+      encoder.writeFloat(val);
+    }
+
+    @Override
+    protected void writeDouble(String name, Double val) throws IOException {
+      encoder.writeDouble(val);
+    }
+
+    @Override
+    protected void writeString(String name, String val) throws IOException {
+      encoder.writeString(val);
+    }
+
+    @Override
+    protected void writeBytes(String name, ByteBuffer val) throws IOException {
+      encoder.writeBytes(val);
+    }
+
+    @Override
+    protected void writeBytes(String name, byte[] val) throws IOException {
+      encoder.writeBytes(val);
+    }
+
+    @Override
+    protected void writeEnum(String name, String val, Schema schema) throws IOException {
+      int idx = schema.getEnumIndex(val);
+      if (idx < 0) {
+        throw new IOException("Invalid enum value " + val);
       }
-      if (objSchema.getType() == Schema.Type.RECORD) {
-        seenRefs.add(object);
-      }
+      encoder.writeInt(idx);
     }
 
-    switch(objSchema.getType()) {
-      case NULL:
-        encoder.writeNull();
-        break;
-      case BOOLEAN:
-        encoder.writeBool((Boolean) object);
-        break;
-      case INT:
-        encoder.writeInt(((Number) object).intValue());
-        break;
-      case LONG:
-        encoder.writeLong(((Number) object).longValue());
-        break;
-      case FLOAT:
-        encoder.writeFloat((Float) object);
-        break;
-      case DOUBLE:
-        encoder.writeDouble((Double) object);
-        break;
-      case STRING:
-        encoder.writeString(object.toString());
-        break;
-      case BYTES:
-        writeBytes(object, encoder);
-        break;
-      case ENUM:
-        writeEnum(object.toString(), encoder, objSchema);
-        break;
-      case ARRAY:
-        writeArray(object, encoder, objSchema.getComponentSchema(), seenRefs);
-        break;
-      case MAP:
-        writeMap(object, encoder, objSchema.getMapSchema(), seenRefs);
-        break;
-      case RECORD:
-        writeRecord(object, encoder, objSchema, seenRefs);
-        break;
-      case UNION:
-        // Assumption in schema generation that index 0 is the object type, index 1 is null.
-        if (object == null) {
-          encoder.writeInt(1);
-        } else {
-          seenRefs.remove(object);
-          encoder.writeInt(0);
-          write(object, encoder, objSchema.getUnionSchema(0), seenRefs);
-        }
-        break;
-    }
-  }
-
-  private void writeBytes(Object object, Encoder encoder) throws IOException {
-    if (object instanceof ByteBuffer) {
-      encoder.writeBytes((ByteBuffer) object);
-    } else if (object instanceof UUID) {
-      UUID uuid = (UUID)  object;
-      ByteBuffer buf = ByteBuffer.allocate(Longs.BYTES * 2);
-      buf.putLong(uuid.getMostSignificantBits()).putLong(uuid.getLeastSignificantBits());
-      encoder.writeBytes((ByteBuffer) buf.flip());
-    } else {
-      encoder.writeBytes((byte[]) object);
-    }
-  }
-
-  private void writeEnum(String value, Encoder encoder, Schema schema) throws IOException {
-    int idx = schema.getEnumIndex(value);
-    if (idx < 0) {
-      throw new IOException("Invalid enum value " + value);
-    }
-    encoder.writeInt(idx);
-  }
-
-  private void writeArray(Object array, Encoder encoder,
-                          Schema componentSchema, Set<Object> seenRefs) throws IOException {
-    int size = 0;
-    if (array instanceof Collection) {
-      Collection col = (Collection) array;
-      encoder.writeInt(col.size());
+    @Override
+    protected void writeArray(String name, Collection col, Schema componentSchema) throws IOException {
+      int size = col.size();
+      encoder.writeInt(size);
       for (Object obj : col) {
-        write(obj, encoder, componentSchema, seenRefs);
+        write(null, obj, componentSchema);
       }
-      size = col.size();
-    } else {
-      size = Array.getLength(array);
+      if (size > 0) {
+        encoder.writeInt(0);
+      }
+    }
+
+    @Override
+    protected void writeArray(String name, Object array, Schema componentSchema) throws IOException {
+      int size = Array.getLength(array);
       encoder.writeInt(size);
       for (int i = 0; i < size; i++) {
-        write(Array.get(array, i), encoder, componentSchema, seenRefs);
+        write(null, Array.get(array, i), componentSchema);
+      }
+      if (size > 0) {
+        encoder.writeInt(0);
       }
     }
-    if (size > 0) {
-      encoder.writeInt(0);
-    }
-  }
 
-  private void writeMap(Object map, Encoder encoder, Map.Entry<Schema,
-                                                                Schema> mapSchema,
-                        Set<Object> seenRefs) throws IOException {
-    Map<?, ?> objMap = (Map<?, ?>) map;
-    int size = objMap.size();
-    encoder.writeInt(size);
-    for (Map.Entry<?, ?> entry : objMap.entrySet()) {
-      write(entry.getKey(), encoder, mapSchema.getKey(), seenRefs);
-      write(entry.getValue(), encoder, mapSchema.getValue(), seenRefs);
-    }
-    if (size > 0) {
-      encoder.writeInt(0);
-    }
-  }
-
-  private void writeRecord(Object record, Encoder encoder,
-                           Schema recordSchema, Set<Object> seenRefs) throws IOException {
-    try {
-      TypeToken<?> type = TypeToken.of(record.getClass());
-
-      Map<String, Method> methods = collectByMethod(type, Maps.<String, Method>newHashMap());
-      Map<String, Field> fields = collectByFields(type, Maps.<String, Field>newHashMap());
-
-      for (Schema.Field field : recordSchema.getFields()) {
-        String fieldName = field.getName();
-        Object value;
-        Field recordField = fields.get(fieldName);
-        if (recordField != null) {
-          recordField.setAccessible(true);
-          value = recordField.get(record);
-        } else {
-          Method method = methods.get(fieldName);
-          if (method == null) {
-            throw new IOException("Unable to read field value through getter. Class=" + type + ", field=" + fieldName);
-          }
-          value = method.invoke(record);
-        }
-
-        Schema fieldSchema = field.getSchema();
-        write(value, encoder, fieldSchema, seenRefs);
+    @Override
+    protected void writeMap(String name, Map<?, ?> map,
+                            Map.Entry<Schema, Schema> mapSchema) throws IOException {
+      int size = map.size();
+      encoder.writeInt(size);
+      Schema keySchema = mapSchema.getKey();
+      Schema valSchema = mapSchema.getValue();
+      for (Map.Entry<?, ?> entry : map.entrySet()) {
+        write(null, entry.getKey(), keySchema);
+        write(null, entry.getValue(), valSchema);
       }
-    } catch (Exception e) {
-      if (e instanceof IOException) {
-        throw (IOException) e;
-      }
-      throw new IOException(e);
-    }
-  }
-
-  private Map<String, Field> collectByFields(TypeToken<?> typeToken, Map<String, Field> fields) {
-    // Collect the field types
-    for (TypeToken<?> classType : typeToken.getTypes().classes()) {
-      Class<?> rawType = classType.getRawType();
-      if (rawType.equals(Object.class)) {
-        // Ignore all object fields
-        continue;
-      }
-
-      for (Field field : rawType.getDeclaredFields()) {
-        if (Modifier.isTransient(field.getModifiers()) || field.isSynthetic()) {
-          continue;
-        }
-        fields.put(field.getName(), field);
+      if (size > 0) {
+        encoder.writeInt(0);
       }
     }
-    return fields;
-  }
 
-  private Map<String, Method> collectByMethod(TypeToken<?> typeToken, Map<String, Method> methods) {
-    for (Method method : typeToken.getRawType().getMethods()) {
-      if (method.getDeclaringClass().equals(Object.class)) {
-        // Ignore all object methods
-        continue;
+    @Override
+    protected void writeUnion(String name, Object val, Schema schema) throws IOException {
+      // Assumption in schema generation that index 0 is the object type, index 1 is null.
+      if (val == null) {
+        encoder.writeInt(1);
+      } else {
+        seenRefs.remove(val);
+        encoder.writeInt(0);
+        write(name, val, schema.getUnionSchema(0));
       }
-      String methodName = method.getName();
-      if (!(methodName.startsWith("get") || methodName.startsWith("is"))
-           || method.isSynthetic() || method.getParameterTypes().length != 0) {
-        // Ignore not getter methods
-        continue;
-      }
-      String fieldName = methodName.startsWith("get") ?
-                           methodName.substring("get".length()) : methodName.substring("is".length());
-      if (fieldName.isEmpty()) {
-        continue;
-      }
-      fieldName = String.format("%c%s", Character.toLowerCase(fieldName.charAt(0)), fieldName.substring(1));
-      if (methods.containsKey(fieldName)) {
-        continue;
-      }
-      methods.put(fieldName, method);
     }
-    return methods;
   }
 }

--- a/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionPutWriter.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionPutWriter.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.io;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.dataset.table.Put;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.common.io.BinaryEncoder;
+import com.google.common.base.Preconditions;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Encodes an object as a {@link Put} for storing it into a {@link Table}. Assumes that objects to write are
+ * records. Fields of simple types are encoded as columns in the table. Complex types (arrays, maps, records),
+ * are binary encoded and stored as blobs.
+ */
+public class ReflectionPutWriter extends ReflectionWriter {
+  private final Put put;
+
+  public ReflectionPutWriter(Put put) {
+    this.put = put;
+  }
+
+  @Override
+  public void write(Object object, Schema objSchema) throws IOException {
+    Preconditions.checkArgument(isRecord(objSchema), "Schema must be a record or nullable record.");
+    super.writeRecord(null, object, objSchema);
+  }
+
+  @Override
+  protected void writeNull(String name) throws IOException {
+  }
+
+  @Override
+  protected void writeBool(String name, Boolean val) throws IOException {
+    put.add(name, val);
+  }
+
+  @Override
+  protected void writeInt(String name, int val) throws IOException {
+    put.add(name, val);
+  }
+
+  @Override
+  protected void writeLong(String name, long val) throws IOException {
+    put.add(name, val);
+  }
+
+  @Override
+  protected void writeFloat(String name, Float val) throws IOException {
+    put.add(name, val);
+  }
+
+  @Override
+  protected void writeDouble(String name, Double val) throws IOException {
+    put.add(name, val);
+  }
+
+  @Override
+  protected void writeString(String name, String val) throws IOException {
+    put.add(name, val);
+  }
+
+  @Override
+  protected void writeBytes(String name, ByteBuffer val) throws IOException {
+    put.add(name, Bytes.toBytes(val));
+  }
+
+  @Override
+  protected void writeBytes(String name, byte[] val) throws IOException {
+    put.add(name, val);
+  }
+
+  @Override
+  protected void writeEnum(String name, String val, Schema schema) throws IOException {
+    int idx = schema.getEnumIndex(val);
+    if (idx < 0) {
+      throw new IOException("Invalid enum value " + val);
+    }
+    put.add(name, idx);
+  }
+
+  @Override
+  protected void writeArray(String name, Collection val, Schema componentSchema) throws IOException {
+    put.add(name, encodeArray(val, componentSchema));
+  }
+
+  @Override
+  protected void writeArray(String name, Object val, Schema componentSchema) throws IOException {
+    put.add(name, encodeArray(val, componentSchema));
+  }
+
+  @Override
+  protected void writeMap(String name, Map<?, ?> val,
+                          Map.Entry<Schema, Schema> mapSchema) throws IOException {
+    put.add(name, encodeMap(val, mapSchema.getKey(), mapSchema.getValue()));
+  }
+
+  @Override
+  protected void writeRecord(String name, Object record, Schema recordSchema) throws IOException {
+    put.add(name, encodeRecord(record, recordSchema));
+  }
+
+  @Override
+  protected void writeUnion(String name, Object val, Schema schema) throws IOException {
+    // only support unions if its for a nullable.
+    if (!schema.isNullable()) {
+      throw new UnsupportedOperationException("Unions that do not represent nullables are not supported.");
+    }
+
+    if (val != null) {
+      seenRefs.remove(val);
+      write(name, val, schema.getNonNullable());
+    }
+  }
+
+  private byte[] encodeArray(Object array, Schema componentSchema) throws IOException {
+    ReflectionDatumWriter datumWriter = new ReflectionDatumWriter(Schema.arrayOf(componentSchema));
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    BinaryEncoder encoder = new BinaryEncoder(bos);
+    datumWriter.encode(array, encoder);
+    return bos.toByteArray();
+  }
+
+  private byte[] encodeMap(Map<?, ?> map, Schema keySchema, Schema valSchema) throws IOException {
+    ReflectionDatumWriter datumWriter = new ReflectionDatumWriter(Schema.mapOf(keySchema, valSchema));
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    BinaryEncoder encoder = new BinaryEncoder(bos);
+    datumWriter.encode(map, encoder);
+    return bos.toByteArray();
+  }
+
+  private byte[] encodeRecord(Object record, Schema schema) throws IOException {
+    ReflectionDatumWriter datumWriter = new ReflectionDatumWriter(schema);
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    BinaryEncoder encoder = new BinaryEncoder(bos);
+    datumWriter.encode(record, encoder);
+    return bos.toByteArray();
+  }
+
+  // return true if the schema is a record or a nullable record
+  private boolean isRecord(Schema schema) {
+    if (schema.isNullable()) {
+      return schema.getNonNullable().getType() == Schema.Type.RECORD;
+    } else {
+      return schema.getType() == Schema.Type.RECORD;
+    }
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionReader.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionReader.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.io;
+
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.common.lang.Instantiator;
+import co.cask.cdap.common.lang.InstantiatorFactory;
+import com.google.common.collect.Maps;
+import com.google.common.primitives.Longs;
+import com.google.common.reflect.TypeToken;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.UUID;
+import javax.annotation.Nullable;
+
+/**
+ * Reflection based reader.
+ *
+ * @param <T> type of object to read
+ */
+public abstract class ReflectionReader<T> {
+
+  private final Map<Class<?>, Instantiator<?>> creators;
+  private final InstantiatorFactory creatorFactory;
+  private final FieldAccessorFactory fieldAccessorFactory;
+
+  public ReflectionReader() {
+    this.creatorFactory = new InstantiatorFactory(true);
+    this.creators = Maps.newIdentityHashMap();
+    this.fieldAccessorFactory = new ReflectionFieldAccessorFactory();
+  }
+
+  /**
+   * Read the object to the target type with target schema, given that it has the given source schema.
+   *
+   * @param sourceSchema the write schema of the object
+   * @param targetSchema the read schema for the object
+   * @param targetTypeToken the type token of the object to read
+   * @return the object of given type and schema
+   * @throws IOException if there was some exception reading the object
+   */
+  public T read(Schema sourceSchema, Schema targetSchema,
+                TypeToken<?> targetTypeToken) throws IOException {
+    return read(null, sourceSchema, targetSchema, targetTypeToken);
+  }
+
+  @SuppressWarnings("unchecked")
+  protected T read(String name, Schema sourceSchema, Schema targetSchema,
+                   TypeToken<?> targetTypeToken) throws IOException {
+
+    if (sourceSchema.getType() != Schema.Type.UNION && targetSchema.getType() == Schema.Type.UNION) {
+      // Try every target schemas
+      for (Schema schema : targetSchema.getUnionSchemas()) {
+        try {
+          return (T) doRead(name, sourceSchema, schema, targetTypeToken);
+        } catch (IOException e) {
+          // Continue;
+        }
+      }
+      throw new IOException(String.format("No matching schema to resolve %s to %s", sourceSchema, targetSchema));
+    }
+    return (T) doRead(name, sourceSchema, targetSchema, targetTypeToken);
+  }
+
+  protected abstract Object readNull(String name) throws IOException;
+
+  protected abstract boolean readBool(String name) throws IOException;
+
+  protected abstract int readInt(String name) throws IOException;
+
+  protected abstract long readLong(String name) throws IOException;
+
+  protected abstract float readFloat(String name) throws IOException;
+
+  protected abstract double readDouble(String name) throws IOException;
+
+  protected abstract String readString(String name) throws IOException;
+
+  protected abstract ByteBuffer readBytes(String name) throws IOException;
+
+  protected abstract Object readEnum(String name, Schema sourceSchema, Schema targetSchema,
+                                     TypeToken<?> targetTypeToken) throws IOException;
+
+  protected abstract Object readArray(String name, Schema sourceSchema, Schema targetSchema,
+                                      TypeToken<?> targetTypeToken) throws IOException;
+
+  protected abstract Object readMap(String name, Schema sourceSchema, Schema targetSchema,
+                                    TypeToken<?> targetTypeToken) throws IOException;
+
+  protected abstract Object readUnion(String name, Schema sourceSchema, Schema targetSchema,
+                                      TypeToken<?> targetTypeToken) throws IOException;
+
+  protected abstract Object readRecord(String name, Schema sourceSchema, Schema targetSchema,
+                                       TypeToken<?> targetTypeToken) throws IOException;
+
+
+  protected Object doRead(String name, Schema sourceSchema,
+                          Schema targetSchema, TypeToken<?> targetTypeToken) throws IOException {
+
+    Schema.Type sourceType = sourceSchema.getType();
+    Schema.Type targetType = targetSchema.getType();
+
+    switch(sourceType) {
+      case NULL:
+        check(sourceType == targetType, "Fails to resolve %s to %s", sourceType, targetType);
+        return readNull(name);
+      case BYTES:
+        check(sourceType == targetType, "Fails to resolve %s to %s", sourceType, targetType);
+        ByteBuffer buffer = readBytes(name);
+
+        if (targetTypeToken.getRawType().equals(byte[].class)) {
+          if (buffer.hasArray()) {
+            byte[] array = buffer.array();
+            if (buffer.remaining() == array.length) {
+              return array;
+            }
+            byte[] bytes = new byte[buffer.remaining()];
+            System.arraycopy(array, buffer.arrayOffset() + buffer.position(), bytes, 0, buffer.remaining());
+            return bytes;
+          } else {
+            byte[] bytes = new byte[buffer.remaining()];
+            buffer.get(bytes);
+            return bytes;
+          }
+        } else if (targetTypeToken.getRawType().equals(UUID.class) && buffer.remaining() == Longs.BYTES * 2) {
+          return new UUID(buffer.getLong(), buffer.getLong());
+        }
+        return buffer;
+      case ENUM:
+        check(sourceType == targetType, "Fails to resolve %s to %s", sourceType, targetType);
+        return readEnum(name, sourceSchema, targetSchema, targetTypeToken);
+      case ARRAY:
+        check(sourceType == targetType, "Fails to resolve %s to %s", sourceType, targetType);
+        return readArray(name, sourceSchema, targetSchema, targetTypeToken);
+      case MAP:
+        check(sourceType == targetType, "Fails to resolve %s to %s", sourceType, targetType);
+        return readMap(name, sourceSchema, targetSchema, targetTypeToken);
+      case RECORD:
+        check(sourceType == targetType, "Fails to resolve %s to %s", sourceType, targetType);
+        return readRecord(name, sourceSchema, targetSchema, targetTypeToken);
+      case UNION:
+        return readUnion(name, sourceSchema, targetSchema, targetTypeToken);
+    }
+    // For simple type other than NULL and BYTES
+    if (sourceType.isSimpleType()) {
+      return resolveType(name, sourceType, targetType, targetTypeToken);
+    }
+    throw new IOException(String.format("Fails to resolve %s to %s", sourceSchema, targetSchema));
+  }
+
+  private Object resolveType(@Nullable String name, Schema.Type sourceType,
+                             Schema.Type targetType, TypeToken<?> targetTypeToken) throws IOException {
+    switch(sourceType) {
+      case BOOLEAN:
+        switch(targetType) {
+          case BOOLEAN:
+            return readBool(name);
+          case STRING:
+            return String.valueOf(readBool(name));
+        }
+        break;
+      case INT:
+        switch(targetType) {
+          case INT:
+            Class<?> targetClass = targetTypeToken.getRawType();
+            int value = readInt(name);
+            if (targetClass.equals(byte.class) || targetClass.equals(Byte.class)) {
+              return (byte) value;
+            }
+            if (targetClass.equals(char.class) || targetClass.equals(Character.class)) {
+              return (char) value;
+            }
+            if (targetClass.equals(short.class) || targetClass.equals(Short.class)) {
+              return (short) value;
+            }
+            return value;
+          case LONG:
+            return (long) readInt(name);
+          case FLOAT:
+            return (float) readInt(name);
+          case DOUBLE:
+            return (double) readInt(name);
+          case STRING:
+            return String.valueOf(readInt(name));
+        }
+        break;
+      case LONG:
+        switch(targetType) {
+          case LONG:
+            return readLong(name);
+          case FLOAT:
+            return (float) readLong(name);
+          case DOUBLE:
+            return (double) readLong(name);
+          case STRING:
+            return String.valueOf(readLong(name));
+        }
+        break;
+      case FLOAT:
+        switch(targetType) {
+          case FLOAT:
+            return readFloat(name);
+          case DOUBLE:
+            return (double) readFloat(name);
+          case STRING:
+            return String.valueOf(readFloat(name));
+        }
+        break;
+      case DOUBLE:
+        switch(targetType) {
+          case DOUBLE:
+            return readDouble(name);
+          case STRING:
+            return String.valueOf(readDouble(name));
+        }
+        break;
+      case STRING:
+        switch(targetType) {
+          case STRING:
+            String str = readString(name);
+            Class<?> targetClass = targetTypeToken.getRawType();
+            if (targetClass.equals(URI.class)) {
+              return URI.create(str);
+            } else if (targetClass.equals(URL.class)) {
+              return new URL(str);
+            }
+            return str;
+        }
+        break;
+    }
+
+    throw new IOException("Fail to resolve type " + sourceType + " to type " + targetType);
+  }
+
+  protected void check(boolean condition, String message, Object... objs) throws IOException {
+    if (!condition) {
+      throw new IOException(String.format(message, objs));
+    }
+  }
+
+  protected IOException propagate(Throwable t) throws IOException {
+    if (t instanceof IOException) {
+      throw (IOException) t;
+    }
+    throw new IOException(t);
+  }
+
+  protected Object create(TypeToken<?> type) {
+    Class<?> rawType = type.getRawType();
+    Instantiator<?> creator = creators.get(rawType);
+    if (creator == null) {
+      creator = creatorFactory.get(type);
+      creators.put(rawType, creator);
+    }
+    return creator.create();
+  }
+
+  protected FieldAccessor getFieldAccessor(TypeToken<?> targetTypeToken, String fieldName) {
+    return fieldAccessorFactory.getFieldAccessor(targetTypeToken, fieldName);
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionRowReader.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionRowReader.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.io;
+
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.dataset.table.Row;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.common.io.BinaryDecoder;
+import com.google.common.base.Preconditions;
+import com.google.common.reflect.TypeToken;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+/**
+ * Decodes an object from a {@link Row} object fetched from a {@link Table}. Assumes that objects
+ * fetched are records. All fields are columns in the row, with simple types stored as their byte representation,
+ * and complex types as Avro-like binary encoded blobs.
+ *
+ * @param <T> the type of object to read
+ */
+// suppress warnings that come from unboxing of objects that we validate are not null
+@SuppressWarnings("ConstantConditions")
+public class ReflectionRowReader<T> extends ReflectionReader<T> {
+  private static final Schema NULL_SCHEMA = Schema.of(Schema.Type.NULL);
+  private final Row row;
+
+  public ReflectionRowReader(Row row) {
+    this.row = row;
+  }
+
+  @SuppressWarnings("unchecked")
+  public T read(Schema sourceSchema, Schema targetSchema,
+                TypeToken<?> targetTypeToken) throws IOException {
+    Preconditions.checkArgument(isRecord(sourceSchema), "Source schema must be a record or nullable record.");
+    Preconditions.checkArgument(isRecord(targetSchema), "Target schema must be a record or nullable record.");
+
+    try {
+      Object record = create(targetTypeToken);
+      for (Schema.Field sourceField : sourceSchema.getFields()) {
+        String sourceFieldName = sourceField.getName();
+        Schema.Field targetField = targetSchema.getField(sourceFieldName);
+        if (targetField == null) {
+          continue;
+        }
+        FieldAccessor fieldAccessor = getFieldAccessor(targetTypeToken, sourceFieldName);
+        fieldAccessor.set(record, read(sourceFieldName, sourceField.getSchema(),
+                                       targetField.getSchema(), fieldAccessor.getType()));
+      }
+      return (T) record;
+    } catch (Exception e) {
+      throw propagate(e);
+    }
+  }
+
+  @Override
+  protected Object readNull(String name) throws IOException {
+    return null;
+  }
+
+  @Override
+  protected boolean readBool(String name) throws IOException {
+    Boolean val = row.getBoolean(name);
+    validateNotNull(val, name);
+    return val;
+  }
+
+  @Override
+  protected int readInt(String name) throws IOException {
+    Integer val = row.getInt(name);
+    validateNotNull(val, name);
+    return val;
+  }
+
+  @Override
+  protected long readLong(String name) throws IOException {
+    Long val = row.getLong(name);
+    validateNotNull(val, name);
+    return val;
+  }
+
+  @Override
+  protected float readFloat(String name) throws IOException {
+    Float val = row.getFloat(name);
+    validateNotNull(val, name);
+    return val;
+  }
+
+  @Override
+  protected double readDouble(String name) throws IOException {
+    Double val = row.getDouble(name);
+    validateNotNull(val, name);
+    return val;
+  }
+
+  @Override
+  protected String readString(String name) throws IOException {
+    String val = row.getString(name);
+    validateNotNull(val, name);
+    return val;
+  }
+
+  @Override
+  protected ByteBuffer readBytes(String name) throws IOException {
+    byte[] val = row.get(name);
+    validateNotNull(val, name);
+    return ByteBuffer.wrap(row.get(name));
+  }
+
+  @Override
+  protected Object readEnum(String name, Schema sourceSchema, Schema targetSchema,
+                            TypeToken<?> targetTypeToken) throws IOException {
+    Integer val = row.getInt(name);
+    validateNotNull(val, name);
+    String enumValue = sourceSchema.getEnumValue(val);
+    check(targetSchema.getEnumValues().contains(enumValue), "Enum value '%s' missing in target.", enumValue);
+    try {
+      return targetTypeToken.getRawType().getMethod("valueOf", String.class).invoke(null, enumValue);
+    } catch (Exception e) {
+      throw new IOException(e);
+    }
+  }
+
+  @Override
+  protected Object readUnion(String name, Schema sourceSchema, Schema targetSchema,
+                             TypeToken<?> targetTypeToken) throws IOException {
+    // assumption is that unions are only possible if they represent a nullable.
+    if (!sourceSchema.isNullable()) {
+      throw new UnsupportedOperationException("Unions that do not represent nullables are not supported.");
+    }
+
+    Schema sourceValueSchema = row.get(name) == null ? NULL_SCHEMA : sourceSchema.getNonNullable();
+    if (targetSchema.getType() == Schema.Type.UNION) {
+      for (Schema targetValueSchema : targetSchema.getUnionSchemas()) {
+        try {
+          return read(name, sourceValueSchema, targetValueSchema, targetTypeToken);
+        } catch (IOException e) {
+          // It's ok to have exception here, as we'll keep trying until exhausted the target union.
+        }
+      }
+      throw new IOException(String.format("Fail to resolve %s to %s", sourceSchema, targetSchema));
+    } else {
+      return read(name, sourceValueSchema, targetSchema, targetTypeToken);
+    }
+  }
+
+  @Override
+  protected Object readArray(String name, Schema sourceSchema, Schema targetSchema,
+                             TypeToken<?> targetTypeToken) throws IOException {
+    return readAndDecode(name, sourceSchema, targetSchema, targetTypeToken);
+  }
+
+  @Override
+  protected Object readMap(String name, Schema sourceSchema, Schema targetSchema,
+                           TypeToken<?> targetTypeToken) throws IOException {
+    return readAndDecode(name, sourceSchema, targetSchema, targetTypeToken);
+  }
+
+  @Override
+  protected Object readRecord(String name, Schema sourceSchema, Schema targetSchema,
+                              TypeToken<?> targetTypeToken) throws IOException {
+    return readAndDecode(name, sourceSchema, targetSchema, targetTypeToken);
+  }
+
+  private Object readAndDecode(String name, Schema sourceSchema, Schema targetSchema,
+                               TypeToken<?> targetTypeToken) throws IOException {
+    byte[] val = row.get(name);
+    validateNotNull(val, name);
+    return decode(val, sourceSchema, targetSchema, targetTypeToken);
+  }
+
+  private <O> O decode(byte[] bytes, Schema sourceSchema, Schema targetSchema,
+                        TypeToken<O> targetTypeToken) throws IOException {
+    ByteArrayInputStream bis = new ByteArrayInputStream(bytes);
+    BinaryDecoder decoder = new BinaryDecoder(bis);
+    ReflectionDatumReader<O> datumReader = new ReflectionDatumReader<O>(targetSchema, targetTypeToken);
+    return datumReader.read(decoder, sourceSchema);
+  }
+
+  // check that the value is not null and throw an exception if it is.
+  // Nullable types depend on this behavior to work correctly, as they cycle through
+  // possible types and catch IOExceptions if the type doesn't work out.
+  private void validateNotNull(Object val, String column) throws IOException {
+    if (val == null) {
+      throw new IOException("No value for " + column + " exists.");
+    }
+  }
+
+  // return true if the schema is a record or a nullable record
+  private boolean isRecord(Schema schema) {
+    if (schema.isNullable()) {
+      return schema.getNonNullable().getType() == Schema.Type.RECORD;
+    } else {
+      return schema.getType() == Schema.Type.RECORD;
+    }
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionWriter.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionWriter.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.io;
+
+import co.cask.cdap.api.data.schema.Schema;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.google.common.primitives.Longs;
+import com.google.common.reflect.TypeToken;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.nio.ByteBuffer;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Base class for writing an object with a {@link Schema}. Examines the schema to cast the object accordingly,
+ * and uses reflection to determine field values if the object is a record. Recursive types are not allowed,
+ * and the writer will keep track of references and throw an exception if it sees a recursive reference. A
+ * new writer should be created for each object written.
+ */
+public abstract class ReflectionWriter {
+
+  protected final Set<Object> seenRefs = Sets.newIdentityHashSet();
+
+  protected abstract void writeNull(String name) throws IOException;
+
+  protected abstract void writeBool(String name, Boolean val) throws IOException;
+
+  protected abstract void writeInt(String name, int val) throws IOException;
+
+  protected abstract void writeLong(String name, long val) throws IOException;
+
+  protected abstract void writeFloat(String name, Float val) throws IOException;
+
+  protected abstract void writeDouble(String name, Double val) throws IOException;
+
+  protected abstract void writeString(String name, String val) throws IOException;
+
+  protected abstract void writeBytes(String name, ByteBuffer val) throws IOException;
+
+  protected abstract void writeBytes(String name, byte[] val) throws IOException;
+
+  protected abstract void writeEnum(String name, String val, Schema schema) throws IOException;
+
+  protected abstract void writeArray(String name, Collection val, Schema componentSchema) throws IOException;
+
+  protected abstract void writeArray(String name, Object val, Schema componentSchema) throws IOException;
+
+  protected abstract void writeMap(String name, Map<?, ?> val,
+                                   Map.Entry<Schema, Schema> mapSchema) throws IOException;
+
+  protected abstract void writeUnion(String name, Object val, Schema schema) throws IOException;
+
+  /**
+   * Write the given object that has the given schema.
+   *
+   * @param object the object to write
+   * @param objSchema the schema of the object to write
+   * @throws IOException if there was an exception writing the object
+   */
+  public void write(Object object, Schema objSchema) throws IOException {
+    write(null, object, objSchema);
+  }
+
+  @SuppressWarnings("ConstantConditions")
+  protected void write(String name, Object object, Schema objSchema) throws IOException {
+    if (object != null) {
+      if (seenRefs.contains(object)) {
+        throw new IOException("Recursive reference not supported.");
+      }
+      if (objSchema.getType() == Schema.Type.RECORD) {
+        seenRefs.add(object);
+      }
+    }
+
+    switch(objSchema.getType()) {
+      case NULL:
+        writeNull(name);
+        break;
+      case BOOLEAN:
+        writeBool(name, (Boolean) object);
+        break;
+      case INT:
+        writeInt(name, ((Number) object).intValue());
+        break;
+      case LONG:
+        writeLong(name, ((Number) object).longValue());
+        break;
+      case FLOAT:
+        writeFloat(name, (Float) object);
+        break;
+      case DOUBLE:
+        writeDouble(name, (Double) object);
+        break;
+      case STRING:
+        writeString(name, object.toString());
+        break;
+      case BYTES:
+        if (object instanceof ByteBuffer) {
+          writeBytes(name, (ByteBuffer) object);
+        } else if (object instanceof UUID) {
+          UUID uuid = (UUID)  object;
+          ByteBuffer buf = ByteBuffer.allocate(Longs.BYTES * 2);
+          buf.putLong(uuid.getMostSignificantBits()).putLong(uuid.getLeastSignificantBits());
+          writeBytes(name, (ByteBuffer) buf.flip());
+        } else {
+          writeBytes(name, (byte[]) object);
+        }
+        break;
+      case ENUM:
+        writeEnum(name, object.toString(), objSchema);
+        break;
+      case ARRAY:
+        if (object instanceof Collection) {
+          writeArray(name, (Collection) object, objSchema.getComponentSchema());
+        } else {
+          writeArray(name, object, objSchema.getComponentSchema());
+        }
+        break;
+      case MAP:
+        writeMap(name, (Map<?, ?>) object, objSchema.getMapSchema());
+        break;
+      case RECORD:
+        writeRecord(name, object, objSchema);
+        break;
+      case UNION:
+        writeUnion(name, object, objSchema);
+        break;
+    }
+  }
+
+  protected void writeRecord(String name, Object record, Schema recordSchema) throws IOException {
+    try {
+      TypeToken<?> type = TypeToken.of(record.getClass());
+
+      Map<String, Method> methods = collectByMethod(type, Maps.<String, Method>newHashMap());
+      Map<String, Field> fields = collectByFields(type, Maps.<String, Field>newHashMap());
+
+      for (Schema.Field field : recordSchema.getFields()) {
+        String fieldName = field.getName();
+        Object value;
+        Field recordField = fields.get(fieldName);
+        if (recordField != null) {
+          recordField.setAccessible(true);
+          value = recordField.get(record);
+        } else {
+          Method method = methods.get(fieldName);
+          if (method == null) {
+            throw new IOException("Unable to read field value through getter. Class=" + type + ", field=" + fieldName);
+          }
+          value = method.invoke(record);
+        }
+
+        Schema fieldSchema = field.getSchema();
+        String nestedFieldName = name == null ? fieldName : scopeFieldName(name, fieldName);
+        write(nestedFieldName, value, fieldSchema);
+      }
+    } catch (Exception e) {
+      if (e instanceof IOException) {
+        throw (IOException) e;
+      }
+      throw new IOException(e);
+    }
+  }
+
+  protected String scopeFieldName(String scope, String fieldName) {
+    return scope + "." + fieldName;
+  }
+
+  private Map<String, Field> collectByFields(TypeToken<?> typeToken, Map<String, Field> fields) {
+    // Collect the field types
+    for (TypeToken<?> classType : typeToken.getTypes().classes()) {
+      Class<?> rawType = classType.getRawType();
+      if (rawType.equals(Object.class)) {
+        // Ignore all object fields
+        continue;
+      }
+
+      for (Field field : rawType.getDeclaredFields()) {
+        if (Modifier.isTransient(field.getModifiers()) || field.isSynthetic()) {
+          continue;
+        }
+        fields.put(field.getName(), field);
+      }
+    }
+    return fields;
+  }
+
+  private Map<String, Method> collectByMethod(TypeToken<?> typeToken, Map<String, Method> methods) {
+    for (Method method : typeToken.getRawType().getMethods()) {
+      if (method.getDeclaringClass().equals(Object.class)) {
+        // Ignore all object methods
+        continue;
+      }
+      String methodName = method.getName();
+      if (!(methodName.startsWith("get") || methodName.startsWith("is"))
+           || method.isSynthetic() || method.getParameterTypes().length != 0) {
+        // Ignore not getter methods
+        continue;
+      }
+      String fieldName = methodName.startsWith("get") ?
+                           methodName.substring("get".length()) : methodName.substring("is".length());
+      if (fieldName.isEmpty()) {
+        continue;
+      }
+      fieldName = String.format("%c%s", Character.toLowerCase(fieldName.charAt(0)), fieldName.substring(1));
+      if (methods.containsKey(fieldName)) {
+        continue;
+      }
+      methods.put(fieldName, method);
+    }
+    return methods;
+  }
+}

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/ReflectionTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/ReflectionTableTest.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.api.dataset.lib;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.table.Put;
+import co.cask.cdap.api.dataset.table.Row;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.data2.dataset2.AbstractDatasetTest;
+import co.cask.cdap.internal.io.ReflectionPutWriter;
+import co.cask.cdap.internal.io.ReflectionRowReader;
+import co.cask.cdap.internal.io.ReflectionSchemaGenerator;
+import co.cask.tephra.TransactionAware;
+import co.cask.tephra.TransactionExecutor;
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.reflect.TypeToken;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ *
+ */
+public class ReflectionTableTest extends AbstractDatasetTest {
+  private static final User SAMUEL = new User(
+    "Samuel L.", "Jackson",
+    Gender.MALE,
+    123,
+    1234567890000L,
+    new Date(2015, 2, 10),
+    50000000.02f,
+    Double.MAX_VALUE,
+    new int[] { 2, 8, 1, 3, 3, 0, 8, 0, 0, 4 },
+    Lists.newArrayList("Shaft", "Mace", "Pulp Fiction guy"),
+    ImmutableMap.of("occupation", "goat", "rank", "1"),
+    new byte[]{0, 1, 2});
+
+  public static enum Gender {
+    MALE,
+    FEMALE
+  }
+
+  public static class Date {
+    private int year;
+    private int month;
+    private int day;
+
+    public Date(int year, int month, int day) {
+      this.year = year;
+      this.month = month;
+      this.day = day;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof Date)) {
+        return false;
+      }
+
+      Date that = (Date) o;
+
+      return year == that.year && month == that.month && day == that.day;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(year, month, day);
+    }
+  }
+
+  public static class User {
+    private String firstName;
+    private String lastName;
+    private Gender gender;
+    private Integer id;
+    private Long timestamp;
+    private Date signupDate;
+    private Float salary;
+    private Double lastPurchase;
+    private int[] digits;
+    private List<String> aliases;
+    private Map<String, String> attributes;
+    private byte[] blob;
+
+    public User(String firstName, String lastName, Gender gender, Integer id, Long timestamp,
+                Date signupDate, Float salary, Double lastPurchase, int[] digits,
+                List<String> aliases, Map<String, String> attributes, byte[] blob) {
+      this.firstName = firstName;
+      this.lastName = lastName;
+      this.gender = gender;
+      this.id = id;
+      this.timestamp = timestamp;
+      this.signupDate = signupDate;
+      this.salary = salary;
+      this.lastPurchase = lastPurchase;
+      this.digits = digits;
+      this.aliases = aliases;
+      this.attributes = attributes;
+      this.blob = blob;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof User)) {
+        return false;
+      }
+
+      User that = (User) o;
+
+      return Objects.equal(firstName, that.firstName) &&
+        Objects.equal(lastName, that.lastName) &&
+        Objects.equal(gender, that.gender) &&
+        Objects.equal(id, that.id) &&
+        Objects.equal(timestamp, that.timestamp) &&
+        Objects.equal(signupDate, that.signupDate) &&
+        Objects.equal(salary, that.salary) &&
+        Objects.equal(lastPurchase, that.lastPurchase) &&
+        Arrays.equals(digits, that.digits) &&
+        Objects.equal(aliases, that.aliases) &&
+        Objects.equal(attributes, that.attributes) &&
+        Arrays.equals(blob, that.blob);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(firstName, lastName, gender, id, timestamp, signupDate, salary,
+                              lastPurchase, digits, aliases, attributes, blob);
+    }
+  }
+
+  public static class User2 {
+    private String firstName;
+    private Long id;
+    private Double salary;
+    private Double lastPurchase;
+    private ByteBuffer blob;
+    private Double newField;
+
+    private User2(String firstName, Long id, Double salary, Double lastPurchase, ByteBuffer blob) {
+      this.firstName = firstName;
+      this.id = id;
+      this.salary = salary;
+      this.lastPurchase = lastPurchase;
+      this.blob = blob;
+      this.newField = null;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof User2)) {
+        return false;
+      }
+
+      User2 that = (User2) o;
+
+      return Objects.equal(firstName, that.firstName) &&
+        Objects.equal(id, that.id) &&
+        Objects.equal(salary, that.salary) &&
+        Objects.equal(lastPurchase, that.lastPurchase) &&
+        Objects.equal(blob, that.blob) &&
+        Objects.equal(newField, that.newField);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(firstName, id, salary, lastPurchase, blob, newField);
+    }
+  }
+
+  @Test
+  public void testPutAndGet() throws Exception {
+    createInstance("table", "users", DatasetProperties.builder().build());
+    try {
+      final Table usersTable = getInstance("users");
+      final byte[] rowKey = Bytes.toBytes(123);
+      final Schema schema = new ReflectionSchemaGenerator().generate(User.class);
+      assertGetAndPut(usersTable, rowKey, SAMUEL, schema);
+    } finally {
+      deleteInstance("users");
+    }
+  }
+
+  @Test
+  public void testNullFields() throws Exception {
+    createInstance("table", "users", DatasetProperties.builder().build());
+    try {
+      final Table usersTable = getInstance("users");
+      final byte[] rowKey = Bytes.toBytes(123);
+      final Schema schema = new ReflectionSchemaGenerator().generate(User.class);
+      assertGetAndPut(usersTable, rowKey, SAMUEL, schema);
+    } finally {
+      deleteInstance("users");
+    }
+  }
+
+  @Test
+  public void testTypeProjection() throws Exception {
+    createInstance("table", "users", DatasetProperties.builder().build());
+    try {
+      final Table usersTable = getInstance("users");
+      final byte[] rowKey = Bytes.toBytes(123);
+      final User2 projected = new User2("Samuel L.", 123L, ((Float) 50000000.02f).doubleValue(), Double.MAX_VALUE,
+                                        ByteBuffer.wrap(new byte[]{0, 1, 2}));
+      final Schema fullSchema = new ReflectionSchemaGenerator().generate(User.class);
+      final Schema projSchema = new ReflectionSchemaGenerator().generate(User2.class);
+
+      // TableDataset is not accessible here, but we know that's the underlying implementation...
+      TransactionExecutor tx = newTransactionExecutor((TransactionAware) usersTable);
+      tx.execute(new TransactionExecutor.Subroutine() {
+        @Override
+        public void apply() throws Exception {
+          Put put = new Put(rowKey);
+          ReflectionPutWriter putWriter = new ReflectionPutWriter(put);
+          putWriter.write(SAMUEL, fullSchema);
+          usersTable.put(put);
+          Row row = usersTable.get(rowKey);
+          ReflectionRowReader<User2> rowReader = new ReflectionRowReader<User2>(row);
+          User2 actual = rowReader.read(fullSchema, projSchema, TypeToken.of(User2.class));
+          Assert.assertEquals(projected, actual);
+        }
+      });
+    } finally {
+      deleteInstance("users");
+    }
+  }
+
+  private void assertGetAndPut(final Table table, final byte[] rowKey, final Object obj,
+                               final Schema schema) throws Exception {
+    // TableDataset is not accessible here, but we know that's the underlying implementation...
+    TransactionExecutor tx = newTransactionExecutor((TransactionAware) table);
+    tx.execute(new TransactionExecutor.Subroutine() {
+      @Override
+      public void apply() throws Exception {
+        Put put = new Put(rowKey);
+        ReflectionPutWriter putWriter = new ReflectionPutWriter(put);
+        putWriter.write(obj, schema);
+        table.put(put);
+        Row row = table.get(rowKey);
+        ReflectionRowReader<User> rowReader = new ReflectionRowReader<User>(row);
+        User actual = rowReader.read(schema, schema, TypeToken.of(User.class));
+        Assert.assertEquals(obj, actual);
+      }
+    });
+  }
+}


### PR DESCRIPTION
can be re-used for formats other than our avro-like binary
encoding. For example, we may want to encode an object as a
Put object to be written to a Table, and decode an object from a
Row object fetched from a Table.