### PR TITLE
upgrade method for time partitioned file sets

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetDataset.java
@@ -90,6 +90,10 @@ public class PartitionedFileSetDataset extends AbstractDataset implements Partit
 
   @Override
   public void addPartition(PartitionKey key, String path) {
+    addPartition(key, path, true);
+  }
+
+  protected void addPartition(PartitionKey key, String path, boolean addToExplore) {
     final byte[] rowKey = generateRowKey(key, partitioning);
     Row row = partitionsTable.get(rowKey);
     if (row != null && !row.isEmpty()) {
@@ -103,8 +107,10 @@ public class PartitionedFileSetDataset extends AbstractDataset implements Partit
               Bytes.toBytes(entry.getValue().toString()));            // "<string rep. of value>"
     }
     partitionsTable.put(put);
-    addPartitionToExplore(key, path);
-    // TODO: make DDL operations transactional [CDAP-1393]
+    if (addToExplore) {
+      addPartitionToExplore(key, path);
+      // TODO: make DDL operations transactional [CDAP-1393]
+    }
   }
 
   protected void addPartitionToExplore(PartitionKey key, String path) {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetDataset.java
@@ -484,12 +484,21 @@ public class TimePartitionedFileSetDataset extends PartitionedFileSetDataset imp
   }
 
   /**
+   * This can be called to determine whether the dataset was created before 2.8 and needs migration.
+   *
+   * @return whether this is a legacy dataset.
+   */
+  public boolean isLegacyDataset() {
+    return isLegacyDataset;
+  }
+
+  /**
    * Migrate legacy partitions to the current format, starting a the given partition time, spending at most a limited
    * number of seconds. The caller can invoke this repeatedly until it returns -1.
    * <p>
    * This method is not in the API for this dataset. It is implementation-specific. The upgrade tool must obtain an
    * instance of {@link TimePartitionedFileSet} and cast it to this class.
-   * 
+   *
    * @param startTime the partition time to start at
    * @param timeLimitInSeconds the number of seconds after which to stop. This is to avoid transaction timeouts.
    * @return the

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetDataset.java
@@ -486,6 +486,10 @@ public class TimePartitionedFileSetDataset extends PartitionedFileSetDataset imp
   /**
    * Migrate legacy partitions to the current format, starting a the given partition time, spending at most a limited
    * number of seconds. The caller can invoke this repeatedly until it returns -1.
+   * <p>
+   * This method is not in the API for this dataset. It is implementation-specific. The upgrade tool must obtain an
+   * instance of {@link TimePartitionedFileSet} and cast it to this class.
+   * 
    * @param startTime the partition time to start at
    * @param timeLimitInSeconds the number of seconds after which to stop. This is to avoid transaction timeouts.
    * @return the

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetDataset.java
@@ -501,7 +501,8 @@ public class TimePartitionedFileSetDataset extends PartitionedFileSetDataset imp
    *
    * @param startTime the partition time to start at
    * @param timeLimitInSeconds the number of seconds after which to stop. This is to avoid transaction timeouts.
-   * @return the
+   * @return the start time for the next call of this method. All partitions with a lesser time stamp have been
+   *     migrated. When there are no more entries to migrate, returns -1.
    */
   public long upgradeLegacyEntries(long startTime, long timeLimitInSeconds) {
     long timeLimit = System.currentTimeMillis() + 1000L * timeLimitInSeconds;

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetTest.java
@@ -587,6 +587,7 @@ public class TimePartitionedFileSetTest extends AbstractDatasetTest {
     // add some legacy partitions
     Assert.assertTrue(withCompat instanceof TimePartitionedFileSetDataset);
     final TimePartitionedFileSetDataset legacyDataset = (TimePartitionedFileSetDataset) withCompat;
+    Assert.assertTrue(legacyDataset.isLegacyDataset());
 
     final long time = DATE_FORMAT.parse("10/17/2014 8:42 am").getTime();
     newTransactionExecutor(txAwares).execute(new TransactionExecutor.Subroutine() {

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetTest.java
@@ -574,6 +574,106 @@ public class TimePartitionedFileSetTest extends AbstractDatasetTest {
     });
   }
 
+  // tests that 2.8+ tpfs can upgrade legacy partitions to new format
+  @Test
+  public void testUpgrade() throws Exception {
+
+    // this should give us one instance that thinks it may have pre-2.8 partitions, and one that does not
+    Map<String, String> legacyArgs = ImmutableMap.of(TimePartitionedFileSetDataset.ARGUMENT_LEGACY_DATASET, "true");
+    final TimePartitionedFileSet withCompat = getInstance(TPFS_INSTANCE, legacyArgs);
+    final TimePartitionedFileSet withoutCompat = getInstance(TPFS_INSTANCE);
+    TransactionAware[] txAwares = { (TransactionAware) withCompat, (TransactionAware) withCompat };
+
+    // add some legacy partitions
+    Assert.assertTrue(withCompat instanceof TimePartitionedFileSetDataset);
+    final TimePartitionedFileSetDataset legacyDataset = (TimePartitionedFileSetDataset) withCompat;
+
+    final long time = DATE_FORMAT.parse("10/17/2014 8:42 am").getTime();
+    newTransactionExecutor(txAwares).execute(new TransactionExecutor.Subroutine() {
+      @Override
+      public void apply() throws Exception {
+        legacyDataset.addLegacyPartition(time, "8:42");
+        legacyDataset.addLegacyPartition(time + HOUR, "9:42");
+        legacyDataset.addLegacyPartition(time + 2 * HOUR, "10:42");
+      }
+    });
+
+    // add some new partitions
+    newTransactionExecutor(txAwares).execute(new TransactionExecutor.Subroutine() {
+      @Override
+      public void apply() throws Exception {
+        withCompat.addPartition(time + 3 * HOUR, "11:42");
+        withCompat.addPartition(time + 4 * HOUR, "12:42");
+      }
+    });
+
+    // with compatibility on, we should see all partitions
+    newTransactionExecutor(txAwares).execute(new TransactionExecutor.Subroutine() {
+      @Override
+      public void apply() throws Exception {
+        Assert.assertEquals(pp("8:42", "9:42", "10:42", "11:42", "12:42"), withCompat.getPartitionPaths(0, MAX));
+        Assert.assertEquals(ImmutableMap.of(time, "8:42",
+                                            time + HOUR, "9:42",
+                                            time + 2 * HOUR, "10:42",
+                                            time + 3 * HOUR, "11:42",
+                                            time + 4 * HOUR, "12:42"), withCompat.getPartitions(0, MAX));
+      }
+    });
+
+    // with compatibility off, we should see only new partitions
+    final PartitionFilter filter2014 = PartitionFilter.builder().addValueCondition("year", 2014).build();
+
+    newTransactionExecutor(txAwares).execute(new TransactionExecutor.Subroutine() {
+      @Override
+      public void apply() throws Exception {
+        // querying with partition filter does not see legacy partitions
+        Assert.assertEquals(pp("11:42", "12:42"), withoutCompat.getPartitionPaths(null));
+        Assert.assertEquals(pp("11:42", "12:42"), withoutCompat.getPartitionPaths(filter2014));
+        Assert.assertEquals(pp("11:42", "12:42"), withoutCompat.getPartitionPaths(0, time + YEAR));
+        Assert.assertEquals(ImmutableMap.of(time + 3 * HOUR, "11:42",
+                                            time + 4 * HOUR, "12:42"), withoutCompat.getPartitions(0, time + YEAR));
+      }
+    });
+
+    // migrate legacy partitions
+    long migratedTime = 0;
+    while (migratedTime >= 0) {
+      migratedTime = newTransactionExecutor(txAwares).execute(
+        new TransactionExecutor.Function<Long, Long>() {
+          @Override
+          public Long apply(Long startTime) throws Exception {
+            return legacyDataset.upgradeLegacyEntries(startTime, 1L);
+          }},
+        migratedTime);
+    }
+
+    // now we should see all partitions with and without backwards compatibility
+    newTransactionExecutor(txAwares).execute(new TransactionExecutor.Subroutine() {
+      @Override
+      public void apply() throws Exception {
+        Assert.assertEquals(pp("8:42", "9:42", "10:42", "11:42", "12:42"), withCompat.getPartitionPaths(null));
+        Assert.assertEquals(pp("8:42", "9:42", "10:42", "11:42", "12:42"), withCompat.getPartitionPaths(0, MAX));
+        Assert.assertEquals(ImmutableMap.of(time, "8:42",
+                                            time + HOUR, "9:42",
+                                            time + 2 * HOUR, "10:42",
+                                            time + 3 * HOUR, "11:42",
+                                            time + 4 * HOUR, "12:42"), withCompat.getPartitions(0, MAX));
+      }
+    });
+    newTransactionExecutor(txAwares).execute(new TransactionExecutor.Subroutine() {
+      @Override
+      public void apply() throws Exception {
+        Assert.assertEquals(pp("8:42", "9:42", "10:42", "11:42", "12:42"), withoutCompat.getPartitionPaths(null));
+        Assert.assertEquals(pp("8:42", "9:42", "10:42", "11:42", "12:42"), withoutCompat.getPartitionPaths(0, MAX));
+        Assert.assertEquals(ImmutableMap.of(time, "8:42",
+                                            time + HOUR, "9:42",
+                                            time + 2 * HOUR, "10:42",
+                                            time + 3 * HOUR, "11:42",
+                                            time + 4 * HOUR, "12:42"), withoutCompat.getPartitions(0, MAX));
+      }
+    });
+  }
+
   private static Set<String> pp(String... paths) {
     return ImmutableSet.copyOf(paths);
   }


### PR DESCRIPTION
- adds an upgrade method. It needs to be called repeatedly until all records are migrated
- that is to prevent transaction timeout. 
- adds a unit test for the upgrade