### PR TITLE
expose MetricStore in metric client guice module

### DIFF
--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.app.Application;
 import co.cask.cdap.api.dataset.DatasetAdmin;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.module.DatasetModule;
+import co.cask.cdap.api.metrics.MetricStore;
 import co.cask.cdap.app.guice.AppFabricServiceRuntimeModule;
 import co.cask.cdap.app.guice.ProgramRunnerRuntimeModule;
 import co.cask.cdap.app.guice.ServiceStoreModules;
@@ -73,8 +74,6 @@ import co.cask.cdap.metrics.MetricsConstants;
 import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
 import co.cask.cdap.metrics.guice.MetricsHandlerModule;
 import co.cask.cdap.metrics.query.MetricsQueryService;
-import co.cask.cdap.metrics.store.DefaultMetricDatasetFactory;
-import co.cask.cdap.metrics.store.DefaultMetricStore;
 import co.cask.cdap.notifications.feeds.guice.NotificationFeedServiceRuntimeModule;
 import co.cask.cdap.notifications.guice.NotificationServiceRuntimeModule;
 import co.cask.cdap.test.internal.AppFabricClient;
@@ -307,7 +306,7 @@ public class TestBase {
     streamCoordinatorClient.startAndWait();
     testManager = new UnitTestManager(injector, appFabricClient, datasetFramework, txSystemClient, discoveryClient);
     // we use MetricStore directly, until RuntimeStats API changes
-    RuntimeStats.metricStore = new DefaultMetricStore(new DefaultMetricDatasetFactory(cConf, dsFramework));
+    RuntimeStats.metricStore = injector.getInstance(MetricStore.class);
   }
 
   private static Module createDataFabricModule(final CConfiguration cConf) {

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/guice/DistributedMetricsClientModule.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/guice/DistributedMetricsClientModule.java
@@ -16,6 +16,7 @@
 package co.cask.cdap.metrics.guice;
 
 import co.cask.cdap.api.data.schema.UnsupportedTypeException;
+import co.cask.cdap.api.metrics.MetricStore;
 import co.cask.cdap.api.metrics.MetricValue;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.metrics.MetricsCollectionService;
@@ -24,6 +25,9 @@ import co.cask.cdap.internal.io.DatumWriterFactory;
 import co.cask.cdap.internal.io.SchemaGenerator;
 import co.cask.cdap.metrics.MetricsConstants;
 import co.cask.cdap.metrics.collect.KafkaMetricsCollectionService;
+import co.cask.cdap.metrics.store.DefaultMetricDatasetFactory;
+import co.cask.cdap.metrics.store.DefaultMetricStore;
+import co.cask.cdap.metrics.store.MetricDatasetFactory;
 import com.google.common.base.Throwables;
 import com.google.common.reflect.TypeToken;
 import com.google.inject.PrivateModule;
@@ -40,6 +44,9 @@ public final class DistributedMetricsClientModule extends PrivateModule {
 
   @Override
   protected void configure() {
+    bind(MetricDatasetFactory.class).to(DefaultMetricDatasetFactory.class).in(Scopes.SINGLETON);
+    bind(MetricStore.class).to(DefaultMetricStore.class);
+    expose(MetricStore.class);
     bind(MetricsCollectionService.class).to(KafkaMetricsCollectionService.class).in(Scopes.SINGLETON);
     expose(MetricsCollectionService.class);
   }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/guice/MetricsClientRuntimeModule.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/guice/MetricsClientRuntimeModule.java
@@ -45,6 +45,7 @@ public final class MetricsClientRuntimeModule extends RuntimeModule {
       protected void configure() {
         bind(MetricDatasetFactory.class).to(DefaultMetricDatasetFactory.class).in(Scopes.SINGLETON);
         bind(MetricStore.class).to(DefaultMetricStore.class);
+        expose(MetricStore.class);
         bind(MetricsCollectionService.class).to(LocalMetricsCollectionService.class).in(Scopes.SINGLETON);
         expose(MetricsCollectionService.class);
       }
@@ -58,6 +59,7 @@ public final class MetricsClientRuntimeModule extends RuntimeModule {
       protected void configure() {
         bind(MetricDatasetFactory.class).to(DefaultMetricDatasetFactory.class).in(Scopes.SINGLETON);
         bind(MetricStore.class).to(DefaultMetricStore.class);
+        expose(MetricStore.class);
         bind(MetricsCollectionService.class).to(LocalMetricsCollectionService.class).in(Scopes.SINGLETON);
         expose(MetricsCollectionService.class);
       }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/guice/MetricsHandlerModule.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/guice/MetricsHandlerModule.java
@@ -42,8 +42,6 @@ import com.google.inject.name.Names;
 public class MetricsHandlerModule extends PrivateModule {
   @Override
   protected void configure() {
-    bind(MetricDatasetFactory.class).to(DefaultMetricDatasetFactory.class).in(Scopes.SINGLETON);
-    bind(MetricStore.class).to(DefaultMetricStore.class);
     bind(MetricsQueryService.class).in(Scopes.SINGLETON);
     expose(MetricsQueryService.class);
 

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/runtime/MetricsProcessorTwillRunnable.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/runtime/MetricsProcessorTwillRunnable.java
@@ -16,7 +16,6 @@
 
 package co.cask.cdap.metrics.runtime;
 
-import co.cask.cdap.api.metrics.MetricStore;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
@@ -40,16 +39,12 @@ import co.cask.cdap.metrics.process.KafkaMetricsProcessorServiceFactory;
 import co.cask.cdap.metrics.process.MessageCallbackFactory;
 import co.cask.cdap.metrics.process.MetricsMessageCallbackFactory;
 import co.cask.cdap.metrics.process.MetricsProcessorStatusService;
-import co.cask.cdap.metrics.store.DefaultMetricDatasetFactory;
-import co.cask.cdap.metrics.store.DefaultMetricStore;
-import co.cask.cdap.metrics.store.MetricDatasetFactory;
 import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.Service;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.PrivateModule;
 import com.google.inject.Provides;
-import com.google.inject.Scopes;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.name.Named;
 import org.apache.hadoop.conf.Configuration;
@@ -130,8 +125,6 @@ public final class MetricsProcessorTwillRunnable extends AbstractMasterTwillRunn
   static final class KafkaMetricsProcessorModule extends PrivateModule {
    @Override
     protected void configure() {
-      bind(MetricDatasetFactory.class).to(DefaultMetricDatasetFactory.class).in(Scopes.SINGLETON);
-      bind(MetricStore.class).to(DefaultMetricStore.class);
       bind(MessageCallbackFactory.class).to(MetricsMessageCallbackFactory.class);
       install(new FactoryModuleBuilder()
                 .build(KafkaMetricsProcessorServiceFactory.class));

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/runtime/MetricsProcessorTwillRunnable.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/runtime/MetricsProcessorTwillRunnable.java
@@ -39,12 +39,15 @@ import co.cask.cdap.metrics.process.KafkaMetricsProcessorServiceFactory;
 import co.cask.cdap.metrics.process.MessageCallbackFactory;
 import co.cask.cdap.metrics.process.MetricsMessageCallbackFactory;
 import co.cask.cdap.metrics.process.MetricsProcessorStatusService;
+import co.cask.cdap.metrics.store.DefaultMetricDatasetFactory;
+import co.cask.cdap.metrics.store.MetricDatasetFactory;
 import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.Service;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.PrivateModule;
 import com.google.inject.Provides;
+import com.google.inject.Scopes;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.name.Named;
 import org.apache.hadoop.conf.Configuration;
@@ -125,6 +128,7 @@ public final class MetricsProcessorTwillRunnable extends AbstractMasterTwillRunn
   static final class KafkaMetricsProcessorModule extends PrivateModule {
    @Override
     protected void configure() {
+      bind(MetricDatasetFactory.class).to(DefaultMetricDatasetFactory.class).in(Scopes.SINGLETON);
       bind(MessageCallbackFactory.class).to(MetricsMessageCallbackFactory.class);
       install(new FactoryModuleBuilder()
                 .build(KafkaMetricsProcessorServiceFactory.class));


### PR DESCRIPTION
MetricStore interface is an API that will be used by different components for querying metrics data. We want to expose it.