### PR TITLE
Namespaced datasets plumbing part 2 - added Id.DatasetInstance

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/config/DefaultConfigStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/config/DefaultConfigStore.java
@@ -31,6 +31,7 @@ import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.DatasetManagementException;
 import co.cask.cdap.data2.dataset2.NamespacedDatasetFramework;
 import co.cask.cdap.data2.dataset2.tx.Transactional;
+import co.cask.cdap.proto.Id;
 import co.cask.tephra.TransactionExecutor;
 import co.cask.tephra.TransactionExecutorFactory;
 import com.google.common.base.Supplier;
@@ -57,6 +58,8 @@ public class DefaultConfigStore implements ConfigStore {
   private static final Gson GSON = new Gson();
   private static final Type MAP_STRING_STRING_TYPE = new TypeToken<Map<String, String>>() { }.getType();
   private static final String PROPERTY_COLUMN = "properties";
+  private static final Id.DatasetInstance configStoreDatasetInstanceId =
+    Id.DatasetInstance.from(Constants.SYSTEM_NAMESPACE, Constants.ConfigStore.CONFIG_TABLE);
 
   private final Transactional<ConfigTable, Table> txnl;
 
@@ -69,9 +72,9 @@ public class DefaultConfigStore implements ConfigStore {
       @Override
       public ConfigTable get() {
         try {
-          Table table = DatasetsUtil.getOrCreateDataset(dsFramework, Constants.ConfigStore.CONFIG_TABLE,
-                                                                "table", DatasetProperties.EMPTY,
-                                                                DatasetDefinition.NO_ARGUMENTS, null);
+          Table table = DatasetsUtil.getOrCreateDataset(dsFramework, configStoreDatasetInstanceId,
+                                                        "table", DatasetProperties.EMPTY,
+                                                        DatasetDefinition.NO_ARGUMENTS, null);
           return new ConfigTable(table);
         } catch (Exception e) {
           LOG.error("Failed to access {} table", Constants.ConfigStore.CONFIG_TABLE, e);
@@ -82,7 +85,7 @@ public class DefaultConfigStore implements ConfigStore {
   }
 
   public static void setupDatasets(DatasetFramework dsFramework) throws DatasetManagementException, IOException {
-    dsFramework.addInstance(Table.class.getName(), Constants.ConfigStore.CONFIG_TABLE, DatasetProperties.EMPTY);
+    dsFramework.addInstance(Table.class.getName(), configStoreDatasetInstanceId, DatasetProperties.EMPTY);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricHttpHandler.java
@@ -1045,7 +1045,7 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
       // remove all data in consolesettings
       consoleSettingsStore.delete();
 
-      dsFramework.deleteAllInstances();
+      dsFramework.deleteAllInstances(namespaceId);
       dsFramework.deleteAllModules();
 
       // todo: do efficiently and also remove timeseries metrics as well: CDAP-1125
@@ -1098,7 +1098,7 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
 
       LOG.info("Deleting all datasets for account '" + account + "'.");
 
-      dsFramework.deleteAllInstances();
+      dsFramework.deleteAllInstances(namespaceId);
 
       LOG.info("All datasets for account '" + account + "' deleted.");
       responder.sendStatus(HttpResponseStatus.OK);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/DatasetServiceStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/DatasetServiceStore.java
@@ -64,7 +64,9 @@ public final class DatasetServiceStore extends AbstractIdleService implements Se
 
   @Override
   protected void startUp() throws Exception {
-    table = DatasetsUtil.getOrCreateDataset(dsFramework, Constants.Service.SERVICE_INSTANCE_TABLE_NAME,
+    Id.DatasetInstance serviceStoreDatasetInstanceId =
+      Id.DatasetInstance.from(Constants.SYSTEM_NAMESPACE, Constants.Service.SERVICE_INSTANCE_TABLE_NAME);
+    table = DatasetsUtil.getOrCreateDataset(dsFramework, serviceStoreDatasetInstanceId,
                                             NoTxKeyValueTable.class.getName(),
                                             DatasetProperties.EMPTY, null, null);
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/util/AbstractAppFabricHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/util/AbstractAppFabricHttpHandler.java
@@ -374,7 +374,7 @@ public abstract class AbstractAppFabricHttpHandler extends AuthenticatedHttpHand
                                Id.Program programId, Data type, String name) {
     Id.Namespace namespace = new Id.Namespace(programId.getNamespaceId());
     if (type == Data.DATASET) {
-      DatasetSpecification dsSpec = getDatasetSpec(dsFramework, name);
+      DatasetSpecification dsSpec = getDatasetSpec(dsFramework, namespace, name);
       String typeName = null;
       if (dsSpec != null) {
         typeName = dsSpec.getType();
@@ -389,15 +389,16 @@ public abstract class AbstractAppFabricHttpHandler extends AuthenticatedHttpHand
 
   private String listDataEntities(Store store, DatasetFramework dsFramework,
                                   Id.Program programId, Data type) throws Exception {
+    Id.Namespace namespaceId = Id.Namespace.from(programId.getNamespaceId());
     if (type == Data.DATASET) {
-      Collection<DatasetSpecification> instances = dsFramework.getInstances();
+      Collection<DatasetSpecification> instances = dsFramework.getInstances(namespaceId);
       List<DatasetRecord> result = Lists.newArrayListWithExpectedSize(instances.size());
       for (DatasetSpecification instance : instances) {
         result.add(makeDataSetRecord(instance.getName(), instance.getType()));
       }
       return GSON.toJson(result);
     } else if (type == Data.STREAM) {
-      Collection<StreamSpecification> specs = store.getAllStreams(new Id.Namespace(programId.getNamespaceId()));
+      Collection<StreamSpecification> specs = store.getAllStreams(namespaceId);
       List<StreamRecord> result = Lists.newArrayListWithExpectedSize(specs.size());
       for (StreamSpecification spec : specs) {
         result.add(makeStreamRecord(spec.getName(), null));
@@ -418,7 +419,7 @@ public abstract class AbstractAppFabricHttpHandler extends AuthenticatedHttpHand
       List<DatasetRecord> result = Lists.newArrayListWithExpectedSize(dataSetsUsed.size());
       for (String dsName : dataSetsUsed) {
         String typeName = null;
-        DatasetSpecification dsSpec = getDatasetSpec(dsFramework, dsName);
+        DatasetSpecification dsSpec = getDatasetSpec(dsFramework, namespace, dsName);
         if (dsSpec != null) {
           typeName = dsSpec.getType();
         }
@@ -438,9 +439,9 @@ public abstract class AbstractAppFabricHttpHandler extends AuthenticatedHttpHand
   }
 
   @Nullable
-  private DatasetSpecification getDatasetSpec(DatasetFramework dsFramework, String dsName) {
+  private DatasetSpecification getDatasetSpec(DatasetFramework dsFramework, Id.Namespace namespaceId, String dsName) {
     try {
-      return dsFramework.getDatasetSpec(dsName);
+      return dsFramework.getDatasetSpec(Id.DatasetInstance.from(namespaceId, dsName));
     } catch (Exception e) {
       LOG.warn("Couldn't get spec for dataset: " + dsName);
       return null;
@@ -518,10 +519,10 @@ public abstract class AbstractAppFabricHttpHandler extends AuthenticatedHttpHand
   private List<ProgramRecord> listProgramsByDataAccess(Store store, DatasetFramework dsFramework,
                                                        Id.Program programId, ProgramType type,
                                                        Data data, String name) throws Exception {
+    Id.Namespace namespaceId = programId.getApplication().getNamespace();
     // search all apps for programs that use this
     List<ProgramRecord> result = Lists.newArrayList();
-    Collection<ApplicationSpecification> appSpecs = store.getAllApplications(
-      new Id.Namespace(programId.getNamespaceId()));
+    Collection<ApplicationSpecification> appSpecs = store.getAllApplications(namespaceId);
     if (appSpecs != null) {
       for (ApplicationSpecification appSpec : appSpecs) {
         if (type == ProgramType.FLOW) {
@@ -552,7 +553,7 @@ public abstract class AbstractAppFabricHttpHandler extends AuthenticatedHttpHand
     // if no programs were found, check whether the data exists, return [] if yes, null if not
     boolean exists = false;
     if (data == Data.DATASET) {
-      exists = dsFramework.hasInstance(name);
+      exists = dsFramework.hasInstance(Id.DatasetInstance.from(namespaceId, name));
     } else if (data == Data.STREAM) {
       exists = store.getStream(new Id.Namespace(Constants.DEFAULT_NAMESPACE), name) != null;
     }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/CreateDatasetInstancesStage.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/CreateDatasetInstancesStage.java
@@ -21,6 +21,7 @@ import co.cask.cdap.data.dataset.DatasetCreationSpec;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.InstanceConflictException;
 import co.cask.cdap.pipeline.AbstractStage;
+import co.cask.cdap.proto.Id;
 import com.google.common.reflect.TypeToken;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,12 +51,14 @@ public class CreateDatasetInstancesStage extends AbstractStage<ApplicationDeploy
   public void process(ApplicationDeployable input) throws Exception {
     // create dataset instances
     ApplicationSpecification specification = input.getSpecification();
+    Id.Namespace namespaceId = input.getId().getNamespace();
     for (Map.Entry<String, DatasetCreationSpec> instanceEntry : specification.getDatasets().entrySet()) {
       String instanceName = instanceEntry.getKey();
+      Id.DatasetInstance instanceId = Id.DatasetInstance.from(namespaceId, instanceName);
       DatasetCreationSpec instanceSpec = instanceEntry.getValue();
       try {
-        if (!datasetFramework.hasInstance(instanceName)) {
-          datasetFramework.addInstance(instanceSpec.getTypeName(), instanceName, instanceSpec.getProperties());
+        if (!datasetFramework.hasInstance(instanceId)) {
+          datasetFramework.addInstance(instanceSpec.getTypeName(), instanceId, instanceSpec.getProperties());
         }
       } catch (InstanceConflictException e) {
         // NO-OP: Instance is simply already created, possibly by an older version of this app OR a different app

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/VerificationStage.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/VerificationStage.java
@@ -99,7 +99,8 @@ public class VerificationStage extends AbstractStage<ApplicationDeployable> {
         throw new RuntimeException(result.getMessage());
       }
       String dsName = dataSetCreateSpec.getInstanceName();
-      DatasetSpecification existingSpec = dsFramework.getDatasetSpec(dsName);
+      Id.DatasetInstance datasetInstanceId = Id.DatasetInstance.from(appId.getNamespace(), dsName);
+      DatasetSpecification existingSpec = dsFramework.getDatasetSpec(datasetInstanceId);
       if (existingSpec != null && !existingSpec.getType().equals(dataSetCreateSpec.getTypeName())) {
           // New app trying to deploy an dataset with same instanceName but different Type than that of existing.
           throw new DataSetException

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractContext.java
@@ -30,6 +30,7 @@ import co.cask.cdap.common.metrics.MetricsCollector;
 import co.cask.cdap.data.dataset.DatasetInstantiator;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.internal.app.program.TypeId;
+import co.cask.cdap.proto.Id;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import org.apache.twill.api.RunId;
@@ -71,7 +72,8 @@ public abstract class AbstractContext extends AbstractServiceDiscoverer implemen
     this.discoveryServiceClient = discoveryServiceClient;
 
     this.programMetrics = metricsCollector;
-    this.dsInstantiator = new DatasetInstantiator(dsFramework, conf, program.getClassLoader(), programMetrics);
+    this.dsInstantiator = new DatasetInstantiator(Id.Namespace.from(namespaceId), dsFramework, conf,
+                                                  program.getClassLoader(), programMetrics);
 
     // todo: this should be instantiated on demand, at run-time dynamically. Esp. bad to do that in ctor...
     // todo: initialized datasets should be managed by DatasetContext (ie. DatasetInstantiator): refactor further

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/DynamicMapReduceContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/DynamicMapReduceContext.java
@@ -30,6 +30,7 @@ import co.cask.cdap.data2.dataset2.DatasetCacheKey;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.DynamicDatasetContext;
 import co.cask.cdap.data2.dataset2.NamespacedDatasetFramework;
+import co.cask.cdap.proto.Id;
 import co.cask.tephra.TransactionContext;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -65,11 +66,9 @@ public class DynamicMapReduceContext extends DynamicDatasetContext implements Ma
                                  DatasetFramework datasetFramework,
                                  TransactionContext transactionContext,
                                  CConfiguration cConf) {
-    super(transactionContext,
+    super(Id.Namespace.from(mapReduceContext.getNamespaceId()), transactionContext,
           new NamespacedDatasetFramework(datasetFramework, new DefaultDatasetNamespace(cConf, Namespace.USER)),
-          mapReduceContext.getProgram().getClassLoader(),
-          null,
-          mapReduceContext.getRuntimeArguments());
+          mapReduceContext.getProgram().getClassLoader(), null, mapReduceContext.getRuntimeArguments());
     this.mapReduceContext = mapReduceContext;
     this.datasetsCache = CacheBuilder.newBuilder()
       .removalListener(new RemovalListener<Long, Map<DatasetCacheKey, Dataset>>() {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/ScheduleStoreTableUtil.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/ScheduleStoreTableUtil.java
@@ -22,6 +22,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.DatasetManagementException;
 import co.cask.cdap.data2.dataset2.lib.table.MetaTableUtil;
+import co.cask.cdap.proto.Id;
 import com.google.inject.Inject;
 
 import java.io.IOException;
@@ -48,6 +49,8 @@ public class ScheduleStoreTableUtil extends MetaTableUtil {
    * @param datasetFramework framework to add types and datasets to
    */
   public static void setupDatasets(DatasetFramework datasetFramework) throws IOException, DatasetManagementException {
-    datasetFramework.addInstance(OrderedTable.class.getName(), SCHEDULE_STORE_DATASET_NAME, DatasetProperties.EMPTY);
+    Id.DatasetInstance scheduleStoreDatasetInstance =
+      Id.DatasetInstance.from(SYSTEM_NAMESPACE, SCHEDULE_STORE_DATASET_NAME);
+    datasetFramework.addInstance(OrderedTable.class.getName(), scheduleStoreDatasetInstance, DatasetProperties.EMPTY);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/BasicServiceWorkerContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/BasicServiceWorkerContext.java
@@ -37,6 +37,7 @@ import co.cask.cdap.data2.dataset2.DynamicDatasetContext;
 import co.cask.cdap.data2.dataset2.NamespacedDatasetFramework;
 import co.cask.cdap.internal.app.runtime.AbstractContext;
 import co.cask.cdap.logging.context.UserServiceLoggingContext;
+import co.cask.cdap.proto.Id;
 import co.cask.tephra.TransactionContext;
 import co.cask.tephra.TransactionFailureException;
 import co.cask.tephra.TransactionSystemClient;
@@ -163,8 +164,8 @@ public class BasicServiceWorkerContext extends AbstractContext implements Servic
     final TransactionContext context = new TransactionContext(transactionSystemClient);
     try {
       context.start();
-      runnable.run(new DynamicDatasetContext(context, datasetFramework, getProgram().getClassLoader(),
-                                             datasets, runtimeArgs) {
+      runnable.run(new DynamicDatasetContext(Id.Namespace.from(program.getNamespaceId()), context, datasetFramework,
+                                             getProgram().getClassLoader(), datasets, runtimeArgs) {
         @Override
         protected LoadingCache<Long, Map<DatasetCacheKey, Dataset>> getDatasetsCache() {
           return datasetsCache;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
@@ -93,6 +93,8 @@ import javax.annotation.Nullable;
 public class DefaultStore implements Store {
   public static final String APP_META_TABLE = "app.meta";
   private static final Logger LOG = LoggerFactory.getLogger(DefaultStore.class);
+  private static final Id.DatasetInstance appMetaDatasetInstanceId =
+    Id.DatasetInstance.from(Constants.SYSTEM_NAMESPACE, APP_META_TABLE);
 
   private final LocationFactory locationFactory;
   private final CConfiguration configuration;
@@ -121,7 +123,7 @@ public class DefaultStore implements Store {
           @Override
           public AppMds get() {
             try {
-              Table mdsTable = DatasetsUtil.getOrCreateDataset(dsFramework, APP_META_TABLE, "table",
+              Table mdsTable = DatasetsUtil.getOrCreateDataset(dsFramework, appMetaDatasetInstanceId, "table",
                                                                DatasetProperties.EMPTY,
                                                                DatasetDefinition.NO_ARGUMENTS, null);
               return new AppMds(mdsTable);
@@ -138,7 +140,7 @@ public class DefaultStore implements Store {
    * @param framework framework to add types and datasets to
    */
   public static void setupDatasets(DatasetFramework framework) throws IOException, DatasetManagementException {
-    framework.addInstance(Table.class.getName(), APP_META_TABLE, DatasetProperties.EMPTY);
+    framework.addInstance(Table.class.getName(), appMetaDatasetInstanceId, DatasetProperties.EMPTY);
   }
 
   @Nullable
@@ -875,7 +877,7 @@ public class DefaultStore implements Store {
 
   @VisibleForTesting
   void clear() throws Exception {
-    DatasetAdmin admin = dsFramework.getAdmin(APP_META_TABLE, null);
+    DatasetAdmin admin = dsFramework.getAdmin(appMetaDatasetInstanceId, null);
     if (admin != null) {
       admin.truncate();
     }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceWithPartitionedTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceWithPartitionedTest.java
@@ -43,6 +43,7 @@ import co.cask.cdap.internal.app.runtime.AbstractListener;
 import co.cask.cdap.internal.app.runtime.BasicArguments;
 import co.cask.cdap.internal.app.runtime.ProgramRunnerFactory;
 import co.cask.cdap.internal.app.runtime.SimpleProgramOptions;
+import co.cask.cdap.proto.Id;
 import co.cask.cdap.test.XSlowTests;
 import co.cask.cdap.test.internal.AppFabricTestHelper;
 import co.cask.tephra.TransactionExecutor;
@@ -80,6 +81,7 @@ import static co.cask.cdap.internal.app.runtime.batch.AppWithTimePartitionedFile
  * app-fabric tests, explore is disabled.
  */
 public class MapReduceWithPartitionedTest {
+  private static final Id.Namespace namespaceId = Id.Namespace.from("myspace");
   private static Injector injector;
   private static TransactionExecutorFactory txExecutorFactory;
 
@@ -116,7 +118,7 @@ public class MapReduceWithPartitionedTest {
 
     DatasetFramework datasetFramework = injector.getInstance(DatasetFramework.class);
     datasetInstantiator =
-      new DatasetInstantiator(datasetFramework, injector.getInstance(CConfiguration.class),
+      new DatasetInstantiator(namespaceId, datasetFramework, injector.getInstance(CConfiguration.class),
                               MapReduceWithPartitionedTest.class.getClassLoader(), null);
 
     txService.startAndWait();
@@ -130,8 +132,8 @@ public class MapReduceWithPartitionedTest {
   @After
   public void after() throws Exception {
     // cleanup user data (only user datasets)
-    for (DatasetSpecification spec : dsFramework.getInstances()) {
-      dsFramework.deleteInstance(spec.getName());
+    for (DatasetSpecification spec : dsFramework.getInstances(namespaceId)) {
+      dsFramework.deleteInstance(Id.DatasetInstance.from(namespaceId, spec.getName()));
     }
   }
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/spark/SparkProgramRunnerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/spark/SparkProgramRunnerTest.java
@@ -35,6 +35,7 @@ import co.cask.cdap.internal.app.runtime.AbstractListener;
 import co.cask.cdap.internal.app.runtime.BasicArguments;
 import co.cask.cdap.internal.app.runtime.ProgramRunnerFactory;
 import co.cask.cdap.internal.app.runtime.SimpleProgramOptions;
+import co.cask.cdap.proto.Id;
 import co.cask.cdap.test.XSlowTests;
 import co.cask.cdap.test.internal.AppFabricTestHelper;
 import co.cask.cdap.test.internal.TempFolder;
@@ -81,6 +82,8 @@ public class SparkProgramRunnerTest {
   final String testString1 = "persisted data";
   final String testString2 = "distributed systems";
 
+  private static final Id.Namespace namespaceId = Id.Namespace.from("myspace");
+
   @ClassRule
   public static TemporaryFolder tmpFolder = new TemporaryFolder();
 
@@ -111,7 +114,7 @@ public class SparkProgramRunnerTest {
 
     DatasetFramework datasetFramework = injector.getInstance(DatasetFramework.class);
     datasetInstantiator =
-      new DatasetInstantiator(datasetFramework, injector.getInstance(CConfiguration.class),
+      new DatasetInstantiator(namespaceId, datasetFramework, injector.getInstance(CConfiguration.class),
                               SparkProgramRunnerTest.class.getClassLoader(), null);
 
     txService.startAndWait();
@@ -125,8 +128,8 @@ public class SparkProgramRunnerTest {
   @After
   public void after() throws Exception {
     // cleanup user data (only user datasets)
-    for (DatasetSpecification spec : dsFramework.getInstances()) {
-      dsFramework.deleteInstance(spec.getName());
+    for (DatasetSpecification spec : dsFramework.getInstances(namespaceId)) {
+      dsFramework.deleteInstance(Id.DatasetInstance.from(namespaceId, spec.getName()));
     }
   }
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/runtime/MultiConsumerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/runtime/MultiConsumerTest.java
@@ -26,6 +26,7 @@ import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.internal.app.deploy.pipeline.ApplicationWithPrograms;
 import co.cask.cdap.internal.app.runtime.ProgramRunnerFactory;
 import co.cask.cdap.internal.app.runtime.SimpleProgramOptions;
+import co.cask.cdap.proto.Id;
 import co.cask.cdap.runtime.app.MultiApp;
 import co.cask.cdap.test.internal.AppFabricTestHelper;
 import co.cask.tephra.TransactionExecutor;
@@ -80,8 +81,9 @@ public class MultiConsumerTest {
 
     DatasetFramework datasetFramework = AppFabricTestHelper.getInjector().getInstance(DatasetFramework.class);
 
-    DatasetInstantiator datasetInstantiator =
-      new DatasetInstantiator(datasetFramework, CConfiguration.create(), getClass().getClassLoader(), null);
+    DatasetInstantiator datasetInstantiator = new DatasetInstantiator(Id.Namespace.from("myspace"), datasetFramework,
+                                                                      CConfiguration.create(),
+                                                                      getClass().getClassLoader(), null);
 
     final KeyValueTable accumulated = datasetInstantiator.getDataset("accumulated");
     TransactionExecutorFactory txExecutorFactory =

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseMetricsTableTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseMetricsTableTest.java
@@ -129,7 +129,8 @@ public class HBaseMetricsTableTest extends MetricsTableTest {
 
   @Override
   protected MetricsTable getTable(String name) throws Exception {
-    return DatasetsUtil.getOrCreateDataset(dsFramework, name, MetricsTable.class.getName(),
+    Id.DatasetInstance metricsDatasetInstanceId = Id.DatasetInstance.from(NAMESPACE_ID, name);
+    return DatasetsUtil.getOrCreateDataset(dsFramework, metricsDatasetInstanceId, MetricsTable.class.getName(),
                                            DatasetProperties.EMPTY, null, null);
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/dataset/DatasetInstantiator.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/dataset/DatasetInstantiator.java
@@ -28,6 +28,7 @@ import co.cask.cdap.data.Namespace;
 import co.cask.cdap.data2.datafabric.DefaultDatasetNamespace;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.NamespacedDatasetFramework;
+import co.cask.cdap.proto.Id;
 import co.cask.tephra.TransactionAware;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
@@ -59,17 +60,22 @@ public class DatasetInstantiator implements DatasetContext {
   private final Map<TransactionAware, String> txAwareToMetricNames = Maps.newIdentityHashMap();
 
   private final MetricsCollector metricsCollector;
+  private final Id.Namespace namespaceId;
 
   /**
    * Constructor from data fabric.
+   *
+   * @param namespaceId the {@link Id.Namespace} in which this dataset exists
    * @param classLoader the class loader to use for loading data set classes.
    *                    If null, then the default class loader is used
    */
-  public DatasetInstantiator(DatasetFramework datasetFramework,
+  public DatasetInstantiator(Id.Namespace namespaceId,
+                             DatasetFramework datasetFramework,
                              CConfiguration configuration,
                              ClassLoader classLoader,
                              @Nullable
                              MetricsCollector metricsCollector) {
+    this.namespaceId = namespaceId;
     this.classLoader = classLoader;
     this.metricsCollector = metricsCollector;
     // todo: should be passed in already namespaced. Refactor
@@ -91,11 +97,11 @@ public class DatasetInstantiator implements DatasetContext {
 
     T dataset;
     try {
-      if (!datasetFramework.hasInstance(name)) {
+      if (!datasetFramework.hasInstance(Id.DatasetInstance.from(namespaceId, name))) {
         throw new DatasetInstantiationException("Trying to access dataset that does not exist: " + name);
       }
 
-      dataset = datasetFramework.getDataset(name, arguments, classLoader);
+      dataset = datasetFramework.getDataset(Id.DatasetInstance.from(namespaceId, name), arguments, classLoader);
       if (dataset == null) {
         throw new DatasetInstantiationException("Failed to access dataset: " + name);
       }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/MDSStreamMetaStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/MDSStreamMetaStore.java
@@ -21,6 +21,7 @@ import co.cask.cdap.api.dataset.DatasetDefinition;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data.Namespace;
 import co.cask.cdap.data2.datafabric.DefaultDatasetNamespace;
 import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
@@ -76,7 +77,9 @@ public final class MDSStreamMetaStore implements StreamMetaStore {
           @Override
           public StreamMds get() {
             try {
-              Table mdsTable = DatasetsUtil.getOrCreateDataset(dsFramework, STREAM_META_TABLE, "table",
+              Id.DatasetInstance streamMetaDatasetInstanceId = Id.DatasetInstance.from(Constants.SYSTEM_NAMESPACE,
+                                                                                       STREAM_META_TABLE);
+              Table mdsTable = DatasetsUtil.getOrCreateDataset(dsFramework, streamMetaDatasetInstanceId, "table",
                                                                DatasetProperties.EMPTY,
                                                                DatasetDefinition.NO_ARGUMENTS, null);
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetMetaTableUtil.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetMetaTableUtil.java
@@ -34,6 +34,11 @@ public class DatasetMetaTableUtil {
   public static final String META_TABLE_NAME = "datasets.type";
   public static final String INSTANCE_TABLE_NAME = "datasets.instance";
 
+  private static final Id.DatasetInstance metaTableInstanceId = Id.DatasetInstance.from(Constants.SYSTEM_NAMESPACE,
+                                                                                        META_TABLE_NAME);
+  private static final Id.DatasetInstance instanceTableInstanceId = Id.DatasetInstance.from(Constants.SYSTEM_NAMESPACE,
+                                                                                            INSTANCE_TABLE_NAME);
+
   private final DatasetFramework framework;
 
   public DatasetMetaTableUtil(DatasetFramework framework) {
@@ -45,13 +50,13 @@ public class DatasetMetaTableUtil {
   }
 
   public DatasetTypeMDS getTypeMetaTable() throws DatasetManagementException, IOException {
-    return (DatasetTypeMDS) DatasetsUtil.getOrCreateDataset(framework, META_TABLE_NAME,
+    return (DatasetTypeMDS) DatasetsUtil.getOrCreateDataset(framework, metaTableInstanceId,
                                                             DatasetTypeMDS.class.getName(),
                                                             DatasetProperties.EMPTY, null, null);
   }
 
   public DatasetInstanceMDS getInstanceMetaTable() throws DatasetManagementException, IOException {
-    return (DatasetInstanceMDS) DatasetsUtil.getOrCreateDataset(framework, INSTANCE_TABLE_NAME,
+    return (DatasetInstanceMDS) DatasetsUtil.getOrCreateDataset(framework, instanceTableInstanceId,
                                                                 DatasetInstanceMDS.class.getName(),
                                                                 DatasetProperties.EMPTY, null, null);
   }
@@ -62,10 +67,8 @@ public class DatasetMetaTableUtil {
    */
   public static void setupDatasets(DatasetFramework datasetFramework) throws IOException, DatasetManagementException {
     addTypes(datasetFramework);
-    datasetFramework.addInstance(DatasetTypeMDS.class.getName(),
-                                 DatasetMetaTableUtil.META_TABLE_NAME, DatasetProperties.EMPTY);
-    datasetFramework.addInstance(DatasetInstanceMDS.class.getName(),
-                                 DatasetMetaTableUtil.INSTANCE_TABLE_NAME, DatasetProperties.EMPTY);
+    datasetFramework.addInstance(DatasetTypeMDS.class.getName(), metaTableInstanceId, DatasetProperties.EMPTY);
+    datasetFramework.addInstance(DatasetInstanceMDS.class.getName(), instanceTableInstanceId, DatasetProperties.EMPTY);
   }
 
   private static void addTypes(DatasetFramework framework) throws DatasetManagementException {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetsUtil.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetsUtil.java
@@ -21,6 +21,7 @@ import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.DatasetManagementException;
 import co.cask.cdap.data2.dataset2.InstanceConflictException;
+import co.cask.cdap.proto.Id;
 import com.google.common.base.Throwables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,31 +45,31 @@ public final class DatasetsUtil {
    * NOTE: does poor job guarding against races, i.e. only one client for this dataset instance is supported at a time
    */
   public static <T extends Dataset> T getOrCreateDataset(DatasetFramework datasetFramework,
-                                                         String instanceName, String typeName,
+                                                         Id.DatasetInstance datasetInstanceId, String typeName,
                                                          DatasetProperties props,
                                                          Map<String, String> arguments,
                                                          ClassLoader cl)
     throws DatasetManagementException, IOException {
 
-    createIfNotExists(datasetFramework, instanceName, typeName, props);
-    return (T) datasetFramework.getDataset(instanceName, arguments, null);
+    createIfNotExists(datasetFramework, datasetInstanceId, typeName, props);
+    return (T) datasetFramework.getDataset(datasetInstanceId, arguments, null);
   }
 
   /**
    * Creates instance of the data set if not exists
    */
   public static void createIfNotExists(DatasetFramework datasetFramework,
-                                       String instanceName, String typeName,
+                                       Id.DatasetInstance datasetInstanceId, String typeName,
                                        DatasetProperties props) throws DatasetManagementException, IOException {
 
-    if (!datasetFramework.hasInstance(instanceName)) {
+    if (!datasetFramework.hasInstance(datasetInstanceId)) {
       try {
-        datasetFramework.addInstance(typeName, instanceName, props);
+        datasetFramework.addInstance(typeName, datasetInstanceId, props);
       } catch (InstanceConflictException e) {
         // Do nothing: someone created this instance in between, just continuing
       } catch (DatasetManagementException e) {
         LOG.error("Could NOT add dataset instance {} of type {} with props {}",
-                  instanceName, typeName, props, e);
+                  datasetInstanceId, typeName, props, e);
         throw Throwables.propagate(e);
       }
     }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFramework.java
@@ -110,33 +110,32 @@ public class RemoteDatasetFramework implements DatasetFramework {
   }
 
   @Override
-  public void addInstance(String datasetType, String datasetInstanceName, DatasetProperties props)
+  public void addInstance(String datasetType, Id.DatasetInstance datasetInstanceId, DatasetProperties props)
     throws DatasetManagementException {
-
-    client.addInstance(datasetInstanceName, datasetType, props);
+    client.addInstance(datasetInstanceId.getId(), datasetType, props);
   }
 
   @Override
-  public void updateInstance(String datasetInstanceName, DatasetProperties props)
+  public void updateInstance(Id.DatasetInstance datasetInstanceId, DatasetProperties props)
     throws DatasetManagementException {
-    client.updateInstance(datasetInstanceName, props);
+    client.updateInstance(datasetInstanceId.getId(), props);
   }
 
   @Override
-  public Collection<DatasetSpecification> getInstances() throws DatasetManagementException {
+  public Collection<DatasetSpecification> getInstances(Id.Namespace namespaceId) throws DatasetManagementException {
     return client.getAllInstances();
   }
 
   @Nullable
   @Override
-  public DatasetSpecification getDatasetSpec(String name) throws DatasetManagementException {
-    DatasetMeta meta = client.getInstance(name);
+  public DatasetSpecification getDatasetSpec(Id.DatasetInstance datasetInstanceId) throws DatasetManagementException {
+    DatasetMeta meta = client.getInstance(datasetInstanceId.getId());
     return meta == null ? null : meta.getSpec();
   }
 
   @Override
-  public boolean hasInstance(String instanceName) throws DatasetManagementException {
-    return client.getInstance(instanceName) != null;
+  public boolean hasInstance(Id.DatasetInstance datasetInstanceId) throws DatasetManagementException {
+    return client.getInstance(datasetInstanceId.getId()) != null;
   }
 
   @Override
@@ -145,23 +144,23 @@ public class RemoteDatasetFramework implements DatasetFramework {
   }
 
   @Override
-  public void deleteInstance(String datasetInstanceName) throws DatasetManagementException {
-    client.deleteInstance(datasetInstanceName);
+  public void deleteInstance(Id.DatasetInstance datasetInstanceId) throws DatasetManagementException {
+    client.deleteInstance(datasetInstanceId.getId());
   }
 
   @Override
-  public void deleteAllInstances() throws DatasetManagementException, IOException {
+  public void deleteAllInstances(Id.Namespace namespaceId) throws DatasetManagementException, IOException {
     // delete all one by one
-    for (DatasetSpecification spec : getInstances()) {
-      deleteInstance(spec.getName());
+    for (DatasetSpecification spec : getInstances(namespaceId)) {
+      Id.DatasetInstance datasetInstanceId = Id.DatasetInstance.from(namespaceId, spec.getName());
+      deleteInstance(datasetInstanceId);
     }
   }
 
   @Override
-  public <T extends DatasetAdmin> T getAdmin(String datasetInstanceName, ClassLoader classLoader)
+  public <T extends DatasetAdmin> T getAdmin(Id.DatasetInstance datasetInstanceId, ClassLoader classLoader)
     throws DatasetManagementException, IOException {
-
-    DatasetMeta instanceInfo = client.getInstance(datasetInstanceName);
+    DatasetMeta instanceInfo = client.getInstance(datasetInstanceId.getId());
     if (instanceInfo == null) {
       return null;
     }
@@ -171,10 +170,9 @@ public class RemoteDatasetFramework implements DatasetFramework {
   }
 
   @Override
-  public <T extends Dataset> T getDataset(String datasetInstanceName, Map<String, String> arguments,
+  public <T extends Dataset> T getDataset(Id.DatasetInstance datasetInstanceId, Map<String, String> arguments,
                                           ClassLoader classLoader) throws DatasetManagementException, IOException {
-
-    DatasetMeta instanceInfo = client.getInstance(datasetInstanceName);
+    DatasetMeta instanceInfo = client.getInstance(datasetInstanceId.getId());
     if (instanceInfo == null) {
       return null;
     }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/DatasetAdminOpHTTPHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/DatasetAdminOpHTTPHandler.java
@@ -27,12 +27,12 @@ import co.cask.cdap.data2.dataset2.DatasetManagementException;
 import co.cask.cdap.gateway.auth.Authenticator;
 import co.cask.cdap.gateway.handlers.AuthenticatedHttpHandler;
 import co.cask.cdap.proto.DatasetTypeMeta;
+import co.cask.cdap.proto.Id;
 import co.cask.http.HttpResponder;
 import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 import com.google.gson.Gson;
 import com.google.inject.Inject;
-import com.google.inject.Singleton;
 import org.apache.commons.lang.StringUtils;
 import org.jboss.netty.handler.codec.http.HttpRequest;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
@@ -40,7 +40,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -67,8 +66,9 @@ public class DatasetAdminOpHTTPHandler extends AuthenticatedHttpHandler {
   public void exists(HttpRequest request, HttpResponder responder,
                      @PathParam("namespace-id") String namespaceId,
                      @PathParam("name") String instanceName) {
+    Id.Namespace namespace = Id.Namespace.from(namespaceId);
     try {
-      DatasetAdmin datasetAdmin = getDatasetAdmin(instanceName);
+      DatasetAdmin datasetAdmin = getDatasetAdmin(Id.DatasetInstance.from(namespace, instanceName));
       responder.sendJson(HttpResponseStatus.OK, new DatasetAdminOpResponse(datasetAdmin.exists(), null));
     } catch (HandlerException e) {
       LOG.debug("Got handler exception", e);
@@ -84,7 +84,7 @@ public class DatasetAdminOpHTTPHandler extends AuthenticatedHttpHandler {
   public void create(HttpRequest request, HttpResponder responder,
                      @PathParam("namespace-id") String namespaceId,
                      @PathParam("name") String name) throws Exception {
-
+    // TODO: Use namespaceId here
     InternalDatasetCreationParams params = GSON.fromJson(request.getContent().toString(Charsets.UTF_8),
                                                          InternalDatasetCreationParams.class);
     Preconditions.checkArgument(params.getProperties() != null, "Missing required 'instanceProps' parameter.");
@@ -143,8 +143,9 @@ public class DatasetAdminOpHTTPHandler extends AuthenticatedHttpHandler {
   public void truncate(HttpRequest request, HttpResponder responder,
                        @PathParam("namespace-id") String namespaceId,
                        @PathParam("name") String instanceName) {
+    Id.Namespace namespace = Id.Namespace.from(namespaceId);
     try {
-      DatasetAdmin datasetAdmin = getDatasetAdmin(instanceName);
+      DatasetAdmin datasetAdmin = getDatasetAdmin(Id.DatasetInstance.from(namespace, instanceName));
       datasetAdmin.truncate();
       responder.sendJson(HttpResponseStatus.OK, new DatasetAdminOpResponse(null, null));
     } catch (HandlerException e) {
@@ -161,8 +162,9 @@ public class DatasetAdminOpHTTPHandler extends AuthenticatedHttpHandler {
   public void upgrade(HttpRequest request, HttpResponder responder,
                       @PathParam("namespace-id") String namespaceId,
                       @PathParam("name") String instanceName) {
+    Id.Namespace namespace = Id.Namespace.from(namespaceId);
     try {
-      DatasetAdmin datasetAdmin = getDatasetAdmin(instanceName);
+      DatasetAdmin datasetAdmin = getDatasetAdmin(Id.DatasetInstance.from(namespace, instanceName));
       datasetAdmin.upgrade();
       responder.sendJson(HttpResponseStatus.OK, new DatasetAdminOpResponse(null, null));
     } catch (HandlerException e) {
@@ -178,11 +180,12 @@ public class DatasetAdminOpHTTPHandler extends AuthenticatedHttpHandler {
     return String.format("Error executing admin operation %s for dataset instance %s", opName, instanceName);
   }
 
-  private DatasetAdmin getDatasetAdmin(String instanceName) throws IOException, DatasetManagementException {
-    DatasetAdmin admin = dsFramework.getAdmin(instanceName, null);
+  private DatasetAdmin getDatasetAdmin(Id.DatasetInstance datasetInstanceId)
+    throws IOException, DatasetManagementException {
+    DatasetAdmin admin = dsFramework.getAdmin(datasetInstanceId, null);
     if (admin == null) {
       throw new HandlerException(HttpResponseStatus.NOT_FOUND,
-                                 "Couldn't obtain DatasetAdmin for dataset instance " + instanceName);
+                                 "Couldn't obtain DatasetAdmin for dataset instance " + datasetInstanceId);
     }
     return admin;
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/DatasetOpExecutor.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/DatasetOpExecutor.java
@@ -19,6 +19,7 @@ package co.cask.cdap.data2.datafabric.dataset.service.executor;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.proto.DatasetTypeMeta;
+import co.cask.cdap.proto.Id;
 import com.google.common.util.concurrent.Service;
 
 import java.io.IOException;
@@ -29,42 +30,50 @@ import java.io.IOException;
 public interface DatasetOpExecutor extends Service {
 
   /**
-   * @param instanceName Name of the dataset instance.
+   * Checks for the existence of a dataset instance
+   *
+   * @param datasetInstanceId {@link Id.DatasetInstance} of the dataset instance.
    * @return true if dataset exists
    * @throws IOException
    */
-  boolean exists(String instanceName) throws Exception;
+  boolean exists(Id.DatasetInstance datasetInstanceId) throws Exception;
 
   /**
-   * Creates dataset.
-   * @param instanceName Name of the dataset instance.
+   * Creates a dataset.
+   *
+   * @param datasetInstanceId {@link Id.DatasetInstance} of the dataset instance.
    * @param typeMeta Data set type meta
    * @param props Data set instance properties
    * @throws IOException
    */
-  DatasetSpecification create(String instanceName, DatasetTypeMeta typeMeta, DatasetProperties props)
+  DatasetSpecification create(Id.DatasetInstance datasetInstanceId, DatasetTypeMeta typeMeta, DatasetProperties props)
     throws Exception;
 
   /**
    * Drops dataset.
+   *
+   *
+   * @param datasetInstanceId {@link Id.DatasetInstance} of the dataset instance.
    * @param typeMeta Data set type meta
    * @param spec Data set instance spec
    * @throws IOException
    */
-  void drop(DatasetSpecification spec, DatasetTypeMeta typeMeta) throws Exception;
+  void drop(Id.DatasetInstance datasetInstanceId, DatasetTypeMeta typeMeta, DatasetSpecification spec) throws Exception;
 
   /**
    * Deletes all data of the dataset.
-   * @param instanceName Name of the dataset instance.
+   *
+   * @param datasetInstanceId {@link Id.DatasetInstance} of the dataset instance.
    * @throws IOException
    */
-  void truncate(String instanceName) throws Exception;
+  void truncate(Id.DatasetInstance datasetInstanceId) throws Exception;
 
   /**
    * Upgrades dataset.
-   * @param instanceName Name of the dataset instance.
+   *
+   * @param datasetInstanceId {@link Id.DatasetInstance} of the dataset instance.
    * @throws IOException
    */
-  void upgrade(String instanceName) throws Exception;
+  void upgrade(Id.DatasetInstance datasetInstanceId) throws Exception;
 
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/InMemoryDatasetOpExecutor.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/InMemoryDatasetOpExecutor.java
@@ -23,6 +23,7 @@ import co.cask.cdap.data2.datafabric.dataset.DatasetType;
 import co.cask.cdap.data2.datafabric.dataset.RemoteDatasetFramework;
 import co.cask.cdap.data2.dataset2.DatasetManagementException;
 import co.cask.cdap.proto.DatasetTypeMeta;
+import co.cask.cdap.proto.Id;
 import com.google.common.util.concurrent.AbstractIdleService;
 import com.google.inject.Inject;
 
@@ -41,12 +42,13 @@ public class InMemoryDatasetOpExecutor extends AbstractIdleService implements Da
   }
 
   @Override
-  public boolean exists(String instanceName) throws Exception {
-    return getAdmin(instanceName).exists();
+  public boolean exists(Id.DatasetInstance datasetInstanceId) throws Exception {
+    return getAdmin(datasetInstanceId).exists();
   }
 
   @Override
-  public DatasetSpecification create(String instanceName, DatasetTypeMeta typeMeta, DatasetProperties props)
+  public DatasetSpecification create(Id.DatasetInstance datasetInstanceId, DatasetTypeMeta typeMeta,
+                                     DatasetProperties props)
     throws Exception {
 
     DatasetType type = client.getDatasetType(typeMeta, null);
@@ -55,7 +57,8 @@ public class InMemoryDatasetOpExecutor extends AbstractIdleService implements Da
       throw new IllegalArgumentException("Dataset type cannot be instantiated for provided type meta: " + typeMeta);
     }
 
-    DatasetSpecification spec = type.configure(instanceName, props);
+    // TODO: Note - for now, just sending the name. However, type likely needs to be namesapce-aware too.
+    DatasetSpecification spec = type.configure(datasetInstanceId.getId(), props);
     DatasetAdmin admin = type.getAdmin(spec);
     admin.create();
 
@@ -63,7 +66,8 @@ public class InMemoryDatasetOpExecutor extends AbstractIdleService implements Da
   }
 
   @Override
-  public void drop(DatasetSpecification spec, DatasetTypeMeta typeMeta) throws Exception {
+  public void drop(Id.DatasetInstance datasetInstanceId, DatasetTypeMeta typeMeta,
+                   DatasetSpecification spec) throws Exception {
     DatasetType type = client.getDatasetType(typeMeta, null);
 
     if (type == null) {
@@ -75,13 +79,13 @@ public class InMemoryDatasetOpExecutor extends AbstractIdleService implements Da
   }
 
   @Override
-  public void truncate(String instanceName) throws Exception {
-    getAdmin(instanceName).truncate();
+  public void truncate(Id.DatasetInstance datasetInstanceId) throws Exception {
+    getAdmin(datasetInstanceId).truncate();
   }
 
   @Override
-  public void upgrade(String instanceName) throws Exception {
-    getAdmin(instanceName).upgrade();
+  public void upgrade(Id.DatasetInstance datasetInstanceId) throws Exception {
+    getAdmin(datasetInstanceId).upgrade();
   }
 
   @Override
@@ -94,7 +98,7 @@ public class InMemoryDatasetOpExecutor extends AbstractIdleService implements Da
 
   }
 
-  private DatasetAdmin getAdmin(String instanceName) throws IOException, DatasetManagementException {
-    return client.getAdmin(instanceName, null);
+  private DatasetAdmin getAdmin(Id.DatasetInstance datasetInstanceId) throws IOException, DatasetManagementException {
+    return client.getAdmin(datasetInstanceId, null);
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DatasetFramework.java
@@ -51,31 +51,31 @@ public interface DatasetFramework {
 
   /**
    * Adds dataset types by adding dataset module to the system.
+   *
    * @param moduleId dataset module id
    * @param module dataset module
    * @throws ModuleConflictException when module with same name is already registered or this module registers a type
    *         with a same name as one of the already registered by another module types
    * @throws DatasetManagementException in case of problems
    */
-  void addModule(Id.DatasetModule moduleId, DatasetModule module)
-    throws DatasetManagementException;
+  void addModule(Id.DatasetModule moduleId, DatasetModule module) throws DatasetManagementException;
 
   /**
    * Deletes dataset module and its types from the system.
+   *
    * @param moduleId dataset module id
    * @throws ModuleConflictException when module cannot be deleted because of its dependant modules or instances
    * @throws DatasetManagementException
    */
-  void deleteModule(Id.DatasetModule moduleId)
-    throws DatasetManagementException;
+  void deleteModule(Id.DatasetModule moduleId) throws DatasetManagementException;
 
   /**
    * Deletes dataset modules and its types from the system.
+   *
    * @throws ModuleConflictException when some of modules can't be deleted because of its dependant modules or instances
    * @throws DatasetManagementException
    */
-  void deleteAllModules()
-    throws DatasetManagementException;
+  void deleteAllModules() throws DatasetManagementException;
 
   /**
    * Adds information about dataset instance to the system.
@@ -86,13 +86,13 @@ public interface DatasetFramework {
    * and later used to initialize {@link DatasetAdmin} and {@link Dataset} for the dataset instance.
    *
    * @param datasetTypeName dataset instance type name
-   * @param datasetInstanceName dataset instance name
+   * @param datasetInstanceId dataset instance name
    * @param props dataset instance properties
    * @throws InstanceConflictException if dataset instance with this name already exists
    * @throws IOException when creation of dataset instance using its admin fails
    * @throws DatasetManagementException
    */
-  void addInstance(String datasetTypeName, String datasetInstanceName, DatasetProperties props)
+  void addInstance(String datasetTypeName, Id.DatasetInstance datasetInstanceId, DatasetProperties props)
     throws DatasetManagementException, IOException;
 
   /**
@@ -103,30 +103,37 @@ public interface DatasetFramework {
    * method to build {@link co.cask.cdap.api.dataset.DatasetSpecification} with new properties,
    * which describes dataset instance and {@link DatasetAdmin} is used to upgrade
    * {@link Dataset} for the dataset instance.
-   * @param datasetInstanceName dataset instance name
+   * @param datasetInstanceId dataset instance name
    * @param props dataset instance properties
    * @throws IOException when creation of dataset instance using its admin fails
    * @throws DatasetManagementException
    */
-  void updateInstance(String datasetInstanceName, DatasetProperties props)
+  void updateInstance(Id.DatasetInstance datasetInstanceId, DatasetProperties props)
     throws DatasetManagementException, IOException;
 
   /**
-   * @return a collection of {@link co.cask.cdap.api.dataset.DatasetSpecification}s for all datasets
+   * Get all dataset instances in the specified namespace
+   *
+   * @param namespaceId the specified namespace id
+   * @return a collection of {@link DatasetSpecification}s for all datasets in the specified namespace
    */
-  Collection<DatasetSpecification> getInstances() throws DatasetManagementException;
+  Collection<DatasetSpecification> getInstances(Id.Namespace namespaceId) throws DatasetManagementException;
 
   /**
+   * Gets the {@link DatasetSpecification} for the specified dataset instance id
+   *
+   * @param datasetInstanceId the {@link Id.DatasetInstance} for which the {@link DatasetSpecification} is desired
    * @return {@link DatasetSpecification} of the dataset or {@code null} if dataset not not exist
    */
   @Nullable
-  DatasetSpecification getDatasetSpec(String name) throws DatasetManagementException;
+  DatasetSpecification getDatasetSpec(Id.DatasetInstance datasetInstanceId) throws DatasetManagementException;
 
   /**
+   * @param datasetInstanceId the {@link Id.DatasetInstance} to check for existence
    * @return true if instance exists, false otherwise
    * @throws DatasetManagementException
    */
-  boolean hasInstance(String instanceName) throws DatasetManagementException;
+  boolean hasInstance(Id.DatasetInstance datasetInstanceId) throws DatasetManagementException;
 
   /**
    * @return true if type exists, false otherwise
@@ -137,38 +144,39 @@ public interface DatasetFramework {
   /**
    * Deletes dataset instance from the system.
    *
-   * @param datasetInstanceName dataset instance name
+   * @param datasetInstanceId dataset instance name
    * @throws InstanceConflictException if dataset instance cannot be deleted because of its dependencies
    * @throws IOException when deletion of dataset instance using its admin fails
    * @throws DatasetManagementException
    */
-  void deleteInstance(String datasetInstanceName) throws DatasetManagementException, IOException;
+  void deleteInstance(Id.DatasetInstance datasetInstanceId) throws DatasetManagementException, IOException;
 
   /**
-   * Deletes all dataset instances from the system.
+   * Deletes all dataset instances in the specified namespace.
    *
+   * @param namespaceId the specified namespace id
    * @throws IOException when deletion of dataset instance using its admin fails
    * @throws DatasetManagementException
    */
-  void deleteAllInstances() throws DatasetManagementException, IOException;
+  void deleteAllInstances(Id.Namespace namespaceId) throws DatasetManagementException, IOException;
 
   /**
    * Gets dataset instance admin to be used to perform administrative operations.
-   * @param datasetInstanceName dataset instance name
    * @param <T> dataset admin type
+   * @param datasetInstanceId dataset instance name
    * @param classLoader classLoader to be used to load classes or {@code null} to use system classLoader
    * @return instance of dataset admin or {@code null} if dataset instance of this name doesn't exist.
    * @throws DatasetManagementException when there's trouble getting dataset meta info
    * @throws IOException when there's trouble to instantiate {@link DatasetAdmin}
    */
   @Nullable
-  <T extends DatasetAdmin> T getAdmin(String datasetInstanceName, @Nullable ClassLoader classLoader)
+  <T extends DatasetAdmin> T getAdmin(Id.DatasetInstance datasetInstanceId, @Nullable ClassLoader classLoader)
     throws DatasetManagementException, IOException;
 
   /**
    * Gets dataset to be used to perform data operations.
-   * @param datasetInstanceName dataset instance name
    * @param <T> dataset type to be returned
+   * @param datasetInstanceId dataset instance id
    * @param arguments runtime arguments for the dataset instance
    * @param classLoader classLoader to be used to load classes or {@code null} to use system classLoader
    * @return instance of dataset or {@code null} if dataset instance of this name doesn't exist.
@@ -176,7 +184,7 @@ public interface DatasetFramework {
    * @throws IOException when there's trouble to instantiate {@link co.cask.cdap.api.dataset.Dataset}
    */
   @Nullable
-  <T extends Dataset> T getDataset(String datasetInstanceName, @Nullable Map<String, String> arguments,
+  <T extends Dataset> T getDataset(Id.DatasetInstance datasetInstanceId, @Nullable Map<String, String> arguments,
                                    @Nullable ClassLoader classLoader)
     throws DatasetManagementException, IOException;
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/MetaTableUtil.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/MetaTableUtil.java
@@ -21,16 +21,21 @@ import co.cask.cdap.api.dataset.DatasetDefinition;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.table.OrderedTable;
 import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data.Namespace;
 import co.cask.cdap.data2.datafabric.DefaultDatasetNamespace;
 import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.NamespacedDatasetFramework;
+import co.cask.cdap.proto.Id;
 
 /**
  * Common utility for managing system metadata tables needed by various services.
  */
 public abstract class MetaTableUtil {
+
+  // Namespace for meta tables is 'system'
+  protected static final Id.Namespace SYSTEM_NAMESPACE = Id.Namespace.from(Constants.SYSTEM_NAMESPACE);
 
   protected final DatasetFramework dsFramework;
 
@@ -40,12 +45,13 @@ public abstract class MetaTableUtil {
   }
 
   public OrderedTable getMetaTable() throws Exception {
-    return DatasetsUtil.getOrCreateDataset(dsFramework, getMetaTableName(), OrderedTable.class.getName(),
+    Id.DatasetInstance metaTableInstanceId = Id.DatasetInstance.from(SYSTEM_NAMESPACE, getMetaTableName());
+    return DatasetsUtil.getOrCreateDataset(dsFramework, metaTableInstanceId, OrderedTable.class.getName(),
                                            DatasetProperties.EMPTY, DatasetDefinition.NO_ARGUMENTS, null);
   }
 
   public void upgrade() throws Exception {
-    DatasetAdmin admin = dsFramework.getAdmin(getMetaTableName(), null);
+    DatasetAdmin admin = dsFramework.getAdmin(Id.DatasetInstance.from(SYSTEM_NAMESPACE, getMetaTableName()), null);
     if (admin != null) {
       admin.upgrade();
     }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/CounterTimeseriesTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/CounterTimeseriesTableTest.java
@@ -19,6 +19,7 @@ package co.cask.cdap.api.dataset.lib;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.data2.dataset2.AbstractDatasetTest;
+import co.cask.cdap.proto.Id;
 import co.cask.tephra.TransactionExecutor;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -35,16 +36,17 @@ import static org.junit.Assert.assertTrue;
  */
 public class CounterTimeseriesTableTest extends AbstractDatasetTest {
   private static CounterTimeseriesTable table = null;
+  private static Id.DatasetInstance counterTable = Id.DatasetInstance.from(NAMESPACE_ID, "counterTable");
 
   @BeforeClass
   public static void setup() throws Exception {
-    createInstance("counterTimeseriesTable", "counterTable", DatasetProperties.EMPTY);
-    table = getInstance("counterTable");
+    createInstance("counterTimeseriesTable", counterTable, DatasetProperties.EMPTY);
+    table = getInstance(counterTable);
   }
 
   @AfterClass
   public static void tearDown() throws Exception {
-    deleteInstance("counterTable");
+    deleteInstance(counterTable);
   }
 
   @Test

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/DatasetWithArgumentsTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/DatasetWithArgumentsTest.java
@@ -33,24 +33,25 @@ import java.util.Collections;
 public class DatasetWithArgumentsTest extends AbstractDatasetTest {
 
   private static final Id.DatasetModule prefix = Id.DatasetModule.from(NAMESPACE_ID, "prefix");
+  private static final Id.DatasetInstance pret = Id.DatasetInstance.from(NAMESPACE_ID, "pret");
 
   @BeforeClass
   public static void beforeClass() throws Exception {
     addModule(prefix, new PrefixedTableModule());
-    createInstance("prefixedTable", "pret", DatasetProperties.EMPTY);
+    createInstance("prefixedTable", pret, DatasetProperties.EMPTY);
   }
 
   @AfterClass
   public static void afterClass() throws Exception {
-    deleteInstance("pret");
+    deleteInstance(pret);
     deleteModule(prefix);
   }
 
   @Test
   public void testPrefixTable() throws Exception {
-    final PrefixedTable table = getInstance("pret", null);
-    final PrefixedTable aTable = getInstance("pret", Collections.singletonMap("prefix", "a"));
-    final PrefixedTable bTable = getInstance("pret", Collections.singletonMap("prefix", "b"));
+    final PrefixedTable table = getInstance(pret, null);
+    final PrefixedTable aTable = getInstance(pret, Collections.singletonMap("prefix", "a"));
+    final PrefixedTable bTable = getInstance(pret, Collections.singletonMap("prefix", "b"));
 
     TransactionExecutor txnl = newTransactionExecutor(aTable, bTable, table);
 

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/IndexedObjectStoreTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/IndexedObjectStoreTest.java
@@ -19,6 +19,7 @@ package co.cask.cdap.api.dataset.lib;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.data2.dataset2.AbstractDatasetTest;
+import co.cask.cdap.proto.Id;
 import co.cask.tephra.TransactionExecutor;
 import com.google.common.collect.ImmutableList;
 import org.junit.Assert;
@@ -31,10 +32,13 @@ import java.util.List;
  * Test for {@link co.cask.cdap.api.dataset.lib.IndexedObjectStore}.
  */
 public class IndexedObjectStoreTest extends AbstractDatasetTest {
+
+  private static final Id.DatasetInstance index = Id.DatasetInstance.from(NAMESPACE_ID, "index");
+
   @Test
   public void testLookupByIndex() throws Exception {
-    createIndexedObjectStoreInstance("index", Feed.class);
-    final IndexedObjectStore<Feed> indexedFeed = getInstance("index");
+    createIndexedObjectStoreInstance(index, Feed.class);
+    final IndexedObjectStore<Feed> indexedFeed = getInstance(index);
     TransactionExecutor txnl = newTransactionExecutor(indexedFeed);
 
     txnl.execute(new TransactionExecutor.Subroutine() {
@@ -63,13 +67,13 @@ public class IndexedObjectStoreTest extends AbstractDatasetTest {
       }
     });
 
-    deleteInstance("index");
+    deleteInstance(index);
   }
 
   @Test
   public void testIndexRewrites() throws Exception {
-    createIndexedObjectStoreInstance("index", Feed.class);
-    final IndexedObjectStore<Feed> indexedFeed = getInstance("index");
+    createIndexedObjectStoreInstance(index, Feed.class);
+    final IndexedObjectStore<Feed> indexedFeed = getInstance(index);
     TransactionExecutor txnl = newTransactionExecutor(indexedFeed);
 
     txnl.execute(new TransactionExecutor.Subroutine() {
@@ -103,13 +107,13 @@ public class IndexedObjectStoreTest extends AbstractDatasetTest {
         Assert.assertEquals(0, feedResult.size());
       }
     });
-    deleteInstance("index");
+    deleteInstance(index);
   }
 
   @Test
   public void testIndexPruning() throws Exception {
-    createIndexedObjectStoreInstance("index", Feed.class);
-    final IndexedObjectStore<Feed> indexedFeed = getInstance("index");
+    createIndexedObjectStoreInstance(index, Feed.class);
+    final IndexedObjectStore<Feed> indexedFeed = getInstance(index);
     TransactionExecutor txnl = newTransactionExecutor(indexedFeed);
 
     txnl.execute(new TransactionExecutor.Subroutine() {
@@ -130,13 +134,13 @@ public class IndexedObjectStoreTest extends AbstractDatasetTest {
       }
     });
 
-    deleteInstance("index");
+    deleteInstance(index);
   }
 
   @Test
   public void testIndexNoSecondaryKeyChanges() throws Exception {
-    createIndexedObjectStoreInstance("index", Feed.class);
-    IndexedObjectStore<Feed> indexedFeed = getInstance("index");
+    createIndexedObjectStoreInstance(index, Feed.class);
+    IndexedObjectStore<Feed> indexedFeed = getInstance(index);
 
     List<String> categories = ImmutableList.of("C++", "C#");
 
@@ -162,13 +166,13 @@ public class IndexedObjectStoreTest extends AbstractDatasetTest {
 
     Assert.assertEquals("http://microsoft.com", feedResult.get(0).getUrl());
 
-    deleteInstance("index");
+    deleteInstance(index);
   }
 
   @Test
   public void testIndexUpdates() throws Exception {
-    createIndexedObjectStoreInstance("index", Feed.class);
-    final IndexedObjectStore<Feed> indexedFeed = getInstance("index");
+    createIndexedObjectStoreInstance(index, Feed.class);
+    final IndexedObjectStore<Feed> indexedFeed = getInstance(index);
     TransactionExecutor txnl = newTransactionExecutor(indexedFeed);
 
     txnl.execute(new TransactionExecutor.Subroutine() {
@@ -191,11 +195,11 @@ public class IndexedObjectStoreTest extends AbstractDatasetTest {
       }
     });
 
-    deleteInstance("index");
+    deleteInstance(index);
   }
 
-  protected void createIndexedObjectStoreInstance(String instanceName, Type type) throws Exception {
-    createInstance("indexedObjectStore", instanceName,
+  protected void createIndexedObjectStoreInstance(Id.DatasetInstance datasetInstanceId, Type type) throws Exception {
+    createInstance("indexedObjectStore", datasetInstanceId,
                    ObjectStores.objectStoreProperties(type, DatasetProperties.EMPTY));
   }
 

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/IndexedTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/IndexedTableTest.java
@@ -25,6 +25,7 @@ import co.cask.cdap.api.dataset.table.Row;
 import co.cask.cdap.api.dataset.table.Scanner;
 import co.cask.cdap.data2.dataset2.AbstractDatasetTest;
 import co.cask.cdap.data2.dataset2.TableTest;
+import co.cask.cdap.proto.Id;
 import co.cask.tephra.TransactionExecutor;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -40,6 +41,8 @@ import static org.junit.Assert.fail;
  * Tests for Index table.
  */
 public class IndexedTableTest extends AbstractDatasetTest {
+
+  private static final Id.DatasetInstance tabInstance = Id.DatasetInstance.from(NAMESPACE_ID, "tab");
 
   private static IndexedTable table;
 
@@ -64,15 +67,15 @@ public class IndexedTableTest extends AbstractDatasetTest {
 
   @BeforeClass
   public static void beforeClass() throws Exception {
-    createInstance("indexedTable", "tab", DatasetProperties.builder()
+    createInstance("indexedTable", tabInstance, DatasetProperties.builder()
       .add(IndexedTableDefinition.INDEX_COLUMNS_CONF_KEY, idxColString)
       .build());
-    table = getInstance("tab");
+    table = getInstance(tabInstance);
   }
 
   @AfterClass
   public static void afterClass() throws Exception {
-    deleteInstance("tab");
+    deleteInstance(tabInstance);
   }
 
   @Test
@@ -257,14 +260,15 @@ public class IndexedTableTest extends AbstractDatasetTest {
 
   @Test
   public void testMultipleIndexedColumns() throws Exception {
-    createInstance("indexedTable", "multicolumntab", DatasetProperties.builder()
+    Id.DatasetInstance multiColumnTabInstance = Id.DatasetInstance.from(NAMESPACE_ID, "multicolumntab");
+    createInstance("indexedTable", multiColumnTabInstance, DatasetProperties.builder()
       .add(IndexedTableDefinition.INDEX_COLUMNS_CONF_KEY, "idx1,idx2,idx3")
       .build());
     final byte[] idxCol1 = Bytes.toBytes("idx1");
     final byte[] idxCol2 = Bytes.toBytes("idx2");
     final byte[] idxCol3 = Bytes.toBytes("idx3");
 
-    final IndexedTable mcTable = getInstance("multicolumntab");
+    final IndexedTable mcTable = getInstance(multiColumnTabInstance);
 
     try {
       TransactionExecutor tx = newTransactionExecutor(mcTable);
@@ -441,7 +445,7 @@ public class IndexedTableTest extends AbstractDatasetTest {
 
       // rows 2 & 4 should be returned for idx2b
     } finally {
-      deleteInstance("multicolumntab");
+      deleteInstance(multiColumnTabInstance);
     }
   }
 
@@ -451,10 +455,11 @@ public class IndexedTableTest extends AbstractDatasetTest {
    */
   @Test
   public void testIndexKeyDelimiterHandling() throws Exception {
-    createInstance("indexedTable", "delimtab", DatasetProperties.builder()
+    Id.DatasetInstance delimTabInstance = Id.DatasetInstance.from(NAMESPACE_ID, "delimtab");
+    createInstance("indexedTable", delimTabInstance, DatasetProperties.builder()
       .add(IndexedTableDefinition.INDEX_COLUMNS_CONF_KEY, idxColString)
       .build());
-    final IndexedTable iTable = getInstance("delimtab");
+    final IndexedTable iTable = getInstance(delimTabInstance);
     final byte[] delim = new byte[]{ 0 };
     try {
       final byte[] valueWithDelimiter = Bytes.concat(idx1, delim, idx2);
@@ -500,16 +505,17 @@ public class IndexedTableTest extends AbstractDatasetTest {
         }
       });
     } finally {
-      deleteInstance("delimtab");
+      deleteInstance(delimTabInstance);
     }
   }
 
   @Test
   public void testIncrementIndexing() throws Exception {
-    createInstance("indexedTable", "incrtab", DatasetProperties.builder()
+    Id.DatasetInstance incrTabInstance = Id.DatasetInstance.from(NAMESPACE_ID, "incrtab");
+    createInstance("indexedTable", incrTabInstance, DatasetProperties.builder()
       .add(IndexedTableDefinition.INDEX_COLUMNS_CONF_KEY, "idx1,idx2,idx3")
       .build());
-    final IndexedTable iTable = getInstance("incrtab");
+    final IndexedTable iTable = getInstance(incrTabInstance);
     final byte[] idxCol1 = Bytes.toBytes("idx1");
     final byte[] idxCol2 = Bytes.toBytes("idx2");
     final byte[] idxCol3 = Bytes.toBytes("idx3");
@@ -656,7 +662,7 @@ public class IndexedTableTest extends AbstractDatasetTest {
         }
       });
     } finally {
-      deleteInstance("incrtab");
+      deleteInstance(incrTabInstance);
     }
   }
   /**

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/KeyValueTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/KeyValueTableTest.java
@@ -21,6 +21,7 @@ import co.cask.cdap.api.data.batch.Split;
 import co.cask.cdap.api.data.batch.SplitReader;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.data2.dataset2.AbstractDatasetTest;
+import co.cask.cdap.proto.Id;
 import co.cask.tephra.TransactionExecutor;
 import co.cask.tephra.TransactionFailureException;
 import com.google.common.collect.Sets;
@@ -47,17 +48,19 @@ public class KeyValueTableTest extends AbstractDatasetTest {
   static final byte[] VAL2 = Bytes.toBytes("VAL2");
   static final byte[] VAL3 = Bytes.toBytes("VAL3");
 
+  private static final Id.DatasetInstance testInstance = Id.DatasetInstance.from(NAMESPACE_ID, "test");
+
   private static KeyValueTable kvTable;
 
   @BeforeClass
   public static void beforeClass() throws Exception {
-    createInstance("keyValueTable", "test", DatasetProperties.EMPTY);
-    kvTable = getInstance("test");
+    createInstance("keyValueTable", testInstance, DatasetProperties.EMPTY);
+    kvTable = getInstance(testInstance);
   }
 
   @AfterClass
   public static void afterClass() throws Exception {
-    deleteInstance("test");
+    deleteInstance(testInstance);
   }
 
   @Test
@@ -180,11 +183,13 @@ public class KeyValueTableTest extends AbstractDatasetTest {
 
   @Test
   public void testTransactionAcrossTables() throws Exception {
-    createInstance("keyValueTable", "t1", DatasetProperties.EMPTY);
-    createInstance("keyValueTable", "t2", DatasetProperties.EMPTY);
+    Id.DatasetInstance t1 = Id.DatasetInstance.from(NAMESPACE_ID, "t1");
+    Id.DatasetInstance t2 = Id.DatasetInstance.from(NAMESPACE_ID, "t2");
+    createInstance("keyValueTable", t1, DatasetProperties.EMPTY);
+    createInstance("keyValueTable", t2, DatasetProperties.EMPTY);
 
-    final KeyValueTable table1 = getInstance("t1");
-    final KeyValueTable table2 = getInstance("t2");
+    final KeyValueTable table1 = getInstance(t1);
+    final KeyValueTable table2 = getInstance(t2);
     TransactionExecutor txnl = newTransactionExecutor(table1, table2);
 
     // write a value to table1 and verify it
@@ -227,8 +232,8 @@ public class KeyValueTableTest extends AbstractDatasetTest {
     });
 
     // verify synchronously that old value are still there
-    final KeyValueTable table1v2 = getInstance("t1");
-    final KeyValueTable table2v2 = getInstance("t2");
+    final KeyValueTable table1v2 = getInstance(t1);
+    final KeyValueTable table2v2 = getInstance(t2);
     TransactionExecutor txnlv2 = newTransactionExecutor(table1v2, table2v2);
     txnlv2.execute(new TransactionExecutor.Subroutine() {
       @Override
@@ -238,15 +243,16 @@ public class KeyValueTableTest extends AbstractDatasetTest {
       }
     });
 
-    deleteInstance("t1");
-    deleteInstance("t2");
+    deleteInstance(t1);
+    deleteInstance(t2);
   }
 
   @Test
   public void testScanning() throws Exception {
-    createInstance("keyValueTable", "tScan", DatasetProperties.EMPTY);
+    Id.DatasetInstance tScan = Id.DatasetInstance.from(NAMESPACE_ID, "tScan");
+    createInstance("keyValueTable", tScan, DatasetProperties.EMPTY);
 
-    final KeyValueTable t = getInstance("tScan");
+    final KeyValueTable t = getInstance(tScan);
     TransactionExecutor txnl = newTransactionExecutor(t);
 
     // start a transaction
@@ -296,14 +302,15 @@ public class KeyValueTableTest extends AbstractDatasetTest {
         }
       }
     });
-    deleteInstance("tScan");
+    deleteInstance(tScan);
   }
 
   @Test
   public void testBatchReads() throws Exception {
-    createInstance("keyValueTable", "tBatch", DatasetProperties.EMPTY);
+    Id.DatasetInstance tBatch = Id.DatasetInstance.from(NAMESPACE_ID, "tBatch");
+    createInstance("keyValueTable", tBatch, DatasetProperties.EMPTY);
 
-    final KeyValueTable t = getInstance("tBatch");
+    final KeyValueTable t = getInstance(tBatch);
     TransactionExecutor txnl = newTransactionExecutor(t);
 
     final SortedSet<Long> keysWritten = Sets.newTreeSet();
@@ -348,7 +355,7 @@ public class KeyValueTableTest extends AbstractDatasetTest {
       }
     });
 
-    deleteInstance("tBatch");
+    deleteInstance(tBatch);
   }
 
   // helper to verify that the split readers for the given splits return exactly a set of keys

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/ReflectionTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/ReflectionTableTest.java
@@ -26,6 +26,7 @@ import co.cask.cdap.data2.dataset2.AbstractDatasetTest;
 import co.cask.cdap.internal.io.ReflectionPutWriter;
 import co.cask.cdap.internal.io.ReflectionRowReader;
 import co.cask.cdap.internal.io.ReflectionSchemaGenerator;
+import co.cask.cdap.proto.Id;
 import co.cask.tephra.TransactionAware;
 import co.cask.tephra.TransactionExecutor;
 import com.google.common.base.Objects;
@@ -44,6 +45,7 @@ import java.util.Map;
  *
  */
 public class ReflectionTableTest extends AbstractDatasetTest {
+  private static final Id.DatasetInstance users = Id.DatasetInstance.from(NAMESPACE_ID, "users");
   private static final User SAMUEL = new User(
     "Samuel L.", "Jackson",
     Gender.MALE,
@@ -200,35 +202,35 @@ public class ReflectionTableTest extends AbstractDatasetTest {
 
   @Test
   public void testPutAndGet() throws Exception {
-    createInstance("table", "users", DatasetProperties.builder().build());
+    createInstance("table", users, DatasetProperties.builder().build());
     try {
-      final Table usersTable = getInstance("users");
+      final Table usersTable = getInstance(users);
       final byte[] rowKey = Bytes.toBytes(123);
       final Schema schema = new ReflectionSchemaGenerator().generate(User.class);
       assertGetAndPut(usersTable, rowKey, SAMUEL, schema);
     } finally {
-      deleteInstance("users");
+      deleteInstance(users);
     }
   }
 
   @Test
   public void testNullFields() throws Exception {
-    createInstance("table", "users", DatasetProperties.builder().build());
+    createInstance("table", users, DatasetProperties.builder().build());
     try {
-      final Table usersTable = getInstance("users");
+      final Table usersTable = getInstance(users);
       final byte[] rowKey = Bytes.toBytes(123);
       final Schema schema = new ReflectionSchemaGenerator().generate(User.class);
       assertGetAndPut(usersTable, rowKey, SAMUEL, schema);
     } finally {
-      deleteInstance("users");
+      deleteInstance(users);
     }
   }
 
   @Test
   public void testTypeProjection() throws Exception {
-    createInstance("table", "users", DatasetProperties.builder().build());
+    createInstance("table", users, DatasetProperties.builder().build());
     try {
-      final Table usersTable = getInstance("users");
+      final Table usersTable = getInstance(users);
       final byte[] rowKey = Bytes.toBytes(123);
       final User2 projected = new User2("Samuel L.", 123L, ((Float) 50000000.02f).doubleValue(), Double.MAX_VALUE,
                                         ByteBuffer.wrap(new byte[]{0, 1, 2}));
@@ -251,7 +253,7 @@ public class ReflectionTableTest extends AbstractDatasetTest {
         }
       });
     } finally {
-      deleteInstance("users");
+      deleteInstance(users);
     }
   }
 

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/TimeseriesTableScannerTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/TimeseriesTableScannerTest.java
@@ -19,6 +19,7 @@ package co.cask.cdap.api.dataset.lib;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.data2.dataset2.AbstractDatasetTest;
+import co.cask.cdap.proto.Id;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -43,6 +44,7 @@ import java.util.concurrent.TimeUnit;
  * Defines a class to test EntryScanner in TimeseriesTable
  */
 public class TimeseriesTableScannerTest extends AbstractDatasetTest {
+  private static final Id.DatasetInstance facts = Id.DatasetInstance.from(NAMESPACE_ID, "facts");
   private static final byte[] ALL_KEY = Bytes.toBytes("a");
   private static final String SRC_TAG = "src";
   private static final String DST_TAG = "dst";
@@ -52,13 +54,13 @@ public class TimeseriesTableScannerTest extends AbstractDatasetTest {
   private static TimeseriesTable table = null;
   @BeforeClass
   public static void setup() throws Exception {
-    createInstance("timeseriesTable", "facts", DatasetProperties.EMPTY);
-    table = getInstance("facts");
+    createInstance("timeseriesTable", facts, DatasetProperties.EMPTY);
+    table = getInstance(facts);
   }
 
   @AfterClass
   public static void tearDown() throws Exception {
-    deleteInstance("facts");
+    deleteInstance(facts);
   }
 
   @Test

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/TimeseriesTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/TimeseriesTableTest.java
@@ -19,6 +19,7 @@ package co.cask.cdap.api.dataset.lib;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.data2.dataset2.AbstractDatasetTest;
+import co.cask.cdap.proto.Id;
 import co.cask.tephra.TransactionExecutor;
 import co.cask.tephra.TransactionFailureException;
 import org.junit.AfterClass;
@@ -36,17 +37,18 @@ import java.util.concurrent.TimeUnit;
  * Time series table tests.
  */
 public class TimeseriesTableTest extends AbstractDatasetTest {
+  private static final Id.DatasetInstance metricsTableInstance = Id.DatasetInstance.from(NAMESPACE_ID, "metricsTable");
   private static TimeseriesTable table;
 
   @BeforeClass
   public static void beforeClass() throws Exception {
-    createInstance("timeseriesTable", "metricsTable", DatasetProperties.EMPTY);
-    table = getInstance("metricsTable");
+    createInstance("timeseriesTable", metricsTableInstance, DatasetProperties.EMPTY);
+    table = getInstance(metricsTableInstance);
   }
 
   @AfterClass
   public static void afterClass() throws Exception {
-    deleteInstance("metricsTable");
+    deleteInstance(metricsTableInstance);
   }
 
   @Test

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandlerV2Test.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandlerV2Test.java
@@ -22,10 +22,12 @@ import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.dataset.table.Get;
 import co.cask.cdap.api.dataset.table.Put;
 import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.dataset2.lib.table.CoreDatasetsModule;
 import co.cask.cdap.data2.dataset2.module.lib.inmemory.InMemoryOrderedTableModule;
 import co.cask.cdap.proto.DatasetInstanceConfiguration;
 import co.cask.cdap.proto.DatasetModuleMeta;
+import co.cask.cdap.proto.Id;
 import co.cask.common.http.HttpRequest;
 import co.cask.common.http.HttpRequests;
 import co.cask.common.http.ObjectResponse;
@@ -163,8 +165,11 @@ public class DatasetInstanceHandlerV2Test extends DatasetServiceTestBase {
     Assert.assertEquals(2, getInstances().getResponseObject().size());
 
     // we want to verify that data is also gone, so we write smth to tables first
-    final Table table1 = dsFramework.getDataset("myTable1", DatasetDefinition.NO_ARGUMENTS, null);
-    final Table table2 = dsFramework.getDataset("myTable2", DatasetDefinition.NO_ARGUMENTS, null);
+    // using default namespace here since this is testing v2 APIs right now. TODO: add tests for v3 APIs
+    final Table table1 = dsFramework.getDataset(Id.DatasetInstance.from(Constants.DEFAULT_NAMESPACE, "myTable1"),
+                                                DatasetDefinition.NO_ARGUMENTS, null);
+    final Table table2 = dsFramework.getDataset(Id.DatasetInstance.from(Constants.DEFAULT_NAMESPACE, "myTable2"),
+                                                DatasetDefinition.NO_ARGUMENTS, null);
     TransactionExecutor txExecutor =
       new DefaultTransactionExecutor(new InMemoryTxSystemClient(txManager),
                                      ImmutableList.of((TransactionAware) table1, (TransactionAware) table2));

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/executor/DatasetOpExecutorServiceTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/executor/DatasetOpExecutorServiceTest.java
@@ -40,6 +40,7 @@ import co.cask.cdap.data2.datafabric.dataset.service.DatasetService;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.gateway.auth.AuthModule;
+import co.cask.cdap.proto.Id;
 import co.cask.common.http.HttpRequest;
 import co.cask.common.http.HttpRequests;
 import co.cask.common.http.HttpResponse;
@@ -76,6 +77,8 @@ import java.util.concurrent.TimeUnit;
 public class DatasetOpExecutorServiceTest {
 
   private static final Gson GSON = new Gson();
+  private static final Id.Namespace namespace = Id.Namespace.from("myspace");
+  private static final Id.DatasetInstance bob = Id.DatasetInstance.from(namespace, "bob");
 
   @ClassRule
   public static TemporaryFolder tmpFolder = new TemporaryFolder();
@@ -140,13 +143,13 @@ public class DatasetOpExecutorServiceTest {
     testAdminOp("bob", "exists", 404, null);
 
     // add instance, should automatically create an instance
-    dsFramework.addInstance("table", "bob", DatasetProperties.EMPTY);
+    dsFramework.addInstance("table", bob, DatasetProperties.EMPTY);
     testAdminOp("bob", "exists", 200, true);
 
     testAdminOp("joe", "exists", 404, null);
 
     // check truncate
-    final Table table = dsFramework.getDataset("bob", DatasetDefinition.NO_ARGUMENTS, null);
+    final Table table = dsFramework.getDataset(bob, DatasetDefinition.NO_ARGUMENTS, null);
     TransactionExecutor txExecutor =
       new DefaultTransactionExecutor(new InMemoryTxSystemClient(txManager),
                                      ImmutableList.of((TransactionAware) table));
@@ -181,7 +184,7 @@ public class DatasetOpExecutorServiceTest {
     testAdminOp("bob", "upgrade", 200, null);
 
     // drop and check non-existence
-    dsFramework.deleteInstance("bob");
+    dsFramework.deleteInstance(bob);
     testAdminOp("bob", "exists", 404, null);
   }
 
@@ -191,15 +194,15 @@ public class DatasetOpExecutorServiceTest {
     testAdminOp("bob", "exists", 404, null);
 
     // add instance, should automatically create an instance
-    dsFramework.addInstance("table", "bob", DatasetProperties.EMPTY);
+    dsFramework.addInstance("table", bob, DatasetProperties.EMPTY);
     testAdminOp("bob", "exists", 200, true);
 
-    dsFramework.updateInstance("bob", DatasetProperties.builder().add("dataset.table.ttl", "10000").build());
+    dsFramework.updateInstance(bob, DatasetProperties.builder().add("dataset.table.ttl", "10000").build());
     // check upgrade
     testAdminOp("bob", "upgrade", 200, null);
 
     // drop and check non-existence
-    dsFramework.deleteInstance("bob");
+    dsFramework.deleteInstance(bob);
     testAdminOp("bob", "exists", 404, null);
   }
 

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/AbstractDatasetFrameworkTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/AbstractDatasetFrameworkTest.java
@@ -45,6 +45,8 @@ public abstract class AbstractDatasetFrameworkTest {
   private static final Id.DatasetModule core = Id.DatasetModule.from(namespaceId, "core");
   private static final Id.DatasetModule keyValue = Id.DatasetModule.from(namespaceId, "keyValue");
   private static final Id.DatasetModule doubleKeyValue = Id.DatasetModule.from(namespaceId, "doubleKeyValue");
+  private static final Id.DatasetInstance myTable = Id.DatasetInstance.from(namespaceId, "my_table");
+  private static final Id.DatasetInstance myTable2 = Id.DatasetInstance.from(namespaceId, "my_table2");
 
   @Test
   public void testSimpleDataset() throws Exception {
@@ -55,15 +57,15 @@ public abstract class AbstractDatasetFrameworkTest {
     framework.addModule(inMemory, new InMemoryOrderedTableModule());
     Assert.assertTrue(framework.hasType("orderedTable"));
 
-    Assert.assertFalse(framework.hasInstance("my_table"));
+    Assert.assertFalse(framework.hasInstance(myTable));
     // Creating instance
-    framework.addInstance("orderedTable", "my_table", DatasetProperties.EMPTY);
-    Assert.assertTrue(framework.hasInstance("my_table"));
+    framework.addInstance("orderedTable", myTable, DatasetProperties.EMPTY);
+    Assert.assertTrue(framework.hasInstance(myTable));
 
     // Doing some admin and data ops
-    DatasetAdmin admin = framework.getAdmin("my_table", null);
+    DatasetAdmin admin = framework.getAdmin(myTable, null);
     Assert.assertNotNull(admin);
-    final OrderedTable table = framework.getDataset("my_table", DatasetDefinition.NO_ARGUMENTS, null);
+    final OrderedTable table = framework.getDataset(myTable, DatasetDefinition.NO_ARGUMENTS, null);
     Assert.assertNotNull(table);
 
     TransactionExecutor txnl = new DefaultTransactionExecutor(new MinimalTxSystemClient(), (TransactionAware) table);
@@ -88,7 +90,7 @@ public abstract class AbstractDatasetFrameworkTest {
     });
 
     // cleanup
-    framework.deleteInstance("my_table");
+    framework.deleteInstance(myTable);
     framework.deleteModule(inMemory);
   }
 
@@ -104,15 +106,15 @@ public abstract class AbstractDatasetFrameworkTest {
     Assert.assertTrue(framework.hasType(SimpleKVTable.class.getName()));
 
     // Creating instance
-    Assert.assertFalse(framework.hasInstance("my_table"));
+    Assert.assertFalse(framework.hasInstance(myTable));
     framework.addInstance(SimpleKVTable.class.getName(),
-                          "my_table", DatasetProperties.EMPTY);
-    Assert.assertTrue(framework.hasInstance("my_table"));
+                          myTable, DatasetProperties.EMPTY);
+    Assert.assertTrue(framework.hasInstance(myTable));
 
     testCompositeDataset(framework);
 
     // cleanup
-    framework.deleteInstance("my_table");
+    framework.deleteInstance(myTable);
     framework.deleteModule(keyValue);
     framework.deleteModule(core);
     framework.deleteModule(inMemory);
@@ -131,14 +133,14 @@ public abstract class AbstractDatasetFrameworkTest {
     Assert.assertTrue(framework.hasType(DoubleWrappedKVTable.class.getName()));
 
     // Creating instance
-    Assert.assertFalse(framework.hasInstance("my_table"));
-    framework.addInstance(DoubleWrappedKVTable.class.getName(), "my_table", DatasetProperties.EMPTY);
-    Assert.assertTrue(framework.hasInstance("my_table"));
+    Assert.assertFalse(framework.hasInstance(myTable));
+    framework.addInstance(DoubleWrappedKVTable.class.getName(), myTable, DatasetProperties.EMPTY);
+    Assert.assertTrue(framework.hasInstance(myTable));
 
     testCompositeDataset(framework);
 
     // cleanup
-    framework.deleteInstance("my_table");
+    framework.deleteInstance(myTable);
     framework.deleteModule(doubleKeyValue);
     framework.deleteModule(keyValue);
     framework.deleteModule(core);
@@ -148,9 +150,9 @@ public abstract class AbstractDatasetFrameworkTest {
   private void testCompositeDataset(DatasetFramework framework) throws Exception {
 
     // Doing some admin and data ops
-    DatasetAdmin admin = framework.getAdmin("my_table", null);
+    DatasetAdmin admin = framework.getAdmin(myTable, null);
     Assert.assertNotNull(admin);
-    final KeyValueTable table = framework.getDataset("my_table", DatasetDefinition.NO_ARGUMENTS, null);
+    final KeyValueTable table = framework.getDataset(myTable, DatasetDefinition.NO_ARGUMENTS, null);
     Assert.assertNotNull(table);
 
     TransactionExecutor txnl = new DefaultTransactionExecutor(new MinimalTxSystemClient(), (TransactionAware) table);
@@ -186,14 +188,14 @@ public abstract class AbstractDatasetFrameworkTest {
     Assert.assertTrue(framework.hasType(Table.class.getName()));
 
     // Creating instances
-    framework.addInstance(OrderedTable.class.getName(), "my_table", DatasetProperties.EMPTY);
-    Assert.assertTrue(framework.hasInstance("my_table"));
-    DatasetSpecification spec = framework.getDatasetSpec("my_table");
+    framework.addInstance(OrderedTable.class.getName(), myTable, DatasetProperties.EMPTY);
+    Assert.assertTrue(framework.hasInstance(myTable));
+    DatasetSpecification spec = framework.getDatasetSpec(myTable);
     Assert.assertNotNull(spec);
-    Assert.assertEquals("my_table", spec.getName());
+    Assert.assertEquals(myTable.getId(), spec.getName());
     Assert.assertEquals(OrderedTable.class.getName(), spec.getType());
-    framework.addInstance(OrderedTable.class.getName(), "my_table2", DatasetProperties.EMPTY);
-    Assert.assertTrue(framework.hasInstance("my_table2"));
+    framework.addInstance(OrderedTable.class.getName(), myTable2, DatasetProperties.EMPTY);
+    Assert.assertTrue(framework.hasInstance(myTable2));
 
     // cleanup
     try {
@@ -206,12 +208,12 @@ public abstract class AbstractDatasetFrameworkTest {
     Assert.assertTrue(framework.hasType(OrderedTable.class.getName()));
     Assert.assertTrue(framework.hasType(Table.class.getName()));
 
-    framework.deleteAllInstances();
-    Assert.assertEquals(0, framework.getInstances().size());
-    Assert.assertFalse(framework.hasInstance("my_table"));
-    Assert.assertNull(framework.getDatasetSpec("my_table"));
-    Assert.assertFalse(framework.hasInstance("my_table2"));
-    Assert.assertNull(framework.getDatasetSpec("my_table2"));
+    framework.deleteAllInstances(namespaceId);
+    Assert.assertEquals(0, framework.getInstances(namespaceId).size());
+    Assert.assertFalse(framework.hasInstance(myTable));
+    Assert.assertNull(framework.getDatasetSpec(myTable));
+    Assert.assertFalse(framework.hasInstance(myTable2));
+    Assert.assertNull(framework.getDatasetSpec(myTable2));
 
     // now it should susceed
     framework.deleteAllModules();

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/AbstractDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/AbstractDatasetTest.java
@@ -104,25 +104,26 @@ public class AbstractDatasetTest {
     framework.deleteModule(moduleId);
   }
 
-  protected static void createInstance(String type, String instanceName, DatasetProperties properties)
+  protected static void createInstance(String type, Id.DatasetInstance datasetInstanceId, DatasetProperties properties)
     throws IOException, DatasetManagementException {
 
-    framework.addInstance(type, instanceName, properties);
+    framework.addInstance(type, datasetInstanceId, properties);
   }
 
-  protected static void deleteInstance(String instanceName) throws IOException, DatasetManagementException {
-    framework.deleteInstance(instanceName);
+  protected static void deleteInstance(Id.DatasetInstance datasetInstanceId)
+    throws IOException, DatasetManagementException {
+    framework.deleteInstance(datasetInstanceId);
   }
 
-  protected static <T extends Dataset> T getInstance(String datasetName)
+  protected static <T extends Dataset> T getInstance(Id.DatasetInstance datasetInstanceId)
     throws DatasetManagementException, IOException {
-
-    return getInstance(datasetName, DatasetDefinition.NO_ARGUMENTS);
+    return getInstance(datasetInstanceId, DatasetDefinition.NO_ARGUMENTS);
   }
 
-  protected static <T extends Dataset> T getInstance(String datasetName, Map<String, String> arguments)
+  protected static <T extends Dataset> T getInstance(Id.DatasetInstance datasetInstanceId,
+                                                     Map<String, String> arguments)
     throws DatasetManagementException, IOException {
-    return framework.getDataset(datasetName, arguments, null);
+    return framework.getDataset(datasetInstanceId, arguments, null);
   }
 
   protected static TransactionExecutor newTransactionExecutor(TransactionAware...tables) {

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/FileSetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/FileSetTest.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.dataset.lib.FileSet;
 import co.cask.cdap.api.dataset.lib.FileSetArguments;
 import co.cask.cdap.api.dataset.lib.FileSetProperties;
 import co.cask.cdap.data2.dataset2.AbstractDatasetTest;
+import co.cask.cdap.proto.Id;
 import com.google.common.collect.Maps;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -34,20 +35,21 @@ import java.util.Map;
 public class FileSetTest extends AbstractDatasetTest {
 
   static FileSet fileSet;
+  private static final Id.DatasetInstance testFileSetInstance = Id.DatasetInstance.from(NAMESPACE_ID, "testFileSet");
 
   @BeforeClass
   public static void beforeClass() throws Exception {
-    createInstance("fileSet", "testFileSet", FileSetProperties.builder()
+    createInstance("fileSet", testFileSetInstance, FileSetProperties.builder()
       .setBasePath("testDir").build());
     Map<String, String> fileArgs = Maps.newHashMap();
     FileSetArguments.setInputPath(fileArgs, "some?File");
     FileSetArguments.setOutputPath(fileArgs, "some?File");
-    fileSet = getInstance("testFileSet", fileArgs);
+    fileSet = getInstance(testFileSetInstance, fileArgs);
   }
 
   @AfterClass
   public static void afterClass() throws Exception {
-    deleteInstance("testFileSet");
+    deleteInstance(testFileSetInstance);
   }
 
   @Test

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetTest.java
@@ -22,6 +22,7 @@ import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
 import co.cask.cdap.api.dataset.lib.PartitionedFileSetProperties;
 import co.cask.cdap.api.dataset.lib.Partitioning;
 import co.cask.cdap.data2.dataset2.AbstractDatasetTest;
+import co.cask.cdap.proto.Id;
 import co.cask.cdap.test.SlowTests;
 import co.cask.tephra.TransactionAware;
 import co.cask.tephra.TransactionExecutor;
@@ -59,9 +60,11 @@ public class PartitionedFileSetTest extends AbstractDatasetTest {
     .addStringField("x")
     .build();
 
+  private static final Id.DatasetInstance pfsInstance = Id.DatasetInstance.from(NAMESPACE_ID, "pfs");
+
   @Before
   public void before() throws Exception {
-    createInstance("partitionedFileSet", "pfs", PartitionedFileSetProperties.builder()
+    createInstance("partitionedFileSet", pfsInstance, PartitionedFileSetProperties.builder()
       .setPartitioning(PARTITIONING_1)
       .setBasePath("testDir")
       .build());
@@ -69,7 +72,7 @@ public class PartitionedFileSetTest extends AbstractDatasetTest {
 
   @After
   public void after() throws Exception {
-    deleteInstance("pfs");
+    deleteInstance(pfsInstance);
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -110,7 +113,7 @@ public class PartitionedFileSetTest extends AbstractDatasetTest {
   @Category(SlowTests.class)
   public void testAddRemoveGetPartitions() throws Exception {
 
-    final PartitionedFileSet dataset = getInstance("pfs");
+    final PartitionedFileSet dataset = getInstance(pfsInstance);
 
     final PartitionKey[][][] keys = new PartitionKey[4][4][4];
     final String[][][] paths = new String[4][4][4];

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/ACLTableDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/ACLTableDatasetTest.java
@@ -41,9 +41,9 @@ public class ACLTableDatasetTest extends AbstractDatasetTest {
   @Test
   public void testBasics() throws Exception {
     addModule(aclTableModule, new ACLTableModule());
-
-    createInstance(ACLTable.class.getName(), "myAclTable", DatasetProperties.EMPTY);
-    ACLTable myAclTable = getInstance("myAclTable");
+    Id.DatasetInstance myAclTableInstance = Id.DatasetInstance.from(NAMESPACE_ID, "myAclTable");
+    createInstance(ACLTable.class.getName(), myAclTableInstance, DatasetProperties.EMPTY);
+    ACLTable myAclTable = getInstance(myAclTableInstance);
 
     final Principal bobUser = new Principal(PrincipalType.USER, "bob");
     final Principal bobGroup = new Principal(PrincipalType.GROUP, "bobs-only");

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/ObjectStoreDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/ObjectStoreDatasetTest.java
@@ -74,15 +74,16 @@ public class ObjectStoreDatasetTest extends AbstractDatasetTest {
     deleteModule(integerStore);
   }
 
-  private void addIntegerStoreInstance(String instanceName) throws Exception {
-    createInstance("integerStore", instanceName, DatasetProperties.EMPTY);
+  private void addIntegerStoreInstance(Id.DatasetInstance datasetInstanceId) throws Exception {
+    createInstance("integerStore", datasetInstanceId, DatasetProperties.EMPTY);
   }
 
   @Test
   public void testStringStore() throws Exception {
-    createObjectStoreInstance("strings", String.class);
+    Id.DatasetInstance strings = Id.DatasetInstance.from(NAMESPACE_ID, "strings");
+    createObjectStoreInstance(strings, String.class);
     
-    ObjectStoreDataset<String> stringStore = getInstance("strings");
+    ObjectStoreDataset<String> stringStore = getInstance(strings);
     String string = "this is a string";
     stringStore.write(a, string);
     String result = stringStore.read(a);
@@ -90,14 +91,15 @@ public class ObjectStoreDatasetTest extends AbstractDatasetTest {
 
     deleteAndVerify(stringStore, a);
 
-    deleteInstance("strings");
+    deleteInstance(strings);
   }
 
   @Test
   public void testPairStore() throws Exception {
-    createObjectStoreInstance("pairs", new TypeToken<ImmutablePair<Integer, String>>() { }.getType());
+    Id.DatasetInstance pairs = Id.DatasetInstance.from(NAMESPACE_ID, "pairs");
+    createObjectStoreInstance(pairs, new TypeToken<ImmutablePair<Integer, String>>() { }.getType());
 
-    ObjectStoreDataset<ImmutablePair<Integer, String>> pairStore = getInstance("pairs");
+    ObjectStoreDataset<ImmutablePair<Integer, String>> pairStore = getInstance(pairs);
     ImmutablePair<Integer, String> pair = new ImmutablePair<Integer, String>(1, "second");
     pairStore.write(a, pair);
     ImmutablePair<Integer, String> result = pairStore.read(a);
@@ -105,14 +107,15 @@ public class ObjectStoreDatasetTest extends AbstractDatasetTest {
 
     deleteAndVerify(pairStore, a);
 
-    deleteInstance("pairs");
+    deleteInstance(pairs);
   }
 
   @Test
   public void testCustomStore() throws Exception {
-    createObjectStoreInstance("customs", new TypeToken<Custom>() { }.getType());
+    Id.DatasetInstance customs = Id.DatasetInstance.from(NAMESPACE_ID, "customs");
+    createObjectStoreInstance(customs, new TypeToken<Custom>() { }.getType());
 
-    ObjectStoreDataset<Custom> customStore = getInstance("customs");
+    ObjectStoreDataset<Custom> customStore = getInstance(customs);
     Custom custom = new Custom(42, Lists.newArrayList("one", "two"));
     customStore.write(a, custom);
     Custom result = customStore.read(a);
@@ -124,14 +127,15 @@ public class ObjectStoreDatasetTest extends AbstractDatasetTest {
 
     deleteAndVerify(customStore, a);
 
-    deleteInstance("customs");
+    deleteInstance(customs);
   }
 
   @Test
   public void testInnerStore() throws Exception {
-    createObjectStoreInstance("inners", new TypeToken<CustomWithInner.Inner<Integer>>() { }.getType());
+    Id.DatasetInstance inners = Id.DatasetInstance.from(NAMESPACE_ID, "inners");
+    createObjectStoreInstance(inners, new TypeToken<CustomWithInner.Inner<Integer>>() { }.getType());
 
-    ObjectStoreDataset<CustomWithInner.Inner<Integer>> innerStore = getInstance("inners");
+    ObjectStoreDataset<CustomWithInner.Inner<Integer>> innerStore = getInstance(inners);
     CustomWithInner.Inner<Integer> inner = new CustomWithInner.Inner<Integer>(42, new Integer(99));
     innerStore.write(a, inner);
     CustomWithInner.Inner<Integer> result = innerStore.read(a);
@@ -139,15 +143,16 @@ public class ObjectStoreDatasetTest extends AbstractDatasetTest {
 
     deleteAndVerify(innerStore, a);
 
-    deleteInstance("inners");
+    deleteInstance(inners);
   }
 
   @Test
   public void testInstantiateWrongClass() throws Exception {
-    createObjectStoreInstance("pairs", new TypeToken<ImmutablePair<Integer, String>>() { }.getType());
+    Id.DatasetInstance pairs = Id.DatasetInstance.from(NAMESPACE_ID, "pairs");
+    createObjectStoreInstance(pairs, new TypeToken<ImmutablePair<Integer, String>>() { }.getType());
 
     // note: due to type erasure, this succeeds
-    final ObjectStoreDataset<Custom> store = getInstance("pairs");
+    final ObjectStoreDataset<Custom> store = getInstance(pairs);
     TransactionExecutor storeTxnl = newTransactionExecutor(store);
     // but now it must fail with incompatible type
     try {
@@ -164,7 +169,7 @@ public class ObjectStoreDatasetTest extends AbstractDatasetTest {
     }
 
     // write a correct object to the pair store
-    final ObjectStoreDataset<ImmutablePair<Integer, String>> pairStore = getInstance("pairs");
+    final ObjectStoreDataset<ImmutablePair<Integer, String>> pairStore = getInstance(pairs);
     TransactionExecutor pairStoreTxnl = newTransactionExecutor(store);
 
     final ImmutablePair<Integer, String> pair = new ImmutablePair<Integer, String>(1, "second");
@@ -199,12 +204,12 @@ public class ObjectStoreDatasetTest extends AbstractDatasetTest {
 
     deleteAndVerify(pairStore, a);
 
-    deleteInstance("pairs");
+    deleteInstance(pairs);
   }
 
   @Test
   public void testWithCustomClassLoader() throws Exception {
-
+    Id.DatasetInstance kv = Id.DatasetInstance.from(NAMESPACE_ID, "kv");
     // create a dummy class loader that records the name of the class it loaded
     final AtomicReference<String> lastClassLoaded = new AtomicReference<String>(null);
     ClassLoader loader = new ClassLoader() {
@@ -215,9 +220,9 @@ public class ObjectStoreDatasetTest extends AbstractDatasetTest {
       }
     };
 
-    createInstance("keyValueTable", "kv", DatasetProperties.EMPTY);
+    createInstance("keyValueTable", kv, DatasetProperties.EMPTY);
 
-    KeyValueTable kvTable = getInstance("kv");
+    KeyValueTable kvTable = getInstance(kv);
     Type type = Custom.class;
     TypeRepresentation typeRep = new TypeRepresentation(type);
     Schema schema = new ReflectionSchemaGenerator().generate(type);
@@ -229,14 +234,15 @@ public class ObjectStoreDatasetTest extends AbstractDatasetTest {
 
     deleteAndVerify(objectStore, Bytes.toBytes("dummy"));
 
-    deleteInstance("kv");
+    deleteInstance(kv);
   }
 
   @Test
   public void testBatchCustomList() throws Exception {
-    createObjectStoreInstance("customlist", new TypeToken<List<Custom>>() { }.getType());
+    Id.DatasetInstance customlist = Id.DatasetInstance.from(NAMESPACE_ID, "customlist");
+    createObjectStoreInstance(customlist, new TypeToken<List<Custom>>() { }.getType());
 
-    final ObjectStoreDataset<List<Custom>> customStore = getInstance("customlist");
+    final ObjectStoreDataset<List<Custom>> customStore = getInstance(customlist);
     TransactionExecutor txnl = newTransactionExecutor(customStore);
 
     final SortedSet<Long> keysWritten = Sets.newTreeSet();
@@ -287,14 +293,15 @@ public class ObjectStoreDatasetTest extends AbstractDatasetTest {
 
     deleteAndVerifyInBatch(customStore, txnl, keysWrittenCopy);
 
-    deleteInstance("customlist");
+    deleteInstance(customlist);
   }
 
   @Test
   public void testBatchReads() throws Exception {
-    createObjectStoreInstance("batch", String.class);
+    Id.DatasetInstance batch = Id.DatasetInstance.from(NAMESPACE_ID, "batch");
+    createObjectStoreInstance(batch, String.class);
 
-    final ObjectStoreDataset<String> t = getInstance("batch");
+    final ObjectStoreDataset<String> t = getInstance(batch);
     TransactionExecutor txnl = newTransactionExecutor(t);
 
     final SortedSet<Long> keysWritten = Sets.newTreeSet();
@@ -338,14 +345,15 @@ public class ObjectStoreDatasetTest extends AbstractDatasetTest {
 
     deleteAndVerifyInBatch(t, txnl, keysWritten);
 
-    deleteInstance("batch");
+    deleteInstance(batch);
   }
 
   @Test
   public void testScanObjectStore() throws Exception {
-    createObjectStoreInstance("scan", String.class);
+    Id.DatasetInstance scan = Id.DatasetInstance.from(NAMESPACE_ID, "scan");
+    createObjectStoreInstance(scan, String.class);
 
-    final ObjectStoreDataset<String> t = getInstance("scan");
+    final ObjectStoreDataset<String> t = getInstance(scan);
     TransactionExecutor txnl = newTransactionExecutor(t);
 
     // write 10 values
@@ -392,7 +400,7 @@ public class ObjectStoreDatasetTest extends AbstractDatasetTest {
     });
 
 
-    deleteInstance("scan");
+    deleteInstance(scan);
   }
 
   // helper to verify that the split readers for the given splits return exactly a set of keys
@@ -419,9 +427,10 @@ public class ObjectStoreDatasetTest extends AbstractDatasetTest {
 
   @Test
   public void testSubclass() throws Exception {
-    addIntegerStoreInstance("ints");
+    Id.DatasetInstance intsInstance = Id.DatasetInstance.from(NAMESPACE_ID, "ints");
+    addIntegerStoreInstance(intsInstance);
 
-    IntegerStore ints = getInstance("ints");
+    IntegerStore ints = getInstance(intsInstance);
     ints.write(42, 101);
     Assert.assertEquals((Integer) 101, ints.read(42));
 
@@ -429,11 +438,11 @@ public class ObjectStoreDatasetTest extends AbstractDatasetTest {
     ints.delete(42);
     Assert.assertNull(ints.read(42));
 
-    deleteInstance("ints");
+    deleteInstance(intsInstance);
   }
 
-  private void createObjectStoreInstance(String instanceName, Type type) throws Exception {
-    createInstance("objectStore", instanceName, ObjectStores.objectStoreProperties(type, DatasetProperties.EMPTY));
+  private void createObjectStoreInstance(Id.DatasetInstance datasetInstanceId, Type type) throws Exception {
+    createInstance("objectStore", datasetInstanceId, ObjectStores.objectStoreProperties(type, DatasetProperties.EMPTY));
   }
 
   private void deleteAndVerify(ObjectStore store, byte[] key) {

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/inmemory/InMemoryMetricsTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/inmemory/InMemoryMetricsTableTest.java
@@ -71,7 +71,8 @@ public class InMemoryMetricsTableTest extends MetricsTableTest {
 
   @Override
   protected MetricsTable getTable(String name) throws Exception {
-    return DatasetsUtil.getOrCreateDataset(dsFramework, name, MetricsTable.class.getName(),
+    Id.DatasetInstance metricsDatasetInstanceId = Id.DatasetInstance.from(NAMESPACE_ID, name);
+    return DatasetsUtil.getOrCreateDataset(dsFramework, metricsDatasetInstanceId, MetricsTable.class.getName(),
                                            DatasetProperties.EMPTY, null, null);
   }
 }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBMetricsTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBMetricsTableTest.java
@@ -78,7 +78,8 @@ public class LevelDBMetricsTableTest extends MetricsTableTest {
 
   @Override
   protected MetricsTable getTable(String name) throws Exception {
-    return DatasetsUtil.getOrCreateDataset(dsFramework, name, MetricsTable.class.getName(),
+    Id.DatasetInstance metricsDatasetInstanceId = Id.DatasetInstance.from(NAMESPACE_ID, name);
+    return DatasetsUtil.getOrCreateDataset(dsFramework, metricsDatasetInstanceId, MetricsTable.class.getName(),
                                            DatasetProperties.EMPTY, null, null);
   }
 }

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/executor/ExploreExecutorHttpHandler.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/executor/ExploreExecutorHttpHandler.java
@@ -184,7 +184,9 @@ public class ExploreExecutorHttpHandler extends AbstractHttpHandler {
   public void enableDataset(@SuppressWarnings("UnusedParameters") HttpRequest request, HttpResponder responder,
                             @PathParam("dataset") final String datasetName) {
     try {
-      Dataset dataset = instantiateDataset(datasetName, responder);
+      // Note: Namespacing will come later.
+      Id.DatasetInstance datasetInstanceId = Id.DatasetInstance.from(Constants.DEFAULT_NAMESPACE, datasetName);
+      Dataset dataset = instantiateDataset(datasetInstanceId, responder);
       if (dataset == null) {
         return; // response sent by instantiateDataset()
       }
@@ -201,7 +203,7 @@ public class ExploreExecutorHttpHandler extends AbstractHttpHandler {
           || dataset instanceof TimePartitionedFileSet
           || dataset instanceof PartitionedFileSet) {
           // this cannot fail because we were able to instantiate the dataset
-          DatasetSpecification spec = datasetFramework.getDatasetSpec(datasetName);
+          DatasetSpecification spec = datasetFramework.getDatasetSpec(datasetInstanceId);
           if (spec != null) {
             Map<String, String> properties = spec.getProperties();
             if (FileSetProperties.isExploreEnabled(properties)) {
@@ -238,10 +240,10 @@ public class ExploreExecutorHttpHandler extends AbstractHttpHandler {
     }
   }
 
-  private Dataset instantiateDataset(String datasetName, HttpResponder responder) throws Exception {
+  private Dataset instantiateDataset(Id.DatasetInstance datasetInstanceId, HttpResponder responder) throws Exception {
     Dataset dataset;
     try {
-      dataset = datasetFramework.getDataset(datasetName, DatasetDefinition.NO_ARGUMENTS, null);
+      dataset = datasetFramework.getDataset(datasetInstanceId, DatasetDefinition.NO_ARGUMENTS, null);
     } catch (Exception e) {
       String className = isClassNotFoundException(e);
       if (className == null) {
@@ -249,14 +251,14 @@ public class ExploreExecutorHttpHandler extends AbstractHttpHandler {
       }
       LOG.info("Cannot load dataset {} because class {} cannot be found. This is probably because class {} is a " +
                  "type parameter of dataset {} that is not present in the dataset's jar file. See the developer " +
-                 "guide for more information.", datasetName, className, className, datasetName);
+                 "guide for more information.", datasetInstanceId, className, className, datasetInstanceId);
       JsonObject json = new JsonObject();
       json.addProperty("handle", QueryHandle.NO_OP.getHandle());
       responder.sendJson(HttpResponseStatus.OK, json);
       return null;
     }
     if (dataset == null) {
-      responder.sendString(HttpResponseStatus.NOT_FOUND, "Cannot load dataset " + datasetName);
+      responder.sendString(HttpResponseStatus.NOT_FOUND, "Cannot load dataset " + datasetInstanceId);
       return null;
     }
     return dataset;
@@ -281,8 +283,9 @@ public class ExploreExecutorHttpHandler extends AbstractHttpHandler {
                              @PathParam("dataset") final String datasetName) {
     try {
       LOG.debug("Disabling explore for dataset instance {}", datasetName);
-
-      Dataset dataset = instantiateDataset(datasetName, responder);
+      // Note: namespacing will come later
+      Id.DatasetInstance datasetInstanceId = Id.DatasetInstance.from(Constants.DEFAULT_NAMESPACE, datasetName);
+      Dataset dataset = instantiateDataset(datasetInstanceId, responder);
       if (dataset == null) {
         return; // response sent by instantiateDataset()
       }
@@ -293,7 +296,7 @@ public class ExploreExecutorHttpHandler extends AbstractHttpHandler {
       } else if (dataset instanceof FileSet
         || dataset instanceof PartitionedFileSet || dataset instanceof TimePartitionedFileSet) {
         // this cannot fail because we were able to instantiate the dataset
-        DatasetSpecification spec = datasetFramework.getDatasetSpec(datasetName);
+        DatasetSpecification spec = datasetFramework.getDatasetSpec(datasetInstanceId);
         if (spec != null) {
           Map<String, String> properties = spec.getProperties();
           if (FileSetProperties.isExploreEnabled(properties)) {
@@ -365,7 +368,9 @@ public class ExploreExecutorHttpHandler extends AbstractHttpHandler {
   public void addPartition(HttpRequest request, HttpResponder responder,
                            @PathParam("dataset") final String datasetName) {
     try {
-      Dataset dataset = instantiateDataset(datasetName, responder);
+      // Note: Namespacing will come later.
+      Id.DatasetInstance datasetInstanceId = Id.DatasetInstance.from(Constants.DEFAULT_NAMESPACE, datasetName);
+      Dataset dataset = instantiateDataset(datasetInstanceId, responder);
       if (dataset == null) {
         return; // response sent by instantiateDataset()
       }
@@ -434,7 +439,9 @@ public class ExploreExecutorHttpHandler extends AbstractHttpHandler {
   public void dropPartition(HttpRequest request, HttpResponder responder,
                             @PathParam("dataset") final String datasetName) {
     try {
-      Dataset dataset = instantiateDataset(datasetName, responder);
+      // Note: Namespacing will come later.
+      Id.DatasetInstance datasetInstanceId = Id.DatasetInstance.from(Constants.DEFAULT_NAMESPACE, datasetName);
+      Dataset dataset = instantiateDataset(datasetInstanceId, responder);
       if (dataset == null) {
         return; // response sent by instantiateDataset()
       }

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/datasets/DatasetSerDe.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/datasets/DatasetSerDe.java
@@ -19,6 +19,7 @@ package co.cask.cdap.hive.datasets;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.hive.context.NullJobConfException;
 import co.cask.cdap.hive.objectinspector.ObjectInspectorFactory;
+import co.cask.cdap.proto.Id;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
@@ -88,6 +89,8 @@ public class DatasetSerDe implements SerDe {
     columnNames = new ArrayList<String>(Arrays.asList(StringUtils.split(properties.getProperty("columns"), ",")));
 
     String datasetName = properties.getProperty(Constants.Explore.DATASET_NAME);
+    // note: namespacing will come in later. Perhaps initialize this class with a namespace or get it in each method
+    Id.DatasetInstance datasetInstanceId = Id.DatasetInstance.from(Constants.DEFAULT_NAMESPACE, datasetName);
     try {
       if (entries != null) {
         // Here, we can't say whether Hive wants to read the table, or write to it
@@ -97,7 +100,7 @@ public class DatasetSerDe implements SerDe {
       } else {
         // When initialize is called to write to a table, entries is null
         try {
-          recordType = DatasetAccessor.getRecordWritableType(datasetName);
+          recordType = DatasetAccessor.getRecordWritableType(datasetInstanceId);
         } catch (NullJobConfException e) {
           // This is the case when this serDe is used by Hive only for its serialize method. In that case,
           // We don't need to initialize a context since serialize does not need any dataset information.

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/BaseHiveExploreServiceTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/BaseHiveExploreServiceTest.java
@@ -99,6 +99,7 @@ public class BaseHiveExploreServiceTest {
 
   protected static final Id.Namespace NAMESPACE_ID = Id.Namespace.from("myspace");
   protected static final Id.DatasetModule KEY_STRUCT_VALUE = Id.DatasetModule.from(NAMESPACE_ID, "keyStructValue");
+  protected static final Id.DatasetInstance MY_TABLE = Id.DatasetInstance.from(NAMESPACE_ID, "my_table");
 
   // Controls for test suite for whether to run BeforeClass/AfterClass
   public static boolean runBefore = true;

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreDisabledTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreDisabledTest.java
@@ -102,16 +102,17 @@ public class ExploreDisabledTest {
     // Try to deploy a dataset that is not record scannable, when explore is enabled.
     // This should be processed with no exception being thrown
     Id.DatasetModule module1 = Id.DatasetModule.from(namespaceId, "module1");
+    Id.DatasetInstance instance1 = Id.DatasetInstance.from(namespaceId, "table1");
     datasetFramework.addModule(module1, new KeyStructValueTableDefinition.KeyStructValueTableModule());
 
     // Performing admin operations to create dataset instance
-    datasetFramework.addInstance("keyStructValueTable", "table1", DatasetProperties.EMPTY);
+    datasetFramework.addInstance("keyStructValueTable", instance1, DatasetProperties.EMPTY);
 
     Transaction tx1 = transactionManager.startShort(100);
 
     // Accessing dataset instance to perform data operations
     KeyStructValueTableDefinition.KeyStructValueTable table =
-      datasetFramework.getDataset("table1", DatasetDefinition.NO_ARGUMENTS, null);
+      datasetFramework.getDataset(instance1, DatasetDefinition.NO_ARGUMENTS, null);
     Assert.assertNotNull(table);
     table.startTx(tx1);
 
@@ -135,7 +136,7 @@ public class ExploreDisabledTest {
 
     Assert.assertEquals(value1, table.get("1"));
 
-    datasetFramework.deleteInstance("table1");
+    datasetFramework.deleteInstance(instance1);
     datasetFramework.deleteModule(module1);
   }
 
@@ -144,16 +145,17 @@ public class ExploreDisabledTest {
     // Try to deploy a dataset that is not record scannable, when explore is enabled.
     // This should be processed with no exceptionbeing thrown
     Id.DatasetModule module2 = Id.DatasetModule.from(namespaceId, "module2");
+    Id.DatasetInstance instance2 = Id.DatasetInstance.from(namespaceId, "table1");
     datasetFramework.addModule(module2, new NotRecordScannableTableDefinition.NotRecordScannableTableModule());
 
     // Performing admin operations to create dataset instance
-    datasetFramework.addInstance("NotRecordScannableTableDef", "table2", DatasetProperties.EMPTY);
+    datasetFramework.addInstance("NotRecordScannableTableDef", instance2, DatasetProperties.EMPTY);
 
     Transaction tx1 = transactionManager.startShort(100);
 
     // Accessing dataset instance to perform data operations
     NotRecordScannableTableDefinition.KeyValueTable table =
-      datasetFramework.getDataset("table2", DatasetDefinition.NO_ARGUMENTS, null);
+      datasetFramework.getDataset(instance2, DatasetDefinition.NO_ARGUMENTS, null);
     Assert.assertNotNull(table);
     table.startTx(tx1);
 
@@ -173,7 +175,7 @@ public class ExploreDisabledTest {
 
     Assert.assertEquals("value1", new String(table.read("key1")));
 
-    datasetFramework.deleteInstance("table2");
+    datasetFramework.deleteInstance(instance2);
     datasetFramework.deleteModule(module2);
   }
 

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreExtensiveSchemaTableTestRun.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreExtensiveSchemaTableTestRun.java
@@ -49,11 +49,11 @@ public class ExploreExtensiveSchemaTableTestRun extends BaseHiveExploreServiceTe
     datasetFramework.addModule(extensiveSchema, new ExtensiveSchemaTableDefinition.ExtensiveSchemaTableModule());
 
     // Performing admin operations to create dataset instance
-    datasetFramework.addInstance("ExtensiveSchemaTable", "my_table", DatasetProperties.EMPTY);
+    datasetFramework.addInstance("ExtensiveSchemaTable", MY_TABLE, DatasetProperties.EMPTY);
 
     // Accessing dataset instance to perform data operations
     ExtensiveSchemaTableDefinition.ExtensiveSchemaTable table =
-      datasetFramework.getDataset("my_table", DatasetDefinition.NO_ARGUMENTS, null);
+      datasetFramework.getDataset(MY_TABLE, DatasetDefinition.NO_ARGUMENTS, null);
     Assert.assertNotNull(table);
 
     Transaction tx1 = transactionManager.startShort(100);
@@ -89,7 +89,7 @@ public class ExploreExtensiveSchemaTableTestRun extends BaseHiveExploreServiceTe
 
   @AfterClass
   public static void stop() throws Exception {
-    datasetFramework.deleteInstance("my_table");
+    datasetFramework.deleteInstance(MY_TABLE);
     datasetFramework.deleteModule(extensiveSchema);
   }
 

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreMetadataTestRun.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreMetadataTestRun.java
@@ -22,6 +22,7 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.explore.client.ExploreExecutionResult;
 import co.cask.cdap.explore.service.datasets.KeyStructValueTableDefinition;
 import co.cask.cdap.proto.ColumnDesc;
+import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.QueryResult;
 import co.cask.cdap.test.SlowTests;
 import com.google.common.collect.Lists;
@@ -38,6 +39,8 @@ import org.junit.experimental.categories.Category;
 @Category(SlowTests.class)
 public class ExploreMetadataTestRun extends BaseHiveExploreServiceTest {
 
+  private static final Id.DatasetInstance otherTable = Id.DatasetInstance.from(NAMESPACE_ID, "other_table");
+
   @BeforeClass
   public static void start() throws Exception {
     startServices();
@@ -45,14 +48,14 @@ public class ExploreMetadataTestRun extends BaseHiveExploreServiceTest {
     datasetFramework.addModule(KEY_STRUCT_VALUE, new KeyStructValueTableDefinition.KeyStructValueTableModule());
 
     // Performing admin operations to create dataset instance
-    datasetFramework.addInstance("keyStructValueTable", "my_table", DatasetProperties.EMPTY);
-    datasetFramework.addInstance("keyStructValueTable", "other_table", DatasetProperties.EMPTY);
+    datasetFramework.addInstance("keyStructValueTable", MY_TABLE, DatasetProperties.EMPTY);
+    datasetFramework.addInstance("keyStructValueTable", otherTable, DatasetProperties.EMPTY);
   }
 
   @AfterClass
   public static void stop() throws Exception {
-    datasetFramework.deleteInstance("my_table");
-    datasetFramework.deleteInstance("other_table");
+    datasetFramework.deleteInstance(MY_TABLE);
+    datasetFramework.deleteInstance(otherTable);
     datasetFramework.deleteModule(KEY_STRUCT_VALUE);
   }
 

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceFileSetTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceFileSetTest.java
@@ -27,7 +27,9 @@ import co.cask.cdap.api.dataset.lib.PartitionedFileSetProperties;
 import co.cask.cdap.api.dataset.lib.Partitioning;
 import co.cask.cdap.api.dataset.lib.TimePartitionedFileSet;
 import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.proto.ColumnDesc;
+import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.QueryResult;
 import co.cask.cdap.test.SlowTests;
 import co.cask.tephra.Transaction;
@@ -63,19 +65,20 @@ public class HiveExploreServiceFileSetTest extends BaseHiveExploreServiceTest {
 
   @After
   public void deleteAll() throws Exception {
-    datasetFramework.deleteAllInstances();
+    datasetFramework.deleteAllInstances(NAMESPACE_ID);
   }
 
   @Test
   public void testCreateAddDrop() throws Exception {
 
     final String datasetName = "files";
+    final Id.DatasetInstance datasetInstanceId = Id.DatasetInstance.from(NAMESPACE_ID, datasetName);
 
     @SuppressWarnings("UnnecessaryLocalVariable")
     final String tableName = datasetName; // in this test context, the hive table name is the same as the dataset name
 
     // create a time partitioned file set
-    datasetFramework.addInstance("fileSet", datasetName, FileSetProperties.builder()
+    datasetFramework.addInstance("fileSet", datasetInstanceId, FileSetProperties.builder()
       // properties for file set
       .setBasePath("/myPath")
         // properties for partitioned hive table
@@ -92,7 +95,7 @@ public class HiveExploreServiceFileSetTest extends BaseHiveExploreServiceTest {
                Lists.newArrayList(new QueryResult(Lists.<Object>newArrayList(tableName))));
 
     // Accessing dataset instance to perform data operations
-    FileSet fileSet = datasetFramework.getDataset(datasetName, DatasetDefinition.NO_ARGUMENTS, null);
+    FileSet fileSet = datasetFramework.getDataset(datasetInstanceId, DatasetDefinition.NO_ARGUMENTS, null);
     Assert.assertNotNull(fileSet);
 
     // add a file
@@ -117,7 +120,7 @@ public class HiveExploreServiceFileSetTest extends BaseHiveExploreServiceTest {
                Lists.newArrayList(new QueryResult(Lists.<Object>newArrayList(5L))));
 
     // drop the dataset
-    datasetFramework.deleteInstance(datasetName);
+    datasetFramework.deleteInstance(datasetInstanceId);
 
     // verify the Hive table is gone
     runCommand("show tables", false,
@@ -130,12 +133,13 @@ public class HiveExploreServiceFileSetTest extends BaseHiveExploreServiceTest {
   public void testPartitionedFileSet() throws Exception {
 
     final String datasetName = "parted";
+    final Id.DatasetInstance datasetInstanceId = Id.DatasetInstance.from(NAMESPACE_ID, datasetName);
 
     @SuppressWarnings("UnnecessaryLocalVariable")
     final String tableName = datasetName; // in this test context, the hive table name is the same as the dataset name
 
     // create a time partitioned file set
-    datasetFramework.addInstance("partitionedFileSet", datasetName, PartitionedFileSetProperties.builder()
+    datasetFramework.addInstance("partitionedFileSet", datasetInstanceId, PartitionedFileSetProperties.builder()
       .setPartitioning(Partitioning.builder()
                          .addStringField("str")
                          .addIntField("num")
@@ -156,7 +160,8 @@ public class HiveExploreServiceFileSetTest extends BaseHiveExploreServiceTest {
                Lists.newArrayList(new QueryResult(Lists.<Object>newArrayList(tableName))));
 
     // Accessing dataset instance to perform data operations
-    PartitionedFileSet partitioned = datasetFramework.getDataset(datasetName, DatasetDefinition.NO_ARGUMENTS, null);
+    PartitionedFileSet partitioned = datasetFramework.getDataset(datasetInstanceId, DatasetDefinition.NO_ARGUMENTS,
+                                                                 null);
     Assert.assertNotNull(partitioned);
     FileSet fileSet = partitioned.getEmbeddedFileSet();
 
@@ -233,7 +238,7 @@ public class HiveExploreServiceFileSetTest extends BaseHiveExploreServiceTest {
                  new QueryResult(Lists.<Object>newArrayList("y2", "#2"))));
 
     // drop the dataset
-    datasetFramework.deleteInstance(datasetName);
+    datasetFramework.deleteInstance(datasetInstanceId);
 
     // verify the Hive table is gone
     runCommand("show tables", false,
@@ -245,12 +250,13 @@ public class HiveExploreServiceFileSetTest extends BaseHiveExploreServiceTest {
   public void testTimePartitionedFileSet() throws Exception {
 
     final String datasetName = "parts";
+    final Id.DatasetInstance datasetInstanceId = Id.DatasetInstance.from(NAMESPACE_ID, datasetName);
 
     @SuppressWarnings("UnnecessaryLocalVariable")
     final String tableName = datasetName; // in this test context, the hive table name is the same as the dataset name
 
     // create a time partitioned file set
-    datasetFramework.addInstance("timePartitionedFileSet", datasetName, FileSetProperties.builder()
+    datasetFramework.addInstance("timePartitionedFileSet", datasetInstanceId, FileSetProperties.builder()
       // properties for file set
       .setBasePath("/somePath")
         // properties for partitioned hive table
@@ -267,7 +273,7 @@ public class HiveExploreServiceFileSetTest extends BaseHiveExploreServiceTest {
                Lists.newArrayList(new QueryResult(Lists.<Object>newArrayList(tableName))));
 
     // Accessing dataset instance to perform data operations
-    TimePartitionedFileSet tpfs = datasetFramework.getDataset(datasetName, DatasetDefinition.NO_ARGUMENTS, null);
+    TimePartitionedFileSet tpfs = datasetFramework.getDataset(datasetInstanceId, DatasetDefinition.NO_ARGUMENTS, null);
     Assert.assertNotNull(tpfs);
     Assert.assertTrue(tpfs instanceof TransactionAware);
 
@@ -335,14 +341,14 @@ public class HiveExploreServiceFileSetTest extends BaseHiveExploreServiceTest {
                  new QueryResult(Lists.<Object>newArrayList("year=2014/month=12/day=10/hour=3/minute=0"))));
 
     // drop the dataset
-    datasetFramework.deleteInstance(datasetName);
+    datasetFramework.deleteInstance(datasetInstanceId);
 
     // verify the Hive table is gone
     runCommand("show tables", false,
                Lists.newArrayList(new ColumnDesc("tab_name", "STRING", 1, "from deserializer")),
                Collections.<QueryResult>emptyList());
 
-    datasetFramework.addInstance("timePartitionedFileSet", datasetName, FileSetProperties.builder()
+    datasetFramework.addInstance("timePartitionedFileSet", datasetInstanceId, FileSetProperties.builder()
       // properties for file set
       .setBasePath("/somePath")
         // properties for partitioned hive table

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceTestRun.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceTestRun.java
@@ -73,11 +73,11 @@ public class HiveExploreServiceTestRun extends BaseHiveExploreServiceTest {
     datasetFramework.addModule(KEY_STRUCT_VALUE, new KeyStructValueTableDefinition.KeyStructValueTableModule());
 
     // Performing admin operations to create dataset instance
-    datasetFramework.addInstance("keyStructValueTable", "my_table", DatasetProperties.EMPTY);
+    datasetFramework.addInstance("keyStructValueTable", MY_TABLE, DatasetProperties.EMPTY);
 
     // Accessing dataset instance to perform data operations
     KeyStructValueTableDefinition.KeyStructValueTable table =
-      datasetFramework.getDataset("my_table", DatasetDefinition.NO_ARGUMENTS, null);
+      datasetFramework.getDataset(MY_TABLE, DatasetDefinition.NO_ARGUMENTS, null);
     Assert.assertNotNull(table);
 
     Transaction tx1 = transactionManager.startShort(100);
@@ -104,7 +104,7 @@ public class HiveExploreServiceTestRun extends BaseHiveExploreServiceTest {
 
   @AfterClass
   public static void stop() throws Exception {
-    datasetFramework.deleteInstance("my_table");
+    datasetFramework.deleteInstance(MY_TABLE);
     datasetFramework.deleteModule(KEY_STRUCT_VALUE);
   }
 
@@ -113,18 +113,20 @@ public class HiveExploreServiceTestRun extends BaseHiveExploreServiceTest {
     // Try to deploy a dataset that is not record scannable, when explore is enabled.
     // This should be processed with no exception being thrown
     Id.DatasetModule module2 = Id.DatasetModule.from(NAMESPACE_ID, "module2");
+    Id.DatasetInstance myTableNotRecordScannable = Id.DatasetInstance.from(NAMESPACE_ID,
+                                                                           "my_table_not_record_scannable");
     datasetFramework.addModule(module2, new NotRecordScannableTableDefinition.NotRecordScannableTableModule());
-    datasetFramework.addInstance("NotRecordScannableTableDef", "my_table_not_record_scannable",
+    datasetFramework.addInstance("NotRecordScannableTableDef", myTableNotRecordScannable,
                                  DatasetProperties.EMPTY);
 
-    datasetFramework.deleteInstance("my_table_not_record_scannable");
+    datasetFramework.deleteInstance(myTableNotRecordScannable);
     datasetFramework.deleteModule(module2);
   }
 
   @Test
   public void testTable() throws Exception {
     KeyStructValueTableDefinition.KeyStructValueTable table =
-      datasetFramework.getDataset("my_table", DatasetDefinition.NO_ARGUMENTS, null);
+      datasetFramework.getDataset(MY_TABLE, DatasetDefinition.NO_ARGUMENTS, null);
     Assert.assertNotNull(table);
     Transaction tx = transactionManager.startShort(100);
     table.startTx(tx);
@@ -286,11 +288,16 @@ public class HiveExploreServiceTestRun extends BaseHiveExploreServiceTest {
 
   @Test
   public void previewResultsTest() throws Exception {
-    datasetFramework.addInstance("keyStructValueTable", "my_table_2", DatasetProperties.EMPTY);
-    datasetFramework.addInstance("keyStructValueTable", "my_table_3", DatasetProperties.EMPTY);
-    datasetFramework.addInstance("keyStructValueTable", "my_table_4", DatasetProperties.EMPTY);
-    datasetFramework.addInstance("keyStructValueTable", "my_table_5", DatasetProperties.EMPTY);
-    datasetFramework.addInstance("keyStructValueTable", "my_table_6", DatasetProperties.EMPTY);
+    Id.DatasetInstance myTable2 = Id.DatasetInstance.from(NAMESPACE_ID, "my_table_2");
+    Id.DatasetInstance myTable3 = Id.DatasetInstance.from(NAMESPACE_ID, "my_table_3");
+    Id.DatasetInstance myTable4 = Id.DatasetInstance.from(NAMESPACE_ID, "my_table_4");
+    Id.DatasetInstance myTable5 = Id.DatasetInstance.from(NAMESPACE_ID, "my_table_5");
+    Id.DatasetInstance myTable6 = Id.DatasetInstance.from(NAMESPACE_ID, "my_table_6");
+    datasetFramework.addInstance("keyStructValueTable", myTable2, DatasetProperties.EMPTY);
+    datasetFramework.addInstance("keyStructValueTable", myTable3, DatasetProperties.EMPTY);
+    datasetFramework.addInstance("keyStructValueTable", myTable4, DatasetProperties.EMPTY);
+    datasetFramework.addInstance("keyStructValueTable", myTable5, DatasetProperties.EMPTY);
+    datasetFramework.addInstance("keyStructValueTable", myTable6, DatasetProperties.EMPTY);
 
     try {
       QueryHandle handle = exploreService.execute("show tables");
@@ -327,11 +334,11 @@ public class HiveExploreServiceTestRun extends BaseHiveExploreServiceTest {
       }
 
     } finally {
-      datasetFramework.deleteInstance("my_table_2");
-      datasetFramework.deleteInstance("my_table_3");
-      datasetFramework.deleteInstance("my_table_4");
-      datasetFramework.deleteInstance("my_table_5");
-      datasetFramework.deleteInstance("my_table_6");
+      datasetFramework.deleteInstance(myTable2);
+      datasetFramework.deleteInstance(myTable3);
+      datasetFramework.deleteInstance(myTable4);
+      datasetFramework.deleteInstance(myTable5);
+      datasetFramework.deleteInstance(myTable6);
     }
   }
 
@@ -478,16 +485,16 @@ public class HiveExploreServiceTestRun extends BaseHiveExploreServiceTest {
 
   @Test
   public void testJoin() throws Exception {
-
+    Id.DatasetInstance myTable1 = Id.DatasetInstance.from(NAMESPACE_ID, "my_table_1");
     // Performing admin operations to create dataset instance
-    datasetFramework.addInstance("keyStructValueTable", "my_table_1", DatasetProperties.EMPTY);
+    datasetFramework.addInstance("keyStructValueTable", myTable1, DatasetProperties.EMPTY);
 
     try {
       Transaction tx1 = transactionManager.startShort(100);
 
       // Accessing dataset instance to perform data operations
       KeyStructValueTableDefinition.KeyStructValueTable table =
-        datasetFramework.getDataset("my_table_1", DatasetDefinition.NO_ARGUMENTS, null);
+        datasetFramework.getDataset(myTable1, DatasetDefinition.NO_ARGUMENTS, null);
       Assert.assertNotNull(table);
       table.startTx(tx1);
 
@@ -566,7 +573,7 @@ public class HiveExploreServiceTestRun extends BaseHiveExploreServiceTest {
                                                          "{\"name\":\"third\",\"ints\":[30,31,32,33,34]}")))
       );
     } finally {
-      datasetFramework.deleteInstance("my_table_1");
+      datasetFramework.deleteInstance(myTable1);
     }
   }
 

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceTimeoutTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceTimeoutTest.java
@@ -70,11 +70,11 @@ public class HiveExploreServiceTimeoutTest extends BaseHiveExploreServiceTest {
     datasetFramework.addModule(KEY_STRUCT_VALUE, new KeyStructValueTableDefinition.KeyStructValueTableModule());
 
     // Performing admin operations to create dataset instance
-    datasetFramework.addInstance("keyStructValueTable", "my_table", DatasetProperties.EMPTY);
+    datasetFramework.addInstance("keyStructValueTable", MY_TABLE, DatasetProperties.EMPTY);
 
     // Accessing dataset instance to perform data operations
     KeyStructValueTableDefinition.KeyStructValueTable table =
-      datasetFramework.getDataset("my_table", DatasetDefinition.NO_ARGUMENTS, null);
+      datasetFramework.getDataset(MY_TABLE, DatasetDefinition.NO_ARGUMENTS, null);
     Assert.assertNotNull(table);
 
     Transaction tx1 = transactionManager.startShort(100);
@@ -103,7 +103,7 @@ public class HiveExploreServiceTimeoutTest extends BaseHiveExploreServiceTest {
 
   @AfterClass
   public static void stop() throws Exception {
-    datasetFramework.deleteInstance("my_table");
+    datasetFramework.deleteInstance(MY_TABLE);
     datasetFramework.deleteModule(KEY_STRUCT_VALUE);
   }
 

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/Main.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/Main.java
@@ -186,10 +186,11 @@ public class Main {
     // metrics data
     DefaultMetricDatasetFactory.setupDatasets(cConf, framework);
 
-    // Upgrade all datasets
-    for (DatasetSpecification spec : framework.getInstances()) {
+    // Upgrade all datasets in system namespace
+    Id.Namespace systemNamespace = Id.Namespace.from(Constants.SYSTEM_NAMESPACE);
+    for (DatasetSpecification spec : framework.getInstances(systemNamespace)) {
       System.out.println(String.format("Upgrading dataset: %s, spec: %s", spec.getName(), spec.toString()));
-      DatasetAdmin admin = framework.getAdmin(spec.getName(), null);
+      DatasetAdmin admin = framework.getAdmin(Id.DatasetInstance.from(systemNamespace, spec.getName()), null);
       // we know admin is not null, since we are looping over existing datasets
       admin.upgrade();
       System.out.println(String.format("Upgraded dataset: %s", spec.getName()));

--- a/cdap-notifications/src/main/java/co/cask/cdap/notifications/feeds/service/MDSNotificationFeedStore.java
+++ b/cdap-notifications/src/main/java/co/cask/cdap/notifications/feeds/service/MDSNotificationFeedStore.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.dataset.DatasetDefinition;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data.Namespace;
 import co.cask.cdap.data2.datafabric.DefaultDatasetNamespace;
 import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
@@ -73,7 +74,9 @@ public final class MDSNotificationFeedStore implements NotificationFeedStore {
         @Override
         public NotificationFeedMds get() {
           try {
-            Table mdsTable = DatasetsUtil.getOrCreateDataset(dsFramework, NOTIFICATION_FEED_TABLE, "table",
+            Id.DatasetInstance notificationsDatasetInstanceId = Id.DatasetInstance.from(Constants.SYSTEM_NAMESPACE,
+                                                                                        NOTIFICATION_FEED_TABLE);
+            Table mdsTable = DatasetsUtil.getOrCreateDataset(dsFramework, notificationsDatasetInstanceId, "table",
                                                              DatasetProperties.EMPTY, DatasetDefinition.NO_ARGUMENTS,
                                                              null);
 

--- a/cdap-notifications/src/main/java/co/cask/cdap/notifications/service/AbstractNotificationService.java
+++ b/cdap-notifications/src/main/java/co/cask/cdap/notifications/service/AbstractNotificationService.java
@@ -77,7 +77,8 @@ public abstract class AbstractNotificationService extends AbstractIdleService im
     }
     for (NotificationCaller caller : callers) {
       Object notification = GSON.fromJson(notificationJson, caller.getNotificationFeedType());
-      caller.received(notification, new BasicNotificationContext(dsFramework, transactionSystemClient));
+      Id.Namespace namespaceId = Id.Namespace.from(feed.getNamespaceId());
+      caller.received(notification, new BasicNotificationContext(namespaceId, dsFramework, transactionSystemClient));
     }
   }
 

--- a/cdap-notifications/src/main/java/co/cask/cdap/notifications/service/BasicNotificationContext.java
+++ b/cdap-notifications/src/main/java/co/cask/cdap/notifications/service/BasicNotificationContext.java
@@ -21,6 +21,7 @@ import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.data2.dataset2.DatasetCacheKey;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.DynamicDatasetContext;
+import co.cask.cdap.proto.Id;
 import co.cask.tephra.TransactionContext;
 import co.cask.tephra.TransactionFailureException;
 import co.cask.tephra.TransactionSystemClient;
@@ -37,10 +38,13 @@ import javax.annotation.Nullable;
 public final class BasicNotificationContext implements NotificationContext {
   private static final Logger LOG = LoggerFactory.getLogger(BasicNotificationContext.class);
 
+  private final Id.Namespace namespaceId;
   private final DatasetFramework dsFramework;
   private final TransactionSystemClient transactionSystemClient;
 
-  public BasicNotificationContext(DatasetFramework dsFramework, TransactionSystemClient transactionSystemClient) {
+  public BasicNotificationContext(Id.Namespace namespaceId, DatasetFramework dsFramework,
+                                  TransactionSystemClient transactionSystemClient) {
+    this.namespaceId = namespaceId;
     this.dsFramework = dsFramework;
     this.transactionSystemClient = transactionSystemClient;
   }
@@ -53,7 +57,8 @@ public final class BasicNotificationContext implements NotificationContext {
         final TransactionContext context = new TransactionContext(transactionSystemClient);
         try {
           context.start();
-          runnable.run(new DynamicDatasetContext(context, dsFramework, context.getClass().getClassLoader()) {
+          runnable.run(new DynamicDatasetContext(namespaceId, context, dsFramework,
+                                                 context.getClass().getClassLoader()) {
             @Nullable
             @Override
             protected LoadingCache<Long, Map<DatasetCacheKey, Dataset>> getDatasetsCache() {

--- a/cdap-notifications/src/test/java/co/cask/cdap/notifications/NotificationTest.java
+++ b/cdap-notifications/src/test/java/co/cask/cdap/notifications/NotificationTest.java
@@ -80,10 +80,11 @@ public abstract class NotificationTest {
 
   private static NotificationService notificationService;
 
+  private static final Id.Namespace namespace = Id.Namespace.from("namespace");
   protected static final Id.NotificationFeed FEED1 = new Id.NotificationFeed.Builder()
-    .setNamespaceId("namespace").setCategory("stream").setName("foo").setDescription("").build();
+    .setNamespaceId(namespace.getId()).setCategory("stream").setName("foo").setDescription("").build();
   protected static final Id.NotificationFeed FEED2 = new Id.NotificationFeed.Builder()
-    .setNamespaceId("namespace").setCategory("stream").setName("bar").setDescription("").build();
+    .setNamespaceId(namespace.getId()).setCategory("stream").setName("bar").setDescription("").build();
 
   protected static NotificationService getNotificationService() {
     return notificationService;
@@ -222,7 +223,8 @@ public abstract class NotificationTest {
   public void useTransactionTest() throws Exception {
     // Performing admin operations to create dataset instance
     // keyValueTable is a system dataset module
-    dsFramework.addInstance("keyValueTable", "myTable", DatasetProperties.EMPTY);
+    Id.DatasetInstance myTableInstance = Id.DatasetInstance.from(namespace, "myTable");
+    dsFramework.addInstance("keyValueTable", myTableInstance, DatasetProperties.EMPTY);
 
     Assert.assertTrue(feedManager.createFeed(FEED1));
     try {
@@ -252,7 +254,7 @@ public abstract class NotificationTest {
         // Waiting for the subscriber to receive that notification
         TimeUnit.SECONDS.sleep(2);
 
-        KeyValueTable table = dsFramework.getDataset("myTable", DatasetDefinition.NO_ARGUMENTS, null);
+        KeyValueTable table = dsFramework.getDataset(myTableInstance, DatasetDefinition.NO_ARGUMENTS, null);
         Assert.assertNotNull(table);
         Transaction tx1 = txManager.startShort(100);
         table.startTx(tx1);
@@ -265,7 +267,7 @@ public abstract class NotificationTest {
         cancellable.cancel();
       }
     } finally {
-      dsFramework.deleteInstance("myTable");
+      dsFramework.deleteInstance(myTableInstance);
       feedManager.deleteFeed(FEED1);
     }
   }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/Id.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/Id.java
@@ -36,6 +36,19 @@ public final class Id  {
   }
 
   /**
+   * Allow '.' and '$' for dataset ids since they can be fully qualified class names
+   */
+  private static boolean isValidDatasetId(String datasetId) {
+    return CharMatcher.inRange('A', 'Z')
+      .or(CharMatcher.inRange('a', 'z'))
+      .or(CharMatcher.is('-'))
+      .or(CharMatcher.is('_'))
+      .or(CharMatcher.inRange('0', '9'))
+      .or(CharMatcher.is('.'))
+      .or(CharMatcher.is('$')).matchesAllOf(datasetId);
+  }
+
+  /**
    * Represents ID of a namespace.
    */
   public static final class Namespace {
@@ -70,6 +83,11 @@ public final class Id  {
 
     public static Namespace from(String namespace) {
       return new Namespace(namespace);
+    }
+
+    @Override
+    public String toString() {
+      return id;
     }
   }
 
@@ -449,23 +467,10 @@ public final class Id  {
     public DatasetModule(final Namespace namespace, final String moduleId) {
       Preconditions.checkNotNull(namespace, "Namespace cannot be null.");
       Preconditions.checkNotNull(moduleId, "Dataset module id cannot be null.");
-      Preconditions.checkArgument(isValidModuleId(moduleId), "Invalid characters found in module Id. " +
-        "Module id can contain alphabets, numbers or _, -, . characters");
+      Preconditions.checkArgument(isValidDatasetId(moduleId), "Invalid characters found in dataset module Id. '" +
+        moduleId + "'. Module id can contain alphabets, numbers or _, -, . or $ characters");
       this.namespace = namespace;
       this.moduleId = moduleId;
-    }
-
-    /**
-     * Allow '.' and '$' for modules since module ids can be fully qualified class names
-     */
-    private boolean isValidModuleId(String moduleId) {
-      return CharMatcher.inRange('A', 'Z')
-        .or(CharMatcher.inRange('a', 'z'))
-        .or(CharMatcher.is('-'))
-        .or(CharMatcher.is('_'))
-        .or(CharMatcher.is('.'))
-        .or(CharMatcher.is('$'))
-        .or(CharMatcher.inRange('0', '9')).matchesAllOf(moduleId);
     }
 
     public Namespace getNamespace() {
@@ -512,6 +517,69 @@ public final class Id  {
 
     public static DatasetModule from(String namespaceId, String moduleId) {
       return new DatasetModule(Namespace.from(namespaceId), moduleId);
+    }
+  }
+
+  /**
+   * Dataset Instance Id identifies a given dataset instance.
+   */
+  public static final class DatasetInstance {
+    private final Namespace namespace;
+    private final String instanceId;
+
+    public DatasetInstance(final Namespace namespace, final String instanceId) {
+      Preconditions.checkNotNull(namespace, "Namespace cannot be null.");
+      Preconditions.checkNotNull(instanceId, "Dataset instance id cannot be null.");
+      Preconditions.checkArgument(isValidDatasetId(instanceId), "Invalid characters found in dataset instance id. '" +
+        instanceId + "'. Instance id can contain alphabets, numbers or _, -, . or $ characters");
+      this.namespace = namespace;
+      this.instanceId = instanceId;
+    }
+
+    public Namespace getNamespace() {
+      return namespace;
+    }
+
+    public String getNamespaceId() {
+      return namespace.getId();
+    }
+
+    public String getId() {
+      return instanceId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+
+      DatasetInstance that = (DatasetInstance) o;
+      return namespace.equals(that.namespace) && instanceId.equals(that.instanceId);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(namespace, instanceId);
+    }
+
+    @Override
+    public String toString() {
+      return Objects.toStringHelper(this)
+        .add("namespace", namespace)
+        .add("instance", instanceId)
+        .toString();
+    }
+
+    public static DatasetInstance from(Namespace id, String instanceId) {
+      return new DatasetInstance(id, instanceId);
+    }
+
+    public static DatasetInstance from(String namespaceId, String instanceId) {
+      return new DatasetInstance(Namespace.from(namespaceId), instanceId);
     }
   }
 }

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/UnitTestManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/UnitTestManager.java
@@ -124,18 +124,20 @@ public class UnitTestManager implements TestManager {
   @Override
   public final <T extends DatasetAdmin> T addDatasetInstance(String datasetTypeName, String datasetInstanceName,
                                                              DatasetProperties props) throws Exception {
-
-    datasetFramework.addInstance(datasetTypeName, datasetInstanceName, props);
-    return datasetFramework.getAdmin(datasetInstanceName, null);
+    //TODO: Expose namespaces later. Hardcoding to default right now.
+    Id.DatasetInstance datasetInstanceId = Id.DatasetInstance.from(DefaultId.NAMESPACE, datasetInstanceName);
+    datasetFramework.addInstance(datasetTypeName, datasetInstanceId, props);
+    return datasetFramework.getAdmin(datasetInstanceId, null);
   }
 
   @Beta
   @Override
   public final <T extends DatasetAdmin> T addDatasetInstance(String datasetTypeName,
                                                              String datasetInstanceName) throws Exception {
-
-    datasetFramework.addInstance(datasetTypeName, datasetInstanceName, DatasetProperties.EMPTY);
-    return datasetFramework.getAdmin(datasetInstanceName, null);
+    //TODO: Expose namespaces later. Hardcoding to default right now.
+    Id.DatasetInstance datasetInstanceId = Id.DatasetInstance.from(DefaultId.NAMESPACE, datasetInstanceName);
+    datasetFramework.addInstance(datasetTypeName, datasetInstanceId, DatasetProperties.EMPTY);
+    return datasetFramework.getAdmin(datasetInstanceId, null);
   }
 
   /**
@@ -146,8 +148,10 @@ public class UnitTestManager implements TestManager {
    */
   @Beta
   public final <T> DataSetManager<T> getDataset(String datasetInstanceName) throws Exception {
+    //TODO: Expose namespaces later. Hardcoding to default right now.
+    Id.DatasetInstance datasetInstanceId = Id.DatasetInstance.from(DefaultId.NAMESPACE, datasetInstanceName);
     @SuppressWarnings("unchecked")
-    final T dataSet = (T) datasetFramework.getDataset(datasetInstanceName, new HashMap<String, String>(), null);
+    final T dataSet = (T) datasetFramework.getDataset(datasetInstanceId, new HashMap<String, String>(), null);
     try {
       final TransactionContext txContext;
       // not every dataset is TransactionAware. FileSets for example, are not transactional.

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultApplicationManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultApplicationManager.java
@@ -104,7 +104,7 @@ public class DefaultApplicationManager implements ApplicationManager {
       File tempDir = tempFolder.newFolder();
       BundleJarUtil.unpackProgramJar(deployedJar, tempDir);
       ClassLoader classLoader = ProgramClassLoader.create(tempDir, getClass().getClassLoader());
-      this.datasetInstantiator = new DatasetInstantiator(datasetFramework, configuration,
+      this.datasetInstantiator = new DatasetInstantiator(Id.Namespace.from(accountId), datasetFramework, configuration,
                                                          new DataSetClassLoader(classLoader),
                                                          // todo: collect metrics for datasets outside programs too
                                                          null);

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/LogSaverTableUtil.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/LogSaverTableUtil.java
@@ -23,6 +23,7 @@ import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.DatasetManagementException;
 import co.cask.cdap.data2.dataset2.lib.table.MetaTableUtil;
 import co.cask.cdap.logging.LoggingConfiguration;
+import co.cask.cdap.proto.Id;
 import com.google.inject.Inject;
 
 import java.io.IOException;
@@ -48,6 +49,7 @@ public class LogSaverTableUtil extends MetaTableUtil {
    * @param datasetFramework framework to add types and datasets to
    */
   public static void setupDatasets(DatasetFramework datasetFramework) throws IOException, DatasetManagementException {
-    datasetFramework.addInstance(OrderedTable.class.getName(), TABLE_NAME, DatasetProperties.EMPTY);
+    Id.DatasetInstance logMetaDatasetInstance = Id.DatasetInstance.from(SYSTEM_NAMESPACE, TABLE_NAME);
+    datasetFramework.addInstance(OrderedTable.class.getName(), logMetaDatasetInstance, DatasetProperties.EMPTY);
   }
 }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/store/DefaultMetricDatasetFactory.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/store/DefaultMetricDatasetFactory.java
@@ -19,6 +19,7 @@ package co.cask.cdap.metrics.store;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.table.OrderedTable;
 import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data.Namespace;
 import co.cask.cdap.data2.datafabric.DefaultDatasetNamespace;
 import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
@@ -30,6 +31,7 @@ import co.cask.cdap.metrics.MetricsConstants;
 import co.cask.cdap.metrics.data.EntityTable;
 import co.cask.cdap.metrics.process.KafkaConsumerMetaTable;
 import co.cask.cdap.metrics.store.timeseries.FactTable;
+import co.cask.cdap.proto.Id;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.base.Throwables;
@@ -100,9 +102,11 @@ public class DefaultMetricDatasetFactory implements MetricDatasetFactory {
   private MetricsTable getOrCreateMetricsTable(String tableName, DatasetProperties props) {
 
     MetricsTable table = null;
+    // metrics tables are in the system namespace
+    Id.DatasetInstance metricsDatasetInstanceId = Id.DatasetInstance.from(Constants.SYSTEM_NAMESPACE, tableName);
     while (table == null) {
       try {
-        table = DatasetsUtil.getOrCreateDataset(dsFramework, tableName,
+        table = DatasetsUtil.getOrCreateDataset(dsFramework, metricsDatasetInstanceId,
                                                 MetricsTable.class.getName(), props, null, null);
       } catch (DatasetManagementException e) {
         // dataset service may be not up yet


### PR DESCRIPTION
Summary:
1. Adds ``Id.DatasetInstance`` containing *namespaceId + datasetInstanceName*.
2. Uses ``Id.DatasetInstance`` in all methods in ``DatasetFramework``.
3. Ignores *namespaceId* currently, usage will come in a separate PR.

Affects a large number of files, but no functional change other than making *namespaceId* available in every dataset instance yet.