### PR TITLE
Create a new StreamSizeScheduler

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -52,12 +52,12 @@ import co.cask.cdap.internal.app.namespace.NamespaceAdmin;
 import co.cask.cdap.internal.app.runtime.adapter.AdapterService;
 import co.cask.cdap.internal.app.runtime.batch.InMemoryTransactionServiceManager;
 import co.cask.cdap.internal.app.runtime.distributed.TransactionServiceManager;
-import co.cask.cdap.internal.app.runtime.schedule.DataSetBasedScheduleStore;
 import co.cask.cdap.internal.app.runtime.schedule.DistributedSchedulerService;
 import co.cask.cdap.internal.app.runtime.schedule.ExecutorThreadPool;
 import co.cask.cdap.internal.app.runtime.schedule.LocalSchedulerService;
 import co.cask.cdap.internal.app.runtime.schedule.Scheduler;
 import co.cask.cdap.internal.app.runtime.schedule.SchedulerService;
+import co.cask.cdap.internal.app.runtime.schedule.store.DatasetBasedTimeScheduleStore;
 import co.cask.cdap.internal.app.store.DefaultStoreFactory;
 import co.cask.cdap.internal.pipeline.SynchronousPipelineFactory;
 import co.cask.cdap.logging.run.AppFabricServiceManager;
@@ -300,7 +300,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
      * injection. It returns a singleton of Scheduler.
      */
     @Provides
-    public Supplier<org.quartz.Scheduler> providesSchedulerSupplier(final DataSetBasedScheduleStore scheduleStore,
+    public Supplier<org.quartz.Scheduler> providesSchedulerSupplier(final DatasetBasedTimeScheduleStore scheduleStore,
                                                                     final CConfiguration cConf) {
       return new Supplier<org.quartz.Scheduler>() {
         private org.quartz.Scheduler scheduler;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/AbstractSchedulerService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/AbstractSchedulerService.java
@@ -98,8 +98,9 @@ public abstract class AbstractSchedulerService extends AbstractIdleService imple
       timeScheduler.schedule(programId, programType, schedule);
     } else if (schedule instanceof StreamSizeSchedule) {
       streamSizeScheduler.schedule(programId, programType, schedule);
+    } else {
+      throw new IllegalStateException("Unhandled type of schedule: " + schedule.getClass());
     }
-    throw new IllegalStateException("Unhandled type of schedule: " + schedule.getClass());
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/AbstractSchedulerService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/AbstractSchedulerService.java
@@ -77,23 +77,33 @@ public abstract class AbstractSchedulerService extends AbstractIdleService imple
       throw Throwables.propagate(e);
     }
 
-    streamSizeScheduler.start();
-    LOG.info("Started stream size scheduler");
+    try {
+      streamSizeScheduler.start();
+      LOG.info("Started stream size scheduler");
+    } catch (Throwable t) {
+      LOG.error("Error starting stream size scheduler {}", t.getCause(), t);
+      throw Throwables.propagate(t);
+    }
   }
 
   /**
    * Stop the quartz scheduler service.
    */
   protected final void stopScheduler() {
-    streamSizeScheduler.stop();
-    LOG.info("Stopped stram size scheduler");
-
     try {
-      timeScheduler.stop();
-      LOG.info("Stopped time scheduler");
-    } catch (SchedulerException e) {
-      LOG.error("Error stopping time scheduler {}", e.getCause(), e);
-      throw Throwables.propagate(e);
+      streamSizeScheduler.stop();
+      LOG.info("Stopped stram size scheduler");
+    } catch (Throwable t) {
+      LOG.error("Error stopping stream size scheduler {}", t.getCause(), t);
+      throw Throwables.propagate(t);
+    } finally {
+      try {
+        timeScheduler.stop();
+        LOG.info("Stopped time scheduler");
+      } catch (SchedulerException e) {
+        LOG.error("Error stopping time scheduler {}", e.getCause(), e);
+        throw Throwables.propagate(e);
+      }
     }
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/DistributedSchedulerService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/DistributedSchedulerService.java
@@ -44,11 +44,12 @@ public final class DistributedSchedulerService extends AbstractSchedulerService 
   private Cancellable cancellable;
 
   @Inject
-  public DistributedSchedulerService(Supplier<Scheduler> schedulerSupplier, StoreFactory storeFactory,
+  public DistributedSchedulerService(Supplier<Scheduler> schedulerSupplier,
+                                     StreamSizeScheduler streamSizeScheduler, StoreFactory storeFactory,
                                      ProgramRuntimeService programRuntimeService,
                                      DiscoveryServiceClient discoveryServiceClient,
                                      PreferencesStore preferencesStore) {
-    super(schedulerSupplier, storeFactory, programRuntimeService, preferencesStore);
+    super(schedulerSupplier, streamSizeScheduler, storeFactory, programRuntimeService, preferencesStore);
     this.discoveryServiceClient = discoveryServiceClient;
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/LocalSchedulerService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/LocalSchedulerService.java
@@ -33,9 +33,10 @@ public final class LocalSchedulerService extends AbstractSchedulerService {
   private static final Logger LOG = LoggerFactory.getLogger(LocalSchedulerService.class);
 
   @Inject
-  public LocalSchedulerService(Supplier<Scheduler> schedulerSupplier, StoreFactory storeFactory,
+  public LocalSchedulerService(Supplier<Scheduler> schedulerSupplier,
+                               StreamSizeScheduler streamSizeScheduler, StoreFactory storeFactory,
                                ProgramRuntimeService programRuntimeService, PreferencesStore preferencesStore) {
-    super(schedulerSupplier, storeFactory, programRuntimeService, preferencesStore);
+    super(schedulerSupplier, streamSizeScheduler, storeFactory, programRuntimeService, preferencesStore);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/StreamSizeScheduler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/StreamSizeScheduler.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.schedule;
+
+import co.cask.cdap.api.schedule.SchedulableProgramType;
+import co.cask.cdap.api.schedule.Schedule;
+import co.cask.cdap.app.runtime.ProgramRuntimeService;
+import co.cask.cdap.app.store.StoreFactory;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.config.PreferencesStore;
+import co.cask.cdap.data2.transaction.stream.StreamAdmin;
+import co.cask.cdap.internal.schedule.StreamSizeSchedule;
+import co.cask.cdap.notifications.service.NotificationService;
+import co.cask.cdap.proto.Id;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/**
+ * {@link Scheduler} that triggers program executions based on data availability in streams.
+ */
+@Singleton
+public class StreamSizeScheduler implements Scheduler {
+  private static final Logger LOG = LoggerFactory.getLogger(StreamSizeScheduler.class);
+
+  private final NotificationService notificationService;
+  private final StreamAdmin streamAdmin;
+  private final StoreFactory storeFactory;
+  private final ProgramRuntimeService programRuntimeService;
+  private final PreferencesStore preferencesStore;
+
+
+  @Inject
+  public StreamSizeScheduler(CConfiguration cConf, NotificationService notificationService, StreamAdmin streamAdmin,
+                             StoreFactory storeFactory, ProgramRuntimeService programRuntimeService,
+                             PreferencesStore preferencesStore) {
+    this.notificationService = notificationService;
+    this.streamAdmin = streamAdmin;
+    this.storeFactory = storeFactory;
+    this.programRuntimeService = programRuntimeService;
+    this.preferencesStore = preferencesStore;
+  }
+
+  public void start() {
+
+  }
+
+  public void stop() {
+
+  }
+
+  @Override
+  public void schedule(Id.Program program, SchedulableProgramType programType, Schedule schedule) {
+    Preconditions.checkArgument(schedule instanceof StreamSizeSchedule,
+                                "Schedule should be of type StreamSizeSchedule");
+  }
+
+  @Override
+  public void schedule(Id.Program program, SchedulableProgramType programType, Iterable<Schedule> schedules) {
+
+  }
+
+  @Override
+  public List<ScheduledRuntime> nextScheduledRuntime(Id.Program program, SchedulableProgramType programType) {
+    return ImmutableList.of();
+  }
+
+  @Override
+  public List<String> getScheduleIds(Id.Program program, SchedulableProgramType programType) {
+    return ImmutableList.of();
+  }
+
+  @Override
+  public void suspendSchedule(Id.Program program, SchedulableProgramType programType, String scheduleName) {
+
+  }
+
+  @Override
+  public void resumeSchedule(Id.Program program, SchedulableProgramType programType, String scheduleName) {
+
+  }
+
+  @Override
+  public void deleteSchedule(Id.Program programId, SchedulableProgramType programType, String scheduleName) {
+
+  }
+
+  @Override
+  public void deleteSchedules(Id.Program programId, SchedulableProgramType programType) {
+
+  }
+
+  @Override
+  public ScheduleState scheduleState(Id.Program program, SchedulableProgramType programType, String scheduleName) {
+    return ScheduleState.NOT_FOUND;
+  }
+
+  private String getScheduleId(Id.Program program, SchedulableProgramType programType, String scheduleName) {
+    return String.format("%s:%s", getProgramScheduleId(program, programType), scheduleName);
+  }
+
+  private String getProgramScheduleId(Id.Program program, SchedulableProgramType programType) {
+    return String.format("%s:%s:%s:%s", program.getNamespaceId(), program.getApplicationId(),
+                         programType.name(), program.getId());
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/TimeScheduler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/TimeScheduler.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.schedule;
+
+import co.cask.cdap.api.schedule.SchedulableProgramType;
+import co.cask.cdap.api.schedule.Schedule;
+import co.cask.cdap.app.runtime.ProgramRuntimeService;
+import co.cask.cdap.app.store.Store;
+import co.cask.cdap.app.store.StoreFactory;
+import co.cask.cdap.config.PreferencesStore;
+import co.cask.cdap.internal.schedule.TimeSchedule;
+import co.cask.cdap.proto.Id;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Supplier;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import org.quartz.CronScheduleBuilder;
+import org.quartz.Job;
+import org.quartz.JobBuilder;
+import org.quartz.JobDetail;
+import org.quartz.JobKey;
+import org.quartz.SchedulerException;
+import org.quartz.Trigger;
+import org.quartz.TriggerBuilder;
+import org.quartz.TriggerKey;
+import org.quartz.spi.JobFactory;
+import org.quartz.spi.TriggerFiredBundle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/**
+ * Class that wraps Quartz scheduler. Needed to delegate start stop operations to classes that extend
+ * DefaultSchedulerService.
+ */
+final class TimeScheduler implements Scheduler {
+  private static final Logger LOG = LoggerFactory.getLogger(TimeScheduler.class);
+
+  private org.quartz.Scheduler scheduler;
+  private final StoreFactory storeFactory;
+  private final Supplier<org.quartz.Scheduler> schedulerSupplier;
+  private final ProgramRuntimeService programRuntimeService;
+  private final PreferencesStore preferencesStore;
+
+  TimeScheduler(Supplier<org.quartz.Scheduler> schedulerSupplier, StoreFactory storeFactory,
+                ProgramRuntimeService programRuntimeService, PreferencesStore preferencesStore) {
+    this.schedulerSupplier = schedulerSupplier;
+    this.storeFactory = storeFactory;
+    this.programRuntimeService = programRuntimeService;
+    this.scheduler = null;
+    this.preferencesStore = preferencesStore;
+  }
+
+  void start() throws SchedulerException {
+    scheduler = schedulerSupplier.get();
+    scheduler.setJobFactory(createJobFactory(storeFactory.create()));
+    scheduler.start();
+  }
+
+  void stop() throws SchedulerException {
+    if (scheduler != null) {
+      scheduler.shutdown();
+    }
+  }
+
+  @Override
+  public void schedule(Id.Program programId, SchedulableProgramType programType, Schedule schedule) {
+    schedule(programId, programType, ImmutableList.of(schedule));
+  }
+
+  @Override
+  public void schedule(Id.Program programId, SchedulableProgramType programType, Iterable<Schedule> schedules) {
+    checkInitialized();
+    Preconditions.checkNotNull(schedules);
+
+    String jobKey = getJobKey(programId, programType).getName();
+    JobDetail job = JobBuilder.newJob(DefaultSchedulerService.ScheduledJob.class)
+      .withIdentity(jobKey)
+      .storeDurably(true)
+      .build();
+    try {
+      scheduler.addJob(job, true);
+    } catch (SchedulerException e) {
+      throw Throwables.propagate(e);
+    }
+    for (Schedule schedule : schedules) {
+      Preconditions.checkArgument(schedule instanceof TimeSchedule);
+      TimeSchedule timeSchedule = (TimeSchedule) schedule;
+      String scheduleName = timeSchedule.getName();
+      String cronEntry = timeSchedule.getCronEntry();
+      String triggerKey = getScheduleId(programId, programType, scheduleName);
+
+      LOG.debug("Scheduling job {} with cron {}", scheduleName, cronEntry);
+
+      Trigger trigger = TriggerBuilder.newTrigger()
+        .withIdentity(triggerKey)
+        .forJob(job)
+        .withSchedule(CronScheduleBuilder.cronSchedule(getQuartzCronExpression(cronEntry)))
+        .build();
+      try {
+        scheduler.scheduleJob(trigger);
+      } catch (SchedulerException e) {
+        throw Throwables.propagate(e);
+      }
+    }
+  }
+
+  @Override
+  public List<ScheduledRuntime> nextScheduledRuntime(Id.Program program, SchedulableProgramType programType) {
+    checkInitialized();
+
+    List<ScheduledRuntime> scheduledRuntimes = Lists.newArrayList();
+    try {
+      for (Trigger trigger : scheduler.getTriggersOfJob(getJobKey(program, programType))) {
+        ScheduledRuntime runtime = new ScheduledRuntime(trigger.getKey().toString(),
+                                                        trigger.getNextFireTime().getTime());
+        scheduledRuntimes.add(runtime);
+      }
+    } catch (SchedulerException e) {
+      throw Throwables.propagate(e);
+    }
+    return scheduledRuntimes;
+  }
+
+  @Override
+  public List<String> getScheduleIds(Id.Program program, SchedulableProgramType programType) {
+    checkInitialized();
+
+    List<String> scheduleIds = Lists.newArrayList();
+    try {
+      for (Trigger trigger : scheduler.getTriggersOfJob(getJobKey(program, programType))) {
+        scheduleIds.add(trigger.getKey().getName());
+      }
+    }   catch (SchedulerException e) {
+      throw Throwables.propagate(e);
+    }
+    return scheduleIds;
+  }
+
+
+  @Override
+  public void suspendSchedule(Id.Program program, SchedulableProgramType programType, String scheduleName) {
+    checkInitialized();
+    try {
+      scheduler.pauseTrigger(new TriggerKey(getScheduleId(program, programType, scheduleName)));
+    } catch (SchedulerException e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  @Override
+  public void resumeSchedule(Id.Program program, SchedulableProgramType programType, String scheduleName) {
+    checkInitialized();
+    try {
+      scheduler.resumeTrigger(new TriggerKey(getScheduleId(program, programType, scheduleName)));
+    } catch (SchedulerException e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  @Override
+  public void deleteSchedule(Id.Program program, SchedulableProgramType programType, String scheduleName) {
+    checkInitialized();
+    try {
+      Trigger trigger = scheduler.getTrigger(new TriggerKey(getScheduleId(program, programType, scheduleName)));
+      Preconditions.checkNotNull(trigger);
+
+      scheduler.unscheduleJob(trigger.getKey());
+
+      JobKey jobKey = trigger.getJobKey();
+      if (scheduler.getTriggersOfJob(jobKey).isEmpty()) {
+        scheduler.deleteJob(jobKey);
+      }
+    } catch (SchedulerException e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  @Override
+  public void deleteSchedules(Id.Program program, SchedulableProgramType programType) {
+    checkInitialized();
+    try {
+      scheduler.deleteJob(getJobKey(program, programType));
+    } catch (SchedulerException e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  @Override
+  public ScheduleState scheduleState(Id.Program program, SchedulableProgramType programType, String scheduleName) {
+    checkInitialized();
+    try {
+      Trigger.TriggerState state = scheduler.getTriggerState(new TriggerKey(getScheduleId(program, programType,
+                                                                                          scheduleName)));
+      // Map trigger state to schedule state.
+      // This method is only interested in returning if the scheduler is
+      // Paused, Scheduled or NotFound.
+      switch (state) {
+        case NONE:
+          return ScheduleState.NOT_FOUND;
+        case PAUSED:
+          return ScheduleState.SUSPENDED;
+        default:
+          return ScheduleState.SCHEDULED;
+      }
+    } catch (SchedulerException e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  private void checkInitialized() {
+    Preconditions.checkNotNull(scheduler, "Scheduler not yet initialized");
+  }
+
+  private String getScheduleId(Id.Program program, SchedulableProgramType programType, String scheduleName) {
+    return String.format("%s:%s", getJobKey(program, programType).getName(), scheduleName);
+  }
+
+
+  private JobKey getJobKey(Id.Program program, SchedulableProgramType programType) {
+    return new JobKey(String.format("%s:%s:%s:%s", program.getNamespaceId(), program.getApplicationId(),
+                                    programType.name(), program.getId()));
+  }
+
+  //Helper function to adapt cron entry to a cronExpression that is usable by quartz.
+  //1. Quartz doesn't support wild-carding of both day-of-the-week and day-of-the-month
+  //2. Quartz resolution is in seconds which cron entry doesn't support.
+  private String getQuartzCronExpression(String cronEntry) {
+    // Checks if the cronEntry is quartz cron Expression or unix like cronEntry format.
+    // CronExpression will directly be used for tests.
+    String parts [] = cronEntry.split(" ");
+    Preconditions.checkArgument(parts.length >= 5 , "Invalid cron entry format");
+    if (parts.length == 5) {
+      //cron entry format
+      StringBuilder cronStringBuilder = new StringBuilder("0 " + cronEntry);
+      if (cronStringBuilder.charAt(cronStringBuilder.length() - 1) == '*') {
+        cronStringBuilder.setCharAt(cronStringBuilder.length() - 1, '?');
+      }
+      return cronStringBuilder.toString();
+    } else {
+      //Use the given cronExpression
+      return cronEntry;
+    }
+  }
+
+  private JobFactory createJobFactory(final Store store) {
+    return new JobFactory() {
+      @Override
+      public Job newJob(TriggerFiredBundle bundle, org.quartz.Scheduler scheduler) throws SchedulerException {
+        Class<? extends Job> jobClass = bundle.getJobDetail().getJobClass();
+
+        if (DefaultSchedulerService.ScheduledJob.class.isAssignableFrom(jobClass)) {
+          return new DefaultSchedulerService.ScheduledJob(store, programRuntimeService, preferencesStore);
+        } else {
+          try {
+            return jobClass.newInstance();
+          } catch (Exception e) {
+            throw new SchedulerException("Failed to create instance of " + jobClass, e);
+          }
+        }
+      }
+    };
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/store/DatasetBasedTimeScheduleStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/store/DatasetBasedTimeScheduleStore.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package co.cask.cdap.internal.app.runtime.schedule;
+package co.cask.cdap.internal.app.runtime.schedule.store;
 
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.dataset.table.OrderedTable;
@@ -48,9 +48,9 @@ import java.util.Set;
 /**
  * ScheduleStore extends from RAMJobStore and persists the trigger and schedule information into datasets.
  */
-public class DataSetBasedScheduleStore extends RAMJobStore {
+public class DatasetBasedTimeScheduleStore extends RAMJobStore {
 
-  private static final Logger LOG = LoggerFactory.getLogger(DataSetBasedScheduleStore.class);
+  private static final Logger LOG = LoggerFactory.getLogger(DatasetBasedTimeScheduleStore.class);
   private static final byte[] JOB_KEY = Bytes.toBytes("jobs");
   private static final byte[] TRIGGER_KEY = Bytes.toBytes("trigger");
 
@@ -59,7 +59,7 @@ public class DataSetBasedScheduleStore extends RAMJobStore {
   private OrderedTable table;
 
   @Inject
-  public DataSetBasedScheduleStore(TransactionExecutorFactory factory, ScheduleStoreTableUtil tableUtil) {
+  public DatasetBasedTimeScheduleStore(TransactionExecutorFactory factory, ScheduleStoreTableUtil tableUtil) {
     this.tableUtil = tableUtil;
     this.factory = factory;
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/store/ScheduleStoreTableUtil.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/store/ScheduleStoreTableUtil.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package co.cask.cdap.internal.app.runtime.schedule;
+package co.cask.cdap.internal.app.runtime.schedule.store;
 
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.table.OrderedTable;
@@ -29,7 +29,7 @@ import java.io.IOException;
 
 /**
  * Helper class for working with the dataset table used by
- * {@link co.cask.cdap.internal.app.runtime.schedule.DataSetBasedScheduleStore}.
+ * {@link DatasetBasedTimeScheduleStore}.
  */
 public class ScheduleStoreTableUtil extends MetaTableUtil {
   public static final String SCHEDULE_STORE_DATASET_NAME = "schedulestore";

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AppFabricServer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AppFabricServer.java
@@ -26,6 +26,7 @@ import co.cask.cdap.common.logging.ServiceLoggingContext;
 import co.cask.cdap.common.metrics.MetricsCollectionService;
 import co.cask.cdap.internal.app.runtime.adapter.AdapterService;
 import co.cask.cdap.internal.app.runtime.schedule.SchedulerService;
+import co.cask.cdap.notifications.service.NotificationService;
 import co.cask.http.HandlerHook;
 import co.cask.http.HttpHandler;
 import co.cask.http.NettyHttpService;
@@ -62,6 +63,7 @@ public final class AppFabricServer extends AbstractIdleService {
   private final SchedulerService schedulerService;
   private final ProgramRuntimeService programRuntimeService;
   private final AdapterService adapterService;
+  private final NotificationService notificationService;
   private final Set<String> servicesNames;
   private final Set<String> handlerHookNames;
 
@@ -75,7 +77,7 @@ public final class AppFabricServer extends AbstractIdleService {
    */
   @Inject
   public AppFabricServer(CConfiguration configuration, DiscoveryService discoveryService,
-                         SchedulerService schedulerService,
+                         SchedulerService schedulerService, NotificationService notificationService,
                          @Named(Constants.AppFabric.SERVER_ADDRESS) InetAddress hostname,
                          @Named("appfabric.http.handler") Set<HttpHandler> handlers,
                          @Nullable MetricsCollectionService metricsCollectionService,
@@ -90,6 +92,7 @@ public final class AppFabricServer extends AbstractIdleService {
     this.metricsCollectionService = metricsCollectionService;
     this.programRuntimeService = programRuntimeService;
     this.adapterService = adapterService;
+    this.notificationService = notificationService;
     this.servicesNames = servicesNames;
     this.handlerHookNames = handlerHookNames;
   }
@@ -107,6 +110,7 @@ public final class AppFabricServer extends AbstractIdleService {
                            configuration.get(Constants.AppFabric.TEMP_DIR)).getAbsoluteFile();
     FileUtils.deleteDirectory(tmpDir);
 
+    notificationService.start();
     schedulerService.start();
     adapterService.start();
     programRuntimeService.start();
@@ -190,5 +194,6 @@ public final class AppFabricServer extends AbstractIdleService {
     programRuntimeService.stopAndWait();
     schedulerService.stopAndWait();
     adapterService.stopAndWait();
+    notificationService.stopAndWait();
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/test/internal/AppFabricTestHelper.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/test/internal/AppFabricTestHelper.java
@@ -33,6 +33,7 @@ import co.cask.cdap.internal.app.deploy.ProgramTerminator;
 import co.cask.cdap.internal.app.deploy.pipeline.ApplicationWithPrograms;
 import co.cask.cdap.internal.app.deploy.pipeline.DeploymentInfo;
 import co.cask.cdap.internal.app.runtime.schedule.SchedulerService;
+import co.cask.cdap.notifications.service.NotificationService;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.test.internal.guice.AppFabricTestModule;
@@ -84,6 +85,7 @@ public class AppFabricTestHelper {
       injector.getInstance(DatasetService.class).startAndWait();
       injector.getInstance(SchedulerService.class).startAndWait();
       injector.getInstance(StreamCoordinatorClient.class).startAndWait();
+      injector.getInstance(NotificationService.class).startAndWait();
     }
     return injector;
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/test/internal/guice/AppFabricTestModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/test/internal/guice/AppFabricTestModule.java
@@ -41,6 +41,7 @@ import co.cask.cdap.logging.guice.LoggingModules;
 import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
 import co.cask.cdap.metrics.guice.MetricsHandlerModule;
 import co.cask.cdap.notifications.feeds.guice.NotificationFeedServiceRuntimeModule;
+import co.cask.cdap.notifications.guice.NotificationServiceRuntimeModule;
 import co.cask.cdap.proto.Id;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.AbstractModule;
@@ -96,6 +97,7 @@ public final class AppFabricTestModule extends AbstractModule {
     install(new MetricsClientRuntimeModule().getInMemoryModules());
     install(new ExploreClientModule());
     install(new NotificationFeedServiceRuntimeModule().getInMemoryModules());
+    install(new NotificationServiceRuntimeModule().getInMemoryModules());
     install(new ConfigStoreModule().getInMemoryModule());
     install(new StreamAdminModules().getInMemoryModules());
     install(new StreamServiceRuntimeModule().getInMemoryModules());

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/SchedulerServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/SchedulerServiceTest.java
@@ -19,11 +19,20 @@ package co.cask.cdap.internal.app.runtime.schedule;
 import co.cask.cdap.AppWithWorkflow;
 import co.cask.cdap.api.schedule.SchedulableProgramType;
 import co.cask.cdap.api.schedule.Schedule;
+import co.cask.cdap.api.schedule.ScheduleSpecification;
 import co.cask.cdap.api.schedule.Schedules;
+import co.cask.cdap.api.workflow.ScheduleProgramInfo;
+import co.cask.cdap.app.ApplicationSpecification;
+import co.cask.cdap.app.store.Store;
+import co.cask.cdap.app.store.StoreFactory;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.internal.app.DefaultApplicationSpecification;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.test.internal.AppFabricTestHelper;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.twill.filesystem.LocalLocationFactory;
+import org.apache.twill.filesystem.LocationFactory;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -33,6 +42,8 @@ import java.util.List;
 
 public class SchedulerServiceTest {
   public static SchedulerService schedulerService;
+  public static Store store;
+  public static LocationFactory locationFactory;
 
   private static final Id.Namespace account = new Id.Namespace(Constants.DEFAULT_NAMESPACE);
   private static final Id.Application appId = new Id.Application(account, AppWithWorkflow.NAME);
@@ -44,6 +55,8 @@ public class SchedulerServiceTest {
   @BeforeClass
   public static void set() {
     schedulerService = AppFabricTestHelper.getInjector().getInstance(SchedulerService.class);
+    store = AppFabricTestHelper.getInjector().getInstance(StoreFactory.class).create();
+    locationFactory = new LocalLocationFactory();
   }
 
   @AfterClass
@@ -54,7 +67,11 @@ public class SchedulerServiceTest {
   @Test
   public void testSchedulesAcrossNamespace() throws Exception {
     AppFabricTestHelper.deployApplication(AppWithWorkflow.class);
+    ApplicationSpecification applicationSpecification = store.getApplication(appId);
+
     schedulerService.schedule(program, programType, ImmutableList.of(schedule1));
+    applicationSpecification = createNewSpecification(applicationSpecification, program, programType, schedule1);
+    store.addApplication(appId, applicationSpecification, locationFactory.create("app"));
 
     Id.Program programInOtherNamespace =
       Id.Program.from(new Id.Application(new Id.Namespace("otherNamespace"), appId.getId()), program.getId());
@@ -66,6 +83,9 @@ public class SchedulerServiceTest {
     Assert.assertEquals(0, scheduleIdsOtherNamespace.size());
 
     schedulerService.schedule(programInOtherNamespace, programType, ImmutableList.of(schedule2));
+    applicationSpecification = createNewSpecification(applicationSpecification, programInOtherNamespace, programType,
+                                                      schedule2);
+    store.addApplication(appId, applicationSpecification, locationFactory.create("app"));
 
     scheduleIdsOtherNamespace = schedulerService.getScheduleIds(programInOtherNamespace, programType);
     Assert.assertEquals(1, scheduleIdsOtherNamespace.size());
@@ -77,13 +97,18 @@ public class SchedulerServiceTest {
   @Test
   public void testSimpleSchedulerLifecycle() throws Exception {
     AppFabricTestHelper.deployApplication(AppWithWorkflow.class);
+    ApplicationSpecification applicationSpecification = store.getApplication(appId);
 
     schedulerService.schedule(program, programType, ImmutableList.of(schedule1));
+    applicationSpecification = createNewSpecification(applicationSpecification, program, programType, schedule1);
+    store.addApplication(appId, applicationSpecification, locationFactory.create("app"));
     List<String> scheduleIds = schedulerService.getScheduleIds(program, programType);
     Assert.assertEquals(1, scheduleIds.size());
     checkState(Scheduler.ScheduleState.SCHEDULED, scheduleIds);
 
     schedulerService.schedule(program, programType, ImmutableList.of(schedule2));
+    applicationSpecification = createNewSpecification(applicationSpecification, program, programType, schedule2);
+    store.addApplication(appId, applicationSpecification, locationFactory.create("app"));
     scheduleIds = schedulerService.getScheduleIds(program, programType);
     Assert.assertEquals(2, scheduleIds.size());
 
@@ -105,7 +130,29 @@ public class SchedulerServiceTest {
   private void checkState(Scheduler.ScheduleState expectedState, List<String> scheduleIds) {
     Assert.assertEquals(expectedState, schedulerService.scheduleState(program, SchedulableProgramType.WORKFLOW,
                                                                       "Schedule1"));
-    Assert.assertEquals(expectedState, schedulerService.scheduleState(program, SchedulableProgramType.WORKFLOW,
-                                                                        "Schedule1"));
+    Assert.assertEquals(expectedState, schedulerService.scheduleState(program, SchedulableProgramType.WORKFLOW, "Schedule1"));
+  }
+
+  private ApplicationSpecification createNewSpecification(ApplicationSpecification spec, Id.Program programId,
+                                                          SchedulableProgramType programType, Schedule schedule) {
+    ImmutableMap.Builder<String, ScheduleSpecification> builder = ImmutableMap.builder();
+    builder.putAll(spec.getSchedules());
+    builder.put(schedule.getName(), new ScheduleSpecification(schedule,
+                                                              new ScheduleProgramInfo(programType, programId.getId()),
+                                                              ImmutableMap.<String, String>of()));
+    return new DefaultApplicationSpecification(
+      spec.getName(),
+      spec.getDescription(),
+      spec.getStreams(),
+      spec.getDatasetModules(),
+      spec.getDatasets(),
+      spec.getFlows(),
+      spec.getProcedures(),
+      spec.getMapReduce(),
+      spec.getSpark(),
+      spec.getWorkflows(),
+      spec.getServices(),
+      builder.build()
+    );
   }
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/SchedulerServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/SchedulerServiceTest.java
@@ -130,7 +130,8 @@ public class SchedulerServiceTest {
   private void checkState(Scheduler.ScheduleState expectedState, List<String> scheduleIds) {
     Assert.assertEquals(expectedState, schedulerService.scheduleState(program, SchedulableProgramType.WORKFLOW,
                                                                       "Schedule1"));
-    Assert.assertEquals(expectedState, schedulerService.scheduleState(program, SchedulableProgramType.WORKFLOW, "Schedule1"));
+    Assert.assertEquals(expectedState, schedulerService.scheduleState(program, SchedulableProgramType.WORKFLOW,
+                                                                      "Schedule1"));
   }
 
   private ApplicationSpecification createNewSpecification(ApplicationSpecification spec, Id.Program programId,

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/scheduler/SchedulerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/scheduler/SchedulerTest.java
@@ -30,8 +30,8 @@ import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetOpExecutor;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.gateway.auth.AuthModule;
-import co.cask.cdap.internal.app.runtime.schedule.DataSetBasedScheduleStore;
-import co.cask.cdap.internal.app.runtime.schedule.ScheduleStoreTableUtil;
+import co.cask.cdap.internal.app.runtime.schedule.store.DatasetBasedTimeScheduleStore;
+import co.cask.cdap.internal.app.runtime.schedule.store.ScheduleStoreTableUtil;
 import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
 import co.cask.cdap.test.SlowTests;
 import co.cask.cdap.test.internal.TempFolder;
@@ -110,7 +110,7 @@ public class SchedulerTest {
     JobStore js;
     if (enablePersistence) {
       CConfiguration conf = injector.getInstance(CConfiguration.class);
-      js = new DataSetBasedScheduleStore(factory, new ScheduleStoreTableUtil(dsFramework, conf));
+      js = new DatasetBasedTimeScheduleStore(factory, new ScheduleStoreTableUtil(dsFramework, conf));
     } else {
       js = new RAMJobStore();
     }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AppFabricTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AppFabricTestBase.java
@@ -21,7 +21,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.discovery.EndpointStrategy;
 import co.cask.cdap.common.discovery.RandomEndpointStrategy;
-import co.cask.cdap.data.stream.StreamCoordinatorClient;
+import co.cask.cdap.data.stream.service.StreamService;
 import co.cask.cdap.data2.datafabric.dataset.service.DatasetService;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetOpExecutor;
 import co.cask.cdap.internal.app.services.AppFabricServer;
@@ -115,7 +115,7 @@ public abstract class AppFabricTestBase {
   private static DatasetOpExecutor dsOpService;
   private static DatasetService datasetService;
   private static TransactionSystemClient txClient;
-  private static StreamCoordinatorClient streamCoordinatorClient;
+  private static StreamService streamService;
   private static final String adapterFolder = "adapter";
 
   @ClassRule
@@ -152,8 +152,8 @@ public abstract class AppFabricTestBase {
     txClient = injector.getInstance(TransactionSystemClient.class);
     metricsService = injector.getInstance(MetricsQueryService.class);
     metricsService.startAndWait();
-    streamCoordinatorClient = injector.getInstance(StreamCoordinatorClient.class);
-    streamCoordinatorClient.startAndWait();
+    streamService = injector.getInstance(StreamService.class);
+    streamService.startAndWait();
 
     createNamespaces();
   }
@@ -161,7 +161,7 @@ public abstract class AppFabricTestBase {
   @AfterClass
   public static void afterClass() throws Exception {
     deleteNamespaces();
-    streamCoordinatorClient.stopAndWait();
+    streamService.stopAndWait();
     appFabricServer.stopAndWait();
     metricsService.stopAndWait();
     datasetService.stopAndWait();

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
@@ -49,6 +49,7 @@ import co.cask.cdap.logging.appender.LogAppenderInitializer;
 import co.cask.cdap.logging.guice.LoggingModules;
 import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
 import co.cask.cdap.notifications.feeds.guice.NotificationFeedServiceRuntimeModule;
+import co.cask.cdap.notifications.guice.NotificationServiceRuntimeModule;
 import com.google.common.base.Charsets;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
@@ -171,6 +172,7 @@ public class MasterServiceMain extends DaemonMain {
       new ServiceStoreModules().getDistributedModule(),
       new ExploreClientModule(),
       new NotificationFeedServiceRuntimeModule().getDistributedModules(),
+      new NotificationServiceRuntimeModule().getDistributedModules(),
       new StreamAdminModules().getDistributedModules()
     );
 

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/Main.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/Main.java
@@ -44,7 +44,7 @@ import co.cask.cdap.data2.transaction.queue.QueueAdmin;
 import co.cask.cdap.data2.transaction.queue.hbase.HBaseQueueAdmin;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
-import co.cask.cdap.internal.app.runtime.schedule.ScheduleStoreTableUtil;
+import co.cask.cdap.internal.app.runtime.schedule.store.ScheduleStoreTableUtil;
 import co.cask.cdap.internal.app.store.DefaultStore;
 import co.cask.cdap.logging.save.LogSaverTableUtil;
 import co.cask.cdap.metrics.store.DefaultMetricDatasetFactory;


### PR DESCRIPTION
- Create a shell of a StreamSizeScheduler. It integrates in the ``AbstractSchedulerService``. 
- The ``TimeScheduler`` is moved, from inside the ``AbstractSchedulerService`` class to its own class.
- The ``AbstractSchedulerService`` uses the metastore to check the type of a schedule, to route the operations to the right scheduler (either TimeScheduler or StreamSizeScheduler).
- The ``SchedulerServiceTest`` is modified so that the schedules that are... scheduled, do appear in the metastore.

Build: http://builds.cask.co/browse/CDAP-DUT819