### PR TITLE
metric store table rename and prepare for upgrade

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseMetricsTableDefinition.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseMetricsTableDefinition.java
@@ -36,7 +36,6 @@ import org.apache.twill.filesystem.LocationFactory;
 
 import java.io.IOException;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 /**
  * HBase based implementation for {@link MetricsTable}.
@@ -72,6 +71,7 @@ public class HBaseMetricsTableDefinition extends AbstractDatasetDefinition<Metri
 
   @Override
   public DatasetAdmin getAdmin(DatasetSpecification spec, ClassLoader classLoader) throws IOException {
+    // todo: CDAP-1458 HTableDatasetAdmin doesn't fit where there are coprocessors set for table, as it does no upgrade
     return new HTableDatasetAdmin(getHTableDescriptor(spec), hConf, hBaseTableUtil);
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HTableDatasetAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HTableDatasetAdmin.java
@@ -61,7 +61,7 @@ public class HTableDatasetAdmin implements DatasetAdmin {
 
   @Override
   public void create() throws IOException {
-    getAdmin().createTable(tableDescriptor);
+    tableUtil.createTableIfNotExists(getAdmin(), tableName, tableDescriptor, null);
   }
 
   @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseTableUtil.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseTableUtil.java
@@ -58,6 +58,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
 import java.util.regex.Matcher;
+import javax.annotation.Nullable;
 
 /**
  * Common utilities for dealing with HBase.
@@ -121,7 +122,7 @@ public abstract class HBaseTableUtil {
    */
   public void createTableIfNotExists(HBaseAdmin admin, byte[] tableName,
                                      HTableDescriptor tableDescriptor,
-                                     byte[][] splitKeys) throws IOException {
+                                     @Nullable byte[][] splitKeys) throws IOException {
     createTableIfNotExists(admin, tableName, tableDescriptor, splitKeys,
                            MAX_CREATE_TABLE_WAIT, TimeUnit.MILLISECONDS);
   }
@@ -137,7 +138,7 @@ public abstract class HBaseTableUtil {
    */
   public void createTableIfNotExists(HBaseAdmin admin, byte[] tableName,
                                      HTableDescriptor tableDescriptor,
-                                     byte[][] splitKeys,
+                                     @Nullable byte[][] splitKeys,
                                      long timeout, TimeUnit timeoutUnit) throws IOException {
     if (admin.tableExists(tableName)) {
       return;

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/Main.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/Main.java
@@ -37,6 +37,7 @@ import co.cask.cdap.data2.dataset2.lib.file.FileSetModule;
 import co.cask.cdap.data2.dataset2.lib.hbase.AbstractHBaseDataSetAdmin;
 import co.cask.cdap.data2.dataset2.lib.table.CoreDatasetsModule;
 import co.cask.cdap.data2.dataset2.lib.table.hbase.HBaseOrderedTableAdmin;
+import co.cask.cdap.data2.dataset2.module.lib.hbase.HBaseMetricsTableModule;
 import co.cask.cdap.data2.dataset2.module.lib.hbase.HBaseOrderedTableModule;
 import co.cask.cdap.data2.transaction.queue.QueueAdmin;
 import co.cask.cdap.data2.transaction.queue.hbase.HBaseQueueAdmin;
@@ -45,6 +46,7 @@ import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
 import co.cask.cdap.internal.app.runtime.schedule.ScheduleStoreTableUtil;
 import co.cask.cdap.internal.app.store.DefaultStore;
 import co.cask.cdap.logging.save.LogSaverTableUtil;
+import co.cask.cdap.metrics.store.DefaultMetricDatasetFactory;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -166,6 +168,7 @@ public class Main {
   }
 
   private void upgradeSystemDatasets(Injector injector) throws Exception {
+    CConfiguration cConf = injector.getInstance(CConfiguration.class);
     // Setting up all system datasets to be upgraded, collecting them from respective components
     DatasetFramework framework = createRegisteredDatasetFramework(injector);
     // dataset service
@@ -178,6 +181,8 @@ public class Main {
     LogSaverTableUtil.setupDatasets(framework);
     // scheduler metadata
     ScheduleStoreTableUtil.setupDatasets(framework);
+    // metrics data
+    DefaultMetricDatasetFactory.setupDatasets(cConf, framework);
 
     // Upgrade all datasets
     for (DatasetSpecification spec : framework.getInstances()) {
@@ -205,6 +210,7 @@ public class Main {
       new NamespacedDatasetFramework(new InMemoryDatasetFramework(registryFactory),
                                      new DefaultDatasetNamespace(cConf, Namespace.SYSTEM));
     datasetFramework.addModule("orderedTable", new HBaseOrderedTableModule());
+    datasetFramework.addModule("metricsTable", new HBaseMetricsTableModule());
     datasetFramework.addModule("core", new CoreDatasetsModule());
     datasetFramework.addModule("fileSet", new FileSetModule());
 

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/MetricsConstants.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/MetricsConstants.java
@@ -42,8 +42,9 @@ public final class MetricsConstants {
     public static final String KAFKA_META_TABLE = "metrics.kafka.meta.table";
   }
 
-  public static final String DEFAULT_ENTITY_TABLE_NAME = "metrics.entity";
-  public static final String DEFAULT_METRIC_TABLE_PREFIX = "metrics.table";
+  // v2 to avoid conflict with data of older metrics system
+  public static final String DEFAULT_ENTITY_TABLE_NAME = "metrics.v2.entity";
+  public static final String DEFAULT_METRIC_TABLE_PREFIX = "metrics.v2.table";
   public static final int DEFAULT_TIME_SERIES_TABLE_ROLL_TIME = 3600;
   public static final long DEFAULT_RETENTION_HOURS = 2;
 

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/store/DefaultMetricDatasetFactory.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/store/DefaultMetricDatasetFactory.java
@@ -16,9 +16,7 @@
 
 package co.cask.cdap.metrics.store;
 
-import co.cask.cdap.api.dataset.DatasetAdmin;
 import co.cask.cdap.api.dataset.DatasetProperties;
-import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.dataset.table.OrderedTable;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.data.Namespace;
@@ -65,8 +63,7 @@ public class DefaultMetricDatasetFactory implements MetricDatasetFactory {
       @Override
       public EntityTable get() {
         String tableName = cConf.get(MetricsConstants.ConfigKeys.ENTITY_TABLE_NAME,
-                                     // todo: remove + ".v2"
-                                     MetricsConstants.DEFAULT_ENTITY_TABLE_NAME) + ".v2";
+                                     MetricsConstants.DEFAULT_ENTITY_TABLE_NAME);
         return new EntityTable(getOrCreateMetricsTable(tableName, DatasetProperties.EMPTY));
       }
     });
@@ -76,8 +73,7 @@ public class DefaultMetricDatasetFactory implements MetricDatasetFactory {
   @Override
   public FactTable get(int resolution) {
     String tableName = cConf.get(MetricsConstants.ConfigKeys.METRICS_TABLE_PREFIX,
-                                 // todo: remove + ".v2"
-                                 MetricsConstants.DEFAULT_METRIC_TABLE_PREFIX) + ".v2" + ".ts." + resolution;
+                                 MetricsConstants.DEFAULT_METRIC_TABLE_PREFIX) + ".ts." + resolution;
     int ttl =  cConf.getInt(MetricsConstants.ConfigKeys.RETENTION_SECONDS + "." + resolution + ".seconds", -1);
 
     DatasetProperties props = ttl > 0 ?
@@ -127,23 +123,26 @@ public class DefaultMetricDatasetFactory implements MetricDatasetFactory {
     return table;
   }
 
-  @Override
-  public void upgrade() throws Exception {
-    // todo: remove + ".v2"
-    String metricsPrefix = cConf.get(MetricsConstants.ConfigKeys.METRICS_TABLE_PREFIX,
-                                     MetricsConstants.DEFAULT_METRIC_TABLE_PREFIX) + ".v2";
-    for (DatasetSpecification spec : dsFramework.getInstances()) {
-      String dsName = spec.getName();
-      if (dsName.contains(metricsPrefix + ".ts.")) {
-        DatasetAdmin admin = dsFramework.getAdmin(dsName, null);
-        if (admin != null) {
-          admin.upgrade();
-        } else {
-          LOG.error("Could not obtain admin to upgrade metrics table: " + dsName);
-          // continue to best effort
-        }
-      }
-    }
+  /**
+   * Adds datasets and types to the given {@link DatasetFramework} used by metrics system.
+   * <p/>
+   * It is primarily used by upgrade tool.
+   *
+   * @param datasetFramework framework to add types and datasets to
+   */
+  public static void setupDatasets(CConfiguration conf, DatasetFramework datasetFramework)
+    throws IOException, DatasetManagementException {
+
+    DefaultMetricDatasetFactory factory = new DefaultMetricDatasetFactory(conf, datasetFramework);
+
+    // adding all fact tables
+    factory.get(1);
+    factory.get(60);
+    factory.get(3600);
+    factory.get(Integer.MAX_VALUE);
+
+    // adding kafka consumer meta
+    factory.createKafkaConsumerMeta();
   }
 
   private int getRollTime(int resolution) {

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/store/MetricDatasetFactory.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/store/MetricDatasetFactory.java
@@ -34,10 +34,4 @@ public interface MetricDatasetFactory {
    * @return A new instance of {@link KafkaConsumerMetaTable}.
    */
   KafkaConsumerMetaTable createKafkaConsumerMeta();
-
-  /**
-   * Upgrade all metric system datasets.
-   * @throws Exception
-   */
-  void upgrade() throws Exception;
 }


### PR DESCRIPTION
Follow up on #1251 , addresses:
* remove + .v2 in dataset names
* upgrade metric datasets (part, see CDAP-1458 for rest)