### PR TITLE
streamCreate returns 400 instead of 500, if given invalid stream name

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamHandler.java
@@ -181,22 +181,21 @@ public final class StreamHandler extends AuthenticatedHttpHandler {
   public void create(HttpRequest request, HttpResponder responder,
                      @PathParam("namespace-id") String namespaceId,
                      @PathParam("stream") String stream) throws Exception {
-    // Verify stream name
-    if (!Id.isId(stream)) {
+    try {
+      String accountID = getAuthenticatedAccountId(request);
+      // Verify stream name
+      Id.Stream streamId = Id.Stream.from(accountID, stream);
+
+      // TODO: Modify the REST API to support custom configurations.
+      streamAdmin.create(streamId);
+      streamMetaStore.addStream(streamId);
+
+      // TODO: For create successful, 201 Created should be returned instead of 200.
+      responder.sendStatus(HttpResponseStatus.OK);
+    } catch (IllegalArgumentException e) {
       responder.sendString(HttpResponseStatus.BAD_REQUEST,
-                           "Stream name can only contains alphanumeric, '-' and '_' characters only.");
-      return;
+                           e.getMessage());
     }
-
-    String accountID = getAuthenticatedAccountId(request);
-    Id.Stream streamId = Id.Stream.from(accountID, stream);
-
-    // TODO: Modify the REST API to support custom configurations.
-    streamAdmin.create(streamId);
-    streamMetaStore.addStream(streamId);
-
-    // TODO: For create successful, 201 Created should be returned instead of 200.
-    responder.sendStatus(HttpResponseStatus.OK);
   }
 
   @POST

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamHandler.java
@@ -41,7 +41,6 @@ import co.cask.http.BodyConsumer;
 import co.cask.http.HandlerContext;
 import co.cask.http.HttpHandler;
 import co.cask.http.HttpResponder;
-import com.google.common.base.CharMatcher;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Closeables;
 import com.google.gson.Gson;
@@ -182,16 +181,15 @@ public final class StreamHandler extends AuthenticatedHttpHandler {
   public void create(HttpRequest request, HttpResponder responder,
                      @PathParam("namespace-id") String namespaceId,
                      @PathParam("stream") String stream) throws Exception {
-
-    String accountID = getAuthenticatedAccountId(request);
-    Id.Stream streamId = Id.Stream.from(accountID, stream);
-
     // Verify stream name
-    if (!isValidName(stream)) {
+    if (!Id.isId(stream)) {
       responder.sendString(HttpResponseStatus.BAD_REQUEST,
                            "Stream name can only contains alphanumeric, '-' and '_' characters only.");
       return;
     }
+
+    String accountID = getAuthenticatedAccountId(request);
+    Id.Stream streamId = Id.Stream.from(accountID, stream);
 
     // TODO: Modify the REST API to support custom configurations.
     streamAdmin.create(streamId);
@@ -411,15 +409,6 @@ public final class StreamHandler extends AuthenticatedHttpHandler {
         }
       }
     };
-  }
-
-  private boolean isValidName(String streamName) {
-    // TODO: This is copied from StreamVerification in app-fabric as this handler is in data-fabric module.
-    return CharMatcher.inRange('A', 'Z')
-      .or(CharMatcher.inRange('a', 'z'))
-      .or(CharMatcher.is('-'))
-      .or(CharMatcher.is('_'))
-      .or(CharMatcher.inRange('0', '9')).matchesAllOf(streamName);
   }
 
   /**

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/StreamHandlerTest.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/StreamHandlerTest.java
@@ -75,6 +75,14 @@ public abstract class StreamHandlerTest extends GatewayTestBase {
   }
 
   @Test
+  public void testStreamCreateInvalidName() throws Exception {
+    // Now, create the new stream with an invalid character: '@'
+    HttpURLConnection urlConn = openURL(constructPath("streams/inv@lidStreamName"), HttpMethod.PUT);
+    Assert.assertEquals(HttpResponseStatus.BAD_REQUEST.getCode(), urlConn.getResponseCode());
+    urlConn.disconnect();
+  }
+
+  @Test
   public void testStreamCreate() throws Exception {
     // Try to get info on a non-existent stream
     HttpURLConnection urlConn = openURL(constructPath("streams/test_stream1/info"),

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/Id.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/Id.java
@@ -27,7 +27,7 @@ import com.google.common.collect.Iterables;
  */
 public final class Id  {
 
-  private static boolean isId(String name) {
+  public static boolean isId(String name) {
     return CharMatcher.inRange('A', 'Z')
       .or(CharMatcher.inRange('a', 'z'))
       .or(CharMatcher.is('-'))

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/Id.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/Id.java
@@ -27,7 +27,7 @@ import com.google.common.collect.Iterables;
  */
 public final class Id  {
 
-  public static boolean isId(String name) {
+  private static boolean isId(String name) {
     return CharMatcher.inRange('A', 'Z')
       .or(CharMatcher.inRange('a', 'z'))
       .or(CharMatcher.is('-'))
@@ -384,7 +384,8 @@ public final class Id  {
       Preconditions.checkNotNull(streamName, "Stream name cannot be null.");
 
       Preconditions.checkArgument(isId(namespace), "Stream namespace has an incorrect format.");
-      Preconditions.checkArgument(isId(streamName), "Stream name has an incorrect format.");
+      Preconditions.checkArgument(isId(streamName),
+                                  "Stream name can only contains alphanumeric, '-' and '_' characters only.");
 
       this.namespace = namespace;
       this.streamName = streamName;


### PR DESCRIPTION
Fixes an issue mentioned in JIRA for stream create:
https://issues.cask.co/browse/CDAP-1469

The issue in the JIRA is actually a much larger issue, dealing with all sorts of other program/data types and their handlers as well.

Build: http://builds.cask.co/browse/CDAP-DUT821-4