### PR TITLE
Fixed histogram rendering in GetStreamStatsCommand

### DIFF
--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetStreamStatsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetStreamStatsCommand.java
@@ -323,15 +323,17 @@ public class GetStreamStatsCommand extends AbstractCommand {
     }
 
     private int getLongestBucketPrefix() {
-      int longestBucket = Collections.max(buckets.elementSet(), new Comparator<Integer>() {
+      Set<Integer> bucketIndices = buckets.elementSet();
+      int longestBucket = Collections.max(bucketIndices, new Comparator<Integer>() {
         @Override
         public int compare(Integer o1, Integer o2) {
-          return (Integer.toString(o1 * BUCKET_SIZE).length() * 2 + buckets.count(o1))
-            - (Integer.toString(o2 * BUCKET_SIZE).length() * 2 + buckets.count(o2));
+          return (Long.toString(o1 * BUCKET_SIZE).length() * 2 + Long.toString(buckets.count(o1)).length())
+            - (Long.toString(o2 * BUCKET_SIZE).length() * 2 + Long.toString(buckets.count(o2)).length());
         }
       });
       Bucket bucket = new Bucket(longestBucket, buckets.count(longestBucket));
-      return bucket.getPrefix().length();
+      String longestBucketPrefix = bucket.getPrefix();
+      return longestBucketPrefix.length();
     }
 
     /**

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetStreamStatsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetStreamStatsCommand.java
@@ -297,10 +297,8 @@ public class GetStreamStatsCommand extends AbstractCommand {
           int barLength = (int) ((bucket.getCount() * 1.0 / maxCount) * maxBarLength);
           if (barLength == 0) {
             printStream.print("|");
-          } else if (barLength == 1) {
-            printStream.print("|>");
-          } else if (barLength > 1) {
-            printStream.print("|" + Strings.repeat("=", barLength - 2) + ">");
+          } else if (barLength >= 1) {
+            printStream.print("|" + Strings.repeat("+", barLength - 1));
           }
           printStream.println();
         }


### PR DESCRIPTION
* Fixed bug in determining length of the longest bucket prefix (e.g. "  [200, 299]: ")
* Changed rendering style to be as shown below:
```
  [8800, 8899]: 12       |+
  [8900, 8999]: 22       |+++
  [9000, 9099]: 16       |+
  [9100, 9199]: 9        |
```