### PR TITLE
[CDAP-1444] Retry logic when trying to create the heartbeats feed

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/DistributedStreamService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/DistributedStreamService.java
@@ -340,8 +340,8 @@ public class DistributedStreamService extends AbstractStreamService {
         }, heartbeatsSubscriptionExecutor);
       } catch (NotificationFeedException e) {
         // Most probably, the dataset service is not up. We retry
-        LOG.warn("Could not subscribe to heartbeats feed", e);
-        TimeUnit.MILLISECONDS.sleep(200);
+        LOG.warn("Could not subscribe to heartbeats feed. {}", e.getMessage());
+        TimeUnit.MILLISECONDS.sleep(1000);
       }
     }
   }
@@ -390,8 +390,8 @@ public class DistributedStreamService extends AbstractStreamService {
         return;
       } catch (NotificationFeedException e) {
         // Most probably, the dataset service is not up. We retry
-        LOG.warn("Could not subscribe to heartbeats feed", e);
-        TimeUnit.MILLISECONDS.sleep(200);
+        LOG.warn("Could not subscribe to heartbeats feed. {}", e.getMessage());
+        TimeUnit.MILLISECONDS.sleep(1000);
       }
     }
   }
@@ -478,6 +478,7 @@ public class DistributedStreamService extends AbstractStreamService {
           for (StreamSpecification spec : streamMetaStore.listStreams(Id.Namespace.from(Constants.DEFAULT_NAMESPACE))) {
             LOG.debug("Adding {} stream as a resource to the coordinator to manager streams leaders.",
                       spec.getName());
+            // TODO use the right namespace in a future PR - Ali :)
             builder.addPartition(new ResourceRequirement.Partition(
               String.format("%s.%s", Constants.DEFAULT_NAMESPACE, spec.getName()), 1));
           }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/DistributedStreamService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/DistributedStreamService.java
@@ -340,7 +340,7 @@ public class DistributedStreamService extends AbstractStreamService {
         }, heartbeatsSubscriptionExecutor);
       } catch (NotificationFeedException e) {
         // Most probably, the dataset service is not up. We retry
-        LOG.warn("Could not subscribe to heartbeats feed. {}", e.getMessage());
+        LOG.warn("Could not perform operation on HeartbeatsFeed. Retrying.", e);
         TimeUnit.MILLISECONDS.sleep(1000);
       }
     }
@@ -390,7 +390,7 @@ public class DistributedStreamService extends AbstractStreamService {
         return;
       } catch (NotificationFeedException e) {
         // Most probably, the dataset service is not up. We retry
-        LOG.warn("Could not subscribe to heartbeats feed. {}", e.getMessage());
+        LOG.warn("Could not perform operation on HeartbeatsFeed. Retrying.", e);
         TimeUnit.MILLISECONDS.sleep(1000);
       }
     }


### PR DESCRIPTION
The past fix was half the fix.
Also, correct a bug introduced when streams were first namespaced.

Build: http://builds.cask.co/browse/CDAP-DUT814-6