### PR TITLE
[CDAP-1462] Stream adapter test sometimes fails

### DIFF
--- a/cdap-examples/StreamConversion/src/test/java/co/cask/cdap/examples/streamconversion/StreamConversionTest.java
+++ b/cdap-examples/StreamConversion/src/test/java/co/cask/cdap/examples/streamconversion/StreamConversionTest.java
@@ -77,7 +77,7 @@ public class StreamConversionTest extends TestBase {
 
     // extract fields from partition time
     Calendar calendar = Calendar.getInstance();
-    calendar.setTimeInMillis(startTime);
+    calendar.setTimeInMillis(partitionTime);
     int year = calendar.get(Calendar.YEAR);
     int month = calendar.get(Calendar.MONTH) + 1;
     int day = calendar.get(Calendar.DAY_OF_MONTH);


### PR DESCRIPTION
use partition time instead of start time to validate