### PR TITLE
Feature/more v3 dataset apis

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -31,8 +31,8 @@ import co.cask.cdap.data.stream.service.StreamHandler;
 import co.cask.cdap.data.stream.service.StreamHandlerV2;
 import co.cask.cdap.data2.datafabric.dataset.DatasetExecutorServiceManager;
 import co.cask.cdap.explore.service.ExploreServiceManager;
+import co.cask.cdap.gateway.handlers.AppFabricDataHttpHandler;
 import co.cask.cdap.gateway.handlers.AppFabricHttpHandler;
-import co.cask.cdap.gateway.handlers.AppFabricStreamHttpHandler;
 import co.cask.cdap.gateway.handlers.AppLifecycleHttpHandler;
 import co.cask.cdap.gateway.handlers.CommonHandlers;
 import co.cask.cdap.gateway.handlers.ConsoleSettingsHttpHandler;
@@ -271,7 +271,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
                                                                         Names.named("appfabric.http.handler"));
       CommonHandlers.add(handlerBinder);
       handlerBinder.addBinding().to(AppFabricHttpHandler.class);
-      handlerBinder.addBinding().to(AppFabricStreamHttpHandler.class);
+      handlerBinder.addBinding().to(AppFabricDataHttpHandler.class);
       handlerBinder.addBinding().to(VersionHandler.class);
       handlerBinder.addBinding().to(MonitorHandler.class);
       handlerBinder.addBinding().to(ServiceHttpHandler.class);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricDataHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricDataHttpHandler.java
@@ -36,10 +36,10 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 
 /**
- *  HttpHandler class for stream requests in app-fabric.
+ *  HttpHandler class for stream and dataset requests in app-fabric.
  */
 @Path(Constants.Gateway.API_VERSION_3 + "/namespaces/{namespace-id}")
-public class AppFabricStreamHttpHandler extends AbstractAppFabricHttpHandler {
+public class AppFabricDataHttpHandler extends AbstractAppFabricHttpHandler {
 
   /**
    * Access Dataset Service
@@ -56,8 +56,8 @@ public class AppFabricStreamHttpHandler extends AbstractAppFabricHttpHandler {
    * Constructs an new instance. Parameters are binded by Guice.
    */
   @Inject
-  public AppFabricStreamHttpHandler(Authenticator authenticator, CConfiguration configuration,
-                                    StoreFactory storeFactory, DatasetFramework dsFramework) {
+  public AppFabricDataHttpHandler(Authenticator authenticator, CConfiguration configuration,
+                                  StoreFactory storeFactory, DatasetFramework dsFramework) {
     super(authenticator);
     this.store = storeFactory.create();
     this.dsFramework =
@@ -95,5 +95,53 @@ public class AppFabricStreamHttpHandler extends AbstractAppFabricHttpHandler {
                                @PathParam("stream-id") final String streamId) {
     programListByDataAccess(request, responder, store, dsFramework, ProgramType.FLOW, Data.STREAM,
                             namespaceId, streamId);
+  }
+
+  /**
+   * Returns a list of dataset associated with account.
+   */
+  @GET
+  @Path("/datasets")
+  public void getDatasets(HttpRequest request, HttpResponder responder,
+                          @PathParam("namespace-id") String namespaceId) {
+    //TODO: use namespace passed in, once datasets are namespaced (https://issues.cask.co/browse/CDAP-775)
+    dataList(request, responder, store, dsFramework, Data.DATASET, Constants.DEFAULT_NAMESPACE, null, null);
+  }
+
+  /**
+   * Returns a dataset associated with account.
+   */
+  @GET
+  @Path("/datasets/{dataset-id}")
+  public void getDatasetSpecification(HttpRequest request, HttpResponder responder,
+                                      @PathParam("namespace-id") String namespaceId,
+                                      @PathParam("dataset-id") final String datasetId) {
+    //TODO: use namespace passed in, once datasets are namespaced (https://issues.cask.co/browse/CDAP-775)
+    dataList(request, responder, store, dsFramework, Data.DATASET, Constants.DEFAULT_NAMESPACE, datasetId, null);
+  }
+
+  /**
+   * Returns a list of dataset associated with application.
+   */
+  @GET
+  @Path("/apps/{app-id}/datasets")
+  public void getDatasetsByApp(HttpRequest request, HttpResponder responder,
+                               @PathParam("namespace-id") String namespaceId,
+                               @PathParam("app-id") final String appId) {
+    //TODO: use namespace passed in, once datasets are namespaced (https://issues.cask.co/browse/CDAP-775)
+    dataList(request, responder, store, dsFramework, Data.DATASET, Constants.DEFAULT_NAMESPACE, null, appId);
+  }
+
+  /**
+   * Returns all flows associated with a dataset.
+   */
+  @GET
+  @Path("/datasets/{dataset-id}/flows")
+  public void getFlowsByDataset(HttpRequest request, HttpResponder responder,
+                               @PathParam("namespace-id") String namespaceId,
+                                @PathParam("dataset-id") final String datasetId) {
+    //TODO: use namespace passed in, once datasets are namespaced (https://issues.cask.co/browse/CDAP-775)
+    programListByDataAccess(request, responder, store, dsFramework, ProgramType.FLOW, Data.DATASET,
+                            Constants.DEFAULT_NAMESPACE, datasetId);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricDataHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricDataHttpHandler.java
@@ -65,7 +65,7 @@ public class AppFabricDataHttpHandler extends AbstractAppFabricHttpHandler {
   }
 
   /**
-   * Returns a list of streams associated with account.
+   * Returns a list of streams associated with namespace.
    */
   @GET
   @Path("/streams")
@@ -98,7 +98,7 @@ public class AppFabricDataHttpHandler extends AbstractAppFabricHttpHandler {
   }
 
   /**
-   * Returns a list of dataset associated with account.
+   * Returns a list of dataset associated with namespace.
    */
   @GET
   @Path("/datasets")
@@ -109,7 +109,7 @@ public class AppFabricDataHttpHandler extends AbstractAppFabricHttpHandler {
   }
 
   /**
-   * Returns a dataset associated with account.
+   * Returns a dataset associated with namespace.
    */
   @GET
   @Path("/datasets/{dataset-id}")

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricDataHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricDataHttpHandler.java
@@ -80,7 +80,7 @@ public class AppFabricDataHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/apps/{app-id}/streams")
   public void getStreamsByApp(HttpRequest request, HttpResponder responder,
                               @PathParam("namespace-id") String namespaceId,
-                              @PathParam("app-id") final String appId) {
+                              @PathParam("app-id") String appId) {
     dataList(request, responder, store, dsFramework, Data.STREAM, namespaceId, null, appId);
   }
 
@@ -91,7 +91,7 @@ public class AppFabricDataHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/streams/{stream-id}/flows")
   public void getFlowsByStream(HttpRequest request, HttpResponder responder,
                                @PathParam("namespace-id") String namespaceId,
-                               @PathParam("stream-id") final String streamId) {
+                               @PathParam("stream-id") String streamId) {
     programListByDataAccess(request, responder, store, dsFramework, ProgramType.FLOW, Data.STREAM,
                             namespaceId, streamId);
   }
@@ -113,7 +113,7 @@ public class AppFabricDataHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/datasets/{dataset-id}")
   public void getDatasetSpecification(HttpRequest request, HttpResponder responder,
                                       @PathParam("namespace-id") String namespaceId,
-                                      @PathParam("dataset-id") final String datasetId) {
+                                      @PathParam("dataset-id") String datasetId) {
     dataList(request, responder, store, dsFramework, Data.DATASET, namespaceId, datasetId, null);
   }
 
@@ -124,7 +124,7 @@ public class AppFabricDataHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/apps/{app-id}/datasets")
   public void getDatasetsByApp(HttpRequest request, HttpResponder responder,
                                @PathParam("namespace-id") String namespaceId,
-                               @PathParam("app-id") final String appId) {
+                               @PathParam("app-id") String appId) {
     dataList(request, responder, store, dsFramework, Data.DATASET, namespaceId, null, appId);
   }
 
@@ -135,7 +135,7 @@ public class AppFabricDataHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/datasets/{dataset-id}/flows")
   public void getFlowsByDataset(HttpRequest request, HttpResponder responder,
                                @PathParam("namespace-id") String namespaceId,
-                                @PathParam("dataset-id") final String datasetId) {
+                                @PathParam("dataset-id") String datasetId) {
     programListByDataAccess(request, responder, store, dsFramework, ProgramType.FLOW, Data.DATASET,
                             namespaceId, datasetId);
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricDataHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricDataHttpHandler.java
@@ -60,8 +60,7 @@ public class AppFabricDataHttpHandler extends AbstractAppFabricHttpHandler {
                                   StoreFactory storeFactory, DatasetFramework dsFramework) {
     super(authenticator);
     this.store = storeFactory.create();
-    this.dsFramework =
-      new NamespacedDatasetFramework(dsFramework, new DefaultDatasetNamespace(configuration));
+    this.dsFramework = new NamespacedDatasetFramework(dsFramework, new DefaultDatasetNamespace(configuration));
   }
 
   /**
@@ -104,8 +103,7 @@ public class AppFabricDataHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/datasets")
   public void getDatasets(HttpRequest request, HttpResponder responder,
                           @PathParam("namespace-id") String namespaceId) {
-    //TODO: use namespace passed in, once datasets are namespaced (https://issues.cask.co/browse/CDAP-775)
-    dataList(request, responder, store, dsFramework, Data.DATASET, Constants.DEFAULT_NAMESPACE, null, null);
+    dataList(request, responder, store, dsFramework, Data.DATASET, namespaceId, null, null);
   }
 
   /**
@@ -116,8 +114,7 @@ public class AppFabricDataHttpHandler extends AbstractAppFabricHttpHandler {
   public void getDatasetSpecification(HttpRequest request, HttpResponder responder,
                                       @PathParam("namespace-id") String namespaceId,
                                       @PathParam("dataset-id") final String datasetId) {
-    //TODO: use namespace passed in, once datasets are namespaced (https://issues.cask.co/browse/CDAP-775)
-    dataList(request, responder, store, dsFramework, Data.DATASET, Constants.DEFAULT_NAMESPACE, datasetId, null);
+    dataList(request, responder, store, dsFramework, Data.DATASET, namespaceId, datasetId, null);
   }
 
   /**
@@ -128,8 +125,7 @@ public class AppFabricDataHttpHandler extends AbstractAppFabricHttpHandler {
   public void getDatasetsByApp(HttpRequest request, HttpResponder responder,
                                @PathParam("namespace-id") String namespaceId,
                                @PathParam("app-id") final String appId) {
-    //TODO: use namespace passed in, once datasets are namespaced (https://issues.cask.co/browse/CDAP-775)
-    dataList(request, responder, store, dsFramework, Data.DATASET, Constants.DEFAULT_NAMESPACE, null, appId);
+    dataList(request, responder, store, dsFramework, Data.DATASET, namespaceId, null, appId);
   }
 
   /**
@@ -140,8 +136,7 @@ public class AppFabricDataHttpHandler extends AbstractAppFabricHttpHandler {
   public void getFlowsByDataset(HttpRequest request, HttpResponder responder,
                                @PathParam("namespace-id") String namespaceId,
                                 @PathParam("dataset-id") final String datasetId) {
-    //TODO: use namespace passed in, once datasets are namespaced (https://issues.cask.co/browse/CDAP-775)
     programListByDataAccess(request, responder, store, dsFramework, ProgramType.FLOW, Data.DATASET,
-                            Constants.DEFAULT_NAMESPACE, datasetId);
+                            namespaceId, datasetId);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricHttpHandler.java
@@ -132,8 +132,7 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
     this.store = storeFactory.create();
     this.queueAdmin = queueAdmin;
     this.txClient = txClient;
-    this.dsFramework =
-      new NamespacedDatasetFramework(dsFramework, new DefaultDatasetNamespace(configuration));
+    this.dsFramework = new NamespacedDatasetFramework(dsFramework, new DefaultDatasetNamespace(configuration));
     this.appLifecycleHttpHandler = appLifecycleHttpHandler;
     this.programLifecycleHttpHandler = programLifecycleHttpHandler;
     this.appFabricDataHttpHandler = appFabricDataHttpHandler;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricHttpHandler.java
@@ -604,7 +604,7 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/apps/{app-id}")
   public BodyConsumer deploy(HttpRequest request, HttpResponder responder, @PathParam("app-id") final String appId,
                              @HeaderParam(ARCHIVE_NAME_HEADER) final String archiveName) {
-      return appLifecycleHttpHandler.deploy(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE, appId,
+    return appLifecycleHttpHandler.deploy(rewriteRequest(request), responder, Constants.DEFAULT_NAMESPACE, appId,
                                             archiveName);
   }
 
@@ -1026,7 +1026,7 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
   public void getFlowsByStream(HttpRequest request, HttpResponder responder,
                                @PathParam("stream-id") final String streamId) {
     appFabricDataHttpHandler.getFlowsByStream(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
-                                                Constants.DEFAULT_NAMESPACE, streamId);
+                                              Constants.DEFAULT_NAMESPACE, streamId);
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricHttpHandler.java
@@ -961,7 +961,7 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/streams")
   public void getStreams(HttpRequest request, HttpResponder responder) {
     appFabricDataHttpHandler.getStreams(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
-                                          Constants.DEFAULT_NAMESPACE);
+                                        Constants.DEFAULT_NAMESPACE);
   }
 
   /**
@@ -982,7 +982,7 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
   public void getStreamsByApp(HttpRequest request, HttpResponder responder,
                               @PathParam("app-id") final String appId) {
     appFabricDataHttpHandler.getStreamsByApp(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
-                                               Constants.DEFAULT_NAMESPACE, appId);
+                                             Constants.DEFAULT_NAMESPACE, appId);
   }
 
   /**
@@ -1035,8 +1035,9 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/datasets/{dataset-id}/flows")
   public void getFlowsByDataset(HttpRequest request, HttpResponder responder,
                                 @PathParam("dataset-id") final String datasetId) {
-    appFabricDataHttpHandler.getFlowsByDataset(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
-                                               Constants.DEFAULT_NAMESPACE, datasetId);
+    appFabricDataHttpHandler.getProgramsByDataset(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
+                                                  Constants.DEFAULT_NAMESPACE,
+                                                  datasetId, ProgramType.FLOW.getCategoryName());
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/util/AbstractAppFabricHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/util/AbstractAppFabricHttpHandler.java
@@ -378,11 +378,7 @@ public abstract class AbstractAppFabricHttpHandler extends AuthenticatedHttpHand
     Id.Namespace namespace = new Id.Namespace(programId.getNamespaceId());
     if (type == Data.DATASET) {
       DatasetSpecification dsSpec = getDatasetSpec(dsFramework, namespace, name);
-      String typeName = null;
-      if (dsSpec != null) {
-        typeName = dsSpec.getType();
-      }
-      return GSON.toJson(makeDataSetRecord(name, typeName));
+      return dsSpec == null ? "" : GSON.toJson(makeDataSetRecord(name, dsSpec.getType()));
     } else if (type == Data.STREAM) {
       StreamSpecification spec = store.getStream(namespace, name);
       return spec == null ? "" : GSON.toJson(makeStreamRecord(spec.getName(), spec));

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/util/AbstractAppFabricHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/util/AbstractAppFabricHttpHandler.java
@@ -397,6 +397,9 @@ public abstract class AbstractAppFabricHttpHandler extends AuthenticatedHttpHand
     Id.Namespace namespace = new Id.Namespace(programId.getNamespaceId());
     ApplicationSpecification appSpec = store.getApplication(new Id.Application(
       namespace, programId.getApplicationId()));
+    if (appSpec == null) {
+      return "";
+    }
     if (type == Data.DATASET) {
       Set<String> dataSetsUsed = dataSetsUsedBy(appSpec);
       List<DatasetRecord> result = Lists.newArrayListWithExpectedSize(dataSetsUsed.size());

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/gateway/handlers/AppFabricDataHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/gateway/handlers/AppFabricDataHttpHandlerTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.gateway.handlers;
+
+import co.cask.cdap.AppWithDataset;
+import co.cask.cdap.WordCountApp;
+import co.cask.cdap.api.dataset.lib.KeyValueTable;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.internal.app.services.http.AppFabricTestBase;
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import org.apache.http.HttpResponse;
+import org.apache.http.util.EntityUtils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+public class AppFabricDataHttpHandlerTest extends AppFabricTestBase {
+
+  @After
+  public void cleanup() throws Exception {
+    HttpResponse response = doPost("/v2/unrecoverable/reset");
+    Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+  }
+
+  @Test
+  public void testGetDatasets() throws Exception {
+    HttpResponse response = deploy(WordCountApp.class, Constants.Gateway.API_VERSION_3_TOKEN, Constants.DEFAULT_NAMESPACE);
+    Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+
+
+    response = deploy(AppWithDataset.class, Constants.Gateway.API_VERSION_3_TOKEN, Constants.DEFAULT_NAMESPACE);
+    Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+
+
+    response = doGet(getVersionedAPIPath("datasets",
+                                         Constants.Gateway.API_VERSION_3_TOKEN, Constants.DEFAULT_NAMESPACE));
+    Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+    String responseString = EntityUtils.toString(response.getEntity());
+    List<Map<String, String>> responseList = new Gson().fromJson(responseString, LIST_MAP_STRING_STRING_TYPE);
+    Map<String, String> expectedDataSets = ImmutableMap.<String, String>builder()
+      .put("mydataset", KeyValueTable.class.getName())
+      .put("myds", KeyValueTable.class.getName())
+      .build();
+    Assert.assertEquals(expectedDataSets.size(), responseList.size());
+    for (Map<String, String> ds : responseList) {
+      Assert.assertTrue("problem with dataset " + ds.get("id"), ds.containsKey("id"));
+      Assert.assertTrue("problem with dataset " + ds.get("id"), ds.containsKey("name"));
+      Assert.assertTrue("problem with dataset " + ds.get("id"), ds.containsKey("classname"));
+      Assert.assertTrue("problem with dataset " + ds.get("id"), expectedDataSets.containsKey(ds.get("id")));
+      Assert.assertEquals("problem with dataset " + ds.get("id"),
+                          expectedDataSets.get(ds.get("id")), ds.get("classname"));
+    }
+  }
+
+  @Test
+  public void testGetDatasetSpecification() throws Exception {
+    HttpResponse response = deploy(AppWithDataset.class, Constants.Gateway.API_VERSION_3_TOKEN, Constants.DEFAULT_NAMESPACE);
+    Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+
+    response = doGet(getVersionedAPIPath("datasets/myds",
+                                         Constants.Gateway.API_VERSION_3_TOKEN, Constants.DEFAULT_NAMESPACE));
+    Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+    String responseString = EntityUtils.toString(response.getEntity());
+    Map<String, String> receivedSpec = new Gson().fromJson(responseString, MAP_STRING_STRING_TYPE);
+    ImmutableMap<String, String> expectedDatasetSpec =
+      ImmutableMap.of("type", "Dataset",
+                      "id", "myds",
+                      "name", "myds",
+                      "classname", "co.cask.cdap.api.dataset.lib.KeyValueTable");
+    Assert.assertEquals(expectedDatasetSpec, receivedSpec);
+  }
+
+  @Test
+  public void testGetDatasetsByApp() throws Exception {
+    HttpResponse response = deploy(WordCountApp.class, Constants.Gateway.API_VERSION_3_TOKEN, Constants.DEFAULT_NAMESPACE);
+    Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+
+    response = doGet(getVersionedAPIPath("apps/WordCountApp/datasets",
+                                         Constants.Gateway.API_VERSION_3_TOKEN, Constants.DEFAULT_NAMESPACE));
+    Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+    String responseString = EntityUtils.toString(response.getEntity());
+    List<Map<String, String>> responseList = new Gson().fromJson(responseString, LIST_MAP_STRING_STRING_TYPE);
+    Assert.assertEquals(1, responseList.size());
+    ImmutableMap<String, String> expectedDataSets = ImmutableMap.<String, String>builder()
+      .put("mydataset", KeyValueTable.class.getName()).build();
+    for (Map<String, String> ds : responseList) {
+      Assert.assertTrue("problem with dataset " + ds.get("id"), ds.containsKey("id"));
+      Assert.assertTrue("problem with dataset " + ds.get("id"), ds.containsKey("name"));
+      Assert.assertTrue("problem with dataset " + ds.get("id"), ds.containsKey("classname"));
+      Assert.assertTrue("problem with dataset " + ds.get("id"), expectedDataSets.containsKey(ds.get("id")));
+      Assert.assertEquals("problem with dataset " + ds.get("id"),
+                          expectedDataSets.get(ds.get("id")), ds.get("classname"));
+    }
+  }
+
+  @Test
+  public void testGetFlowsByDataset() throws Exception {
+    HttpResponse response = deploy(WordCountApp.class, Constants.Gateway.API_VERSION_3_TOKEN, Constants.DEFAULT_NAMESPACE);
+    Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+
+    response = doGet(getVersionedAPIPath("datasets/mydataset/flows",
+                                         Constants.Gateway.API_VERSION_3_TOKEN, Constants.DEFAULT_NAMESPACE));
+    Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+    String responseString = EntityUtils.toString(response.getEntity());
+    List<Map<String, String>> responseList = new Gson().fromJson(responseString, LIST_MAP_STRING_STRING_TYPE);
+
+    ImmutableMap<String, String> expectedFlow = ImmutableMap.of("type", "Flow",
+                                                      "app", "WordCountApp",
+                                                      "id", "WordCountFlow",
+                                                      "name", "WordCountFlow",
+                                                      "description", "Flow for counting words");
+    Assert.assertEquals(1, responseList.size());
+    Assert.assertEquals(expectedFlow, responseList.get(0));
+  }
+}


### PR DESCRIPTION
Expose the following 3 APIs in v3 handlers.
Currently ignores namespace passed in (will utilize that once datasets are namespaced).

`/v3/namespaces/<namespaceId>/datasets`
`/v3/namespaces/<namespaceId>/datasets/<datasetId>`
`/v3/namespaces/<namespaceId>/datasets<datasetId>/flows`
`/v3/namespaces/<namespaceId>/apps/<appId>/datasets`

https://issues.cask.co/browse/CDAP-1375
Builds:
just this PR: http://builds.cask.co/browse/CDAP-DUT842-5