### PR TITLE
Use same category order in GenerateCLIDocsTableCommand and HelpCommand

### DIFF
--- a/cdap-cli/src/main/java/co/cask/cdap/cli/docs/GenerateCLIDocsTableCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/docs/GenerateCLIDocsTableCommand.java
@@ -51,9 +51,9 @@ public class GenerateCLIDocsTableCommand extends HelpCommand {
   public void execute(Arguments arguments, PrintStream output) throws Exception {
     Multimap<String, Command> categorizedCommands = categorizeCommands(
       commands.get(), CommandCategory.GENERAL, Predicates.<Command>alwaysTrue());
-    for (String category : categorizedCommands.keySet()) {
-      output.printf("   **%s**\n", simpleTitleCase(category));
-      List<Command> commandList = Lists.newArrayList(categorizedCommands.get(category));
+    for (CommandCategory category : CommandCategory.values()) {
+      output.printf("   **%s**\n", simpleTitleCase(category.getName()));
+      List<Command> commandList = Lists.newArrayList(categorizedCommands.get(category.getName()));
       Collections.sort(commandList, new Comparator<Command>() {
         @Override
         public int compare(Command command, Command command2) {


### PR DESCRIPTION
```
   **General**
   ``connect <cdap-instance-uri>``,"Connects to a CDAP instance."
   ``exit``,"Exits the CLI"
   ``help [<command-category>]``,"Prints this helper text. Optionally provide <command-category> to get help with a specific category"
   ``quit``,"Exits the CLI"
   ``search commands <query>``,"Searches available commands using regex"
   ``version``,"Prints the version"
   **Namespace**
   ``create namespace <namespace-id> [<namespace-display-name>] [<namespace-description>]``,"Creates a namespace in CDAP."
   ``delete namespace <namespace-id>``,"Deletes a Namespace."
   ``describe namespace <namespace-id>``,"Describes a Namespace."
   ``list namespaces``,"Lists all Namespaces."
   ``use namespace <namespace-id>``,"Changes the current Namespace"
   **Lifecycle**
   ``create adapter <adapter-name> type <adapter-type> [props <adapter-props>] src <adapter-source> [src-props <adapter-source-config>] sink <adapter-sink> [sink-props <adapter-sink-config>]``,"Creates a Adapter"
   ``create stream <new-stream-id>``,"Creates a Stream"
   ``create stream-conversion adapter <adapter-name> on <stream-id> [frequency <frequency>] [format <format>] [schema <schema>] [headers <headers>] [to <dataset-name>]``,"Creates a stream conversion Adapter that periodically reads from a stream and writes to a time-partitioned fileset. frequency is a number followed by a 'm', 'h', or 'd' for minute, hour, or day.format is the name of the stream format, such as 'text', 'avro', 'csv', or 'tsv'.schema is a sql-like schema of comma separated column name followed by column type.headers is a comma separated list of stream headers to include in the output schema.dataset-name is the name of the time partitioned file set to write to."
   ``delete adapter <adapter-name>``,"Deletes an Adapter"
   ``delete app <app-id>``,"Deletes an application"
   ``deploy app <app-jar-file>``,"Deploys an application"
   ``describe app <app-id>``,"Shows detailed information about an application"
   ``describe stream <stream-id>``,"Shows detailed information about a Stream"
   ``get endpoints service <app-id.service-id>``,"List the endpoints that a Service exposes"
   ``get flow live <app-id.flow-id>``,"Gets the live info of a Flow"
   ``get flow logs <app-id.flow-id> [<start-time>] [<end-time>]``,"Gets the logs of a Flow"
   ``get flow runs <app-id.flow-id> [<status>] [<start-time>] [<end-time>] [<limit>]``,"Gets the run history of a Flow"
   ``get flow runtimeargs <app-id.flow-id>``,"Gets the runtime arguments of a Flow"
   ``get flow status <app-id.flow-id>``,"Gets the status of a Flow"
   ``get flowlet instances <app-id.flow-id.flowlet-id>``,"Gets the instances of a Flowlet"
   ``get mapreduce logs <app-id.mapreduce-id> [<start-time>] [<end-time>]``,"Gets the logs of a MapReduce Program"
   ``get mapreduce runs <app-id.mapreduce-id> [<status>] [<start-time>] [<end-time>] [<limit>]``,"Gets the run history of a MapReduce Program"
   ``get mapreduce runtimeargs <app-id.mapreduce-id>``,"Gets the runtime arguments of a MapReduce Program"
   ``get mapreduce status <app-id.mapreduce-id>``,"Gets the status of a MapReduce Program"
   ``get procedure instances <app-id.procedure-id>``,"Gets the instances of a Procedure"
   ``get procedure live <app-id.procedure-id>``,"Gets the live info of a Procedure"
   ``get procedure logs <app-id.procedure-id> [<start-time>] [<end-time>]``,"Gets the logs of a Procedure"
   ``get procedure runs <app-id.procedure-id> [<status>] [<start-time>] [<end-time>] [<limit>]``,"Gets the run history of a Procedure"
   ``get procedure runtimeargs <app-id.procedure-id>``,"Gets the runtime arguments of a Procedure"
   ``get procedure status <app-id.procedure-id>``,"Gets the status of a Procedure"
   ``get runnable instances <app-id.service-id.runnable-id>``,"Gets the instances of a Runnable"
   ``get runnable logs <app-id.service-id.runnable-id> [<start-time>] [<end-time>]``,"Gets the logs of a Runnable"
   ``get runnable runs <app-id.service-id.runnable-id> [<status>] [<start-time>] [<end-time>] [<limit>]``,"Gets the run history of a Runnable"
   ``get service runtimeargs <app-id.service-id>``,"Gets the runtime arguments of a Service"
   ``get service status <app-id.service-id>``,"Gets the status of a Service"
   ``get spark logs <app-id.spark-id> [<start-time>] [<end-time>]``,"Gets the logs of a Spark Program"
   ``get spark runs <app-id.spark-id> [<status>] [<start-time>] [<end-time>] [<limit>]``,"Gets the run history of a Spark Program"
   ``get spark runtimeargs <app-id.spark-id>``,"Gets the runtime arguments of a Spark Program"
   ``get spark status <app-id.spark-id>``,"Gets the status of a Spark Program"
   ``get stream <stream-id> [<start-time>] [<end-time>] [<limit>]``,"Gets events from a Stream. The time format for <start-time> and <end-time> can be a timestamp in milliseconds or a relative time in the form of [+|-][0-9][d|h|m|s]. <start-time> is relative to current time; <end-time>, it is relative to start time. Special constants ""min"" and ""max"" can also be used to represent ""0"" and ""max timestamp"" respectively."
   ``get stream-stats <stream-id> [limit <limit>] [start <start-time>] [end <end-time>]``,"Gets statistics for a Stream. The <limit> limits how many Stream events to analyze; default is 100.The time format for <start-time> and <end-time> can be a timestamp in milliseconds or a relative time in the form of [+|-][0-9][d|h|m|s]. <start-time> is relative to current time; <end-time>, it is relative to start time. Special constants ""min"" and ""max"" can also be used to represent ""0"" and ""max timestamp"" respectively."
   ``get workflow runs <app-id.workflow-id> [<status>] [<start-time>] [<end-time>] [<limit>]``,"Gets the run history of a Workflow"
   ``get workflow runtimeargs <app-id.workflow-id>``,"Gets the runtime arguments of a Workflow"
   ``get workflow status <app-id.workflow-id>``,"Gets the status of a Workflow"
   ``list adapters``,"Lists all Adapters"
   ``list apps``,"Lists all applications"
   ``list flows``,"Lists Flows"
   ``list mapreduce``,"Lists MapReduce Programs"
   ``list procedures``,"Lists Procedures"
   ``list programs``,"Lists all programs"
   ``list services``,"Lists Services"
   ``list spark``,"Lists Spark Programs"
   ``list streams``,"Lists Streams"
   ``list workflows``,"Lists Workflows"
   ``set flow runtimeargs <app-id.flow-id> <runtime-args>``,"Sets the runtime arguments of a Flow. <runtime-args> is specified in the format ""key1=a key2=b"""
   ``set flowlet instances <app-id.flow-id.flowlet-id> <num-instances>``,"Sets the instances of a Flowlet"
   ``set mapreduce runtimeargs <app-id.mapreduce-id> <runtime-args>``,"Sets the runtime arguments of a MapReduce Program. <runtime-args> is specified in the format ""key1=a key2=b"""
   ``set procedure instances <app-id.procedure-id> <num-instances>``,"Sets the instances of a Procedure"
   ``set procedure runtimeargs <app-id.procedure-id> <runtime-args>``,"Sets the runtime arguments of a Procedure. <runtime-args> is specified in the format ""key1=a key2=b"""
   ``set runnable instances <app-id.service-id.runnable-id> <num-instances>``,"Sets the instances of a Runnable"
   ``set service runtimeargs <app-id.service-id> <runtime-args>``,"Sets the runtime arguments of a Service. <runtime-args> is specified in the format ""key1=a key2=b"""
   ``set spark runtimeargs <app-id.spark-id> <runtime-args>``,"Sets the runtime arguments of a Spark Program. <runtime-args> is specified in the format ""key1=a key2=b"""
   ``set stream format <stream-id> <format> [<schema>] [<settings>]``,"Sets the format of a Stream. <schema> is a sql-like schema ""column_name data_type, ..."" or avro-like json schema and <settings> is specified in the format ""key1=v1, key2=v2"""
   ``set stream properties <stream-id> <local-file-path>``,"Sets the properties of a stream, such as TTL, format, and notification threshold."
   ``set stream ttl <stream-id> <ttl-in-seconds>``,"Sets the Time-to-Live (TTL) of a Stream"
   ``set workflow runtimeargs <app-id.workflow-id> <runtime-args>``,"Sets the runtime arguments of a Workflow. <runtime-args> is specified in the format ""key1=a key2=b"""
   ``start flow <app-id.flow-id> [<runtime-args>]``,"Starts a Flow. <runtime-args> is specified in the format ""key1=a key2=b"""
   ``start mapreduce <app-id.mapreduce-id> [<runtime-args>]``,"Starts a MapReduce Program. <runtime-args> is specified in the format ""key1=a key2=b"""
   ``start procedure <app-id.procedure-id> [<runtime-args>]``,"Starts a Procedure. <runtime-args> is specified in the format ""key1=a key2=b"""
   ``start service <app-id.service-id> [<runtime-args>]``,"Starts a Service. <runtime-args> is specified in the format ""key1=a key2=b"""
   ``start spark <app-id.spark-id> [<runtime-args>]``,"Starts a Spark Program. <runtime-args> is specified in the format ""key1=a key2=b"""
   ``start workflow <app-id.workflow-id> [<runtime-args>]``,"Starts a Workflow. <runtime-args> is specified in the format ""key1=a key2=b"""
   ``stop flow <app-id.flow-id>``,"Stops a Flow"
   ``stop mapreduce <app-id.mapreduce-id>``,"Stops a MapReduce Program"
   ``stop procedure <app-id.procedure-id>``,"Stops a Procedure"
   ``stop service <app-id.service-id>``,"Stops a Service"
   ``stop spark <app-id.spark-id>``,"Stops a Spark Program"
   ``stop workflow <app-id.workflow-id>``,"Stops a Workflow"
   ``truncate stream <stream-id>``,"Truncates a Stream"
   **Dataset**
   ``create dataset instance <dataset-type> <new-dataset-name>``,"Creates a Dataset"
   ``delete dataset instance <dataset-name>``,"Deletes a Dataset"
   ``delete dataset module <dataset-module>``,"Deletes a Dataset module"
   ``deploy dataset module <new-dataset-module> <module-jar-file> <module-jar-classname>``,"Deploys a Dataset module"
   ``describe dataset module <dataset-module>``,"Shows information about a Dataset module"
   ``describe dataset type <dataset-type>``,"Shows information about a Dataset type"
   ``list dataset instances``,"Lists all Datasets"
   ``list dataset modules``,"Lists Dataset modules"
   ``list dataset types``,"Lists Dataset types"
   ``truncate dataset instance <dataset-name>``,"Truncates a Dataset"
   **Explore**
   ``execute <query> [<timeout>]``,"Executes a Dataset query with optional timeout (default = 60) in minutes"
   **Ingest**
   ``load stream <stream-id> <local-file-path> [<content-type>]``,"Loads a file to a Stream. The content of the file will become multiple events in the stream, based on the content type. If <content-type> is not provided, it will be detected by the file extension"
   ``send stream <stream-id> <stream-event>``,"Sends an event to a Stream"
   **Egress**
   ``call procedure <app-id.procedure-id> <app-id.method-id> [<parameter-map>]``,"Calls a Procedure"
   ``call service <app-id.service-id> <http-method> <endpoint> [headers <headers>] [body <body>]``,"Calls a Service endpoint. The header is formatted as ""{'key':'value', ...}"" and the body is a String."
```