### PR TITLE
Namespace-local DatasetServiceClient.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricHttpHandler.java
@@ -1046,7 +1046,7 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
       consoleSettingsStore.delete();
 
       dsFramework.deleteAllInstances(namespaceId);
-      dsFramework.deleteAllModules();
+      dsFramework.deleteAllModules(namespaceId);
 
       // todo: do efficiently and also remove timeseries metrics as well: CDAP-1125
       appLifecycleHttpHandler.deleteMetrics(account, null);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
@@ -30,6 +30,7 @@ import co.cask.cdap.proto.DatasetInstanceConfiguration;
 import co.cask.cdap.proto.DatasetMeta;
 import co.cask.cdap.proto.DatasetModuleMeta;
 import co.cask.cdap.proto.DatasetTypeMeta;
+import co.cask.cdap.proto.Id;
 import co.cask.common.http.HttpMethod;
 import co.cask.common.http.HttpRequest;
 import co.cask.common.http.HttpRequests;
@@ -65,14 +66,16 @@ class DatasetServiceClient {
   private static final Gson GSON = new Gson();
 
   private final Supplier<EndpointStrategy> endpointStrategySupplier;
+  private final Id.Namespace namespaceId;
 
-  public DatasetServiceClient(final DiscoveryServiceClient discoveryClient) {
+  public DatasetServiceClient(final DiscoveryServiceClient discoveryClient, Id.Namespace namespaceId) {
     this.endpointStrategySupplier = Suppliers.memoize(new Supplier<EndpointStrategy>() {
       @Override
       public EndpointStrategy get() {
         return new RandomEndpointStrategy(discoveryClient.discover(Constants.Service.DATASET_MANAGER));
       }
     });
+    this.namespaceId = namespaceId;
   }
 
   @Nullable
@@ -293,7 +296,7 @@ class DatasetServiceClient {
       throw new DatasetManagementException("Cannot discover dataset service");
     }
     InetSocketAddress addr = discoverable.getSocketAddress();
-    return String.format("http://%s:%s%s/data/%s", addr.getHostName(), addr.getPort(),
-                         Constants.Gateway.API_VERSION_2, resource);
+    return String.format("http://%s:%s%s/namespaces/%s/data/%s", addr.getHostName(), addr.getPort(),
+                         Constants.Gateway.API_VERSION_3, namespaceId.getId(), resource);
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DatasetFramework.java
@@ -70,12 +70,12 @@ public interface DatasetFramework {
   void deleteModule(Id.DatasetModule moduleId) throws DatasetManagementException;
 
   /**
-   * Deletes dataset modules and its types from the system.
+   * Deletes dataset modules and its types in the specified namespace.
    *
    * @throws ModuleConflictException when some of modules can't be deleted because of its dependant modules or instances
    * @throws DatasetManagementException
    */
-  void deleteAllModules() throws DatasetManagementException;
+  void deleteAllModules(Id.Namespace namespaceId) throws DatasetManagementException;
 
   /**
    * Adds information about dataset instance to the system.

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/InMemoryDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/InMemoryDatasetFramework.java
@@ -96,7 +96,7 @@ public class InMemoryDatasetFramework implements DatasetFramework {
   }
 
   @Override
-  public synchronized void deleteAllModules() throws DatasetManagementException {
+  public synchronized void deleteAllModules(Id.Namespace namespaceId) throws DatasetManagementException {
     // check if there are any datasets that use non-default types that we want to remove
     for (DatasetSpecification spec : instances.values()) {
       if (!defaultTypes.contains(spec.getType())) {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/NamespacedDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/NamespacedDatasetFramework.java
@@ -54,8 +54,8 @@ public class NamespacedDatasetFramework implements DatasetFramework {
   }
 
   @Override
-  public void deleteAllModules() throws DatasetManagementException {
-    delegate.deleteAllModules();
+  public void deleteAllModules(Id.Namespace namespaceId) throws DatasetManagementException {
+    delegate.deleteAllModules(namespaceId);
   }
 
   @Override

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/AbstractDatasetFrameworkTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/AbstractDatasetFrameworkTest.java
@@ -199,7 +199,7 @@ public abstract class AbstractDatasetFrameworkTest {
 
     // cleanup
     try {
-      framework.deleteAllModules();
+      framework.deleteAllModules(namespaceId);
       Assert.fail("should not delete modules: there are datasets using their types");
     } catch (DatasetManagementException e) {
       // expected
@@ -216,7 +216,7 @@ public abstract class AbstractDatasetFrameworkTest {
     Assert.assertNull(framework.getDatasetSpec(myTable2));
 
     // now it should susceed
-    framework.deleteAllModules();
+    framework.deleteAllModules(namespaceId);
     Assert.assertFalse(framework.hasType(OrderedTable.class.getName()));
     Assert.assertFalse(framework.hasType(Table.class.getName()));
   }


### PR DESCRIPTION
Main functional changes:
1. ``DatasetServiceClient`` is namespace-local.
2. ``RemoteDatasetFramework`` has a cache of ``Id.Namespace`` -> ``DatasetServiceClient``
3. ``DatasetFramework``'s ``deleteAllModules()`` method is now ``deleteAllModules(Id.Namespace)``