### PR TITLE
[CDAP-1371] Added mock v3 APIs for Dataset Types. v2 APIs delegate to v3...

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetService.java
@@ -84,9 +84,10 @@ public class DatasetService extends AbstractExecutionThreadService {
                         Set<DatasetMetricsReporter> metricReporters) throws Exception {
 
     this.typeManager = typeManager;
-
+    DatasetTypeHandler datasetTypeHandler = new DatasetTypeHandler(typeManager, locationFactory, cConf);
+    DatasetTypeHandlerV2 datasetTypeHandlerV2 = new DatasetTypeHandlerV2(datasetTypeHandler);
     NettyHttpService.Builder builder = new CommonNettyHttpServiceBuilder(cConf);
-    builder.addHttpHandlers(ImmutableList.of(new DatasetTypeHandler(typeManager, locationFactory, cConf),
+    builder.addHttpHandlers(ImmutableList.of(datasetTypeHandler, datasetTypeHandlerV2,
                                              new DatasetInstanceHandler(typeManager, instanceManager, opExecutorClient,
                                                                         exploreFacade, cConf)));
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetTypeHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetTypeHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -55,7 +55,7 @@ import javax.ws.rs.PathParam;
  * Handles dataset type management calls.
  */
 // todo: do we want to make it authenticated? or do we treat it always as "internal" piece?
-@Path(Constants.Gateway.API_VERSION_2)
+@Path(Constants.Gateway.API_VERSION_3 + "/namespaces/{namespace-id}")
 public class DatasetTypeHandler extends AbstractHttpHandler {
   public static final String HEADER_CLASS_NAME = "X-Class-Name";
 
@@ -87,7 +87,7 @@ public class DatasetTypeHandler extends AbstractHttpHandler {
 
   @GET
   @Path("/data/modules")
-  public void listModules(HttpRequest request, final HttpResponder responder) {
+  public void listModules(HttpRequest request, HttpResponder responder, @PathParam("namespace-id") String namespaceId) {
     // Sorting by name for convenience
     List<DatasetModuleMeta> list = Lists.newArrayList(manager.getModules());
     Collections.sort(list, new Comparator<DatasetModuleMeta>() {
@@ -101,7 +101,8 @@ public class DatasetTypeHandler extends AbstractHttpHandler {
 
   @DELETE
   @Path("/data/modules")
-  public void deleteModules(HttpRequest request, final HttpResponder responder) {
+  public void deleteModules(HttpRequest request, HttpResponder responder,
+                            @PathParam("namespace-id") String namespaceId) {
     try {
       manager.deleteModules();
       responder.sendStatus(HttpResponseStatus.OK);
@@ -112,8 +113,8 @@ public class DatasetTypeHandler extends AbstractHttpHandler {
 
   @PUT
   @Path("/data/modules/{name}")
-  public BodyConsumer addModule(final HttpRequest request, final HttpResponder responder,
-                                @PathParam("name") final String name,
+  public BodyConsumer addModule(HttpRequest request, HttpResponder responder,
+                                @PathParam("namespace-id") String namespaceId, @PathParam("name") final String name,
                                 @HeaderParam(HEADER_CLASS_NAME) final String className) throws IOException {
 
     // Store uploaded content to a local temp file
@@ -186,7 +187,8 @@ public class DatasetTypeHandler extends AbstractHttpHandler {
 
   @DELETE
   @Path("/data/modules/{name}")
-  public void deleteModule(HttpRequest request, final HttpResponder responder, @PathParam("name") String name) {
+  public void deleteModule(HttpRequest request, HttpResponder responder,
+                           @PathParam("namespace-id") String namespaceId, @PathParam("name") String name) {
     boolean deleted;
     try {
       deleted = manager.deleteModule(name);
@@ -205,7 +207,8 @@ public class DatasetTypeHandler extends AbstractHttpHandler {
 
   @GET
   @Path("/data/modules/{name}")
-  public void getModuleInfo(HttpRequest request, final HttpResponder responder, @PathParam("name") String name) {
+  public void getModuleInfo(HttpRequest request, HttpResponder responder,
+                            @PathParam("namespace-id") String namespaceId, @PathParam("name") String name) {
     DatasetModuleMeta moduleMeta = manager.getModule(name);
     if (moduleMeta == null) {
       responder.sendStatus(HttpResponseStatus.NOT_FOUND);
@@ -216,7 +219,8 @@ public class DatasetTypeHandler extends AbstractHttpHandler {
 
   @GET
   @Path("/data/types")
-  public void listTypes(HttpRequest request, final HttpResponder responder) {
+  public void listTypes(HttpRequest request, HttpResponder responder,
+                        @PathParam("namespace-id") String namespaceId) {
     // Sorting by name for convenience
     List<DatasetTypeMeta> list = Lists.newArrayList(manager.getTypes());
     Collections.sort(list, new Comparator<DatasetTypeMeta>() {
@@ -230,8 +234,8 @@ public class DatasetTypeHandler extends AbstractHttpHandler {
 
   @GET
   @Path("/data/types/{name}")
-  public void getTypeInfo(HttpRequest request, final HttpResponder responder,
-                      @PathParam("name") String name) {
+  public void getTypeInfo(HttpRequest request, HttpResponder responder,
+                          @PathParam("namespace-id") String namespaceId, @PathParam("name") String name) {
 
     DatasetTypeMeta typeMeta = manager.getTypeInfo(name);
     if (typeMeta == null) {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetTypeHandlerV2.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetTypeHandlerV2.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.datafabric.dataset.service;
+
+import co.cask.cdap.common.conf.Constants;
+import co.cask.http.AbstractHttpHandler;
+import co.cask.http.BodyConsumer;
+import co.cask.http.HandlerContext;
+import co.cask.http.HttpResponder;
+import com.google.inject.Inject;
+import org.jboss.netty.handler.codec.http.HttpRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+import java.io.IOException;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+/**
+ * Handles dataset type management calls.
+ */
+// todo: do we want to make it authenticated? or do we treat it always as "internal" piece?
+@Path(Constants.Gateway.API_VERSION_2)
+public class DatasetTypeHandlerV2 extends AbstractHttpHandler {
+  private static final Logger LOG = LoggerFactory.getLogger(DatasetTypeHandlerV2.class);
+  private static final String HEADER_CLASS_NAME = "X-Class-Name";
+
+  private final DatasetTypeHandler datasetTypeHandler;
+
+  @Inject
+  public DatasetTypeHandlerV2(DatasetTypeHandler datasetTypeHandler) {
+    this.datasetTypeHandler = datasetTypeHandler;
+  }
+
+  @Override
+  public void init(HandlerContext context) {
+    LOG.info("Starting DatasetTypeHandler");
+  }
+
+  @Override
+  public void destroy(HandlerContext context) {
+    LOG.info("Stopping DatasetTypeHandler");
+  }
+
+  @GET
+  @Path("/data/modules")
+  public void listModules(HttpRequest request, HttpResponder responder) {
+    datasetTypeHandler.listModules(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE);
+  }
+
+  @DELETE
+  @Path("/data/modules")
+  public void deleteModules(HttpRequest request, HttpResponder responder) {
+    datasetTypeHandler.deleteModules(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE);
+  }
+
+  @PUT
+  @Path("/data/modules/{name}")
+  public BodyConsumer addModule(HttpRequest request, HttpResponder responder,
+                                @PathParam("name") String name,
+                                @HeaderParam(HEADER_CLASS_NAME) String className) throws IOException {
+    return datasetTypeHandler.addModule(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE, name,
+                                        className);
+  }
+
+  @DELETE
+  @Path("/data/modules/{name}")
+  public void deleteModule(HttpRequest request, HttpResponder responder, @PathParam("name") String name) {
+    datasetTypeHandler.deleteModule(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE, name);
+  }
+
+  @GET
+  @Path("/data/modules/{name}")
+  public void getModuleInfo(HttpRequest request, HttpResponder responder, @PathParam("name") String name) {
+    datasetTypeHandler.getModuleInfo(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE, name);
+  }
+
+  @GET
+  @Path("/data/types")
+  public void listTypes(HttpRequest request, HttpResponder responder) {
+    datasetTypeHandler.listTypes(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE);
+  }
+
+  @GET
+  @Path("/data/types/{name}")
+  public void getTypeInfo(HttpRequest request, HttpResponder responder, @PathParam("name") String name) {
+    datasetTypeHandler.getTypeInfo(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE, name);
+  }
+
+  /**
+   * Updates the request URI to its v3 URI before delegating the call to the corresponding v3 handler.
+   * Note: This piece of code is duplicated in various handlers, but its ok since this temporary, till we
+   * support v2 APIs
+   *
+   * @param request the original {@link HttpRequest}
+   * @return {@link HttpRequest} with modified URI
+   */
+  public HttpRequest rewriteRequest(HttpRequest request) {
+    String originalUri = request.getUri();
+    request.setUri(originalUri.replaceFirst(Constants.Gateway.API_VERSION_2, Constants.Gateway.API_VERSION_3 +
+      "/namespaces/" + Constants.DEFAULT_NAMESPACE));
+    return request;
+  }
+}

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandlerTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandlerTest.java
@@ -89,10 +89,10 @@ public class DatasetInstanceHandlerTest extends DatasetServiceTestBase {
     // type meta should have 2 modules that has to be loaded to create type's class and in the order they must be loaded
     List<DatasetModuleMeta> modules = datasetInfo.getType().getModules();
     Assert.assertEquals(2, modules.size());
-    DatasetTypeHandlerTest.verify(modules.get(0), "module1", TestModule1.class, ImmutableList.of("datasetType1"),
-                                  Collections.<String>emptyList(), ImmutableList.of("module2"));
-    DatasetTypeHandlerTest.verify(modules.get(1), "module2", TestModule2.class, ImmutableList.of("datasetType2"),
-                                  ImmutableList.of("module1"), Collections.<String>emptyList());
+    DatasetTypeHandlerV2Test.verify(modules.get(0), "module1", TestModule1.class, ImmutableList.of("datasetType1"),
+                                    Collections.<String>emptyList(), ImmutableList.of("module2"));
+    DatasetTypeHandlerV2Test.verify(modules.get(1), "module2", TestModule2.class, ImmutableList.of("datasetType2"),
+                                    ImmutableList.of("module1"), Collections.<String>emptyList());
 
     // try to retrieve non-existed instance
     Assert.assertEquals(HttpStatus.SC_NOT_FOUND, getInstance("non-existing-dataset").getResponseCode());

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetTypeHandlerV2Test.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetTypeHandlerV2Test.java
@@ -39,9 +39,9 @@ import java.util.List;
 import javax.annotation.Nullable;
 
 /**
- * Unit-test for {@link DatasetTypeHandler}
+ * Unit-test for {@link DatasetTypeHandlerV2}
  */
-public class DatasetTypeHandlerTest extends DatasetServiceTestBase {
+public class DatasetTypeHandlerV2Test extends DatasetServiceTestBase {
 
   @Test
   public void testBasics() throws Exception {

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterPathLookup.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterPathLookup.java
@@ -146,6 +146,15 @@ public final class RouterPathLookup extends AuthenticatedHttpHandler {
     } else if (uriParts.length >= 2 && uriParts[1].equals("metrics")) {
       //Metrics Search Handler Path /v3/metrics
       return Constants.Service.METRICS;
+    } else if ((uriParts.length >= 4) && uriParts[3].equals("data")) {
+      if ((uriParts.length >= 5) && uriParts[4].equals("explore")
+        && (uriParts[5].equals("queries") || uriParts[5].equals("jdbc") || uriParts[5].equals("tables"))) {
+        return Constants.Service.EXPLORE_HTTP_USER_SERVICE;
+      } else if ((uriParts.length == 8) && uriParts[4].equals("explore") && uriParts[5].equals("datasets")) {
+        // v3/namespaces/<namespace>/data/explore/datasets/<dataset>/schema
+        return Constants.Service.EXPLORE_HTTP_USER_SERVICE;
+      }
+      return Constants.Service.DATASET_MANAGER;
     }
     return Constants.Service.APP_FABRIC_HTTP;
   }


### PR DESCRIPTION
... APIs with 'default' namespace. v3 APIs currently ignore namespace.

Mock APIs to unblock UI folks.

No functionality change yet. v3 APIs accept namespace-id, but ignore them. Will use namespace-id in later PRs.

Build: https://builds.cask.co/browse/CDAP-DUT760