### PR TITLE
Remove name field from StreamProperties

### DIFF
--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/DescribeStreamCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/DescribeStreamCommand.java
@@ -50,13 +50,13 @@ public class DescribeStreamCommand extends AbstractAuthCommand {
     StreamProperties config = streamClient.getConfig(streamId);
 
     new AsciiTable<StreamProperties>(
-      new String[] { "name", "ttl", "format", "schema" },
+      new String[] { "ttl", "format", "schema" },
       Lists.newArrayList(config),
       new RowMaker<StreamProperties>() {
         @Override
         public Object[] makeRow(StreamProperties object) {
           FormatSpecification format = object.getFormat();
-          return new Object[] { object.getName(), object.getTTL(), format.getName(), format.getSchema().toString() };
+          return new Object[] { object.getTTL(), format.getName(), format.getSchema().toString() };
         }
       }
     ).print(output);

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetStreamFormatCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetStreamFormatCommand.java
@@ -61,7 +61,7 @@ public class SetStreamFormatCommand extends AbstractAuthCommand {
       settings = Splitter.on(" ").withKeyValueSeparator("=").split(arguments.get(ArgumentName.SETTINGS.toString()));
     }
     FormatSpecification formatSpecification = new FormatSpecification(formatName, schema, settings);
-    StreamProperties streamProperties = new StreamProperties(streamId, currentProperties.getTTL(),
+    StreamProperties streamProperties = new StreamProperties(currentProperties.getTTL(),
                                                              formatSpecification, currentProperties.getThreshold());
     streamClient.setStreamProperties(streamId, streamProperties);
     output.printf("Successfully set format of stream '%s'\n", streamId);

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/StreamClientTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/StreamClientTestRun.java
@@ -69,7 +69,6 @@ public class StreamClientTestRun extends ClientTestBase {
     Assert.assertEquals(baseStreamCount + 1, streamClient.list().size());
     StreamProperties config = streamClient.getConfig(testStreamId);
     Assert.assertNotNull(config);
-    Assert.assertEquals(testStreamId, config.getName());
     // TODO: getting and setting config for stream is not supported with in-memory
 //    streamClient.setTTL(testStreamId, 123);
 //    streamClient.sendEvent(testStreamId, testStreamEvent);

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/NoopStreamAdmin.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/NoopStreamAdmin.java
@@ -53,7 +53,7 @@ public class NoopStreamAdmin implements StreamAdmin {
   }
 
   @Override
-  public void updateConfig(StreamProperties properties) throws IOException {
+  public void updateConfig(String streamName, StreamProperties properties) throws IOException {
   }
 
   @Override

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/StreamCoordinatorTestBase.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/StreamCoordinatorTestBase.java
@@ -119,7 +119,7 @@ public abstract class StreamCoordinatorTestBase {
             for (int i = 0; i < 100; i++) {
               Long ttl = (threadId == 0) ? (long) (i * 1000) : null;
               Integer threshold = (threadId == 1) ? i : null;
-              streamAdmin.updateConfig(new StreamProperties(streamName, ttl, null, threshold));
+              streamAdmin.updateConfig(streamName, new StreamProperties(ttl, null, threshold));
             }
             completeLatch.countDown();
           } catch (Exception e) {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/AbstractStreamCoordinatorClient.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/AbstractStreamCoordinatorClient.java
@@ -110,7 +110,6 @@ public abstract class AbstractStreamCoordinatorClient extends AbstractIdleServic
           }
           // Merge the old and new properties.
           return new CoordinatorStreamProperties(
-            properties.getName(),
             firstNotNull(properties.getTTL(), oldProperties.getTTL()),
             firstNotNull(properties.getFormat(), oldProperties.getFormat()),
             firstNotNull(properties.getThreshold(), oldProperties.getThreshold()),

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/CoordinatorStreamProperties.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/CoordinatorStreamProperties.java
@@ -27,9 +27,8 @@ public class CoordinatorStreamProperties extends StreamProperties {
 
   private final Integer generation;
 
-  public CoordinatorStreamProperties(String name, Long ttl,
-                                     FormatSpecification format, Integer threshold, Integer generation) {
-    super(name, ttl, format, threshold);
+  public CoordinatorStreamProperties(Long ttl, FormatSpecification format, Integer threshold, Integer generation) {
+    super(ttl, format, threshold);
     this.generation = generation;
   }
 
@@ -40,7 +39,6 @@ public class CoordinatorStreamProperties extends StreamProperties {
   @Override
   public String toString() {
     return Objects.toStringHelper(this)
-      .add("name", getName())
       .add("ttl", getTTL())
       .add("format", getFormat())
       .add("threshold", getThreshold())

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseStreamAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseStreamAdmin.java
@@ -79,7 +79,7 @@ public class HBaseStreamAdmin extends HBaseQueueAdmin implements StreamAdmin {
   }
 
   @Override
-  public void updateConfig(StreamProperties properties) throws IOException {
+  public void updateConfig(String streamName, StreamProperties properties) throws IOException {
     throw new UnsupportedOperationException("Stream config not supported for non-file based stream.");
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/inmemory/InMemoryStreamAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/inmemory/InMemoryStreamAdmin.java
@@ -46,7 +46,7 @@ public class InMemoryStreamAdmin extends InMemoryQueueAdmin implements StreamAdm
   }
 
   @Override
-  public void updateConfig(StreamProperties properties) throws IOException {
+  public void updateConfig(String streamName, StreamProperties properties) throws IOException {
     throw new UnsupportedOperationException("Stream config not supported for non-file based stream.");
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/leveldb/LevelDBStreamAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/leveldb/LevelDBStreamAdmin.java
@@ -67,7 +67,7 @@ public class LevelDBStreamAdmin extends LevelDBQueueAdmin implements StreamAdmin
   }
 
   @Override
-  public void updateConfig(StreamProperties properties) throws IOException {
+  public void updateConfig(String streamName, StreamProperties properties) throws IOException {
     throw new UnsupportedOperationException("Stream config not supported for non-file based stream.");
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/StreamAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/StreamAdmin.java
@@ -66,7 +66,7 @@ public interface StreamAdmin extends EntityAdmin {
    * Overwrites existing configuration for the given stream.
    * @param properties New configuration of the stream.
    */
-  void updateConfig(StreamProperties properties) throws IOException;
+  void updateConfig(String streamName, StreamProperties properties) throws IOException;
 
   /**
    * Get the size of the data persisted for the stream with config {@code streamConfig}.

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceStreamTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceStreamTest.java
@@ -187,7 +187,7 @@ public class HiveExploreServiceStreamTest extends BaseHiveExploreServiceTest {
     );
     FormatSpecification formatSpecification = new FormatSpecification(
       Formats.AVRO, schema, Collections.<String, String>emptyMap());
-    StreamProperties properties = new StreamProperties("avroStream", Long.MAX_VALUE, formatSpecification, 1000);
+    StreamProperties properties = new StreamProperties(Long.MAX_VALUE, formatSpecification, 1000);
     setStreamProperties("avroStream", properties);
 
     // our schemas are compatible

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/StreamHandlerTestRun.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/StreamHandlerTestRun.java
@@ -144,7 +144,7 @@ public class StreamHandlerTestRun extends GatewayTestBase {
     formatSpecification = new FormatSpecification(TextRecordFormat.class.getCanonicalName(),
                             schema,
                             ImmutableMap.of(TextRecordFormat.CHARSET, "utf8"));
-    StreamProperties streamProperties = new StreamProperties("stream_info", 2L, formatSpecification, 20);
+    StreamProperties streamProperties = new StreamProperties(2L, formatSpecification, 20);
     urlConn.getOutputStream().write(GSON.toJson(streamProperties).getBytes(Charsets.UTF_8));
     Assert.assertEquals(HttpResponseStatus.OK.getCode(), urlConn.getResponseCode());
     urlConn.disconnect();
@@ -175,7 +175,7 @@ public class StreamHandlerTestRun extends GatewayTestBase {
     urlConn.setDoOutput(true);
     // don't give the schema to make sure a default gets used
     FormatSpecification formatSpecification = new FormatSpecification(Formats.TEXT, null, null);
-    StreamProperties streamProperties = new StreamProperties("stream_defaults", 2L, formatSpecification, 20);
+    StreamProperties streamProperties = new StreamProperties(2L, formatSpecification, 20);
     urlConn.getOutputStream().write(GSON.toJson(streamProperties).getBytes(Charsets.UTF_8));
     Assert.assertEquals(HttpResponseStatus.OK.getCode(), urlConn.getResponseCode());
     urlConn.disconnect();
@@ -188,7 +188,7 @@ public class StreamHandlerTestRun extends GatewayTestBase {
                                                        Charsets.UTF_8), StreamProperties.class);
     urlConn.disconnect();
 
-    StreamProperties expected = new StreamProperties("stream_defaults", 2L, StreamConfig.DEFAULT_STREAM_FORMAT, 20);
+    StreamProperties expected = new StreamProperties(2L, StreamConfig.DEFAULT_STREAM_FORMAT, 20);
     Assert.assertEquals(expected, actual);
   }
 
@@ -214,7 +214,7 @@ public class StreamHandlerTestRun extends GatewayTestBase {
     urlConn = openURL(String.format("http://%s:%d/v2/streams/stream_badconf/config",
                                     HOSTNAME, port), HttpMethod.PUT);
     urlConn.setDoOutput(true);
-    StreamProperties streamProperties = new StreamProperties("stream_badconf", -1L, null, 20);
+    StreamProperties streamProperties = new StreamProperties(-1L, null, 20);
     urlConn.getOutputStream().write(GSON.toJson(streamProperties).getBytes(Charsets.UTF_8));
     Assert.assertEquals(HttpResponseStatus.BAD_REQUEST.getCode(), urlConn.getResponseCode());
     urlConn.disconnect();
@@ -224,7 +224,7 @@ public class StreamHandlerTestRun extends GatewayTestBase {
                                     HOSTNAME, port), HttpMethod.PUT);
     urlConn.setDoOutput(true);
     FormatSpecification formatSpec = new FormatSpecification(null, null, null);
-    streamProperties = new StreamProperties("stream_badconf", 2L, formatSpec, 20);
+    streamProperties = new StreamProperties(2L, formatSpec, 20);
     urlConn.getOutputStream().write(GSON.toJson(streamProperties).getBytes(Charsets.UTF_8));
     Assert.assertEquals(HttpResponseStatus.BAD_REQUEST.getCode(), urlConn.getResponseCode());
     urlConn.disconnect();
@@ -234,7 +234,7 @@ public class StreamHandlerTestRun extends GatewayTestBase {
                                     HOSTNAME, port), HttpMethod.PUT);
     urlConn.setDoOutput(true);
     formatSpec = new FormatSpecification("gibberish", null, null);
-    streamProperties = new StreamProperties("stream_badconf", 2L, formatSpec, 20);
+    streamProperties = new StreamProperties(2L, formatSpec, 20);
     urlConn.getOutputStream().write(GSON.toJson(streamProperties).getBytes(Charsets.UTF_8));
     Assert.assertEquals(HttpResponseStatus.BAD_REQUEST.getCode(), urlConn.getResponseCode());
     urlConn.disconnect();
@@ -245,7 +245,7 @@ public class StreamHandlerTestRun extends GatewayTestBase {
     urlConn.setDoOutput(true);
     Schema schema = Schema.recordOf("event", Schema.Field.of("col", Schema.of(Schema.Type.DOUBLE)));
     formatSpec = new FormatSpecification(TextRecordFormat.class.getCanonicalName(), schema, null);
-    streamProperties = new StreamProperties("stream_badconf", 2L, formatSpec, 20);
+    streamProperties = new StreamProperties(2L, formatSpec, 20);
     urlConn.getOutputStream().write(GSON.toJson(streamProperties).getBytes(Charsets.UTF_8));
     Assert.assertEquals(HttpResponseStatus.BAD_REQUEST.getCode(), urlConn.getResponseCode());
     urlConn.disconnect();
@@ -254,7 +254,7 @@ public class StreamHandlerTestRun extends GatewayTestBase {
     urlConn = openURL(String.format("http://%s:%d/v2/streams/stream_badconf/config",
                                     HOSTNAME, port), HttpMethod.PUT);
     urlConn.setDoOutput(true);
-    streamProperties = new StreamProperties("stream_badconf", 2L, null, -20);
+    streamProperties = new StreamProperties(2L, null, -20);
     urlConn.getOutputStream().write(GSON.toJson(streamProperties).getBytes(Charsets.UTF_8));
     Assert.assertEquals(HttpResponseStatus.BAD_REQUEST.getCode(), urlConn.getResponseCode());
     urlConn.disconnect();

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/StreamProperties.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/StreamProperties.java
@@ -23,23 +23,14 @@ import com.google.common.base.Objects;
  */
 public class StreamProperties {
 
-  private final String name;
   private final Long ttl;
   private final FormatSpecification format;
   private final Integer threshold;
 
-  public StreamProperties(String name, Long ttl, FormatSpecification format, Integer threshold) {
-    this.name = name;
+  public StreamProperties(Long ttl, FormatSpecification format, Integer threshold) {
     this.ttl = ttl;
     this.format = format;
     this.threshold = threshold;
-  }
-
-  /**
-   * @return Name of the stream.
-   */
-  public String getName() {
-    return name;
   }
 
   /**
@@ -75,21 +66,19 @@ public class StreamProperties {
 
     StreamProperties that = (StreamProperties) o;
 
-    return Objects.equal(name, that.name) &&
-      Objects.equal(ttl, that.ttl) &&
+    return Objects.equal(ttl, that.ttl) &&
       Objects.equal(format, that.format) &
       Objects.equal(threshold, that.threshold);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(name, ttl, format, threshold);
+    return Objects.hashCode(ttl, format, threshold);
   }
 
   @Override
   public String toString() {
     return Objects.toStringHelper(this)
-      .add("name", name)
       .add("ttl", ttl)
       .add("format", format)
       .add("threshold", threshold)


### PR DESCRIPTION
The field `name` is unnecessary in StreamProperties, because its used as an interchange between client/server. Anytime the StreamProperties is exchanged, the surrounding system is already operating on a particular stream.
For instance, when user does a PUT of StreamProperties via REST call, they anyways pass streamName in the path of the endpoint (so no need to have two sources for the same piece of information). Same for retrieval of StreamProperties.

Build: http://builds.cask.co/browse/CDAP-DUT765-4