### PR TITLE
namespace clients

### DIFF
--- a/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
+++ b/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
@@ -410,8 +410,6 @@ public class CLIMainTest extends StandaloneTestBase {
 
   @Test
   public void testAdapters() throws Exception {
-    String namespaceId = Constants.DEFAULT_NAMESPACE;
-
     // Create Adapter
     String createCommand = "create adapter someAdapter type dummyAdapter" +
       " props " + GSON.toJson(ImmutableMap.of("frequency", "1m")) +
@@ -420,8 +418,8 @@ public class CLIMainTest extends StandaloneTestBase {
     testCommandOutputContains(cli, createCommand, "Successfully created adapter");
 
     // Check that the created adapter is present
-    adapterClient.waitForExists(namespaceId, "someAdapter", 30, TimeUnit.SECONDS);
-    Assert.assertTrue(adapterClient.exists(namespaceId, "someAdapter"));
+    adapterClient.waitForExists("someAdapter", 30, TimeUnit.SECONDS);
+    Assert.assertTrue(adapterClient.exists("someAdapter"));
 
     testCommandOutputContains(cli, "list adapters", "someAdapter");
     testCommandOutputContains(cli, "get adapter someAdapter", "someAdapter");

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/CommandCategory.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/CommandCategory.java
@@ -21,6 +21,7 @@ package co.cask.cdap.cli;
  */
 public enum CommandCategory {
   GENERAL("General"),
+  NAMESPACE("Namespace"),
   LIFECYCLE("Lifecycle"),
   DATASET("Dataset"),
   EXPLORE("Explore"),

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/CreateAdapterCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/CreateAdapterCommand.java
@@ -38,12 +38,10 @@ public class CreateAdapterCommand extends AbstractAuthCommand {
   private static final Gson GSON = new Gson();
 
   private final AdapterClient adapterClient;
-  private final CLIConfig cliConfig;
 
   @Inject
   public CreateAdapterCommand(AdapterClient adapterClient, CLIConfig cliConfig) {
     super(cliConfig);
-    this.cliConfig = cliConfig;
     this.adapterClient = adapterClient;
   }
 
@@ -65,7 +63,7 @@ public class CreateAdapterCommand extends AbstractAuthCommand {
     adapterConfig.sink = new AdapterConfig.Sink(
       arguments.get(ArgumentName.ADAPTER_SINK.toString()), sinkProps);
 
-    adapterClient.create(cliConfig.getCurrentNamespace(), adapterName, adapterConfig);
+    adapterClient.create(adapterName, adapterConfig);
     output.printf("Successfully created adapter named '%s' with config '%s'\n",
                   adapterName, GSON.toJson(adapterConfig));
   }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/CreateStreamConversionAdapterCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/CreateStreamConversionAdapterCommand.java
@@ -47,12 +47,10 @@ public class CreateStreamConversionAdapterCommand extends AbstractAuthCommand {
   private static final Gson GSON = new Gson();
 
   private final AdapterClient adapterClient;
-  private final CLIConfig cliConfig;
 
   @Inject
   public CreateStreamConversionAdapterCommand(AdapterClient adapterClient, CLIConfig cliConfig) {
     super(cliConfig);
-    this.cliConfig = cliConfig;
     this.adapterClient = adapterClient;
   }
 
@@ -97,7 +95,7 @@ public class CreateStreamConversionAdapterCommand extends AbstractAuthCommand {
     adapterConfig.source = new AdapterConfig.Source(sourceName, Collections.<String, String>emptyMap());
     adapterConfig.sink = new AdapterConfig.Sink(sinkName, sinkProps);
 
-    adapterClient.create(cliConfig.getCurrentNamespace(), adapterName, adapterConfig);
+    adapterClient.create(adapterName, adapterConfig);
     output.printf("Successfully created adapter named '%s' with config '%s'\n",
                   adapterName, GSON.toJson(adapterConfig));
   }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeleteAdapterCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeleteAdapterCommand.java
@@ -32,12 +32,10 @@ import java.io.PrintStream;
 public class DeleteAdapterCommand extends AbstractAuthCommand {
 
   private final AdapterClient adapterClient;
-  private final CLIConfig cliConfig;
 
   @Inject
   public DeleteAdapterCommand(AdapterClient adapterClient, CLIConfig cliConfig) {
     super(cliConfig);
-    this.cliConfig = cliConfig;
     this.adapterClient = adapterClient;
   }
 
@@ -45,7 +43,7 @@ public class DeleteAdapterCommand extends AbstractAuthCommand {
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     String adapterName = arguments.get(ArgumentName.ADAPTER.toString());
 
-    adapterClient.delete(cliConfig.getCurrentNamespace(), adapterName);
+    adapterClient.delete(adapterName);
     output.printf("Successfully deleted adapter named '%s'\n", adapterName);
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListAdaptersCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListAdaptersCommand.java
@@ -38,18 +38,16 @@ public class ListAdaptersCommand extends AbstractAuthCommand {
   private static final Gson GSON = new Gson();
 
   private final AdapterClient adapterClient;
-  private final CLIConfig cliConfig;
 
   @Inject
   public ListAdaptersCommand(AdapterClient adapterClient, CLIConfig cliConfig) {
     super(cliConfig);
-    this.cliConfig = cliConfig;
     this.adapterClient = adapterClient;
   }
 
   @Override
   public void perform(Arguments arguments, PrintStream output) throws Exception {
-    List<AdapterSpecification> list = adapterClient.list(cliConfig.getCurrentNamespace());
+    List<AdapterSpecification> list = adapterClient.list();
 
     new AsciiTable<AdapterSpecification>(
       new String[]{"name", "type", "sources", "sinks", "properties"}, list,

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/UseNamespaceCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/UseNamespaceCommand.java
@@ -20,6 +20,7 @@ import co.cask.cdap.cli.ArgumentName;
 import co.cask.cdap.cli.CLIConfig;
 import co.cask.cdap.cli.ElementType;
 import co.cask.cdap.cli.util.AbstractAuthCommand;
+import co.cask.cdap.client.NamespaceClient;
 import co.cask.common.cli.Arguments;
 import com.google.inject.Inject;
 
@@ -31,16 +32,21 @@ import java.io.PrintStream;
 public class UseNamespaceCommand extends AbstractAuthCommand {
 
   private final CLIConfig cliConfig;
+  private final NamespaceClient namespaceClient;
+
 
   @Inject
-  public UseNamespaceCommand(CLIConfig cliConfig) {
+  public UseNamespaceCommand(CLIConfig cliConfig, NamespaceClient namespaceClient) {
     super(cliConfig);
     this.cliConfig = cliConfig;
+    this.namespaceClient = namespaceClient;
   }
 
   @Override
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     String namespace = arguments.get(ArgumentName.NAMESPACE_ID.toString());
+    // Check if namespace exists; throws exception if namespace doesn't exist.
+    namespaceClient.get(namespace);
     cliConfig.setCurrentNamespace(namespace);
     output.printf("Now using namespace '%s'\n", namespace);
   }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/commandset/DefaultCommands.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/commandset/DefaultCommands.java
@@ -48,7 +48,7 @@ public class DefaultCommands extends CommandSet<Command> {
         //TODO: uncomment to expose Preferences cli commands
 //      .add(injector.getInstance(PreferencesCommandSet.class))
         //TODO: uncomment when namespace is ready
-//      .add(injector.getInstance(NamespaceCommands.class))
+      .add(injector.getInstance(NamespaceCommands.class))
         .build());
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/commandset/NamespaceCommands.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/commandset/NamespaceCommands.java
@@ -48,6 +48,6 @@ public class NamespaceCommands extends CommandSet<Command> implements Categorize
 
   @Override
   public String getCategory() {
-    return CommandCategory.LIFECYCLE.getName();
+    return CommandCategory.NAMESPACE.getName();
   }
 }

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/AdapterClientTest.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/AdapterClientTest.java
@@ -77,14 +77,14 @@ public class AdapterClientTest extends ClientTestBase {
   @Before
   public void setUp() throws Throwable {
     super.setUp();
+    clientConfig.setNamespace(Constants.DEFAULT_NAMESPACE);
     adapterClient = new AdapterClient(clientConfig);
     applicationClient = new ApplicationClient(clientConfig);
   }
 
   @Test
   public void testAdapters() throws Exception {
-    String namespaceId = Constants.DEFAULT_NAMESPACE;
-    List<AdapterSpecification> initialList = adapterClient.list(namespaceId);
+    List<AdapterSpecification> initialList = adapterClient.list();
     Assert.assertEquals(0, initialList.size());
 
     AdapterConfig adapterConfig = new AdapterConfig();
@@ -94,31 +94,31 @@ public class AdapterClientTest extends ClientTestBase {
     adapterConfig.sink = new AdapterConfig.Sink("mySink", ImmutableMap.of("dataset.class", FileSet.class.getName()));
 
     // Create Adapter
-    adapterClient.create(namespaceId, "someAdapter", adapterConfig);
+    adapterClient.create("someAdapter", adapterConfig);
 
     // Check that the created adapter is present
-    adapterClient.waitForExists(namespaceId, "someAdapter", 30, TimeUnit.SECONDS);
-    Assert.assertTrue(adapterClient.exists(namespaceId, "someAdapter"));
-    AdapterSpecification someAdapter = adapterClient.get(namespaceId, "someAdapter");
+    adapterClient.waitForExists("someAdapter", 30, TimeUnit.SECONDS);
+    Assert.assertTrue(adapterClient.exists("someAdapter"));
+    AdapterSpecification someAdapter = adapterClient.get("someAdapter");
     Assert.assertNotNull(someAdapter);
 
     // list all adapters
-    List<AdapterSpecification> list = adapterClient.list(namespaceId);
+    List<AdapterSpecification> list = adapterClient.list();
     Assert.assertArrayEquals(new AdapterSpecification[] {someAdapter}, list.toArray());
 
     // Delete Adapter
-    adapterClient.delete(namespaceId, "someAdapter");
+    adapterClient.delete("someAdapter");
 
     // verify that the adapter is deleted
-    Assert.assertFalse(adapterClient.exists(namespaceId, "someAdapter"));
+    Assert.assertFalse(adapterClient.exists("someAdapter"));
     try {
-      adapterClient.get(namespaceId, "someAdapter");
+      adapterClient.get("someAdapter");
       Assert.fail();
     } catch (AdapterNotFoundException e) {
       // Expected
     }
 
-    List<AdapterSpecification> finalList = adapterClient.list(namespaceId);
+    List<AdapterSpecification> finalList = adapterClient.list();
     Assert.assertEquals(0, finalList.size());
 
     applicationClient.deleteAll();

--- a/cdap-client/src/main/java/co/cask/cdap/client/AdapterClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/AdapterClient.java
@@ -62,13 +62,12 @@ public class AdapterClient {
   /**
    * Lists all adapters.
    *
-   * @param namespace the namespace to use
    * @return list of {@link AdapterSpecification}.
    * @throws java.io.IOException if a network error occurred
    * @throws UnAuthorizedAccessTokenException if the request is not authorized successfully in the gateway server
    */
-  public List<AdapterSpecification> list(String namespace) throws IOException, UnAuthorizedAccessTokenException {
-    URL url = config.resolveURL("v3", namespace, "adapters");
+  public List<AdapterSpecification> list() throws IOException, UnAuthorizedAccessTokenException {
+    URL url = config.resolveURLV3("adapters");
     HttpResponse response = restClient.execute(HttpMethod.GET, url, config.getAccessToken());
     return ObjectResponse.fromJsonBody(response, new TypeToken<List<AdapterSpecification>>() { })
       .getResponseObject();
@@ -77,14 +76,13 @@ public class AdapterClient {
   /**
    * Gets an adapter.
    *
-   * @param namespace the namespace to use
    * @return an {@link AdapterSpecification}.
    * @throws java.io.IOException if a network error occurred
    * @throws UnAuthorizedAccessTokenException if the request is not authorized successfully in the gateway server
    */
-  public AdapterSpecification get(String namespace, String adapterName)
+  public AdapterSpecification get(String adapterName)
     throws AdapterNotFoundException, IOException, UnAuthorizedAccessTokenException {
-    URL url = config.resolveURL("v3", namespace, "adapters/" + adapterName);
+    URL url = config.resolveURLV3("adapters/" + adapterName);
     HttpResponse response = restClient.execute(HttpMethod.GET, url, config.getAccessToken(),
                                                HttpURLConnection.HTTP_NOT_FOUND);
     if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
@@ -96,7 +94,6 @@ public class AdapterClient {
   /**
    * Creates an adapter.
    *
-   * @param namespace the namespace to use
    * @param adapterName name of the adapter to create
    * @param adapterConfig properties of the adapter to create
    * @throws AdapterTypeNotFoundException if the desired adapter type was not found
@@ -104,10 +101,10 @@ public class AdapterClient {
    * @throws IOException if a network error occurred
    * @throws UnAuthorizedAccessTokenException if the request is not authorized successfully in the gateway server
    */
-  public void create(String namespace, String adapterName, AdapterConfig adapterConfig)
+  public void create(String adapterName, AdapterConfig adapterConfig)
     throws AdapterTypeNotFoundException, BadRequestException, IOException, UnAuthorizedAccessTokenException {
 
-    URL url = config.resolveURL("v3", namespace, String.format("adapters/%s", adapterName));
+    URL url = config.resolveURLV3(String.format("adapters/%s", adapterName));
     HttpRequest request = HttpRequest.post(url).withBody(GSON.toJson(adapterConfig)).build();
 
     HttpResponse response = restClient.execute(request, config.getAccessToken(), HttpURLConnection.HTTP_NOT_FOUND,
@@ -122,15 +119,14 @@ public class AdapterClient {
   /**
    * Deletes an adapter.
    *
-   * @param namespace the namespace to use
    * @param adapterName Name of the adapter to delete
    * @throws AdapterNotFoundException if the adapter with the specified name could not be found
    * @throws java.io.IOException if a network error occurred
    * @throws UnAuthorizedAccessTokenException if the request is not authorized successfully in the gateway server
    */
-  public void delete(String namespace, String adapterName) throws AdapterNotFoundException, IOException,
+  public void delete(String adapterName) throws AdapterNotFoundException, IOException,
     UnAuthorizedAccessTokenException {
-    URL url = config.resolveURL("v3", namespace, String.format("adapters/%s", adapterName));
+    URL url = config.resolveURLV3(String.format("adapters/%s", adapterName));
     HttpResponse response = restClient.execute(HttpMethod.DELETE, url, config.getAccessToken(),
                                                HttpURLConnection.HTTP_NOT_FOUND);
     if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
@@ -141,14 +137,13 @@ public class AdapterClient {
   /**
    * Checks if a adapter exists.
    *
-   * @param namespace the namespace to use
    * @param adapterName Name of the adapter to check
    * @return true if the adapter exists
    * @throws java.io.IOException if a network error occurred
    * @throws UnAuthorizedAccessTokenException if the request is not authorized successfully in the gateway server
    */
-  public boolean exists(String namespace, String adapterName) throws IOException, UnAuthorizedAccessTokenException {
-    URL url = config.resolveURL("v3", namespace, String.format("adapters/%s", adapterName));
+  public boolean exists(String adapterName) throws IOException, UnAuthorizedAccessTokenException {
+    URL url = config.resolveURLV3(String.format("adapters/%s", adapterName));
     HttpResponse response = restClient.execute(HttpMethod.GET, url, config.getAccessToken(),
                                                HttpURLConnection.HTTP_NOT_FOUND);
     return response.getResponseCode() != HttpURLConnection.HTTP_NOT_FOUND;
@@ -157,7 +152,6 @@ public class AdapterClient {
   /**
    * Waits for an adapter to exist.
    *
-   * @param namespace the namespace to use
    * @param adapterName Name of the adapter to check
    * @param timeout time to wait before timing out
    * @param timeoutUnit time unit of timeout
@@ -166,14 +160,14 @@ public class AdapterClient {
    * @throws TimeoutException if the adapter was not yet existent before {@code timeout} milliseconds
    * @throws InterruptedException if interrupted while waiting
    */
-  public void waitForExists(final String namespace, final String adapterName, long timeout, TimeUnit timeoutUnit)
+  public void waitForExists(final String adapterName, long timeout, TimeUnit timeoutUnit)
     throws IOException, UnAuthorizedAccessTokenException, TimeoutException, InterruptedException {
 
     try {
       Tasks.waitFor(true, new Callable<Boolean>() {
         @Override
         public Boolean call() throws Exception {
-          return exists(namespace, adapterName);
+          return exists(adapterName);
         }
       }, timeout, timeoutUnit, 1, TimeUnit.SECONDS);
     } catch (ExecutionException e) {
@@ -192,14 +186,14 @@ public class AdapterClient {
    * @throws TimeoutException if the adapter was not yet deleted before {@code timeout} milliseconds
    * @throws InterruptedException if interrupted while waiting
    */
-  public void waitForDeleted(final String namespace, final String adapterName, long timeout, TimeUnit timeoutUnit)
+  public void waitForDeleted(final String adapterName, long timeout, TimeUnit timeoutUnit)
     throws IOException, UnAuthorizedAccessTokenException, TimeoutException, InterruptedException {
 
     try {
       Tasks.waitFor(false, new Callable<Boolean>() {
         @Override
         public Boolean call() throws Exception {
-          return exists(namespace, adapterName);
+          return exists(adapterName);
         }
       }, timeout, timeoutUnit, 1, TimeUnit.SECONDS);
     } catch (ExecutionException e) {

--- a/cdap-client/src/main/java/co/cask/cdap/client/ApplicationClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ApplicationClient.java
@@ -68,7 +68,7 @@ public class ApplicationClient {
    * @throws UnAuthorizedAccessTokenException if the request is not authorized successfully in the gateway server
    */
   public List<ApplicationRecord> list() throws IOException, UnAuthorizedAccessTokenException {
-    HttpResponse response = restClient.execute(HttpMethod.GET, config.resolveURL("apps"), config.getAccessToken());
+    HttpResponse response = restClient.execute(HttpMethod.GET, config.resolveURLV3("apps"), config.getAccessToken());
     return ObjectResponse.fromJsonBody(response, new TypeToken<List<ApplicationRecord>>() { }).getResponseObject();
   }
 
@@ -81,7 +81,7 @@ public class ApplicationClient {
    * @throws UnAuthorizedAccessTokenException if the request is not authorized successfully in the gateway server
    */
   public void delete(String appId) throws ApplicationNotFoundException, IOException, UnAuthorizedAccessTokenException {
-    HttpResponse response = restClient.execute(HttpMethod.DELETE, config.resolveURL("apps/" + appId),
+    HttpResponse response = restClient.execute(HttpMethod.DELETE, config.resolveURLV3("apps/" + appId),
                                                config.getAccessToken(), HttpURLConnection.HTTP_NOT_FOUND);
     if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
       throw new ApplicationNotFoundException(appId);
@@ -95,7 +95,7 @@ public class ApplicationClient {
    * @throws UnAuthorizedAccessTokenException if the request is not authorized successfully in the gateway server
    */
   public void deleteAll() throws IOException, UnAuthorizedAccessTokenException {
-    restClient.execute(HttpMethod.DELETE, config.resolveURL("apps"), config.getAccessToken());
+    restClient.execute(HttpMethod.DELETE, config.resolveURLV3("apps"), config.getAccessToken());
   }
 
   /**
@@ -107,7 +107,7 @@ public class ApplicationClient {
    * @throws UnAuthorizedAccessTokenException if the request is not authorized successfully in the gateway server
    */
   public boolean exists(String appId) throws IOException, UnAuthorizedAccessTokenException {
-    HttpResponse response = restClient.execute(HttpMethod.GET, config.resolveURL("apps/" + appId),
+    HttpResponse response = restClient.execute(HttpMethod.GET, config.resolveURLV3("apps/" + appId),
                                                config.getAccessToken(), HttpURLConnection.HTTP_NOT_FOUND);
     return response.getResponseCode() != HttpURLConnection.HTTP_NOT_FOUND;
   }
@@ -171,7 +171,7 @@ public class ApplicationClient {
    * @throws IOException if a network error occurred
    */
   public void deploy(File jarFile) throws IOException, UnAuthorizedAccessTokenException {
-    URL url = config.resolveURL("apps");
+    URL url = config.resolveURLV3("apps");
     Map<String, String> headers = ImmutableMap.of("X-Archive-Name", jarFile.getName());
 
     HttpRequest request = HttpRequest.post(url).addHeaders(headers).withBody(jarFile).build();
@@ -191,7 +191,7 @@ public class ApplicationClient {
 
     Preconditions.checkArgument(programType.isListable());
 
-    URL url = config.resolveURL(programType.getCategoryName());
+    URL url = config.resolveURLV3(programType.getCategoryName());
     HttpRequest request = HttpRequest.get(url).build();
 
     ObjectResponse<List<ProgramRecord>> response = ObjectResponse.fromJsonBody(
@@ -235,7 +235,7 @@ public class ApplicationClient {
     throws ApplicationNotFoundException, IOException, UnAuthorizedAccessTokenException {
     Preconditions.checkArgument(programType.isListable());
 
-    URL url = config.resolveURL(String.format("apps/%s/%s", appId, programType.getCategoryName()));
+    URL url = config.resolveURLV3(String.format("apps/%s/%s", appId, programType.getCategoryName()));
     HttpRequest request = HttpRequest.get(url).build();
 
     ObjectResponse<List<ProgramRecord>> response = ObjectResponse.fromJsonBody(

--- a/cdap-client/src/main/java/co/cask/cdap/client/ProgramClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ProgramClient.java
@@ -307,7 +307,7 @@ public class ProgramClient {
   public int getProcedureInstances(String appId, String procedureId) throws IOException, NotFoundException,
     UnAuthorizedAccessTokenException {
 
-    URL url = config.resolveURLV3(String.format("apps/%s/procedures/%s/instances", appId, procedureId));
+    URL url = config.resolveURL(String.format("apps/%s/procedures/%s/instances", appId, procedureId));
     HttpResponse response = restClient.execute(HttpMethod.GET, url, config.getAccessToken(),
                                                HttpURLConnection.HTTP_NOT_FOUND);
     if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {

--- a/cdap-client/src/main/java/co/cask/cdap/client/ProgramClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ProgramClient.java
@@ -80,7 +80,7 @@ public class ProgramClient {
   public void start(String appId, ProgramType programType, String programName, Map<String, String> runtimeArgs)
     throws IOException, ProgramNotFoundException, UnAuthorizedAccessTokenException {
 
-    URL url = config.resolveURL(String.format("apps/%s/%s/%s/start",
+    URL url = config.resolveURLV3(String.format("apps/%s/%s/%s/start",
                                               appId, programType.getCategoryName(), programName));
     HttpRequest request = HttpRequest.post(url).withBody(GSON.toJson(runtimeArgs)).build();
     HttpResponse response = restClient.execute(request, config.getAccessToken(), HttpURLConnection.HTTP_NOT_FOUND);
@@ -102,7 +102,7 @@ public class ProgramClient {
   public void start(String appId, ProgramType programType, String programName)
     throws IOException, ProgramNotFoundException, UnAuthorizedAccessTokenException {
 
-    URL url = config.resolveURL(String.format("apps/%s/%s/%s/start",
+    URL url = config.resolveURLV3(String.format("apps/%s/%s/%s/start",
                                               appId, programType.getCategoryName(), programName));
     HttpRequest request = HttpRequest.post(url).build();
     HttpResponse response = restClient.execute(request, config.getAccessToken(), HttpURLConnection.HTTP_NOT_FOUND);
@@ -124,7 +124,8 @@ public class ProgramClient {
   public void stop(String appId, ProgramType programType, String programName)
     throws IOException, ProgramNotFoundException, UnAuthorizedAccessTokenException {
 
-    URL url = config.resolveURL(String.format("apps/%s/%s/%s/stop", appId, programType.getCategoryName(), programName));
+    URL url = config.resolveURLV3(String.format("apps/%s/%s/%s/stop",
+                                                appId, programType.getCategoryName(), programName));
     HttpResponse response = restClient.execute(HttpMethod.POST, url, config.getAccessToken(),
                                                HttpURLConnection.HTTP_NOT_FOUND);
     if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
@@ -174,7 +175,7 @@ public class ProgramClient {
   public String getStatus(String appId, ProgramType programType, String programName)
     throws IOException, ProgramNotFoundException, UnAuthorizedAccessTokenException {
 
-    URL url = config.resolveURL(String.format("apps/%s/%s/%s/status",
+    URL url = config.resolveURLV3(String.format("apps/%s/%s/%s/status",
                                               appId, programType.getCategoryName(), programName));
     HttpResponse response = restClient.execute(HttpMethod.GET, url, config.getAccessToken(),
                                                HttpURLConnection.HTTP_NOT_FOUND);
@@ -233,7 +234,7 @@ public class ProgramClient {
   public DistributedProgramLiveInfo getLiveInfo(String appId, ProgramType programType, String programName)
     throws IOException, ProgramNotFoundException, UnAuthorizedAccessTokenException {
 
-    URL url = config.resolveURL(String.format("apps/%s/%s/%s/live-info",
+    URL url = config.resolveURLV3(String.format("apps/%s/%s/%s/live-info",
                                               appId, programType.getCategoryName(), programName));
     HttpResponse response = restClient.execute(HttpMethod.GET, url, config.getAccessToken(),
                                                HttpURLConnection.HTTP_NOT_FOUND);
@@ -258,7 +259,7 @@ public class ProgramClient {
   public int getFlowletInstances(String appId, String flowId, String flowletId)
     throws IOException, NotFoundException, UnAuthorizedAccessTokenException {
 
-    URL url = config.resolveURL(String.format("apps/%s/flows/%s/flowlets/%s/instances", appId, flowId, flowletId));
+    URL url = config.resolveURLV3(String.format("apps/%s/flows/%s/flowlets/%s/instances", appId, flowId, flowletId));
     HttpResponse response = restClient.execute(HttpMethod.GET, url, config.getAccessToken(),
                                                HttpURLConnection.HTTP_NOT_FOUND);
     if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
@@ -282,7 +283,7 @@ public class ProgramClient {
   public void setFlowletInstances(String appId, String flowId, String flowletId, int instances)
     throws IOException, NotFoundException, UnAuthorizedAccessTokenException {
 
-    URL url = config.resolveURL(String.format("apps/%s/flows/%s/flowlets/%s/instances", appId, flowId, flowletId));
+    URL url = config.resolveURLV3(String.format("apps/%s/flows/%s/flowlets/%s/instances", appId, flowId, flowletId));
     HttpRequest request = HttpRequest.put(url).withBody(GSON.toJson(new Instances(instances))).build();
 
     HttpResponse response = restClient.execute(request, config.getAccessToken(), HttpURLConnection.HTTP_NOT_FOUND);
@@ -306,7 +307,7 @@ public class ProgramClient {
   public int getProcedureInstances(String appId, String procedureId) throws IOException, NotFoundException,
     UnAuthorizedAccessTokenException {
 
-    URL url = config.resolveURL(String.format("apps/%s/procedures/%s/instances", appId, procedureId));
+    URL url = config.resolveURLV3(String.format("apps/%s/procedures/%s/instances", appId, procedureId));
     HttpResponse response = restClient.execute(HttpMethod.GET, url, config.getAccessToken(),
                                                HttpURLConnection.HTTP_NOT_FOUND);
     if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
@@ -331,7 +332,7 @@ public class ProgramClient {
   public void setProcedureInstances(String appId, String procedureId, int instances)
     throws IOException, NotFoundException, UnAuthorizedAccessTokenException {
 
-    URL url = config.resolveURL(String.format("apps/%s/procedures/%s/instances", appId, procedureId));
+    URL url = config.resolveURLV3(String.format("apps/%s/procedures/%s/instances", appId, procedureId));
     HttpRequest request = HttpRequest.put(url).withBody(GSON.toJson(new Instances(instances))).build();
 
     HttpResponse response = restClient.execute(request, config.getAccessToken(), HttpURLConnection.HTTP_NOT_FOUND);
@@ -354,7 +355,7 @@ public class ProgramClient {
   public int getServiceRunnableInstances(String appId, String serviceId, String runnableId)
     throws IOException, NotFoundException, UnAuthorizedAccessTokenException {
 
-    URL url = config.resolveURL(String.format("apps/%s/services/%s/runnables/%s/instances",
+    URL url = config.resolveURLV3(String.format("apps/%s/services/%s/runnables/%s/instances",
                                               appId, serviceId, runnableId));
     HttpResponse response = restClient.execute(HttpMethod.GET, url, config.getAccessToken(),
                                                HttpURLConnection.HTTP_NOT_FOUND);
@@ -379,7 +380,7 @@ public class ProgramClient {
   public void setServiceRunnableInstances(String appId, String serviceId, String runnableId, int instances)
     throws IOException, NotFoundException, UnAuthorizedAccessTokenException {
 
-    URL url = config.resolveURL(String.format("apps/%s/services/%s/runnables/%s/instances",
+    URL url = config.resolveURLV3(String.format("apps/%s/services/%s/runnables/%s/instances",
                                               appId, serviceId, runnableId));
     HttpRequest request = HttpRequest.put(url).withBody(GSON.toJson(new Instances(instances))).build();
 
@@ -410,7 +411,7 @@ public class ProgramClient {
                                        Constants.AppFabric.QUERY_PARAM_END_TIME, endTime,
                                        Constants.AppFabric.QUERY_PARAM_LIMIT, limit);
 
-    URL url = config.resolveURL(String.format("apps/%s/%s/%s/runs?%s",
+    URL url = config.resolveURLV3(String.format("apps/%s/%s/%s/runs?%s",
                                           appId, programType.getCategoryName(), programId, queryParams));
 
     HttpResponse response = restClient.execute(HttpMethod.GET, url, config.getAccessToken(),
@@ -441,7 +442,7 @@ public class ProgramClient {
                                        Constants.AppFabric.QUERY_PARAM_END_TIME, endTime,
                                        Constants.AppFabric.QUERY_PARAM_LIMIT, limit);
 
-    URL url = config.resolveURL(String.format("apps/%s/%s/%s/runs?%s",
+    URL url = config.resolveURLV3(String.format("apps/%s/%s/%s/runs?%s",
                                               appId, programType.getCategoryName(), programId, queryParams));
 
     HttpResponse response = restClient.execute(HttpMethod.GET, url, config.getAccessToken(),
@@ -470,7 +471,7 @@ public class ProgramClient {
   public String getProgramLogs(String appId, ProgramType programType, String programId, long start, long stop)
     throws IOException, NotFoundException, UnAuthorizedAccessTokenException {
 
-    URL url = config.resolveURL(String.format("apps/%s/%s/%s/logs?start=%d&stop=%d",
+    URL url = config.resolveURLV3(String.format("apps/%s/%s/%s/logs?start=%d&stop=%d",
                                               appId, programType.getCategoryName(), programId, start, stop));
     HttpResponse response = restClient.execute(HttpMethod.GET, url, config.getAccessToken());
     if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
@@ -496,7 +497,7 @@ public class ProgramClient {
   public String getServiceRunnableLogs(String appId, String serviceId, String runnableId, long start, long stop)
     throws IOException, NotFoundException, UnAuthorizedAccessTokenException {
 
-    URL url = config.resolveURL(String.format("apps/%s/services/%s/runnables/%s/logs?start=%d&stop=%d",
+    URL url = config.resolveURLV3(String.format("apps/%s/services/%s/runnables/%s/logs?start=%d&stop=%d",
                                               appId, serviceId, runnableId, start, stop));
     HttpResponse response = restClient.execute(HttpMethod.GET, url, config.getAccessToken(),
                                                HttpURLConnection.HTTP_NOT_FOUND);
@@ -521,7 +522,7 @@ public class ProgramClient {
   public Map<String, String> getRuntimeArgs(String appId, ProgramType programType, String programId)
     throws IOException, UnAuthorizedAccessTokenException, ProgramNotFoundException {
     String path = String.format("apps/%s/%s/%s/runtimeargs", appId, programType.getCategoryName(), programId);
-    HttpResponse response = restClient.execute(HttpMethod.GET, config.resolveURL(path), config.getAccessToken(),
+    HttpResponse response = restClient.execute(HttpMethod.GET, config.resolveURLV3(path), config.getAccessToken(),
                                                HttpURLConnection.HTTP_NOT_FOUND);
     if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
       throw new ProgramNotFoundException(programType, appId, programId);
@@ -543,7 +544,7 @@ public class ProgramClient {
   public void setRuntimeArgs(String appId, ProgramType programType, String programId, Map<String, String> runtimeArgs)
     throws IOException, UnAuthorizedAccessTokenException, ProgramNotFoundException {
     String path = String.format("apps/%s/%s/%s/runtimeargs", appId, programType.getCategoryName(), programId);
-    HttpRequest request = HttpRequest.put(config.resolveURL(path)).withBody(GSON.toJson(runtimeArgs)).build();
+    HttpRequest request = HttpRequest.put(config.resolveURLV3(path)).withBody(GSON.toJson(runtimeArgs)).build();
     HttpResponse response = restClient.execute(request, config.getAccessToken(), HttpURLConnection.HTTP_NOT_FOUND);
     if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
       throw new ProgramNotFoundException(programType, appId, programId);

--- a/cdap-client/src/main/java/co/cask/cdap/client/ServiceClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ServiceClient.java
@@ -61,7 +61,7 @@ public class ServiceClient {
    */
   public ServiceSpecification get(String appId, String serviceId)
     throws IOException, UnAuthorizedAccessTokenException, NotFoundException {
-    URL url = config.resolveURL(String.format("apps/%s/services/%s", appId, serviceId));
+    URL url = config.resolveURLV3(String.format("apps/%s/services/%s", appId, serviceId));
     HttpResponse response = restClient.execute(HttpMethod.GET, url, config.getAccessToken(),
                                                HttpURLConnection.HTTP_NOT_FOUND);
 
@@ -95,6 +95,6 @@ public class ServiceClient {
     throws NotFoundException, IOException, UnAuthorizedAccessTokenException {
     // Make sure the service actually exists
     get(appId, serviceId);
-    return config.resolveURL(String.format("apps/%s/services/%s/methods/", appId, serviceId));
+    return config.resolveURLV3(String.format("apps/%s/services/%s/methods/", appId, serviceId));
   }
 }


### PR DESCRIPTION
I needed this change to make it easier to demo namespaces of streams.
Dataset-related clients are not being namespaced in this PR, as the entities are not namespaced in CDAP.

Build: http://builds.cask.co/browse/CDAP-DUT801-5