### PR TITLE
 Procedure operations to use v2 APIs

### DIFF
--- a/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
+++ b/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
@@ -55,11 +55,9 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -233,6 +231,29 @@ public class CLIMainTest extends StandaloneTestBase {
       testCommandOutputContains(cli, "stop procedure " + qualifiedProcedureId, "Successfully stopped Procedure");
       assertProgramStatus(programClient, FakeApp.NAME, ProgramType.PROCEDURE, FakeProcedure.NAME, "STOPPED");
     }
+  }
+
+  @Test
+  public void testProcedureInNonDefaultNamespace() throws Exception {
+    testCommandOutputContains(cli, "create namespace foo", "Namespace 'foo' created successfully");
+    testCommandOutputContains(cli, "use namespace foo", "Now using namespace 'foo'");
+
+    String qualifiedProcedureId = String.format("%s.%s", FakeApp.NAME, FakeProcedure.NAME);
+
+    String expectedErrMsg = "Error: Procedure operations are only supported in the default namespace.";
+    testCommandOutputContains(cli, "start procedure " + qualifiedProcedureId, expectedErrMsg);
+    testCommandOutputContains(cli, "get procedure status " + qualifiedProcedureId, expectedErrMsg);
+    testCommandOutputContains(cli, "get procedure live " + qualifiedProcedureId, expectedErrMsg);
+    testCommandOutputContains(cli, "get procedure instances " + qualifiedProcedureId, expectedErrMsg);
+    testCommandOutputContains(cli, "set procedure instances " + qualifiedProcedureId + " 2", expectedErrMsg);
+    testCommandOutputContains(cli, "set procedure runtimeargs " + qualifiedProcedureId + " key=1", expectedErrMsg);
+    testCommandOutputContains(cli, "get procedure runtimeargs " + qualifiedProcedureId, expectedErrMsg);
+    testCommandOutputContains(cli, "get procedure logs " + qualifiedProcedureId, expectedErrMsg);
+    testCommandOutputContains(cli, "call procedure " + qualifiedProcedureId
+      + " " + FakeProcedure.METHOD_NAME + " 'customer bob'", expectedErrMsg);
+    testCommandOutputContains(cli, "stop procedure " + qualifiedProcedureId, expectedErrMsg);
+
+    testCommandOutputContains(cli, "use namespace default", "Now using namespace 'default'");
   }
 
   @Test

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/ProcedureClientTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/ProcedureClientTestRun.java
@@ -70,6 +70,20 @@ public class ProcedureClientTestRun extends ClientTestBase {
                                          ImmutableMap.of("customer", "joe"));
     Assert.assertEquals(GSON.toJson(ImmutableMap.of("customer", "realjoe")), result);
 
+    // Validate that procedure calls can not be made to non-default namespaces
+    String testNamespace = clientConfig.getNamespace();
+    clientConfig.setNamespace("fooNamespace");
+    try {
+      procedureClient.call(FakeApp.NAME, FakeProcedure.NAME, FakeProcedure.METHOD_NAME,
+                           ImmutableMap.of("customer", "joe"));
+      Assert.fail("Procedure calls should not be supported in non-default namespaces.");
+    } catch (IllegalStateException e) {
+      String expectedErrMsg = "Procedure operations are only supported in the default namespace.";
+      Assert.assertEquals(expectedErrMsg, e.getMessage());
+    }
+    // revert namespace to continue execution of test
+    clientConfig.setNamespace(testNamespace);
+
     // stop procedure
     programClient.stop(FakeApp.NAME, ProgramType.PROCEDURE, FakeProcedure.NAME);
     assertProgramStopped(programClient, FakeApp.NAME, ProgramType.PROCEDURE, FakeProcedure.NAME);

--- a/cdap-client/src/main/java/co/cask/cdap/client/ApplicationClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ApplicationClient.java
@@ -18,6 +18,7 @@ package co.cask.cdap.client;
 
 import co.cask.cdap.client.config.ClientConfig;
 import co.cask.cdap.client.util.RESTClient;
+import co.cask.cdap.client.util.VersionMigrationUtils;
 import co.cask.cdap.common.exception.ApplicationNotFoundException;
 import co.cask.cdap.common.exception.UnAuthorizedAccessTokenException;
 import co.cask.cdap.common.utils.Tasks;
@@ -193,7 +194,8 @@ public class ApplicationClient {
 
     Preconditions.checkArgument(programType.isListable());
 
-    URL url = config.resolveNamespacedURLV3(programType.getCategoryName());
+    String path = programType.getCategoryName();
+    URL url = VersionMigrationUtils.resolveURL(config, programType, path);
     HttpRequest request = HttpRequest.get(url).build();
 
     ObjectResponse<List<ProgramRecord>> response = ObjectResponse.fromJsonBody(
@@ -213,7 +215,7 @@ public class ApplicationClient {
 
     ImmutableMap.Builder<ProgramType, List<ProgramRecord>> allPrograms = ImmutableMap.builder();
     for (ProgramType programType : ProgramType.values()) {
-      if (programType.isListable()) {
+      if (programType.isListable() && VersionMigrationUtils.isProgramSupported(config, programType)) {
         List<ProgramRecord> programRecords = Lists.newArrayList();
         programRecords.addAll(listAllPrograms(programType));
         allPrograms.put(programType, programRecords);
@@ -237,7 +239,8 @@ public class ApplicationClient {
     throws ApplicationNotFoundException, IOException, UnAuthorizedAccessTokenException {
     Preconditions.checkArgument(programType.isListable());
 
-    URL url = config.resolveNamespacedURLV3(String.format("apps/%s/%s", appId, programType.getCategoryName()));
+    String path = String.format("apps/%s/%s", appId, programType.getCategoryName());
+    URL url = VersionMigrationUtils.resolveURL(config, programType, path);
     HttpRequest request = HttpRequest.get(url).build();
 
     ObjectResponse<List<ProgramRecord>> response = ObjectResponse.fromJsonBody(
@@ -265,7 +268,7 @@ public class ApplicationClient {
 
     ImmutableMap.Builder<ProgramType, List<ProgramRecord>> allPrograms = ImmutableMap.builder();
     for (ProgramType programType : ProgramType.values()) {
-      if (programType.isListable()) {
+      if (programType.isListable() && VersionMigrationUtils.isProgramSupported(config, programType)) {
         List<ProgramRecord> programRecords = Lists.newArrayList();
         programRecords.addAll(listPrograms(appId, programType));
         allPrograms.put(programType, programRecords);

--- a/cdap-client/src/main/java/co/cask/cdap/client/ProcedureClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ProcedureClient.java
@@ -18,6 +18,7 @@ package co.cask.cdap.client;
 
 import co.cask.cdap.client.config.ClientConfig;
 import co.cask.cdap.client.util.RESTClient;
+import co.cask.cdap.client.util.VersionMigrationUtils;
 import co.cask.cdap.common.exception.BadRequestException;
 import co.cask.cdap.common.exception.NotFoundException;
 import co.cask.cdap.common.exception.UnAuthorizedAccessTokenException;
@@ -70,7 +71,7 @@ public class ProcedureClient {
    */
   public String call(String appId, String procedureId, String methodId, Map<String, String> parameters)
     throws BadRequestException, NotFoundException, IOException, UnAuthorizedAccessTokenException {
-
+    VersionMigrationUtils.assertProcedureSupported(config);
     URL url = config.resolveURL(String.format("apps/%s/procedures/%s/methods/%s", appId, procedureId, methodId));
     HttpRequest request = HttpRequest.post(url).withBody(GSON.toJson(parameters)).build();
 
@@ -94,6 +95,7 @@ public class ProcedureClient {
    * @throws UnAuthorizedAccessTokenException if the request is not authorized successfully in the gateway server
    */
   public List<ProgramRecord> list() throws IOException, UnAuthorizedAccessTokenException {
+    VersionMigrationUtils.assertProcedureSupported(config);
     URL url = config.resolveURL("procedures");
     HttpResponse response = restClient.execute(HttpMethod.GET, url, config.getAccessToken());
     return ObjectResponse.fromJsonBody(response, new TypeToken<List<ProgramRecord>>() { }).getResponseObject();

--- a/cdap-client/src/main/java/co/cask/cdap/client/ProgramClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ProgramClient.java
@@ -18,6 +18,7 @@ package co.cask.cdap.client;
 
 import co.cask.cdap.client.config.ClientConfig;
 import co.cask.cdap.client.util.RESTClient;
+import co.cask.cdap.client.util.VersionMigrationUtils;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.exception.NotFoundException;
 import co.cask.cdap.common.exception.ProgramNotFoundException;
@@ -80,8 +81,8 @@ public class ProgramClient {
   public void start(String appId, ProgramType programType, String programName, Map<String, String> runtimeArgs)
     throws IOException, ProgramNotFoundException, UnAuthorizedAccessTokenException {
 
-    URL url = config.resolveNamespacedURLV3(String.format("apps/%s/%s/%s/start",
-                                                          appId, programType.getCategoryName(), programName));
+    String path = String.format("apps/%s/%s/%s/start", appId, programType.getCategoryName(), programName);
+    URL url = VersionMigrationUtils.resolveURL(config, programType, path);
     HttpRequest request = HttpRequest.post(url).withBody(GSON.toJson(runtimeArgs)).build();
     HttpResponse response = restClient.execute(request, config.getAccessToken(), HttpURLConnection.HTTP_NOT_FOUND);
     if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
@@ -102,8 +103,8 @@ public class ProgramClient {
   public void start(String appId, ProgramType programType, String programName)
     throws IOException, ProgramNotFoundException, UnAuthorizedAccessTokenException {
 
-    URL url = config.resolveNamespacedURLV3(String.format("apps/%s/%s/%s/start",
-                                                          appId, programType.getCategoryName(), programName));
+    String path = String.format("apps/%s/%s/%s/start", appId, programType.getCategoryName(), programName);
+    URL url = VersionMigrationUtils.resolveURL(config, programType, path);
     HttpRequest request = HttpRequest.post(url).build();
     HttpResponse response = restClient.execute(request, config.getAccessToken(), HttpURLConnection.HTTP_NOT_FOUND);
     if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
@@ -124,8 +125,8 @@ public class ProgramClient {
   public void stop(String appId, ProgramType programType, String programName)
     throws IOException, ProgramNotFoundException, UnAuthorizedAccessTokenException {
 
-    URL url = config.resolveNamespacedURLV3(String.format("apps/%s/%s/%s/stop",
-                                                          appId, programType.getCategoryName(), programName));
+    String path = String.format("apps/%s/%s/%s/stop", appId, programType.getCategoryName(), programName);
+    URL url = VersionMigrationUtils.resolveURL(config, programType, path);
     HttpResponse response = restClient.execute(HttpMethod.POST, url, config.getAccessToken(),
                                                HttpURLConnection.HTTP_NOT_FOUND);
     if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
@@ -175,8 +176,8 @@ public class ProgramClient {
   public String getStatus(String appId, ProgramType programType, String programName)
     throws IOException, ProgramNotFoundException, UnAuthorizedAccessTokenException {
 
-    URL url = config.resolveNamespacedURLV3(String.format("apps/%s/%s/%s/status",
-                                                          appId, programType.getCategoryName(), programName));
+    String path = String.format("apps/%s/%s/%s/status", appId, programType.getCategoryName(), programName);
+    URL url = VersionMigrationUtils.resolveURL(config, programType, path);
     HttpResponse response = restClient.execute(HttpMethod.GET, url, config.getAccessToken(),
                                                HttpURLConnection.HTTP_NOT_FOUND);
     if (HttpURLConnection.HTTP_NOT_FOUND == response.getResponseCode()) {
@@ -234,8 +235,8 @@ public class ProgramClient {
   public DistributedProgramLiveInfo getLiveInfo(String appId, ProgramType programType, String programName)
     throws IOException, ProgramNotFoundException, UnAuthorizedAccessTokenException {
 
-    URL url = config.resolveNamespacedURLV3(String.format("apps/%s/%s/%s/live-info",
-                                                          appId, programType.getCategoryName(), programName));
+    String path = String.format("apps/%s/%s/%s/live-info", appId, programType.getCategoryName(), programName);
+    URL url = VersionMigrationUtils.resolveURL(config, programType, path);
     HttpResponse response = restClient.execute(HttpMethod.GET, url, config.getAccessToken(),
                                                HttpURLConnection.HTTP_NOT_FOUND);
     if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
@@ -309,7 +310,8 @@ public class ProgramClient {
   public int getProcedureInstances(String appId, String procedureId) throws IOException, NotFoundException,
     UnAuthorizedAccessTokenException {
 
-    URL url = config.resolveURL(String.format("apps/%s/procedures/%s/instances", appId, procedureId));
+    String path = String.format("apps/%s/procedures/%s/instances", appId, procedureId);
+    URL url = VersionMigrationUtils.resolveURL(config, ProgramType.PROCEDURE, path);
     HttpResponse response = restClient.execute(HttpMethod.GET, url, config.getAccessToken(),
                                                HttpURLConnection.HTTP_NOT_FOUND);
     if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
@@ -334,7 +336,8 @@ public class ProgramClient {
   public void setProcedureInstances(String appId, String procedureId, int instances)
     throws IOException, NotFoundException, UnAuthorizedAccessTokenException {
 
-    URL url = config.resolveURL(String.format("apps/%s/procedures/%s/instances", appId, procedureId));
+    String path = String.format("apps/%s/procedures/%s/instances", appId, procedureId);
+    URL url = VersionMigrationUtils.resolveURL(config, ProgramType.PROCEDURE, path);
     HttpRequest request = HttpRequest.put(url).withBody(GSON.toJson(new Instances(instances))).build();
 
     HttpResponse response = restClient.execute(request, config.getAccessToken(), HttpURLConnection.HTTP_NOT_FOUND);
@@ -413,9 +416,10 @@ public class ProgramClient {
                                        Constants.AppFabric.QUERY_PARAM_END_TIME, endTime,
                                        Constants.AppFabric.QUERY_PARAM_LIMIT, limit);
 
-    URL url = config.resolveNamespacedURLV3(String.format("apps/%s/%s/%s/runs?%s",
-                                                          appId, programType.getCategoryName(),
-                                                          programId, queryParams));
+    String path = String.format("apps/%s/%s/%s/runs?%s",
+                                appId, programType.getCategoryName(),
+                                programId, queryParams);
+    URL url = VersionMigrationUtils.resolveURL(config, programType, path);
 
     HttpResponse response = restClient.execute(HttpMethod.GET, url, config.getAccessToken(),
                                                HttpURLConnection.HTTP_NOT_FOUND);
@@ -445,9 +449,10 @@ public class ProgramClient {
                                        Constants.AppFabric.QUERY_PARAM_END_TIME, endTime,
                                        Constants.AppFabric.QUERY_PARAM_LIMIT, limit);
 
-    URL url = config.resolveNamespacedURLV3(String.format("apps/%s/%s/%s/runs?%s",
-                                                          appId, programType.getCategoryName(),
-                                                          programId, queryParams));
+    String path = String.format("apps/%s/%s/%s/runs?%s",
+                                appId, programType.getCategoryName(),
+                                programId, queryParams);
+    URL url = VersionMigrationUtils.resolveURL(config, programType, path);
 
     HttpResponse response = restClient.execute(HttpMethod.GET, url, config.getAccessToken(),
                                                HttpURLConnection.HTTP_NOT_FOUND);
@@ -475,9 +480,10 @@ public class ProgramClient {
   public String getProgramLogs(String appId, ProgramType programType, String programId, long start, long stop)
     throws IOException, NotFoundException, UnAuthorizedAccessTokenException {
 
-    URL url = config.resolveNamespacedURLV3(String.format("apps/%s/%s/%s/logs?start=%d&stop=%d",
-                                                          appId, programType.getCategoryName(),
-                                                          programId, start, stop));
+    String path = String.format("apps/%s/%s/%s/logs?start=%d&stop=%d",
+                                appId, programType.getCategoryName(),
+                                programId, start, stop);
+    URL url = VersionMigrationUtils.resolveURL(config, programType, path);
     HttpResponse response = restClient.execute(HttpMethod.GET, url, config.getAccessToken());
     if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
       throw new ProgramNotFoundException(programType, appId, programId);
@@ -527,8 +533,8 @@ public class ProgramClient {
   public Map<String, String> getRuntimeArgs(String appId, ProgramType programType, String programId)
     throws IOException, UnAuthorizedAccessTokenException, ProgramNotFoundException {
     String path = String.format("apps/%s/%s/%s/runtimeargs", appId, programType.getCategoryName(), programId);
-    HttpResponse response = restClient.execute(HttpMethod.GET, config.resolveNamespacedURLV3(path),
-                                               config.getAccessToken(),
+    URL url = VersionMigrationUtils.resolveURL(config, programType, path);
+    HttpResponse response = restClient.execute(HttpMethod.GET, url, config.getAccessToken(),
                                                HttpURLConnection.HTTP_NOT_FOUND);
     if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
       throw new ProgramNotFoundException(programType, appId, programId);
@@ -550,8 +556,8 @@ public class ProgramClient {
   public void setRuntimeArgs(String appId, ProgramType programType, String programId, Map<String, String> runtimeArgs)
     throws IOException, UnAuthorizedAccessTokenException, ProgramNotFoundException {
     String path = String.format("apps/%s/%s/%s/runtimeargs", appId, programType.getCategoryName(), programId);
-    HttpRequest request = HttpRequest.put(config.resolveNamespacedURLV3(path))
-      .withBody(GSON.toJson(runtimeArgs)).build();
+    URL url = VersionMigrationUtils.resolveURL(config, programType, path);
+    HttpRequest request = HttpRequest.put(url).withBody(GSON.toJson(runtimeArgs)).build();
     HttpResponse response = restClient.execute(request, config.getAccessToken(), HttpURLConnection.HTTP_NOT_FOUND);
     if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
       throw new ProgramNotFoundException(programType, appId, programId);

--- a/cdap-client/src/main/java/co/cask/cdap/client/util/VersionMigrationUtils.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/util/VersionMigrationUtils.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.client.util;
+
+import co.cask.cdap.client.config.ClientConfig;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.proto.ProgramType;
+import com.google.common.base.Preconditions;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+/**
+ * Utility methods used by CDAP Clients for CDAP API version migration
+ */
+public class VersionMigrationUtils {
+
+  private VersionMigrationUtils() {
+  }
+
+  /**
+   * @param config the config object being used by a client
+   * @return true if procedures are supported with the given configuration; false otherwise.
+   */
+  public static boolean isProcedureSupported(ClientConfig config) {
+    return Constants.DEFAULT_NAMESPACE.equals(config.getNamespace());
+  }
+
+  /**
+   * @param config the config object being used by a client
+   * @param programType the type of program being checked
+   * @return true if the programType is supported by the given configuration; false otherwise.
+   */
+  public static boolean isProgramSupported(ClientConfig config, ProgramType programType) {
+    return !(ProgramType.PROCEDURE == programType) || isProcedureSupported(config);
+  }
+
+  /**
+   * @throws IllegalStateException if procedures are not supported with the given configuration
+   * @param config the config object being used by a client
+   */
+  public static void assertProcedureSupported(ClientConfig config) {
+    Preconditions.checkState(isProcedureSupported(config),
+                             "Procedure operations are only supported in the default namespace.");
+  }
+
+  /**
+   * Uses v2 or v3 APIs depending on the program type, due to the fact that procedures are not supported in v3 APIs.
+   * @param config the config object being used by a client
+   * @param programType type of program on which an operation is being executed
+   * @param path endpoint attempted to hit
+   * @return resolved URL for the specified path
+   * @throws MalformedURLException
+   */
+  public static URL resolveURL(ClientConfig config, ProgramType programType, String path) throws MalformedURLException {
+    if (ProgramType.PROCEDURE == programType) {
+      VersionMigrationUtils.assertProcedureSupported(config);
+      return config.resolveURL(path);
+    } else {
+      return config.resolveNamespacedURLV3(path);
+    }
+  }
+}

--- a/cdap-client/src/main/java/co/cask/cdap/client/util/VersionMigrationUtils.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/util/VersionMigrationUtils.java
@@ -57,7 +57,7 @@ public class VersionMigrationUtils {
     Preconditions.checkState(isProcedureSupported(config),
                              "Procedure operations are only supported in the default namespace.");
     Preconditions.checkState(Constants.Gateway.API_VERSION_2_TOKEN.equals(config.getApiVersion()),
-                             "Procedure operations are only supported in V2 APIs");
+                             "Procedure operations are only supported in V2 APIs.");
   }
 
   /**

--- a/cdap-client/src/main/java/co/cask/cdap/client/util/VersionMigrationUtils.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/util/VersionMigrationUtils.java
@@ -56,6 +56,8 @@ public class VersionMigrationUtils {
   public static void assertProcedureSupported(ClientConfig config) {
     Preconditions.checkState(isProcedureSupported(config),
                              "Procedure operations are only supported in the default namespace.");
+    Preconditions.checkState(Constants.Gateway.API_VERSION_2_TOKEN.equals(config.getApiVersion()),
+                             "Procedure operations are only supported in V2 APIs");
   }
 
   /**


### PR DESCRIPTION
V3 procedure APIs will be removed.
In order to facilitate that, moving procedure operations from CLI + Client to hit the V2 endpoints.
These effective changes can be removed once procedures are completely removed from CDAP.

Now, from the CLI, procedure operations will only function if the user is in the default namespace. Otherwise, they will receive an error message:
```Error: Procedure operations are only supported in the default namespace.```

Build: http://builds.cask.co/browse/CDAP-DUT856-4