### PR TITLE
Feature/v3 stream apis

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -32,6 +32,7 @@ import co.cask.cdap.data.stream.service.StreamHandlerV2;
 import co.cask.cdap.data2.datafabric.dataset.DatasetExecutorServiceManager;
 import co.cask.cdap.explore.service.ExploreServiceManager;
 import co.cask.cdap.gateway.handlers.AppFabricHttpHandler;
+import co.cask.cdap.gateway.handlers.AppFabricStreamHttpHandler;
 import co.cask.cdap.gateway.handlers.AppLifecycleHttpHandler;
 import co.cask.cdap.gateway.handlers.CommonHandlers;
 import co.cask.cdap.gateway.handlers.ConsoleSettingsHttpHandler;
@@ -270,6 +271,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
                                                                         Names.named("appfabric.http.handler"));
       CommonHandlers.add(handlerBinder);
       handlerBinder.addBinding().to(AppFabricHttpHandler.class);
+      handlerBinder.addBinding().to(AppFabricStreamHttpHandler.class);
       handlerBinder.addBinding().to(VersionHandler.class);
       handlerBinder.addBinding().to(MonitorHandler.class);
       handlerBinder.addBinding().to(ServiceHttpHandler.class);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -26,7 +26,7 @@ import co.cask.cdap.common.utils.Networks;
 import co.cask.cdap.config.guice.ConfigStoreModule;
 import co.cask.cdap.data.stream.StreamServiceManager;
 import co.cask.cdap.data.stream.service.StreamFetchHandler;
-import co.cask.cdap.data.stream.service.StreamHandler;
+import co.cask.cdap.data.stream.service.StreamHandlerV2;
 import co.cask.cdap.data2.datafabric.dataset.DatasetExecutorServiceManager;
 import co.cask.cdap.explore.service.ExploreServiceManager;
 import co.cask.cdap.gateway.handlers.AppFabricHttpHandler;
@@ -106,7 +106,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
 
   @Override
   public Module getInMemoryModules() {
-    return Modules.combine(new AppFabricServiceModule(StreamHandler.class, StreamFetchHandler.class),
+    return Modules.combine(new AppFabricServiceModule(StreamHandlerV2.class, StreamFetchHandler.class),
                            new ConfigStoreModule().getInMemoryModule(),
                            new AbstractModule() {
                              @Override
@@ -151,7 +151,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
   @Override
   public Module getStandaloneModules() {
 
-    return Modules.combine(new AppFabricServiceModule(StreamHandler.class, StreamFetchHandler.class),
+    return Modules.combine(new AppFabricServiceModule(StreamHandlerV2.class, StreamFetchHandler.class),
                            new ConfigStoreModule().getStandaloneModule(),
                            new AbstractModule() {
                              @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -26,6 +26,8 @@ import co.cask.cdap.common.utils.Networks;
 import co.cask.cdap.config.guice.ConfigStoreModule;
 import co.cask.cdap.data.stream.StreamServiceManager;
 import co.cask.cdap.data.stream.service.StreamFetchHandler;
+import co.cask.cdap.data.stream.service.StreamFetchHandlerV2;
+import co.cask.cdap.data.stream.service.StreamHandler;
 import co.cask.cdap.data.stream.service.StreamHandlerV2;
 import co.cask.cdap.data2.datafabric.dataset.DatasetExecutorServiceManager;
 import co.cask.cdap.explore.service.ExploreServiceManager;
@@ -106,7 +108,8 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
 
   @Override
   public Module getInMemoryModules() {
-    return Modules.combine(new AppFabricServiceModule(StreamHandlerV2.class, StreamFetchHandler.class),
+    return Modules.combine(new AppFabricServiceModule(StreamHandlerV2.class, StreamFetchHandlerV2.class,
+                                                      StreamHandler.class, StreamFetchHandler.class),
                            new ConfigStoreModule().getInMemoryModule(),
                            new AbstractModule() {
                              @Override
@@ -151,7 +154,8 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
   @Override
   public Module getStandaloneModules() {
 
-    return Modules.combine(new AppFabricServiceModule(StreamHandlerV2.class, StreamFetchHandler.class),
+    return Modules.combine(new AppFabricServiceModule(StreamHandlerV2.class, StreamFetchHandlerV2.class,
+                                                      StreamHandler.class, StreamFetchHandler.class),
                            new ConfigStoreModule().getStandaloneModule(),
                            new AbstractModule() {
                              @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricHttpHandler.java
@@ -16,14 +16,6 @@
 
 package co.cask.cdap.gateway.handlers;
 
-import co.cask.cdap.api.data.stream.StreamSpecification;
-import co.cask.cdap.api.dataset.DatasetSpecification;
-import co.cask.cdap.api.flow.FlowSpecification;
-import co.cask.cdap.api.flow.FlowletConnection;
-import co.cask.cdap.api.flow.FlowletDefinition;
-import co.cask.cdap.api.mapreduce.MapReduceSpecification;
-import co.cask.cdap.api.procedure.ProcedureSpecification;
-import co.cask.cdap.app.ApplicationSpecification;
 import co.cask.cdap.app.runtime.ProgramRuntimeService;
 import co.cask.cdap.app.services.Data;
 import co.cask.cdap.app.store.Store;
@@ -43,29 +35,22 @@ import co.cask.cdap.gateway.handlers.util.AbstractAppFabricHttpHandler;
 import co.cask.cdap.internal.UserErrors;
 import co.cask.cdap.internal.UserMessages;
 import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
-import co.cask.cdap.proto.DatasetRecord;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.Instances;
-import co.cask.cdap.proto.ProgramRecord;
 import co.cask.cdap.proto.ProgramStatus;
 import co.cask.cdap.proto.ProgramType;
-import co.cask.cdap.proto.StreamRecord;
 import co.cask.http.BodyConsumer;
 import co.cask.http.ChunkResponder;
 import co.cask.http.HttpResponder;
 import co.cask.tephra.TransactionSystemClient;
-import com.google.common.base.Charsets;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import com.google.common.io.Closeables;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.inject.Inject;
 import org.jboss.netty.buffer.ChannelBuffers;
-import org.jboss.netty.handler.codec.http.HttpHeaders;
 import org.jboss.netty.handler.codec.http.HttpRequest;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.slf4j.Logger;
@@ -73,10 +58,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Collection;
-import java.util.List;
-import java.util.Set;
-import javax.annotation.Nullable;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
@@ -93,11 +74,6 @@ import javax.ws.rs.QueryParam;
 @Path(Constants.Gateway.API_VERSION_2) //this will be removed/changed when gateway goes.
 public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
   private static final Logger LOG = LoggerFactory.getLogger(AppFabricHttpHandler.class);
-
-  /**
-   * Json serializer.
-   */
-  private static final Gson GSON = new Gson();
 
   /**
    * Configuration object passed from higher up.
@@ -135,6 +111,8 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
 
   private final ProgramLifecycleHttpHandler programLifecycleHttpHandler;
 
+  private final AppFabricStreamHttpHandler appFabricStreamHttpHandler;
+
   private final PreferencesStore preferencesStore;
 
   private final ConsoleSettingsStore consoleSettingsStore;
@@ -149,6 +127,7 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
                               QueueAdmin queueAdmin, TransactionSystemClient txClient, DatasetFramework dsFramework,
                               AppLifecycleHttpHandler appLifecycleHttpHandler,
                               ProgramLifecycleHttpHandler programLifecycleHttpHandler,
+                              AppFabricStreamHttpHandler appFabricStreamHttpHandler,
                               PreferencesStore preferencesStore, ConsoleSettingsStore consoleSettingsStore) {
 
     super(authenticator);
@@ -162,6 +141,7 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
       new NamespacedDatasetFramework(dsFramework, new DefaultDatasetNamespace(configuration, Namespace.USER));
     this.appLifecycleHttpHandler = appLifecycleHttpHandler;
     this.programLifecycleHttpHandler = programLifecycleHttpHandler;
+    this.appFabricStreamHttpHandler = appFabricStreamHttpHandler;
     this.preferencesStore = preferencesStore;
     this.consoleSettingsStore = consoleSettingsStore;
   }
@@ -815,13 +795,7 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
   @DELETE
   @Path("/streams")
   public void deleteStreams(HttpRequest request, HttpResponder responder) {
-    try {
-      streamAdmin.dropAll();
-      responder.sendStatus(HttpResponseStatus.OK);
-    } catch (Exception e) {
-      LOG.error("Error while deleting streams", e);
-      responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, e.getMessage());
-    }
+    appFabricStreamHttpHandler.deleteStreams(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE);
   }
 
   @GET
@@ -957,7 +931,7 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
   @GET
   @Path("/streams")
   public void getStreams(HttpRequest request, HttpResponder responder) {
-    dataList(request, responder, Data.STREAM, null, null);
+    appFabricStreamHttpHandler.getStreams(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE);
   }
 
   /**
@@ -967,7 +941,8 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/streams/{stream-id}")
   public void getStreamSpecification(HttpRequest request, HttpResponder responder,
                                      @PathParam("stream-id") final String streamId) {
-    dataList(request, responder, Data.STREAM, streamId, null);
+    appFabricStreamHttpHandler.getStreamSpecification(rewriteRequest(request), responder,
+                                                      Constants.DEFAULT_NAMESPACE, streamId);
   }
 
   /**
@@ -977,7 +952,7 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/apps/{app-id}/streams")
   public void getStreamsByApp(HttpRequest request, HttpResponder responder,
                               @PathParam("app-id") final String appId) {
-    dataList(request, responder, Data.STREAM, null, appId);
+    appFabricStreamHttpHandler.getStreamsByApp(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE, appId);
   }
 
   /**
@@ -986,7 +961,7 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
   @GET
   @Path("/datasets")
   public void getDatasets(HttpRequest request, HttpResponder responder) {
-    dataList(request, responder, Data.DATASET, null, null);
+    dataList(request, responder, store, dsFramework, Data.DATASET, null, null);
   }
 
   /**
@@ -996,7 +971,7 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/datasets/{dataset-id}")
   public void getDatasetSpecification(HttpRequest request, HttpResponder responder,
                                       @PathParam("dataset-id") final String datasetId) {
-    dataList(request, responder, Data.DATASET, datasetId, null);
+    dataList(request, responder, store, dsFramework, Data.DATASET, datasetId, null);
   }
 
   /**
@@ -1006,147 +981,7 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/apps/{app-id}/datasets")
   public void getDatasetsByApp(HttpRequest request, HttpResponder responder,
                                @PathParam("app-id") final String appId) {
-    dataList(request, responder, Data.DATASET, null, appId);
-  }
-
-  private void dataList(HttpRequest request, HttpResponder responder, Data type, String name, String appId) {
-    try {
-      if ((name != null && name.isEmpty()) || (appId != null && appId.isEmpty())) {
-        responder.sendString(HttpResponseStatus.BAD_REQUEST, "Empty name provided");
-        return;
-      }
-
-      String accountId = getAuthenticatedAccountId(request);
-      Id.Program program = Id.Program.from(accountId, appId == null ? "" : appId, "");
-      String json = name != null ? getDataEntity(program, type, name) :
-        appId != null ? listDataEntitiesByApp(program, type) : listDataEntities(program, type);
-      if (json.isEmpty()) {
-        responder.sendStatus(HttpResponseStatus.NOT_FOUND);
-      } else {
-        responder.sendByteArray(HttpResponseStatus.OK, json.getBytes(Charsets.UTF_8),
-                                ImmutableMultimap.of(HttpHeaders.Names.CONTENT_TYPE, "application/json"));
-      }
-    } catch (SecurityException e) {
-      responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);
-    } catch (Throwable e) {
-      LOG.error("Got exception : ", e);
-      responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
-    }
-  }
-
-  private String getDataEntity(Id.Program programId, Data type, String name) {
-    Id.Namespace namespace = new Id.Namespace(programId.getNamespaceId());
-    if (type == Data.DATASET) {
-      DatasetSpecification dsSpec = getDatasetSpec(name);
-      String typeName = null;
-      if (dsSpec != null) {
-        typeName = dsSpec.getType();
-      }
-      return GSON.toJson(makeDataSetRecord(name, typeName));
-    } else if (type == Data.STREAM) {
-      StreamSpecification spec = store.getStream(namespace, name);
-      return spec == null ? "" : GSON.toJson(makeStreamRecord(spec.getName(), spec));
-    }
-    return "";
-  }
-
-  private String listDataEntities(Id.Program programId, Data type) throws Exception {
-    if (type == Data.DATASET) {
-      Collection<DatasetSpecification> instances = dsFramework.getInstances();
-      List<DatasetRecord> result = Lists.newArrayListWithExpectedSize(instances.size());
-      for (DatasetSpecification instance : instances) {
-        result.add(makeDataSetRecord(instance.getName(), instance.getType()));
-      }
-      return GSON.toJson(result);
-    } else if (type == Data.STREAM) {
-      Collection<StreamSpecification> specs = store.getAllStreams(new Id.Namespace(programId.getNamespaceId()));
-      List<StreamRecord> result = Lists.newArrayListWithExpectedSize(specs.size());
-      for (StreamSpecification spec : specs) {
-        result.add(makeStreamRecord(spec.getName(), null));
-      }
-      return GSON.toJson(result);
-    }
-    return "";
-
-  }
-
-  private String listDataEntitiesByApp(Id.Program programId, Data type) throws Exception {
-    Id.Namespace namespace = new Id.Namespace(programId.getNamespaceId());
-    ApplicationSpecification appSpec = store.getApplication(new Id.Application(
-      namespace, programId.getApplicationId()));
-    if (type == Data.DATASET) {
-      Set<String> dataSetsUsed = dataSetsUsedBy(appSpec);
-      List<DatasetRecord> result = Lists.newArrayListWithExpectedSize(dataSetsUsed.size());
-      for (String dsName : dataSetsUsed) {
-        String typeName = null;
-        DatasetSpecification dsSpec = getDatasetSpec(dsName);
-        if (dsSpec != null) {
-          typeName = dsSpec.getType();
-        }
-        result.add(makeDataSetRecord(dsName, typeName));
-      }
-      return GSON.toJson(result);
-    }
-    if (type == Data.STREAM) {
-      Set<String> streamsUsed = streamsUsedBy(appSpec);
-      List<StreamRecord> result = Lists.newArrayListWithExpectedSize(streamsUsed.size());
-      for (String streamName : streamsUsed) {
-        result.add(makeStreamRecord(streamName, null));
-      }
-      return GSON.toJson(result);
-    }
-    return "";
-  }
-
-  @Nullable
-  private DatasetSpecification getDatasetSpec(String dsName) {
-    try {
-      return dsFramework.getDatasetSpec(dsName);
-    } catch (Exception e) {
-      LOG.warn("Couldn't get spec for dataset: " + dsName);
-      return null;
-    }
-  }
-
-  private Set<String> dataSetsUsedBy(FlowSpecification flowSpec) {
-    Set<String> result = Sets.newHashSet();
-    for (FlowletDefinition flowlet : flowSpec.getFlowlets().values()) {
-      result.addAll(flowlet.getDatasets());
-    }
-    return result;
-  }
-
-  private Set<String> dataSetsUsedBy(ApplicationSpecification appSpec) {
-    Set<String> result = Sets.newHashSet();
-    for (FlowSpecification flowSpec : appSpec.getFlows().values()) {
-      result.addAll(dataSetsUsedBy(flowSpec));
-    }
-    for (ProcedureSpecification procSpec : appSpec.getProcedures().values()) {
-      result.addAll(procSpec.getDataSets());
-    }
-    for (MapReduceSpecification mrSpec : appSpec.getMapReduce().values()) {
-      result.addAll(mrSpec.getDataSets());
-    }
-    return result;
-  }
-
-  private Set<String> streamsUsedBy(FlowSpecification flowSpec) {
-    Set<String> result = Sets.newHashSet();
-    for (FlowletConnection con : flowSpec.getConnections()) {
-      if (FlowletConnection.Type.STREAM == con.getSourceType()) {
-        result.add(con.getSourceName());
-      }
-    }
-    return result;
-  }
-
-  private Set<String> streamsUsedBy(ApplicationSpecification appSpec) {
-    Set<String> result = Sets.newHashSet();
-    for (FlowSpecification flowSpec : appSpec.getFlows().values()) {
-      result.addAll(streamsUsedBy(flowSpec));
-    }
-    result.addAll(appSpec.getStreams().keySet());
-    return result;
+    dataList(request, responder, store, dsFramework, Data.DATASET, null, appId);
   }
 
   /**
@@ -1156,7 +991,8 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/streams/{stream-id}/flows")
   public void getFlowsByStream(HttpRequest request, HttpResponder responder,
                                @PathParam("stream-id") final String streamId) {
-    programListByDataAccess(request, responder, ProgramType.FLOW, Data.STREAM, streamId);
+    appFabricStreamHttpHandler.getFlowsByStream(rewriteRequest(request), responder,
+                                                Constants.DEFAULT_NAMESPACE, streamId);
   }
 
   /**
@@ -1166,105 +1002,7 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/datasets/{dataset-id}/flows")
   public void getFlowsByDataset(HttpRequest request, HttpResponder responder,
                                 @PathParam("dataset-id") final String datasetId) {
-    programListByDataAccess(request, responder, ProgramType.FLOW, Data.DATASET, datasetId);
-  }
-
-  private void programListByDataAccess(HttpRequest request, HttpResponder responder,
-                                       ProgramType type, Data data, String name) {
-    try {
-      if (name.isEmpty()) {
-        responder.sendString(HttpResponseStatus.BAD_REQUEST, data.prettyName().toLowerCase() + " name is empty");
-        return;
-      }
-      String accountId = getAuthenticatedAccountId(request);
-      Id.Program programId = Id.Program.from(accountId, "", "");
-      List<ProgramRecord> programRecords = listProgramsByDataAccess(programId, type, data, name);
-      if (programRecords == null) {
-        responder.sendStatus(HttpResponseStatus.NOT_FOUND);
-      } else {
-        responder.sendJson(HttpResponseStatus.OK, programRecords);
-      }
-    } catch (SecurityException e) {
-      responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);
-    } catch (Throwable e) {
-      LOG.error("Got exception:", e);
-      responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
-    }
-  }
-
-  /**
-   * @return list of program records, an empty list if no programs were found, or null if the stream or
-   * dataset does not exist
-   */
-  private List<ProgramRecord> listProgramsByDataAccess(Id.Program programId, ProgramType type,
-                                                       Data data, String name) throws Exception {
-    // search all apps for programs that use this
-    List<ProgramRecord> result = Lists.newArrayList();
-    Collection<ApplicationSpecification> appSpecs = store.getAllApplications(
-      new Id.Namespace(programId.getNamespaceId()));
-    if (appSpecs != null) {
-      for (ApplicationSpecification appSpec : appSpecs) {
-        if (type == ProgramType.FLOW) {
-          for (FlowSpecification flowSpec : appSpec.getFlows().values()) {
-            if ((data == Data.DATASET && usesDataSet(flowSpec, name))
-              || (data == Data.STREAM && usesStream(flowSpec, name))) {
-              result.add(makeProgramRecord(appSpec.getName(), flowSpec, ProgramType.FLOW));
-            }
-          }
-        } else if (type == ProgramType.PROCEDURE) {
-          for (ProcedureSpecification procedureSpec : appSpec.getProcedures().values()) {
-            if (data == Data.DATASET && procedureSpec.getDataSets().contains(name)) {
-              result.add(makeProgramRecord(appSpec.getName(), procedureSpec, ProgramType.PROCEDURE));
-            }
-          }
-        } else if (type == ProgramType.MAPREDUCE) {
-          for (MapReduceSpecification mrSpec : appSpec.getMapReduce().values()) {
-            if (data == Data.DATASET && mrSpec.getDataSets().contains(name)) {
-              result.add(makeProgramRecord(appSpec.getName(), mrSpec, ProgramType.MAPREDUCE));
-            }
-          }
-        }
-      }
-    }
-    if (!result.isEmpty()) {
-      return result;
-    }
-    // if no programs were found, check whether the data exists, return [] if yes, null if not
-    boolean exists = false;
-    if (data == Data.DATASET) {
-      exists = dsFramework.hasInstance(name);
-    } else if (data == Data.STREAM) {
-      exists = store.getStream(new Id.Namespace(Constants.DEFAULT_NAMESPACE), name) != null;
-    }
-    return exists ? result : null;
-  }
-
-  private static boolean usesDataSet(FlowSpecification flowSpec, String dataset) {
-    for (FlowletDefinition flowlet : flowSpec.getFlowlets().values()) {
-      if (flowlet.getDatasets().contains(dataset)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  private static boolean usesStream(FlowSpecification flowSpec, String stream) {
-    for (FlowletConnection con : flowSpec.getConnections()) {
-      if (FlowletConnection.Type.STREAM == con.getSourceType() && stream.equals(con.getSourceName())) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-   /* -----------------  helpers to return Json consistently -------------- */
-
-  private static DatasetRecord makeDataSetRecord(String name, String classname) {
-    return new DatasetRecord("Dataset", name, name, classname);
-  }
-
-  private static StreamRecord makeStreamRecord(String name, StreamSpecification specification) {
-    return new StreamRecord("Stream", name, name, GSON.toJson(specification));
+    programListByDataAccess(request, responder, store, dsFramework, ProgramType.FLOW, Data.DATASET, datasetId);
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricHttpHandler.java
@@ -22,6 +22,7 @@ import co.cask.cdap.app.store.Store;
 import co.cask.cdap.app.store.StoreFactory;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.http.RESTMigrationUtils;
 import co.cask.cdap.config.ConsoleSettingsStore;
 import co.cask.cdap.config.PreferencesStore;
 import co.cask.cdap.data.Namespace;
@@ -936,7 +937,8 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
   @GET
   @Path("/streams")
   public void getStreams(HttpRequest request, HttpResponder responder) {
-    appFabricStreamHttpHandler.getStreams(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE);
+    appFabricStreamHttpHandler.getStreams(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
+                                          Constants.DEFAULT_NAMESPACE);
   }
 
   /**
@@ -946,7 +948,7 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/streams/{stream-id}")
   public void getStreamSpecification(HttpRequest request, HttpResponder responder,
                                      @PathParam("stream-id") final String streamId) {
-    dataList(request, responder, store, dsFramework, Data.STREAM, streamId, null);
+    dataList(request, responder, store, dsFramework, Data.STREAM, Constants.DEFAULT_NAMESPACE, streamId, null);
   }
 
   /**
@@ -956,7 +958,8 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/apps/{app-id}/streams")
   public void getStreamsByApp(HttpRequest request, HttpResponder responder,
                               @PathParam("app-id") final String appId) {
-    appFabricStreamHttpHandler.getStreamsByApp(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE, appId);
+    appFabricStreamHttpHandler.getStreamsByApp(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
+                                               Constants.DEFAULT_NAMESPACE, appId);
   }
 
   /**
@@ -965,7 +968,7 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
   @GET
   @Path("/datasets")
   public void getDatasets(HttpRequest request, HttpResponder responder) {
-    dataList(request, responder, store, dsFramework, Data.DATASET, null, null);
+    dataList(request, responder, store, dsFramework, Data.DATASET, Constants.DEFAULT_NAMESPACE, null, null);
   }
 
   /**
@@ -975,7 +978,7 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/datasets/{dataset-id}")
   public void getDatasetSpecification(HttpRequest request, HttpResponder responder,
                                       @PathParam("dataset-id") final String datasetId) {
-    dataList(request, responder, store, dsFramework, Data.DATASET, datasetId, null);
+    dataList(request, responder, store, dsFramework, Data.DATASET, Constants.DEFAULT_NAMESPACE, datasetId, null);
   }
 
   /**
@@ -985,7 +988,7 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/apps/{app-id}/datasets")
   public void getDatasetsByApp(HttpRequest request, HttpResponder responder,
                                @PathParam("app-id") final String appId) {
-    dataList(request, responder, store, dsFramework, Data.DATASET, null, appId);
+    dataList(request, responder, store, dsFramework, Data.DATASET, Constants.DEFAULT_NAMESPACE, null, appId);
   }
 
   /**
@@ -995,7 +998,7 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/streams/{stream-id}/flows")
   public void getFlowsByStream(HttpRequest request, HttpResponder responder,
                                @PathParam("stream-id") final String streamId) {
-    appFabricStreamHttpHandler.getFlowsByStream(rewriteRequest(request), responder,
+    appFabricStreamHttpHandler.getFlowsByStream(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
                                                 Constants.DEFAULT_NAMESPACE, streamId);
   }
 
@@ -1006,7 +1009,8 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/datasets/{dataset-id}/flows")
   public void getFlowsByDataset(HttpRequest request, HttpResponder responder,
                                 @PathParam("dataset-id") final String datasetId) {
-    programListByDataAccess(request, responder, store, dsFramework, ProgramType.FLOW, Data.DATASET, datasetId);
+    programListByDataAccess(request, responder, store, dsFramework, ProgramType.FLOW, Data.DATASET,
+                            Constants.DEFAULT_NAMESPACE, datasetId);
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricHttpHandler.java
@@ -99,23 +99,19 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
    * Store manages non-runtime lifecycle.
    */
   private final Store store;
+  private final PreferencesStore preferencesStore;
+  private final ConsoleSettingsStore consoleSettingsStore;
 
   private final QueueAdmin queueAdmin;
-
   private final StreamAdmin streamAdmin;
 
   /**
    * V3 API Handlers
    */
   private final AppLifecycleHttpHandler appLifecycleHttpHandler;
-
   private final ProgramLifecycleHttpHandler programLifecycleHttpHandler;
-
   private final AppFabricStreamHttpHandler appFabricStreamHttpHandler;
 
-  private final PreferencesStore preferencesStore;
-
-  private final ConsoleSettingsStore consoleSettingsStore;
 
   /**
    * Constructs an new instance. Parameters are binded by Guice.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricHttpHandler.java
@@ -47,7 +47,6 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.io.Closeables;
-import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.inject.Inject;
 import org.jboss.netty.buffer.ChannelBuffers;
@@ -795,7 +794,13 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
   @DELETE
   @Path("/streams")
   public void deleteStreams(HttpRequest request, HttpResponder responder) {
-    appFabricStreamHttpHandler.deleteStreams(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE);
+    try {
+      streamAdmin.dropAll();
+      responder.sendStatus(HttpResponseStatus.OK);
+    } catch (Exception e) {
+      LOG.error("Error while deleting streams", e);
+      responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, e.getMessage());
+    }
   }
 
   @GET
@@ -941,8 +946,7 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/streams/{stream-id}")
   public void getStreamSpecification(HttpRequest request, HttpResponder responder,
                                      @PathParam("stream-id") final String streamId) {
-    appFabricStreamHttpHandler.getStreamSpecification(rewriteRequest(request), responder,
-                                                      Constants.DEFAULT_NAMESPACE, streamId);
+    dataList(request, responder, store, dsFramework, Data.STREAM, streamId, null);
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricStreamHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricStreamHttpHandler.java
@@ -37,7 +37,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 
 /**
- *  HttpHandler class for app-fabric requests.
+ *  HttpHandler class for stream requests in app-fabric.
  */
 @Path(Constants.Gateway.API_VERSION_3 + "/namespaces/{namespace-id}")
 public class AppFabricStreamHttpHandler extends AbstractAppFabricHttpHandler {
@@ -53,14 +53,12 @@ public class AppFabricStreamHttpHandler extends AbstractAppFabricHttpHandler {
   private final Store store;
 
 
-
   /**
    * Constructs an new instance. Parameters are binded by Guice.
    */
   @Inject
   public AppFabricStreamHttpHandler(Authenticator authenticator, CConfiguration configuration,
                                     StoreFactory storeFactory, DatasetFramework dsFramework) {
-
     super(authenticator);
     this.store = storeFactory.create();
     this.dsFramework =

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricStreamHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricStreamHttpHandler.java
@@ -72,7 +72,7 @@ public class AppFabricStreamHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/streams")
   public void getStreams(HttpRequest request, HttpResponder responder,
                          @PathParam("namespace-id") String namespaceId) {
-    dataList(request, responder, store, dsFramework, Data.STREAM, null, null);
+    dataList(request, responder, store, dsFramework, Data.STREAM, namespaceId, null, null);
   }
 
   /**
@@ -83,7 +83,7 @@ public class AppFabricStreamHttpHandler extends AbstractAppFabricHttpHandler {
   public void getStreamsByApp(HttpRequest request, HttpResponder responder,
                               @PathParam("namespace-id") String namespaceId,
                               @PathParam("app-id") final String appId) {
-    dataList(request, responder, store, dsFramework, Data.STREAM, null, appId);
+    dataList(request, responder, store, dsFramework, Data.STREAM, namespaceId, null, appId);
   }
 
   /**
@@ -94,6 +94,7 @@ public class AppFabricStreamHttpHandler extends AbstractAppFabricHttpHandler {
   public void getFlowsByStream(HttpRequest request, HttpResponder responder,
                                @PathParam("namespace-id") String namespaceId,
                                @PathParam("stream-id") final String streamId) {
-    programListByDataAccess(request, responder, store, dsFramework, ProgramType.FLOW, Data.STREAM, streamId);
+    programListByDataAccess(request, responder, store, dsFramework, ProgramType.FLOW, Data.STREAM,
+                            namespaceId, streamId);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricStreamHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricStreamHttpHandler.java
@@ -25,18 +25,13 @@ import co.cask.cdap.data.Namespace;
 import co.cask.cdap.data2.datafabric.DefaultDatasetNamespace;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.NamespacedDatasetFramework;
-import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.gateway.auth.Authenticator;
 import co.cask.cdap.gateway.handlers.util.AbstractAppFabricHttpHandler;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.http.HttpResponder;
 import com.google.inject.Inject;
 import org.jboss.netty.handler.codec.http.HttpRequest;
-import org.jboss.netty.handler.codec.http.HttpResponseStatus;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -46,7 +41,6 @@ import javax.ws.rs.PathParam;
  */
 @Path(Constants.Gateway.API_VERSION_3 + "/namespaces/{namespace-id}")
 public class AppFabricStreamHttpHandler extends AbstractAppFabricHttpHandler {
-  private static final Logger LOG = LoggerFactory.getLogger(AppFabricStreamHttpHandler.class);
 
   /**
    * Access Dataset Service
@@ -59,34 +53,18 @@ public class AppFabricStreamHttpHandler extends AbstractAppFabricHttpHandler {
   private final Store store;
 
 
-  private final StreamAdmin streamAdmin;
-
 
   /**
    * Constructs an new instance. Parameters are binded by Guice.
    */
   @Inject
   public AppFabricStreamHttpHandler(Authenticator authenticator, CConfiguration configuration,
-                                    StoreFactory storeFactory, StreamAdmin streamAdmin, DatasetFramework dsFramework) {
+                                    StoreFactory storeFactory, DatasetFramework dsFramework) {
 
     super(authenticator);
-    this.streamAdmin = streamAdmin;
     this.store = storeFactory.create();
     this.dsFramework =
       new NamespacedDatasetFramework(dsFramework, new DefaultDatasetNamespace(configuration, Namespace.USER));
-  }
-
-  @DELETE
-  @Path("/streams")
-  public void deleteStreams(HttpRequest request, HttpResponder responder,
-                            @PathParam("namespace-id") String namespaceId) {
-    try {
-      streamAdmin.dropAll();
-      responder.sendStatus(HttpResponseStatus.OK);
-    } catch (Exception e) {
-      LOG.error("Error while deleting streams", e);
-      responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, e.getMessage());
-    }
   }
 
   /**
@@ -97,17 +75,6 @@ public class AppFabricStreamHttpHandler extends AbstractAppFabricHttpHandler {
   public void getStreams(HttpRequest request, HttpResponder responder,
                          @PathParam("namespace-id") String namespaceId) {
     dataList(request, responder, store, dsFramework, Data.STREAM, null, null);
-  }
-
-  /**
-   * Returns a stream associated with account.
-   */
-  @GET
-  @Path("/streams/{stream-id}")
-  public void getStreamSpecification(HttpRequest request, HttpResponder responder,
-                                     @PathParam("namespace-id") String namespaceId,
-                                     @PathParam("stream-id") final String streamId) {
-    dataList(request, responder, store, dsFramework, Data.STREAM, streamId, null);
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/util/AbstractAppFabricHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/util/AbstractAppFabricHttpHandler.java
@@ -17,30 +17,44 @@
 package co.cask.cdap.gateway.handlers.util;
 
 import co.cask.cdap.api.ProgramSpecification;
+import co.cask.cdap.api.data.stream.StreamSpecification;
+import co.cask.cdap.api.dataset.DatasetSpecification;
+import co.cask.cdap.api.flow.FlowSpecification;
+import co.cask.cdap.api.flow.FlowletConnection;
+import co.cask.cdap.api.flow.FlowletDefinition;
+import co.cask.cdap.api.mapreduce.MapReduceSpecification;
+import co.cask.cdap.api.procedure.ProcedureSpecification;
 import co.cask.cdap.app.ApplicationSpecification;
 import co.cask.cdap.app.runtime.ProgramRuntimeService;
+import co.cask.cdap.app.services.Data;
 import co.cask.cdap.app.store.Store;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.http.RESTMigrationUtils;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.gateway.auth.Authenticator;
 import co.cask.cdap.gateway.handlers.AuthenticatedHttpHandler;
 import co.cask.cdap.internal.UserErrors;
 import co.cask.cdap.internal.UserMessages;
+import co.cask.cdap.proto.DatasetRecord;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.Instances;
 import co.cask.cdap.proto.ProgramRecord;
 import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.StreamRecord;
 import co.cask.http.HttpResponder;
 import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
 import org.jboss.netty.buffer.ChannelBuffer;
 import org.jboss.netty.buffer.ChannelBufferInputStream;
+import org.jboss.netty.handler.codec.http.HttpHeaders;
 import org.jboss.netty.handler.codec.http.HttpRequest;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.slf4j.Logger;
@@ -54,6 +68,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
@@ -326,5 +341,251 @@ public abstract class AbstractAppFabricHttpHandler extends AuthenticatedHttpHand
     request.setUri(originalUri.replaceFirst(Constants.Gateway.API_VERSION_2, Constants.Gateway.API_VERSION_3 +
       "/namespaces/" + Constants.DEFAULT_NAMESPACE));
     return request;
+  }
+
+
+  protected final void dataList(HttpRequest request, HttpResponder responder, Store store, DatasetFramework dsFramework,
+                        Data type, String name, String appId) {
+    try {
+      if ((name != null && name.isEmpty()) || (appId != null && appId.isEmpty())) {
+        responder.sendString(HttpResponseStatus.BAD_REQUEST, "Empty name provided");
+        return;
+      }
+
+      String accountId = getAuthenticatedAccountId(request);
+      Id.Program program = Id.Program.from(accountId, appId == null ? "" : appId, "");
+      String json = name != null ? getDataEntity(store, dsFramework, program, type, name) :
+        appId != null ? listDataEntitiesByApp(store, dsFramework, program, type)
+          : listDataEntities(store, dsFramework, program, type);
+      if (json.isEmpty()) {
+        responder.sendStatus(HttpResponseStatus.NOT_FOUND);
+      } else {
+        responder.sendByteArray(HttpResponseStatus.OK, json.getBytes(Charsets.UTF_8),
+                                ImmutableMultimap.of(HttpHeaders.Names.CONTENT_TYPE, "application/json"));
+      }
+    } catch (SecurityException e) {
+      responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);
+    } catch (Throwable e) {
+      LOG.error("Got exception : ", e);
+      responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  private String getDataEntity(Store store, DatasetFramework dsFramework,
+                               Id.Program programId, Data type, String name) {
+    Id.Namespace namespace = new Id.Namespace(programId.getNamespaceId());
+    if (type == Data.DATASET) {
+      DatasetSpecification dsSpec = getDatasetSpec(dsFramework, name);
+      String typeName = null;
+      if (dsSpec != null) {
+        typeName = dsSpec.getType();
+      }
+      return GSON.toJson(makeDataSetRecord(name, typeName));
+    } else if (type == Data.STREAM) {
+      StreamSpecification spec = store.getStream(namespace, name);
+      return spec == null ? "" : GSON.toJson(makeStreamRecord(spec.getName(), spec));
+    }
+    return "";
+  }
+
+  private String listDataEntities(Store store, DatasetFramework dsFramework,
+                                  Id.Program programId, Data type) throws Exception {
+    if (type == Data.DATASET) {
+      Collection<DatasetSpecification> instances = dsFramework.getInstances();
+      List<DatasetRecord> result = Lists.newArrayListWithExpectedSize(instances.size());
+      for (DatasetSpecification instance : instances) {
+        result.add(makeDataSetRecord(instance.getName(), instance.getType()));
+      }
+      return GSON.toJson(result);
+    } else if (type == Data.STREAM) {
+      Collection<StreamSpecification> specs = store.getAllStreams(new Id.Namespace(programId.getNamespaceId()));
+      List<StreamRecord> result = Lists.newArrayListWithExpectedSize(specs.size());
+      for (StreamSpecification spec : specs) {
+        result.add(makeStreamRecord(spec.getName(), null));
+      }
+      return GSON.toJson(result);
+    }
+    return "";
+
+  }
+
+  private String listDataEntitiesByApp(Store store, DatasetFramework dsFramework,
+                                       Id.Program programId, Data type) throws Exception {
+    Id.Namespace namespace = new Id.Namespace(programId.getNamespaceId());
+    ApplicationSpecification appSpec = store.getApplication(new Id.Application(
+      namespace, programId.getApplicationId()));
+    if (type == Data.DATASET) {
+      Set<String> dataSetsUsed = dataSetsUsedBy(appSpec);
+      List<DatasetRecord> result = Lists.newArrayListWithExpectedSize(dataSetsUsed.size());
+      for (String dsName : dataSetsUsed) {
+        String typeName = null;
+        DatasetSpecification dsSpec = getDatasetSpec(dsFramework, dsName);
+        if (dsSpec != null) {
+          typeName = dsSpec.getType();
+        }
+        result.add(makeDataSetRecord(dsName, typeName));
+      }
+      return GSON.toJson(result);
+    }
+    if (type == Data.STREAM) {
+      Set<String> streamsUsed = streamsUsedBy(appSpec);
+      List<StreamRecord> result = Lists.newArrayListWithExpectedSize(streamsUsed.size());
+      for (String streamName : streamsUsed) {
+        result.add(makeStreamRecord(streamName, null));
+      }
+      return GSON.toJson(result);
+    }
+    return "";
+  }
+
+  @Nullable
+  private DatasetSpecification getDatasetSpec(DatasetFramework dsFramework, String dsName) {
+    try {
+      return dsFramework.getDatasetSpec(dsName);
+    } catch (Exception e) {
+      LOG.warn("Couldn't get spec for dataset: " + dsName);
+      return null;
+    }
+  }
+
+  private Set<String> dataSetsUsedBy(FlowSpecification flowSpec) {
+    Set<String> result = Sets.newHashSet();
+    for (FlowletDefinition flowlet : flowSpec.getFlowlets().values()) {
+      result.addAll(flowlet.getDatasets());
+    }
+    return result;
+  }
+
+  private Set<String> dataSetsUsedBy(ApplicationSpecification appSpec) {
+    Set<String> result = Sets.newHashSet();
+    for (FlowSpecification flowSpec : appSpec.getFlows().values()) {
+      result.addAll(dataSetsUsedBy(flowSpec));
+    }
+    for (ProcedureSpecification procSpec : appSpec.getProcedures().values()) {
+      result.addAll(procSpec.getDataSets());
+    }
+    for (MapReduceSpecification mrSpec : appSpec.getMapReduce().values()) {
+      result.addAll(mrSpec.getDataSets());
+    }
+    return result;
+  }
+
+  private Set<String> streamsUsedBy(FlowSpecification flowSpec) {
+    Set<String> result = Sets.newHashSet();
+    for (FlowletConnection con : flowSpec.getConnections()) {
+      if (FlowletConnection.Type.STREAM == con.getSourceType()) {
+        result.add(con.getSourceName());
+      }
+    }
+    return result;
+  }
+
+  private Set<String> streamsUsedBy(ApplicationSpecification appSpec) {
+    Set<String> result = Sets.newHashSet();
+    for (FlowSpecification flowSpec : appSpec.getFlows().values()) {
+      result.addAll(streamsUsedBy(flowSpec));
+    }
+    result.addAll(appSpec.getStreams().keySet());
+    return result;
+  }
+
+  protected final void programListByDataAccess(HttpRequest request, HttpResponder responder,
+                                               Store store, DatasetFramework dsFramework,
+                                               ProgramType type, Data data, String name) {
+    try {
+      if (name.isEmpty()) {
+        responder.sendString(HttpResponseStatus.BAD_REQUEST, data.prettyName().toLowerCase() + " name is empty");
+        return;
+      }
+      String accountId = getAuthenticatedAccountId(request);
+      Id.Program programId = Id.Program.from(accountId, "", "");
+      List<ProgramRecord> programRecords = listProgramsByDataAccess(store, dsFramework, programId, type, data, name);
+      if (programRecords == null) {
+        responder.sendStatus(HttpResponseStatus.NOT_FOUND);
+      } else {
+        responder.sendJson(HttpResponseStatus.OK, programRecords);
+      }
+    } catch (SecurityException e) {
+      responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);
+    } catch (Throwable e) {
+      LOG.error("Got exception:", e);
+      responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  /**
+   * @return list of program records, an empty list if no programs were found, or null if the stream or
+   * dataset does not exist
+   */
+  private List<ProgramRecord> listProgramsByDataAccess(Store store, DatasetFramework dsFramework,
+                                                       Id.Program programId, ProgramType type,
+                                                       Data data, String name) throws Exception {
+    // search all apps for programs that use this
+    List<ProgramRecord> result = Lists.newArrayList();
+    Collection<ApplicationSpecification> appSpecs = store.getAllApplications(
+      new Id.Namespace(programId.getNamespaceId()));
+    if (appSpecs != null) {
+      for (ApplicationSpecification appSpec : appSpecs) {
+        if (type == ProgramType.FLOW) {
+          for (FlowSpecification flowSpec : appSpec.getFlows().values()) {
+            if ((data == Data.DATASET && usesDataSet(flowSpec, name))
+              || (data == Data.STREAM && usesStream(flowSpec, name))) {
+              result.add(makeProgramRecord(appSpec.getName(), flowSpec, ProgramType.FLOW));
+            }
+          }
+        } else if (type == ProgramType.PROCEDURE) {
+          for (ProcedureSpecification procedureSpec : appSpec.getProcedures().values()) {
+            if (data == Data.DATASET && procedureSpec.getDataSets().contains(name)) {
+              result.add(makeProgramRecord(appSpec.getName(), procedureSpec, ProgramType.PROCEDURE));
+            }
+          }
+        } else if (type == ProgramType.MAPREDUCE) {
+          for (MapReduceSpecification mrSpec : appSpec.getMapReduce().values()) {
+            if (data == Data.DATASET && mrSpec.getDataSets().contains(name)) {
+              result.add(makeProgramRecord(appSpec.getName(), mrSpec, ProgramType.MAPREDUCE));
+            }
+          }
+        }
+      }
+    }
+    if (!result.isEmpty()) {
+      return result;
+    }
+    // if no programs were found, check whether the data exists, return [] if yes, null if not
+    boolean exists = false;
+    if (data == Data.DATASET) {
+      exists = dsFramework.hasInstance(name);
+    } else if (data == Data.STREAM) {
+      exists = store.getStream(new Id.Namespace(Constants.DEFAULT_NAMESPACE), name) != null;
+    }
+    return exists ? result : null;
+  }
+
+  private static boolean usesDataSet(FlowSpecification flowSpec, String dataset) {
+    for (FlowletDefinition flowlet : flowSpec.getFlowlets().values()) {
+      if (flowlet.getDatasets().contains(dataset)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean usesStream(FlowSpecification flowSpec, String stream) {
+    for (FlowletConnection con : flowSpec.getConnections()) {
+      if (FlowletConnection.Type.STREAM == con.getSourceType() && stream.equals(con.getSourceName())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /* -----------------  helpers to return Json consistently -------------- */
+
+  protected final static DatasetRecord makeDataSetRecord(String name, String classname) {
+    return new DatasetRecord("Dataset", name, name, classname);
+  }
+
+  protected final static StreamRecord makeStreamRecord(String name, StreamSpecification specification) {
+    return new StreamRecord("Stream", name, name, GSON.toJson(specification));
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/util/AbstractAppFabricHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/util/AbstractAppFabricHttpHandler.java
@@ -581,11 +581,11 @@ public abstract class AbstractAppFabricHttpHandler extends AuthenticatedHttpHand
 
   /* -----------------  helpers to return Json consistently -------------- */
 
-  protected final static DatasetRecord makeDataSetRecord(String name, String classname) {
+  protected static final DatasetRecord makeDataSetRecord(String name, String classname) {
     return new DatasetRecord("Dataset", name, name, classname);
   }
 
-  protected final static StreamRecord makeStreamRecord(String name, StreamSpecification specification) {
+  protected static final StreamRecord makeStreamRecord(String name, StreamSpecification specification) {
     return new StreamRecord("Stream", name, name, GSON.toJson(specification));
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/util/AbstractAppFabricHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/util/AbstractAppFabricHttpHandler.java
@@ -345,15 +345,14 @@ public abstract class AbstractAppFabricHttpHandler extends AuthenticatedHttpHand
 
 
   protected final void dataList(HttpRequest request, HttpResponder responder, Store store, DatasetFramework dsFramework,
-                        Data type, String name, String appId) {
+                                Data type, String namespace, String name, String appId) {
     try {
       if ((name != null && name.isEmpty()) || (appId != null && appId.isEmpty())) {
         responder.sendString(HttpResponseStatus.BAD_REQUEST, "Empty name provided");
         return;
       }
 
-      String accountId = getAuthenticatedAccountId(request);
-      Id.Program program = Id.Program.from(accountId, appId == null ? "" : appId, "");
+      Id.Program program = Id.Program.from(namespace, appId == null ? "" : appId, "");
       String json = name != null ? getDataEntity(store, dsFramework, program, type, name) :
         appId != null ? listDataEntitiesByApp(store, dsFramework, program, type)
           : listDataEntities(store, dsFramework, program, type);
@@ -491,14 +490,13 @@ public abstract class AbstractAppFabricHttpHandler extends AuthenticatedHttpHand
 
   protected final void programListByDataAccess(HttpRequest request, HttpResponder responder,
                                                Store store, DatasetFramework dsFramework,
-                                               ProgramType type, Data data, String name) {
+                                               ProgramType type, Data data, String namespace, String name) {
     try {
       if (name.isEmpty()) {
         responder.sendString(HttpResponseStatus.BAD_REQUEST, data.prettyName().toLowerCase() + " name is empty");
         return;
       }
-      String accountId = getAuthenticatedAccountId(request);
-      Id.Program programId = Id.Program.from(accountId, "", "");
+      Id.Program programId = Id.Program.from(namespace, "", "");
       List<ProgramRecord> programRecords = listProgramsByDataAccess(store, dsFramework, programId, type, data, name);
       if (programRecords == null) {
         responder.sendStatus(HttpResponseStatus.NOT_FOUND);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamFetchHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamFetchHandler.java
@@ -63,7 +63,7 @@ import javax.ws.rs.QueryParam;
 /**
  * A HTTP handler for handling getting stream events.
  */
-@Path(Constants.Gateway.API_VERSION_3 + "/namespaces/{namespace-id}")
+@Path(Constants.Gateway.API_VERSION_3 + "/namespaces/{namespace-id}/streams")
 public final class StreamFetchHandler extends AuthenticatedHttpHandler {
 
   private static final Gson GSON = StreamEventTypeAdapter.register(new GsonBuilder()).create();

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamFetchHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamFetchHandler.java
@@ -63,7 +63,7 @@ import javax.ws.rs.QueryParam;
 /**
  * A HTTP handler for handling getting stream events.
  */
-@Path(Constants.Gateway.API_VERSION_2 + "/streams")
+@Path(Constants.Gateway.API_VERSION_3 + "/namespaces/{namespace-id}")
 public final class StreamFetchHandler extends AuthenticatedHttpHandler {
 
   private static final Gson GSON = StreamEventTypeAdapter.register(new GsonBuilder()).create();
@@ -99,6 +99,7 @@ public final class StreamFetchHandler extends AuthenticatedHttpHandler {
   @GET
   @Path("/{stream}/events")
   public void fetch(HttpRequest request, HttpResponder responder,
+                    @PathParam("namespace-id") String namespaceId,
                     @PathParam("stream") String stream,
                     @QueryParam("start") long startTime,
                     @QueryParam("end") @DefaultValue("9223372036854775807") long endTime,

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamFetchHandlerV2.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamFetchHandlerV2.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.data.stream.service;
 
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.http.RESTMigrationUtils;
 import co.cask.cdap.common.stream.StreamEventTypeAdapter;
 import co.cask.cdap.gateway.auth.Authenticator;
 import co.cask.cdap.gateway.handlers.AuthenticatedHttpHandler;
@@ -64,23 +65,7 @@ public final class StreamFetchHandlerV2 extends AuthenticatedHttpHandler {
                     @QueryParam("start") long startTime,
                     @QueryParam("end") @DefaultValue("9223372036854775807") long endTime,
                     @QueryParam("limit") @DefaultValue("2147483647") int limit) throws Exception {
-    streamFetchHandler.fetch(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE, stream,
-                             startTime, endTime, limit);
+    streamFetchHandler.fetch(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
+                             Constants.DEFAULT_NAMESPACE, stream, startTime, endTime, limit);
   }
-
-  /**
-   * Updates the request URI to its v3 URI before delegating the call to the corresponding v3 handler.
-   * Note: This piece of code is duplicated in LogHandler, but its ok since this temporary, till we
-   * support v2 APIs
-   *
-   * @param request the original {@link HttpRequest}
-   * @return {@link HttpRequest} with modified URI
-   */
-  public HttpRequest rewriteRequest(HttpRequest request) {
-    String originalUri = request.getUri();
-    request.setUri(originalUri.replaceFirst(Constants.Gateway.API_VERSION_2, Constants.Gateway.API_VERSION_3 +
-      "/namespaces/" + Constants.DEFAULT_NAMESPACE));
-    return request;
-  }
-
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamFetchHandlerV2.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamFetchHandlerV2.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data.stream.service;
+
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.stream.StreamEventTypeAdapter;
+import co.cask.cdap.gateway.auth.Authenticator;
+import co.cask.cdap.gateway.handlers.AuthenticatedHttpHandler;
+import co.cask.http.HttpResponder;
+import com.google.inject.Inject;
+import org.jboss.netty.handler.codec.http.HttpRequest;
+
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
+
+/**
+ * A HTTP handler for handling getting stream events.
+ */
+@Path(Constants.Gateway.API_VERSION_2 + "/streams")
+public final class StreamFetchHandlerV2 extends AuthenticatedHttpHandler {
+
+  // StreamFetchHandler for V3 APIs,to which calls will be delegated to.
+  private final StreamFetchHandler streamFetchHandler;
+
+  @Inject
+  public StreamFetchHandlerV2(Authenticator authenticator, StreamFetchHandler streamFetchHandler) {
+    super(authenticator);
+    this.streamFetchHandler = streamFetchHandler;
+  }
+
+  /**
+   * Handler for the HTTP API {@code /streams/[stream_name]/events?start=[start_ts]&end=[end_ts]&limit=[event_limit]}
+   * <p/>
+   * Response with
+   * 404 if stream not exists.
+   * 204 if no event in the given start/end time range
+   * 200 if there is event
+   * <p/>
+   * Response body is an Json array of StreamEvent object
+   *
+   * @see StreamEventTypeAdapter for the format of StreamEvent object.
+   */
+  @GET
+  @Path("/{stream}/events")
+  public void fetch(HttpRequest request, HttpResponder responder,
+                    @PathParam("stream") String stream,
+                    @QueryParam("start") long startTime,
+                    @QueryParam("end") @DefaultValue("9223372036854775807") long endTime,
+                    @QueryParam("limit") @DefaultValue("2147483647") int limit) throws Exception {
+    streamFetchHandler.fetch(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE, stream,
+                             startTime, endTime, limit);
+  }
+
+  /**
+   * Updates the request URI to its v3 URI before delegating the call to the corresponding v3 handler.
+   * Note: This piece of code is duplicated in LogHandler, but its ok since this temporary, till we
+   * support v2 APIs
+   *
+   * @param request the original {@link HttpRequest}
+   * @return {@link HttpRequest} with modified URI
+   */
+  public HttpRequest rewriteRequest(HttpRequest request) {
+    String originalUri = request.getUri();
+    request.setUri(originalUri.replaceFirst(Constants.Gateway.API_VERSION_2, Constants.Gateway.API_VERSION_3 +
+      "/namespaces/" + Constants.DEFAULT_NAMESPACE));
+    return request;
+  }
+
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -79,11 +79,11 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 
 /**
- * The {@link HttpHandler} for handling REST call to stream endpoints.
+ * The {@link HttpHandler} for handling REST call to V3 stream APIs.
  *
  * TODO: Currently stream "dataset" is implementing old dataset API, hence not supporting multi-tenancy.
  */
-@Path(Constants.Gateway.API_VERSION_2 + "/streams")
+@Path(Constants.Gateway.API_VERSION_3 + "/namespaces/{namespace-id}")
 public final class StreamHandler extends AuthenticatedHttpHandler {
 
   private static final Logger LOG = LoggerFactory.getLogger(StreamHandler.class);
@@ -160,6 +160,7 @@ public final class StreamHandler extends AuthenticatedHttpHandler {
   @GET
   @Path("/{stream}/info")
   public void getInfo(HttpRequest request, HttpResponder responder,
+                      @PathParam("namespace-id") String namespaceId,
                       @PathParam("stream") String stream) throws Exception {
     String accountID = getAuthenticatedAccountId(request);
 
@@ -177,6 +178,7 @@ public final class StreamHandler extends AuthenticatedHttpHandler {
   @PUT
   @Path("/{stream}")
   public void create(HttpRequest request, HttpResponder responder,
+                     @PathParam("namespace-id") String namespaceId,
                      @PathParam("stream") String stream) throws Exception {
 
     String accountID = getAuthenticatedAccountId(request);
@@ -199,6 +201,7 @@ public final class StreamHandler extends AuthenticatedHttpHandler {
   @POST
   @Path("/{stream}")
   public void enqueue(HttpRequest request, HttpResponder responder,
+                      @PathParam("namespace-id") String namespaceId,
                       @PathParam("stream") String stream) throws Exception {
 
     String accountId = getAuthenticatedAccountId(request);
@@ -217,6 +220,7 @@ public final class StreamHandler extends AuthenticatedHttpHandler {
   @POST
   @Path("/{stream}/async")
   public void asyncEnqueue(HttpRequest request, HttpResponder responder,
+                           @PathParam("namespace-id") String namespaceId,
                            @PathParam("stream") String stream) throws Exception {
     String accountId = getAuthenticatedAccountId(request);
     // No need to copy the content buffer as we always uses a ChannelBufferFactory that won't reuse buffer.
@@ -229,6 +233,7 @@ public final class StreamHandler extends AuthenticatedHttpHandler {
   @POST
   @Path("/{stream}/batch")
   public BodyConsumer batch(HttpRequest request, HttpResponder responder,
+                            @PathParam("namespace-id") String namespaceId,
                             @PathParam("stream") String stream) throws Exception {
     String accountId = getAuthenticatedAccountId(request);
 
@@ -248,6 +253,7 @@ public final class StreamHandler extends AuthenticatedHttpHandler {
   @POST
   @Path("/{stream}/truncate")
   public void truncate(HttpRequest request, HttpResponder responder,
+                       @PathParam("namespace-id") String namespaceId,
                        @PathParam("stream") String stream) throws Exception {
     String accountId = getAuthenticatedAccountId(request);
 
@@ -267,6 +273,7 @@ public final class StreamHandler extends AuthenticatedHttpHandler {
   @PUT
   @Path("/{stream}/config")
   public void setConfig(HttpRequest request, HttpResponder responder,
+                        @PathParam("namespace-id") String namespaceId,
                         @PathParam("stream") String stream) throws Exception {
 
     String accountId = getAuthenticatedAccountId(request);
@@ -450,7 +457,7 @@ public final class StreamHandler extends AuthenticatedHttpHandler {
   }
 
   /**
-   *  Adapter class for {@link co.cask.cdap.proto.StreamProperties}. Its main purpose is to transform
+   *  Adapter class for {@link StreamProperties}. Its main purpose is to transform
    *  the unit of TTL, which is second in JSON, but millisecond in the StreamProperties object.
    */
   private static final class StreamPropertiesAdapter implements JsonSerializer<StreamProperties>,

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamHandler.java
@@ -50,10 +50,10 @@ import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
-import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 import com.google.inject.Inject;
+import com.google.inject.Singleton;
 import org.apache.twill.common.Threads;
 import org.jboss.netty.buffer.ChannelBufferInputStream;
 import org.jboss.netty.handler.codec.http.HttpHeaders;
@@ -83,6 +83,7 @@ import javax.ws.rs.PathParam;
  *
  * TODO: Currently stream "dataset" is implementing old dataset API, hence not supporting multi-tenancy.
  */
+@Singleton
 @Path(Constants.Gateway.API_VERSION_3 + "/namespaces/{namespace-id}/streams")
 public final class StreamHandler extends AuthenticatedHttpHandler {
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamHandler.java
@@ -83,7 +83,7 @@ import javax.ws.rs.PathParam;
  *
  * TODO: Currently stream "dataset" is implementing old dataset API, hence not supporting multi-tenancy.
  */
-@Path(Constants.Gateway.API_VERSION_3 + "/namespaces/{namespace-id}")
+@Path(Constants.Gateway.API_VERSION_3 + "/namespaces/{namespace-id}/streams")
 public final class StreamHandler extends AuthenticatedHttpHandler {
 
   private static final Logger LOG = LoggerFactory.getLogger(StreamHandler.class);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamHandlerV2.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamHandlerV2.java
@@ -16,6 +16,7 @@
 package co.cask.cdap.data.stream.service;
 
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.http.RESTMigrationUtils;
 import co.cask.cdap.gateway.auth.Authenticator;
 import co.cask.cdap.gateway.handlers.AuthenticatedHttpHandler;
 import co.cask.http.BodyConsumer;
@@ -51,63 +52,55 @@ public final class StreamHandlerV2 extends AuthenticatedHttpHandler {
   @Path("/{stream}/info")
   public void getInfo(HttpRequest request, HttpResponder responder,
                       @PathParam("stream") String stream) throws Exception {
-    streamHandler.getInfo(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE, stream);
+    streamHandler.getInfo(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
+                          Constants.DEFAULT_NAMESPACE, stream);
   }
 
   @PUT
   @Path("/{stream}")
   public void create(HttpRequest request, HttpResponder responder,
                      @PathParam("stream") String stream) throws Exception {
-    streamHandler.create(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE, stream);
+    streamHandler.create(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
+                         Constants.DEFAULT_NAMESPACE, stream);
   }
 
   @POST
   @Path("/{stream}")
   public void enqueue(HttpRequest request, HttpResponder responder,
                       @PathParam("stream") String stream) throws Exception {
-    streamHandler.enqueue(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE, stream);
+    streamHandler.enqueue(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
+                          Constants.DEFAULT_NAMESPACE, stream);
   }
 
   @POST
   @Path("/{stream}/async")
   public void asyncEnqueue(HttpRequest request, HttpResponder responder,
                            @PathParam("stream") String stream) throws Exception {
-    streamHandler.asyncEnqueue(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE, stream);
+    streamHandler.asyncEnqueue(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
+                               Constants.DEFAULT_NAMESPACE, stream);
   }
 
   @POST
   @Path("/{stream}/batch")
   public BodyConsumer batch(HttpRequest request, HttpResponder responder,
                             @PathParam("stream") String stream) throws Exception {
-    return streamHandler.batch(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE, stream);
+    return streamHandler.batch(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
+                               Constants.DEFAULT_NAMESPACE, stream);
   }
 
   @POST
   @Path("/{stream}/truncate")
   public void truncate(HttpRequest request, HttpResponder responder,
                        @PathParam("stream") String stream) throws Exception {
-    streamHandler.truncate(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE, stream);
+    streamHandler.truncate(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
+                           Constants.DEFAULT_NAMESPACE, stream);
   }
 
   @PUT
   @Path("/{stream}/config")
   public void setConfig(HttpRequest request, HttpResponder responder,
                         @PathParam("stream") String stream) throws Exception {
-    streamHandler.setConfig(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE, stream);
-  }
-
-  /**
-   * Updates the request URI to its v3 URI before delegating the call to the corresponding v3 handler.
-   * Note: This piece of code is duplicated in LogHandler, but its ok since this temporary, till we
-   * support v2 APIs
-   *
-   * @param request the original {@link HttpRequest}
-   * @return {@link HttpRequest} with modified URI
-   */
-  public HttpRequest rewriteRequest(HttpRequest request) {
-    String originalUri = request.getUri();
-    request.setUri(originalUri.replaceFirst(Constants.Gateway.API_VERSION_2, Constants.Gateway.API_VERSION_3 +
-      "/namespaces/" + Constants.DEFAULT_NAMESPACE));
-    return request;
+    streamHandler.setConfig(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
+                            Constants.DEFAULT_NAMESPACE, stream);
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamHandlerV2.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamHandlerV2.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright © 2014-2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.data.stream.service;
+
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.gateway.auth.Authenticator;
+import co.cask.cdap.gateway.handlers.AuthenticatedHttpHandler;
+import co.cask.http.BodyConsumer;
+import co.cask.http.HttpHandler;
+import co.cask.http.HttpResponder;
+import com.google.inject.Inject;
+import org.jboss.netty.handler.codec.http.HttpRequest;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+/**
+ * The {@link HttpHandler} for handling REST call to stream endpoints.
+ *
+ * TODO: Currently stream "dataset" is implementing old dataset API, hence not supporting multi-tenancy.
+ */
+@Path(Constants.Gateway.API_VERSION_2 + "/streams")
+public final class StreamHandlerV2 extends AuthenticatedHttpHandler {
+
+  // StreamHandler for V3 APIs,to which calls will be delegated to.
+  private final StreamHandler streamHandler;
+
+  @Inject
+  public StreamHandlerV2(Authenticator authenticator, StreamHandler streamHandler) {
+    super(authenticator);
+    this.streamHandler = streamHandler;
+  }
+
+  @GET
+  @Path("/{stream}/info")
+  public void getInfo(HttpRequest request, HttpResponder responder,
+                      @PathParam("stream") String stream) throws Exception {
+    streamHandler.getInfo(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE, stream);
+  }
+
+  @PUT
+  @Path("/{stream}")
+  public void create(HttpRequest request, HttpResponder responder,
+                     @PathParam("stream") String stream) throws Exception {
+    streamHandler.create(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE, stream);
+  }
+
+  @POST
+  @Path("/{stream}")
+  public void enqueue(HttpRequest request, HttpResponder responder,
+                      @PathParam("stream") String stream) throws Exception {
+    streamHandler.enqueue(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE, stream);
+  }
+
+  @POST
+  @Path("/{stream}/async")
+  public void asyncEnqueue(HttpRequest request, HttpResponder responder,
+                           @PathParam("stream") String stream) throws Exception {
+    streamHandler.asyncEnqueue(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE, stream);
+  }
+
+  @POST
+  @Path("/{stream}/batch")
+  public BodyConsumer batch(HttpRequest request, HttpResponder responder,
+                            @PathParam("stream") String stream) throws Exception {
+    return streamHandler.batch(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE, stream);
+  }
+
+  @POST
+  @Path("/{stream}/truncate")
+  public void truncate(HttpRequest request, HttpResponder responder,
+                       @PathParam("stream") String stream) throws Exception {
+    streamHandler.truncate(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE, stream);
+  }
+
+  @PUT
+  @Path("/{stream}/config")
+  public void setConfig(HttpRequest request, HttpResponder responder,
+                        @PathParam("stream") String stream) throws Exception {
+    streamHandler.setConfig(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE, stream);
+  }
+
+  /**
+   * Updates the request URI to its v3 URI before delegating the call to the corresponding v3 handler.
+   * Note: This piece of code is duplicated in LogHandler, but its ok since this temporary, till we
+   * support v2 APIs
+   *
+   * @param request the original {@link HttpRequest}
+   * @return {@link HttpRequest} with modified URI
+   */
+  public HttpRequest rewriteRequest(HttpRequest request) {
+    String originalUri = request.getUri();
+    request.setUri(originalUri.replaceFirst(Constants.Gateway.API_VERSION_2, Constants.Gateway.API_VERSION_3 +
+      "/namespaces/" + Constants.DEFAULT_NAMESPACE));
+    return request;
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamServiceModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamServiceModule.java
@@ -33,6 +33,8 @@ public class StreamServiceModule extends PrivateModule {
     Multibinder<HttpHandler> handlerBinder = Multibinder.newSetBinder(binder(), HttpHandler.class,
                                                                       Names.named(Constants.Stream.STREAM_HANDLER));
     handlerBinder.addBinding().to(StreamHandlerV2.class);
+    handlerBinder.addBinding().to(StreamFetchHandlerV2.class);
+    handlerBinder.addBinding().to(StreamHandler.class);
     handlerBinder.addBinding().to(StreamFetchHandler.class);
     CommonHandlers.add(handlerBinder);
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamServiceModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamServiceModule.java
@@ -32,7 +32,7 @@ public class StreamServiceModule extends PrivateModule {
   protected void configure() {
     Multibinder<HttpHandler> handlerBinder = Multibinder.newSetBinder(binder(), HttpHandler.class,
                                                                       Names.named(Constants.Stream.STREAM_HANDLER));
-    handlerBinder.addBinding().to(StreamHandler.class);
+    handlerBinder.addBinding().to(StreamHandlerV2.class);
     handlerBinder.addBinding().to(StreamFetchHandler.class);
     CommonHandlers.add(handlerBinder);
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamServiceRuntimeModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamServiceRuntimeModule.java
@@ -75,6 +75,8 @@ public final class StreamServiceRuntimeModule extends RuntimeModule {
         Multibinder<HttpHandler> handlerBinder = Multibinder.newSetBinder(binder(), HttpHandler.class,
                                                                           Names.named(Constants.Stream.STREAM_HANDLER));
         handlerBinder.addBinding().to(StreamHandlerV2.class);
+        handlerBinder.addBinding().to(StreamFetchHandlerV2.class);
+        handlerBinder.addBinding().to(StreamHandler.class);
         handlerBinder.addBinding().to(StreamFetchHandler.class);
         CommonHandlers.add(handlerBinder);
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamServiceRuntimeModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamServiceRuntimeModule.java
@@ -74,7 +74,7 @@ public final class StreamServiceRuntimeModule extends RuntimeModule {
 
         Multibinder<HttpHandler> handlerBinder = Multibinder.newSetBinder(binder(), HttpHandler.class,
                                                                           Names.named(Constants.Stream.STREAM_HANDLER));
-        handlerBinder.addBinding().to(StreamHandler.class);
+        handlerBinder.addBinding().to(StreamHandlerV2.class);
         handlerBinder.addBinding().to(StreamFetchHandler.class);
         CommonHandlers.add(handlerBinder);
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamWriterSizeCollector.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamWriterSizeCollector.java
@@ -19,7 +19,7 @@ package co.cask.cdap.data.stream.service;
 import com.google.common.util.concurrent.Service;
 
 /**
- * Keep track of the sizes of the files written by one {@link StreamHandler}.
+ * Keep track of the sizes of the files written by one {@link StreamHandlerV2}.
  */
 public interface StreamWriterSizeCollector extends Service {
 

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/BaseHiveExploreServiceTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/BaseHiveExploreServiceTest.java
@@ -28,6 +28,8 @@ import co.cask.cdap.data.runtime.DataSetServiceModules;
 import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data.stream.StreamAdminModules;
 import co.cask.cdap.data.stream.service.StreamFetchHandler;
+import co.cask.cdap.data.stream.service.StreamFetchHandlerV2;
+import co.cask.cdap.data.stream.service.StreamHandler;
 import co.cask.cdap.data.stream.service.StreamHandlerV2;
 import co.cask.cdap.data.stream.service.StreamHttpService;
 import co.cask.cdap.data.stream.service.StreamService;
@@ -305,6 +307,8 @@ public class BaseHiveExploreServiceTest {
           Multibinder<HttpHandler> handlerBinder =
             Multibinder.newSetBinder(binder(), HttpHandler.class, Names.named(Constants.Stream.STREAM_HANDLER));
           handlerBinder.addBinding().to(StreamHandlerV2.class);
+          handlerBinder.addBinding().to(StreamFetchHandlerV2.class);
+          handlerBinder.addBinding().to(StreamHandler.class);
           handlerBinder.addBinding().to(StreamFetchHandler.class);
           CommonHandlers.add(handlerBinder);
 
@@ -351,6 +355,8 @@ public class BaseHiveExploreServiceTest {
           Multibinder<HttpHandler> handlerBinder =
             Multibinder.newSetBinder(binder(), HttpHandler.class, Names.named(Constants.Stream.STREAM_HANDLER));
           handlerBinder.addBinding().to(StreamHandlerV2.class);
+          handlerBinder.addBinding().to(StreamFetchHandlerV2.class);
+          handlerBinder.addBinding().to(StreamHandler.class);
           handlerBinder.addBinding().to(StreamFetchHandler.class);
           CommonHandlers.add(handlerBinder);
 

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/BaseHiveExploreServiceTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/BaseHiveExploreServiceTest.java
@@ -28,7 +28,7 @@ import co.cask.cdap.data.runtime.DataSetServiceModules;
 import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data.stream.StreamAdminModules;
 import co.cask.cdap.data.stream.service.StreamFetchHandler;
-import co.cask.cdap.data.stream.service.StreamHandler;
+import co.cask.cdap.data.stream.service.StreamHandlerV2;
 import co.cask.cdap.data.stream.service.StreamHttpService;
 import co.cask.cdap.data.stream.service.StreamService;
 import co.cask.cdap.data.stream.service.StreamServiceRuntimeModule;
@@ -304,7 +304,7 @@ public class BaseHiveExploreServiceTest {
 
           Multibinder<HttpHandler> handlerBinder =
             Multibinder.newSetBinder(binder(), HttpHandler.class, Names.named(Constants.Stream.STREAM_HANDLER));
-          handlerBinder.addBinding().to(StreamHandler.class);
+          handlerBinder.addBinding().to(StreamHandlerV2.class);
           handlerBinder.addBinding().to(StreamFetchHandler.class);
           CommonHandlers.add(handlerBinder);
 
@@ -350,7 +350,7 @@ public class BaseHiveExploreServiceTest {
 
           Multibinder<HttpHandler> handlerBinder =
             Multibinder.newSetBinder(binder(), HttpHandler.class, Names.named(Constants.Stream.STREAM_HANDLER));
-          handlerBinder.addBinding().to(StreamHandler.class);
+          handlerBinder.addBinding().to(StreamHandlerV2.class);
           handlerBinder.addBinding().to(StreamFetchHandler.class);
           CommonHandlers.add(handlerBinder);
 

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterPathLookup.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterPathLookup.java
@@ -91,8 +91,8 @@ public final class RouterPathLookup extends AuthenticatedHttpHandler {
     } else if ((uriParts.length == 3) && uriParts[1].equals("explore") && uriParts[2].equals("status")) {
       return Constants.Service.EXPLORE_HTTP_USER_SERVICE;
     } else if ((uriParts.length >= 2) && uriParts[1].equals("streams")) {
-      // /v2/streams/<stream-id> GET should go to AppFabricHttp, PUT, POST should go to Stream Handler
       // /v2/streams should go to AppFabricHttp
+      // /v2/streams/<stream-id> GET should go to AppFabricHttp, PUT, POST should go to Stream Handler
       // GET /v2/streams/flows should go to AppFabricHttp, rest should go Stream Handler
       if (uriParts.length == 2) {
         return Constants.Service.APP_FABRIC_HTTP;
@@ -130,7 +130,7 @@ public final class RouterPathLookup extends AuthenticatedHttpHandler {
     }
   }
 
-  private String getV3RoutingService(String [] uriParts, AllowedMethod method, HttpRequest request) {
+  private String getV3RoutingService(String [] uriParts, AllowedMethod requestMethod, HttpRequest request) {
     if ((uriParts.length >= 2) && uriParts[1].equals("feeds")) {
       // TODO find a better way to handle that - this looks hackish
       return null;
@@ -140,6 +140,20 @@ public final class RouterPathLookup extends AuthenticatedHttpHandler {
       //Discoverable Service Name -> "service.%s.%s.%s", namespaceId, appId, serviceId
       String serviceName = String.format("service.%s.%s.%s", uriParts[2], uriParts[4], uriParts[6]);
       return serviceName;
+    } else if ((uriParts.length >= 4) && uriParts[3].equals("streams")) {
+      //     /v3/namespaces/<namespace>/streams goes to AppFabricHttp
+      //     /v3/namespaces/<namespace>/streams/<stream-id> PUT, POST should go to Stream Handler
+      // GET /v3/namespaces/<namespace>/streams/flows should go to AppFabricHttp
+      // All else go to Stream Handler
+      if (uriParts.length == 4) {
+        return Constants.Service.APP_FABRIC_HTTP;
+      } else if (uriParts.length == 5) {
+        return Constants.Service.STREAMS;
+      } else if ((uriParts.length == 6) && uriParts[3].equals("flows") && requestMethod.equals(AllowedMethod.GET)) {
+        return Constants.Service.APP_FABRIC_HTTP;
+      } else {
+        return Constants.Service.STREAMS;
+      }
     } else if (uriParts.length >= 8 && uriParts[7].equals("logs")) {
       //Log Handler Path /v3/namespaces/<namespaceid>apps/<appid>/<programid-type>/<programid>/logs
       return Constants.Service.METRICS;

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/GatewayFastTestsSuite.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/GatewayFastTestsSuite.java
@@ -21,7 +21,6 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.gateway.handlers.PingHandlerTestRun;
 import co.cask.cdap.gateway.handlers.ProcedureHandlerTestRun;
 import co.cask.cdap.gateway.handlers.RuntimeArgumentTestRun;
-import co.cask.cdap.gateway.handlers.StreamHandlerTestRun;
 import co.cask.cdap.gateway.handlers.hooks.MetricsReporterHookTestRun;
 import com.google.common.base.Charsets;
 import com.google.common.base.Throwables;
@@ -63,7 +62,6 @@ import javax.annotation.Nullable;
   PingHandlerTestRun.class,
   ProcedureHandlerTestRun.class,
   MetricsReporterHookTestRun.class,
-  StreamHandlerTestRun.class,
   RuntimeArgumentTestRun.class
 })
 

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/StreamHandlerTest.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/StreamHandlerTest.java
@@ -24,6 +24,7 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.stream.StreamEventTypeAdapter;
 import co.cask.cdap.data.format.TextRecordFormat;
 import co.cask.cdap.data2.transaction.stream.StreamConfig;
+import co.cask.cdap.gateway.GatewayFastTestsSuite;
 import co.cask.cdap.gateway.GatewayTestBase;
 import co.cask.cdap.internal.io.SchemaTypeAdapter;
 import co.cask.cdap.proto.StreamProperties;
@@ -33,28 +34,33 @@ import com.google.common.io.ByteStreams;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import org.apache.http.HttpResponse;
 import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.List;
 
 /**
  * Test stream handler. This is not part of GatewayFastTestsSuite because it needs to start the gateway multiple times.
  */
-public class StreamHandlerTestRun extends GatewayTestBase {
+public abstract class StreamHandlerTest extends GatewayTestBase {
   private static final String API_KEY = GatewayTestBase.getAuthHeader().getValue();
-  private static final String HOSTNAME = "127.0.0.1";
 
   private static final Gson GSON = StreamEventTypeAdapter.register(
     new GsonBuilder().registerTypeAdapter(Schema.class, new SchemaTypeAdapter())).create();
 
-  private HttpURLConnection openURL(String location, HttpMethod method) throws IOException {
-    URL url = new URL(location);
+
+  protected abstract URL constructPath(String path) throws URISyntaxException, MalformedURLException;
+
+  private HttpURLConnection openURL(URL url, HttpMethod method) throws IOException {
     HttpURLConnection urlConn = (HttpURLConnection) url.openConnection();
     urlConn.setRequestMethod(method.getName());
     urlConn.setRequestProperty(Constants.Gateway.API_KEY, API_KEY);
@@ -62,47 +68,48 @@ public class StreamHandlerTestRun extends GatewayTestBase {
     return urlConn;
   }
 
+  @After
+  public void reset() throws Exception {
+    HttpResponse httpResponse = GatewayFastTestsSuite.doPost("/v2/unrecoverable/reset", null);
+    Assert.assertEquals(200, httpResponse.getStatusLine().getStatusCode());
+  }
+
   @Test
   public void testStreamCreate() throws Exception {
-    int port = GatewayTestBase.getPort();
-
-    // Try to get info on a non-existant stream
-    HttpURLConnection urlConn = openURL(String.format("http://%s:%d/v2/streams/test_stream1/info", HOSTNAME, port),
+    // Try to get info on a non-existent stream
+    HttpURLConnection urlConn = openURL(constructPath("streams/test_stream1/info"),
                                         HttpMethod.GET);
 
     Assert.assertEquals(HttpResponseStatus.NOT_FOUND.getCode(), urlConn.getResponseCode());
     urlConn.disconnect();
 
     // try to POST info to the non-existent stream
-    urlConn = openURL(String.format("http://%s:%d/v2/streams/non_existent_stream", HOSTNAME, port), HttpMethod.POST);
+    urlConn = openURL(constructPath("streams/non_existent_stream"), HttpMethod.POST);
     Assert.assertEquals(HttpResponseStatus.NOT_FOUND.getCode(), urlConn.getResponseCode());
     urlConn.disconnect();
     
     // Now, create the new stream.
-    urlConn = openURL(String.format("http://%s:%d/v2/streams/test_stream1", HOSTNAME, port), HttpMethod.PUT);
+    urlConn = openURL(constructPath("streams/test_stream1"), HttpMethod.PUT);
     Assert.assertEquals(HttpResponseStatus.OK.getCode(), urlConn.getResponseCode());
     urlConn.disconnect();
 
     // getInfo should now return 200
-    urlConn = openURL(String.format("http://%s:%d/v2/streams/test_stream1/info", HOSTNAME, port),
-                                        HttpMethod.GET);
+    urlConn = openURL(constructPath("streams/test_stream1/info"), HttpMethod.GET);
     Assert.assertEquals(HttpResponseStatus.OK.getCode(), urlConn.getResponseCode());
     urlConn.disconnect();
   }
 
   @Test
   public void testSimpleStreamEnqueue() throws Exception {
-    int port = GatewayTestBase.getPort();
-
     // Create new stream.
-    HttpURLConnection urlConn = openURL(String.format("http://%s:%d/v2/streams/test_stream_enqueue", HOSTNAME, port),
+    HttpURLConnection urlConn = openURL(constructPath("streams/test_stream_enqueue"),
                                         HttpMethod.PUT);
     Assert.assertEquals(HttpResponseStatus.OK.getCode(), urlConn.getResponseCode());
     urlConn.disconnect();
 
     // Enqueue 10 entries
     for (int i = 0; i < 10; ++i) {
-      urlConn = openURL(String.format("http://%s:%d/v2/streams/test_stream_enqueue", HOSTNAME, port), HttpMethod.POST);
+      urlConn = openURL(constructPath("streams/test_stream_enqueue"), HttpMethod.POST);
       urlConn.setDoOutput(true);
       urlConn.addRequestProperty("test_stream_enqueue.header1", Integer.toString(i));
       urlConn.getOutputStream().write(Integer.toString(i).getBytes(Charsets.UTF_8));
@@ -111,7 +118,7 @@ public class StreamHandlerTestRun extends GatewayTestBase {
     }
 
     // Fetch 10 entries
-    urlConn = openURL(String.format("http://%s:%d/v2/streams/test_stream_enqueue/events?limit=10", HOSTNAME, port),
+    urlConn = openURL(constructPath("streams/test_stream_enqueue/events?limit=10"),
                       HttpMethod.GET);
     List<StreamEvent> events = GSON.fromJson(new String(ByteStreams.toByteArray(urlConn.getInputStream()),
                                                         Charsets.UTF_8),
@@ -127,17 +134,13 @@ public class StreamHandlerTestRun extends GatewayTestBase {
 
   @Test
   public void testStreamInfo() throws Exception {
-    int port = GatewayTestBase.getPort();
-
     // Now, create the new stream.
-    HttpURLConnection urlConn = openURL(String.format("http://%s:%d/v2/streams/stream_info",
-                                                      HOSTNAME, port), HttpMethod.PUT);
+    HttpURLConnection urlConn = openURL(constructPath("streams/stream_info"), HttpMethod.PUT);
     Assert.assertEquals(HttpResponseStatus.OK.getCode(), urlConn.getResponseCode());
     urlConn.disconnect();
 
     // put a new config
-    urlConn = openURL(String.format("http://%s:%d/v2/streams/stream_info/config",
-                                    HOSTNAME, port), HttpMethod.PUT);
+    urlConn = openURL(constructPath("streams/stream_info/config"), HttpMethod.PUT);
     urlConn.setDoOutput(true);
     Schema schema = Schema.recordOf("event", Schema.Field.of("purchase", Schema.of(Schema.Type.STRING)));
     FormatSpecification formatSpecification;
@@ -150,7 +153,7 @@ public class StreamHandlerTestRun extends GatewayTestBase {
     urlConn.disconnect();
 
     // test the config ttl by calling info
-    urlConn = openURL(String.format("http://%s:%d/v2/streams/stream_info/info", HOSTNAME, port),
+    urlConn = openURL(constructPath("streams/stream_info/info"),
                       HttpMethod.GET);
     Assert.assertEquals(HttpResponseStatus.OK.getCode(), urlConn.getResponseCode());
     StreamProperties actual = GSON.fromJson(new String(ByteStreams.toByteArray(urlConn.getInputStream()),
@@ -161,17 +164,13 @@ public class StreamHandlerTestRun extends GatewayTestBase {
 
   @Test
   public void testPutStreamConfigDefaults() throws Exception {
-    int port = GatewayTestBase.getPort();
-
     // Now, create the new stream.
-    HttpURLConnection urlConn = openURL(String.format("http://%s:%d/v2/streams/stream_defaults",
-                                                      HOSTNAME, port), HttpMethod.PUT);
+    HttpURLConnection urlConn = openURL(constructPath("streams/stream_defaults"), HttpMethod.PUT);
     Assert.assertEquals(HttpResponseStatus.OK.getCode(), urlConn.getResponseCode());
     urlConn.disconnect();
 
     // put a new config
-    urlConn = openURL(String.format("http://%s:%d/v2/streams/stream_defaults/config",
-                                    HOSTNAME, port), HttpMethod.PUT);
+    urlConn = openURL(constructPath("streams/stream_defaults/config"), HttpMethod.PUT);
     urlConn.setDoOutput(true);
     // don't give the schema to make sure a default gets used
     FormatSpecification formatSpecification = new FormatSpecification(Formats.TEXT, null, null);
@@ -181,7 +180,7 @@ public class StreamHandlerTestRun extends GatewayTestBase {
     urlConn.disconnect();
 
     // test the config ttl by calling info
-    urlConn = openURL(String.format("http://%s:%d/v2/streams/stream_defaults/info", HOSTNAME, port),
+    urlConn = openURL(constructPath("streams/stream_defaults/info"),
                       HttpMethod.GET);
     Assert.assertEquals(HttpResponseStatus.OK.getCode(), urlConn.getResponseCode());
     StreamProperties actual = GSON.fromJson(new String(ByteStreams.toByteArray(urlConn.getInputStream()),
@@ -194,25 +193,20 @@ public class StreamHandlerTestRun extends GatewayTestBase {
 
   @Test
   public void testPutInvalidStreamConfig() throws Exception {
-    int port = GatewayTestBase.getPort();
-
     // create the new stream.
-    HttpURLConnection urlConn = openURL(String.format("http://%s:%d/v2/streams/stream_badconf",
-                                                      HOSTNAME, port), HttpMethod.PUT);
+    HttpURLConnection urlConn = openURL(constructPath("streams/stream_badconf"), HttpMethod.PUT);
     Assert.assertEquals(HttpResponseStatus.OK.getCode(), urlConn.getResponseCode());
     urlConn.disconnect();
 
     // put a config with invalid json
-    urlConn = openURL(String.format("http://%s:%d/v2/streams/stream_badconf/config",
-                                    HOSTNAME, port), HttpMethod.PUT);
+    urlConn = openURL(constructPath("streams/stream_badconf/config"), HttpMethod.PUT);
     urlConn.setDoOutput(true);
     urlConn.getOutputStream().write("ttl:2".getBytes(Charsets.UTF_8));
     Assert.assertEquals(HttpResponseStatus.BAD_REQUEST.getCode(), urlConn.getResponseCode());
     urlConn.disconnect();
 
     // put a config with an invalid TTL
-    urlConn = openURL(String.format("http://%s:%d/v2/streams/stream_badconf/config",
-                                    HOSTNAME, port), HttpMethod.PUT);
+    urlConn = openURL(constructPath("streams/stream_badconf/config"), HttpMethod.PUT);
     urlConn.setDoOutput(true);
     StreamProperties streamProperties = new StreamProperties("stream_badconf", -1L, null, 20);
     urlConn.getOutputStream().write(GSON.toJson(streamProperties).getBytes(Charsets.UTF_8));
@@ -220,8 +214,7 @@ public class StreamHandlerTestRun extends GatewayTestBase {
     urlConn.disconnect();
 
     // put a config with a format without a format class
-    urlConn = openURL(String.format("http://%s:%d/v2/streams/stream_badconf/config",
-                                    HOSTNAME, port), HttpMethod.PUT);
+    urlConn = openURL(constructPath("streams/stream_badconf/config"), HttpMethod.PUT);
     urlConn.setDoOutput(true);
     FormatSpecification formatSpec = new FormatSpecification(null, null, null);
     streamProperties = new StreamProperties("stream_badconf", 2L, formatSpec, 20);
@@ -230,8 +223,7 @@ public class StreamHandlerTestRun extends GatewayTestBase {
     urlConn.disconnect();
 
     // put a config with a format with a bad format class
-    urlConn = openURL(String.format("http://%s:%d/v2/streams/stream_badconf/config",
-                                    HOSTNAME, port), HttpMethod.PUT);
+    urlConn = openURL(constructPath("streams/stream_badconf/config"), HttpMethod.PUT);
     urlConn.setDoOutput(true);
     formatSpec = new FormatSpecification("gibberish", null, null);
     streamProperties = new StreamProperties("stream_badconf", 2L, formatSpec, 20);
@@ -240,8 +232,7 @@ public class StreamHandlerTestRun extends GatewayTestBase {
     urlConn.disconnect();
 
     // put a config with an incompatible format and schema
-    urlConn = openURL(String.format("http://%s:%d/v2/streams/stream_badconf/config",
-                                    HOSTNAME, port), HttpMethod.PUT);
+    urlConn = openURL(constructPath("streams/stream_badconf/config"), HttpMethod.PUT);
     urlConn.setDoOutput(true);
     Schema schema = Schema.recordOf("event", Schema.Field.of("col", Schema.of(Schema.Type.DOUBLE)));
     formatSpec = new FormatSpecification(TextRecordFormat.class.getCanonicalName(), schema, null);
@@ -251,8 +242,7 @@ public class StreamHandlerTestRun extends GatewayTestBase {
     urlConn.disconnect();
 
     // put a config with a bad threshold
-    urlConn = openURL(String.format("http://%s:%d/v2/streams/stream_badconf/config",
-                                    HOSTNAME, port), HttpMethod.PUT);
+    urlConn = openURL(constructPath("streams/stream_badconf/config"), HttpMethod.PUT);
     urlConn.setDoOutput(true);
     streamProperties = new StreamProperties("stream_badconf", 2L, null, -20);
     urlConn.getOutputStream().write(GSON.toJson(streamProperties).getBytes(Charsets.UTF_8));

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/StreamHandlerTestV2.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/StreamHandlerTestV2.java
@@ -23,7 +23,7 @@ import java.net.URL;
 /**
  * Tests v2 stream endpoints
  */
-public class V2StreamHandlerTest extends StreamHandlerTest {
+public class StreamHandlerTestV2 extends StreamHandlerTest {
   @Override
   protected URL constructPath(String path) throws URISyntaxException, MalformedURLException {
     return getEndPoint(String.format("/v2/%s", path)).toURL();

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/StreamHandlerTestV3.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/StreamHandlerTestV3.java
@@ -25,7 +25,7 @@ import java.net.URL;
 /**
  * Tests v3 stream endpoints with default namespace
  */
-public class V3StreamHandlerTest extends StreamHandlerTest {
+public class StreamHandlerTestV3 extends StreamHandlerTest {
   @Override
   protected URL constructPath(String path) throws URISyntaxException, MalformedURLException {
     return getEndPoint(String.format("/v3/namespaces/%s/%s", Constants.DEFAULT_NAMESPACE, path)).toURL();

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/V2StreamHandlerTest.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/V2StreamHandlerTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.gateway.handlers;
+
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+/**
+ * Tests v2 stream endpoints
+ */
+public class V2StreamHandlerTest extends StreamHandlerTest {
+  @Override
+  protected URL constructPath(String path) throws URISyntaxException, MalformedURLException {
+    return getEndPoint(String.format("/v2/%s", path)).toURL();
+  }
+}

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/V3StreamHandlerTest.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/V3StreamHandlerTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.gateway.handlers;
+
+import co.cask.cdap.common.conf.Constants;
+
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+/**
+ * Tests v3 stream endpoints with default namespace
+ */
+public class V3StreamHandlerTest extends StreamHandlerTest {
+  @Override
+  protected URL constructPath(String path) throws URISyntaxException, MalformedURLException {
+    return getEndPoint(String.format("/v3/namespaces/%s/%s", Constants.DEFAULT_NAMESPACE, path)).toURL();
+  }
+}

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/hooks/MetricsReporterHookTestRun.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/hooks/MetricsReporterHookTestRun.java
@@ -17,9 +17,11 @@
 package co.cask.cdap.gateway.handlers.hooks;
 
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.data.stream.service.StreamHandlerV2;
 import co.cask.cdap.gateway.GatewayFastTestsSuite;
 import co.cask.cdap.gateway.GatewayTestBase;
 import co.cask.cdap.gateway.MockMetricsCollectionService;
+import com.google.common.base.Joiner;
 import com.google.inject.Injector;
 import org.apache.http.HttpResponse;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
@@ -60,7 +62,10 @@ public class MetricsReporterHookTestRun extends GatewayTestBase {
 
   @Test
   public void testMetricsNotFound() throws Exception {
-    String context = Constants.SYSTEM_NAMESPACE + "." + Constants.Stream.STREAM_HANDLER + ".StreamHandler.getInfo";
+    String context = Joiner.on(".").join(Constants.SYSTEM_NAMESPACE,
+                                         Constants.Stream.STREAM_HANDLER,
+                                         StreamHandlerV2.class.getSimpleName(),
+                                         "getInfo");
     long received = mockMetricsCollectionService.getMetrics(context, "request.received");
     long successful = mockMetricsCollectionService.getMetrics(context, "response.successful");
     long clientError = mockMetricsCollectionService.getMetrics(context, "response.client-error");

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
@@ -43,7 +43,10 @@ import co.cask.cdap.data.stream.StreamCoordinatorClient;
 import co.cask.cdap.data.stream.StreamFileWriterFactory;
 import co.cask.cdap.data.stream.service.BasicStreamWriterSizeCollector;
 import co.cask.cdap.data.stream.service.LocalStreamFileJanitorService;
+import co.cask.cdap.data.stream.service.StreamFetchHandler;
+import co.cask.cdap.data.stream.service.StreamFetchHandlerV2;
 import co.cask.cdap.data.stream.service.StreamFileJanitorService;
+import co.cask.cdap.data.stream.service.StreamHandler;
 import co.cask.cdap.data.stream.service.StreamHandlerV2;
 import co.cask.cdap.data.stream.service.StreamWriterSizeCollector;
 import co.cask.cdap.data2.datafabric.DefaultDatasetNamespace;
@@ -245,6 +248,9 @@ public class TestBase {
         @Override
         protected void configure() {
           bind(StreamHandlerV2.class).in(Scopes.SINGLETON);
+          bind(StreamFetchHandlerV2.class).in(Scopes.SINGLETON);
+          bind(StreamHandler.class).in(Scopes.SINGLETON);
+          bind(StreamFetchHandler.class).in(Scopes.SINGLETON);
           bind(StreamFileJanitorService.class).to(LocalStreamFileJanitorService.class).in(Scopes.SINGLETON);
           bind(StreamWriterSizeCollector.class).to(BasicStreamWriterSizeCollector.class).in(Scopes.SINGLETON);
           bind(StreamCoordinatorClient.class).to(InMemoryStreamCoordinatorClient.class).in(Scopes.SINGLETON);

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
@@ -44,7 +44,7 @@ import co.cask.cdap.data.stream.StreamFileWriterFactory;
 import co.cask.cdap.data.stream.service.BasicStreamWriterSizeCollector;
 import co.cask.cdap.data.stream.service.LocalStreamFileJanitorService;
 import co.cask.cdap.data.stream.service.StreamFileJanitorService;
-import co.cask.cdap.data.stream.service.StreamHandler;
+import co.cask.cdap.data.stream.service.StreamHandlerV2;
 import co.cask.cdap.data.stream.service.StreamWriterSizeCollector;
 import co.cask.cdap.data2.datafabric.DefaultDatasetNamespace;
 import co.cask.cdap.data2.datafabric.dataset.service.DatasetService;
@@ -244,7 +244,7 @@ public class TestBase {
       new AbstractModule() {
         @Override
         protected void configure() {
-          bind(StreamHandler.class).in(Scopes.SINGLETON);
+          bind(StreamHandlerV2.class).in(Scopes.SINGLETON);
           bind(StreamFileJanitorService.class).to(LocalStreamFileJanitorService.class).in(Scopes.SINGLETON);
           bind(StreamWriterSizeCollector.class).to(BasicStreamWriterSizeCollector.class).in(Scopes.SINGLETON);
           bind(StreamCoordinatorClient.class).to(InMemoryStreamCoordinatorClient.class).in(Scopes.SINGLETON);

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultStreamWriter.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultStreamWriter.java
@@ -17,7 +17,7 @@
 package co.cask.cdap.test.internal;
 
 import co.cask.cdap.common.queue.QueueName;
-import co.cask.cdap.data.stream.service.StreamHandler;
+import co.cask.cdap.data.stream.service.StreamHandlerV2;
 import co.cask.cdap.test.StreamWriter;
 import com.google.common.base.Charsets;
 import com.google.common.base.Throwables;
@@ -44,14 +44,14 @@ public final class DefaultStreamWriter implements StreamWriter {
 
   private final String accountId;
   private final QueueName streamName;
-  private final StreamHandler streamHandler;
+  private final StreamHandlerV2 streamHandlerV2;
 
   @Inject
-  public DefaultStreamWriter(StreamHandler streamHandler,
+  public DefaultStreamWriter(StreamHandlerV2 streamHandlerV2,
                              @Assisted QueueName streamName,
                              @Assisted("accountId") String accountId) throws IOException {
 
-    this.streamHandler = streamHandler;
+    this.streamHandlerV2 = streamHandlerV2;
     this.streamName = streamName;
     this.accountId = accountId;
   }
@@ -64,7 +64,7 @@ public final class DefaultStreamWriter implements StreamWriter {
 
     MockResponder responder = new MockResponder();
     try {
-      streamHandler.create(httpRequest, responder, streamName.getSimpleName());
+      streamHandlerV2.create(httpRequest, responder, streamName.getSimpleName());
     } catch (Exception e) {
       Throwables.propagateIfPossible(e, IOException.class);
       throw Throwables.propagate(e);
@@ -123,7 +123,7 @@ public final class DefaultStreamWriter implements StreamWriter {
 
     MockResponder responder = new MockResponder();
     try {
-      streamHandler.enqueue(httpRequest, responder, streamName.getSimpleName());
+      streamHandlerV2.enqueue(httpRequest, responder, streamName.getSimpleName());
     } catch (Exception e) {
       Throwables.propagateIfPossible(e, IOException.class);
       throw Throwables.propagate(e);


### PR DESCRIPTION
Summary:
- Update the Stream Handlers to handle methods with /v3/namespace/<namespace> prefix. These handlers ignore the namespace value and simply use the default namespace, until streams are completely namespaced.

- Added Stream Handlers to handle the old v2 apis to redirect to the /v3 handlers, with default namespace.

- All v2 stream endpoints have a v3 stream equivalent except for the following two which are not going to be supported in v3 APIs ([V3 Stream APIs](https://wiki.continuuity.com/display/ENG/V3+Stream+APIs)):

    1) `DELETE /streams`
    2) `GET /streams/<streamId>`

- Update StreamHandlerTestRun to run against both v2 and v3 APIs (using default namespace).

Note that a good portion of the diff (+-300 lines) is due to moving the dataList, programListByDataAccess, etc to Abstract handler class.

Build: http://builds.cask.co/browse/CDAP-DUT751-10