### PR TITLE
Feature/update mds key

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/AppMetadataStore.java
@@ -306,7 +306,8 @@ public class AppMetadataStore extends MetadataStoreDataset {
 
   public List<AdapterSpecification> getAllAdapters(Id.Namespace id) {
     List<AdapterSpecification> adapterSpecs = Lists.newArrayList();
-    List<AdapterMeta> adapterMetas = list(new MDSKey.Builder().add(TYPE_ADAPTER, id.getId()).build(), AdapterMeta.class);
+    List<AdapterMeta> adapterMetas = list(new MDSKey.Builder().add(TYPE_ADAPTER, id.getId()).build(),
+                                          AdapterMeta.class);
     for (AdapterMeta adapterMeta : adapterMetas) {
       adapterSpecs.add(adapterMeta.getSpec());
     }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/MDSStreamMetaStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/MDSStreamMetaStore.java
@@ -27,6 +27,7 @@ import co.cask.cdap.data2.datafabric.DefaultDatasetNamespace;
 import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.NamespacedDatasetFramework;
+import co.cask.cdap.data2.dataset2.lib.table.MDSKey;
 import co.cask.cdap.data2.dataset2.lib.table.MetadataStoreDataset;
 import co.cask.cdap.data2.dataset2.tx.Transactional;
 import co.cask.cdap.proto.Id;
@@ -130,7 +131,7 @@ public final class MDSStreamMetaStore implements StreamMetaStore {
     return txnl.executeUnchecked(new TransactionExecutor.Function<StreamMds, List<StreamSpecification>>() {
       @Override
       public List<StreamSpecification> apply(StreamMds mds) throws Exception {
-        return mds.streams.list(new MetadataStoreDataset.Key.Builder().add(TYPE_STREAM, namespaceId.getId()).build(),
+        return mds.streams.list(new MDSKey.Builder().add(TYPE_STREAM, namespaceId.getId()).build(),
                                 StreamSpecification.class);
       }
     });
@@ -143,10 +144,10 @@ public final class MDSStreamMetaStore implements StreamMetaStore {
         @Override
         public Multimap<Id.Namespace, StreamSpecification> apply(StreamMds mds) throws Exception {
           ImmutableMultimap.Builder<Id.Namespace, StreamSpecification> builder = ImmutableMultimap.builder();
-          Map<MetadataStoreDataset.Key, StreamSpecification> streamSpecs =
-            mds.streams.listKV(new MetadataStoreDataset.Key.Builder().add(TYPE_STREAM).build(),
+          Map<MDSKey, StreamSpecification> streamSpecs =
+            mds.streams.listKV(new MDSKey.Builder().add(TYPE_STREAM).build(),
                                StreamSpecification.class);
-          for (Map.Entry<MetadataStoreDataset.Key, StreamSpecification> streamSpecEntry : streamSpecs.entrySet()) {
+          for (Map.Entry<MDSKey, StreamSpecification> streamSpecEntry : streamSpecs.entrySet()) {
             List<byte[]> keyParts = streamSpecEntry.getKey().split();
             // Namespace id is the key part with index 1.
             String namespaceId = Bytes.toString(keyParts.get(1));
@@ -157,8 +158,8 @@ public final class MDSStreamMetaStore implements StreamMetaStore {
       });
   }
 
-  private MetadataStoreDataset.Key getKey(Id.Stream streamId) {
-    return new MetadataStoreDataset.Key.Builder()
+  private MDSKey getKey(Id.Stream streamId) {
+    return new MDSKey.Builder()
       .add(TYPE_STREAM, streamId.getNamespaceId(), streamId.getName()).build();
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/MDSKey.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/MDSKey.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.dataset2.lib.table;
+
+import co.cask.cdap.api.common.Bytes;
+import com.google.common.collect.Lists;
+import com.google.common.primitives.Ints;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Metadata entry key
+ */
+public final class MDSKey {
+  private final byte[] key;
+
+  MDSKey(byte[] key) {
+    this.key = key;
+  }
+
+  public byte[] getKey() {
+    return key;
+  }
+
+  /**
+   * Splits the keys into the parts that comprise this.
+   */
+  public List<byte[]> split() {
+    List<byte[]> bytes = Lists.newArrayList();
+    int offset = 0;
+    while (offset < key.length) {
+      int length = Bytes.toInt(key, offset);
+      offset += Ints.BYTES;
+      bytes.add(Arrays.copyOfRange(key, offset, offset + length));
+      offset += length;
+    }
+    return bytes;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    MDSKey that = (MDSKey) o;
+    return Bytes.equals(this.key, that.key);
+  }
+
+  @Override
+  public int hashCode() {
+    return Bytes.hashCode(key);
+  }
+
+  /**
+   * Builds {@link MDSKey}s.
+   */
+  public static final class Builder {
+    private byte[] key;
+
+    public Builder() {
+      key = new byte[0];
+    }
+
+    public Builder(MDSKey start) {
+      this.key = start.getKey();
+    }
+
+    public Builder add(byte[] part) {
+      key = Bytes.add(key, part);
+      return this;
+    }
+
+    public Builder add(String part) {
+      byte[] b = Bytes.toBytes(part);
+      key = Bytes.add(key, Bytes.toBytes(b.length), b);
+      return this;
+    }
+
+    public Builder add(String... parts) {
+      for (String part : parts) {
+        add(part);
+      }
+      return this;
+    }
+
+    public Builder add(long part) {
+      add(Bytes.toBytes(part));
+      return this;
+    }
+
+    public MDSKey build() {
+      return new MDSKey(key);
+    }
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/MDSKey.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/MDSKey.java
@@ -29,7 +29,7 @@ import java.util.List;
 public final class MDSKey {
   private final byte[] key;
 
-  MDSKey(byte[] key) {
+  public MDSKey(byte[] key) {
     this.key = key;
   }
 
@@ -84,14 +84,14 @@ public final class MDSKey {
       this.key = start.getKey();
     }
 
+    // Encodes parts of the key with segments of <length> <value>
     public Builder add(byte[] part) {
-      key = Bytes.add(key, part);
+      key = Bytes.add(key, Bytes.toBytes(part.length), part);
       return this;
     }
 
     public Builder add(String part) {
-      byte[] b = Bytes.toBytes(part);
-      key = Bytes.add(key, Bytes.toBytes(b.length), b);
+      add(Bytes.toBytes(part));
       return this;
     }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/MetadataStoreDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/MetadataStoreDataset.java
@@ -124,7 +124,7 @@ public class MetadataStoreDataset extends AbstractDataset {
         T value = deserialize(columnValue, classOfT);
 
         if (filter.apply(value)) {
-          MDSKey key = new MDSKey.Builder().add(next.getRow()).build();
+          MDSKey key = new MDSKey(next.getRow());
           map.put(key, value);
         }
       }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/MetadataStoreDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/MetadataStoreDataset.java
@@ -28,10 +28,8 @@ import com.google.common.base.Predicates;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.google.common.primitives.Ints;
 import com.google.gson.Gson;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -63,7 +61,7 @@ public class MetadataStoreDataset extends AbstractDataset {
 
   // returns first that matches
   @Nullable
-  public <T> T get(Key id, Class<T> classOfT) {
+  public <T> T get(MDSKey id, Class<T> classOfT) {
     try {
       Scanner scan = table.scan(id.getKey(), Bytes.stopKeyForPrefix(id.getKey()));
       Row row = scan.next();
@@ -83,39 +81,39 @@ public class MetadataStoreDataset extends AbstractDataset {
   }
 
   // lists all that has same first id parts
-  public <T> List<T> list(Key id, Class<T> classOfT) {
+  public <T> List<T> list(MDSKey id, Class<T> classOfT) {
     return list(id, classOfT, Integer.MAX_VALUE);
   }
 
   // lists all that has same first id parts, with a limit
-  public <T> List<T> list(Key id, Class<T> classOfT, int limit) {
+  public <T> List<T> list(MDSKey id, Class<T> classOfT, int limit) {
     return list(id, null, classOfT, limit, Predicates.<T>alwaysTrue());
   }
 
   // lists all that has first id parts in range of startId and stopId
-  public <T> List<T> list(Key startId, @Nullable Key stopId, Class<T> classOfT, int limit,
+  public <T> List<T> list(MDSKey startId, @Nullable MDSKey stopId, Class<T> classOfT, int limit,
                           Predicate<T> filter) {
     return Lists.newArrayList(listKV(startId, stopId, classOfT, limit, filter).values());
   }
 
   // returns mapping of all that has same first id parts
-  public <T> Map<Key, T> listKV(Key id, Class<T> classOfT) {
+  public <T> Map<MDSKey, T> listKV(MDSKey id, Class<T> classOfT) {
     return listKV(id, classOfT, Integer.MAX_VALUE);
   }
 
   // returns mapping of  all that has same first id parts, with a limit
-  public <T> Map<Key, T> listKV(Key id, Class<T> classOfT, int limit) {
+  public <T> Map<MDSKey, T> listKV(MDSKey id, Class<T> classOfT, int limit) {
     return listKV(id, null, classOfT, limit, Predicates.<T>alwaysTrue());
   }
 
   // returns mapping of all that has first id parts in range of startId and stopId
-  public <T> Map<Key, T> listKV(Key startId, @Nullable Key stopId, Class<T> classOfT, int limit,
+  public <T> Map<MDSKey, T> listKV(MDSKey startId, @Nullable MDSKey stopId, Class<T> classOfT, int limit,
                                    Predicate<T> filter) {
     byte[] startKey = startId.getKey();
     byte[] stopKey = stopId == null ? Bytes.stopKeyForPrefix(startKey) : stopId.getKey();
 
     try {
-      Map<Key, T> map = Maps.newLinkedHashMap();
+      Map<MDSKey, T> map = Maps.newLinkedHashMap();
       Scanner scan = table.scan(startKey, stopKey);
       Row next;
       while ((limit-- > 0) && (next = scan.next()) != null) {
@@ -126,7 +124,7 @@ public class MetadataStoreDataset extends AbstractDataset {
         T value = deserialize(columnValue, classOfT);
 
         if (filter.apply(value)) {
-          Key key = new Key.Builder().add(next.getRow()).build();
+          MDSKey key = new MDSKey.Builder().add(next.getRow()).build();
           map.put(key, value);
         }
       }
@@ -136,7 +134,7 @@ public class MetadataStoreDataset extends AbstractDataset {
     }
   }
 
-  public <T> void deleteAll(Key id) {
+  public <T> void deleteAll(MDSKey id) {
     byte[] prefix = id.getKey();
     byte[] stopKey = Bytes.stopKeyForPrefix(prefix);
 
@@ -155,101 +153,11 @@ public class MetadataStoreDataset extends AbstractDataset {
     }
   }
 
-  public <T> void write(Key id, T value) {
+  public <T> void write(MDSKey id, T value) {
     try {
       table.put(new Put(id.getKey()).add(COLUMN, serialize(value)));
     } catch (Exception e) {
       throw Throwables.propagate(e);
-    }
-  }
-
-  /**
-   * Metadata entry key
-   */
-  public static final class Key {
-    private final byte[] key;
-
-    private Key(byte[] key) {
-      this.key = key;
-    }
-
-    public byte[] getKey() {
-      return key;
-    }
-
-    /**
-     * Splits the keys into the parts that comprise this.
-     */
-    public List<byte[]> split() {
-      List<byte[]> bytes = Lists.newArrayList();
-      int offset = 0;
-      while (offset < key.length) {
-        int length = Bytes.toInt(key, offset);
-        offset += Ints.BYTES;
-        bytes.add(Arrays.copyOfRange(key, offset, offset + length));
-        offset += length;
-      }
-      return bytes;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-
-      Key that = (Key) o;
-      return Bytes.equals(this.key, that.key);
-    }
-
-    @Override
-    public int hashCode() {
-      return Bytes.hashCode(key);
-    }
-
-    /**
-     * Builds {@link Key}s.
-     */
-    public static final class Builder {
-      private byte[] key;
-
-      public Builder() {
-        key = new byte[0];
-      }
-
-      public Builder(Key start) {
-        this.key = start.getKey();
-      }
-
-      public Builder add(byte[] part) {
-        key = Bytes.add(key, part);
-        return this;
-      }
-
-      public Builder add(String part) {
-        byte[] b = Bytes.toBytes(part);
-        key = Bytes.add(key, Bytes.toBytes(b.length), b);
-        return this;
-      }
-
-      public Builder add(String... parts) {
-        for (String part : parts) {
-          add(part);
-        }
-        return this;
-      }
-
-      public Builder add(long part) {
-        add(Bytes.toBytes(part));
-        return this;
-      }
-
-      public Key build() {
-        return new Key(key);
-      }
     }
   }
 

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/MDSKeyTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/MDSKeyTest.java
@@ -27,19 +27,48 @@ import java.util.List;
 public class MDSKeyTest {
 
   @Test
-  public void testKeyBuildSplit() {
+  public void simpleStringKeySplit() {
+    // Tests key: [ "part1", "part2", "part3" ]
     List<String> originalKeyParts = ImmutableList.of("part1", "part2", "part3");
     MDSKey.Builder builder = new MDSKey.Builder();
     for (String part : originalKeyParts) {
       builder.add(part);
     }
-    MDSKey MDSKey = builder.build();
+    MDSKey mdsKey = builder.build();
 
     List<String> splitKeyParts = Lists.newArrayList();
-    List<byte[]> splittedBytes = MDSKey.split();
+    List<byte[]> splittedBytes = mdsKey.split();
     for (byte[] bytes : splittedBytes) {
       splitKeyParts.add(Bytes.toString(bytes));
     }
     Assert.assertEquals(originalKeyParts, splitKeyParts);
+  }
+
+  @Test
+  public void testComplexKeySplit() {
+    // Tests key: [ "part1", "part2", "", 4l, byte[] { 0x5 } ]
+    List<String> firstParts = ImmutableList.of("part1", "part2", "");
+    long fourthPart = 4L;
+    byte[] fifthPart = new byte[] { 0x5 };
+
+    MDSKey.Builder builder = new MDSKey.Builder();
+    // intentionally testing the MDSKey.Builder#add(String... parts) method.
+    builder.add(firstParts.get(0), firstParts.get(1), firstParts.get(2));
+
+    builder.add(fourthPart);
+    builder.add(fifthPart);
+    MDSKey mdsKey = builder.build();
+
+    List<byte[]> splittedBytes = mdsKey.split();
+    List<String> splitKeyParts = Lists.newArrayList();
+
+    int i = 0;
+    for (; i < firstParts.size(); i++) {
+      splitKeyParts.add(Bytes.toString(splittedBytes.get(i)));
+    }
+    Assert.assertEquals(firstParts, splitKeyParts);
+
+    Assert.assertEquals(fourthPart, Bytes.toLong(splittedBytes.get(3)));
+    Assert.assertTrue(Bytes.equals(fifthPart, splittedBytes.get(4)));
   }
 }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/MDSKeyTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/MDSKeyTest.java
@@ -24,19 +24,19 @@ import org.junit.Test;
 
 import java.util.List;
 
-public class MetadataStoreDatasetTest {
+public class MDSKeyTest {
 
   @Test
   public void testKeyBuildSplit() {
     List<String> originalKeyParts = ImmutableList.of("part1", "part2", "part3");
-    MetadataStoreDataset.Key.Builder builder = new MetadataStoreDataset.Key.Builder();
+    MDSKey.Builder builder = new MDSKey.Builder();
     for (String part : originalKeyParts) {
       builder.add(part);
     }
-    MetadataStoreDataset.Key key = builder.build();
+    MDSKey MDSKey = builder.build();
 
     List<String> splitKeyParts = Lists.newArrayList();
-    List<byte[]> splittedBytes = key.split();
+    List<byte[]> splittedBytes = MDSKey.split();
     for (byte[] bytes : splittedBytes) {
       splitKeyParts.add(Bytes.toString(bytes));
     }

--- a/cdap-notifications/src/main/java/co/cask/cdap/notifications/feeds/service/MDSNotificationFeedStore.java
+++ b/cdap-notifications/src/main/java/co/cask/cdap/notifications/feeds/service/MDSNotificationFeedStore.java
@@ -26,6 +26,7 @@ import co.cask.cdap.data2.datafabric.DefaultDatasetNamespace;
 import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.NamespacedDatasetFramework;
+import co.cask.cdap.data2.dataset2.lib.table.MDSKey;
 import co.cask.cdap.data2.dataset2.lib.table.MetadataStoreDataset;
 import co.cask.cdap.data2.dataset2.tx.Transactional;
 import co.cask.cdap.proto.Id;
@@ -139,8 +140,8 @@ public final class MDSNotificationFeedStore implements NotificationFeedStore {
     });
   }
 
-  private MetadataStoreDataset.Key getKey(String id) {
-    return new MetadataStoreDataset.Key.Builder().add(TYPE_NOTIFICATION_FEED, id).build();
+  private MDSKey getKey(String id) {
+    return new MDSKey.Builder().add(TYPE_NOTIFICATION_FEED, id).build();
   }
 
   private static final class NotificationFeedMds implements Iterable<MetadataStoreDataset> {


### PR DESCRIPTION
Separated into two commits:
1) Simply extracting from inner class.
2) In mds key, prefixing all byte[] parts by the length of the byte[], for purposes of easy, generic splitting of the key.

Alternative is here, according to Andreas' suggestion: https://github.com/caskdata/cdap/pull/1337

Build: http://builds.cask.co/browse/CDAP-DUT809-5
Note: Build is failing due to a bug in AppMds#getActiveRuns, which these changes surface.