### PR TITLE
Fixes Javadoc and SDK build

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/app/AbstractApplication.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/app/AbstractApplication.java
@@ -259,7 +259,9 @@ public abstract class AbstractApplication implements Application {
    * @param cronTab the crontab entry for the Schedule
    * @param workflowName the name of the Workflow
    * @param properties properties to be added for the Schedule
-   * @deprecated As of version 2.8.0, replaced by {@link #scheduleWorkflow(Schedule, String, Map<String, String>)}
+   * @deprecated As of version 2.8.0, replaced by 
+   *            {@link #scheduleWorkflow(Schedule, String, Map) 
+   *             scheduleWorkflow(Schedule, String, Map&lt;String, String&gt;)}
    */
   @Deprecated
   protected void scheduleWorkflow(String scheduleName, String cronTab, String workflowName,

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/CounterTimeseriesTable.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/CounterTimeseriesTable.java
@@ -94,8 +94,8 @@ public class CounterTimeseriesTable extends TimeseriesDataset {
 
   /**
    * Reads entries for a given time range and returns an <code>Iterator<Counter></code>.
-   * Provides the same functionality as {@link #read(byte[], long, long, byte[]...)} but accepts additional
-   * parameters for pagination purposes.
+   * Provides the same functionality as {@link #read(byte[], long, long, byte[][]) read(byte[], long, long, byte[]...)}
+   * but accepts additional parameters for pagination purposes.
    *
    * @param counter name of the counter to read
    * @param startTime defines start of the time range to read, inclusive

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/TimeseriesTable.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/TimeseriesTable.java
@@ -125,8 +125,8 @@ public class TimeseriesTable extends TimeseriesDataset
 
   /**
    * Reads entries for a given time range and returns an <code>Iterator<Entry></code>.
-   * Provides the same functionality as {@link #read(byte[], long, long, byte[]...)} but accepts additional
-   * parameters for pagination purposes.
+   * Provides the same functionality as {@link #read(byte[], long, long, byte[][]) read(byte[], long, long, byte[]...)} 
+   * but accepts additional parameters for pagination purposes.
    * NOTE: A limit is placed on the max number of time intervals to be scanned during a read, as defined by
    * {@link #MAX_ROWS_TO_SCAN_PER_READ}.
    *

--- a/cdap-docs/_common/common-build.sh
+++ b/cdap-docs/_common/common-build.sh
@@ -154,9 +154,13 @@ function build_javadocs_full() {
   MAVEN_OPTS="-Xmx512m" mvn clean site -DskipTests
 }
 
-function build_javadocs_sdk() {
+function build_javadocs_api() {
   cd $PROJECT_PATH
   MAVEN_OPTS="-Xmx512m"  mvn clean package javadoc:javadoc -pl $API -am -DskipTests -P release
+}
+
+function build_javadocs_sdk() {
+  build_javadocs_api
   copy_javadocs_sdk
 }
 

--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -63,6 +63,7 @@ function usage() {
   echo "    docs-github    Clean build of HTML docs and Javadocs, zipped for placing on GitHub"
   echo "    docs-web       Clean build of HTML docs and Javadocs, zipped for placing on docs.cask.co webserver"
   echo ""
+  echo "    javadocs       Build Javadocs"
   echo "    licenses       Clean build of License Dependency PDFs"
   echo "    sdk            Build SDK"
   echo "    version        Print the version information"
@@ -79,6 +80,7 @@ function run_command() {
     docs )              build_docs; exit 1;;
     docs-github )       build_docs_github; exit 1;;
     docs-web )          build_docs_web; exit 1;;
+    javadocs )          build_javadocs; exit 1;;
     licenses )          build_license_depends; exit 1;;
     sdk )               build_sdk; exit 1;;
     version )           print_version; exit 1;;
@@ -181,6 +183,11 @@ function build_all() {
   mv $SCRIPT_PATH/$BUILD_TEMP/*.zip $SCRIPT_PATH/$BUILD
   rm -rf $SCRIPT_PATH/$BUILD_TEMP
   bell
+}
+
+function build_javadocs() {
+  # Uses function from common
+  build_javadocs_api
 }
 
 function build_docs_javadocs() {


### PR DESCRIPTION
Fixes broken Javadoc build. 
Fixes two long-standing Javadoc warnings (bugs) that resulted from using "..." where "[]" was required.

Added code to documentation build scripts to allow for building just the Javadocs.
Produces a clean Javadoc build. First in a very long time...