### PR TITLE
Namespaced datasets plumbing part 1 - Added Id.DatasetModule to identify...

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/DatasetServiceStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/DatasetServiceStore.java
@@ -30,6 +30,7 @@ import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.InMemoryDatasetFramework;
 import co.cask.cdap.data2.dataset2.NamespacedDatasetFramework;
 import co.cask.cdap.data2.dataset2.lib.kv.NoTxKeyValueTable;
+import co.cask.cdap.proto.Id;
 import co.cask.tephra.TransactionFailureException;
 import com.google.common.util.concurrent.AbstractIdleService;
 import com.google.inject.Inject;
@@ -47,7 +48,7 @@ public final class DatasetServiceStore extends AbstractIdleService implements Se
                              @Named("serviceModule") DatasetModule datasetModule) throws Exception {
     this.dsFramework = new NamespacedDatasetFramework(new InMemoryDatasetFramework(dsRegistryFactory),
                                                       new DefaultDatasetNamespace(cConf, Namespace.SYSTEM));
-    this.dsFramework.addModule("basicKVTable", datasetModule);
+    this.dsFramework.addModule(Id.DatasetModule.from(Constants.SYSTEM_NAMESPACE, "basicKVTable"), datasetModule);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/DeployDatasetModulesStage.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/DeployDatasetModulesStage.java
@@ -23,6 +23,7 @@ import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.ModuleConflictException;
 import co.cask.cdap.data2.dataset2.SingleTypeModule;
 import co.cask.cdap.pipeline.AbstractStage;
+import co.cask.cdap.proto.Id;
 import com.google.common.reflect.TypeToken;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -63,12 +64,13 @@ public class DeployDatasetModulesStage extends AbstractStage<ApplicationDeployab
         // note: we can deploy module or create module from Dataset class
         // note: it seems dangerous to instantiate dataset module here, but this will be fine when we move deploy into
         //       isolated user's environment (e.g. separate yarn container)
+        Id.DatasetModule moduleId = Id.DatasetModule.from(input.getId().getNamespaceId(), moduleName);
         if (DatasetModule.class.isAssignableFrom(clazz)) {
-          datasetFramework.addModule(moduleName, (DatasetModule) clazz.newInstance());
+          datasetFramework.addModule(moduleId, (DatasetModule) clazz.newInstance());
         } else if (Dataset.class.isAssignableFrom(clazz)) {
           // checking if type is in already
           if (!datasetFramework.hasType(clazz.getName())) {
-            datasetFramework.addModule(moduleName, new SingleTypeModule((Class<Dataset>) clazz));
+            datasetFramework.addModule(moduleId, new SingleTypeModule((Class<Dataset>) clazz));
           }
         } else {
           String msg = String.format(

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseMetricsTableTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseMetricsTableTest.java
@@ -37,6 +37,7 @@ import co.cask.cdap.data2.dataset2.InMemoryDatasetFramework;
 import co.cask.cdap.data2.dataset2.lib.table.MetricsTable;
 import co.cask.cdap.data2.dataset2.lib.table.MetricsTableTest;
 import co.cask.cdap.data2.dataset2.module.lib.hbase.HBaseMetricsTableModule;
+import co.cask.cdap.proto.Id;
 import co.cask.cdap.test.SlowTests;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -63,6 +64,7 @@ public class HBaseMetricsTableTest extends MetricsTableTest {
   private static HBaseTestBase testHBase;
 
   private static DatasetFramework dsFramework;
+  private static final Id.Namespace NAMESPACE_ID = Id.Namespace.from("myspace");
 
   @BeforeClass
   public static void setup() throws Exception {
@@ -87,7 +89,7 @@ public class HBaseMetricsTableTest extends MetricsTableTest {
                                              });
 
     dsFramework = new InMemoryDatasetFramework(injector.getInstance(DatasetDefinitionRegistryFactory.class));
-    dsFramework.addModule("metrics-hbase", new HBaseMetricsTableModule());
+    dsFramework.addModule(Id.DatasetModule.from(NAMESPACE_ID, "metrics-hbase"), new HBaseMetricsTableModule());
   }
 
   @AfterClass

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetMetaTableUtil.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetMetaTableUtil.java
@@ -17,11 +17,13 @@
 package co.cask.cdap.data2.datafabric.dataset;
 
 import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.datafabric.dataset.service.mds.DatasetInstanceMDS;
 import co.cask.cdap.data2.datafabric.dataset.service.mds.DatasetTypeMDS;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.DatasetManagementException;
 import co.cask.cdap.data2.dataset2.SingleTypeModule;
+import co.cask.cdap.proto.Id;
 
 import java.io.IOException;
 
@@ -67,7 +69,9 @@ public class DatasetMetaTableUtil {
   }
 
   private static void addTypes(DatasetFramework framework) throws DatasetManagementException {
-    framework.addModule("typeMDSModule", new SingleTypeModule(DatasetTypeMDS.class));
-    framework.addModule("instanceMDSModule", new SingleTypeModule(DatasetInstanceMDS.class));
+    Id.DatasetModule typeMDSModuleId = Id.DatasetModule.from(Constants.SYSTEM_NAMESPACE, "typeMDSModule");
+    Id.DatasetModule instanceMDSModuleId = Id.DatasetModule.from(Constants.SYSTEM_NAMESPACE, "instanceMDSModule");
+    framework.addModule(typeMDSModuleId, new SingleTypeModule(DatasetTypeMDS.class));
+    framework.addModule(instanceMDSModuleId, new SingleTypeModule(DatasetInstanceMDS.class));
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFramework.java
@@ -33,6 +33,7 @@ import co.cask.cdap.data2.dataset2.module.lib.DatasetModules;
 import co.cask.cdap.proto.DatasetMeta;
 import co.cask.cdap.proto.DatasetModuleMeta;
 import co.cask.cdap.proto.DatasetTypeMeta;
+import co.cask.cdap.proto.Id;
 import com.google.common.base.Objects;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
@@ -77,7 +78,7 @@ public class RemoteDatasetFramework implements DatasetFramework {
   }
 
   @Override
-  public void addModule(String moduleName, DatasetModule module)
+  public void addModule(Id.DatasetModule moduleId, DatasetModule module)
     throws DatasetManagementException {
 
     // We support easier APIs for custom datasets: user can implement dataset and make it available for others to use
@@ -95,12 +96,12 @@ public class RemoteDatasetFramework implements DatasetFramework {
       typeClass = module.getClass();
     }
 
-    addModule(moduleName, typeClass);
+    addModule(moduleId, typeClass);
   }
 
   @Override
-  public void deleteModule(String moduleName) throws DatasetManagementException {
-    client.deleteModule(moduleName);
+  public void deleteModule(Id.DatasetModule moduleId) throws DatasetManagementException {
+    client.deleteModule(moduleId.getId());
   }
 
   @Override
@@ -182,18 +183,18 @@ public class RemoteDatasetFramework implements DatasetFramework {
     return (T) type.getDataset(instanceInfo.getSpec(), arguments);
   }
 
-  private void addModule(String moduleName, Class<?> typeClass) throws DatasetManagementException {
+  private void addModule(Id.DatasetModule moduleId, Class<?> typeClass) throws DatasetManagementException {
     try {
       File tempFile = File.createTempFile(typeClass.getName(), ".jar");
       try {
         Location tempJarPath = createDeploymentJar(typeClass, new LocalLocationFactory().create(tempFile.toURI()));
-        client.addModule(moduleName, typeClass.getName(), tempJarPath);
+        client.addModule(moduleId.getId(), typeClass.getName(), tempJarPath);
       } finally {
         tempFile.delete();
       }
     } catch (IOException e) {
       String msg = String.format("Could not create jar for deploying dataset module %s with main class %s",
-                                 moduleName, typeClass.getName());
+                                 moduleId, typeClass.getName());
       LOG.error(msg, e);
       throw new DatasetManagementException(msg, e);
     }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DatasetFramework.java
@@ -21,6 +21,7 @@ import co.cask.cdap.api.dataset.DatasetAdmin;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.dataset.module.DatasetModule;
+import co.cask.cdap.proto.Id;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -50,22 +51,22 @@ public interface DatasetFramework {
 
   /**
    * Adds dataset types by adding dataset module to the system.
-   * @param moduleName dataset module name
+   * @param moduleId dataset module id
    * @param module dataset module
    * @throws ModuleConflictException when module with same name is already registered or this module registers a type
    *         with a same name as one of the already registered by another module types
    * @throws DatasetManagementException in case of problems
    */
-  void addModule(String moduleName, DatasetModule module)
+  void addModule(Id.DatasetModule moduleId, DatasetModule module)
     throws DatasetManagementException;
 
   /**
    * Deletes dataset module and its types from the system.
-   * @param moduleName dataset module name
+   * @param moduleId dataset module id
    * @throws ModuleConflictException when module cannot be deleted because of its dependant modules or instances
    * @throws DatasetManagementException
    */
-  void deleteModule(String moduleName)
+  void deleteModule(Id.DatasetModule moduleId)
     throws DatasetManagementException;
 
   /**

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/NamespacedDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/NamespacedDatasetFramework.java
@@ -21,6 +21,7 @@ import co.cask.cdap.api.dataset.DatasetAdmin;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.dataset.module.DatasetModule;
+import co.cask.cdap.proto.Id;
 import com.google.common.collect.ImmutableList;
 
 import java.io.IOException;
@@ -41,15 +42,15 @@ public class NamespacedDatasetFramework implements DatasetFramework {
   }
 
   @Override
-  public void addModule(String moduleName, DatasetModule module)
+  public void addModule(Id.DatasetModule moduleId, DatasetModule module)
     throws DatasetManagementException {
 
-    delegate.addModule(moduleName, module);
+    delegate.addModule(moduleId, module);
   }
 
   @Override
-  public void deleteModule(String moduleName) throws DatasetManagementException {
-    delegate.deleteModule(moduleName);
+  public void deleteModule(Id.DatasetModule moduleId) throws DatasetManagementException {
+    delegate.deleteModule(moduleId);
   }
 
   @Override

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/DatasetWithArgumentsTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/DatasetWithArgumentsTest.java
@@ -18,6 +18,7 @@ package co.cask.cdap.api.dataset.lib;
 
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.data2.dataset2.AbstractDatasetTest;
+import co.cask.cdap.proto.Id;
 import co.cask.tephra.TransactionExecutor;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -31,16 +32,18 @@ import java.util.Collections;
  */
 public class DatasetWithArgumentsTest extends AbstractDatasetTest {
 
+  private static final Id.DatasetModule prefix = Id.DatasetModule.from(NAMESPACE_ID, "prefix");
+
   @BeforeClass
   public static void beforeClass() throws Exception {
-    addModule("prefix", new PrefixedTableModule());
+    addModule(prefix, new PrefixedTableModule());
     createInstance("prefixedTable", "pret", DatasetProperties.EMPTY);
   }
 
   @AfterClass
   public static void afterClass() throws Exception {
     deleteInstance("pret");
-    deleteModule("prefix");
+    deleteModule(prefix);
   }
 
   @Test

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/AbstractDatasetFrameworkTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/AbstractDatasetFrameworkTest.java
@@ -25,6 +25,7 @@ import co.cask.cdap.api.dataset.table.OrderedTable;
 import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.data2.dataset2.lib.table.CoreDatasetsModule;
 import co.cask.cdap.data2.dataset2.module.lib.inmemory.InMemoryOrderedTableModule;
+import co.cask.cdap.proto.Id;
 import co.cask.tephra.DefaultTransactionExecutor;
 import co.cask.tephra.TransactionAware;
 import co.cask.tephra.TransactionExecutor;
@@ -39,14 +40,19 @@ public abstract class AbstractDatasetFrameworkTest {
 
   protected abstract DatasetFramework getFramework();
 
+  private static final Id.Namespace namespaceId = Id.Namespace.from("myspace");
+  private static final Id.DatasetModule inMemory = Id.DatasetModule.from(namespaceId, "inMemory");
+  private static final Id.DatasetModule core = Id.DatasetModule.from(namespaceId, "core");
+  private static final Id.DatasetModule keyValue = Id.DatasetModule.from(namespaceId, "keyValue");
+  private static final Id.DatasetModule doubleKeyValue = Id.DatasetModule.from(namespaceId, "doubleKeyValue");
+
   @Test
   public void testSimpleDataset() throws Exception {
     // Configuring Dataset types
     DatasetFramework framework = getFramework();
-    String moduleName = "inMemory";
 
     Assert.assertFalse(framework.hasType("orderedTable"));
-    framework.addModule(moduleName, new InMemoryOrderedTableModule());
+    framework.addModule(inMemory, new InMemoryOrderedTableModule());
     Assert.assertTrue(framework.hasType("orderedTable"));
 
     Assert.assertFalse(framework.hasInstance("my_table"));
@@ -83,7 +89,7 @@ public abstract class AbstractDatasetFrameworkTest {
 
     // cleanup
     framework.deleteInstance("my_table");
-    framework.deleteModule("inMemory");
+    framework.deleteModule(inMemory);
   }
 
   @Test
@@ -91,10 +97,10 @@ public abstract class AbstractDatasetFrameworkTest {
     // Configuring Dataset types
     DatasetFramework framework = getFramework();
 
-    framework.addModule("inMemory", new InMemoryOrderedTableModule());
-    framework.addModule("core", new CoreDatasetsModule());
+    framework.addModule(inMemory, new InMemoryOrderedTableModule());
+    framework.addModule(core, new CoreDatasetsModule());
     Assert.assertFalse(framework.hasType(SimpleKVTable.class.getName()));
-    framework.addModule("keyValue", new SingleTypeModule(SimpleKVTable.class));
+    framework.addModule(keyValue, new SingleTypeModule(SimpleKVTable.class));
     Assert.assertTrue(framework.hasType(SimpleKVTable.class.getName()));
 
     // Creating instance
@@ -107,9 +113,9 @@ public abstract class AbstractDatasetFrameworkTest {
 
     // cleanup
     framework.deleteInstance("my_table");
-    framework.deleteModule("keyValue");
-    framework.deleteModule("core");
-    framework.deleteModule("inMemory");
+    framework.deleteModule(keyValue);
+    framework.deleteModule(core);
+    framework.deleteModule(inMemory);
   }
 
   @Test
@@ -117,11 +123,11 @@ public abstract class AbstractDatasetFrameworkTest {
     // Configuring Dataset types
     DatasetFramework framework = getFramework();
 
-    framework.addModule("inMemory", new InMemoryOrderedTableModule());
-    framework.addModule("core", new CoreDatasetsModule());
-    framework.addModule("keyValue", new SingleTypeModule(SimpleKVTable.class));
+    framework.addModule(inMemory, new InMemoryOrderedTableModule());
+    framework.addModule(core, new CoreDatasetsModule());
+    framework.addModule(keyValue, new SingleTypeModule(SimpleKVTable.class));
     Assert.assertFalse(framework.hasType(DoubleWrappedKVTable.class.getName()));
-    framework.addModule("doubleKeyValue", new SingleTypeModule(DoubleWrappedKVTable.class));
+    framework.addModule(doubleKeyValue, new SingleTypeModule(DoubleWrappedKVTable.class));
     Assert.assertTrue(framework.hasType(DoubleWrappedKVTable.class.getName()));
 
     // Creating instance
@@ -133,10 +139,10 @@ public abstract class AbstractDatasetFrameworkTest {
 
     // cleanup
     framework.deleteInstance("my_table");
-    framework.deleteModule("doubleKeyValue");
-    framework.deleteModule("keyValue");
-    framework.deleteModule("core");
-    framework.deleteModule("inMemory");
+    framework.deleteModule(doubleKeyValue);
+    framework.deleteModule(keyValue);
+    framework.deleteModule(core);
+    framework.deleteModule(inMemory);
   }
 
   private void testCompositeDataset(DatasetFramework framework) throws Exception {
@@ -174,8 +180,8 @@ public abstract class AbstractDatasetFrameworkTest {
     // Adding modules
     DatasetFramework framework = getFramework();
 
-    framework.addModule("inMemory", new InMemoryOrderedTableModule());
-    framework.addModule("core", new CoreDatasetsModule());
+    framework.addModule(inMemory, new InMemoryOrderedTableModule());
+    framework.addModule(core, new CoreDatasetsModule());
     Assert.assertTrue(framework.hasType(OrderedTable.class.getName()));
     Assert.assertTrue(framework.hasType(Table.class.getName()));
 

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/AbstractDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/AbstractDatasetTest.java
@@ -30,6 +30,7 @@ import co.cask.cdap.data2.dataset2.lib.partitioned.PartitionedFileSetModule;
 import co.cask.cdap.data2.dataset2.lib.partitioned.TimePartitionedFileSetModule;
 import co.cask.cdap.data2.dataset2.lib.table.CoreDatasetsModule;
 import co.cask.cdap.data2.dataset2.module.lib.inmemory.InMemoryOrderedTableModule;
+import co.cask.cdap.proto.Id;
 import co.cask.tephra.DefaultTransactionExecutor;
 import co.cask.tephra.TransactionAware;
 import co.cask.tephra.TransactionExecutor;
@@ -51,7 +52,14 @@ public class AbstractDatasetTest {
   @ClassRule
   public static TemporaryFolder tmpFolder = new TemporaryFolder();
 
+  protected static final Id.Namespace NAMESPACE_ID = Id.Namespace.from("myspace");
+
   private static DatasetFramework framework;
+  private static final Id.DatasetModule inMemory = Id.DatasetModule.from(NAMESPACE_ID, "inMemory");
+  private static final Id.DatasetModule core = Id.DatasetModule.from(NAMESPACE_ID, "core");
+  private static final Id.DatasetModule fileSet = Id.DatasetModule.from(NAMESPACE_ID, "fileSet");
+  private static final Id.DatasetModule tpfs = Id.DatasetModule.from(NAMESPACE_ID, "tpfs");
+  private static final Id.DatasetModule pfs = Id.DatasetModule.from(NAMESPACE_ID, "pfs");
 
   @BeforeClass
   public static void init() throws Exception {
@@ -72,28 +80,28 @@ public class AbstractDatasetTest {
         return registry;
       }
     });
-    framework.addModule("inMemory", new InMemoryOrderedTableModule());
-    framework.addModule("core", new CoreDatasetsModule());
-    framework.addModule("fileSet", new FileSetModule());
-    framework.addModule("tpfs", new TimePartitionedFileSetModule());
-    framework.addModule("pfs", new PartitionedFileSetModule());
+    framework.addModule(inMemory, new InMemoryOrderedTableModule());
+    framework.addModule(core, new CoreDatasetsModule());
+    framework.addModule(fileSet, new FileSetModule());
+    framework.addModule(tpfs, new TimePartitionedFileSetModule());
+    framework.addModule(pfs, new PartitionedFileSetModule());
   }
 
   @AfterClass
   public static void destroy() throws Exception {
-    framework.deleteModule("pfs");
-    framework.deleteModule("tpfs");
-    framework.deleteModule("fileSet");
-    framework.deleteModule("core");
-    framework.deleteModule("inMemory");
+    framework.deleteModule(pfs);
+    framework.deleteModule(tpfs);
+    framework.deleteModule(fileSet);
+    framework.deleteModule(core);
+    framework.deleteModule(inMemory);
   }
 
-  protected static void addModule(String name, DatasetModule module) throws DatasetManagementException {
-    framework.addModule(name, module);
+  protected static void addModule(Id.DatasetModule moduleId, DatasetModule module) throws DatasetManagementException {
+    framework.addModule(moduleId, module);
   }
 
-  protected static void deleteModule(String name) throws DatasetManagementException {
-    framework.deleteModule(name);
+  protected static void deleteModule(Id.DatasetModule moduleId) throws DatasetManagementException {
+    framework.deleteModule(moduleId);
   }
 
   protected static void createInstance(String type, String instanceName, DatasetProperties properties)

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/ACLTableDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/ACLTableDatasetTest.java
@@ -25,6 +25,7 @@ import co.cask.cdap.api.security.PermissionType;
 import co.cask.cdap.api.security.Principal;
 import co.cask.cdap.api.security.PrincipalType;
 import co.cask.cdap.data2.dataset2.AbstractDatasetTest;
+import co.cask.cdap.proto.Id;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -35,9 +36,11 @@ import java.util.List;
  */
 public class ACLTableDatasetTest extends AbstractDatasetTest {
 
+  private static final Id.DatasetModule aclTableModule = Id.DatasetModule.from(NAMESPACE_ID, "aclTableModule");
+
   @Test
   public void testBasics() throws Exception {
-    addModule("aclTableModule", new ACLTableModule());
+    addModule(aclTableModule, new ACLTableModule());
 
     createInstance(ACLTable.class.getName(), "myAclTable", DatasetProperties.EMPTY);
     ACLTable myAclTable = getInstance("myAclTable");
@@ -81,7 +84,7 @@ public class ACLTableDatasetTest extends AbstractDatasetTest {
     Assert.assertEquals(1, actualBobsAcl.getPermissions().size());
     Assert.assertTrue(actualBobsAcl.getPermissions().contains(PermissionType.WRITE));
 
-    deleteModule("aclTableModule");
+    deleteModule(aclTableModule);
   }
 
 }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/MetricsTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/MetricsTableTest.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.dataset.table.Row;
 import co.cask.cdap.api.dataset.table.Scanner;
 import co.cask.cdap.common.utils.ImmutablePair;
+import co.cask.cdap.proto.Id;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -44,6 +45,8 @@ public abstract class MetricsTableTest {
   private static final byte ONES = 0x7f;
 
   protected abstract MetricsTable getTable(String name) throws Exception;
+
+  protected static final Id.Namespace NAMESPACE_ID = Id.Namespace.from("myspace");
 
   protected static final byte[] A = Bytes.toBytes(1L);
   protected static final byte[] B = Bytes.toBytes(2L);

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/ObjectStoreDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/ObjectStoreDatasetTest.java
@@ -32,6 +32,7 @@ import co.cask.cdap.common.utils.ImmutablePair;
 import co.cask.cdap.data2.dataset2.AbstractDatasetTest;
 import co.cask.cdap.internal.io.ReflectionSchemaGenerator;
 import co.cask.cdap.internal.io.TypeRepresentation;
+import co.cask.cdap.proto.Id;
 import co.cask.tephra.TransactionExecutor;
 import co.cask.tephra.TransactionFailureException;
 import com.google.common.base.Preconditions;
@@ -61,14 +62,16 @@ public class ObjectStoreDatasetTest extends AbstractDatasetTest {
 
   private static final byte[] a = { 'a' };
 
+  private static final Id.DatasetModule integerStore = Id.DatasetModule.from(NAMESPACE_ID, "integerStore");
+
   @BeforeClass
   public static void beforeClass() throws Exception {
-    addModule("integerStore", new IntegerStoreModule());
+    addModule(integerStore, new IntegerStoreModule());
   }
 
   @AfterClass
   public static void afterClass() throws Exception {
-    deleteModule("integerStore");
+    deleteModule(integerStore);
   }
 
   private void addIntegerStoreInstance(String instanceName) throws Exception {

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/inmemory/InMemoryMetricsTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/inmemory/InMemoryMetricsTableTest.java
@@ -31,6 +31,7 @@ import co.cask.cdap.data2.dataset2.InMemoryDatasetFramework;
 import co.cask.cdap.data2.dataset2.lib.table.MetricsTable;
 import co.cask.cdap.data2.dataset2.lib.table.MetricsTableTest;
 import co.cask.cdap.data2.dataset2.module.lib.inmemory.InMemoryMetricsTableModule;
+import co.cask.cdap.proto.Id;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -41,6 +42,9 @@ import org.junit.BeforeClass;
  * test in-memory metrics tables.
  */
 public class InMemoryMetricsTableTest extends MetricsTableTest {
+
+  private static final Id.DatasetModule metricsInMemoryModule = Id.DatasetModule.from(NAMESPACE_ID, "metrics-inmemory");
+
   private static DatasetFramework dsFramework;
 
   @BeforeClass
@@ -62,7 +66,7 @@ public class InMemoryMetricsTableTest extends MetricsTableTest {
       });
 
     dsFramework = new InMemoryDatasetFramework(injector.getInstance(DatasetDefinitionRegistryFactory.class));
-    dsFramework.addModule("metrics-inmemory", new InMemoryMetricsTableModule());
+    dsFramework.addModule(metricsInMemoryModule, new InMemoryMetricsTableModule());
   }
 
   @Override

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBMetricsTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBMetricsTableTest.java
@@ -32,6 +32,7 @@ import co.cask.cdap.data2.dataset2.InMemoryDatasetFramework;
 import co.cask.cdap.data2.dataset2.lib.table.MetricsTable;
 import co.cask.cdap.data2.dataset2.lib.table.MetricsTableTest;
 import co.cask.cdap.data2.dataset2.module.lib.leveldb.LevelDBMetricsTableModule;
+import co.cask.cdap.proto.Id;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -44,6 +45,9 @@ import org.junit.rules.TemporaryFolder;
  * metrics table test for levelDB.
  */
 public class LevelDBMetricsTableTest extends MetricsTableTest {
+
+  private static final Id.DatasetModule metricsLevelDBModule = Id.DatasetModule.from(NAMESPACE_ID, "metrics-inmemory");
+
   private static DatasetFramework dsFramework;
 
   @ClassRule
@@ -69,7 +73,7 @@ public class LevelDBMetricsTableTest extends MetricsTableTest {
       });
 
     dsFramework = new InMemoryDatasetFramework(injector.getInstance(DatasetDefinitionRegistryFactory.class));
-    dsFramework.addModule("metrics-leveldb", new LevelDBMetricsTableModule());
+    dsFramework.addModule(metricsLevelDBModule, new LevelDBMetricsTableModule());
   }
 
   @Override

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/BaseHiveExploreServiceTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/BaseHiveExploreServiceTest.java
@@ -50,6 +50,7 @@ import co.cask.cdap.notifications.feeds.NotificationFeedManager;
 import co.cask.cdap.notifications.feeds.service.NoOpNotificationFeedManager;
 import co.cask.cdap.notifications.guice.NotificationServiceRuntimeModule;
 import co.cask.cdap.proto.ColumnDesc;
+import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.QueryHandle;
 import co.cask.cdap.proto.QueryResult;
 import co.cask.cdap.proto.QueryStatus;
@@ -95,6 +96,10 @@ public class BaseHiveExploreServiceTest {
   private static final Gson GSON = new GsonBuilder()
     .registerTypeAdapter(Schema.class, new SchemaTypeAdapter())
     .create();
+
+  protected static final Id.Namespace NAMESPACE_ID = Id.Namespace.from("myspace");
+  protected static final Id.DatasetModule KEY_STRUCT_VALUE = Id.DatasetModule.from(NAMESPACE_ID, "keyStructValue");
+
   // Controls for test suite for whether to run BeforeClass/AfterClass
   public static boolean runBefore = true;
   public static boolean runAfter = true;

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreDisabledTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreDisabledTest.java
@@ -42,6 +42,7 @@ import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
 import co.cask.cdap.notifications.feeds.NotificationFeedManager;
 import co.cask.cdap.notifications.feeds.service.NoOpNotificationFeedManager;
 import co.cask.cdap.notifications.guice.NotificationServiceRuntimeModule;
+import co.cask.cdap.proto.Id;
 import co.cask.tephra.Transaction;
 import co.cask.tephra.TransactionManager;
 import com.google.common.collect.ImmutableList;
@@ -68,6 +69,7 @@ public class ExploreDisabledTest {
   private static DatasetOpExecutor dsOpExecutor;
   private static DatasetService datasetService;
   private static ExploreClient exploreClient;
+  private static final Id.Namespace namespaceId = Id.Namespace.from("myspace");
 
   @BeforeClass
   public static void start() throws Exception {
@@ -99,7 +101,8 @@ public class ExploreDisabledTest {
   public void testDeployRecordScannable() throws Exception {
     // Try to deploy a dataset that is not record scannable, when explore is enabled.
     // This should be processed with no exception being thrown
-    datasetFramework.addModule("module1", new KeyStructValueTableDefinition.KeyStructValueTableModule());
+    Id.DatasetModule module1 = Id.DatasetModule.from(namespaceId, "module1");
+    datasetFramework.addModule(module1, new KeyStructValueTableDefinition.KeyStructValueTableModule());
 
     // Performing admin operations to create dataset instance
     datasetFramework.addInstance("keyStructValueTable", "table1", DatasetProperties.EMPTY);
@@ -133,14 +136,15 @@ public class ExploreDisabledTest {
     Assert.assertEquals(value1, table.get("1"));
 
     datasetFramework.deleteInstance("table1");
-    datasetFramework.deleteModule("module1");
+    datasetFramework.deleteModule(module1);
   }
 
   @Test
   public void testDeployNotRecordScannable() throws Exception {
     // Try to deploy a dataset that is not record scannable, when explore is enabled.
     // This should be processed with no exceptionbeing thrown
-    datasetFramework.addModule("module2", new NotRecordScannableTableDefinition.NotRecordScannableTableModule());
+    Id.DatasetModule module2 = Id.DatasetModule.from(namespaceId, "module2");
+    datasetFramework.addModule(module2, new NotRecordScannableTableDefinition.NotRecordScannableTableModule());
 
     // Performing admin operations to create dataset instance
     datasetFramework.addInstance("NotRecordScannableTableDef", "table2", DatasetProperties.EMPTY);
@@ -170,7 +174,7 @@ public class ExploreDisabledTest {
     Assert.assertEquals("value1", new String(table.read("key1")));
 
     datasetFramework.deleteInstance("table2");
-    datasetFramework.deleteModule("module2");
+    datasetFramework.deleteModule(module2);
   }
 
   private static List<Module> createInMemoryModules(CConfiguration configuration, Configuration hConf) {

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreExtensiveSchemaTableTestRun.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreExtensiveSchemaTableTestRun.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.dataset.DatasetDefinition;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.explore.service.datasets.ExtensiveSchemaTableDefinition;
 import co.cask.cdap.proto.ColumnDesc;
+import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.QueryResult;
 import co.cask.cdap.proto.TableInfo;
 import co.cask.cdap.test.SlowTests;
@@ -39,11 +40,13 @@ import org.junit.experimental.categories.Category;
 @Category(SlowTests.class)
 public class ExploreExtensiveSchemaTableTestRun extends BaseHiveExploreServiceTest {
 
+  private static final Id.DatasetModule extensiveSchema = Id.DatasetModule.from(NAMESPACE_ID, "extensiveSchema");
+
   @BeforeClass
   public static void start() throws Exception {
     startServices();
 
-    datasetFramework.addModule("extensiveSchema", new ExtensiveSchemaTableDefinition.ExtensiveSchemaTableModule());
+    datasetFramework.addModule(extensiveSchema, new ExtensiveSchemaTableDefinition.ExtensiveSchemaTableModule());
 
     // Performing admin operations to create dataset instance
     datasetFramework.addInstance("ExtensiveSchemaTable", "my_table", DatasetProperties.EMPTY);
@@ -87,7 +90,7 @@ public class ExploreExtensiveSchemaTableTestRun extends BaseHiveExploreServiceTe
   @AfterClass
   public static void stop() throws Exception {
     datasetFramework.deleteInstance("my_table");
-    datasetFramework.deleteModule("extensiveSchema");
+    datasetFramework.deleteModule(extensiveSchema);
   }
 
   @Test

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreMetadataTestRun.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreMetadataTestRun.java
@@ -42,7 +42,7 @@ public class ExploreMetadataTestRun extends BaseHiveExploreServiceTest {
   public static void start() throws Exception {
     startServices();
 
-    datasetFramework.addModule("keyStructValue", new KeyStructValueTableDefinition.KeyStructValueTableModule());
+    datasetFramework.addModule(KEY_STRUCT_VALUE, new KeyStructValueTableDefinition.KeyStructValueTableModule());
 
     // Performing admin operations to create dataset instance
     datasetFramework.addInstance("keyStructValueTable", "my_table", DatasetProperties.EMPTY);
@@ -53,7 +53,7 @@ public class ExploreMetadataTestRun extends BaseHiveExploreServiceTest {
   public static void stop() throws Exception {
     datasetFramework.deleteInstance("my_table");
     datasetFramework.deleteInstance("other_table");
-    datasetFramework.deleteModule("keyStructValue");
+    datasetFramework.deleteModule(KEY_STRUCT_VALUE);
   }
 
   @Test

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceTestRun.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceTestRun.java
@@ -28,6 +28,7 @@ import co.cask.cdap.hive.datasets.DatasetInputFormat;
 import co.cask.cdap.hive.datasets.DatasetSerDe;
 import co.cask.cdap.hive.datasets.DatasetStorageHandler;
 import co.cask.cdap.proto.ColumnDesc;
+import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.QueryHandle;
 import co.cask.cdap.proto.QueryInfo;
 import co.cask.cdap.proto.QueryResult;
@@ -69,7 +70,7 @@ public class HiveExploreServiceTestRun extends BaseHiveExploreServiceTest {
   public static void start() throws Exception {
     startServices();
 
-    datasetFramework.addModule("keyStructValue", new KeyStructValueTableDefinition.KeyStructValueTableModule());
+    datasetFramework.addModule(KEY_STRUCT_VALUE, new KeyStructValueTableDefinition.KeyStructValueTableModule());
 
     // Performing admin operations to create dataset instance
     datasetFramework.addInstance("keyStructValueTable", "my_table", DatasetProperties.EMPTY);
@@ -104,19 +105,20 @@ public class HiveExploreServiceTestRun extends BaseHiveExploreServiceTest {
   @AfterClass
   public static void stop() throws Exception {
     datasetFramework.deleteInstance("my_table");
-    datasetFramework.deleteModule("keyStructValue");
+    datasetFramework.deleteModule(KEY_STRUCT_VALUE);
   }
 
   @Test
   public void testDeployNotRecordScannable() throws Exception {
     // Try to deploy a dataset that is not record scannable, when explore is enabled.
     // This should be processed with no exception being thrown
-    datasetFramework.addModule("module2", new NotRecordScannableTableDefinition.NotRecordScannableTableModule());
+    Id.DatasetModule module2 = Id.DatasetModule.from(NAMESPACE_ID, "module2");
+    datasetFramework.addModule(module2, new NotRecordScannableTableDefinition.NotRecordScannableTableModule());
     datasetFramework.addInstance("NotRecordScannableTableDef", "my_table_not_record_scannable",
                                  DatasetProperties.EMPTY);
 
     datasetFramework.deleteInstance("my_table_not_record_scannable");
-    datasetFramework.deleteModule("module2");
+    datasetFramework.deleteModule(module2);
   }
 
   @Test

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceTimeoutTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceTimeoutTest.java
@@ -22,6 +22,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.explore.service.datasets.KeyStructValueTableDefinition;
 import co.cask.cdap.proto.ColumnDesc;
+import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.QueryHandle;
 import co.cask.cdap.proto.QueryStatus;
 import co.cask.cdap.test.XSlowTests;
@@ -66,7 +67,7 @@ public class HiveExploreServiceTimeoutTest extends BaseHiveExploreServiceTest {
 
     exploreService = injector.getInstance(ExploreService.class);
 
-    datasetFramework.addModule("keyStructValue", new KeyStructValueTableDefinition.KeyStructValueTableModule());
+    datasetFramework.addModule(KEY_STRUCT_VALUE, new KeyStructValueTableDefinition.KeyStructValueTableModule());
 
     // Performing admin operations to create dataset instance
     datasetFramework.addInstance("keyStructValueTable", "my_table", DatasetProperties.EMPTY);
@@ -103,7 +104,7 @@ public class HiveExploreServiceTimeoutTest extends BaseHiveExploreServiceTest {
   @AfterClass
   public static void stop() throws Exception {
     datasetFramework.deleteInstance("my_table");
-    datasetFramework.deleteModule("keyStructValue");
+    datasetFramework.deleteModule(KEY_STRUCT_VALUE);
   }
 
   @Test

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/WritableDatasetTestRun.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/WritableDatasetTestRun.java
@@ -23,6 +23,7 @@ import co.cask.cdap.explore.service.datasets.KeyExtendedStructValueTableDefiniti
 import co.cask.cdap.explore.service.datasets.KeyStructValueTableDefinition;
 import co.cask.cdap.explore.service.datasets.KeyValueTableDefinition;
 import co.cask.cdap.explore.service.datasets.WritableKeyStructValueTableDefinition;
+import co.cask.cdap.proto.Id;
 import co.cask.cdap.test.XSlowTests;
 import co.cask.tephra.Transaction;
 import com.google.common.collect.ImmutableList;
@@ -42,10 +43,17 @@ import java.net.URL;
  */
 @Category(XSlowTests.class)
 public class WritableDatasetTestRun extends BaseHiveExploreServiceTest {
+
+  private static final Id.DatasetModule keyExtendedStructValueTable =
+    Id.DatasetModule.from(NAMESPACE_ID, "keyExtendedStructValueTable");
+  private static final Id.DatasetModule kvTable = Id.DatasetModule.from(NAMESPACE_ID, "kvTable");
+  private static final Id.DatasetModule writableKeyStructValueTable =
+    Id.DatasetModule.from(NAMESPACE_ID, "writableKeyStructValueTable");
+
   @BeforeClass
   public static void start() throws Exception {
     startServices();
-    datasetFramework.addModule("keyStructValue", new KeyStructValueTableDefinition.KeyStructValueTableModule());
+    datasetFramework.addModule(KEY_STRUCT_VALUE, new KeyStructValueTableDefinition.KeyStructValueTableModule());
   }
 
   private static void initKeyValueTable(String tableName, boolean addData) throws Exception {
@@ -81,7 +89,7 @@ public class WritableDatasetTestRun extends BaseHiveExploreServiceTest {
 
   @AfterClass
   public static void stop() throws Exception {
-    datasetFramework.deleteModule("keyStructValue");
+    datasetFramework.deleteModule(KEY_STRUCT_VALUE);
   }
 
   @Test
@@ -127,7 +135,7 @@ public class WritableDatasetTestRun extends BaseHiveExploreServiceTest {
   @Test
   public void writeIntoOtherDatasetTest() throws Exception {
 
-    datasetFramework.addModule("keyExtendedStructValueTable",
+    datasetFramework.addModule(keyExtendedStructValueTable,
                                new KeyExtendedStructValueTableDefinition.KeyExtendedStructValueTableModule());
     datasetFramework.addInstance("keyExtendedStructValueTable", "extended_table", DatasetProperties.EMPTY);
     try {
@@ -174,18 +182,18 @@ public class WritableDatasetTestRun extends BaseHiveExploreServiceTest {
     } finally {
       datasetFramework.deleteInstance("my_table");
       datasetFramework.deleteInstance("extended_table");
-      datasetFramework.deleteModule("keyExtendedStructValueTable");
+      datasetFramework.deleteModule(keyExtendedStructValueTable);
     }
   }
 
   @Test
   public void writeIntoNonScannableDataset() throws Exception {
 
-    datasetFramework.addModule("keyExtendedStructValueTable",
+    datasetFramework.addModule(keyExtendedStructValueTable,
                                new KeyExtendedStructValueTableDefinition.KeyExtendedStructValueTableModule());
     datasetFramework.addInstance("keyExtendedStructValueTable", "extended_table", DatasetProperties.EMPTY);
 
-    datasetFramework.addModule("writableKeyStructValueTable",
+    datasetFramework.addModule(writableKeyStructValueTable,
                                new WritableKeyStructValueTableDefinition.KeyStructValueTableModule());
     datasetFramework.addInstance("writableKeyStructValueTable", "writable_table", DatasetProperties.EMPTY);
     try {
@@ -232,8 +240,8 @@ public class WritableDatasetTestRun extends BaseHiveExploreServiceTest {
     } finally {
       datasetFramework.deleteInstance("writable_table");
       datasetFramework.deleteInstance("extended_table");
-      datasetFramework.deleteModule("writableKeyStructValueTable");
-      datasetFramework.deleteModule("keyExtendedStructValueTable");
+      datasetFramework.deleteModule(writableKeyStructValueTable);
+      datasetFramework.deleteModule(keyExtendedStructValueTable);
     }
   }
 
@@ -277,7 +285,7 @@ public class WritableDatasetTestRun extends BaseHiveExploreServiceTest {
   @Test
   public void writeFromNativeTableIntoDatasetTest() throws Exception {
 
-    datasetFramework.addModule("kvTable", new KeyValueTableDefinition.KeyValueTableModule());
+    datasetFramework.addModule(kvTable, new KeyValueTableDefinition.KeyValueTableModule());
     datasetFramework.addInstance("kvTable", "simple_table", DatasetProperties.EMPTY);
     try {
       URL loadFileUrl = getClass().getResource("/test_table.dat");
@@ -302,14 +310,14 @@ public class WritableDatasetTestRun extends BaseHiveExploreServiceTest {
     } finally {
       exploreClient.submit("drop table if exists test").get().close();
       datasetFramework.deleteInstance("simple_table");
-      datasetFramework.deleteModule("kvTable");
+      datasetFramework.deleteModule(kvTable);
     }
   }
 
   @Test
   public void writeFromDatasetIntoNativeTableTest() throws Exception {
 
-    datasetFramework.addModule("kvTable", new KeyValueTableDefinition.KeyValueTableModule());
+    datasetFramework.addModule(kvTable, new KeyValueTableDefinition.KeyValueTableModule());
     datasetFramework.addInstance("kvTable", "simple_table", DatasetProperties.EMPTY);
     try {
       exploreClient.submit("create table test (first INT, second STRING) ROW FORMAT " +
@@ -341,7 +349,7 @@ public class WritableDatasetTestRun extends BaseHiveExploreServiceTest {
     } finally {
       exploreClient.submit("drop table if exists test").get().close();
       datasetFramework.deleteInstance("simple_table");
-      datasetFramework.deleteModule("kvTable");
+      datasetFramework.deleteModule(kvTable);
     }
   }
 

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/Main.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/Main.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.dataset.module.DatasetDefinitionRegistry;
 import co.cask.cdap.api.dataset.table.OrderedTable;
 import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.LocationRuntimeModule;
 import co.cask.cdap.common.utils.ProjectInfo;
@@ -45,6 +46,7 @@ import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
 import co.cask.cdap.internal.app.runtime.schedule.ScheduleStoreTableUtil;
 import co.cask.cdap.internal.app.store.DefaultStore;
 import co.cask.cdap.logging.save.LogSaverTableUtil;
+import co.cask.cdap.proto.Id;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -204,9 +206,11 @@ public class Main {
     DatasetFramework datasetFramework =
       new NamespacedDatasetFramework(new InMemoryDatasetFramework(registryFactory),
                                      new DefaultDatasetNamespace(cConf, Namespace.SYSTEM));
-    datasetFramework.addModule("orderedTable", new HBaseOrderedTableModule());
-    datasetFramework.addModule("core", new CoreDatasetsModule());
-    datasetFramework.addModule("fileSet", new FileSetModule());
+    // TODO: this doesn't sound right. find out why its needed.
+    datasetFramework.addModule(Id.DatasetModule.from(Constants.SYSTEM_NAMESPACE, "orderedTable"),
+                               new HBaseOrderedTableModule());
+    datasetFramework.addModule(Id.DatasetModule.from(Constants.SYSTEM_NAMESPACE, "core"), new CoreDatasetsModule());
+    datasetFramework.addModule(Id.DatasetModule.from(Constants.SYSTEM_NAMESPACE, "fileSet"), new FileSetModule());
 
     return datasetFramework;
   }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/Id.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/Id.java
@@ -74,7 +74,7 @@ public final class Id  {
   }
 
   /**
-   * Program Id identifies a given application.
+   * Application Id identifies a given application.
    * Application is global unique if used within context of namespace.
    */
   public static final class Application {
@@ -353,7 +353,6 @@ public final class Id  {
     }
   }
 
-
   /**
    * Id.Stream uniquely identifies a stream.
    */
@@ -437,6 +436,82 @@ public final class Id  {
         .add("namespace", namespace)
         .add("streamName", streamName)
         .toString();
+    }
+  }
+
+  /**
+   * Dataset Module Id identifies a given dataset module.
+   */
+  public static final class DatasetModule {
+    private final Namespace namespace;
+    private final String moduleId;
+
+    public DatasetModule(final Namespace namespace, final String moduleId) {
+      Preconditions.checkNotNull(namespace, "Namespace cannot be null.");
+      Preconditions.checkNotNull(moduleId, "Dataset module id cannot be null.");
+      Preconditions.checkArgument(isValidModuleId(moduleId), "Invalid characters found in module Id. " +
+        "Module id can contain alphabets, numbers or _, -, . characters");
+      this.namespace = namespace;
+      this.moduleId = moduleId;
+    }
+
+    /**
+     * Allow '.' and '$' for modules since module ids can be fully qualified class names
+     */
+    private boolean isValidModuleId(String moduleId) {
+      return CharMatcher.inRange('A', 'Z')
+        .or(CharMatcher.inRange('a', 'z'))
+        .or(CharMatcher.is('-'))
+        .or(CharMatcher.is('_'))
+        .or(CharMatcher.is('.'))
+        .or(CharMatcher.is('$'))
+        .or(CharMatcher.inRange('0', '9')).matchesAllOf(moduleId);
+    }
+
+    public Namespace getNamespace() {
+      return namespace;
+    }
+
+    public String getNamespaceId() {
+      return namespace.getId();
+    }
+
+    public String getId() {
+      return moduleId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+
+      DatasetModule that = (DatasetModule) o;
+      return namespace.equals(that.namespace) && moduleId.equals(that.moduleId);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(namespace, moduleId);
+    }
+
+    @Override
+    public String toString() {
+      return Objects.toStringHelper(this)
+       .add("namespace", namespace)
+       .add("module", moduleId)
+       .toString();
+    }
+
+    public static DatasetModule from(Namespace id, String moduleId) {
+      return new DatasetModule(id, moduleId);
+    }
+
+    public static DatasetModule from(String namespaceId, String moduleId) {
+      return new DatasetModule(Namespace.from(namespaceId), moduleId);
     }
   }
 }

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/UnitTestManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/UnitTestManager.java
@@ -28,6 +28,7 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.discovery.StickyEndpointStrategy;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.explore.jdbc.ExploreDriver;
+import co.cask.cdap.proto.Id;
 import co.cask.cdap.test.internal.AppFabricClient;
 import co.cask.cdap.test.internal.ApplicationManagerFactory;
 import co.cask.cdap.test.internal.DefaultId;
@@ -115,7 +116,8 @@ public class UnitTestManager implements TestManager {
   @Override
   public final void deployDatasetModule(String moduleName, Class<? extends DatasetModule> datasetModule)
     throws Exception {
-    datasetFramework.addModule(moduleName, datasetModule.newInstance());
+    //TODO: Expose namespaces later. Hardcoding to default right now.
+    datasetFramework.addModule(Id.DatasetModule.from(DefaultId.NAMESPACE, moduleName), datasetModule.newInstance());
   }
 
   @Beta

--- a/cdap-watchdog-tests/src/test/java/co/cask/cdap/metrics/data/EntityTableTest.java
+++ b/cdap-watchdog-tests/src/test/java/co/cask/cdap/metrics/data/EntityTableTest.java
@@ -34,6 +34,7 @@ import co.cask.cdap.data2.dataset2.DefaultDatasetDefinitionRegistry;
 import co.cask.cdap.data2.dataset2.InMemoryDatasetFramework;
 import co.cask.cdap.data2.dataset2.lib.table.MetricsTable;
 import co.cask.cdap.data2.dataset2.module.lib.hbase.HBaseMetricsTableModule;
+import co.cask.cdap.proto.Id;
 import co.cask.cdap.test.SlowTests;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
@@ -53,6 +54,7 @@ public class EntityTableTest {
 
   private static DatasetFramework dsFramework;
   private static HBaseTestBase testHBase;
+  private static final Id.Namespace NAMESPACE_ID = Id.Namespace.from("myspace");
 
   protected MetricsTable getTable(String name) throws Exception {
     return DatasetsUtil.getOrCreateDataset(dsFramework, name, MetricsTable.class.getName(),
@@ -143,7 +145,7 @@ public class EntityTableTest {
                                              });
 
     dsFramework = new InMemoryDatasetFramework(injector.getInstance(DatasetDefinitionRegistryFactory.class));
-    dsFramework.addModule("metrics-hbase", new HBaseMetricsTableModule());
+    dsFramework.addModule(Id.DatasetModule.from(NAMESPACE_ID, "metrics-hbase"), new HBaseMetricsTableModule());
   }
 
   @AfterClass

--- a/cdap-watchdog-tests/src/test/java/co/cask/cdap/metrics/data/MetricsTestHelper.java
+++ b/cdap-watchdog-tests/src/test/java/co/cask/cdap/metrics/data/MetricsTestHelper.java
@@ -34,6 +34,7 @@ import co.cask.cdap.data2.dataset2.InMemoryDatasetFramework;
 import co.cask.cdap.data2.dataset2.module.lib.hbase.HBaseMetricsTableModule;
 import co.cask.cdap.data2.dataset2.module.lib.leveldb.LevelDBMetricsTableModule;
 import co.cask.cdap.metrics.MetricsConstants;
+import co.cask.cdap.proto.Id;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -47,6 +48,8 @@ import java.io.File;
  * Helper class for constructing different test environments for running metrics tests.
  */
 public class MetricsTestHelper {
+
+  private static final Id.Namespace NAMESPACE_ID = Id.Namespace.from("myspace");
 
   public static MetricsTableFactory createLocalMetricsTableFactory(File dataDir) throws DatasetManagementException {
     CConfiguration cConf = CConfiguration.create();
@@ -70,7 +73,7 @@ public class MetricsTestHelper {
 
     DatasetFramework dsFramework =
       new InMemoryDatasetFramework(injector.getInstance(DatasetDefinitionRegistryFactory.class));
-    dsFramework.addModule("metricsTable-leveldb", new LevelDBMetricsTableModule());
+    dsFramework.addModule(Id.DatasetModule.from(NAMESPACE_ID, "metricsTable-leveldb"), new LevelDBMetricsTableModule());
     return new DefaultMetricsTableFactory(cConf, dsFramework);
   }
 
@@ -101,7 +104,7 @@ public class MetricsTestHelper {
 
     DatasetFramework dsFramework =
       new InMemoryDatasetFramework(injector.getInstance(DatasetDefinitionRegistryFactory.class));
-    dsFramework.addModule("metrics-hbase", new HBaseMetricsTableModule());
+    dsFramework.addModule(Id.DatasetModule.from(NAMESPACE_ID, "metrics-hbase"), new HBaseMetricsTableModule());
     return new DefaultMetricsTableFactory(cConf, dsFramework);
   }
 

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/file/TestFileLogging.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/file/TestFileLogging.java
@@ -35,6 +35,7 @@ import co.cask.cdap.logging.context.FlowletLoggingContext;
 import co.cask.cdap.logging.filter.Filter;
 import co.cask.cdap.logging.read.LogEvent;
 import co.cask.cdap.logging.read.StandaloneLogReader;
+import co.cask.cdap.proto.Id;
 import co.cask.tephra.TransactionManager;
 import co.cask.tephra.inmemory.InMemoryTxSystemClient;
 import org.apache.commons.io.FileUtils;
@@ -62,11 +63,12 @@ public class TestFileLogging {
 
   private static DatasetFramework dsFramework;
   private static InMemoryTxSystemClient txClient;
+  private static final Id.Namespace NAMESPACE_ID = Id.Namespace.from("myspace");
 
   @BeforeClass
   public static void setUpContext() throws Exception {
     dsFramework = new InMemoryDatasetFramework(new InMemoryDefinitionRegistryFactory());
-    dsFramework.addModule("table", new InMemoryOrderedTableModule());
+    dsFramework.addModule(Id.DatasetModule.from(NAMESPACE_ID, "table"), new InMemoryOrderedTableModule());
 
     LoggingContextAccessor.setLoggingContext(new FlowletLoggingContext("TFL_ACCT_1", "APP_1", "FLOW_1", "FLOWLET_1"));
     logBaseDir = "/tmp/log_files_" + new Random(System.currentTimeMillis()).nextLong();

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/kafka/TestKafkaLogging.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/kafka/TestKafkaLogging.java
@@ -32,6 +32,7 @@ import co.cask.cdap.logging.appender.LogAppenderInitializer;
 import co.cask.cdap.logging.appender.LoggingTester;
 import co.cask.cdap.logging.context.FlowletLoggingContext;
 import co.cask.cdap.logging.read.DistributedLogReader;
+import co.cask.cdap.proto.Id;
 import co.cask.cdap.test.SlowTests;
 import co.cask.tephra.TransactionManager;
 import co.cask.tephra.inmemory.InMemoryTxSystemClient;
@@ -55,11 +56,12 @@ public class TestKafkaLogging extends KafkaTestBase {
   private static InMemoryTxSystemClient txClient = null;
   private static DatasetFramework dsFramework;
   private static CConfiguration cConf;
+  private static final Id.Namespace NAMESPACE_ID = Id.Namespace.from("myspace");
 
   @BeforeClass
   public static void init() throws Exception {
     dsFramework = new InMemoryDatasetFramework(new InMemoryDefinitionRegistryFactory());
-    dsFramework.addModule("table", new InMemoryOrderedTableModule());
+    dsFramework.addModule(Id.DatasetModule.from(NAMESPACE_ID, "table"), new InMemoryOrderedTableModule());
 
     Configuration txConf = HBaseConfiguration.create();
     TransactionManager txManager = new TransactionManager(txConf);

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/save/LogSaverTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/save/LogSaverTest.java
@@ -43,6 +43,7 @@ import co.cask.cdap.logging.read.AvroFileLogReader;
 import co.cask.cdap.logging.read.DistributedLogReader;
 import co.cask.cdap.logging.read.LogEvent;
 import co.cask.cdap.logging.serialize.LogSchema;
+import co.cask.cdap.proto.Id;
 import co.cask.cdap.test.SlowTests;
 import co.cask.cdap.watchdog.election.MultiLeaderElection;
 import co.cask.tephra.TransactionManager;
@@ -101,11 +102,12 @@ public class LogSaverTest extends KafkaTestBase {
   private static DatasetFramework dsFramework;
   private static LogSaverTableUtil tableUtil;
   private static CConfiguration cConf;
+  private static final Id.Namespace NAMESPACE_ID = Id.Namespace.from("myspace");
 
   @BeforeClass
   public static void startLogSaver() throws Exception {
     dsFramework = new InMemoryDatasetFramework(new InMemoryDefinitionRegistryFactory());
-    dsFramework.addModule("table", new InMemoryOrderedTableModule());
+    dsFramework.addModule(Id.DatasetModule.from(NAMESPACE_ID, "table"), new InMemoryOrderedTableModule());
 
     String logBaseDir = temporaryFolder.newFolder().getAbsolutePath();
     LOG.info("Log base dir {}", logBaseDir);

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/write/LogCleanupTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/write/LogCleanupTest.java
@@ -26,6 +26,7 @@ import co.cask.cdap.data2.dataset2.InMemoryDatasetFramework;
 import co.cask.cdap.data2.dataset2.module.lib.inmemory.InMemoryOrderedTableModule;
 import co.cask.cdap.logging.context.FlowletLoggingContext;
 import co.cask.cdap.logging.save.LogSaverTableUtil;
+import co.cask.cdap.proto.Id;
 import co.cask.tephra.TransactionManager;
 import co.cask.tephra.TransactionSystemClient;
 import co.cask.tephra.inmemory.InMemoryTxSystemClient;
@@ -65,6 +66,7 @@ public class LogCleanupTest {
   public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
 
   private static final int RETENTION_DURATION_MS = 100000;
+  private static final Id.Namespace NAMESPACE_ID = Id.Namespace.from("myspace");
 
   private static LocationFactory locationFactory;
 
@@ -76,7 +78,7 @@ public class LogCleanupTest {
   @Test
   public void testCleanup() throws Exception {
     DatasetFramework dsFramework = new InMemoryDatasetFramework(new InMemoryDefinitionRegistryFactory());
-    dsFramework.addModule("table", new InMemoryOrderedTableModule());
+    dsFramework.addModule(Id.DatasetModule.from(NAMESPACE_ID, "table"), new InMemoryOrderedTableModule());
 
     CConfiguration cConf = CConfiguration.create();
 

--- a/cdap-watchdog/src/test/java/co/cask/cdap/metrics/data/LevelDBFilterableOVCTableTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/metrics/data/LevelDBFilterableOVCTableTest.java
@@ -31,6 +31,7 @@ import co.cask.cdap.metrics.MetricsConstants;
 import co.cask.cdap.metrics.transport.MetricType;
 import co.cask.cdap.metrics.transport.MetricsRecord;
 import co.cask.cdap.metrics.transport.TagMetric;
+import co.cask.cdap.proto.Id;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.inject.AbstractModule;
@@ -56,6 +57,7 @@ public class LevelDBFilterableOVCTableTest {
   public static TemporaryFolder tmpFolder = new TemporaryFolder();
   private static MetricsTableFactory tableFactory;
   private static final int rollTime = 60;
+  private static final Id.Namespace NAMESPACE_ID = Id.Namespace.from("myspace");
 
   @Test
   public void testAggregatesQuery() throws Exception {
@@ -217,7 +219,7 @@ public class LevelDBFilterableOVCTableTest {
       });
     DatasetFramework dsFramework =
       new InMemoryDatasetFramework(injector.getInstance(DatasetDefinitionRegistryFactory.class));
-    dsFramework.addModule("metrics-leveldb", new InMemoryMetricsTableModule());
+    dsFramework.addModule(Id.DatasetModule.from(NAMESPACE_ID, "metrics-leveldb"), new InMemoryMetricsTableModule());
     tableFactory = new DefaultMetricsTableFactory(cConf, dsFramework);
   }
 }

--- a/cdap-watchdog/src/test/java/co/cask/cdap/metrics/data/TimeSeriesCleanupTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/metrics/data/TimeSeriesCleanupTest.java
@@ -31,6 +31,7 @@ import co.cask.cdap.metrics.MetricsConstants;
 import co.cask.cdap.metrics.transport.MetricType;
 import co.cask.cdap.metrics.transport.MetricsRecord;
 import co.cask.cdap.metrics.transport.TagMetric;
+import co.cask.cdap.proto.Id;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.inject.AbstractModule;
@@ -54,6 +55,7 @@ public class TimeSeriesCleanupTest {
   public static TemporaryFolder tmpFolder = new TemporaryFolder();
 
   private static MetricsTableFactory tableFactory;
+  private static final Id.Namespace NAMESPACE_ID = Id.Namespace.from("myspace");
 
   @Test
   public void testDeleteBefore() throws Exception {
@@ -149,7 +151,7 @@ public class TimeSeriesCleanupTest {
       });
     DatasetFramework dsFramework =
       new InMemoryDatasetFramework(injector.getInstance(DatasetDefinitionRegistryFactory.class));
-    dsFramework.addModule("metrics-leveldb", new InMemoryMetricsTableModule());
+    dsFramework.addModule(Id.DatasetModule.from(NAMESPACE_ID, "metrics-leveldb"), new InMemoryMetricsTableModule());
     tableFactory = new DefaultMetricsTableFactory(cConf, dsFramework);
   }
 }


### PR DESCRIPTION
... a dataset module as namespace id + module name

Summary:

1. Basic plumbing for dataset modules. Adds ``Id.DatasetModule`` and uses it instead of a ``String`` dataset module name.
2. ``DatasetFramework`` is namespace-aware. ``DatasetServiceClient`` will be made namespace-local.
3. Does not contain changes to use the ``namespaceId`` from the ``Id.DatasetModule`` yet, that will come in a later PR.
4. Uses *system* namespace for default modules.

Build: https://builds.cask.co/browse/CDAP-DUT772-6