### PR TITLE
fix metric standalone binding for unit-tests

### DIFF
--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/guice/MetricsClientRuntimeModule.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/guice/MetricsClientRuntimeModule.java
@@ -57,6 +57,7 @@ public final class MetricsClientRuntimeModule extends RuntimeModule {
       @Override
       protected void configure() {
         bind(MetricDatasetFactory.class).to(DefaultMetricDatasetFactory.class).in(Scopes.SINGLETON);
+        bind(MetricStore.class).to(DefaultMetricStore.class);
         bind(MetricsCollectionService.class).to(LocalMetricsCollectionService.class).in(Scopes.SINGLETON);
         expose(MetricsCollectionService.class);
       }


### PR DESCRIPTION
NOTE: merges into metric-store-integrated branch (as per #1251)