### PR TITLE
v3 dataset admin handler

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/util/AbstractAppFabricHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/util/AbstractAppFabricHttpHandler.java
@@ -21,6 +21,7 @@ import co.cask.cdap.app.ApplicationSpecification;
 import co.cask.cdap.app.runtime.ProgramRuntimeService;
 import co.cask.cdap.app.store.Store;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.http.RESTMigrationUtils;
 import co.cask.cdap.gateway.auth.Authenticator;
 import co.cask.cdap.gateway.handlers.AuthenticatedHttpHandler;
 import co.cask.cdap.internal.UserErrors;
@@ -315,8 +316,7 @@ public abstract class AbstractAppFabricHttpHandler extends AuthenticatedHttpHand
 
   /**
    * Updates the request URI to its v3 URI before delegating the call to the corresponding v3 handler.
-   * Note: This piece of code is duplicated in LogHandler, but its ok since this temporary, till we
-   * support v2 APIs
+   * TODO: Should use {@link RESTMigrationUtils#rewriteV2RequestToV3} instead
    *
    * @param request the original {@link HttpRequest}
    * @return {@link HttpRequest} with modified URI

--- a/cdap-common/src/main/java/co/cask/cdap/common/http/RESTMigrationUtils.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/http/RESTMigrationUtils.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.http;
+
+import co.cask.cdap.common.conf.Constants;
+import org.jboss.netty.handler.codec.http.HttpRequest;
+
+/**
+ * Utilities for use during REST API migration
+ */
+public class RESTMigrationUtils {
+
+  /**
+   * Updates the v2 request URI to its v3 URI before delegating the call to the corresponding v3 handler.
+   *
+   * @param request the original {@link HttpRequest}
+   * @return {@link HttpRequest} with modified URI
+   */
+  public static HttpRequest rewriteV2RequestToV3(HttpRequest request) {
+    String originalUri = request.getUri();
+    request.setUri(originalUri.replaceFirst(Constants.Gateway.API_VERSION_2, Constants.Gateway.API_VERSION_3 +
+      "/namespaces/" + Constants.DEFAULT_NAMESPACE));
+    return request;
+  }
+
+  private RESTMigrationUtils() {
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataSetServiceModules.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataSetServiceModules.java
@@ -21,6 +21,7 @@ import co.cask.cdap.api.dataset.module.DatasetModule;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.datafabric.dataset.service.DatasetService;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetAdminOpHTTPHandler;
+import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetAdminOpHTTPHandlerV2;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetOpExecutor;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetOpExecutorService;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.LocalDatasetOpExecutor;
@@ -107,6 +108,7 @@ public class DataSetServiceModules {
         Named datasetUserName = Names.named(Constants.Service.DATASET_EXECUTOR);
         Multibinder<HttpHandler> handlerBinder = Multibinder.newSetBinder(binder(), HttpHandler.class, datasetUserName);
         CommonHandlers.add(handlerBinder);
+        handlerBinder.addBinding().to(DatasetAdminOpHTTPHandlerV2.class);
         handlerBinder.addBinding().to(DatasetAdminOpHTTPHandler.class);
 
         Multibinder.newSetBinder(binder(), DatasetMetricsReporter.class);
@@ -155,6 +157,7 @@ public class DataSetServiceModules {
         Named datasetUserName = Names.named(Constants.Service.DATASET_EXECUTOR);
         Multibinder<HttpHandler> handlerBinder = Multibinder.newSetBinder(binder(), HttpHandler.class, datasetUserName);
         CommonHandlers.add(handlerBinder);
+        handlerBinder.addBinding().to(DatasetAdminOpHTTPHandlerV2.class);
         handlerBinder.addBinding().to(DatasetAdminOpHTTPHandler.class);
 
         bind(DatasetOpExecutorService.class).in(Scopes.SINGLETON);
@@ -203,6 +206,7 @@ public class DataSetServiceModules {
         Named datasetUserName = Names.named(Constants.Service.DATASET_EXECUTOR);
         Multibinder<HttpHandler> handlerBinder = Multibinder.newSetBinder(binder(), HttpHandler.class, datasetUserName);
         CommonHandlers.add(handlerBinder);
+        handlerBinder.addBinding().to(DatasetAdminOpHTTPHandlerV2.class);
         handlerBinder.addBinding().to(DatasetAdminOpHTTPHandler.class);
 
         bind(DatasetOpExecutorService.class).in(Scopes.SINGLETON);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandler.java
@@ -315,7 +315,7 @@ public class DatasetInstanceHandler extends AbstractHttpHandler {
                                  name, e.getMessage());
       LOG.error(msg, e);
       // TODO: at this time we want to still allow using dataset even if it cannot be used for exploration
-      //responder.sendError(HttpResponseStatus.INTERNAL_SERVER_ERROR, msg);
+      //responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, msg);
       //return;
     }
   }
@@ -330,7 +330,7 @@ public class DatasetInstanceHandler extends AbstractHttpHandler {
                                  name, creationProperties.getProperties(), e.getMessage());
       LOG.error(msg, e);
       // TODO: at this time we want to still allow using dataset even if it cannot be used for exploration
-      //responder.sendError(HttpResponseStatus.INTERNAL_SERVER_ERROR, msg);
+      //responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, msg);
       //return;
     }
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandlerV2.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandlerV2.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.data2.datafabric.dataset.service;
 
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.http.RESTMigrationUtils;
 import co.cask.cdap.proto.DatasetInstanceConfiguration;
 import co.cask.http.AbstractHttpHandler;
 import co.cask.http.HttpResponder;
@@ -46,13 +47,16 @@ public class DatasetInstanceHandlerV2 extends AbstractHttpHandler {
   @GET
   @Path("/data/datasets/")
   public void list(HttpRequest request, HttpResponder responder) {
-    datasetInstanceHandler.list(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE);
+    datasetInstanceHandler.list(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
+                                Constants.DEFAULT_NAMESPACE);
   }
 
   @GET
   @Path("/data/datasets/{name}")
-  public void getInfo(HttpRequest request, HttpResponder responder, @PathParam("name") String name) {
-    datasetInstanceHandler.getInfo(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE, name);
+  public void getInfo(HttpRequest request, HttpResponder responder,
+                      @PathParam("name") String name) {
+    datasetInstanceHandler.getInfo(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
+                                   Constants.DEFAULT_NAMESPACE, name);
   }
 
   /**
@@ -60,8 +64,10 @@ public class DatasetInstanceHandlerV2 extends AbstractHttpHandler {
    */
   @PUT
   @Path("/data/datasets/{name}")
-  public void create(HttpRequest request, final HttpResponder responder, @PathParam("name") String name) {
-    datasetInstanceHandler.create(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE, name);
+  public void create(HttpRequest request, HttpResponder responder,
+                     @PathParam("name") String name) {
+    datasetInstanceHandler.create(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
+                                  Constants.DEFAULT_NAMESPACE, name);
   }
 
   /**
@@ -70,44 +76,35 @@ public class DatasetInstanceHandlerV2 extends AbstractHttpHandler {
    */
   @PUT
   @Path("/data/datasets/{name}/properties")
-  public void update(HttpRequest request, HttpResponder responder, @PathParam("name") String name) {
-    datasetInstanceHandler.update(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE, name);
+  public void update(HttpRequest request, HttpResponder responder,
+                     @PathParam("name") String name) {
+    datasetInstanceHandler.update(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
+                                  Constants.DEFAULT_NAMESPACE, name);
   }
 
   @DELETE
   @Path("/data/datasets/{name}")
-  public void drop(HttpRequest request, HttpResponder responder, @PathParam("name") String name) {
-    datasetInstanceHandler.drop(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE, name);
+  public void drop(HttpRequest request, HttpResponder responder,
+                   @PathParam("name") String name) {
+    datasetInstanceHandler.drop(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
+                                Constants.DEFAULT_NAMESPACE, name);
   }
 
   @POST
   @Path("/data/datasets/{name}/admin/{method}")
-  public void executeAdmin(HttpRequest request, HttpResponder responder, @PathParam("name") String instanceName,
+  public void executeAdmin(HttpRequest request, HttpResponder responder,
+                           @PathParam("name") String instanceName,
                            @PathParam("method") String method) {
-    datasetInstanceHandler.executeAdmin(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE, instanceName,
-                                        method);
+    datasetInstanceHandler.executeAdmin(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
+                                        Constants.DEFAULT_NAMESPACE, instanceName, method);
   }
 
   @POST
   @Path("/data/datasets/{name}/data/{method}")
-  public void executeDataOp(HttpRequest request, HttpResponder responder, @PathParam("name") String instanceName,
+  public void executeDataOp(HttpRequest request, HttpResponder responder,
+                            @PathParam("name") String instanceName,
                             @PathParam("method") String method) {
-    datasetInstanceHandler.executeDataOp(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE, instanceName,
-                                         method);
-  }
-
-  /**
-   * Updates the request URI to its v3 URI before delegating the call to the corresponding v3 handler.
-   * Note: This piece of code is duplicated in various handlers, but its ok since this temporary, till we
-   * support v2 APIs
-   *
-   * @param request the original {@link HttpRequest}
-   * @return {@link HttpRequest} with modified URI
-   */
-  public HttpRequest rewriteRequest(HttpRequest request) {
-    String originalUri = request.getUri();
-    request.setUri(originalUri.replaceFirst(Constants.Gateway.API_VERSION_2, Constants.Gateway.API_VERSION_3 +
-      "/namespaces/" + Constants.DEFAULT_NAMESPACE));
-    return request;
+    datasetInstanceHandler.executeDataOp(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
+                                         Constants.DEFAULT_NAMESPACE, instanceName, method);
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetTypeHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetTypeHandler.java
@@ -107,7 +107,7 @@ public class DatasetTypeHandler extends AbstractHttpHandler {
       manager.deleteModules();
       responder.sendStatus(HttpResponseStatus.OK);
     } catch (DatasetModuleConflictException e) {
-      responder.sendError(HttpResponseStatus.CONFLICT, e.getMessage());
+      responder.sendString(HttpResponseStatus.CONFLICT, e.getMessage());
     }
   }
 
@@ -193,7 +193,7 @@ public class DatasetTypeHandler extends AbstractHttpHandler {
     try {
       deleted = manager.deleteModule(name);
     } catch (DatasetModuleConflictException e) {
-      responder.sendError(HttpResponseStatus.CONFLICT, e.getMessage());
+      responder.sendString(HttpResponseStatus.CONFLICT, e.getMessage());
       return;
     }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetTypeHandlerV2.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetTypeHandlerV2.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.data2.datafabric.dataset.service;
 
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.http.RESTMigrationUtils;
 import co.cask.http.AbstractHttpHandler;
 import co.cask.http.BodyConsumer;
 import co.cask.http.HandlerContext;
@@ -36,7 +37,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 
 /**
- * Handles dataset type management calls.
+ * Handles dataset type management v2 API calls.
  */
 // todo: do we want to make it authenticated? or do we treat it always as "internal" piece?
 @Path(Constants.Gateway.API_VERSION_2)
@@ -64,13 +65,15 @@ public class DatasetTypeHandlerV2 extends AbstractHttpHandler {
   @GET
   @Path("/data/modules")
   public void listModules(HttpRequest request, HttpResponder responder) {
-    datasetTypeHandler.listModules(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE);
+    datasetTypeHandler.listModules(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
+                                   Constants.DEFAULT_NAMESPACE);
   }
 
   @DELETE
   @Path("/data/modules")
   public void deleteModules(HttpRequest request, HttpResponder responder) {
-    datasetTypeHandler.deleteModules(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE);
+    datasetTypeHandler.deleteModules(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
+                                     Constants.DEFAULT_NAMESPACE);
   }
 
   @PUT
@@ -78,46 +81,35 @@ public class DatasetTypeHandlerV2 extends AbstractHttpHandler {
   public BodyConsumer addModule(HttpRequest request, HttpResponder responder,
                                 @PathParam("name") String name,
                                 @HeaderParam(HEADER_CLASS_NAME) String className) throws IOException {
-    return datasetTypeHandler.addModule(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE, name,
-                                        className);
+    return datasetTypeHandler.addModule(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
+                                        Constants.DEFAULT_NAMESPACE, name, className);
   }
 
   @DELETE
   @Path("/data/modules/{name}")
   public void deleteModule(HttpRequest request, HttpResponder responder, @PathParam("name") String name) {
-    datasetTypeHandler.deleteModule(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE, name);
+    datasetTypeHandler.deleteModule(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
+                                    Constants.DEFAULT_NAMESPACE, name);
   }
 
   @GET
   @Path("/data/modules/{name}")
   public void getModuleInfo(HttpRequest request, HttpResponder responder, @PathParam("name") String name) {
-    datasetTypeHandler.getModuleInfo(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE, name);
+    datasetTypeHandler.getModuleInfo(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
+                                     Constants.DEFAULT_NAMESPACE, name);
   }
 
   @GET
   @Path("/data/types")
   public void listTypes(HttpRequest request, HttpResponder responder) {
-    datasetTypeHandler.listTypes(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE);
+    datasetTypeHandler.listTypes(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
+                                 Constants.DEFAULT_NAMESPACE);
   }
 
   @GET
   @Path("/data/types/{name}")
   public void getTypeInfo(HttpRequest request, HttpResponder responder, @PathParam("name") String name) {
-    datasetTypeHandler.getTypeInfo(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE, name);
-  }
-
-  /**
-   * Updates the request URI to its v3 URI before delegating the call to the corresponding v3 handler.
-   * Note: This piece of code is duplicated in various handlers, but its ok since this temporary, till we
-   * support v2 APIs
-   *
-   * @param request the original {@link HttpRequest}
-   * @return {@link HttpRequest} with modified URI
-   */
-  public HttpRequest rewriteRequest(HttpRequest request) {
-    String originalUri = request.getUri();
-    request.setUri(originalUri.replaceFirst(Constants.Gateway.API_VERSION_2, Constants.Gateway.API_VERSION_3 +
-      "/namespaces/" + Constants.DEFAULT_NAMESPACE));
-    return request;
+    datasetTypeHandler.getTypeInfo(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
+                                   Constants.DEFAULT_NAMESPACE, name);
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/DatasetAdminOpHTTPHandlerV2.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/DatasetAdminOpHTTPHandlerV2.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.datafabric.dataset.service.executor;
+
+import co.cask.cdap.api.dataset.DatasetAdmin;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.http.RESTMigrationUtils;
+import co.cask.cdap.gateway.auth.Authenticator;
+import co.cask.cdap.gateway.handlers.AuthenticatedHttpHandler;
+import co.cask.http.HttpResponder;
+import com.google.inject.Inject;
+import org.jboss.netty.handler.codec.http.HttpRequest;
+
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+/**
+ * v2 REST endpoints for {@link DatasetAdmin} operations.
+ */
+@Path(Constants.Gateway.API_VERSION_2)
+public class DatasetAdminOpHTTPHandlerV2 extends AuthenticatedHttpHandler {
+
+  private final DatasetAdminOpHTTPHandler datasetAdminOpHTTPHandler;
+
+  @Inject
+  public DatasetAdminOpHTTPHandlerV2(Authenticator authenticator, DatasetAdminOpHTTPHandler datasetAdminOpHTTPHandler) {
+    super(authenticator);
+    this.datasetAdminOpHTTPHandler = datasetAdminOpHTTPHandler;
+  }
+
+  @POST
+  @Path("/data/datasets/{name}/admin/exists")
+  public void exists(HttpRequest request, HttpResponder responder,
+                     @PathParam("name") String instanceName) {
+    datasetAdminOpHTTPHandler.exists(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
+                                     Constants.DEFAULT_NAMESPACE, instanceName);
+  }
+
+  @POST
+  @Path("/data/datasets/{name}/admin/create")
+  public void create(HttpRequest request, HttpResponder responder,
+                     @PathParam("name") String name) throws Exception {
+    datasetAdminOpHTTPHandler.create(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
+                                     Constants.DEFAULT_NAMESPACE, name);
+  }
+
+  @POST
+  @Path("/data/datasets/{name}/admin/drop")
+  public void drop(HttpRequest request, HttpResponder responder,
+                   @PathParam("name") String instanceName) throws Exception {
+    datasetAdminOpHTTPHandler.drop(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
+                                   Constants.DEFAULT_NAMESPACE, instanceName);
+  }
+
+  @POST
+  @Path("/data/datasets/{name}/admin/truncate")
+  public void truncate(HttpRequest request, HttpResponder responder,
+                       @PathParam("name") String instanceName) {
+    datasetAdminOpHTTPHandler.truncate(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
+                                       Constants.DEFAULT_NAMESPACE, instanceName);
+  }
+
+  @POST
+  @Path("/data/datasets/{name}/admin/upgrade")
+  public void upgrade(HttpRequest request, HttpResponder responder,
+                      @PathParam("name") String instanceName) {
+    datasetAdminOpHTTPHandler.upgrade(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
+                                      Constants.DEFAULT_NAMESPACE, instanceName);
+  }
+}

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
@@ -25,6 +25,7 @@ import co.cask.cdap.common.metrics.NoOpMetricsCollectionService;
 import co.cask.cdap.data2.datafabric.dataset.instance.DatasetInstanceManager;
 import co.cask.cdap.data2.datafabric.dataset.service.DatasetService;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetAdminOpHTTPHandler;
+import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetAdminOpHTTPHandlerV2;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetOpExecutorService;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.InMemoryDatasetOpExecutor;
 import co.cask.cdap.data2.datafabric.dataset.service.mds.MDSDatasetsRegistry;
@@ -99,7 +100,9 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
                                            new LocalDatasetTypeClassLoaderFactory());
 
     ImmutableSet<HttpHandler> handlers =
-      ImmutableSet.<HttpHandler>of(new DatasetAdminOpHTTPHandler(new NoAuthenticator(), framework));
+      ImmutableSet.<HttpHandler>of(
+        new DatasetAdminOpHTTPHandlerV2(new NoAuthenticator(),
+                                        new DatasetAdminOpHTTPHandler(new NoAuthenticator(), framework)));
     opExecutorService = new DatasetOpExecutorService(cConf, discoveryService, metricsCollectionService, handlers);
 
     opExecutorService.startAndWait();

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
@@ -29,6 +29,7 @@ import co.cask.cdap.data2.datafabric.dataset.InMemoryDefinitionRegistryFactory;
 import co.cask.cdap.data2.datafabric.dataset.RemoteDatasetFramework;
 import co.cask.cdap.data2.datafabric.dataset.instance.DatasetInstanceManager;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetAdminOpHTTPHandler;
+import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetAdminOpHTTPHandlerV2;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetOpExecutorService;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.InMemoryDatasetOpExecutor;
 import co.cask.cdap.data2.datafabric.dataset.service.mds.MDSDatasetsRegistry;
@@ -119,7 +120,9 @@ public abstract class DatasetServiceTestBase {
                                              new LocalDatasetTypeClassLoaderFactory());
 
     ImmutableSet<HttpHandler> handlers =
-      ImmutableSet.<HttpHandler>of(new DatasetAdminOpHTTPHandler(new NoAuthenticator(), dsFramework));
+      ImmutableSet.<HttpHandler>of(
+        new DatasetAdminOpHTTPHandlerV2(new NoAuthenticator(),
+                                        new DatasetAdminOpHTTPHandler(new NoAuthenticator(), dsFramework)));
     opExecutorService = new DatasetOpExecutorService(cConf, discoveryService, metricsCollectionService, handlers);
 
     opExecutorService.startAndWait();

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/LogHandlerV2.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/LogHandlerV2.java
@@ -18,6 +18,7 @@ package co.cask.cdap.logging.gateway.handlers;
 
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.http.RESTMigrationUtils;
 import co.cask.cdap.common.logging.LoggingContext;
 import co.cask.cdap.gateway.auth.Authenticator;
 import co.cask.cdap.gateway.handlers.AuthenticatedHttpHandler;
@@ -114,8 +115,8 @@ public class LogHandlerV2 extends AuthenticatedHttpHandler {
                    @PathParam("entity-id") String entityId, @QueryParam("start") long fromTimeMs,
                    @QueryParam("stop") long toTimeMs, @QueryParam("escape") @DefaultValue("true") boolean escape,
                    @QueryParam("filter") @DefaultValue("") String filterStr) {
-    logHandler.list(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE, appId, entityType, entityId,
-                    fromTimeMs, toTimeMs, escape, filterStr);
+    logHandler.list(RESTMigrationUtils.rewriteV2RequestToV3(request), responder, Constants.DEFAULT_NAMESPACE, appId,
+                    entityType, entityId, fromTimeMs, toTimeMs, escape, filterStr);
   }
 
   @GET
@@ -148,8 +149,8 @@ public class LogHandlerV2 extends AuthenticatedHttpHandler {
                    @QueryParam("fromOffset") @DefaultValue("-1") long fromOffset,
                    @QueryParam("escape") @DefaultValue("true") boolean escape,
                    @QueryParam("filter") @DefaultValue("") String filterStr) {
-    logHandler.next(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE, appId, entityType, entityId,
-                    maxEvents, fromOffset, escape, filterStr);
+    logHandler.next(RESTMigrationUtils.rewriteV2RequestToV3(request), responder, Constants.DEFAULT_NAMESPACE, appId,
+                    entityType, entityId, maxEvents, fromOffset, escape, filterStr);
   }
 
   @GET
@@ -182,22 +183,7 @@ public class LogHandlerV2 extends AuthenticatedHttpHandler {
                    @QueryParam("fromOffset") @DefaultValue("-1") long fromOffset,
                    @QueryParam("escape") @DefaultValue("true") boolean escape,
                    @QueryParam("filter") @DefaultValue("") String filterStr) {
-    logHandler.prev(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE, appId, entityType, entityId,
-                    maxEvents, fromOffset, escape, filterStr);
-  }
-
-  /**
-   * Updates the request URI to its v3 URI before delegating the call to the corresponding v3 handler.
-   * Note: This piece of code is duplicated from AbstractAppFabricHttpHandler, but is ok since it is temporary until we
-   * support v2 APIs.
-   *
-   * @param request the original {@link HttpRequest}
-   * @return {@link HttpRequest} with modified URI
-   */
-  public HttpRequest rewriteRequest(HttpRequest request) {
-    String originalUri = request.getUri();
-    request.setUri(originalUri.replaceFirst(Constants.Gateway.API_VERSION_2, Constants.Gateway.API_VERSION_3 +
-      "/namespaces/" + Constants.DEFAULT_NAMESPACE));
-    return request;
+    logHandler.prev(RESTMigrationUtils.rewriteV2RequestToV3(request), responder, Constants.DEFAULT_NAMESPACE, appId,
+                    entityType, entityId, maxEvents, fromOffset, escape, filterStr);
   }
 }


### PR DESCRIPTION
Adds mock v3 APIs for dataset admin op handler.

v2 APIs deletegate to v3 handler.

Actual namespace usage will come in a later PR.

Build: http://builds.cask.co/browse/CDAP-DUT759