### PR TITLE
Feature/create namespace hbase init

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/NamespaceHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/NamespaceHttpHandler.java
@@ -105,10 +105,8 @@ public class NamespaceHttpHandler extends AbstractAppFabricHttpHandler {
 
     if (isReserved(namespaceId)) {
       responder.sendString(HttpResponseStatus.BAD_REQUEST,
-                           String.format("Cannot create namespace %s. '%s' and '%s' are reserved namespaces.",
-                                         namespaceId,
-                                         Constants.DEFAULT_NAMESPACE,
-                                         Constants.SYSTEM_NAMESPACE));
+                           String.format("Cannot delete the namespace '%s'. '%s' is a reserved namespace.",
+                                         namespaceId, namespaceId));
       return;
     }
 
@@ -147,10 +145,8 @@ public class NamespaceHttpHandler extends AbstractAppFabricHttpHandler {
   public void delete(HttpRequest request, HttpResponder responder, @PathParam("namespace-id") String namespace) {
     if (isReserved(namespace)) {
       responder.sendString(HttpResponseStatus.FORBIDDEN,
-                           String.format("Cannot delete namespace '%s'. '%s' and '%s' are reserved namespaces.",
-                                         namespace,
-                                         Constants.DEFAULT_NAMESPACE,
-                                         Constants.SYSTEM_NAMESPACE));
+                           String.format("Cannot delete the namespace '%s'. '%s' is a reserved namespace.",
+                                         namespace, namespace));
       return;
     }
     Id.Namespace namespaceId = Id.Namespace.from(namespace);
@@ -175,6 +171,7 @@ public class NamespaceHttpHandler extends AbstractAppFabricHttpHandler {
   }
 
   private boolean isReserved(String namespaceId) {
-    return Constants.DEFAULT_NAMESPACE.equals(namespaceId) || Constants.SYSTEM_NAMESPACE.equals(namespaceId);
+    return Constants.DEFAULT_NAMESPACE.equals(namespaceId) || Constants.SYSTEM_NAMESPACE.equals(namespaceId) ||
+      Constants.Logging.SYSTEM_NAME.equals(namespaceId);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/NamespaceAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/NamespaceAdmin.java
@@ -18,6 +18,7 @@ package co.cask.cdap.internal.app.namespace;
 
 import co.cask.cdap.common.exception.AlreadyExistsException;
 import co.cask.cdap.common.exception.NotFoundException;
+import co.cask.cdap.data2.dataset2.DatasetManagementException;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 
@@ -58,14 +59,16 @@ public interface NamespaceAdmin {
    *
    * @param metadata the {@link NamespaceMeta} for the new namespace to be created
    * @throws AlreadyExistsException if the specified namespace already exists
+   * @throws NamespaceCannotBeCreatedException if the creation operation was unsuccessful
    */
-  public void createNamespace(NamespaceMeta metadata) throws AlreadyExistsException, IOException;
+  public void createNamespace(NamespaceMeta metadata) throws AlreadyExistsException, NamespaceCannotBeCreatedException;
 
   /**
    * Deletes the specified namespace
    *
    * @param namespaceId the {@link Id.Namespace} of the specified namespace
    * @throws NotFoundException if the specified namespace does not exist
+   * @throws NamespaceCannotBeDeletedException if the deletion operation was unsuccessful
    */
-  public void deleteNamespace(Id.Namespace namespaceId) throws NotFoundException, IOException;
+  public void deleteNamespace(Id.Namespace namespaceId) throws NotFoundException, NamespaceCannotBeDeletedException;
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/NamespaceCannotBeCreatedException.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/NamespaceCannotBeCreatedException.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.namespace;
+
+/**
+ * Thrown when a namespace cannot be created due to errors.
+ * TODO: Make generic and move to common if its needed elsewhere
+ */
+public class NamespaceCannotBeCreatedException extends Exception {
+
+  private final String namespaceId;
+  private final String reason;
+
+  public NamespaceCannotBeCreatedException(String namespaceId, String reason) {
+    super(String.format("Namespace %s cannot be created. Reason: %s", namespaceId, reason));
+    this.namespaceId = namespaceId;
+    this.reason = reason;
+  }
+
+  public NamespaceCannotBeCreatedException(String namespaceId, Throwable cause) {
+    super(String.format("Namespace %s cannot be created. Reason: %s", namespaceId, cause.getMessage()), cause);
+    this.namespaceId = namespaceId;
+    this.reason = cause.getMessage();
+  }
+
+  public String getNamespaceId() {
+    return namespaceId;
+  }
+
+  public String getReason() {
+    return reason;
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/NamespaceCannotBeDeletedException.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/NamespaceCannotBeDeletedException.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.namespace;
+
+import co.cask.cdap.common.exception.CannotBeDeletedException;
+
+/**
+ * Thrown when a namespace cannot be deleted
+ */
+public final class NamespaceCannotBeDeletedException extends CannotBeDeletedException {
+
+  private final String namespaceId;
+
+  public NamespaceCannotBeDeletedException(String namespaceId, String reason) {
+    super("namespace", namespaceId, reason);
+    this.namespaceId = namespaceId;
+  }
+
+  public NamespaceCannotBeDeletedException(String namespaceId, Throwable cause) {
+    super("namespace", namespaceId, cause);
+    this.namespaceId = namespaceId;
+  }
+
+  public String getNamespaceId() {
+    return namespaceId;
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdminTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdminTest.java
@@ -33,7 +33,8 @@ public class DefaultNamespaceAdminTest extends AppFabricTestBase {
   private static final NamespaceAdmin namespaceAdmin = getInjector().getInstance(NamespaceAdmin.class);
 
   @Test
-  public void testNamespaces() throws AlreadyExistsException, IOException {
+  public void testNamespaces() throws AlreadyExistsException, IOException, NamespaceCannotBeCreatedException,
+    NamespaceCannotBeDeletedException {
     String namespace = "namespace";
     Id.Namespace namespaceId = Id.Namespace.from(namespace);
     NamespaceMeta.Builder builder = new NamespaceMeta.Builder();
@@ -63,7 +64,7 @@ public class DefaultNamespaceAdminTest extends AppFabricTestBase {
       namespaceAdmin.createNamespace(null);
       Assert.fail("Namespace with null metadata should fail.");
     } catch (IllegalArgumentException e) {
-      Assert.assertEquals("Namespace metadata cannot be null.", e.getMessage());
+      Assert.assertEquals("Namespace metadata should not be null.", e.getMessage());
     }
 
     Assert.assertEquals(initialCount, namespaceAdmin.listNamespaces().size());

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -701,6 +701,9 @@ public final class Constants {
   public static final String SYSTEM_NAMESPACE = "system";
   public static final Id.Namespace SYSTEM_NAMESPACE_ID = Id.Namespace.from(SYSTEM_NAMESPACE);
 
+  public static final String TRASH_LOCATION = "fs.trash.location";
+  public static final String DEFAULT_TRASH_LOCATION = ".Trash";
+
   /**
    * Constants related to external systems.
    */

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/CannotBeDeletedException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/CannotBeDeletedException.java
@@ -16,6 +16,8 @@
 
 package co.cask.cdap.common.exception;
 
+import javax.annotation.Nullable;
+
 /**
  * Thrown when an element cannot be deleted.
  */
@@ -23,9 +25,24 @@ public class CannotBeDeletedException extends Exception {
 
   private final String elementType;
   private final String elementId;
+  private String reason;
 
   public CannotBeDeletedException(String elementType, String elementId) {
-    super(String.format("Element '%s' of type '%s' cannot be deleted", elementId, elementType));
+    super(String.format("Element '%s' of type '%s' cannot be deleted.", elementId, elementType));
+    this.elementType = elementType;
+    this.elementId = elementId;
+  }
+
+  public CannotBeDeletedException(String elementType, String elementId, String reason) {
+    super(String.format("Element '%s' of type '%s' cannot be deleted. Reason: %s", elementId, elementType, reason));
+    this.elementType = elementType;
+    this.elementId = elementId;
+    this.reason = reason;
+  }
+
+  public CannotBeDeletedException(String elementType, String elementId, Throwable cause) {
+    super(String.format("Element '%s' of type '%s' cannot be deleted. Reason: %s",
+                        elementId, elementType, cause.getMessage()), cause);
     this.elementType = elementType;
     this.elementId = elementId;
   }
@@ -42,5 +59,13 @@ public class CannotBeDeletedException extends Exception {
    */
   public String getElementId() {
     return elementId;
+  }
+
+  /**
+   * @return the reason why the element cannot be deleted
+   */
+  @Nullable
+  public String getReason() {
+    return reason;
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataSetServiceModules.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataSetServiceModules.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -20,6 +20,9 @@ import co.cask.cdap.api.dataset.module.DatasetDefinitionRegistry;
 import co.cask.cdap.api.dataset.module.DatasetModule;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.datafabric.dataset.service.DatasetService;
+import co.cask.cdap.data2.datafabric.dataset.service.DistributedUnderlyingSystemNamespaceAdmin;
+import co.cask.cdap.data2.datafabric.dataset.service.LocalUnderlyingSystemNamespaceAdmin;
+import co.cask.cdap.data2.datafabric.dataset.service.UnderlyingSystemNamespaceAdmin;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetAdminOpHTTPHandler;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetAdminOpHTTPHandlerV2;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetOpExecutor;
@@ -118,6 +121,9 @@ public class DataSetServiceModules {
 
         bind(DatasetOpExecutor.class).to(LocalDatasetOpExecutor.class);
         expose(DatasetOpExecutor.class);
+
+        bind(UnderlyingSystemNamespaceAdmin.class).to(LocalUnderlyingSystemNamespaceAdmin.class);
+        expose(UnderlyingSystemNamespaceAdmin.class);
       }
     };
 
@@ -165,6 +171,9 @@ public class DataSetServiceModules {
 
         bind(DatasetOpExecutor.class).to(LocalDatasetOpExecutor.class);
         expose(DatasetOpExecutor.class);
+
+        bind(UnderlyingSystemNamespaceAdmin.class).to(LocalUnderlyingSystemNamespaceAdmin.class);
+        expose(UnderlyingSystemNamespaceAdmin.class);
       }
     };
 
@@ -214,6 +223,9 @@ public class DataSetServiceModules {
 
         bind(DatasetOpExecutor.class).to(YarnDatasetOpExecutor.class);
         expose(DatasetOpExecutor.class);
+
+        bind(UnderlyingSystemNamespaceAdmin.class).to(DistributedUnderlyingSystemNamespaceAdmin.class);
+        expose(UnderlyingSystemNamespaceAdmin.class);
       }
     };
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
@@ -213,6 +213,22 @@ class DatasetServiceClient {
     }
   }
 
+  public void createNamespace() throws DatasetManagementException {
+    HttpResponse response = doPut("admin/create", GSON.toJson(namespaceId));
+    if (HttpResponseStatus.OK.getCode() != response.getResponseCode()) {
+      throw new DatasetManagementException(String.format("Failed to create namespace, details: %s",
+                                                         getDetails(response)));
+    }
+  }
+
+  public void deleteNamespace() throws DatasetManagementException {
+    HttpResponse response = doDelete("admin/delete");
+    if (HttpResponseStatus.OK.getCode() != response.getResponseCode()) {
+      throw new DatasetManagementException(String.format("Failed to delete namespace, details: %s",
+                                                         getDetails(response)));
+    }
+  }
+
   private HttpResponse doGet(String resource) throws DatasetManagementException {
     return doRequest(HttpMethod.GET, resource);
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFramework.java
@@ -199,6 +199,16 @@ public class RemoteDatasetFramework implements DatasetFramework {
     return (T) type.getDataset(instanceInfo.getSpec(), arguments);
   }
 
+  @Override
+  public void createNamespace(Id.Namespace namespaceId) throws DatasetManagementException {
+    clientCache.getUnchecked(namespaceId).createNamespace();
+  }
+
+  @Override
+  public void deleteNamespace(Id.Namespace namespaceId) throws DatasetManagementException {
+    clientCache.getUnchecked(namespaceId).deleteNamespace();
+  }
+
   private void addModule(Id.DatasetModule moduleId, Class<?> typeClass) throws DatasetManagementException {
     try {
       File tempFile = File.createTempFile(typeClass.getName(), ".jar");

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetService.java
@@ -81,7 +81,8 @@ public class DatasetService extends AbstractExecutionThreadService {
                         DatasetOpExecutor opExecutorClient,
                         MDSDatasetsRegistry mdsDatasets,
                         ExploreFacade exploreFacade,
-                        Set<DatasetMetricsReporter> metricReporters) throws Exception {
+                        Set<DatasetMetricsReporter> metricReporters,
+                        UnderlyingSystemNamespaceAdmin underlyingSystemNamespaceAdmin) throws Exception {
 
     this.typeManager = typeManager;
     DatasetTypeHandler datasetTypeHandler = new DatasetTypeHandler(typeManager, locationFactory, cConf);
@@ -89,9 +90,12 @@ public class DatasetService extends AbstractExecutionThreadService {
     DatasetInstanceHandler datasetInstanceHandler = new DatasetInstanceHandler(typeManager, instanceManager,
                                                                                opExecutorClient, exploreFacade, cConf);
     DatasetInstanceHandlerV2 datasetInstanceHandlerV2 = new DatasetInstanceHandlerV2(datasetInstanceHandler);
+    UnderlyingSystemNamespaceHandler underlyingSystemNamespaceHandler =
+      new UnderlyingSystemNamespaceHandler(underlyingSystemNamespaceAdmin);
     NettyHttpService.Builder builder = new CommonNettyHttpServiceBuilder(cConf);
     builder.addHttpHandlers(ImmutableList.of(datasetTypeHandler, datasetTypeHandlerV2,
-                                             datasetInstanceHandler, datasetInstanceHandlerV2));
+                                             datasetInstanceHandler, datasetInstanceHandlerV2,
+                                             underlyingSystemNamespaceHandler));
 
     builder.setHandlerHooks(ImmutableList.of(new MetricsReporterHook(metricsCollectionService,
                                                                      Constants.Service.DATASET_MANAGER)));

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DistributedUnderlyingSystemNamespaceAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DistributedUnderlyingSystemNamespaceAdmin.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.datafabric.dataset.service;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
+import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
+import co.cask.cdap.proto.Id;
+import com.google.inject.Inject;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.hadoop.hbase.client.HBaseAdmin;
+import org.apache.twill.filesystem.LocationFactory;
+
+import java.io.IOException;
+
+/**
+ * Manages namespaces on underlying systems - HDFS, HBase, Hive, etc.
+ */
+public final class DistributedUnderlyingSystemNamespaceAdmin extends UnderlyingSystemNamespaceAdmin {
+
+  private final Configuration hConf;
+  private final HBaseTableUtil tableUtil;
+  private HBaseAdmin hBaseAdmin;
+
+  @Inject
+  public DistributedUnderlyingSystemNamespaceAdmin(CConfiguration cConf, LocationFactory locationFactory) {
+    super(cConf, locationFactory);
+    this.hConf = HBaseConfiguration.create();
+    this.tableUtil = new HBaseTableUtilFactory().get();
+  }
+
+  @Override
+  public void create(Id.Namespace namespaceId) throws IOException {
+    // create filesystem directory
+    super.create(namespaceId);
+    // TODO: CDAP-1519: Create base directory for filesets under namespace home
+    // create HBase namespace
+    tableUtil.createNamespaceIfNotExists(getAdmin(), namespaceId);
+  }
+
+  @Override
+  public void delete(Id.Namespace namespaceId) throws IOException {
+    // soft delete namespace directory from filesystem
+    super.delete(namespaceId);
+    // delete HBase namespace
+    tableUtil.deleteNamespaceIfExists(getAdmin(), Id.Namespace.from(namespaceId.getId()));
+  }
+
+  private HBaseAdmin getAdmin() throws IOException {
+    if (hBaseAdmin == null) {
+      hBaseAdmin = new HBaseAdmin(hConf);
+    }
+    return hBaseAdmin;
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/LocalUnderlyingSystemNamespaceAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/LocalUnderlyingSystemNamespaceAdmin.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.datafabric.dataset.service;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import com.google.inject.Inject;
+import org.apache.twill.filesystem.LocationFactory;
+
+/**
+ * Manages namespaces on local underlying systems.
+ */
+public final class LocalUnderlyingSystemNamespaceAdmin extends UnderlyingSystemNamespaceAdmin {
+
+  @Inject
+  public LocalUnderlyingSystemNamespaceAdmin(CConfiguration cConf, LocationFactory locationFactory) {
+    super(cConf, locationFactory);
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/UnderlyingSystemNamespaceAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/UnderlyingSystemNamespaceAdmin.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.datafabric.dataset.service;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.io.Locations;
+import co.cask.cdap.proto.Id;
+import org.apache.twill.filesystem.Location;
+import org.apache.twill.filesystem.LocationFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+/**
+ * Performs namespace admin operations on underlying storage (HBase, Filesystem, Hive, etc)
+ */
+public class UnderlyingSystemNamespaceAdmin {
+  private static final Logger LOG = LoggerFactory.getLogger(UnderlyingSystemNamespaceAdmin.class);
+
+  private final CConfiguration cConf;
+  private final LocationFactory locationFactory;
+
+  protected UnderlyingSystemNamespaceAdmin(CConfiguration cConf, LocationFactory locationFactory) {
+    this.cConf = cConf;
+    this.locationFactory = locationFactory;
+  }
+
+  /**
+   * Create a namespace in the underlying system.
+   * Can perform operations such as creating directories, creating namespaces, etc.
+   * The default implementation creates the namespace directory on the filesystem.
+   * Subclasses can override to add more logic such as create namespaces in HBase, etc.
+   *
+   * @param namespaceId {@link Id.Namespace} for the namespace to create
+   * @throws IOException if there are errors while creating the namespace
+   */
+  protected void create(Id.Namespace namespaceId) throws IOException {
+    Location namespaceHome = locationFactory.create(namespaceId.getId());
+    if (namespaceHome.exists()) {
+      throw new IOException(String.format("Home directory '%s' for namespace '%s' already exists.",
+                                          namespaceHome.toURI().toString(), namespaceId));
+    }
+    if (!namespaceHome.mkdirs()) {
+      throw new IOException(String.format("Error while creating home directory '%s' for namesapce '%s'",
+                                          namespaceHome.toURI().toString(), namespaceId));
+    }
+  }
+
+  /**
+   * Delete a namespace from the underlying system
+   * Can perform operations such as deleting directories, deleting namespaces, etc.
+   * The default implementation soft deletes the namespace directory on the filesystem.
+   * Subclasses can override to add more logic such as delete namespaces in HBase, etc.
+   *
+   * @param namespaceId {@link Id.Namespace} for the namespace to delete
+   * @throws IOException if there are errors while deleting the namespace
+   */
+  protected void delete(Id.Namespace namespaceId) throws IOException {
+    Location namespaceHome = locationFactory.create(namespaceId.getId());
+    Location trashLocation = locationFactory.create(cConf.get(Constants.TRASH_LOCATION,
+                                                              Constants.DEFAULT_TRASH_LOCATION));
+    Locations.mkdirsIfNotExists(trashLocation);
+    if (namespaceHome.exists()) {
+      if (namespaceHome.renameTo(trashLocation.append(namespaceId.getId())) == null) {
+        throw new IOException(String.format("Error while deleting home directory '%s' for namespace '%s'",
+                                            namespaceHome.toURI().toString(), namespaceId.getId()));
+      }
+    } else {
+      // warn that namespace home was not found and skip delete step
+      LOG.warn(String.format("Home directory '%s' for namespace '%s' does not exist.",
+                             namespaceHome.toURI().toString(), namespaceId));
+    }
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/UnderlyingSystemNamespaceHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/UnderlyingSystemNamespaceHandler.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.datafabric.dataset.service;
+
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.proto.Id;
+import co.cask.http.AbstractHttpHandler;
+import co.cask.http.HttpHandler;
+import co.cask.http.HttpResponder;
+import com.google.inject.Inject;
+import org.jboss.netty.handler.codec.http.HttpRequest;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+
+import java.io.IOException;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+/**
+ * {@link HttpHandler} for admin operations on underlying systems - Filesystem, HBase, Hive.
+ */
+@Path(Constants.Gateway.API_VERSION_3 + "/namespaces/{namespace-id}")
+public class UnderlyingSystemNamespaceHandler extends AbstractHttpHandler {
+
+  private final UnderlyingSystemNamespaceAdmin underlyingSystemNamespaceAdmin;
+
+  @Inject
+  public UnderlyingSystemNamespaceHandler(UnderlyingSystemNamespaceAdmin underlyingSystemNamespaceAdmin) {
+    this.underlyingSystemNamespaceAdmin = underlyingSystemNamespaceAdmin;
+  }
+
+  @PUT
+  @Path("/data/admin/create")
+  public void createNamespace(HttpRequest request, HttpResponder responder,
+                              @PathParam("namespace-id") String namespaceId) {
+    try {
+      underlyingSystemNamespaceAdmin.create(Id.Namespace.from(namespaceId));
+    } catch (IOException e) {
+      responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR,
+                           "Error while creating namespace - " + e.getMessage());
+      return;
+    }
+    responder.sendString(HttpResponseStatus.OK,
+                         String.format("Created namespace %s successfully", namespaceId));
+  }
+
+  @DELETE
+  @Path("/data/admin/delete")
+  public void deleteNamespace(HttpRequest request, HttpResponder responder,
+                              @PathParam("namespace-id") String namespaceId) {
+    try {
+      underlyingSystemNamespaceAdmin.delete(Id.Namespace.from(namespaceId));
+    } catch (IOException e) {
+      responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR,
+                           "Error while deleting namespace - " + e.getMessage());
+      return;
+    }
+    responder.sendString(HttpResponseStatus.OK,
+                         String.format("Deleted namespace %s successfully", namespaceId));
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DatasetFramework.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -200,4 +200,8 @@ public interface DatasetFramework {
   <T extends Dataset> T getDataset(Id.DatasetInstance datasetInstanceId, @Nullable Map<String, String> arguments,
                                    @Nullable ClassLoader classLoader)
     throws DatasetManagementException, IOException;
+
+  void createNamespace(Id.Namespace namespaceId) throws DatasetManagementException;
+
+  void deleteNamespace(Id.Namespace namespaceId) throws DatasetManagementException;
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/InMemoryDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/InMemoryDatasetFramework.java
@@ -61,6 +61,7 @@ public class InMemoryDatasetFramework implements DatasetFramework {
   private final Set<String> defaultTypes = Sets.newHashSet();
   private final Map<Id.Namespace, List<String>> nonDefaultTypes = Maps.newHashMap();
   private final Map<Id.DatasetInstance, DatasetSpecification> instances = Maps.newHashMap();
+  private final List<Id.Namespace> namespaces = Lists.newArrayList();
 
   // NOTE: used only for "internal" operations, that doesn't return to client object of custom type
   // NOTE: for getting dataset/admin objects we construct fresh new one using all modules (no dependency management in
@@ -338,6 +339,22 @@ public class InMemoryDatasetFramework implements DatasetFramework {
       return registry;
     }
     return null;
+  }
+
+  @Override
+  public synchronized void createNamespace(Id.Namespace namespaceId) throws DatasetManagementException {
+    if (namespaces.contains(namespaceId)) {
+      throw new DatasetManagementException(String.format("Namespace %s already exists.", namespaceId.getId()));
+    }
+    namespaces.add(namespaceId);
+  }
+
+  @Override
+  public synchronized void deleteNamespace(Id.Namespace namespaceId) throws DatasetManagementException {
+    if (!namespaces.contains(namespaceId)) {
+      throw new DatasetManagementException(String.format("Namespace %s does not exist", namespaceId.getId()));
+    }
+    namespaces.remove(namespaceId);
   }
 
   // NOTE: this class is needed to collect all types added by a module

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/NamespacedDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/NamespacedDatasetFramework.java
@@ -136,6 +136,16 @@ public class NamespacedDatasetFramework implements DatasetFramework {
     return delegate.getDataset(namespace(datasetInstanceId), arguments, classLoader);
   }
 
+  @Override
+  public void createNamespace(Id.Namespace namespaceId) throws DatasetManagementException {
+    delegate.createNamespace(namespaceId);
+  }
+
+  @Override
+  public void deleteNamespace(Id.Namespace namespaceId) throws DatasetManagementException {
+    delegate.deleteNamespace(namespaceId);
+  }
+
   @Nullable
   private DatasetSpecification fromNamespaced(Id.Namespace namespaceId, @Nullable DatasetSpecification spec) {
     if (spec == null) {

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
@@ -147,7 +147,8 @@ public abstract class DatasetServiceTestBase {
                                  new InMemoryDatasetOpExecutor(dsFramework),
                                  mdsDatasetsRegistry,
                                  new ExploreFacade(new DiscoveryExploreClient(discoveryService), cConf),
-                                 new HashSet<DatasetMetricsReporter>());
+                                 new HashSet<DatasetMetricsReporter>(),
+                                 new LocalUnderlyingSystemNamespaceAdmin(cConf, locationFactory));
 
     // Start dataset service, wait for it to be discoverable
     service.start();
@@ -188,6 +189,12 @@ public abstract class DatasetServiceTestBase {
 
   protected URL getUrl(String resource) throws MalformedURLException {
     return new URL("http://" + "localhost" + ":" + getPort() + Constants.Gateway.API_VERSION_2 + resource);
+  }
+
+  protected URL getUnderlyingNamespaceAdminUrl(String namespace, String operation) throws MalformedURLException {
+    String resource = String.format("%s/namespaces/%s/data/admin/%s",
+                                    Constants.Gateway.API_VERSION_3, namespace, operation);
+    return new URL("http://" + "localhost" + ":" + getPort() + resource);
   }
 
   protected int deployModule(String moduleName, Class moduleClass) throws Exception {

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/UnderlyingSystemNamespaceHandlerTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/UnderlyingSystemNamespaceHandlerTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.datafabric.dataset.service;
+
+import co.cask.common.http.HttpRequest;
+import co.cask.common.http.HttpRequests;
+import co.cask.common.http.HttpResponse;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+/**
+ * Tests for {@link UnderlyingSystemNamespaceHandler}
+ */
+public class UnderlyingSystemNamespaceHandlerTest extends DatasetServiceTestBase {
+
+  @Test
+  public void test() throws IOException {
+    Assert.assertEquals(200, createNamespace("myspace").getResponseCode());
+    Assert.assertEquals(500, createNamespace("myspace").getResponseCode());
+    Assert.assertEquals(200, deleteNamespace("myspace").getResponseCode());
+  }
+
+  private HttpResponse createNamespace(String namespaceId) throws IOException {
+    HttpRequest request = HttpRequest.put(getUnderlyingNamespaceAdminUrl(namespaceId, "create")).build();
+    return HttpRequests.execute(request);
+  }
+
+  private HttpResponse deleteNamespace(String namespaceId) throws IOException {
+    HttpRequest request = HttpRequest.delete(getUnderlyingNamespaceAdminUrl(namespaceId, "delete")).build();
+    return HttpRequests.execute(request);
+  }
+}

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/AbstractDatasetFrameworkTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/AbstractDatasetFrameworkTest.java
@@ -288,4 +288,18 @@ public abstract class AbstractDatasetFrameworkTest {
     Assert.assertFalse(framework.hasType(tableType));
     Assert.assertFalse(framework.hasType(simpleKvType));
   }
+
+  @Test
+  public void testNamespaces() throws DatasetManagementException {
+    DatasetFramework framework = getFramework();
+
+    Id.Namespace namespace = Id.Namespace.from("yourspace");
+    framework.createNamespace(namespace);
+    try {
+      framework.createNamespace(namespace);
+      Assert.fail("Should not be able to create a duplicate namespace");
+    } catch (DatasetManagementException e) {
+    }
+    framework.deleteNamespace(namespace);
+  }
 }


### PR DESCRIPTION
Summary:

Jira: https://issues.cask.co/browse/CDAP-903

1. Added ``UnderlyingSystemNamespaceHandler`` (for lack of a better name) to manage namespaces in underlying systems that CDAP uses. The handler will run in ``DatasetService``.
2. Added methods in ``DatasetFramework`` to create/delete namespaces in underlying systems by making calls to endpoints in ``UnderlyingSystemNamespaceHandler``.
3. Namespace create endpoint now creates the ``/cdap/[ns-id]`` directory and the ``cdap_[ns-id]`` Hbase namespace (if HBase namespaces are available) using ``DatasetFramework``.
4. Namespace delete is now governed by the **unrecoverable** parameter. If that is not set, it will abort delete. If set, it will try to delete all the elements that the namespace contains.
5. Improved ``CannotBeDeletedException`` by adding *reason* and *cause* fields.
6. Added "cdap" to the list of reserved namespaces. As a related minor fix, also fixed https://issues.cask.co/browse/CDAP-1430

Build: https://builds.cask.co/browse/CDAP-DUT858-3