### PR TITLE
Namespaced dataset types/dataset modules

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppLifecycleHttpHandler.java
@@ -479,7 +479,7 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
     String appFabricDir = configuration.get(Constants.AppFabric.OUTPUT_DIR);
     // note: cannot create an appId subdirectory under the namespace directory here because appId could be null here
     final Location archive =
-      namespaceHomeLocation.append(appFabricDir).append(Constants.AppFabric.ARCHIVE_DIR).append(archiveName);
+      namespaceHomeLocation.append(appFabricDir).append(Constants.ARCHIVE_DIR).append(archiveName);
 
     return new AbstractBodyConsumer(File.createTempFile("app-", ".jar", tempDir)) {
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/DeployDatasetModulesStage.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/DeployDatasetModulesStage.java
@@ -64,12 +64,15 @@ public class DeployDatasetModulesStage extends AbstractStage<ApplicationDeployab
         // note: we can deploy module or create module from Dataset class
         // note: it seems dangerous to instantiate dataset module here, but this will be fine when we move deploy into
         //       isolated user's environment (e.g. separate yarn container)
-        Id.DatasetModule moduleId = Id.DatasetModule.from(input.getId().getNamespace(), moduleName);
+        Id.Namespace moduleNamespace = input.getId().getNamespace();
+        Id.DatasetModule moduleId = Id.DatasetModule.from(moduleNamespace, moduleName);
         if (DatasetModule.class.isAssignableFrom(clazz)) {
           datasetFramework.addModule(moduleId, (DatasetModule) clazz.newInstance());
         } else if (Dataset.class.isAssignableFrom(clazz)) {
           // checking if type is in already
-          if (!datasetFramework.hasSystemType(clazz.getName())) {
+          // note: this does not allow upgrade even for user modules. Re-visit when upgrade is possible
+          if (!datasetFramework.hasSystemType(clazz.getName()) &&
+            !datasetFramework.hasType(Id.DatasetType.from(moduleNamespace, clazz.getName()))) {
             datasetFramework.addModule(moduleId, new SingleTypeModule((Class<Dataset>) clazz));
           }
         } else {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/DeployDatasetModulesStage.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/DeployDatasetModulesStage.java
@@ -64,12 +64,12 @@ public class DeployDatasetModulesStage extends AbstractStage<ApplicationDeployab
         // note: we can deploy module or create module from Dataset class
         // note: it seems dangerous to instantiate dataset module here, but this will be fine when we move deploy into
         //       isolated user's environment (e.g. separate yarn container)
-        Id.DatasetModule moduleId = Id.DatasetModule.from(input.getId().getNamespaceId(), moduleName);
+        Id.DatasetModule moduleId = Id.DatasetModule.from(input.getId().getNamespace(), moduleName);
         if (DatasetModule.class.isAssignableFrom(clazz)) {
           datasetFramework.addModule(moduleId, (DatasetModule) clazz.newInstance());
         } else if (Dataset.class.isAssignableFrom(clazz)) {
           // checking if type is in already
-          if (!datasetFramework.hasType(clazz.getName())) {
+          if (!datasetFramework.hasSystemType(clazz.getName())) {
             datasetFramework.addModule(moduleId, new SingleTypeModule((Class<Dataset>) clazz));
           }
         } else {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/AdapterService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/AdapterService.java
@@ -337,7 +337,7 @@ public class AdapterService extends AbstractIdleService {
 
       String appFabricDir = configuration.get(Constants.AppFabric.OUTPUT_DIR);
       Location destination = namespaceHomeLocation.append(appFabricDir)
-        .append(Constants.AppFabric.ARCHIVE_DIR).append(adapterTypeInfo.getFile().getName());
+        .append(Constants.ARCHIVE_DIR).append(adapterTypeInfo.getFile().getName());
       DeploymentInfo deploymentInfo = new DeploymentInfo(adapterTypeInfo.getFile(), destination,
                                                          ApplicationDeployScope.SYSTEM);
       ApplicationWithPrograms applicationWithPrograms =

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/runtime/OpenCloseDataSetTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/runtime/OpenCloseDataSetTest.java
@@ -22,6 +22,7 @@ import co.cask.cdap.api.flow.flowlet.StreamEvent;
 import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.app.runtime.ProgramRunner;
+import co.cask.cdap.common.io.Locations;
 import co.cask.cdap.common.queue.QueueName;
 import co.cask.cdap.common.stream.StreamEventCodec;
 import co.cask.cdap.data2.queue.QueueClientFactory;
@@ -50,7 +51,11 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.twill.discovery.Discoverable;
 import org.apache.twill.discovery.DiscoveryServiceClient;
+import org.apache.twill.filesystem.Location;
+import org.apache.twill.filesystem.LocationFactory;
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -83,6 +88,13 @@ public class OpenCloseDataSetTest {
       }
     }
   };
+
+  @BeforeClass
+  public static void setup() throws IOException {
+    Location location = AppFabricTestHelper.getInjector().getInstance(LocationFactory.class)
+      .create(DefaultId.NAMESPACE.getId());
+    Locations.mkdirsIfNotExists(location);
+  }
 
   @Test(timeout = 120000)
   public void testDataSetsAreClosed() throws Exception {
@@ -193,5 +205,12 @@ public class OpenCloseDataSetTest {
     Assert.assertEquals(TrackingTable.getTracker("cdap.user.bar", "open"),
                         TrackingTable.getTracker("cdap.user.bar", "close"));
 
+  }
+
+  @AfterClass
+  public static void tearDown() throws IOException {
+    Location location = AppFabricTestHelper.getInjector().getInstance(LocationFactory.class)
+      .create(DefaultId.NAMESPACE.getId());
+    Locations.deleteQuietly(location, true);
   }
 }

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -23,6 +23,8 @@ import java.util.concurrent.TimeUnit;
  */
 public final class Constants {
 
+  public static final String ARCHIVE_DIR = "archive";
+
   /**
    * Global Service names.
    */
@@ -121,7 +123,6 @@ public final class Constants {
 
     public static final String SERVICE_DESCRIPTION = "Service for managing application lifecycle.";
 
-    public static final String ARCHIVE_DIR = "archive";
   }
 
   /**

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -16,6 +16,8 @@
 
 package co.cask.cdap.common.conf;
 
+import co.cask.cdap.proto.Id;
+
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -680,6 +682,7 @@ public final class Constants {
    * 'system' reserved namespace name
    */
   public static final String SYSTEM_NAMESPACE = "system";
+  public static final Id.Namespace SYSTEM_NAMESPACE_ID = Id.Namespace.from(SYSTEM_NAMESPACE);
 
   /**
    * Constants related to external systems.

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetMetaTableUtil.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetMetaTableUtil.java
@@ -34,10 +34,10 @@ public class DatasetMetaTableUtil {
   public static final String META_TABLE_NAME = "datasets.type";
   public static final String INSTANCE_TABLE_NAME = "datasets.instance";
 
-  private static final Id.DatasetInstance metaTableInstanceId = Id.DatasetInstance.from(Constants.SYSTEM_NAMESPACE,
-                                                                                        META_TABLE_NAME);
-  private static final Id.DatasetInstance instanceTableInstanceId = Id.DatasetInstance.from(Constants.SYSTEM_NAMESPACE,
-                                                                                            INSTANCE_TABLE_NAME);
+  private static final Id.DatasetInstance metaTableInstanceId =
+    Id.DatasetInstance.from(Constants.SYSTEM_NAMESPACE_ID,  META_TABLE_NAME);
+  private static final Id.DatasetInstance instanceTableInstanceId =
+    Id.DatasetInstance.from(Constants.SYSTEM_NAMESPACE_ID, INSTANCE_TABLE_NAME);
 
   private final DatasetFramework framework;
 
@@ -73,8 +73,8 @@ public class DatasetMetaTableUtil {
 
   private static void addTypes(DatasetFramework framework) throws DatasetManagementException {
     // meta tables should be in the system namespace
-    Id.DatasetModule typeMDSModuleId = Id.DatasetModule.from(Constants.SYSTEM_NAMESPACE, "typeMDSModule");
-    Id.DatasetModule instanceMDSModuleId = Id.DatasetModule.from(Constants.SYSTEM_NAMESPACE, "instanceMDSModule");
+    Id.DatasetModule typeMDSModuleId = Id.DatasetModule.from(Constants.SYSTEM_NAMESPACE_ID, "typeMDSModule");
+    Id.DatasetModule instanceMDSModuleId = Id.DatasetModule.from(Constants.SYSTEM_NAMESPACE_ID, "instanceMDSModule");
     framework.addModule(typeMDSModuleId, new SingleTypeModule(DatasetTypeMDS.class));
     framework.addModule(instanceMDSModuleId, new SingleTypeModule(DatasetInstanceMDS.class));
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetMetaTableUtil.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetMetaTableUtil.java
@@ -72,6 +72,7 @@ public class DatasetMetaTableUtil {
   }
 
   private static void addTypes(DatasetFramework framework) throws DatasetManagementException {
+    // meta tables should be in the system namespace
     Id.DatasetModule typeMDSModuleId = Id.DatasetModule.from(Constants.SYSTEM_NAMESPACE, "typeMDSModule");
     Id.DatasetModule instanceMDSModuleId = Id.DatasetModule.from(Constants.SYSTEM_NAMESPACE, "instanceMDSModule");
     framework.addModule(typeMDSModuleId, new SingleTypeModule(DatasetTypeMDS.class));

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFramework.java
@@ -150,9 +150,13 @@ public class RemoteDatasetFramework implements DatasetFramework {
   }
 
   @Override
-  public boolean hasType(String typeName) throws DatasetManagementException {
-    // hasType is really hasDefaultType, so using system namespace
-    return clientCache.getUnchecked(Id.Namespace.from(Constants.SYSTEM_NAMESPACE)).getType(typeName) != null;
+  public boolean hasSystemType(String typeName) throws DatasetManagementException {
+    return hasType(Id.DatasetType.from(Constants.SYSTEM_NAMESPACE, typeName));
+  }
+
+  @Override
+  public boolean hasType(Id.DatasetType datasetTypeId) throws DatasetManagementException {
+    return clientCache.getUnchecked(datasetTypeId.getNamespace()).getType(datasetTypeId.getTypeName()) != null;
   }
 
   @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandler.java
@@ -316,7 +316,7 @@ public class DatasetInstanceHandler extends AbstractHttpHandler {
     DatasetTypeMeta typeMeta = implManager.getTypeInfo(datasetTypeId);
     if (typeMeta == null) {
       // Type not found in the instance's namespace. Now try finding it in the system namespace
-      Id.DatasetType systemDatasetTypeId = Id.DatasetType.from(Constants.SYSTEM_NAMESPACE, typeName);
+      Id.DatasetType systemDatasetTypeId = Id.DatasetType.from(Constants.SYSTEM_NAMESPACE_ID, typeName);
       typeMeta = implManager.getTypeInfo(systemDatasetTypeId);
     }
     return typeMeta;
@@ -328,7 +328,7 @@ public class DatasetInstanceHandler extends AbstractHttpHandler {
    * @return true if dropped successfully, false if dataset is not found.
    * @throws Exception on error.
    */
-  private boolean dropDataset(Id.DatasetInstance datasetInstaceId, DatasetSpecification spec) throws Exception {
+  private boolean dropDataset(Id.DatasetInstance datasetInstanceId, DatasetSpecification spec) throws Exception {
     String name = spec.getName();
 
     disableExplore(name);
@@ -337,11 +337,11 @@ public class DatasetInstanceHandler extends AbstractHttpHandler {
       return false;
     }
 
-    DatasetTypeMeta typeMeta = getTypeInfo(datasetInstaceId.getNamespace(), spec.getType());
+    DatasetTypeMeta typeMeta = getTypeInfo(datasetInstanceId.getNamespace(), spec.getType());
     if (typeMeta == null) {
       return false;
     }
-    opExecutorClient.drop(datasetInstaceId, typeMeta, spec);
+    opExecutorClient.drop(datasetInstanceId, typeMeta, spec);
     return true;
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetTypeHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetTypeHandler.java
@@ -25,6 +25,7 @@ import co.cask.cdap.data2.datafabric.dataset.type.DatasetModuleConflictException
 import co.cask.cdap.data2.datafabric.dataset.type.DatasetTypeManager;
 import co.cask.cdap.proto.DatasetModuleMeta;
 import co.cask.cdap.proto.DatasetTypeMeta;
+import co.cask.cdap.proto.Id;
 import co.cask.http.AbstractHttpHandler;
 import co.cask.http.BodyConsumer;
 import co.cask.http.HandlerContext;
@@ -64,15 +65,12 @@ public class DatasetTypeHandler extends AbstractHttpHandler {
   private final DatasetTypeManager manager;
   private final LocationFactory locationFactory;
   private final CConfiguration cConf;
-  private final String archiveDirBase;
 
   @Inject
   public DatasetTypeHandler(DatasetTypeManager manager, LocationFactory locationFactory, CConfiguration conf) {
     this.manager = manager;
     this.locationFactory = locationFactory;
     this.cConf = conf;
-    String dataFabricDir = conf.get(Constants.Dataset.Manager.OUTPUT_DIR);
-    this.archiveDirBase = dataFabricDir + "/archive";
   }
 
   @Override
@@ -89,7 +87,7 @@ public class DatasetTypeHandler extends AbstractHttpHandler {
   @Path("/data/modules")
   public void listModules(HttpRequest request, HttpResponder responder, @PathParam("namespace-id") String namespaceId) {
     // Sorting by name for convenience
-    List<DatasetModuleMeta> list = Lists.newArrayList(manager.getModules());
+    List<DatasetModuleMeta> list = Lists.newArrayList(manager.getModules(Id.Namespace.from(namespaceId)));
     Collections.sort(list, new Comparator<DatasetModuleMeta>() {
       @Override
       public int compare(DatasetModuleMeta o1, DatasetModuleMeta o2) {
@@ -103,8 +101,13 @@ public class DatasetTypeHandler extends AbstractHttpHandler {
   @Path("/data/modules")
   public void deleteModules(HttpRequest request, HttpResponder responder,
                             @PathParam("namespace-id") String namespaceId) {
+    if (Constants.SYSTEM_NAMESPACE.equals(namespaceId)) {
+      responder.sendString(HttpResponseStatus.FORBIDDEN,
+                           String.format("Cannot delete modules from '%s' namespace.", namespaceId));
+      return;
+    }
     try {
-      manager.deleteModules();
+      manager.deleteModules(Id.Namespace.from(namespaceId));
       responder.sendStatus(HttpResponseStatus.OK);
     } catch (DatasetModuleConflictException e) {
       responder.sendString(HttpResponseStatus.CONFLICT, e.getMessage());
@@ -116,13 +119,31 @@ public class DatasetTypeHandler extends AbstractHttpHandler {
   public BodyConsumer addModule(HttpRequest request, HttpResponder responder,
                                 @PathParam("namespace-id") String namespaceId, @PathParam("name") final String name,
                                 @HeaderParam(HEADER_CLASS_NAME) final String className) throws IOException {
+    if (Constants.SYSTEM_NAMESPACE.equals(namespaceId)) {
+      responder.sendString(HttpResponseStatus.FORBIDDEN,
+                           String.format("Cannot add module to '%s' namespace.", namespaceId));
+      return null;
+    }
+
+    // verify namespace directory exists
+    // TODO: CDAP-1366 - should have a namespaceClient to make a REST API call to check if the namespace exists
+    final Location namespaceHomeLocation = locationFactory.create(namespaceId);
+    if (!namespaceHomeLocation.exists()) {
+      String msg = String.format("Home directory %s for namespace %s not found",
+                                 namespaceHomeLocation.toURI().getPath(), namespaceId);
+      LOG.error(msg);
+      responder.sendString(HttpResponseStatus.NOT_FOUND, msg);
+      return null;
+    }
 
     // Store uploaded content to a local temp file
-    File tempDir = new File(cConf.get(Constants.CFG_LOCAL_DATA_DIR),
-                            cConf.get(Constants.AppFabric.TEMP_DIR)).getAbsoluteFile();
+    String tempBase = String.format("%s/%s", cConf.get(Constants.CFG_LOCAL_DATA_DIR), namespaceId);
+    File tempDir = new File(tempBase, cConf.get(Constants.AppFabric.TEMP_DIR)).getAbsoluteFile();
     if (!DirUtils.mkdirs(tempDir)) {
       throw new IOException("Could not create temporary directory at: " + tempDir);
     }
+
+    final Id.DatasetModule datasetModuleId = Id.DatasetModule.from(namespaceId, name);
 
     return new AbstractBodyConsumer(File.createTempFile("dataset-", ".jar", tempDir)) {
       @Override
@@ -137,16 +158,18 @@ public class DatasetTypeHandler extends AbstractHttpHandler {
           return;
         }
 
-        LOG.info("Adding module {}, class name: {}", name, className);
+        LOG.info("Adding module {}, class name: {}", datasetModuleId, className);
 
-        Location archiveDir = locationFactory.create(archiveDirBase).append("account_placeholder");
+        String dataFabricDir = cConf.get(Constants.Dataset.Manager.OUTPUT_DIR);
+        Location archiveDir = namespaceHomeLocation.append(dataFabricDir).append(name)
+          .append(Constants.ARCHIVE_DIR);
         String archiveName = name + ".jar";
         Location archive = archiveDir.append(archiveName);
 
         // Copy uploaded content to a temporary location
         Location tmpLocation = archive.getTempFile(".tmp");
         try {
-          conflictIfModuleExists(name);
+          conflictIfModuleExists(datasetModuleId);
 
           Locations.mkdirsIfNotExists(archiveDir);
 
@@ -154,18 +177,18 @@ public class DatasetTypeHandler extends AbstractHttpHandler {
           Files.copy(uploadedFile, Locations.newOutputSupplier(tmpLocation));
 
           // Check if the module exists one more time to minimize the window of possible conflict
-          conflictIfModuleExists(name);
+          conflictIfModuleExists(datasetModuleId);
 
           // Finally, move archive to final location
-          LOG.debug("Storing module {} jar at {}", name, archive.toURI());
+          LOG.debug("Storing module {} jar at {}", datasetModuleId, archive.toURI());
           if (tmpLocation.renameTo(archive) == null) {
             throw new IOException(String.format("Could not move archive from location: %s, to location: %s",
                                                 tmpLocation.toURI(), archive.toURI()));
           }
 
-          manager.addModule(name, className, archive);
+          manager.addModule(datasetModuleId, className, archive);
           // todo: response with DatasetModuleMeta of just added module (and log this info)
-          LOG.info("Added module {}", name);
+          LOG.info("Added module {}", datasetModuleId);
           responder.sendStatus(HttpResponseStatus.OK);
         } catch (Exception e) {
           // In case copy to temporary file failed, or rename failed
@@ -189,9 +212,14 @@ public class DatasetTypeHandler extends AbstractHttpHandler {
   @Path("/data/modules/{name}")
   public void deleteModule(HttpRequest request, HttpResponder responder,
                            @PathParam("namespace-id") String namespaceId, @PathParam("name") String name) {
+    if (Constants.SYSTEM_NAMESPACE.equals(namespaceId)) {
+      responder.sendString(HttpResponseStatus.FORBIDDEN,
+                           String.format("Cannot delete module '%s' from '%s' namespace.", name, namespaceId));
+      return;
+    }
     boolean deleted;
     try {
-      deleted = manager.deleteModule(name);
+      deleted = manager.deleteModule(Id.DatasetModule.from(namespaceId, name));
     } catch (DatasetModuleConflictException e) {
       responder.sendString(HttpResponseStatus.CONFLICT, e.getMessage());
       return;
@@ -209,7 +237,7 @@ public class DatasetTypeHandler extends AbstractHttpHandler {
   @Path("/data/modules/{name}")
   public void getModuleInfo(HttpRequest request, HttpResponder responder,
                             @PathParam("namespace-id") String namespaceId, @PathParam("name") String name) {
-    DatasetModuleMeta moduleMeta = manager.getModule(name);
+    DatasetModuleMeta moduleMeta = manager.getModule(Id.DatasetModule.from(namespaceId, name));
     if (moduleMeta == null) {
       responder.sendStatus(HttpResponseStatus.NOT_FOUND);
     } else {
@@ -222,7 +250,7 @@ public class DatasetTypeHandler extends AbstractHttpHandler {
   public void listTypes(HttpRequest request, HttpResponder responder,
                         @PathParam("namespace-id") String namespaceId) {
     // Sorting by name for convenience
-    List<DatasetTypeMeta> list = Lists.newArrayList(manager.getTypes());
+    List<DatasetTypeMeta> list = Lists.newArrayList(manager.getTypes(Id.Namespace.from(namespaceId)));
     Collections.sort(list, new Comparator<DatasetTypeMeta>() {
       @Override
       public int compare(DatasetTypeMeta o1, DatasetTypeMeta o2) {
@@ -237,7 +265,7 @@ public class DatasetTypeHandler extends AbstractHttpHandler {
   public void getTypeInfo(HttpRequest request, HttpResponder responder,
                           @PathParam("namespace-id") String namespaceId, @PathParam("name") String name) {
 
-    DatasetTypeMeta typeMeta = manager.getTypeInfo(name);
+    DatasetTypeMeta typeMeta = manager.getTypeInfo(Id.DatasetType.from(namespaceId, name));
     if (typeMeta == null) {
       responder.sendStatus(HttpResponseStatus.NOT_FOUND);
     } else {
@@ -248,14 +276,14 @@ public class DatasetTypeHandler extends AbstractHttpHandler {
   /**
    * Checks if the given module name already exists.
    *
-   * @param moduleName name of the module to check
+   * @param datasetModuleId {@link Id.DatasetModule} of the module to check
    * @throws DatasetModuleConflictException if the module exists
    */
-  private void conflictIfModuleExists(String moduleName) throws DatasetModuleConflictException {
-    DatasetModuleMeta existing = manager.getModule(moduleName);
+  private void conflictIfModuleExists(Id.DatasetModule datasetModuleId) throws DatasetModuleConflictException {
+    DatasetModuleMeta existing = manager.getModule(datasetModuleId);
     if (existing != null) {
       String message = String.format("Cannot add module %s: module with same name already exists: %s",
-                                     moduleName, existing);
+                                     datasetModuleId, existing);
       throw new DatasetModuleConflictException(message);
     }
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/DatasetAdminOpHTTPHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/DatasetAdminOpHTTPHandler.java
@@ -93,7 +93,7 @@ public class DatasetAdminOpHTTPHandler extends AuthenticatedHttpHandler {
     DatasetProperties props = params.getProperties();
     DatasetTypeMeta typeMeta = params.getTypeMeta();
 
-    LOG.info("Creating dataset instance {}, type meta: {}, props: {}", name, typeMeta, props);
+    LOG.info("Creating dataset instance {}.{}, type meta: {}, props: {}", namespaceId, name, typeMeta, props);
     DatasetType type = dsFramework.getDatasetType(typeMeta, null);
 
     if (type == null) {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/mds/DatasetTypeMDS.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/mds/DatasetTypeMDS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,12 +16,16 @@
 
 package co.cask.cdap.data2.datafabric.dataset.service.mds;
 
-import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.dataset.module.EmbeddedDataset;
-import co.cask.cdap.api.dataset.table.OrderedTable;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.data2.dataset2.lib.table.MDSKey;
+import co.cask.cdap.data2.dataset2.lib.table.MetadataStoreDataset;
 import co.cask.cdap.proto.DatasetModuleMeta;
 import co.cask.cdap.proto.DatasetTypeMeta;
+import co.cask.cdap.proto.Id;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 
 import java.util.Collection;
@@ -32,91 +36,117 @@ import javax.annotation.Nullable;
 /**
  * Dataset types and modules metadata store
  */
-public class DatasetTypeMDS extends AbstractObjectsStore {
+public class DatasetTypeMDS extends MetadataStoreDataset {
   /**
    * Prefix for rows containing module info.
    * NOTE: we store in same table list of modules, with keys being <MODULES_PREFIX><module_name> and
    *       types to modules mapping with keys being <TYPE_TO_MODULE_PREFIX><type_name>
    */
-  private static final byte[] MODULES_PREFIX = Bytes.toBytes("m_");
+  private static final String MODULES_PREFIX = "m_";
 
   /**
    * Prefix for rows containing type -> module mapping
    * see {@link #MODULES_PREFIX} for more info.
    */
-  private static final byte[] TYPE_TO_MODULE_PREFIX = Bytes.toBytes("t_");
+  private static final String TYPE_TO_MODULE_PREFIX = "t_";
 
-  public DatasetTypeMDS(DatasetSpecification spec, @EmbeddedDataset("") OrderedTable table) {
-    super(spec, table);
+  public DatasetTypeMDS(DatasetSpecification spec, @EmbeddedDataset("") Table table) {
+    super(table);
   }
 
   @Nullable
-  public DatasetModuleMeta getModule(String name) {
-    return get(getModuleKey(name), DatasetModuleMeta.class);
+  public DatasetModuleMeta getModule(Id.DatasetModule datasetModuleId) {
+    return get(getModuleKey(datasetModuleId.getNamespaceId(), datasetModuleId.getId()), DatasetModuleMeta.class);
   }
 
   @Nullable
-  public DatasetModuleMeta getModuleByType(String typeName) {
-    String moduleName = get(getTypeKey(typeName), String.class);
+  public DatasetModuleMeta getModuleByType(Id.DatasetType datasetTypeId) {
+    Id.DatasetModule datasetModuleId = get(getTypeKey(datasetTypeId.getNamespaceId(), datasetTypeId.getTypeName()),
+                                           Id.DatasetModule.class);
+    if (datasetModuleId == null) {
+      return null;
+    }
+    // TODO: Slightly strange. Maybe change signature to accept Id.Namespace separately from typeName
+    return getModule(datasetModuleId);
+  }
+
+  public DatasetTypeMeta getType(Id.DatasetType datasetTypeId) {
+    DatasetModuleMeta moduleName = getModuleByType(datasetTypeId);
     if (moduleName == null) {
       return null;
     }
-    return getModule(moduleName);
+    return getTypeMeta(datasetTypeId.getNamespace(), datasetTypeId.getTypeName(), moduleName);
   }
 
-  public DatasetTypeMeta getType(String typeName) {
-    DatasetModuleMeta moduleName = getModuleByType(typeName);
-    if (moduleName == null) {
-      return null;
-    }
-    return getTypeMeta(typeName, moduleName);
+  public Collection<DatasetModuleMeta> getModules(Id.Namespace namespaceId) {
+    return list(getModuleKey(namespaceId.getId()), DatasetModuleMeta.class);
   }
 
-  public Collection<DatasetModuleMeta> getModules() {
-    byte[] prefix = getModuleKey("");
-    return scan(prefix, DatasetModuleMeta.class).values();
-  }
-
-  public Collection<DatasetTypeMeta> getTypes() {
+  public Collection<DatasetTypeMeta> getTypes(Id.Namespace namespaceId) {
     List<DatasetTypeMeta> types = Lists.newArrayList();
-    for (Map.Entry<String, String> entry : getTypesMapping().entrySet()) {
-      types.add(getTypeMeta(entry.getKey(), entry.getValue()));
+    for (Map.Entry<MDSKey, Id.DatasetModule> entry : getTypesMapping(namespaceId).entrySet()) {
+      MDSKey.Splitter splitter = entry.getKey().split();
+      // first part is TYPE_TO_MODULE_PREFIX
+      splitter.skipString();
+      // second part is namespace
+      splitter.skipString();
+      // third part is the type name, which is what we expect
+      String key = splitter.getString();
+      types.add(getTypeMeta(namespaceId, key, entry.getValue()));
     }
     return types;
   }
 
-  public void write(DatasetModuleMeta moduleMeta) {
-    put(getModuleKey(moduleMeta.getName()), moduleMeta);
+  public void writeModule(Id.Namespace namespaceId, DatasetModuleMeta moduleMeta) {
+    Id.DatasetModule datasetModuleId = Id.DatasetModule.from(namespaceId, moduleMeta.getName());
+    write(getModuleKey(namespaceId.getId(), moduleMeta.getName()), moduleMeta);
 
     for (String type : moduleMeta.getTypes()) {
-      write(type, moduleMeta.getName());
+      writeTypeToModuleMapping(Id.DatasetType.from(namespaceId, type), datasetModuleId);
     }
   }
 
-  public void deleteModule(String name) {
-    DatasetModuleMeta module = getModule(name);
+  public void deleteModule(Id.DatasetModule datasetModuleId) {
+    DatasetModuleMeta module = getModule(datasetModuleId);
     if (module == null) {
       // that's fine: module is not there
       return;
     }
 
-    delete(getModuleKey(module.getName()));
+    deleteAll(getModuleKey(datasetModuleId.getNamespaceId(), datasetModuleId.getId()));
 
     for (String type : module.getTypes()) {
-      delete(getTypeKey(type));
+      deleteAll(getTypeKey(datasetModuleId.getNamespaceId(), type));
     }
   }
 
-  private DatasetTypeMeta getTypeMeta(String typeName, String moduleName) {
-    DatasetModuleMeta moduleMeta = getModule(moduleName);
-    return getTypeMeta(typeName, moduleMeta);
+  public void deleteModules(Id.Namespace namespaceId) {
+    Collection<DatasetModuleMeta> modules = getModules(namespaceId);
+    for (DatasetModuleMeta module : modules) {
+      deleteModule(Id.DatasetModule.from(namespaceId, module.getName()));
+    }
   }
 
-  private DatasetTypeMeta getTypeMeta(String typeName, DatasetModuleMeta moduleMeta) {
+  private DatasetTypeMeta getTypeMeta(Id.Namespace namespaceId, String typeName, Id.DatasetModule datasetModuleId) {
+    DatasetModuleMeta moduleMeta = getModule(datasetModuleId);
+    return getTypeMeta(namespaceId, typeName, moduleMeta);
+  }
+
+  private DatasetTypeMeta getTypeMeta(Id.Namespace namespaceId, String typeName, DatasetModuleMeta moduleMeta) {
     List<DatasetModuleMeta> modulesToLoad = Lists.newArrayList();
     // adding first all modules we depend on, then myself
     for (String usedModule : moduleMeta.getUsesModules()) {
-      modulesToLoad.add(getModule(usedModule));
+      // Try to find module in the specified namespace first
+      DatasetModuleMeta usedModuleMeta = getModule(Id.DatasetModule.from(namespaceId, usedModule));
+      // if not found, try to load it from system namespace
+      if (usedModuleMeta == null) {
+        usedModuleMeta = getModule(Id.DatasetModule.from(Constants.SYSTEM_NAMESPACE, usedModule));
+        // Module could not be found in either user or system namespace, bail out
+        Preconditions.checkState(usedModuleMeta != null,
+                                 String.format("Unable to find metadata about module %s that module %s uses.",
+                                               usedModule, moduleMeta.getName()));
+      }
+      modulesToLoad.add(usedModuleMeta);
     }
     modulesToLoad.add(moduleMeta);
 
@@ -124,20 +154,35 @@ public class DatasetTypeMDS extends AbstractObjectsStore {
   }
 
   // type -> moduleName
-  private Map<String, String> getTypesMapping() {
-    byte[] prefix = getTypeKey("");
-    return scan(prefix, String.class);
+  private Map<MDSKey, Id.DatasetModule> getTypesMapping(Id.Namespace namespaceId) {
+    return listKV(getTypeKey(namespaceId.getId()), Id.DatasetModule.class);
   }
 
-  private void write(String typeName, String moduleName) {
-    put(getTypeKey(typeName), moduleName);
+  private void writeTypeToModuleMapping(Id.DatasetType datasetTypeId, Id.DatasetModule datasetModuleId) {
+    write(getTypeKey(datasetTypeId.getNamespaceId(), datasetTypeId.getTypeName()), datasetModuleId);
   }
 
-  private byte[] getModuleKey(String name) {
-    return Bytes.add(MODULES_PREFIX, Bytes.toBytes(name));
+  private MDSKey getModuleKey(String namespace) {
+    return getModuleKey(namespace, null);
   }
 
-  private byte[] getTypeKey(String name) {
-    return Bytes.add(TYPE_TO_MODULE_PREFIX, Bytes.toBytes(name));
+  private MDSKey getModuleKey(String namespace, @Nullable String moduleName) {
+    return getKey(MODULES_PREFIX, namespace, moduleName);
+  }
+
+  private MDSKey getTypeKey(String namespace) {
+    return getTypeKey(namespace, null);
+  }
+
+  private MDSKey getTypeKey(String namespace, @Nullable String typeName) {
+    return getKey(TYPE_TO_MODULE_PREFIX, namespace, typeName);
+  }
+
+  private MDSKey getKey(String type, String namespace, @Nullable String name) {
+    MDSKey.Builder builder = new MDSKey.Builder().add(type).add(namespace);
+    if (name != null) {
+      builder.add(name);
+    }
+    return builder.build();
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DatasetFramework.java
@@ -22,6 +22,7 @@ import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.dataset.module.DatasetModule;
 import co.cask.cdap.proto.Id;
+import com.google.common.annotations.VisibleForTesting;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -72,6 +73,7 @@ public interface DatasetFramework {
   /**
    * Deletes dataset modules and its types in the specified namespace.
    *
+   * @param namespaceId the {@link Id.Namespace} to delete all modules from.
    * @throws ModuleConflictException when some of modules can't be deleted because of its dependant modules or instances
    * @throws DatasetManagementException
    */
@@ -136,10 +138,21 @@ public interface DatasetFramework {
   boolean hasInstance(Id.DatasetInstance datasetInstanceId) throws DatasetManagementException;
 
   /**
-   * @return true if type exists, false otherwise
+   * Checks if the specified type exists in the 'system' namespace
+   *
+   * @return true if type exists in the 'system' namespace, false otherwise
    * @throws DatasetManagementException
    */
-  boolean hasType(String typeName) throws DatasetManagementException;
+  boolean hasSystemType(String typeName) throws DatasetManagementException;
+
+  /**
+   * Checks if the specified type exists in the specified namespace
+   *
+   * @return true if type exists in the specified namespace, false otherwise
+   * @throws DatasetManagementException
+   */
+  @VisibleForTesting
+  boolean hasType(Id.DatasetType datasetTypeId) throws DatasetManagementException;
 
   /**
    * Deletes dataset instance from the system.

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/InMemoryDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/InMemoryDatasetFramework.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -41,6 +41,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -52,18 +53,21 @@ import javax.annotation.Nullable;
  */
 public class InMemoryDatasetFramework implements DatasetFramework {
   private static final Logger LOG = LoggerFactory.getLogger(InMemoryDatasetFramework.class);
+  private static final Id.Namespace systemNamespace = Id.Namespace.from(Constants.SYSTEM_NAMESPACE);
 
   private DatasetDefinitionRegistryFactory registryFactory;
   private Map<String, ? extends DatasetModule> defaultModules;
 
   private final Map<Id.DatasetModule, String> moduleClasses = Maps.newLinkedHashMap();
   private final Set<String> defaultTypes = Sets.newHashSet();
+  private final Map<Id.Namespace, List<String>> nonDefaultTypes = Maps.newHashMap();
   private final Map<Id.DatasetInstance, DatasetSpecification> instances = Maps.newHashMap();
 
   // NOTE: used only for "internal" operations, that doesn't return to client object of custom type
   // NOTE: for getting dataset/admin objects we construct fresh new one using all modules (no dependency management in
   //       this in-mem implementation for now) and passed client (program) classloader
-  private DatasetDefinitionRegistry registry;
+  // NOTE: We maintain one DatasetDefinitionRegistry per namespace
+  private Map<Id.Namespace, DatasetDefinitionRegistry> registries = Maps.newLinkedHashMap();
 
   public InMemoryDatasetFramework(DatasetDefinitionRegistryFactory registryFactory) {
     this(registryFactory, new HashMap<String, DatasetModule>());
@@ -78,9 +82,8 @@ public class InMemoryDatasetFramework implements DatasetFramework {
   }
 
   @Override
-  public synchronized void addModule(Id.DatasetModule moduleId, DatasetModule module)
-    throws ModuleConflictException {
-
+  public synchronized void addModule(Id.DatasetModule moduleId,
+                                     DatasetModule module) throws ModuleConflictException {
     if (moduleClasses.containsKey(moduleId)) {
       throw new ModuleConflictException("Cannot add module " + moduleId + ": it already exists.");
     }
@@ -88,18 +91,21 @@ public class InMemoryDatasetFramework implements DatasetFramework {
   }
 
   @Override
-  public synchronized void deleteModule(Id.DatasetModule moduleId) throws ModuleConflictException {
+  public synchronized void deleteModule(Id.DatasetModule moduleId) throws DatasetManagementException {
     // todo: check if existnig datasets or modules use this module
     moduleClasses.remove(moduleId);
+    List<String> availableModuleClasses = getAvailableModuleClasses(moduleId.getNamespace());
     // this will cleanup types
-    registry = createRegistry(registry.getClass().getClassLoader());
+    DatasetDefinitionRegistry registry = createRegistry(availableModuleClasses, registries.getClass().getClassLoader());
+    registries.put(moduleId.getNamespace(), registry);
   }
 
   @Override
-  public synchronized void deleteAllModules(Id.Namespace namespaceId) throws DatasetManagementException {
-    // check if there are any datasets that use non-default types that we want to remove
+  public synchronized void deleteAllModules(Id.Namespace namespaceId) throws ModuleConflictException {
+    // check if there are any datasets that use types from the namespace from which we want to remove all modules
+    List<String> typesInNamespace = nonDefaultTypes.get(namespaceId);
     for (DatasetSpecification spec : instances.values()) {
-      if (!defaultTypes.contains(spec.getType())) {
+      if (typesInNamespace.contains(spec.getType())) {
         throw new ModuleConflictException("Cannot delete all modules, some datasets use them");
       }
     }
@@ -113,10 +119,10 @@ public class InMemoryDatasetFramework implements DatasetFramework {
       throw new InstanceConflictException("Dataset instance with name already exists: " + datasetInstanceId);
     }
 
-    Preconditions.checkArgument(registry.hasType(datasetType), "Dataset type '%s' is not registered", datasetType);
+    DatasetDefinitionRegistry registry = getRegistryForType(datasetInstanceId.getNamespace(), datasetType);
+    Preconditions.checkArgument(registry != null, "Dataset type '%s' is not registered", datasetType);
     DatasetDefinition def = registry.get(datasetType);
     DatasetSpecification spec = def.configure(datasetInstanceId.getId(), props);
-    instances.put(datasetInstanceId, spec);
     def.getAdmin(spec, null).create();
     instances.put(datasetInstanceId, spec);
     LOG.info("Created dataset {} of type {}", datasetInstanceId, datasetType);
@@ -130,7 +136,8 @@ public class InMemoryDatasetFramework implements DatasetFramework {
       throw new InstanceConflictException("Dataset instance with name does not exist: " + datasetInstanceId);
     }
     String datasetType = oldSpec.getType();
-    Preconditions.checkArgument(registry.hasType(datasetType), "Dataset type '%s' is not registered", datasetType);
+    DatasetDefinitionRegistry registry = getRegistryForType(datasetInstanceId.getNamespace(), datasetType);
+    Preconditions.checkArgument(registry != null, "Dataset type '%s' is not registered", datasetType);
     DatasetDefinition def = registry.get(datasetType);
     DatasetSpecification spec = def.configure(datasetInstanceId.getId(), props);
     instances.put(datasetInstanceId, spec);
@@ -155,14 +162,25 @@ public class InMemoryDatasetFramework implements DatasetFramework {
   }
 
   @Override
-  public synchronized boolean hasType(String typeName) throws DatasetManagementException {
-    return registry.hasType(typeName);
+  public boolean hasSystemType(String typeName) throws DatasetManagementException {
+    return hasType(Id.DatasetType.from(Constants.SYSTEM_NAMESPACE, typeName));
+  }
+
+  @Override
+  public boolean hasType(Id.DatasetType datasetTypeId) throws DatasetManagementException {
+    if (registries.containsKey(datasetTypeId.getNamespace())) {
+      return registries.get(datasetTypeId.getNamespace()).hasType(datasetTypeId.getTypeName());
+    }
+    return false;
   }
 
   @Override
   public synchronized void deleteInstance(Id.DatasetInstance datasetInstanceId)
     throws InstanceConflictException, IOException {
     DatasetSpecification spec = instances.remove(datasetInstanceId);
+    String datasetType = spec.getType();
+    DatasetDefinitionRegistry registry = getRegistryForType(datasetInstanceId.getNamespace(), datasetType);
+    Preconditions.checkState(registry != null, "Dataset type '%s' is not registered", datasetType);
     DatasetDefinition def = registry.get(spec.getType());
     def.getAdmin(spec, null).drop();
   }
@@ -170,6 +188,9 @@ public class InMemoryDatasetFramework implements DatasetFramework {
   @Override
   public synchronized void deleteAllInstances(Id.Namespace namespaceId) throws DatasetManagementException, IOException {
     for (DatasetSpecification spec : instances.values()) {
+      String datasetType = spec.getType();
+      DatasetDefinitionRegistry registry = getRegistryForType(namespaceId, datasetType);
+      Preconditions.checkState(registry != null, "Dataset type '%s' is not registered", datasetType);
       DatasetDefinition def = registry.get(spec.getType());
       def.getAdmin(spec, null).drop();
     }
@@ -185,27 +206,29 @@ public class InMemoryDatasetFramework implements DatasetFramework {
     if (spec == null) {
       return null;
     }
-    DatasetDefinition impl = createRegistry(classLoader).get(spec.getType());
+    List<String> availableModuleClasses = getAvailableModuleClasses(datasetInstanceId.getNamespace());
+    DatasetDefinition impl = createRegistry(availableModuleClasses, classLoader).get(spec.getType());
     return (T) impl.getAdmin(spec, classLoader);
   }
 
   @Override
   public synchronized <T extends Dataset> T getDataset(Id.DatasetInstance datasetInstanceId,
                                                        Map<String, String> arguments,
-                                                       @Nullable ClassLoader classLoader)
-    throws IOException {
+                                                       @Nullable ClassLoader classLoader) throws IOException {
 
     DatasetSpecification spec = instances.get(datasetInstanceId);
     if (spec == null) {
       return null;
     }
-    DatasetDefinition def = createRegistry(classLoader).get(spec.getType());
+    List<String> availableModuleClasses = getAvailableModuleClasses(datasetInstanceId.getNamespace());
+    DatasetDefinition def = createRegistry(availableModuleClasses, classLoader).get(spec.getType());
     return (T) (def.getDataset(spec, arguments, classLoader));
   }
 
-  private DatasetDefinitionRegistry createRegistry(@Nullable ClassLoader classLoader) {
+  private DatasetDefinitionRegistry createRegistry(List<String> availableModuleClasses,
+                                                   @Nullable ClassLoader classLoader) {
     DatasetDefinitionRegistry registry = registryFactory.create();
-    for (String moduleClassName : moduleClasses.values()) {
+    for (String moduleClassName : availableModuleClasses) {
       // todo: this module loading and registering code somewhat duplicated in RemoteDatasetFramework
       Class<?> moduleClass;
 
@@ -233,13 +256,57 @@ public class InMemoryDatasetFramework implements DatasetFramework {
     return registry;
   }
 
+  private List<String> getAvailableModuleClasses(Id.Namespace namespace) {
+    LinkedList<String> allClasses = getAllModuleClasses(systemNamespace);
+    if (systemNamespace.equals(namespace)) {
+      return allClasses;
+    }
+    LinkedList<String> namespaceClasses = getAllModuleClasses(namespace);
+    for (String namespaceClass : namespaceClasses) {
+      int idx = allClasses.indexOf(namespaceClass);
+      if (idx > -1) {
+        allClasses.remove(idx);
+        allClasses.add(idx, namespaceClass);
+      } else {
+        allClasses.addLast(namespaceClass);
+      }
+    }
+    return allClasses;
+  }
+
+  private LinkedList<String> getAllModuleClasses(Id.Namespace namespace) {
+    Set<String> classes = Sets.newHashSet();
+    LinkedList<String> classesl = Lists.newLinkedList();
+    for (Map.Entry<Id.DatasetModule, String> entry : moduleClasses.entrySet()) {
+      if (entry.getKey().getNamespace().equals(namespace)) {
+        classes.add(entry.getValue());
+        classesl.addLast(entry.getValue());
+      }
+    }
+    return classesl;
+  }
+
   private void add(Id.DatasetModule moduleId, DatasetModule module, boolean defaultModule) {
+    DatasetDefinitionRegistry registry;
+    if (registries.containsKey(moduleId.getNamespace())) {
+      registry = registries.get(moduleId.getNamespace());
+    } else {
+      registry = registryFactory.create();
+    }
     TypesTrackingRegistry trackingRegistry = new TypesTrackingRegistry(registry);
     module.register(trackingRegistry);
     if (defaultModule) {
       defaultTypes.addAll(trackingRegistry.getTypes());
+    } else {
+      List<String> existingTypesInNamespace = nonDefaultTypes.get(moduleId.getNamespace());
+      if (existingTypesInNamespace == null) {
+        existingTypesInNamespace = Lists.newArrayList();
+      }
+      existingTypesInNamespace.addAll(trackingRegistry.getTypes());
+      nonDefaultTypes.put(moduleId.getNamespace(), existingTypesInNamespace);
     }
     moduleClasses.put(moduleId, DatasetModules.getDatasetModuleClass(module).getName());
+    registries.put(moduleId.getNamespace(), registry);
   }
 
   private void resetRegistry() {
@@ -247,12 +314,25 @@ public class InMemoryDatasetFramework implements DatasetFramework {
 
     moduleClasses.clear();
     defaultTypes.clear();
-    registry = registryFactory.create();
+    registries.clear();
     for (Map.Entry<String, ? extends DatasetModule> entry : defaultModules.entrySet()) {
       LOG.info("Adding Default module: " + entry.getKey() + " " + this.toString());
       // default modules in system namespace
       add(Id.DatasetModule.from(Constants.SYSTEM_NAMESPACE, entry.getKey()), entry.getValue(), true);
     }
+  }
+
+  @Nullable
+  private DatasetDefinitionRegistry getRegistryForType(Id.Namespace namespaceId, String datasetType) {
+    DatasetDefinitionRegistry registry = registries.get(namespaceId);
+    if (registry != null && registry.hasType(datasetType)) {
+      return registry;
+    }
+    registry = registries.get(systemNamespace);
+    if (registry != null && registry.hasType(datasetType)) {
+      return registry;
+    }
+    return null;
   }
 
   // NOTE: this class is needed to collect all types added by a module
@@ -277,7 +357,19 @@ public class InMemoryDatasetFramework implements DatasetFramework {
 
     @Override
     public <T extends DatasetDefinition> T get(String datasetTypeName) {
-      return delegate.get(datasetTypeName);
+      // In real-world scenarios, default modules are guaranteed to always exist in the system namespace.
+      // Hence, we could add a preconditions check here to verify that registries contains types from system namespace
+      // However, a lot of our tests (AbstractDatasetTest) start without default modules, so not adding that check.
+      // In any case, the pattern here of first looking for the definition in own namespace, then in system is valid
+      // and the else block should throw an exception if the dataset type is not found in the current or the system
+      // namespace.
+      if (delegate.hasType(datasetTypeName)) {
+        return delegate.get(datasetTypeName);
+      } else if (registries.containsKey(systemNamespace)) {
+        return registries.get(systemNamespace).get(datasetTypeName);
+      } else {
+        throw new IllegalStateException(String.format("Dataset type %s not found.", datasetTypeName));
+      }
     }
 
     @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/NamespacedDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/NamespacedDatasetFramework.java
@@ -97,8 +97,13 @@ public class NamespacedDatasetFramework implements DatasetFramework {
   }
 
   @Override
-  public boolean hasType(String typeName) throws DatasetManagementException {
-    return delegate.hasType(typeName);
+  public boolean hasSystemType(String typeName) throws DatasetManagementException {
+    return delegate.hasSystemType(typeName);
+  }
+
+  @Override
+  public boolean hasType(Id.DatasetType datasetTypeId) throws DatasetManagementException {
+    return delegate.hasType(datasetTypeId);
   }
 
   @Override

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,10 +16,11 @@
 
 package co.cask.cdap.data2.datafabric.dataset;
 
-import co.cask.cdap.api.dataset.module.DatasetModule;
+import co.cask.cdap.api.dataset.table.OrderedTable;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.CConfigurationUtil;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.io.Locations;
 import co.cask.cdap.common.metrics.MetricsCollectionService;
 import co.cask.cdap.common.metrics.NoOpMetricsCollectionService;
 import co.cask.cdap.data2.datafabric.dataset.instance.DatasetInstanceManager;
@@ -33,12 +34,17 @@ import co.cask.cdap.data2.datafabric.dataset.type.DatasetTypeManager;
 import co.cask.cdap.data2.datafabric.dataset.type.LocalDatasetTypeClassLoaderFactory;
 import co.cask.cdap.data2.dataset2.AbstractDatasetFrameworkTest;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.dataset2.DatasetManagementException;
 import co.cask.cdap.data2.dataset2.InMemoryDatasetFramework;
+import co.cask.cdap.data2.dataset2.SimpleKVTable;
+import co.cask.cdap.data2.dataset2.SingleTypeModule;
+import co.cask.cdap.data2.dataset2.lib.table.CoreDatasetsModule;
 import co.cask.cdap.data2.dataset2.module.lib.inmemory.InMemoryOrderedTableModule;
 import co.cask.cdap.data2.metrics.DatasetMetricsReporter;
 import co.cask.cdap.explore.client.DiscoveryExploreClient;
 import co.cask.cdap.explore.client.ExploreFacade;
 import co.cask.cdap.gateway.auth.NoAuthenticator;
+import co.cask.cdap.proto.Id;
 import co.cask.http.HttpHandler;
 import co.cask.tephra.TransactionManager;
 import co.cask.tephra.inmemory.InMemoryTxSystemClient;
@@ -53,12 +59,13 @@ import org.apache.twill.discovery.InMemoryDiscoveryService;
 import org.apache.twill.discovery.ServiceDiscovered;
 import org.apache.twill.filesystem.LocalLocationFactory;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -71,6 +78,7 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
   private DatasetOpExecutorService opExecutorService;
   private DatasetService service;
   private RemoteDatasetFramework framework;
+  private LocalLocationFactory locationFactory;
 
   @ClassRule
   public static TemporaryFolder tmpFolder = new TemporaryFolder();
@@ -78,9 +86,8 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
   @Before
   public void before() throws Exception {
     CConfiguration cConf = CConfiguration.create();
-    File datasetDir = new File(tmpFolder.newFolder(), "dataset");
-    datasetDir.mkdirs();
-    cConf.set(Constants.Dataset.Manager.OUTPUT_DIR, datasetDir.getAbsolutePath());
+    File dataDir = new File(tmpFolder.newFolder(), "data");
+    cConf.set(Constants.CFG_LOCAL_DATA_DIR, dataDir.getAbsolutePath());
     cConf.set(Constants.Dataset.Manager.ADDRESS, "localhost");
     cConf.setBoolean(Constants.Dangerous.UNRECOVERABLE_RESET, true);
 
@@ -95,7 +102,7 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
     txManager.startAndWait();
     InMemoryTxSystemClient txSystemClient = new InMemoryTxSystemClient(txManager);
 
-    LocalLocationFactory locationFactory = new LocalLocationFactory();
+    locationFactory = new LocalLocationFactory(new File(cConf.get(Constants.CFG_LOCAL_DATA_DIR)));
     framework = new RemoteDatasetFramework(discoveryService, new InMemoryDefinitionRegistryFactory(),
                                            new LocalDatasetTypeClassLoaderFactory());
 
@@ -109,16 +116,15 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
 
     InMemoryDatasetFramework mdsFramework =
       new InMemoryDatasetFramework(new InMemoryDefinitionRegistryFactory(),
-                                   ImmutableMap.of("memoryTable", new InMemoryOrderedTableModule()));
+                                   ImmutableMap.of("memoryTable", new InMemoryOrderedTableModule(),
+                                                   "core", new CoreDatasetsModule()));
     MDSDatasetsRegistry mdsDatasetsRegistry = new MDSDatasetsRegistry(txSystemClient, mdsFramework, cConf);
 
     service = new DatasetService(cConf,
                                  locationFactory,
                                  discoveryService,
                                  discoveryService,
-                                 new DatasetTypeManager(mdsDatasetsRegistry, locationFactory,
-                                                        // note: in this test we start with empty modules
-                                                        Collections.<String, DatasetModule>emptyMap()),
+                                 new DatasetTypeManager(mdsDatasetsRegistry, locationFactory, DEFAULT_MODULES),
                                  new DatasetInstanceManager(mdsDatasetsRegistry),
                                  metricsCollectionService,
                                  new InMemoryDatasetOpExecutor(framework),
@@ -138,11 +144,45 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
     }, Threads.SAME_THREAD_EXECUTOR);
 
     startLatch.await(5, TimeUnit.SECONDS);
+
+    // this usually happens while creating a namespace, however not doing that in data fabric tests
+    Locations.mkdirsIfNotExists(locationFactory.create(Constants.SYSTEM_NAMESPACE));
+    Locations.mkdirsIfNotExists(locationFactory.create(NAMESPACE_ID.getId()));
+  }
+
+  // Note: Cannot have these system namespace restrictions in system namespace since we use it internally in
+  // DatasetMetaTable util to add modules to system namespace. However, we should definitely impose these restrictions
+  // in RemoteDatasetFramework.
+  @Test
+  public void testSystemNamespace() throws DatasetManagementException {
+    Id.Namespace systemNamespace = Id.Namespace.from(Constants.SYSTEM_NAMESPACE);
+    DatasetFramework framework = getFramework();
+    // Adding module to system namespace should fail
+    try {
+      framework.addModule(Id.DatasetModule.from(systemNamespace, "keyValue"),
+                          new SingleTypeModule(SimpleKVTable.class));
+      Assert.fail("Should not be able to add a module to system namespace");
+    } catch (DatasetManagementException e) {
+    }
+    Assert.assertTrue(framework.hasSystemType("orderedTable"));
+    Assert.assertTrue(framework.hasSystemType(OrderedTable.class.getName()));
+    try {
+      framework.deleteModule(Id.DatasetModule.from(systemNamespace, "orderedTable-memory"));
+      Assert.fail("Should not be able to delete a default module.");
+    } catch (DatasetManagementException e) {
+    }
+    try {
+      framework.deleteAllModules(systemNamespace);
+      Assert.fail("Should not be able to delete modules from system namespace");
+    } catch (DatasetManagementException e) {
+    }
   }
 
   @After
   public void after() {
     Services.chainStop(service, opExecutorService, txManager);
+    Locations.deleteQuietly(locationFactory.create(NAMESPACE_ID.getId()));
+    Locations.deleteQuietly(locationFactory.create(Constants.SYSTEM_NAMESPACE));
   }
 
   @Override

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
@@ -155,11 +155,10 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
   // in RemoteDatasetFramework.
   @Test
   public void testSystemNamespace() throws DatasetManagementException {
-    Id.Namespace systemNamespace = Id.Namespace.from(Constants.SYSTEM_NAMESPACE);
     DatasetFramework framework = getFramework();
     // Adding module to system namespace should fail
     try {
-      framework.addModule(Id.DatasetModule.from(systemNamespace, "keyValue"),
+      framework.addModule(Id.DatasetModule.from(Constants.SYSTEM_NAMESPACE_ID, "keyValue"),
                           new SingleTypeModule(SimpleKVTable.class));
       Assert.fail("Should not be able to add a module to system namespace");
     } catch (DatasetManagementException e) {
@@ -167,12 +166,12 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
     Assert.assertTrue(framework.hasSystemType("orderedTable"));
     Assert.assertTrue(framework.hasSystemType(OrderedTable.class.getName()));
     try {
-      framework.deleteModule(Id.DatasetModule.from(systemNamespace, "orderedTable-memory"));
+      framework.deleteModule(Id.DatasetModule.from(Constants.SYSTEM_NAMESPACE_ID, "orderedTable-memory"));
       Assert.fail("Should not be able to delete a default module.");
     } catch (DatasetManagementException e) {
     }
     try {
-      framework.deleteAllModules(systemNamespace);
+      framework.deleteAllModules(Constants.SYSTEM_NAMESPACE_ID);
       Assert.fail("Should not be able to delete modules from system namespace");
     } catch (DatasetManagementException e) {
     }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -20,6 +20,7 @@ import co.cask.cdap.api.dataset.module.DatasetModule;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.CConfigurationUtil;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.io.Locations;
 import co.cask.cdap.common.lang.jar.JarFinder;
 import co.cask.cdap.common.metrics.MetricsCollectionService;
 import co.cask.cdap.common.metrics.NoOpMetricsCollectionService;
@@ -85,6 +86,7 @@ public abstract class DatasetServiceTestBase {
   private InMemoryDiscoveryService discoveryService;
   private DatasetOpExecutorService opExecutorService;
   private DatasetService service;
+  private LocalLocationFactory locationFactory;
   protected TransactionManager txManager;
   protected RemoteDatasetFramework dsFramework;
 
@@ -96,11 +98,12 @@ public abstract class DatasetServiceTestBase {
   @Before
   public void before() throws Exception {
     CConfiguration cConf = CConfiguration.create();
-    File datasetDir = new File(tmpFolder.newFolder(), "dataset");
-    if (!DirUtils.mkdirs(datasetDir)) {
-      throw new RuntimeException(String.format("Could not create DatasetFramework output dir %s", datasetDir));
+    File dataDir = new File(tmpFolder.newFolder(), "data");
+    cConf.set(Constants.CFG_LOCAL_DATA_DIR, dataDir.getAbsolutePath());
+    if (!DirUtils.mkdirs(dataDir)) {
+      throw new RuntimeException(String.format("Could not create DatasetFramework output dir %s", dataDir));
     }
-    cConf.set(Constants.Dataset.Manager.OUTPUT_DIR, datasetDir.getAbsolutePath());
+    cConf.set(Constants.Dataset.Manager.OUTPUT_DIR, dataDir.getAbsolutePath());
     cConf.set(Constants.Dataset.Manager.ADDRESS, "localhost");
     cConf.setBoolean(Constants.Dangerous.UNRECOVERABLE_RESET, true);
 
@@ -115,7 +118,7 @@ public abstract class DatasetServiceTestBase {
     txManager.startAndWait();
     InMemoryTxSystemClient txSystemClient = new InMemoryTxSystemClient(txManager);
 
-    LocalLocationFactory locationFactory = new LocalLocationFactory();
+    locationFactory = new LocalLocationFactory(new File(cConf.get(Constants.CFG_LOCAL_DATA_DIR)));
     dsFramework = new RemoteDatasetFramework(discoveryService, new InMemoryDefinitionRegistryFactory(),
                                              new LocalDatasetTypeClassLoaderFactory());
 
@@ -159,11 +162,14 @@ public abstract class DatasetServiceTestBase {
     }, Threads.SAME_THREAD_EXECUTOR);
 
     startLatch.await(5, TimeUnit.SECONDS);
+    // this usually happens while creating a namespace, however not doing that in data fabric tests
+    Locations.mkdirsIfNotExists(locationFactory.create(Constants.DEFAULT_NAMESPACE));
   }
 
   @After
   public void after() {
     Services.chainStop(service, opExecutorService, txManager);
+    Locations.deleteQuietly(locationFactory.create(Constants.DEFAULT_NAMESPACE));
   }
 
   private synchronized int getPort() {

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/AbstractDatasetFrameworkTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/AbstractDatasetFrameworkTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -21,6 +21,7 @@ import co.cask.cdap.api.dataset.DatasetAdmin;
 import co.cask.cdap.api.dataset.DatasetDefinition;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.DatasetSpecification;
+import co.cask.cdap.api.dataset.module.DatasetModule;
 import co.cask.cdap.api.dataset.table.OrderedTable;
 import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.data2.dataset2.lib.table.CoreDatasetsModule;
@@ -30,8 +31,11 @@ import co.cask.tephra.DefaultTransactionExecutor;
 import co.cask.tephra.TransactionAware;
 import co.cask.tephra.TransactionExecutor;
 import co.cask.tephra.inmemory.MinimalTxSystemClient;
+import com.google.common.collect.Maps;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.Map;
 
 /**
  *
@@ -40,58 +44,106 @@ public abstract class AbstractDatasetFrameworkTest {
 
   protected abstract DatasetFramework getFramework();
 
-  private static final Id.Namespace namespaceId = Id.Namespace.from("myspace");
-  private static final Id.DatasetModule inMemory = Id.DatasetModule.from(namespaceId, "inMemory");
-  private static final Id.DatasetModule core = Id.DatasetModule.from(namespaceId, "core");
-  private static final Id.DatasetModule keyValue = Id.DatasetModule.from(namespaceId, "keyValue");
-  private static final Id.DatasetModule doubleKeyValue = Id.DatasetModule.from(namespaceId, "doubleKeyValue");
-  private static final Id.DatasetInstance myTable = Id.DatasetInstance.from(namespaceId, "my_table");
-  private static final Id.DatasetInstance myTable2 = Id.DatasetInstance.from(namespaceId, "my_table2");
+  protected static final Map<String, DatasetModule> DEFAULT_MODULES;
+  static {
+    DEFAULT_MODULES = Maps.newLinkedHashMap();
+    DEFAULT_MODULES.put("orderedTable-memory", new InMemoryOrderedTableModule());
+    DEFAULT_MODULES.put("core", new CoreDatasetsModule());
+  }
+
+  protected static final Id.Namespace NAMESPACE_ID = Id.Namespace.from("myspace");
+  private static final Id.DatasetModule inMemory = Id.DatasetModule.from(NAMESPACE_ID, "inMemory");
+  private static final Id.DatasetModule core = Id.DatasetModule.from(NAMESPACE_ID, "core");
+  private static final Id.DatasetModule keyValue = Id.DatasetModule.from(NAMESPACE_ID, "keyValue");
+  private static final Id.DatasetModule doubleKeyValue = Id.DatasetModule.from(NAMESPACE_ID, "doubleKeyValue");
+  private static final Id.DatasetInstance myTable = Id.DatasetInstance.from(NAMESPACE_ID, "my_table");
+  private static final Id.DatasetInstance myTable2 = Id.DatasetInstance.from(NAMESPACE_ID, "my_table2");
+  private static final Id.DatasetType inMemoryType = Id.DatasetType.from(NAMESPACE_ID, "orderedTable");
+  private static final Id.DatasetType tableType = Id.DatasetType.from(NAMESPACE_ID, "table");
+  private static final Id.DatasetType simpleKvType = Id.DatasetType.from(NAMESPACE_ID, SimpleKVTable.class.getName());
+  private static final Id.DatasetType doubleKvType = Id.DatasetType.from(NAMESPACE_ID,
+                                                                         DoubleWrappedKVTable.class.getName());
 
   @Test
   public void testSimpleDataset() throws Exception {
     // Configuring Dataset types
     DatasetFramework framework = getFramework();
-
-    Assert.assertFalse(framework.hasType("orderedTable"));
-    framework.addModule(inMemory, new InMemoryOrderedTableModule());
-    Assert.assertTrue(framework.hasType("orderedTable"));
+    // system namespace has a module orderedTable-inMemory
+    Assert.assertTrue(framework.hasSystemType("orderedTable"));
+    // myspace namespace has no modules
+    Assert.assertFalse(framework.hasType(inMemoryType));
+    Assert.assertFalse(framework.hasType(simpleKvType));
+    // add module to namespace 'myspace'
+    framework.addModule(keyValue, new SingleTypeModule(SimpleKVTable.class));
+    // make sure it got added to 'myspace'
+    Assert.assertTrue(framework.hasType(simpleKvType));
+    // but not to 'system'
+    Assert.assertFalse(framework.hasSystemType(SimpleKVTable.class.getName()));
 
     Assert.assertFalse(framework.hasInstance(myTable));
-    // Creating instance
-    framework.addInstance("orderedTable", myTable, DatasetProperties.EMPTY);
+    // Creating instance using a type from own namespace
+    framework.addInstance(SimpleKVTable.class.getName(), myTable, DatasetProperties.EMPTY);
+    // verify it got added to the right namespace
     Assert.assertTrue(framework.hasInstance(myTable));
+    // and not to the system namespace
+    // TODO: Enable after namespacing instances
+    // Assert.assertFalse(framework.hasInstance(Id.DatasetInstance.from(Constants.SYSTEM_NAMESPACE, "my_table")));
 
     // Doing some admin and data ops
     DatasetAdmin admin = framework.getAdmin(myTable, null);
     Assert.assertNotNull(admin);
-    final OrderedTable table = framework.getDataset(myTable, DatasetDefinition.NO_ARGUMENTS, null);
+    final SimpleKVTable table = framework.getDataset(myTable, DatasetDefinition.NO_ARGUMENTS, null);
     Assert.assertNotNull(table);
 
     TransactionExecutor txnl = new DefaultTransactionExecutor(new MinimalTxSystemClient(), (TransactionAware) table);
     txnl.execute(new TransactionExecutor.Subroutine() {
       @Override
       public void apply() throws Exception {
-        table.put(Bytes.toBytes("key1"), Bytes.toBytes("column1"), Bytes.toBytes("value1"));
+        table.put("key1", "value1");
       }
     });
     txnl.execute(new TransactionExecutor.Subroutine() {
       @Override
       public void apply() throws Exception {
-        Assert.assertEquals("value1", Bytes.toString(table.get(Bytes.toBytes("key1"), Bytes.toBytes("column1"))));
+        Assert.assertEquals("value1", table.get("key1"));
       }
     });
     admin.truncate();
     txnl.execute(new TransactionExecutor.Subroutine() {
       @Override
       public void apply() throws Exception {
-        Assert.assertTrue(table.get(Bytes.toBytes("key1")).isEmpty());
+        Assert.assertTrue(table.get("key1") == null);
       }
     });
 
     // cleanup
     framework.deleteInstance(myTable);
-    framework.deleteModule(inMemory);
+    framework.deleteModule(keyValue);
+
+    // recreate instance without adding a module in 'myspace'. This should use types from default namespace
+    framework.addInstance("orderedTable", myTable, DatasetProperties.EMPTY);
+    // verify it got added to the right namespace
+    Assert.assertTrue(framework.hasInstance(myTable));
+    admin = framework.getAdmin(myTable, null);
+    Assert.assertNotNull(admin);
+    final OrderedTable orderedTable = framework.getDataset(myTable, DatasetDefinition.NO_ARGUMENTS, null);
+    Assert.assertNotNull(orderedTable);
+    txnl.execute(new TransactionExecutor.Subroutine() {
+      @Override
+      public void apply() throws Exception {
+        orderedTable.put(Bytes.toBytes("key1"), Bytes.toBytes("column1"), Bytes.toBytes("value1"));
+      }
+    });
+    txnl.execute(new TransactionExecutor.Subroutine() {
+      @Override
+      public void apply() throws Exception {
+        Assert.assertEquals("value1", Bytes.toString(orderedTable.get(Bytes.toBytes("key1"),
+                                                                      Bytes.toBytes("column1"))));
+      }
+    });
+
+    // cleanup
+    framework.deleteInstance(myTable);
   }
 
   @Test
@@ -101,14 +153,15 @@ public abstract class AbstractDatasetFrameworkTest {
 
     framework.addModule(inMemory, new InMemoryOrderedTableModule());
     framework.addModule(core, new CoreDatasetsModule());
-    Assert.assertFalse(framework.hasType(SimpleKVTable.class.getName()));
+    Assert.assertFalse(framework.hasSystemType(SimpleKVTable.class.getName()));
+    Assert.assertFalse(framework.hasType(simpleKvType));
     framework.addModule(keyValue, new SingleTypeModule(SimpleKVTable.class));
-    Assert.assertTrue(framework.hasType(SimpleKVTable.class.getName()));
+    Assert.assertTrue(framework.hasType(simpleKvType));
+    Assert.assertFalse(framework.hasSystemType(SimpleKVTable.class.getName()));
 
     // Creating instance
     Assert.assertFalse(framework.hasInstance(myTable));
-    framework.addInstance(SimpleKVTable.class.getName(),
-                          myTable, DatasetProperties.EMPTY);
+    framework.addInstance(SimpleKVTable.class.getName(), myTable, DatasetProperties.EMPTY);
     Assert.assertTrue(framework.hasInstance(myTable));
 
     testCompositeDataset(framework);
@@ -128,9 +181,11 @@ public abstract class AbstractDatasetFrameworkTest {
     framework.addModule(inMemory, new InMemoryOrderedTableModule());
     framework.addModule(core, new CoreDatasetsModule());
     framework.addModule(keyValue, new SingleTypeModule(SimpleKVTable.class));
-    Assert.assertFalse(framework.hasType(DoubleWrappedKVTable.class.getName()));
+    Assert.assertFalse(framework.hasSystemType(DoubleWrappedKVTable.class.getName()));
+    Assert.assertFalse(framework.hasType(doubleKvType));
     framework.addModule(doubleKeyValue, new SingleTypeModule(DoubleWrappedKVTable.class));
-    Assert.assertTrue(framework.hasType(DoubleWrappedKVTable.class.getName()));
+    Assert.assertTrue(framework.hasType(doubleKvType));
+    Assert.assertFalse(framework.hasSystemType(DoubleWrappedKVTable.class.getName()));
 
     // Creating instance
     Assert.assertFalse(framework.hasInstance(myTable));
@@ -179,13 +234,22 @@ public abstract class AbstractDatasetFrameworkTest {
 
   @Test
   public void testBasicManagement() throws Exception {
+    Id.DatasetType orderedTableType = Id.DatasetType.from(NAMESPACE_ID, OrderedTable.class.getName());
+    Id.DatasetType tableType = Id.DatasetType.from(NAMESPACE_ID, Table.class.getName());
+
     // Adding modules
     DatasetFramework framework = getFramework();
 
     framework.addModule(inMemory, new InMemoryOrderedTableModule());
     framework.addModule(core, new CoreDatasetsModule());
-    Assert.assertTrue(framework.hasType(OrderedTable.class.getName()));
-    Assert.assertTrue(framework.hasType(Table.class.getName()));
+    framework.addModule(keyValue, new SingleTypeModule(SimpleKVTable.class));
+    // keyvalue has been added in the system namespace
+    Assert.assertTrue(framework.hasSystemType(OrderedTable.class.getName()));
+    Assert.assertTrue(framework.hasSystemType(Table.class.getName()));
+    Assert.assertFalse(framework.hasSystemType(SimpleKVTable.class.getName()));
+    Assert.assertTrue(framework.hasType(orderedTableType));
+    Assert.assertTrue(framework.hasType(tableType));
+    Assert.assertTrue(framework.hasType(simpleKvType));
 
     // Creating instances
     framework.addInstance(OrderedTable.class.getName(), myTable, DatasetProperties.EMPTY);
@@ -199,26 +263,29 @@ public abstract class AbstractDatasetFrameworkTest {
 
     // cleanup
     try {
-      framework.deleteAllModules(namespaceId);
+      framework.deleteAllModules(NAMESPACE_ID);
       Assert.fail("should not delete modules: there are datasets using their types");
     } catch (DatasetManagementException e) {
       // expected
     }
     // types are still there
-    Assert.assertTrue(framework.hasType(OrderedTable.class.getName()));
-    Assert.assertTrue(framework.hasType(Table.class.getName()));
+    Assert.assertTrue(framework.hasType(orderedTableType));
+    Assert.assertTrue(framework.hasType(tableType));
+    Assert.assertTrue(framework.hasType(simpleKvType));
 
-    framework.deleteAllInstances(namespaceId);
-    Assert.assertEquals(0, framework.getInstances(namespaceId).size());
+    framework.deleteAllInstances(NAMESPACE_ID);
+    Assert.assertEquals(0, framework.getInstances(NAMESPACE_ID).size());
     Assert.assertFalse(framework.hasInstance(myTable));
     Assert.assertNull(framework.getDatasetSpec(myTable));
     Assert.assertFalse(framework.hasInstance(myTable2));
     Assert.assertNull(framework.getDatasetSpec(myTable2));
 
-    // now it should susceed
-    framework.deleteAllModules(namespaceId);
-    Assert.assertFalse(framework.hasType(OrderedTable.class.getName()));
-    Assert.assertFalse(framework.hasType(Table.class.getName()));
+    // now it should succeed
+    framework.deleteAllModules(NAMESPACE_ID);
+    Assert.assertTrue(framework.hasSystemType(OrderedTable.class.getName()));
+    Assert.assertTrue(framework.hasSystemType(Table.class.getName()));
+    Assert.assertFalse(framework.hasType(orderedTableType));
+    Assert.assertFalse(framework.hasType(tableType));
+    Assert.assertFalse(framework.hasType(simpleKvType));
   }
-
 }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/InMemoryDatasetFrameworkTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/InMemoryDatasetFrameworkTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -22,8 +22,9 @@ import co.cask.cdap.data2.datafabric.dataset.InMemoryDefinitionRegistryFactory;
  *
  */
 public class InMemoryDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
+
   @Override
   protected DatasetFramework getFramework() {
-    return new InMemoryDatasetFramework(new InMemoryDefinitionRegistryFactory());
+    return new InMemoryDatasetFramework(new InMemoryDefinitionRegistryFactory(), DEFAULT_MODULES);
   }
 }

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/BaseHiveExploreServiceTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/BaseHiveExploreServiceTest.java
@@ -23,6 +23,7 @@ import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
 import co.cask.cdap.common.guice.IOModule;
 import co.cask.cdap.common.guice.LocationRuntimeModule;
+import co.cask.cdap.common.io.Locations;
 import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.DataSetServiceModules;
 import co.cask.cdap.data.runtime.DataSetsModules;
@@ -71,6 +72,7 @@ import com.google.inject.Scopes;
 import com.google.inject.multibindings.Multibinder;
 import com.google.inject.name.Names;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.twill.filesystem.LocationFactory;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -97,7 +99,8 @@ public class BaseHiveExploreServiceTest {
     .registerTypeAdapter(Schema.class, new SchemaTypeAdapter())
     .create();
 
-  protected static final Id.Namespace NAMESPACE_ID = Id.Namespace.from("myspace");
+  // TODO: When datasets are namespaced, we should add tests for multiple, non-default namespaces.
+  protected static final Id.Namespace NAMESPACE_ID = Id.Namespace.from("default");
   protected static final Id.DatasetModule KEY_STRUCT_VALUE = Id.DatasetModule.from(NAMESPACE_ID, "keyStructValue");
   protected static final Id.DatasetInstance MY_TABLE = Id.DatasetInstance.from(NAMESPACE_ID, "my_table");
 
@@ -113,23 +116,23 @@ public class BaseHiveExploreServiceTest {
   protected static ExploreService exploreService;
   protected static StreamHttpService streamHttpService;
   protected static StreamService streamService;
-
   protected static ExploreClient exploreClient;
+  protected static LocationFactory locationFactory;
 
   protected static Injector injector;
 
   @ClassRule
   public static TemporaryFolder tmpFolder = new TemporaryFolder();
 
-  protected static void startServices() throws Exception {
-    startServices(CConfiguration.create());
+  protected static void initialize() throws Exception {
+    initialize(CConfiguration.create());
   }
 
-  protected static void startServices(CConfiguration cConf) throws Exception {
-    startServices(cConf, false);
+  protected static void initialize(CConfiguration cConf) throws Exception {
+    initialize(cConf, false);
   }
 
-  protected static void startServices(CConfiguration cConf, boolean useStandalone) throws Exception {
+  protected static void initialize(CConfiguration cConf, boolean useStandalone) throws Exception {
     if (!runBefore) {
       return;
     }
@@ -157,6 +160,10 @@ public class BaseHiveExploreServiceTest {
     streamService.startAndWait();
     streamHttpService = injector.getInstance(StreamHttpService.class);
     streamHttpService.startAndWait();
+
+    locationFactory = injector.getInstance(LocationFactory.class);
+    // This usually happens during namespace create, but adding it here instead of explicitly creating a namespace
+    Locations.mkdirsIfNotExists(locationFactory.create(NAMESPACE_ID.getId()));
   }
 
   @AfterClass
@@ -165,6 +172,7 @@ public class BaseHiveExploreServiceTest {
       return;
     }
 
+    Locations.deleteQuietly(locationFactory.create(NAMESPACE_ID.getId()), true);
     streamHttpService.stopAndWait();
     streamService.stopAndWait();
     exploreClient.close();

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreExtensiveSchemaTableTestRun.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreExtensiveSchemaTableTestRun.java
@@ -44,7 +44,7 @@ public class ExploreExtensiveSchemaTableTestRun extends BaseHiveExploreServiceTe
 
   @BeforeClass
   public static void start() throws Exception {
-    startServices();
+    initialize();
 
     datasetFramework.addModule(extensiveSchema, new ExtensiveSchemaTableDefinition.ExtensiveSchemaTableModule());
 

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreMetadataTestRun.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreMetadataTestRun.java
@@ -17,8 +17,6 @@
 package co.cask.cdap.explore.service;
 
 import co.cask.cdap.api.dataset.DatasetProperties;
-import co.cask.cdap.common.conf.CConfiguration;
-import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.explore.client.ExploreExecutionResult;
 import co.cask.cdap.explore.service.datasets.KeyStructValueTableDefinition;
 import co.cask.cdap.proto.ColumnDesc;
@@ -43,7 +41,7 @@ public class ExploreMetadataTestRun extends BaseHiveExploreServiceTest {
 
   @BeforeClass
   public static void start() throws Exception {
-    startServices();
+    initialize();
 
     datasetFramework.addModule(KEY_STRUCT_VALUE, new KeyStructValueTableDefinition.KeyStructValueTableModule());
 

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreServiceTestsSuite.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreServiceTestsSuite.java
@@ -36,7 +36,7 @@ public class ExploreServiceTestsSuite {
 
   @BeforeClass
   public static void init() throws Exception {
-    BaseHiveExploreServiceTest.startServices();
+    BaseHiveExploreServiceTest.initialize();
     BaseHiveExploreServiceTest.runBefore = false;
     BaseHiveExploreServiceTest.runAfter = false;
   }

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceFileSetTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceFileSetTest.java
@@ -61,7 +61,7 @@ public class HiveExploreServiceFileSetTest extends BaseHiveExploreServiceTest {
 
   @BeforeClass
   public static void start() throws Exception {
-    startServices(CConfiguration.create(), false);
+    initialize(CConfiguration.create(), false);
   }
 
   @After

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceStopTestRun.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceStopTestRun.java
@@ -31,7 +31,7 @@ public class HiveExploreServiceStopTestRun extends BaseHiveExploreServiceTest {
 
   @BeforeClass
   public static void start() throws Exception {
-    startServices();
+    initialize();
   }
 
   @Test

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceStreamTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceStreamTest.java
@@ -24,7 +24,6 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.explore.client.ExploreExecutionResult;
 import co.cask.cdap.proto.ColumnDesc;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.QueryResult;
 import co.cask.cdap.proto.StreamProperties;
 import co.cask.cdap.test.SlowTests;
@@ -70,7 +69,7 @@ public class HiveExploreServiceStreamTest extends BaseHiveExploreServiceTest {
   public static void start() throws Exception {
     // use leveldb implementations, since stream input format examines the filesystem
     // to determine input splits.
-    startServices(CConfiguration.create(), true);
+    initialize(CConfiguration.create(), true);
 
     createStream(streamName);
     sendStreamEvent(streamName, headers, Bytes.toBytes(body1));

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceTestRun.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceTestRun.java
@@ -68,7 +68,7 @@ import static co.cask.cdap.explore.service.datasets.KeyStructValueTableDefinitio
 public class HiveExploreServiceTestRun extends BaseHiveExploreServiceTest {
   @BeforeClass
   public static void start() throws Exception {
-    startServices();
+    initialize();
 
     datasetFramework.addModule(KEY_STRUCT_VALUE, new KeyStructValueTableDefinition.KeyStructValueTableModule());
 

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceTimeoutTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceTimeoutTest.java
@@ -22,7 +22,6 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.explore.service.datasets.KeyStructValueTableDefinition;
 import co.cask.cdap.proto.ColumnDesc;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.QueryHandle;
 import co.cask.cdap.proto.QueryStatus;
 import co.cask.cdap.test.XSlowTests;
@@ -63,7 +62,7 @@ public class HiveExploreServiceTimeoutTest extends BaseHiveExploreServiceTest {
     cConfiguration.setLong(Constants.Explore.INACTIVE_OPERATION_TIMEOUT_SECS, INACTIVE_OPERATION_TIMEOUT_SECS);
     cConfiguration.setLong(Constants.Explore.CLEANUP_JOB_SCHEDULE_SECS, CLEANUP_JOB_SCHEDULE_SECS);
 
-    startServices(cConfiguration);
+    initialize(cConfiguration);
 
     exploreService = injector.getInstance(ExploreService.class);
 

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/WritableDatasetTestRun.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/WritableDatasetTestRun.java
@@ -54,7 +54,7 @@ public class WritableDatasetTestRun extends BaseHiveExploreServiceTest {
 
   @BeforeClass
   public static void start() throws Exception {
-    startServices();
+    initialize();
     datasetFramework.addModule(KEY_STRUCT_VALUE, new KeyStructValueTableDefinition.KeyStructValueTableModule());
   }
 

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/Id.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/Id.java
@@ -459,13 +459,76 @@ public final class Id  {
   }
 
   /**
+   * Dataset Type Id identifies a given dataset module.
+   */
+  public static final class DatasetType {
+    private final Namespace namespace;
+    private final String typeName;
+
+    private DatasetType(Namespace namespace, String typeName) {
+      Preconditions.checkNotNull(namespace, "Namespace cannot be null.");
+      Preconditions.checkNotNull(typeName, "Dataset type id cannot be null.");
+      Preconditions.checkArgument(isValidDatasetId(typeName), "Invalid characters found in dataset type Id. '" +
+        typeName + "'. Module id can contain alphabets, numbers or _, -, . or $ characters");
+      this.namespace = namespace;
+      this.typeName = typeName;
+    }
+
+    public Namespace getNamespace() {
+      return namespace;
+    }
+
+    public String getNamespaceId() {
+      return namespace.getId();
+    }
+
+    public String getTypeName() {
+      return typeName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+
+      DatasetType that = (DatasetType) o;
+      return namespace.equals(that.namespace) && typeName.equals(that.typeName);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(namespace, typeName);
+    }
+
+    @Override
+    public String toString() {
+      return Objects.toStringHelper(this)
+        .add("namespace", namespace)
+        .add("typeName", typeName)
+        .toString();
+    }
+
+    public static DatasetType from(Namespace id, String typeId) {
+      return new DatasetType(id, typeId);
+    }
+
+    public static DatasetType from(String namespaceId, String typeId) {
+      return new DatasetType(Namespace.from(namespaceId), typeId);
+    }
+  }
+
+  /**
    * Dataset Module Id identifies a given dataset module.
    */
   public static final class DatasetModule {
     private final Namespace namespace;
     private final String moduleId;
 
-    public DatasetModule(final Namespace namespace, final String moduleId) {
+    private DatasetModule(Namespace namespace, String moduleId) {
       Preconditions.checkNotNull(namespace, "Namespace cannot be null.");
       Preconditions.checkNotNull(moduleId, "Dataset module id cannot be null.");
       Preconditions.checkArgument(isValidDatasetId(moduleId), "Invalid characters found in dataset module Id. '" +
@@ -528,7 +591,7 @@ public final class Id  {
     private final Namespace namespace;
     private final String instanceId;
 
-    public DatasetInstance(final Namespace namespace, final String instanceId) {
+    private DatasetInstance(Namespace namespace, String instanceId) {
       Preconditions.checkNotNull(namespace, "Namespace cannot be null.");
       Preconditions.checkNotNull(instanceId, "Dataset instance id cannot be null.");
       Preconditions.checkArgument(isValidDatasetId(instanceId), "Invalid characters found in dataset instance id. '" +

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
@@ -686,6 +686,8 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
 
   @Test(timeout = 60000L)
   public void testDatasetWithoutApp() throws Exception {
+    // TODO: Although this has nothing to do with this testcase, deploying a dummy app to create the default namespace
+    deployApplication(DummyApp.class);
     deployDatasetModule("my-kv", AppsWithDataset.KeyValueTableDefinition.Module.class);
     addDatasetInstance("myKeyValueTable", "myTable", DatasetProperties.EMPTY).create();
     DataSetManager<AppsWithDataset.KeyValueTableDefinition.KeyValueTable> dataSetManager = getDataset("myTable");

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/file/TestFileLogging.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/file/TestFileLogging.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -20,6 +20,7 @@ import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.core.util.StatusPrinter;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.CConfigurationUtil;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.logging.LoggingContext;
 import co.cask.cdap.common.logging.LoggingContextAccessor;
 import co.cask.cdap.data2.datafabric.dataset.InMemoryDefinitionRegistryFactory;
@@ -63,12 +64,12 @@ public class TestFileLogging {
 
   private static DatasetFramework dsFramework;
   private static InMemoryTxSystemClient txClient;
-  private static final Id.Namespace NAMESPACE_ID = Id.Namespace.from("myspace");
 
   @BeforeClass
   public static void setUpContext() throws Exception {
     dsFramework = new InMemoryDatasetFramework(new InMemoryDefinitionRegistryFactory());
-    dsFramework.addModule(Id.DatasetModule.from(NAMESPACE_ID, "table"), new InMemoryOrderedTableModule());
+    dsFramework.addModule(Id.DatasetModule.from(Constants.SYSTEM_NAMESPACE, "table"),
+                          new InMemoryOrderedTableModule());
 
     LoggingContextAccessor.setLoggingContext(new FlowletLoggingContext("TFL_ACCT_1", "APP_1", "FLOW_1", "FLOWLET_1"));
     logBaseDir = "/tmp/log_files_" + new Random(System.currentTimeMillis()).nextLong();

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/file/TestFileLogging.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/file/TestFileLogging.java
@@ -68,7 +68,7 @@ public class TestFileLogging {
   @BeforeClass
   public static void setUpContext() throws Exception {
     dsFramework = new InMemoryDatasetFramework(new InMemoryDefinitionRegistryFactory());
-    dsFramework.addModule(Id.DatasetModule.from(Constants.SYSTEM_NAMESPACE, "table"),
+    dsFramework.addModule(Id.DatasetModule.from(Constants.SYSTEM_NAMESPACE_ID, "table"),
                           new InMemoryOrderedTableModule());
 
     LoggingContextAccessor.setLoggingContext(new FlowletLoggingContext("TFL_ACCT_1", "APP_1", "FLOW_1", "FLOWLET_1"));

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/kafka/TestKafkaLogging.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/kafka/TestKafkaLogging.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -19,6 +19,7 @@ package co.cask.cdap.logging.appender.kafka;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.core.util.StatusPrinter;
 import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.logging.LoggingContext;
 import co.cask.cdap.common.logging.LoggingContextAccessor;
 import co.cask.cdap.data2.datafabric.dataset.InMemoryDefinitionRegistryFactory;
@@ -56,12 +57,12 @@ public class TestKafkaLogging extends KafkaTestBase {
   private static InMemoryTxSystemClient txClient = null;
   private static DatasetFramework dsFramework;
   private static CConfiguration cConf;
-  private static final Id.Namespace NAMESPACE_ID = Id.Namespace.from("myspace");
 
   @BeforeClass
   public static void init() throws Exception {
     dsFramework = new InMemoryDatasetFramework(new InMemoryDefinitionRegistryFactory());
-    dsFramework.addModule(Id.DatasetModule.from(NAMESPACE_ID, "table"), new InMemoryOrderedTableModule());
+    dsFramework.addModule(Id.DatasetModule.from(Constants.SYSTEM_NAMESPACE, "table"),
+                          new InMemoryOrderedTableModule());
 
     Configuration txConf = HBaseConfiguration.create();
     TransactionManager txManager = new TransactionManager(txConf);

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/kafka/TestKafkaLogging.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/kafka/TestKafkaLogging.java
@@ -61,7 +61,7 @@ public class TestKafkaLogging extends KafkaTestBase {
   @BeforeClass
   public static void init() throws Exception {
     dsFramework = new InMemoryDatasetFramework(new InMemoryDefinitionRegistryFactory());
-    dsFramework.addModule(Id.DatasetModule.from(Constants.SYSTEM_NAMESPACE, "table"),
+    dsFramework.addModule(Id.DatasetModule.from(Constants.SYSTEM_NAMESPACE_ID, "table"),
                           new InMemoryOrderedTableModule());
 
     Configuration txConf = HBaseConfiguration.create();

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/save/LogSaverTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/save/LogSaverTest.java
@@ -106,7 +106,7 @@ public class LogSaverTest extends KafkaTestBase {
   @BeforeClass
   public static void startLogSaver() throws Exception {
     dsFramework = new InMemoryDatasetFramework(new InMemoryDefinitionRegistryFactory());
-    dsFramework.addModule(Id.DatasetModule.from(Constants.SYSTEM_NAMESPACE, "table"),
+    dsFramework.addModule(Id.DatasetModule.from(Constants.SYSTEM_NAMESPACE_ID, "table"),
                           new InMemoryOrderedTableModule());
 
     String logBaseDir = temporaryFolder.newFolder().getAbsolutePath();

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/save/LogSaverTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/save/LogSaverTest.java
@@ -102,12 +102,12 @@ public class LogSaverTest extends KafkaTestBase {
   private static DatasetFramework dsFramework;
   private static LogSaverTableUtil tableUtil;
   private static CConfiguration cConf;
-  private static final Id.Namespace NAMESPACE_ID = Id.Namespace.from("myspace");
 
   @BeforeClass
   public static void startLogSaver() throws Exception {
     dsFramework = new InMemoryDatasetFramework(new InMemoryDefinitionRegistryFactory());
-    dsFramework.addModule(Id.DatasetModule.from(NAMESPACE_ID, "table"), new InMemoryOrderedTableModule());
+    dsFramework.addModule(Id.DatasetModule.from(Constants.SYSTEM_NAMESPACE, "table"),
+                          new InMemoryOrderedTableModule());
 
     String logBaseDir = temporaryFolder.newFolder().getAbsolutePath();
     LOG.info("Log base dir {}", logBaseDir);

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/write/LogCleanupTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/write/LogCleanupTest.java
@@ -78,7 +78,7 @@ public class LogCleanupTest {
   @Test
   public void testCleanup() throws Exception {
     DatasetFramework dsFramework = new InMemoryDatasetFramework(new InMemoryDefinitionRegistryFactory());
-    dsFramework.addModule(Id.DatasetModule.from(Constants.SYSTEM_NAMESPACE, "table"),
+    dsFramework.addModule(Id.DatasetModule.from(Constants.SYSTEM_NAMESPACE_ID, "table"),
                           new InMemoryOrderedTableModule());
 
     CConfiguration cConf = CConfiguration.create();

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/write/LogCleanupTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/write/LogCleanupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -18,6 +18,7 @@ package co.cask.cdap.logging.write;
 
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.CConfigurationUtil;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.io.Locations;
 import co.cask.cdap.common.logging.LoggingContext;
 import co.cask.cdap.data2.datafabric.dataset.InMemoryDefinitionRegistryFactory;
@@ -66,7 +67,6 @@ public class LogCleanupTest {
   public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
 
   private static final int RETENTION_DURATION_MS = 100000;
-  private static final Id.Namespace NAMESPACE_ID = Id.Namespace.from("myspace");
 
   private static LocationFactory locationFactory;
 
@@ -78,7 +78,8 @@ public class LogCleanupTest {
   @Test
   public void testCleanup() throws Exception {
     DatasetFramework dsFramework = new InMemoryDatasetFramework(new InMemoryDefinitionRegistryFactory());
-    dsFramework.addModule(Id.DatasetModule.from(NAMESPACE_ID, "table"), new InMemoryOrderedTableModule());
+    dsFramework.addModule(Id.DatasetModule.from(Constants.SYSTEM_NAMESPACE, "table"),
+                          new InMemoryOrderedTableModule());
 
     CConfiguration cConf = CConfiguration.create();
 


### PR DESCRIPTION
Have to re-open a PR for #1354 because I'm hitting some github bug when you use rebase with integration branches.

Description from original PR: 

Summary:

Going to do namespaced datasets in 3 PRs:
This PR: Namespaced dataset modules, types

* **Incompatible change**: ``DatasetTypeMDS`` extends ``MetadataStoreDataset`` and uses ``MDSKey`` as the key to keep it consistent with ``AppMetadataStore``. Similar change for ``DatasetInstanceMDS`` will come in a following PR.
* ``DatasetTypeHandler`` is namespaced. 
* Dataset type loading logic: Try to find in current namespace first. If not found, look for it in the system namespace.
* Upgrade tool for these changes is a WIP, will happen before Monday.


Two other PRs coming up, before merge to develop.
1. Updates to NamespacedDatasetFramework to use namespaces
2. Namespaced dataset instances.
Cannot merge to develop individually because some APIs cannot work without the complete integration.