### PR TITLE
CDAP-1411 refactor reflection writer/reader classes so that they

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionDatumReader.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionDatumReader.java
@@ -18,136 +18,84 @@ package co.cask.cdap.internal.io;
 
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.common.io.Decoder;
-import co.cask.cdap.common.lang.Instantiator;
-import co.cask.cdap.common.lang.InstantiatorFactory;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Maps;
-import com.google.common.primitives.Longs;
 import com.google.common.reflect.TypeToken;
 
 import java.io.IOException;
 import java.lang.reflect.Array;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.net.URI;
-import java.net.URL;
 import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Map;
-import java.util.UUID;
 
 /**
- * Reflection based Datnum Reader.
+ * Reflection based Datum Reader.
  *
  * @param <T> type T reader
  */
-public final class ReflectionDatumReader<T> implements DatumReader<T> {
+public final class ReflectionDatumReader<T> extends ReflectionReader<Decoder, T> implements DatumReader<T> {
 
-  private final Schema schema;
-  private final TypeToken<T> type;
-  private final Map<Class<?>, Instantiator<?>> creators;
-  private final InstantiatorFactory creatorFactory;
-  private final FieldAccessorFactory fieldAccessorFactory;
-
-  @SuppressWarnings("unchecked")
   public ReflectionDatumReader(Schema schema, TypeToken<T> type) {
-    this.schema = schema;
-    this.type = type;
-    this.creatorFactory = new InstantiatorFactory(true);
-    this.creators = Maps.newIdentityHashMap();
-    this.fieldAccessorFactory = new ReflectionFieldAccessorFactory();
+    super(schema, type);
   }
 
-  @SuppressWarnings("unchecked")
   @Override
-  public T read(Decoder decoder, Schema sourceSchema) throws IOException {
-    return (T) read(decoder, sourceSchema, schema, type);
+  protected Object readNull(Decoder decoder) throws IOException {
+    return decoder.readNull();
   }
 
-  private Object read(Decoder decoder, Schema sourceSchema,
-                      Schema targetSchema, TypeToken<?> targetTypeToken) throws IOException {
-
-    if (sourceSchema.getType() != Schema.Type.UNION && targetSchema.getType() == Schema.Type.UNION) {
-      // Try every target schemas
-      for (Schema schema : targetSchema.getUnionSchemas()) {
-        try {
-          return doRead(decoder, sourceSchema, schema, targetTypeToken);
-        } catch (IOException e) {
-          // Continue;
-        }
-      }
-      throw new IOException(String.format("No matching schema to resolve %s to %s", sourceSchema, targetSchema));
-    }
-    return doRead(decoder, sourceSchema, targetSchema, targetTypeToken);
+  @Override
+  protected boolean readBool(Decoder decoder) throws IOException {
+    return decoder.readBool();
   }
 
-  private Object doRead(Decoder decoder, Schema sourceSchema,
-                        Schema targetSchema, TypeToken<?> targetTypeToken) throws IOException {
-
-    Schema.Type sourceType = sourceSchema.getType();
-    Schema.Type targetType = targetSchema.getType();
-
-    switch(sourceType) {
-      case NULL:
-        check(sourceType == targetType, "Fails to resolve %s to %s", sourceType, targetType);
-        return decoder.readNull();
-      case BYTES:
-        check(sourceType == targetType, "Fails to resolve %s to %s", sourceType, targetType);
-        return readBytes(decoder, targetTypeToken);
-      case ENUM:
-        String enumValue = sourceSchema.getEnumValue(decoder.readInt());
-        check(targetSchema.getEnumValues().contains(enumValue), "Enum value '%s' missing in target.", enumValue);
-        try {
-          return targetTypeToken.getRawType().getMethod("valueOf", String.class).invoke(null, enumValue);
-        } catch (Exception e) {
-          throw new IOException(e);
-        }
-      case ARRAY:
-        check(sourceType == targetType, "Fails to resolve %s to %s", sourceType, targetType);
-        return readArray(decoder, sourceSchema, targetSchema, targetTypeToken);
-      case MAP:
-        check(sourceType == targetType, "Fails to resolve %s to %s", sourceType, targetType);
-        return readMap(decoder, sourceSchema, targetSchema, targetTypeToken);
-      case RECORD:
-        check(sourceType == targetType, "Fails to resolve %s to %s", sourceType, targetType);
-        return readRecord(decoder, sourceSchema, targetSchema, targetTypeToken);
-      case UNION:
-        return readUnion(decoder, sourceSchema, targetSchema, targetTypeToken);
-    }
-    // For simple type other than NULL and BYTES
-    if (sourceType.isSimpleType()) {
-      return resolveType(decoder, sourceType, targetType, targetTypeToken);
-    }
-    throw new IOException(String.format("Fails to resolve %s to %s", sourceSchema, targetSchema));
+  @Override
+  protected int readInt(Decoder decoder) throws IOException {
+    return decoder.readInt();
   }
 
-  private Object readBytes(Decoder decoder, TypeToken<?> targetTypeToken) throws IOException {
-    ByteBuffer buffer = decoder.readBytes();
-
-    if (targetTypeToken.getRawType().equals(byte[].class)) {
-      if (buffer.hasArray()) {
-        byte[] array = buffer.array();
-        if (buffer.remaining() == array.length) {
-          return array;
-        }
-        byte[] bytes = new byte[buffer.remaining()];
-        System.arraycopy(array, buffer.arrayOffset() + buffer.position(), bytes, 0, buffer.remaining());
-        return bytes;
-      } else {
-        byte[] bytes = new byte[buffer.remaining()];
-        buffer.get(bytes);
-        return bytes;
-      }
-    } else if (targetTypeToken.getRawType().equals(UUID.class) && buffer.remaining() == Longs.BYTES * 2) {
-      return new UUID(buffer.getLong(), buffer.getLong());
-    }
-    return buffer;
+  @Override
+  protected long readLong(Decoder decoder) throws IOException {
+    return decoder.readLong();
   }
 
-  @SuppressWarnings("unchecked")
-  private Object readArray(Decoder decoder, Schema sourceSchema,
-                           Schema targetSchema, TypeToken<?> targetTypeToken) throws IOException {
+  @Override
+  protected float readFloat(Decoder decoder) throws IOException {
+    return decoder.readFloat();
+  }
 
+  @Override
+  protected double readDouble(Decoder decoder) throws IOException {
+    return decoder.readDouble();
+  }
+
+  @Override
+  protected String readString(Decoder decoder) throws IOException {
+    return decoder.readString();
+  }
+
+  @Override
+  protected ByteBuffer readBytes(Decoder decoder) throws IOException {
+    return decoder.readBytes();
+  }
+
+  @Override
+  protected Object readEnum(Decoder decoder, Schema sourceSchema, Schema targetSchema,
+                            TypeToken<?> targetTypeToken) throws IOException {
+    String enumValue = sourceSchema.getEnumValue(decoder.readInt());
+    check(targetSchema.getEnumValues().contains(enumValue), "Enum value '%s' missing in target.", enumValue);
+    try {
+      return targetTypeToken.getRawType().getMethod("valueOf", String.class).invoke(null, enumValue);
+    } catch (Exception e) {
+      throw new IOException(e);
+    }
+  }
+
+  @SuppressWarnings({"unchecked", "ConstantConditions"})
+  @Override
+  protected Object readArray(Decoder decoder, Schema sourceSchema, Schema targetSchema,
+                             TypeToken<?> targetTypeToken) throws IOException {
     TypeToken<?> componentType = null;
     if (targetTypeToken.isArray()) {
       componentType = targetTypeToken.getComponentType();
@@ -180,15 +128,19 @@ public final class ReflectionDatumReader<T> implements DatumReader<T> {
     return collection;
   }
 
-  @SuppressWarnings("unchecked")
-  private Map<Object, Object> readMap(Decoder decoder, Schema sourceSchema,
-                                      Schema targetSchema, TypeToken<?> targetTypeToken) throws IOException {
+  @Override
+  protected Object readMap(Decoder decoder, Schema sourceSchema, Schema targetSchema,
+                           TypeToken<?> targetTypeToken) throws IOException {
     check(Map.class.isAssignableFrom(targetTypeToken.getRawType()), "Only map type is supported for map data.");
     Type type = targetTypeToken.getType();
     Preconditions.checkArgument(type instanceof ParameterizedType, "Only parameterized map is supported.");
+    // suppressing warning because we know type is not null
+    @SuppressWarnings("ConstantConditions")
     Type[] typeArgs = ((ParameterizedType) type).getActualTypeArguments();
 
     int len = decoder.readInt();
+    // unchecked cast is ok, we're assuming the type token is correct
+    @SuppressWarnings("unchecked")
     Map<Object, Object> map = (Map<Object, Object>) create(targetTypeToken);
     while (len != 0) {
       for (int i = 0; i < len; i++) {
@@ -204,28 +156,9 @@ public final class ReflectionDatumReader<T> implements DatumReader<T> {
     return map;
   }
 
-  private Object readRecord(Decoder decoder, Schema sourceSchema,
-                            Schema targetSchema, TypeToken<?> targetTypeToken) throws IOException {
-    try {
-      Object record = create(targetTypeToken);
-      for (Schema.Field sourceField : sourceSchema.getFields()) {
-        Schema.Field targetField = targetSchema.getField(sourceField.getName());
-        if (targetField == null) {
-          skip(decoder, sourceField.getSchema());
-          continue;
-        }
-        FieldAccessor fieldAccessor = fieldAccessorFactory.getFieldAccessor(targetTypeToken, sourceField.getName());
-        fieldAccessor.set(record,
-                          read(decoder, sourceField.getSchema(), targetField.getSchema(), fieldAccessor.getType()));
-      }
-      return record;
-    } catch (Exception e) {
-      throw propagate(e);
-    }
-  }
-
-  private Object readUnion(Decoder decoder, Schema sourceSchema,
-                           Schema targetSchema, TypeToken<?> targetTypeToken) throws IOException {
+  @Override
+  protected Object readUnion(Decoder decoder, Schema sourceSchema, Schema targetSchema,
+                             TypeToken<?> targetTypeToken) throws IOException {
     int idx = decoder.readInt();
     Schema sourceValueSchema = sourceSchema.getUnionSchemas().get(idx);
 
@@ -250,6 +183,27 @@ public final class ReflectionDatumReader<T> implements DatumReader<T> {
       throw new IOException(String.format("Fail to resolve %s to %s", sourceSchema, targetSchema));
     } else {
       return read(decoder, sourceValueSchema, targetSchema, targetTypeToken);
+    }
+  }
+
+  @Override
+  protected Object readRecord(Decoder decoder, Schema sourceSchema, Schema targetSchema,
+                              TypeToken<?> targetTypeToken) throws IOException {
+    try {
+      Object record = create(targetTypeToken);
+      for (Schema.Field sourceField : sourceSchema.getFields()) {
+        Schema.Field targetField = targetSchema.getField(sourceField.getName());
+        if (targetField == null) {
+          skip(decoder, sourceField.getSchema());
+          continue;
+        }
+        FieldAccessor fieldAccessor = getFieldAccessor(targetTypeToken, sourceField.getName());
+        fieldAccessor.set(record,
+                          read(decoder, sourceField.getSchema(), targetField.getSchema(), fieldAccessor.getType()));
+      }
+      return record;
+    } catch (Exception e) {
+      throw propagate(e);
     }
   }
 
@@ -317,112 +271,5 @@ public final class ReflectionDatumReader<T> implements DatumReader<T> {
     for (Schema.Field field : recordSchema.getFields()) {
       skip(decoder, field.getSchema());
     }
-  }
-
-  private Object resolveType(Decoder decoder, Schema.Type sourceType,
-                             Schema.Type targetType, TypeToken<?> targetTypeToken) throws IOException {
-    switch(sourceType) {
-      case BOOLEAN:
-        switch(targetType) {
-          case BOOLEAN:
-            return decoder.readBool();
-          case STRING:
-            return String.valueOf(decoder.readBool());
-        }
-        break;
-      case INT:
-        switch(targetType) {
-          case INT:
-            Class<?> targetClass = targetTypeToken.getRawType();
-            int value = decoder.readInt();
-            if (targetClass.equals(byte.class) || targetClass.equals(Byte.class)) {
-              return (byte) value;
-            }
-            if (targetClass.equals(char.class) || targetClass.equals(Character.class)) {
-              return (char) value;
-            }
-            if (targetClass.equals(short.class) || targetClass.equals(Short.class)) {
-              return (short) value;
-            }
-            return value;
-          case LONG:
-            return (long) decoder.readInt();
-          case FLOAT:
-            return (float) decoder.readInt();
-          case DOUBLE:
-            return (double) decoder.readInt();
-          case STRING:
-            return String.valueOf(decoder.readInt());
-        }
-        break;
-      case LONG:
-        switch(targetType) {
-          case LONG:
-            return decoder.readLong();
-          case FLOAT:
-            return (float) decoder.readLong();
-          case DOUBLE:
-            return (double) decoder.readLong();
-          case STRING:
-            return String.valueOf(decoder.readLong());
-        }
-        break;
-      case FLOAT:
-        switch(targetType) {
-          case FLOAT:
-            return decoder.readFloat();
-          case DOUBLE:
-            return (double) decoder.readFloat();
-          case STRING:
-            return String.valueOf(decoder.readFloat());
-        }
-        break;
-      case DOUBLE:
-        switch(targetType) {
-          case DOUBLE:
-            return decoder.readDouble();
-          case STRING:
-            return String.valueOf(decoder.readDouble());
-        }
-        break;
-      case STRING:
-        switch(targetType) {
-          case STRING:
-            String str = decoder.readString();
-            Class<?> targetClass = targetTypeToken.getRawType();
-            if (targetClass.equals(URI.class)) {
-              return URI.create(str);
-            } else if (targetClass.equals(URL.class)) {
-              return new URL(str);
-            }
-            return str;
-        }
-        break;
-    }
-
-    throw new IOException("Fail to resolve type " + sourceType + " to type " + targetType);
-  }
-
-  private void check(boolean condition, String message, Object... objs) throws IOException {
-    if (!condition) {
-      throw new IOException(String.format(message, objs));
-    }
-  }
-
-  private IOException propagate(Throwable t) throws IOException {
-    if (t instanceof IOException) {
-      throw (IOException) t;
-    }
-    throw new IOException(t);
-  }
-
-  private Object create(TypeToken<?> type) {
-    Class<?> rawType = type.getRawType();
-    Instantiator<?> creator = creators.get(rawType);
-    if (creator == null) {
-      creator = creatorFactory.get(type);
-      creators.put(rawType, creator);
-    }
-    return creator.create();
   }
 }

--- a/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionDatumWriter.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionDatumWriter.java
@@ -102,7 +102,7 @@ public final class ReflectionDatumWriter<T> extends ReflectionWriter<Encoder, T>
   }
 
   @Override
-  protected void writeArray(Encoder encoder, Collection col, Schema componentSchema) throws IOException {
+  protected void writeArray(Encoder encoder, Collection<?> col, Schema componentSchema) throws IOException {
     int size = col.size();
     encoder.writeInt(size);
     for (Object obj : col) {

--- a/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionDatumWriter.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionDatumWriter.java
@@ -18,35 +18,24 @@ package co.cask.cdap.internal.io;
 
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.common.io.Encoder;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
-import com.google.common.primitives.Longs;
-import com.google.common.reflect.TypeToken;
 
 import java.io.IOException;
 import java.lang.reflect.Array;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
 
 /**
  * A {@link DatumWriter} that uses java reflection to encode data. The encoding schema it uses is
- * the same as the binary encoding as specified in Avro, with the enhancement of support non-string
- * map key.
+ * the same as the binary encoding as specified in Avro, with the enhancement of support for non-string
+ * map keys.
  *
  * @param <T> Type T to be written.
  */
-public final class ReflectionDatumWriter<T> implements DatumWriter<T> {
-
-  private final Schema schema;
+public final class ReflectionDatumWriter<T> extends ReflectionWriter<Encoder, T> implements DatumWriter<T> {
 
   public ReflectionDatumWriter(Schema schema) {
-    this.schema = schema;
+    super(schema);
   }
 
   public Schema getSchema() {
@@ -55,204 +44,111 @@ public final class ReflectionDatumWriter<T> implements DatumWriter<T> {
 
   @Override
   public void encode(T data, Encoder encoder) throws IOException {
-    Set<Object> seenRefs = Sets.newIdentityHashSet();
-    write(data, encoder, schema, seenRefs);
+    write(data, encoder);
   }
 
-  private void write(Object object, Encoder encoder, Schema objSchema, Set<Object> seenRefs) throws IOException {
-    if (object != null) {
-      if (seenRefs.contains(object)) {
-        throw new IOException("Circular reference not supported.");
-      }
-      if (objSchema.getType() == Schema.Type.RECORD) {
-        seenRefs.add(object);
-      }
-    }
-
-    switch(objSchema.getType()) {
-      case NULL:
-        encoder.writeNull();
-        break;
-      case BOOLEAN:
-        encoder.writeBool((Boolean) object);
-        break;
-      case INT:
-        encoder.writeInt(((Number) object).intValue());
-        break;
-      case LONG:
-        encoder.writeLong(((Number) object).longValue());
-        break;
-      case FLOAT:
-        encoder.writeFloat((Float) object);
-        break;
-      case DOUBLE:
-        encoder.writeDouble((Double) object);
-        break;
-      case STRING:
-        encoder.writeString(object.toString());
-        break;
-      case BYTES:
-        writeBytes(object, encoder);
-        break;
-      case ENUM:
-        writeEnum(object.toString(), encoder, objSchema);
-        break;
-      case ARRAY:
-        writeArray(object, encoder, objSchema.getComponentSchema(), seenRefs);
-        break;
-      case MAP:
-        writeMap(object, encoder, objSchema.getMapSchema(), seenRefs);
-        break;
-      case RECORD:
-        writeRecord(object, encoder, objSchema, seenRefs);
-        break;
-      case UNION:
-        // Assumption in schema generation that index 0 is the object type, index 1 is null.
-        if (object == null) {
-          encoder.writeInt(1);
-        } else {
-          seenRefs.remove(object);
-          encoder.writeInt(0);
-          write(object, encoder, objSchema.getUnionSchema(0), seenRefs);
-        }
-        break;
-    }
+  @Override
+  protected void writeNull(Encoder encoder) throws IOException {
+    encoder.writeNull();
   }
 
-  private void writeBytes(Object object, Encoder encoder) throws IOException {
-    if (object instanceof ByteBuffer) {
-      encoder.writeBytes((ByteBuffer) object);
-    } else if (object instanceof UUID) {
-      UUID uuid = (UUID)  object;
-      ByteBuffer buf = ByteBuffer.allocate(Longs.BYTES * 2);
-      buf.putLong(uuid.getMostSignificantBits()).putLong(uuid.getLeastSignificantBits());
-      encoder.writeBytes((ByteBuffer) buf.flip());
-    } else {
-      encoder.writeBytes((byte[]) object);
-    }
+  @Override
+  protected void writeBool(Encoder encoder, Boolean val) throws IOException {
+    encoder.writeBool(val);
   }
 
-  private void writeEnum(String value, Encoder encoder, Schema schema) throws IOException {
-    int idx = schema.getEnumIndex(value);
+  @Override
+  protected void writeInt(Encoder encoder, int val) throws IOException {
+    encoder.writeInt(val);
+  }
+
+  @Override
+  protected void writeLong(Encoder encoder, long val) throws IOException {
+    encoder.writeLong(val);
+  }
+
+  @Override
+  protected void writeFloat(Encoder encoder, Float val) throws IOException {
+    encoder.writeFloat(val);
+  }
+
+  @Override
+  protected void writeDouble(Encoder encoder, Double val) throws IOException {
+    encoder.writeDouble(val);
+  }
+
+  @Override
+  protected void writeString(Encoder encoder, String val) throws IOException {
+    encoder.writeString(val);
+  }
+
+  @Override
+  protected void writeBytes(Encoder encoder, ByteBuffer val) throws IOException {
+    encoder.writeBytes(val);
+  }
+
+  @Override
+  protected void writeBytes(Encoder encoder, byte[] val) throws IOException {
+    encoder.writeBytes(val);
+  }
+
+  @Override
+  protected void writeEnum(Encoder encoder, String val, Schema schema) throws IOException {
+    int idx = schema.getEnumIndex(val);
     if (idx < 0) {
-      throw new IOException("Invalid enum value " + value);
+      throw new IOException("Invalid enum value " + val);
     }
     encoder.writeInt(idx);
   }
 
-  private void writeArray(Object array, Encoder encoder,
-                          Schema componentSchema, Set<Object> seenRefs) throws IOException {
-    int size = 0;
-    if (array instanceof Collection) {
-      Collection col = (Collection) array;
-      encoder.writeInt(col.size());
-      for (Object obj : col) {
-        write(obj, encoder, componentSchema, seenRefs);
-      }
-      size = col.size();
-    } else {
-      size = Array.getLength(array);
-      encoder.writeInt(size);
-      for (int i = 0; i < size; i++) {
-        write(Array.get(array, i), encoder, componentSchema, seenRefs);
-      }
-    }
-    if (size > 0) {
-      encoder.writeInt(0);
-    }
-  }
-
-  private void writeMap(Object map, Encoder encoder, Map.Entry<Schema,
-                                                                Schema> mapSchema,
-                        Set<Object> seenRefs) throws IOException {
-    Map<?, ?> objMap = (Map<?, ?>) map;
-    int size = objMap.size();
+  @Override
+  protected void writeArray(Encoder encoder, Collection col, Schema componentSchema) throws IOException {
+    int size = col.size();
     encoder.writeInt(size);
-    for (Map.Entry<?, ?> entry : objMap.entrySet()) {
-      write(entry.getKey(), encoder, mapSchema.getKey(), seenRefs);
-      write(entry.getValue(), encoder, mapSchema.getValue(), seenRefs);
+    for (Object obj : col) {
+      write(encoder, obj, componentSchema);
     }
     if (size > 0) {
       encoder.writeInt(0);
     }
   }
 
-  private void writeRecord(Object record, Encoder encoder,
-                           Schema recordSchema, Set<Object> seenRefs) throws IOException {
-    try {
-      TypeToken<?> type = TypeToken.of(record.getClass());
-
-      Map<String, Method> methods = collectByMethod(type, Maps.<String, Method>newHashMap());
-      Map<String, Field> fields = collectByFields(type, Maps.<String, Field>newHashMap());
-
-      for (Schema.Field field : recordSchema.getFields()) {
-        String fieldName = field.getName();
-        Object value;
-        Field recordField = fields.get(fieldName);
-        if (recordField != null) {
-          recordField.setAccessible(true);
-          value = recordField.get(record);
-        } else {
-          Method method = methods.get(fieldName);
-          if (method == null) {
-            throw new IOException("Unable to read field value through getter. Class=" + type + ", field=" + fieldName);
-          }
-          value = method.invoke(record);
-        }
-
-        Schema fieldSchema = field.getSchema();
-        write(value, encoder, fieldSchema, seenRefs);
-      }
-    } catch (Exception e) {
-      if (e instanceof IOException) {
-        throw (IOException) e;
-      }
-      throw new IOException(e);
+  @Override
+  protected void writeArray(Encoder encoder, Object array, Schema componentSchema) throws IOException {
+    int size = Array.getLength(array);
+    encoder.writeInt(size);
+    for (int i = 0; i < size; i++) {
+      write(encoder, Array.get(array, i), componentSchema);
+    }
+    if (size > 0) {
+      encoder.writeInt(0);
     }
   }
 
-  private Map<String, Field> collectByFields(TypeToken<?> typeToken, Map<String, Field> fields) {
-    // Collect the field types
-    for (TypeToken<?> classType : typeToken.getTypes().classes()) {
-      Class<?> rawType = classType.getRawType();
-      if (rawType.equals(Object.class)) {
-        // Ignore all object fields
-        continue;
-      }
-
-      for (Field field : rawType.getDeclaredFields()) {
-        if (Modifier.isTransient(field.getModifiers()) || field.isSynthetic()) {
-          continue;
-        }
-        fields.put(field.getName(), field);
-      }
+  @Override
+  protected void writeMap(Encoder encoder, Map<?, ?> map, Map.Entry<Schema, Schema> mapSchema) throws IOException {
+    int size = map.size();
+    encoder.writeInt(size);
+    Schema keySchema = mapSchema.getKey();
+    Schema valSchema = mapSchema.getValue();
+    for (Map.Entry<?, ?> entry : map.entrySet()) {
+      write(encoder, entry.getKey(), keySchema);
+      write(encoder, entry.getValue(), valSchema);
     }
-    return fields;
+    if (size > 0) {
+      encoder.writeInt(0);
+    }
   }
 
-  private Map<String, Method> collectByMethod(TypeToken<?> typeToken, Map<String, Method> methods) {
-    for (Method method : typeToken.getRawType().getMethods()) {
-      if (method.getDeclaringClass().equals(Object.class)) {
-        // Ignore all object methods
-        continue;
-      }
-      String methodName = method.getName();
-      if (!(methodName.startsWith("get") || methodName.startsWith("is"))
-           || method.isSynthetic() || method.getParameterTypes().length != 0) {
-        // Ignore not getter methods
-        continue;
-      }
-      String fieldName = methodName.startsWith("get") ?
-                           methodName.substring("get".length()) : methodName.substring("is".length());
-      if (fieldName.isEmpty()) {
-        continue;
-      }
-      fieldName = String.format("%c%s", Character.toLowerCase(fieldName.charAt(0)), fieldName.substring(1));
-      if (methods.containsKey(fieldName)) {
-        continue;
-      }
-      methods.put(fieldName, method);
+  @Override
+  protected void writeUnion(Encoder encoder, Object val, Schema schema) throws IOException {
+    // Assumption in schema generation that index 0 is the object type, index 1 is null.
+    if (val == null) {
+      encoder.writeInt(1);
+    } else {
+      seenRefs.remove(val);
+      encoder.writeInt(0);
+      write(encoder, val, schema.getUnionSchema(0));
     }
-    return methods;
   }
 }

--- a/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionPutWriter.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionPutWriter.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.io;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.dataset.table.Put;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.common.io.BinaryEncoder;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Encodes an object as a {@link Put} for storing it into a {@link Table}. Assumes that objects to write are
+ * records. Fields of simple types are encoded as columns in the table. Complex types (arrays, maps, records),
+ * are binary encoded and stored as blobs.
+ *
+ * @param <T> the type of object to encode as a {@link Put}
+ */
+public class ReflectionPutWriter<T> extends ReflectionWriter<Put, T> {
+  private final List<String> fieldNames;
+  private int index;
+
+  public ReflectionPutWriter(Schema schema) {
+    super(schema);
+    Preconditions.checkArgument(schema.getType() == Schema.Type.RECORD, "Schema must be a record.");
+    List<Schema.Field> schemaFields = schema.getFields();
+    int numFields = schemaFields.size();
+    Preconditions.checkArgument(numFields > 0, "Record must contain at least one field.");
+    this.fieldNames = Lists.newArrayListWithCapacity(numFields);
+    for (Schema.Field schemaField : schemaFields) {
+      this.fieldNames.add(schemaField.getName());
+    }
+    this.index = 0;
+  }
+
+  private String nextField() {
+    String name = fieldNames.get(index);
+    index++;
+    return name;
+  }
+
+  @Override
+  public void write(T object, Put put) throws IOException {
+    index = 0;
+    seenRefs = Sets.newIdentityHashSet();
+    super.writeRecord(put, object, schema);
+  }
+
+  @Override
+  protected void writeNull(Put put) throws IOException {
+    nextField();
+  }
+
+  @Override
+  protected void writeBool(Put put, Boolean val) throws IOException {
+    put.add(nextField(), val);
+  }
+
+  @Override
+  protected void writeInt(Put put, int val) throws IOException {
+    put.add(nextField(), val);
+  }
+
+  @Override
+  protected void writeLong(Put put, long val) throws IOException {
+    put.add(nextField(), val);
+  }
+
+  @Override
+  protected void writeFloat(Put put, Float val) throws IOException {
+    put.add(nextField(), val);
+  }
+
+  @Override
+  protected void writeDouble(Put put, Double val) throws IOException {
+    put.add(nextField(), val);
+  }
+
+  @Override
+  protected void writeString(Put put, String val) throws IOException {
+    put.add(nextField(), val);
+  }
+
+  @Override
+  protected void writeBytes(Put put, ByteBuffer val) throws IOException {
+    put.add(nextField(), Bytes.toBytes(val));
+  }
+
+  @Override
+  protected void writeBytes(Put put, byte[] val) throws IOException {
+    put.add(nextField(), val);
+  }
+
+  @Override
+  protected void writeEnum(Put put, String val, Schema schema) throws IOException {
+    int idx = schema.getEnumIndex(val);
+    if (idx < 0) {
+      throw new IOException("Invalid enum value " + val);
+    }
+    put.add(nextField(), idx);
+  }
+
+  @Override
+  protected void writeArray(Put put, Collection val, Schema componentSchema) throws IOException {
+    put.add(nextField(), encodeArray(val, componentSchema));
+  }
+
+  @Override
+  protected void writeArray(Put put, Object val, Schema componentSchema) throws IOException {
+    put.add(nextField(), encodeArray(val, componentSchema));
+  }
+
+  @Override
+  protected void writeMap(Put put, Map<?, ?> val, Map.Entry<Schema, Schema> mapSchema) throws IOException {
+    put.add(nextField(), encodeMap(val, mapSchema.getKey(), mapSchema.getValue()));
+  }
+
+  @Override
+  protected void writeRecord(Put put, Object record, Schema recordSchema) throws IOException {
+    put.add(nextField(), encodeRecord(record, recordSchema));
+  }
+
+  @Override
+  protected void writeUnion(Put put, Object val, Schema schema) throws IOException {
+    // only support unions if its for a nullable.
+    if (!schema.isNullable()) {
+      throw new UnsupportedOperationException("Unions that do not represent nullables are not supported.");
+    }
+
+    if (val != null) {
+      seenRefs.remove(val);
+      write(put, val, schema.getNonNullable());
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private byte[] encodeArray(Object array, Schema componentSchema) throws IOException {
+    ReflectionDatumWriter datumWriter = new ReflectionDatumWriter(Schema.arrayOf(componentSchema));
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    BinaryEncoder encoder = new BinaryEncoder(bos);
+    datumWriter.encode(array, encoder);
+    return bos.toByteArray();
+  }
+
+  @SuppressWarnings("unchecked")
+  private byte[] encodeMap(Map<?, ?> map, Schema keySchema, Schema valSchema) throws IOException {
+    ReflectionDatumWriter datumWriter = new ReflectionDatumWriter(Schema.mapOf(keySchema, valSchema));
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    BinaryEncoder encoder = new BinaryEncoder(bos);
+    datumWriter.encode(map, encoder);
+    return bos.toByteArray();
+  }
+
+  @SuppressWarnings("unchecked")
+  private byte[] encodeRecord(Object record, Schema schema) throws IOException {
+    ReflectionDatumWriter datumWriter = new ReflectionDatumWriter(schema);
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    BinaryEncoder encoder = new BinaryEncoder(bos);
+    datumWriter.encode(record, encoder);
+    return bos.toByteArray();
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionPutWriter.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionPutWriter.java
@@ -124,7 +124,7 @@ public class ReflectionPutWriter<T> extends ReflectionWriter<Put, T> {
   }
 
   @Override
-  protected void writeArray(Put put, Collection val, Schema componentSchema) throws IOException {
+  protected void writeArray(Put put, Collection<?> val, Schema componentSchema) throws IOException {
     put.add(nextField(), encodeArray(val, componentSchema));
   }
 

--- a/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionReader.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionReader.java
@@ -33,10 +33,10 @@ import java.util.UUID;
 /**
  * Reflection based reader.
  *
- * @param <SOURCE> type of object to read from
+ * @param <FROM> type of object to read from
  * @param <TO> type of object to read
  */
-public abstract class ReflectionReader<SOURCE, TO> {
+public abstract class ReflectionReader<FROM, TO> {
 
   private final Map<Class<?>, Instantiator<?>> creators;
   private final InstantiatorFactory creatorFactory;
@@ -60,12 +60,12 @@ public abstract class ReflectionReader<SOURCE, TO> {
    * @return the object of given type and schema
    * @throws IOException if there was some exception reading the object
    */
-  public TO read(SOURCE source, Schema sourceSchema) throws IOException {
+  public TO read(FROM source, Schema sourceSchema) throws IOException {
     return read(source, sourceSchema, schema, type);
   }
 
   @SuppressWarnings("unchecked")
-  protected TO read(SOURCE source, Schema sourceSchema, Schema targetSchema,
+  protected TO read(FROM source, Schema sourceSchema, Schema targetSchema,
                     TypeToken<?> targetTypeToken) throws IOException {
     if (sourceSchema.getType() != Schema.Type.UNION && targetSchema.getType() == Schema.Type.UNION) {
       // Try every target schemas
@@ -81,39 +81,39 @@ public abstract class ReflectionReader<SOURCE, TO> {
     return (TO) doRead(source, sourceSchema, targetSchema, targetTypeToken);
   }
 
-  protected abstract Object readNull(SOURCE source) throws IOException;
+  protected abstract Object readNull(FROM source) throws IOException;
 
-  protected abstract boolean readBool(SOURCE source) throws IOException;
+  protected abstract boolean readBool(FROM source) throws IOException;
 
-  protected abstract int readInt(SOURCE source) throws IOException;
+  protected abstract int readInt(FROM source) throws IOException;
 
-  protected abstract long readLong(SOURCE source) throws IOException;
+  protected abstract long readLong(FROM source) throws IOException;
 
-  protected abstract float readFloat(SOURCE source) throws IOException;
+  protected abstract float readFloat(FROM source) throws IOException;
 
-  protected abstract double readDouble(SOURCE source) throws IOException;
+  protected abstract double readDouble(FROM source) throws IOException;
 
-  protected abstract String readString(SOURCE source) throws IOException;
+  protected abstract String readString(FROM source) throws IOException;
 
-  protected abstract ByteBuffer readBytes(SOURCE source) throws IOException;
+  protected abstract ByteBuffer readBytes(FROM source) throws IOException;
 
-  protected abstract Object readEnum(SOURCE source, Schema sourceSchema, Schema targetSchema,
+  protected abstract Object readEnum(FROM source, Schema sourceSchema, Schema targetSchema,
                                      TypeToken<?> targetTypeToken) throws IOException;
 
-  protected abstract Object readArray(SOURCE source, Schema sourceSchema, Schema targetSchema,
+  protected abstract Object readArray(FROM source, Schema sourceSchema, Schema targetSchema,
                                       TypeToken<?> targetTypeToken) throws IOException;
 
-  protected abstract Object readMap(SOURCE source, Schema sourceSchema, Schema targetSchema,
+  protected abstract Object readMap(FROM source, Schema sourceSchema, Schema targetSchema,
                                     TypeToken<?> targetTypeToken) throws IOException;
 
-  protected abstract Object readUnion(SOURCE source, Schema sourceSchema, Schema targetSchema,
+  protected abstract Object readUnion(FROM source, Schema sourceSchema, Schema targetSchema,
                                       TypeToken<?> targetTypeToken) throws IOException;
 
-  protected abstract Object readRecord(SOURCE source, Schema sourceSchema, Schema targetSchema,
+  protected abstract Object readRecord(FROM source, Schema sourceSchema, Schema targetSchema,
                                        TypeToken<?> targetTypeToken) throws IOException;
 
 
-  protected Object doRead(SOURCE source, Schema sourceSchema, Schema targetSchema,
+  protected Object doRead(FROM source, Schema sourceSchema, Schema targetSchema,
                           TypeToken<?> targetTypeToken) throws IOException {
 
     Schema.Type sourceType = sourceSchema.getType();
@@ -167,7 +167,7 @@ public abstract class ReflectionReader<SOURCE, TO> {
     throw new IOException(String.format("Fails to resolve %s to %s", sourceSchema, targetSchema));
   }
 
-  private Object resolveType(SOURCE source, Schema.Type sourceType, Schema.Type targetType,
+  private Object resolveType(FROM source, Schema.Type sourceType, Schema.Type targetType,
                              TypeToken<?> targetTypeToken) throws IOException {
     switch(sourceType) {
       case BOOLEAN:

--- a/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionReader.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionReader.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.io;
+
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.common.lang.Instantiator;
+import co.cask.cdap.common.lang.InstantiatorFactory;
+import com.google.common.collect.Maps;
+import com.google.common.primitives.Longs;
+import com.google.common.reflect.TypeToken;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Reflection based reader.
+ *
+ * @param <SOURCE> type of object to read from
+ * @param <TO> type of object to read
+ */
+public abstract class ReflectionReader<SOURCE, TO> {
+
+  private final Map<Class<?>, Instantiator<?>> creators;
+  private final InstantiatorFactory creatorFactory;
+  private final FieldAccessorFactory fieldAccessorFactory;
+  protected final Schema schema;
+  protected final TypeToken<TO> type;
+
+  protected ReflectionReader(Schema schema, TypeToken<TO> type) {
+    this.creatorFactory = new InstantiatorFactory(true);
+    this.creators = Maps.newIdentityHashMap();
+    this.fieldAccessorFactory = new ReflectionFieldAccessorFactory();
+    this.schema = schema;
+    this.type = type;
+  }
+
+  /**
+   * Read from the source to create the target type with target schema.
+   *
+   * @param source the source from which to read the object
+   * @param sourceSchema the write schema of the object
+   * @return the object of given type and schema
+   * @throws IOException if there was some exception reading the object
+   */
+  public TO read(SOURCE source, Schema sourceSchema) throws IOException {
+    return read(source, sourceSchema, schema, type);
+  }
+
+  @SuppressWarnings("unchecked")
+  protected TO read(SOURCE source, Schema sourceSchema, Schema targetSchema,
+                    TypeToken<?> targetTypeToken) throws IOException {
+    if (sourceSchema.getType() != Schema.Type.UNION && targetSchema.getType() == Schema.Type.UNION) {
+      // Try every target schemas
+      for (Schema schema : targetSchema.getUnionSchemas()) {
+        try {
+          return (TO) doRead(source, sourceSchema, schema, targetTypeToken);
+        } catch (IOException e) {
+          // Continue;
+        }
+      }
+      throw new IOException(String.format("No matching schema to resolve %s to %s", sourceSchema, targetSchema));
+    }
+    return (TO) doRead(source, sourceSchema, targetSchema, targetTypeToken);
+  }
+
+  protected abstract Object readNull(SOURCE source) throws IOException;
+
+  protected abstract boolean readBool(SOURCE source) throws IOException;
+
+  protected abstract int readInt(SOURCE source) throws IOException;
+
+  protected abstract long readLong(SOURCE source) throws IOException;
+
+  protected abstract float readFloat(SOURCE source) throws IOException;
+
+  protected abstract double readDouble(SOURCE source) throws IOException;
+
+  protected abstract String readString(SOURCE source) throws IOException;
+
+  protected abstract ByteBuffer readBytes(SOURCE source) throws IOException;
+
+  protected abstract Object readEnum(SOURCE source, Schema sourceSchema, Schema targetSchema,
+                                     TypeToken<?> targetTypeToken) throws IOException;
+
+  protected abstract Object readArray(SOURCE source, Schema sourceSchema, Schema targetSchema,
+                                      TypeToken<?> targetTypeToken) throws IOException;
+
+  protected abstract Object readMap(SOURCE source, Schema sourceSchema, Schema targetSchema,
+                                    TypeToken<?> targetTypeToken) throws IOException;
+
+  protected abstract Object readUnion(SOURCE source, Schema sourceSchema, Schema targetSchema,
+                                      TypeToken<?> targetTypeToken) throws IOException;
+
+  protected abstract Object readRecord(SOURCE source, Schema sourceSchema, Schema targetSchema,
+                                       TypeToken<?> targetTypeToken) throws IOException;
+
+
+  protected Object doRead(SOURCE source, Schema sourceSchema, Schema targetSchema,
+                          TypeToken<?> targetTypeToken) throws IOException {
+
+    Schema.Type sourceType = sourceSchema.getType();
+    Schema.Type targetType = targetSchema.getType();
+
+    switch(sourceType) {
+      case NULL:
+        check(sourceType == targetType, "Fails to resolve %s to %s", sourceType, targetType);
+        return readNull(source);
+      case BYTES:
+        check(sourceType == targetType, "Fails to resolve %s to %s", sourceType, targetType);
+        ByteBuffer buffer = readBytes(source);
+
+        if (targetTypeToken.getRawType().equals(byte[].class)) {
+          if (buffer.hasArray()) {
+            byte[] array = buffer.array();
+            if (buffer.remaining() == array.length) {
+              return array;
+            }
+            byte[] bytes = new byte[buffer.remaining()];
+            System.arraycopy(array, buffer.arrayOffset() + buffer.position(), bytes, 0, buffer.remaining());
+            return bytes;
+          } else {
+            byte[] bytes = new byte[buffer.remaining()];
+            buffer.get(bytes);
+            return bytes;
+          }
+        } else if (targetTypeToken.getRawType().equals(UUID.class) && buffer.remaining() == Longs.BYTES * 2) {
+          return new UUID(buffer.getLong(), buffer.getLong());
+        }
+        return buffer;
+      case ENUM:
+        check(sourceType == targetType, "Fails to resolve %s to %s", sourceType, targetType);
+        return readEnum(source, sourceSchema, targetSchema, targetTypeToken);
+      case ARRAY:
+        check(sourceType == targetType, "Fails to resolve %s to %s", sourceType, targetType);
+        return readArray(source, sourceSchema, targetSchema, targetTypeToken);
+      case MAP:
+        check(sourceType == targetType, "Fails to resolve %s to %s", sourceType, targetType);
+        return readMap(source, sourceSchema, targetSchema, targetTypeToken);
+      case RECORD:
+        check(sourceType == targetType, "Fails to resolve %s to %s", sourceType, targetType);
+        return readRecord(source, sourceSchema, targetSchema, targetTypeToken);
+      case UNION:
+        return readUnion(source, sourceSchema, targetSchema, targetTypeToken);
+    }
+    // For simple type other than NULL and BYTES
+    if (sourceType.isSimpleType()) {
+      return resolveType(source, sourceType, targetType, targetTypeToken);
+    }
+    throw new IOException(String.format("Fails to resolve %s to %s", sourceSchema, targetSchema));
+  }
+
+  private Object resolveType(SOURCE source, Schema.Type sourceType, Schema.Type targetType,
+                             TypeToken<?> targetTypeToken) throws IOException {
+    switch(sourceType) {
+      case BOOLEAN:
+        switch(targetType) {
+          case BOOLEAN:
+            return readBool(source);
+          case STRING:
+            return String.valueOf(readBool(source));
+        }
+        break;
+      case INT:
+        switch(targetType) {
+          case INT:
+            Class<?> targetClass = targetTypeToken.getRawType();
+            int value = readInt(source);
+            if (targetClass.equals(byte.class) || targetClass.equals(Byte.class)) {
+              return (byte) value;
+            }
+            if (targetClass.equals(char.class) || targetClass.equals(Character.class)) {
+              return (char) value;
+            }
+            if (targetClass.equals(short.class) || targetClass.equals(Short.class)) {
+              return (short) value;
+            }
+            return value;
+          case LONG:
+            return (long) readInt(source);
+          case FLOAT:
+            return (float) readInt(source);
+          case DOUBLE:
+            return (double) readInt(source);
+          case STRING:
+            return String.valueOf(readInt(source));
+        }
+        break;
+      case LONG:
+        switch(targetType) {
+          case LONG:
+            return readLong(source);
+          case FLOAT:
+            return (float) readLong(source);
+          case DOUBLE:
+            return (double) readLong(source);
+          case STRING:
+            return String.valueOf(readLong(source));
+        }
+        break;
+      case FLOAT:
+        switch(targetType) {
+          case FLOAT:
+            return readFloat(source);
+          case DOUBLE:
+            return (double) readFloat(source);
+          case STRING:
+            return String.valueOf(readFloat(source));
+        }
+        break;
+      case DOUBLE:
+        switch(targetType) {
+          case DOUBLE:
+            return readDouble(source);
+          case STRING:
+            return String.valueOf(readDouble(source));
+        }
+        break;
+      case STRING:
+        switch(targetType) {
+          case STRING:
+            String str = readString(source);
+            Class<?> targetClass = targetTypeToken.getRawType();
+            if (targetClass.equals(URI.class)) {
+              return URI.create(str);
+            } else if (targetClass.equals(URL.class)) {
+              return new URL(str);
+            }
+            return str;
+        }
+        break;
+    }
+
+    throw new IOException("Fail to resolve type " + sourceType + " to type " + targetType);
+  }
+
+  protected void check(boolean condition, String message, Object... objs) throws IOException {
+    if (!condition) {
+      throw new IOException(String.format(message, objs));
+    }
+  }
+
+  protected IOException propagate(Throwable t) throws IOException {
+    if (t instanceof IOException) {
+      throw (IOException) t;
+    }
+    throw new IOException(t);
+  }
+
+  protected Object create(TypeToken<?> type) {
+    Class<?> rawType = type.getRawType();
+    Instantiator<?> creator = creators.get(rawType);
+    if (creator == null) {
+      creator = creatorFactory.get(type);
+      creators.put(rawType, creator);
+    }
+    return creator.create();
+  }
+
+  protected FieldAccessor getFieldAccessor(TypeToken<?> targetTypeToken, String fieldName) {
+    return fieldAccessorFactory.getFieldAccessor(targetTypeToken, fieldName);
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionRowReader.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionRowReader.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.io;
+
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.dataset.table.Row;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.common.io.BinaryDecoder;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.common.reflect.TypeToken;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+
+/**
+ * Decodes an object from a {@link Row} object fetched from a {@link Table}. Assumes that objects
+ * fetched are records. All fields are columns in the row, with simple types stored as their byte representation,
+ * and complex types as Avro-like binary encoded blobs.
+ *
+ * @param <T> the type of object to read
+ */
+// suppress warnings that come from unboxing of objects that we validate are not null
+@SuppressWarnings("ConstantConditions")
+public class ReflectionRowReader<T> extends ReflectionReader<Row, T> {
+  private static final Schema NULL_SCHEMA = Schema.of(Schema.Type.NULL);
+  private List<String> fieldNames;
+  private int index;
+
+  public ReflectionRowReader(Schema schema, TypeToken<T> type) {
+    super(schema, type);
+    Preconditions.checkArgument(schema.getType() == Schema.Type.RECORD, "Target schema must be a record.");
+  }
+
+  @SuppressWarnings("unchecked")
+  public T read(Row row, Schema sourceSchema) throws IOException {
+    Preconditions.checkArgument(sourceSchema.getType() == Schema.Type.RECORD, "Source schema must be a record.");
+    initializeRead(sourceSchema);
+    try {
+      Object record = create(type);
+      for (Schema.Field sourceField : sourceSchema.getFields()) {
+        String sourceFieldName = sourceField.getName();
+        Schema.Field targetField = schema.getField(sourceFieldName);
+        if (targetField == null) {
+          index++;
+          continue;
+        }
+        FieldAccessor fieldAccessor = getFieldAccessor(type, sourceFieldName);
+        fieldAccessor.set(record, read(row, sourceField.getSchema(),
+                                       targetField.getSchema(), fieldAccessor.getType()));
+      }
+      return (T) record;
+    } catch (Exception e) {
+      throw propagate(e);
+    }
+  }
+
+  @Override
+  protected Object readNull(Row row) throws IOException {
+    index++;
+    return null;
+  }
+
+  @Override
+  protected boolean readBool(Row row) throws IOException {
+    String name = fieldNames.get(index);
+    Boolean val = row.getBoolean(name);
+    validateNotNull(val, name);
+    index++;
+    return val;
+  }
+
+  @Override
+  protected int readInt(Row row) throws IOException {
+    String name = fieldNames.get(index);
+    Integer val = row.getInt(name);
+    validateNotNull(val, name);
+    index++;
+    return val;
+  }
+
+  @Override
+  protected long readLong(Row row) throws IOException {
+    String name = fieldNames.get(index);
+    Long val = row.getLong(name);
+    validateNotNull(val, name);
+    index++;
+    return val;
+  }
+
+  @Override
+  protected float readFloat(Row row) throws IOException {
+    String name = fieldNames.get(index);
+    Float val = row.getFloat(name);
+    validateNotNull(val, name);
+    index++;
+    return val;
+  }
+
+  @Override
+  protected double readDouble(Row row) throws IOException {
+    String name = fieldNames.get(index);
+    Double val = row.getDouble(name);
+    validateNotNull(val, name);
+    index++;
+    return val;
+  }
+
+  @Override
+  protected String readString(Row row) throws IOException {
+    String name = fieldNames.get(index);
+    String val = row.getString(name);
+    validateNotNull(val, name);
+    index++;
+    return val;
+  }
+
+  @Override
+  protected ByteBuffer readBytes(Row row) throws IOException {
+    String name = fieldNames.get(index);
+    byte[] val = row.get(name);
+    validateNotNull(val, name);
+    index++;
+    return ByteBuffer.wrap(val);
+  }
+
+  @Override
+  protected Object readEnum(Row row, Schema sourceSchema, Schema targetSchema,
+                            TypeToken<?> targetTypeToken) throws IOException {
+    String name = fieldNames.get(index);
+    Integer val = row.getInt(name);
+    validateNotNull(val, name);
+    String enumValue = sourceSchema.getEnumValue(val);
+    check(targetSchema.getEnumValues().contains(enumValue), "Enum value '%s' missing in target.", enumValue);
+    try {
+      Object obj = targetTypeToken.getRawType().getMethod("valueOf", String.class).invoke(null, enumValue);
+      index++;
+      return obj;
+    } catch (Exception e) {
+      throw new IOException(e);
+    }
+  }
+
+  @Override
+  protected Object readUnion(Row row, Schema sourceSchema, Schema targetSchema,
+                             TypeToken<?> targetTypeToken) throws IOException {
+    // assumption is that unions are only possible if they represent a nullable.
+    if (!sourceSchema.isNullable()) {
+      throw new UnsupportedOperationException("Unions that do not represent nullables are not supported.");
+    }
+
+    String name = fieldNames.get(index);
+    Schema sourceValueSchema = row.get(name) == null ? NULL_SCHEMA : sourceSchema.getNonNullable();
+    if (targetSchema.getType() == Schema.Type.UNION) {
+      for (Schema targetValueSchema : targetSchema.getUnionSchemas()) {
+        try {
+          return read(row, sourceValueSchema, targetValueSchema, targetTypeToken);
+        } catch (IOException e) {
+          // It's ok to have exception here, as we'll keep trying until exhausted the target union.
+        }
+      }
+      throw new IOException(String.format("Fail to resolve %s to %s", sourceSchema, targetSchema));
+    } else {
+      return read(row, sourceValueSchema, targetSchema, targetTypeToken);
+    }
+  }
+
+  @Override
+  protected Object readArray(Row row, Schema sourceSchema, Schema targetSchema,
+                             TypeToken<?> targetTypeToken) throws IOException {
+    return readAndDecode(row, sourceSchema, targetSchema, targetTypeToken);
+  }
+
+  @Override
+  protected Object readMap(Row row, Schema sourceSchema, Schema targetSchema,
+                           TypeToken<?> targetTypeToken) throws IOException {
+    return readAndDecode(row, sourceSchema, targetSchema, targetTypeToken);
+  }
+
+  @Override
+  protected Object readRecord(Row row, Schema sourceSchema, Schema targetSchema,
+                              TypeToken<?> targetTypeToken) throws IOException {
+    return readAndDecode(row, sourceSchema, targetSchema, targetTypeToken);
+  }
+
+  private Object readAndDecode(Row row, Schema sourceSchema, Schema targetSchema,
+                               TypeToken<?> targetTypeToken) throws IOException {
+    String name = fieldNames.get(index);
+    byte[] val = row.get(name);
+    validateNotNull(val, name);
+    Object obj = decode(val, sourceSchema, targetSchema, targetTypeToken);
+    index++;
+    return obj;
+  }
+
+  private <O> O decode(byte[] bytes, Schema sourceSchema, Schema targetSchema,
+                       TypeToken<O> targetTypeToken) throws IOException {
+    ByteArrayInputStream bis = new ByteArrayInputStream(bytes);
+    BinaryDecoder decoder = new BinaryDecoder(bis);
+    ReflectionDatumReader<O> datumReader = new ReflectionDatumReader<O>(targetSchema, targetTypeToken);
+    return datumReader.read(decoder, sourceSchema);
+  }
+
+  // check that the value is not null and throw an exception if it is.
+  // Nullable types depend on this behavior to work correctly, as they cycle through
+  // possible types and catch IOExceptions if the type doesn't work out.
+  private void validateNotNull(Object val, String column) throws IOException {
+    if (val == null) {
+      throw new IOException("No value for " + column + " exists.");
+    }
+  }
+
+  private void initializeRead(Schema sourceSchema) {
+    List<Schema.Field> schemaFields = sourceSchema.getFields();
+    int numFields = schemaFields.size();
+    Preconditions.checkArgument(numFields > 0, "Record must contain at least one field.");
+    this.fieldNames = Lists.newArrayListWithCapacity(numFields);
+    for (Schema.Field schemaField : schemaFields) {
+      this.fieldNames.add(schemaField.getName());
+    }
+    this.index = 0;
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionWriter.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionWriter.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.io;
+
+import co.cask.cdap.api.data.schema.Schema;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.google.common.primitives.Longs;
+import com.google.common.reflect.TypeToken;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.nio.ByteBuffer;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Base class for writing an object with a {@link Schema}. Examines the schema to cast the object accordingly,
+ * and uses reflection to determine field values if the object is a record. Recursive types are not allowed.
+ *
+ * @param <WRITER> the type of writer used to encode objects
+ * @param <TYPE> the type of object to write
+ */
+public abstract class ReflectionWriter<WRITER, TYPE> {
+
+  protected final Schema schema;
+  protected Set<Object> seenRefs;
+
+  protected ReflectionWriter(Schema schema) {
+    this.schema = schema;
+  }
+
+  public void write(TYPE object, WRITER writer) throws IOException {
+    seenRefs = Sets.newIdentityHashSet();
+    write(writer, object, schema);
+  }
+
+  protected abstract void writeNull(WRITER writer) throws IOException;
+
+  protected abstract void writeBool(WRITER writer, Boolean val) throws IOException;
+
+  protected abstract void writeInt(WRITER writer, int val) throws IOException;
+
+  protected abstract void writeLong(WRITER writer, long val) throws IOException;
+
+  protected abstract void writeFloat(WRITER writer, Float val) throws IOException;
+
+  protected abstract void writeDouble(WRITER writer, Double val) throws IOException;
+
+  protected abstract void writeString(WRITER writer, String val) throws IOException;
+
+  protected abstract void writeBytes(WRITER writer, ByteBuffer val) throws IOException;
+
+  protected abstract void writeBytes(WRITER writer, byte[] val) throws IOException;
+
+  protected abstract void writeEnum(WRITER writer, String val, Schema schema) throws IOException;
+
+  protected abstract void writeArray(WRITER writer, Collection val, Schema componentSchema) throws IOException;
+
+  protected abstract void writeArray(WRITER writer, Object val, Schema componentSchema) throws IOException;
+
+  protected abstract void writeMap(WRITER writer, Map<?, ?> val,
+                                   Map.Entry<Schema, Schema> mapSchema) throws IOException;
+
+  protected abstract void writeUnion(WRITER writer, Object val, Schema unionSchema) throws IOException;
+
+  /**
+   * Write the given object that has the given schema.
+   *
+   * @param object the object to write
+   * @param objSchema the schema of the object to write
+   * @throws IOException if there was an exception writing the object
+   */
+  @SuppressWarnings("ConstantConditions")
+  protected void write(WRITER writer, Object object, Schema objSchema) throws IOException {
+    if (object != null) {
+      if (seenRefs.contains(object)) {
+        throw new IOException("Recursive reference not supported.");
+      }
+      if (objSchema.getType() == Schema.Type.RECORD) {
+        seenRefs.add(object);
+      }
+    }
+
+    switch(objSchema.getType()) {
+      case NULL:
+        writeNull(writer);
+        break;
+      case BOOLEAN:
+        writeBool(writer, (Boolean) object);
+        break;
+      case INT:
+        writeInt(writer, ((Number) object).intValue());
+        break;
+      case LONG:
+        writeLong(writer, ((Number) object).longValue());
+        break;
+      case FLOAT:
+        writeFloat(writer, (Float) object);
+        break;
+      case DOUBLE:
+        writeDouble(writer, (Double) object);
+        break;
+      case STRING:
+        writeString(writer, object.toString());
+        break;
+      case BYTES:
+        if (object instanceof ByteBuffer) {
+          writeBytes(writer, (ByteBuffer) object);
+        } else if (object instanceof UUID) {
+          UUID uuid = (UUID)  object;
+          ByteBuffer buf = ByteBuffer.allocate(Longs.BYTES * 2);
+          buf.putLong(uuid.getMostSignificantBits()).putLong(uuid.getLeastSignificantBits());
+          writeBytes(writer, (ByteBuffer) buf.flip());
+        } else {
+          writeBytes(writer, (byte[]) object);
+        }
+        break;
+      case ENUM:
+        writeEnum(writer, object.toString(), objSchema);
+        break;
+      case ARRAY:
+        if (object instanceof Collection) {
+          writeArray(writer, (Collection) object, objSchema.getComponentSchema());
+        } else {
+          writeArray(writer, object, objSchema.getComponentSchema());
+        }
+        break;
+      case MAP:
+        writeMap(writer, (Map<?, ?>) object, objSchema.getMapSchema());
+        break;
+      case RECORD:
+        writeRecord(writer, object, objSchema);
+        break;
+      case UNION:
+        writeUnion(writer, object, objSchema);
+        break;
+    }
+  }
+
+  protected void writeRecord(WRITER writer, Object record, Schema recordSchema) throws IOException {
+    try {
+      TypeToken<?> type = TypeToken.of(record.getClass());
+
+      Map<String, Method> methods = collectByMethod(type, Maps.<String, Method>newHashMap());
+      Map<String, Field> fields = collectByFields(type, Maps.<String, Field>newHashMap());
+
+      for (Schema.Field field : recordSchema.getFields()) {
+        String fieldName = field.getName();
+        Object value;
+        Field recordField = fields.get(fieldName);
+        if (recordField != null) {
+          recordField.setAccessible(true);
+          value = recordField.get(record);
+        } else {
+          Method method = methods.get(fieldName);
+          if (method == null) {
+            throw new IOException("Unable to read field value through getter. Class=" + type + ", field=" + fieldName);
+          }
+          value = method.invoke(record);
+        }
+
+        Schema fieldSchema = field.getSchema();
+        write(writer, value, fieldSchema);
+      }
+    } catch (Exception e) {
+      if (e instanceof IOException) {
+        throw (IOException) e;
+      }
+      throw new IOException(e);
+    }
+  }
+
+  private Map<String, Field> collectByFields(TypeToken<?> typeToken, Map<String, Field> fields) {
+    // Collect the field types
+    for (TypeToken<?> classType : typeToken.getTypes().classes()) {
+      Class<?> rawType = classType.getRawType();
+      if (rawType.equals(Object.class)) {
+        // Ignore all object fields
+        continue;
+      }
+
+      for (Field field : rawType.getDeclaredFields()) {
+        if (Modifier.isTransient(field.getModifiers()) || field.isSynthetic()) {
+          continue;
+        }
+        fields.put(field.getName(), field);
+      }
+    }
+    return fields;
+  }
+
+  private Map<String, Method> collectByMethod(TypeToken<?> typeToken, Map<String, Method> methods) {
+    for (Method method : typeToken.getRawType().getMethods()) {
+      if (method.getDeclaringClass().equals(Object.class)) {
+        // Ignore all object methods
+        continue;
+      }
+      String methodName = method.getName();
+      if (!(methodName.startsWith("get") || methodName.startsWith("is"))
+           || method.isSynthetic() || method.getParameterTypes().length != 0) {
+        // Ignore not getter methods
+        continue;
+      }
+      String fieldName = methodName.startsWith("get") ?
+                           methodName.substring("get".length()) : methodName.substring("is".length());
+      if (fieldName.isEmpty()) {
+        continue;
+      }
+      fieldName = String.format("%c%s", Character.toLowerCase(fieldName.charAt(0)), fieldName.substring(1));
+      if (methods.containsKey(fieldName)) {
+        continue;
+      }
+      methods.put(fieldName, method);
+    }
+    return methods;
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionWriter.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionWriter.java
@@ -73,7 +73,7 @@ public abstract class ReflectionWriter<WRITER, TYPE> {
 
   protected abstract void writeEnum(WRITER writer, String val, Schema schema) throws IOException;
 
-  protected abstract void writeArray(WRITER writer, Collection val, Schema componentSchema) throws IOException;
+  protected abstract void writeArray(WRITER writer, Collection<?> val, Schema componentSchema) throws IOException;
 
   protected abstract void writeArray(WRITER writer, Object val, Schema componentSchema) throws IOException;
 
@@ -139,7 +139,7 @@ public abstract class ReflectionWriter<WRITER, TYPE> {
         break;
       case ARRAY:
         if (object instanceof Collection) {
-          writeArray(writer, (Collection) object, objSchema.getComponentSchema());
+          writeArray(writer, (Collection<?>) object, objSchema.getComponentSchema());
         } else {
           writeArray(writer, object, objSchema.getComponentSchema());
         }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/ReflectionTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/ReflectionTableTest.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.api.dataset.lib;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.table.Put;
+import co.cask.cdap.api.dataset.table.Row;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.data2.dataset2.AbstractDatasetTest;
+import co.cask.cdap.internal.io.ReflectionPutWriter;
+import co.cask.cdap.internal.io.ReflectionRowReader;
+import co.cask.cdap.internal.io.ReflectionSchemaGenerator;
+import co.cask.tephra.TransactionAware;
+import co.cask.tephra.TransactionExecutor;
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.reflect.TypeToken;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ *
+ */
+public class ReflectionTableTest extends AbstractDatasetTest {
+  private static final User SAMUEL = new User(
+    "Samuel L.", "Jackson",
+    Gender.MALE,
+    123,
+    1234567890000L,
+    new Date(2015, 2, 10),
+    50000000.02f,
+    Double.MAX_VALUE,
+    new int[] { 2, 8, 1, 3, 3, 0, 8, 0, 0, 4 },
+    Lists.newArrayList("Shaft", "Mace", "Pulp Fiction guy"),
+    ImmutableMap.of("occupation", "goat", "rank", "1"),
+    new byte[] { 0, 1, 2 });
+
+  public static enum Gender {
+    MALE,
+    FEMALE
+  }
+
+  public static class Date {
+    private int year;
+    private int month;
+    private int day;
+
+    public Date(int year, int month, int day) {
+      this.year = year;
+      this.month = month;
+      this.day = day;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof Date)) {
+        return false;
+      }
+
+      Date that = (Date) o;
+
+      return year == that.year && month == that.month && day == that.day;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(year, month, day);
+    }
+  }
+
+  public static class User {
+    private String firstName;
+    private String lastName;
+    private Gender gender;
+    private Integer id;
+    private Long timestamp;
+    private Date signupDate;
+    private Float salary;
+    private Double lastPurchase;
+    private int[] digits;
+    private List<String> aliases;
+    private Map<String, String> attributes;
+    private byte[] blob;
+
+    public User(String firstName, String lastName, Gender gender, Integer id, Long timestamp,
+                Date signupDate, Float salary, Double lastPurchase, int[] digits,
+                List<String> aliases, Map<String, String> attributes, byte[] blob) {
+      this.firstName = firstName;
+      this.lastName = lastName;
+      this.gender = gender;
+      this.id = id;
+      this.timestamp = timestamp;
+      this.signupDate = signupDate;
+      this.salary = salary;
+      this.lastPurchase = lastPurchase;
+      this.digits = digits;
+      this.aliases = aliases;
+      this.attributes = attributes;
+      this.blob = blob;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof User)) {
+        return false;
+      }
+
+      User that = (User) o;
+
+      return Objects.equal(firstName, that.firstName) &&
+        Objects.equal(lastName, that.lastName) &&
+        Objects.equal(gender, that.gender) &&
+        Objects.equal(id, that.id) &&
+        Objects.equal(timestamp, that.timestamp) &&
+        Objects.equal(signupDate, that.signupDate) &&
+        Objects.equal(salary, that.salary) &&
+        Objects.equal(lastPurchase, that.lastPurchase) &&
+        Arrays.equals(digits, that.digits) &&
+        Objects.equal(aliases, that.aliases) &&
+        Objects.equal(attributes, that.attributes) &&
+        Arrays.equals(blob, that.blob);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(firstName, lastName, gender, id, timestamp, signupDate, salary,
+                              lastPurchase, digits, aliases, attributes, blob);
+    }
+  }
+
+  public static class User2 {
+    private String firstName;
+    private Long id;
+    private Double salary;
+    private Double lastPurchase;
+    private ByteBuffer blob;
+    private Double newField;
+
+    private User2(String firstName, Long id, Double salary, Double lastPurchase, ByteBuffer blob) {
+      this.firstName = firstName;
+      this.id = id;
+      this.salary = salary;
+      this.lastPurchase = lastPurchase;
+      this.blob = blob;
+      this.newField = null;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof User2)) {
+        return false;
+      }
+
+      User2 that = (User2) o;
+
+      return Objects.equal(firstName, that.firstName) &&
+        Objects.equal(id, that.id) &&
+        Objects.equal(salary, that.salary) &&
+        Objects.equal(lastPurchase, that.lastPurchase) &&
+        Objects.equal(blob, that.blob) &&
+        Objects.equal(newField, that.newField);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(firstName, id, salary, lastPurchase, blob, newField);
+    }
+  }
+
+  @Test
+  public void testPutAndGet() throws Exception {
+    createInstance("table", "users", DatasetProperties.builder().build());
+    try {
+      final Table usersTable = getInstance("users");
+      final byte[] rowKey = Bytes.toBytes(123);
+      final Schema schema = new ReflectionSchemaGenerator().generate(User.class);
+      assertGetAndPut(usersTable, rowKey, SAMUEL, schema);
+    } finally {
+      deleteInstance("users");
+    }
+  }
+
+  @Test
+  public void testNullFields() throws Exception {
+    createInstance("table", "users", DatasetProperties.builder().build());
+    try {
+      final Table usersTable = getInstance("users");
+      final byte[] rowKey = Bytes.toBytes(123);
+      final Schema schema = new ReflectionSchemaGenerator().generate(User.class);
+      assertGetAndPut(usersTable, rowKey, SAMUEL, schema);
+    } finally {
+      deleteInstance("users");
+    }
+  }
+
+  @Test
+  public void testTypeProjection() throws Exception {
+    createInstance("table", "users", DatasetProperties.builder().build());
+    try {
+      final Table usersTable = getInstance("users");
+      final byte[] rowKey = Bytes.toBytes(123);
+      final User2 projected = new User2("Samuel L.", 123L, ((Float) 50000000.02f).doubleValue(), Double.MAX_VALUE,
+                                        ByteBuffer.wrap(new byte[]{0, 1, 2}));
+      final Schema fullSchema = new ReflectionSchemaGenerator().generate(User.class);
+      final Schema projSchema = new ReflectionSchemaGenerator().generate(User2.class);
+
+      // TableDataset is not accessible here, but we know that's the underlying implementation...
+      TransactionExecutor tx = newTransactionExecutor((TransactionAware) usersTable);
+      tx.execute(new TransactionExecutor.Subroutine() {
+        @Override
+        public void apply() throws Exception {
+          Put put = new Put(rowKey);
+          ReflectionPutWriter<User> putWriter = new ReflectionPutWriter<User>(fullSchema);
+          putWriter.write(SAMUEL, put);
+          usersTable.put(put);
+          Row row = usersTable.get(rowKey);
+          ReflectionRowReader<User2> rowReader = new ReflectionRowReader<User2>(projSchema, TypeToken.of(User2.class));
+          User2 actual = rowReader.read(row, fullSchema);
+          Assert.assertEquals(projected, actual);
+        }
+      });
+    } finally {
+      deleteInstance("users");
+    }
+  }
+
+  private void assertGetAndPut(final Table table, final byte[] rowKey, final User obj,
+                               final Schema schema) throws Exception {
+    // TableDataset is not accessible here, but we know that's the underlying implementation...
+    TransactionExecutor tx = newTransactionExecutor((TransactionAware) table);
+    tx.execute(new TransactionExecutor.Subroutine() {
+      @Override
+      public void apply() throws Exception {
+        Put put = new Put(rowKey);
+        ReflectionPutWriter<User> putWriter = new ReflectionPutWriter<User>(schema);
+        putWriter.write(obj, put);
+        table.put(put);
+        Row row = table.get(rowKey);
+        ReflectionRowReader<User> rowReader = new ReflectionRowReader<User>(schema, TypeToken.of(User.class));
+        User actual = rowReader.read(row, schema);
+        Assert.assertEquals(obj, actual);
+      }
+    });
+  }
+}


### PR DESCRIPTION
can be re-used for formats other than our avro-like binary
encoding. Also adding classes that encode objects as Put objects
to be written to a Table, and decode objects from Row objects
fetched from a Table.