### PR TITLE
 (CDAP-1516) Namespace Explore operations

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/CreateStreamsStage.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/CreateStreamsStage.java
@@ -58,7 +58,7 @@ public class CreateStreamsStage extends AbstractStage<ApplicationDeployable> {
       if (!streamAdmin.exists(streamId)) {
         streamAdmin.create(streamId);
         if (enableExplore) {
-          exploreFacade.enableExploreStream(streamName);
+          exploreFacade.enableExploreStream(streamId);
         }
       }
     }

--- a/cdap-client/src/main/java/co/cask/cdap/client/QueryClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/QueryClient.java
@@ -20,6 +20,7 @@ import co.cask.cdap.client.config.ClientConfig;
 import co.cask.cdap.explore.client.ExploreClient;
 import co.cask.cdap.explore.client.ExploreExecutionResult;
 import co.cask.cdap.explore.client.SuppliedAddressExploreClient;
+import co.cask.cdap.proto.Id;
 import com.google.common.base.Supplier;
 import com.google.common.util.concurrent.ListenableFuture;
 
@@ -30,10 +31,13 @@ import javax.inject.Inject;
  */
 public class QueryClient {
 
+  private final ClientConfig config;
   private final ExploreClient exploreClient;
 
   @Inject
   public QueryClient(final ClientConfig config) {
+    this.config = config;
+
     Supplier<String> hostname = new Supplier<String>() {
       @Override
       public String get() {
@@ -59,7 +63,7 @@ public class QueryClient {
       }
     };
 
-    this.exploreClient = new SuppliedAddressExploreClient(hostname, port, accessToken);
+    exploreClient = new SuppliedAddressExploreClient(hostname, port, accessToken);
   }
 
   /**
@@ -71,6 +75,6 @@ public class QueryClient {
    *         network error occurs, if the query is malformed, or if the query is cancelled.
    */
   public ListenableFuture<ExploreExecutionResult> execute(String query) {
-    return exploreClient.submit(query);
+    return exploreClient.submit(Id.Namespace.from(config.getNamespace()), query);
   }
 }

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -578,6 +578,7 @@ public final class Constants {
     public static final String START_ON_DEMAND = "explore.start.on.demand";
 
     public static final String DATASET_NAME = "explore.dataset.name";
+    public static final String DATASET_NAMESPACE = "explore.dataset.namespace";
     public static final String DATASET_STORAGE_HANDLER_CLASS = "co.cask.cdap.hive.datasets.DatasetStorageHandler";
     public static final String STREAM_NAME = "explore.stream.name";
     public static final String STREAM_NAMESPACE = "explore.stream.namespace";

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandler.java
@@ -19,7 +19,6 @@ package co.cask.cdap.data2.datafabric.dataset.service;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.dataset.table.Table;
-import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.exception.HandlerException;
 import co.cask.cdap.data2.datafabric.dataset.instance.DatasetInstanceManager;
@@ -77,17 +76,13 @@ public class DatasetInstanceHandler extends AbstractHttpHandler {
   private final DatasetOpExecutor opExecutorClient;
   private final ExploreFacade exploreFacade;
 
-  private final CConfiguration conf;
-
   @Inject
   public DatasetInstanceHandler(DatasetTypeManager implManager, DatasetInstanceManager instanceManager,
-                                DatasetOpExecutor opExecutorClient, ExploreFacade exploreFacade,
-                                CConfiguration conf) {
+                                DatasetOpExecutor opExecutorClient, ExploreFacade exploreFacade) {
     this.opExecutorClient = opExecutorClient;
     this.implManager = implManager;
     this.instanceManager = instanceManager;
     this.exploreFacade = exploreFacade;
-    this.conf = conf;
   }
 
   @GET
@@ -139,16 +134,17 @@ public class DatasetInstanceHandler extends AbstractHttpHandler {
       return;
     }
 
+    Id.DatasetInstance datasetInstance = Id.DatasetInstance.from(namespaceId, name);
     // Disable explore if the table already existed
     if (existing != null) {
-      disableExplore(name);
+      disableExplore(datasetInstance);
     }
 
     if (!createDatasetInstance(creationProperties, namespaceId, name, responder, "create")) {
       return;
     }
 
-    enableExplore(name, creationProperties);
+    enableExplore(datasetInstance, creationProperties);
 
     responder.sendStatus(HttpResponseStatus.OK);
   }
@@ -182,13 +178,14 @@ public class DatasetInstanceHandler extends AbstractHttpHandler {
       return;
     }
 
-    disableExplore(name);
+    Id.DatasetInstance datasetInstance = Id.DatasetInstance.from(namespaceId, name);
+    disableExplore(datasetInstance);
 
     if (!createDatasetInstance(creationProperties, namespaceId, name, responder, "update")) {
       return;
     }
 
-    enableExplore(name, creationProperties);
+    enableExplore(datasetInstance, creationProperties);
 
     //caling admin upgrade, after updating specification
     executeAdmin(request, responder, namespaceId, name, "upgrade");
@@ -330,9 +327,7 @@ public class DatasetInstanceHandler extends AbstractHttpHandler {
    * @throws Exception on error.
    */
   private boolean dropDataset(Id.DatasetInstance datasetInstanceId, DatasetSpecification spec) throws Exception {
-    String name = spec.getName();
-
-    disableExplore(name);
+    disableExplore(datasetInstanceId);
 
     if (!instanceManager.delete(datasetInstanceId)) {
       return false;
@@ -346,15 +341,14 @@ public class DatasetInstanceHandler extends AbstractHttpHandler {
     return true;
   }
 
-  // TODO: Needs to be namespaced
-  private void disableExplore(String name) {
+  private void disableExplore(Id.DatasetInstance datasetInstance) {
     // Disable ad-hoc exploration of dataset
     // Note: today explore enable is not transactional with dataset create - CDAP-8
     try {
-      exploreFacade.disableExploreDataset(name);
+      exploreFacade.disableExploreDataset(datasetInstance);
     } catch (Exception e) {
       String msg = String.format("Cannot disable exploration of dataset instance %s: %s",
-                                 name, e.getMessage());
+                                 datasetInstance, e.getMessage());
       LOG.error(msg, e);
       // TODO: at this time we want to still allow using dataset even if it cannot be used for exploration
       //responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, msg);
@@ -362,14 +356,14 @@ public class DatasetInstanceHandler extends AbstractHttpHandler {
     }
   }
 
-  private void enableExplore(String name, DatasetInstanceConfiguration creationProperties) {
+  private void enableExplore(Id.DatasetInstance datasetInstance, DatasetInstanceConfiguration creationProperties) {
     // Enable ad-hoc exploration of dataset
     // Note: today explore enable is not transactional with dataset create - CDAP-8
     try {
-      exploreFacade.enableExploreDataset(name);
+      exploreFacade.enableExploreDataset(datasetInstance);
     } catch (Exception e) {
       String msg = String.format("Cannot enable exploration of dataset instance %s of type %s: %s",
-                                 name, creationProperties.getProperties(), e.getMessage());
+                                 datasetInstance, creationProperties.getProperties(), e.getMessage());
       LOG.error(msg, e);
       // TODO: at this time we want to still allow using dataset even if it cannot be used for exploration
       //responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, msg);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetService.java
@@ -88,7 +88,7 @@ public class DatasetService extends AbstractExecutionThreadService {
     DatasetTypeHandler datasetTypeHandler = new DatasetTypeHandler(typeManager, locationFactory, cConf);
     DatasetTypeHandlerV2 datasetTypeHandlerV2 = new DatasetTypeHandlerV2(datasetTypeHandler);
     DatasetInstanceHandler datasetInstanceHandler = new DatasetInstanceHandler(typeManager, instanceManager,
-                                                                               opExecutorClient, exploreFacade, cConf);
+                                                                               opExecutorClient, exploreFacade);
     DatasetInstanceHandlerV2 datasetInstanceHandlerV2 = new DatasetInstanceHandlerV2(datasetInstanceHandler);
     UnderlyingSystemNamespaceHandler underlyingSystemNamespaceHandler =
       new UnderlyingSystemNamespaceHandler(underlyingSystemNamespaceAdmin);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DistributedUnderlyingSystemNamespaceAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DistributedUnderlyingSystemNamespaceAdmin.java
@@ -19,6 +19,8 @@ package co.cask.cdap.data2.datafabric.dataset.service;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
+import co.cask.cdap.explore.client.ExploreFacade;
+import co.cask.cdap.explore.service.ExploreException;
 import co.cask.cdap.proto.Id;
 import com.google.inject.Inject;
 import org.apache.hadoop.conf.Configuration;
@@ -27,6 +29,7 @@ import org.apache.hadoop.hbase.client.HBaseAdmin;
 import org.apache.twill.filesystem.LocationFactory;
 
 import java.io.IOException;
+import java.sql.SQLException;
 
 /**
  * Manages namespaces on underlying systems - HDFS, HBase, Hive, etc.
@@ -38,14 +41,15 @@ public final class DistributedUnderlyingSystemNamespaceAdmin extends UnderlyingS
   private HBaseAdmin hBaseAdmin;
 
   @Inject
-  public DistributedUnderlyingSystemNamespaceAdmin(CConfiguration cConf, LocationFactory locationFactory) {
-    super(cConf, locationFactory);
+  public DistributedUnderlyingSystemNamespaceAdmin(CConfiguration cConf, LocationFactory locationFactory,
+                                                   ExploreFacade exploreFacade) {
+    super(cConf, locationFactory, exploreFacade);
     this.hConf = HBaseConfiguration.create();
     this.tableUtil = new HBaseTableUtilFactory().get();
   }
 
   @Override
-  public void create(Id.Namespace namespaceId) throws IOException {
+  public void create(Id.Namespace namespaceId) throws IOException, ExploreException, SQLException {
     // create filesystem directory
     super.create(namespaceId);
     // TODO: CDAP-1519: Create base directory for filesets under namespace home
@@ -54,7 +58,7 @@ public final class DistributedUnderlyingSystemNamespaceAdmin extends UnderlyingS
   }
 
   @Override
-  public void delete(Id.Namespace namespaceId) throws IOException {
+  public void delete(Id.Namespace namespaceId) throws IOException, ExploreException, SQLException {
     // soft delete namespace directory from filesystem
     super.delete(namespaceId);
     // delete HBase namespace

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/LocalUnderlyingSystemNamespaceAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/LocalUnderlyingSystemNamespaceAdmin.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.data2.datafabric.dataset.service;
 
 import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.explore.client.ExploreFacade;
 import com.google.inject.Inject;
 import org.apache.twill.filesystem.LocationFactory;
 
@@ -26,7 +27,8 @@ import org.apache.twill.filesystem.LocationFactory;
 public final class LocalUnderlyingSystemNamespaceAdmin extends UnderlyingSystemNamespaceAdmin {
 
   @Inject
-  public LocalUnderlyingSystemNamespaceAdmin(CConfiguration cConf, LocationFactory locationFactory) {
-    super(cConf, locationFactory);
+  public LocalUnderlyingSystemNamespaceAdmin(CConfiguration cConf, LocationFactory locationFactory,
+                                             ExploreFacade exploreFacade) {
+    super(cConf, locationFactory, exploreFacade);
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/UnderlyingSystemNamespaceAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/UnderlyingSystemNamespaceAdmin.java
@@ -18,7 +18,8 @@ package co.cask.cdap.data2.datafabric.dataset.service;
 
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
-import co.cask.cdap.common.io.Locations;
+import co.cask.cdap.explore.client.ExploreFacade;
+import co.cask.cdap.explore.service.ExploreException;
 import co.cask.cdap.proto.Id;
 import org.apache.twill.filesystem.Location;
 import org.apache.twill.filesystem.LocationFactory;
@@ -26,6 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.sql.SQLException;
 
 /**
  * Performs namespace admin operations on underlying storage (HBase, Filesystem, Hive, etc)
@@ -35,10 +37,13 @@ public class UnderlyingSystemNamespaceAdmin {
 
   private final CConfiguration cConf;
   private final LocationFactory locationFactory;
+  private final ExploreFacade exploreFacade;
 
-  protected UnderlyingSystemNamespaceAdmin(CConfiguration cConf, LocationFactory locationFactory) {
+  protected UnderlyingSystemNamespaceAdmin(CConfiguration cConf, LocationFactory locationFactory,
+                                           ExploreFacade exploreFacade) {
     this.cConf = cConf;
     this.locationFactory = locationFactory;
+    this.exploreFacade = exploreFacade;
   }
 
   /**
@@ -50,7 +55,7 @@ public class UnderlyingSystemNamespaceAdmin {
    * @param namespaceId {@link Id.Namespace} for the namespace to create
    * @throws IOException if there are errors while creating the namespace
    */
-  protected void create(Id.Namespace namespaceId) throws IOException {
+  protected void create(Id.Namespace namespaceId) throws IOException, ExploreException, SQLException {
     Location namespaceHome = locationFactory.create(namespaceId.getId());
     if (namespaceHome.exists()) {
       throw new IOException(String.format("Home directory '%s' for namespace '%s' already exists.",
@@ -59,6 +64,10 @@ public class UnderlyingSystemNamespaceAdmin {
     if (!namespaceHome.mkdirs()) {
       throw new IOException(String.format("Error while creating home directory '%s' for namesapce '%s'",
                                           namespaceHome.toURI().toString(), namespaceId));
+    }
+
+    if (cConf.getBoolean(Constants.Explore.EXPLORE_ENABLED)) {
+      exploreFacade.createNamespace(namespaceId);
     }
   }
 
@@ -71,7 +80,7 @@ public class UnderlyingSystemNamespaceAdmin {
    * @param namespaceId {@link Id.Namespace} for the namespace to delete
    * @throws IOException if there are errors while deleting the namespace
    */
-  protected void delete(Id.Namespace namespaceId) throws IOException {
+  protected void delete(Id.Namespace namespaceId) throws IOException, ExploreException, SQLException {
     // TODO: CDAP-1581: Implement soft delete
     Location namespaceHome = locationFactory.create(namespaceId.getId());
     if (namespaceHome.exists() && !namespaceHome.delete(true)) {
@@ -81,6 +90,10 @@ public class UnderlyingSystemNamespaceAdmin {
       // warn that namespace home was not found and skip delete step
       LOG.warn(String.format("Home directory '%s' for namespace '%s' does not exist.",
                              namespaceHome.toURI().toString(), namespaceId));
+    }
+
+    if (cConf.getBoolean(Constants.Explore.EXPLORE_ENABLED)) {
+      exploreFacade.removeNamespace(namespaceId);
     }
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/UnderlyingSystemNamespaceHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/UnderlyingSystemNamespaceHandler.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.data2.datafabric.dataset.service;
 
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.explore.service.ExploreException;
 import co.cask.cdap.proto.Id;
 import co.cask.http.AbstractHttpHandler;
 import co.cask.http.HttpHandler;
@@ -26,6 +27,7 @@ import org.jboss.netty.handler.codec.http.HttpRequest;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 
 import java.io.IOException;
+import java.sql.SQLException;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
@@ -54,6 +56,14 @@ public class UnderlyingSystemNamespaceHandler extends AbstractHttpHandler {
       responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR,
                            "Error while creating namespace - " + e.getMessage());
       return;
+    } catch (ExploreException e) {
+      responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR,
+                           "Error while creating namespace in Hive - " + e.getMessage());
+      return;
+    } catch (SQLException e) {
+      responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR,
+                           "Error while creating namespace in Hive - " + e.getMessage());
+      return;
     }
     responder.sendString(HttpResponseStatus.OK,
                          String.format("Created namespace %s successfully", namespaceId));
@@ -69,7 +79,15 @@ public class UnderlyingSystemNamespaceHandler extends AbstractHttpHandler {
       responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR,
                            "Error while deleting namespace - " + e.getMessage());
       return;
-    }
+    } catch (ExploreException e) {
+      responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR,
+                           "Error while creating namespace in Hive - " + e.getMessage());
+      return;
+    } catch (SQLException e) {
+      responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR,
+                           "Error while creating namespace in Hive - " + e.getMessage());
+      return;
+  }
     responder.sendString(HttpResponseStatus.OK,
                          String.format("Deleted namespace %s successfully", namespaceId));
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetDataset.java
@@ -32,7 +32,9 @@ import co.cask.cdap.api.dataset.table.Put;
 import co.cask.cdap.api.dataset.table.Row;
 import co.cask.cdap.api.dataset.table.Scanner;
 import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.data2.util.hbase.TableId;
 import co.cask.cdap.explore.client.ExploreFacade;
+import co.cask.cdap.proto.Id;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
@@ -118,7 +120,9 @@ public class PartitionedFileSetDataset extends AbstractDataset implements Partit
       ExploreFacade exploreFacade = exploreFacadeProvider.get();
       if (exploreFacade != null) {
         try {
-          exploreFacade.addPartition(getName(), key, files.getLocation(path).toURI().getPath());
+          TableId tableId = TableId.from(getName());
+          Id.DatasetInstance datasetInstance = Id.DatasetInstance.from(tableId.getNamespace(), getName());
+          exploreFacade.addPartition(datasetInstance, key, files.getLocation(path).toURI().getPath());
         } catch (Exception e) {
           throw new DataSetException(String.format(
             "Unable to add partition for key %s with path %s to explore table.", key.toString(), path), e);
@@ -140,7 +144,9 @@ public class PartitionedFileSetDataset extends AbstractDataset implements Partit
       ExploreFacade exploreFacade = exploreFacadeProvider.get();
       if (exploreFacade != null) {
         try {
-          exploreFacade.dropPartition(getName(), key);
+          TableId tableId = TableId.from(getName());
+          Id.DatasetInstance datasetInstance = Id.DatasetInstance.from(tableId.getNamespace(), getName());
+          exploreFacade.dropPartition(datasetInstance, key);
         } catch (Exception e) {
           throw new DataSetException(String.format(
             "Unable to drop partition for key %s from explore table.", key.toString()), e);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/FileStreamAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/FileStreamAdmin.java
@@ -229,8 +229,8 @@ public class FileStreamAdmin implements StreamAdmin {
               Schema currSchema = oldProperties.getFormat().getSchema();
               Schema newSchema = format.getSchema();
               if (!currSchema.equals(newSchema)) {
-                alterExploreStream(streamId.getName(), false);
-                alterExploreStream(streamId.getName(), true);
+                alterExploreStream(streamId, false);
+                alterExploreStream(streamId, true);
               }
             }
 
@@ -290,7 +290,7 @@ public class FileStreamAdmin implements StreamAdmin {
                                                null, threshold);
         writeConfig(config);
         createStreamFeeds(config);
-        alterExploreStream(streamId.getName(), true);
+        alterExploreStream(streamId, true);
         return config;
       }
     });
@@ -452,7 +452,7 @@ public class FileStreamAdmin implements StreamAdmin {
     }
   }
 
-  private void alterExploreStream(String stream, boolean enable) {
+  private void alterExploreStream(Id.Stream stream, boolean enable) {
     if (cConf.getBoolean(Constants.Explore.EXPLORE_ENABLED)) {
       // It shouldn't happen.
       Preconditions.checkNotNull(exploreFacade, "Explore enabled but no ExploreFacade instance is available");

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
@@ -120,6 +120,7 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
                                                    "core", new CoreDatasetsModule()));
     MDSDatasetsRegistry mdsDatasetsRegistry = new MDSDatasetsRegistry(txSystemClient, mdsFramework, cConf);
 
+    ExploreFacade exploreFacade = new ExploreFacade(new DiscoveryExploreClient(discoveryService), cConf);
     service = new DatasetService(cConf,
                                  locationFactory,
                                  discoveryService,
@@ -129,9 +130,9 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
                                  metricsCollectionService,
                                  new InMemoryDatasetOpExecutor(framework),
                                  mdsDatasetsRegistry,
-                                 new ExploreFacade(new DiscoveryExploreClient(discoveryService), cConf),
+                                 exploreFacade,
                                  new HashSet<DatasetMetricsReporter>(),
-                                 new LocalUnderlyingSystemNamespaceAdmin(cConf, locationFactory));
+                                 new LocalUnderlyingSystemNamespaceAdmin(cConf, locationFactory, exploreFacade));
     // Start dataset service, wait for it to be discoverable
     service.start();
     final CountDownLatch startLatch = new CountDownLatch(1);

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
@@ -135,6 +135,7 @@ public abstract class DatasetServiceTestBase {
                               new InMemoryDatasetFramework(new InMemoryDefinitionRegistryFactory(),
                                                            DataSetServiceModules.INMEMORY_DATASET_MODULES), cConf);
 
+    ExploreFacade exploreFacade = new ExploreFacade(new DiscoveryExploreClient(discoveryService), cConf);
     service = new DatasetService(cConf,
                                  locationFactory,
                                  discoveryService,
@@ -146,9 +147,9 @@ public abstract class DatasetServiceTestBase {
                                  metricsCollectionService,
                                  new InMemoryDatasetOpExecutor(dsFramework),
                                  mdsDatasetsRegistry,
-                                 new ExploreFacade(new DiscoveryExploreClient(discoveryService), cConf),
+                                 exploreFacade,
                                  new HashSet<DatasetMetricsReporter>(),
-                                 new LocalUnderlyingSystemNamespaceAdmin(cConf, locationFactory));
+                                 new LocalUnderlyingSystemNamespaceAdmin(cConf, locationFactory, exploreFacade));
 
     // Start dataset service, wait for it to be discoverable
     service.start();

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/AbstractExploreClient.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/AbstractExploreClient.java
@@ -22,6 +22,7 @@ import co.cask.cdap.explore.service.ExploreException;
 import co.cask.cdap.explore.service.HandleNotFoundException;
 import co.cask.cdap.explore.service.MetaDataInfo;
 import co.cask.cdap.proto.ColumnDesc;
+import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.QueryHandle;
 import co.cask.cdap.proto.QueryResult;
 import co.cask.cdap.proto.QueryStatus;
@@ -57,6 +58,7 @@ import javax.annotation.Nullable;
  */
 public abstract class AbstractExploreClient extends ExploreHttpClient implements ExploreClient {
   private static final Gson GSON = new Gson();
+
   private final ListeningScheduledExecutorService executor;
 
   protected AbstractExploreClient() {
@@ -77,7 +79,7 @@ public abstract class AbstractExploreClient extends ExploreHttpClient implements
   }
 
   @Override
-  public ListenableFuture<Void> disableExploreDataset(final String datasetInstance) {
+  public ListenableFuture<Void> disableExploreDataset(final Id.DatasetInstance datasetInstance) {
     ListenableFuture<ExploreExecutionResult> futureResults = getResultsFuture(new HandleProducer() {
       @Override
       public QueryHandle getHandle() throws ExploreException, SQLException {
@@ -90,7 +92,7 @@ public abstract class AbstractExploreClient extends ExploreHttpClient implements
   }
 
   @Override
-  public ListenableFuture<Void> enableExploreDataset(final String datasetInstance) {
+  public ListenableFuture<Void> enableExploreDataset(final Id.DatasetInstance datasetInstance) {
     ListenableFuture<ExploreExecutionResult> futureResults = getResultsFuture(new HandleProducer() {
       @Override
       public QueryHandle getHandle() throws ExploreException, SQLException {
@@ -103,11 +105,11 @@ public abstract class AbstractExploreClient extends ExploreHttpClient implements
   }
 
   @Override
-  public ListenableFuture<Void> enableExploreStream(final String streamName) {
+  public ListenableFuture<Void> enableExploreStream(final Id.Stream stream) {
     ListenableFuture<ExploreExecutionResult> futureResults = getResultsFuture(new HandleProducer() {
       @Override
       public QueryHandle getHandle() throws ExploreException, SQLException {
-        return doEnableExploreStream(streamName);
+        return doEnableExploreStream(stream);
       }
     });
 
@@ -116,11 +118,11 @@ public abstract class AbstractExploreClient extends ExploreHttpClient implements
   }
 
   @Override
-  public ListenableFuture<Void> disableExploreStream(final String streamName) {
+  public ListenableFuture<Void> disableExploreStream(final Id.Stream stream) {
     ListenableFuture<ExploreExecutionResult> futureResults = getResultsFuture(new HandleProducer() {
       @Override
       public QueryHandle getHandle() throws ExploreException, SQLException {
-        return doDisableExploreStream(streamName);
+        return doDisableExploreStream(stream);
       }
     });
 
@@ -129,11 +131,12 @@ public abstract class AbstractExploreClient extends ExploreHttpClient implements
   }
 
   @Override
-  public ListenableFuture<Void> addPartition(final String datasetName, final PartitionKey key, final String path) {
+  public ListenableFuture<Void> addPartition(final Id.DatasetInstance datasetInstance,
+                                             final PartitionKey key, final String path) {
     ListenableFuture<ExploreExecutionResult> futureResults = getResultsFuture(new HandleProducer() {
       @Override
       public QueryHandle getHandle() throws ExploreException, SQLException {
-        return doAddPartition(datasetName, key, path);
+        return doAddPartition(datasetInstance, key, path);
       }
     });
 
@@ -142,11 +145,11 @@ public abstract class AbstractExploreClient extends ExploreHttpClient implements
   }
 
   @Override
-  public ListenableFuture<Void> dropPartition(final String datasetName, final PartitionKey key) {
+  public ListenableFuture<Void> dropPartition(final Id.DatasetInstance datasetInstance, final PartitionKey key) {
     ListenableFuture<ExploreExecutionResult> futureResults = getResultsFuture(new HandleProducer() {
       @Override
       public QueryHandle getHandle() throws ExploreException, SQLException {
-        return doDropPartition(datasetName, key);
+        return doDropPartition(datasetInstance, key);
       }
     });
 
@@ -155,11 +158,11 @@ public abstract class AbstractExploreClient extends ExploreHttpClient implements
   }
 
   @Override
-  public ListenableFuture<ExploreExecutionResult> submit(final String statement) {
+  public ListenableFuture<ExploreExecutionResult> submit(final Id.Namespace namespace, final String statement) {
     return getResultsFuture(new HandleProducer() {
       @Override
       public QueryHandle getHandle() throws ExploreException, SQLException {
-        return execute(statement);
+        return execute(namespace, statement);
       }
     });
   }
@@ -249,6 +252,26 @@ public abstract class AbstractExploreClient extends ExploreHttpClient implements
       @Override
       public QueryHandle getHandle() throws ExploreException, SQLException {
         return getTypeInfo();
+      }
+    });
+  }
+
+  @Override
+  public ListenableFuture<ExploreExecutionResult> addNamespace(final Id.Namespace namespace) {
+    return getResultsFuture(new HandleProducer() {
+      @Override
+      public QueryHandle getHandle() throws ExploreException, SQLException {
+        return createNamespace(namespace);
+      }
+    });
+  }
+
+  @Override
+  public ListenableFuture<ExploreExecutionResult> removeNamespace(final Id.Namespace namespace) {
+    return getResultsFuture(new HandleProducer() {
+      @Override
+      public QueryHandle getHandle() throws ExploreException, SQLException {
+        return deleteNamespace(namespace);
       }
     });
   }

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/ExploreClient.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/ExploreClient.java
@@ -18,6 +18,7 @@ package co.cask.cdap.explore.client;
 
 import co.cask.cdap.api.dataset.lib.PartitionKey;
 import co.cask.cdap.explore.service.MetaDataInfo;
+import co.cask.cdap.proto.Id;
 import com.google.common.util.concurrent.ListenableFuture;
 
 import java.io.Closeable;
@@ -37,68 +38,69 @@ public interface ExploreClient extends Closeable {
   /**
    * Enables ad-hoc exploration of the given {@link co.cask.cdap.api.data.batch.RecordScannable}.
    *
-   * @param datasetInstance dataset instance name.
+   * @param datasetInstance dataset instance id.
    * @return a {@code Future} object that can either successfully complete, or enter a failed state depending on
    *         the success of the enable operation.
    */
-  ListenableFuture<Void> enableExploreDataset(String datasetInstance);
+  ListenableFuture<Void> enableExploreDataset(Id.DatasetInstance datasetInstance);
 
   /**
    * Disable ad-hoc exploration of the given {@link co.cask.cdap.api.data.batch.RecordScannable}.
    *
-   * @param datasetInstance dataset instance name.
+   * @param datasetInstance dataset instance id.
    * @return a {@code Future} object that can either successfully complete, or enter a failed state depending on
    *         the success of the disable operation.
    */
-  ListenableFuture<Void> disableExploreDataset(String datasetInstance);
+  ListenableFuture<Void> disableExploreDataset(Id.DatasetInstance datasetInstance);
 
   /**
    * Enables ad-hoc exploration of the given stream.
    *
-   * @param streamName stream name.
+   * @param stream stream id.
    * @return a {@code Future} object that can either successfully complete, or enter a failed state depending on
    *         the success of the enable operation.
    */
-  ListenableFuture<Void> enableExploreStream(String streamName);
+  ListenableFuture<Void> enableExploreStream(Id.Stream stream);
 
   /**
    * Disable ad-hoc exploration of the given stream.
    *
-   * @param streamName stream name.
+   * @param stream stream id.
    * @return a {@code Future} object that can either successfully complete, or enter a failed state depending on
    *         the success of the enable operation.
    */
-  ListenableFuture<Void> disableExploreStream(String streamName);
+  ListenableFuture<Void> disableExploreStream(Id.Stream stream);
 
   /**
    * Add a partition to a dataset's table.
    *
-   * @param datasetName name of the dataset
+   * @param datasetInstance instance of the dataset
    * @param key the partition key
    * @param path the file system path of the partition
    * @return a {@code Future} object that can either successfully complete, or enter a failed state depending on
    *         the success of the operation.
    */
-  ListenableFuture<Void> addPartition(String datasetName, PartitionKey key, String path);
+  ListenableFuture<Void> addPartition(Id.DatasetInstance datasetInstance, PartitionKey key, String path);
 
   /**
    * Drop a partition from a dataset's table.
    *
-   * @param datasetName name of the dataset
+   * @param datasetInstance instance of the dataset
    * @param key the partition key
    * @return a {@code Future} object that can either successfully complete, or enter a failed state depending on
    *         the success of the operation.
    */
-  ListenableFuture<Void> dropPartition(String datasetName, PartitionKey key);
+  ListenableFuture<Void> dropPartition(Id.DatasetInstance datasetInstance, PartitionKey key);
 
   /**
    * Execute a Hive SQL statement asynchronously. The returned {@link ListenableFuture} can be used to get the
    * schema of the operation, and it contains an iterator on the results of the statement.
    *
+   * @param namespace namespace to run the statement in.
    * @param statement SQL statement.
    * @return {@link ListenableFuture} eventually containing the results of the statement execution.
    */
-  ListenableFuture<ExploreExecutionResult> submit(String statement);
+  ListenableFuture<ExploreExecutionResult> submit(Id.Namespace namespace, String statement);
 
   ///// METADATA
 
@@ -208,4 +210,20 @@ public interface ExploreClient extends Closeable {
    * @return {@link ListenableFuture} eventually containing the different data types available in Explore.
    */
   ListenableFuture<ExploreExecutionResult> dataTypes();
+
+  /**
+   * Creates a namespace in Explore.
+   *
+   * @param namespace namespace to create.
+   * @return {@link ListenableFuture} eventually creating the namespace (database in Hive).
+   */
+  ListenableFuture<ExploreExecutionResult> addNamespace(Id.Namespace namespace);
+
+  /**
+   * Deletes a namespace in Explore.
+   *
+   * @param namespace namespace to delete.
+   * @return {@link ListenableFuture} eventually deleting the namespace (database in Hive).
+   */
+  ListenableFuture<ExploreExecutionResult> removeNamespace(Id.Namespace namespace);
 }

--- a/cdap-explore-jdbc/src/main/java/co/cask/cdap/explore/jdbc/ExploreConnection.java
+++ b/cdap-explore-jdbc/src/main/java/co/cask/cdap/explore/jdbc/ExploreConnection.java
@@ -51,11 +51,13 @@ import java.util.concurrent.Executor;
 public class ExploreConnection implements Connection {
   private static final Logger LOG = LoggerFactory.getLogger(ExploreConnection.class);
 
+  private final String namespace;
   private ExploreClient exploreClient;
   private boolean isClosed = false;
 
-  ExploreConnection(ExploreClient exploreClient) {
+  ExploreConnection(ExploreClient exploreClient, String namespace) {
     this.exploreClient = exploreClient;
+    this.namespace = namespace;
   }
 
   @Override
@@ -63,7 +65,7 @@ public class ExploreConnection implements Connection {
     if (isClosed) {
       throw new SQLException("Can't create Statement, connection is closed");
     }
-    return new ExploreStatement(this, exploreClient);
+    return new ExploreStatement(this, exploreClient, namespace);
   }
 
   @Override
@@ -71,7 +73,7 @@ public class ExploreConnection implements Connection {
     if (isClosed) {
       throw new SQLException("Can't create Statement, connection is closed");
     }
-    return new ExplorePreparedStatement(this, exploreClient, sql);
+    return new ExplorePreparedStatement(this, exploreClient, sql, namespace);
   }
 
   @Override

--- a/cdap-explore-jdbc/src/main/java/co/cask/cdap/explore/jdbc/ExploreDriver.java
+++ b/cdap-explore-jdbc/src/main/java/co/cask/cdap/explore/jdbc/ExploreDriver.java
@@ -65,17 +65,25 @@ public class ExploreDriver implements Driver {
     ConnectionParams params = parseConnectionUrl(url);
 
     String authToken = null;
+    String namespace;
 
     List<String> tokenParams = Lists.newArrayList(params.getExtraInfos().get(ConnectionParams.Info.EXPLORE_AUTH_TOKEN));
-    if (tokenParams != null && !tokenParams.isEmpty() && !tokenParams.get(0).isEmpty()) {
+    if (!tokenParams.isEmpty() && !tokenParams.get(0).isEmpty()) {
       authToken = tokenParams.get(0);
+    }
+
+    List<String> namespaceParams = Lists.newArrayList(params.getExtraInfos().get(ConnectionParams.Info.NAMESPACE));
+    if (!namespaceParams.isEmpty() && !namespaceParams.get(0).isEmpty()) {
+      namespace = namespaceParams.get(0);
+    } else {
+      namespace = Constants.DEFAULT_NAMESPACE;
     }
 
     ExploreClient exploreClient = new FixedAddressExploreClient(params.getHost(), params.getPort(), authToken);
     if (!exploreClient.isServiceAvailable()) {
       throw new SQLException("Cannot connect to " + url + ", service unavailable");
     }
-    return new ExploreConnection(exploreClient);
+    return new ExploreConnection(exploreClient, namespace);
   }
 
   @Override
@@ -163,9 +171,10 @@ public class ExploreDriver implements Driver {
      * Extra Explore connection parameter.
      */
     public enum Info {
-      EXPLORE_AUTH_TOKEN("auth.token");
+      EXPLORE_AUTH_TOKEN("auth.token"),
+      NAMESPACE("namespace");
 
-      private String name;
+      private final String name;
 
       private Info(String name) {
         this.name = name;

--- a/cdap-explore-jdbc/src/main/java/co/cask/cdap/explore/jdbc/ExplorePreparedStatement.java
+++ b/cdap-explore-jdbc/src/main/java/co/cask/cdap/explore/jdbc/ExplorePreparedStatement.java
@@ -57,8 +57,8 @@ public class ExplorePreparedStatement extends ExploreStatement implements Prepar
   // Save the SQL parameters {paramLoc:paramValue}
   private final Map<Integer, String> parameters = Maps.newHashMap();
 
-  ExplorePreparedStatement(Connection connection, ExploreClient exploreClient, String sql) {
-    super(connection, exploreClient);
+  ExplorePreparedStatement(Connection connection, ExploreClient exploreClient, String sql, String namespace) {
+    super(connection, exploreClient, namespace);
 
     // Although a PreparedStatement is meant to precompile sql statement, our Explore client
     // interface does not allow it.

--- a/cdap-explore-jdbc/src/main/java/co/cask/cdap/explore/jdbc/ExploreStatement.java
+++ b/cdap-explore-jdbc/src/main/java/co/cask/cdap/explore/jdbc/ExploreStatement.java
@@ -20,6 +20,7 @@ import co.cask.cdap.explore.client.ExploreClient;
 import co.cask.cdap.explore.client.ExploreExecutionResult;
 import co.cask.cdap.explore.service.HandleNotFoundException;
 import co.cask.cdap.explore.service.UnexpectedQueryStatusException;
+import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.QueryStatus;
 import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -70,10 +71,12 @@ public class ExploreStatement implements Statement {
 
   private Connection connection;
   private ExploreClient exploreClient;
+  private final Id.Namespace namespace;
 
-  ExploreStatement(Connection connection, ExploreClient exploreClient) {
+  ExploreStatement(Connection connection, ExploreClient exploreClient, String namespace) {
     this.connection = connection;
     this.exploreClient = exploreClient;
+    this.namespace = Id.Namespace.from(namespace);
   }
 
   @Override
@@ -87,7 +90,7 @@ public class ExploreStatement implements Statement {
     return resultSet;
   }
 
-  /*
+  /**
    * Executes a query and wait until it is finished, but does not close the session.
    */
   @Override
@@ -102,7 +105,7 @@ public class ExploreStatement implements Statement {
       resultSet = null;
     }
 
-    futureResults = exploreClient.submit(sql);
+    futureResults = exploreClient.submit(namespace, sql);
     try {
       resultSet = new ExploreResultSet(futureResults.get(), this, maxRows);
       // NOTE: Javadoc states: "returns false if the first result is an update count or there is no result"

--- a/cdap-explore-jdbc/src/test/java/co/cask/cdap/explore/jdbc/ExplorePreparedStatementTest.java
+++ b/cdap-explore-jdbc/src/test/java/co/cask/cdap/explore/jdbc/ExplorePreparedStatementTest.java
@@ -46,7 +46,7 @@ public class ExplorePreparedStatementTest {
 
 
     ExplorePreparedStatement statement = new ExplorePreparedStatement(null, exploreClient,
-                                                                      "SELECT * FROM table WHERE id=?, name=?");
+                                                                      "SELECT * FROM table WHERE id=?, name=?", "");
     statement.setInt(1, 100);
     try {
       statement.execute();
@@ -64,26 +64,27 @@ public class ExplorePreparedStatementTest {
     Assert.assertFalse(rs.isClosed());
     Assert.assertFalse(rs.next());
 
-    statement = new ExplorePreparedStatement(null, exploreClient, "SELECT * FROM table WHERE name='?'");
+    statement = new ExplorePreparedStatement(null, exploreClient, "SELECT * FROM table WHERE name='?'", "");
     Assert.assertEquals("SELECT * FROM table WHERE name='?'", statement.updateSql());
 
-    statement = new ExplorePreparedStatement(null, exploreClient, "SELECT * FROM table WHERE name='?', id=?");
+    statement = new ExplorePreparedStatement(null, exploreClient, "SELECT * FROM table WHERE name='?', id=?", "");
     statement.setInt(1, 100);
     Assert.assertEquals("SELECT * FROM table WHERE name='?', id=100", statement.updateSql());
 
-    statement = new ExplorePreparedStatement(null, exploreClient, "SELECT * FROM table WHERE name=\"?\", id=?");
+    statement = new ExplorePreparedStatement(null, exploreClient, "SELECT * FROM table WHERE name=\"?\", id=?", "");
     statement.setInt(1, 100);
     Assert.assertEquals("SELECT * FROM table WHERE name=\"?\", id=100", statement.updateSql());
 
-    statement = new ExplorePreparedStatement(null, exploreClient, "SELECT * FROM table WHERE name=\"'?'\", id=?");
+    statement = new ExplorePreparedStatement(null, exploreClient, "SELECT * FROM table WHERE name=\"'?'\", id=?", "");
     statement.setInt(1, 100);
     Assert.assertEquals("SELECT * FROM table WHERE name=\"'?'\", id=100", statement.updateSql());
 
-    statement = new ExplorePreparedStatement(null, exploreClient, "SELECT * FROM table WHERE name=\"'?\", id=?");
+    statement = new ExplorePreparedStatement(null, exploreClient, "SELECT * FROM table WHERE name=\"'?\", id=?", "");
     statement.setInt(1, 100);
     Assert.assertEquals("SELECT * FROM table WHERE name=\"'?\", id=100", statement.updateSql());
 
-    statement = new ExplorePreparedStatement(null, exploreClient, "SELECT * FROM table WHERE name=\"\\\"?\\\"\", id=?");
+    statement = new ExplorePreparedStatement(null, exploreClient,
+                                             "SELECT * FROM table WHERE name=\"\\\"?\\\"\", id=?", "");
     statement.setInt(1, 100);
     Assert.assertEquals("SELECT * FROM table WHERE name=\"\\\"?\\\"\", id=100", statement.updateSql());
   }

--- a/cdap-explore-jdbc/src/test/java/co/cask/cdap/explore/jdbc/ExploreResultSetTest.java
+++ b/cdap-explore-jdbc/src/test/java/co/cask/cdap/explore/jdbc/ExploreResultSetTest.java
@@ -18,6 +18,7 @@ package co.cask.cdap.explore.jdbc;
 
 import co.cask.cdap.explore.client.ExploreClient;
 import co.cask.cdap.proto.ColumnDesc;
+import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.QueryResult;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -66,7 +67,7 @@ public class ExploreResultSetTest {
                 true,
                 0x1,
                 (short) 2,
-                new Long(10),
+                (long) 10,
                 "2014-06-20",
                 "2014-06-20 07:37:00",
                 "1000000000",
@@ -77,8 +78,8 @@ public class ExploreResultSetTest {
         ))
     );
 
-    ResultSet resultSet = new ExploreResultSet(exploreClient.submit("mock_query").get(),
-                                               new ExploreStatement(null, exploreClient),
+    ResultSet resultSet = new ExploreResultSet(exploreClient.submit(Id.Namespace.from(""), "mock_query").get(),
+                                               new ExploreStatement(null, exploreClient, ""),
                                                0);
     Assert.assertTrue(resultSet.next());
     Assert.assertEquals(resultSet.getObject(1), resultSet.getObject("column1"));
@@ -119,8 +120,8 @@ public class ExploreResultSetTest {
         ))
     );
 
-    ResultSet resultSet = new ExploreResultSet(exploreClient.submit("mock_query").get(),
-                                               new ExploreStatement(null, exploreClient),
+    ResultSet resultSet = new ExploreResultSet(exploreClient.submit(Id.Namespace.from(""), "mock_query").get(),
+                                               new ExploreStatement(null, exploreClient, ""),
                                                0);
     Assert.assertTrue(resultSet.next());
     Assert.assertEquals(1, resultSet.findColumn("column1"));

--- a/cdap-explore-jdbc/src/test/java/co/cask/cdap/explore/jdbc/ExploreStatementTest.java
+++ b/cdap-explore-jdbc/src/test/java/co/cask/cdap/explore/jdbc/ExploreStatementTest.java
@@ -50,7 +50,7 @@ public class ExploreStatementTest {
     );
 
     // Make sure an empty query still has a ResultSet associated to it
-    ExploreStatement statement = new ExploreStatement(null, exploreClient);
+    ExploreStatement statement = new ExploreStatement(null, exploreClient, "");
     Assert.assertTrue(statement.execute("mock_query_1"));
     ResultSet rs = statement.getResultSet();
     Assert.assertNotNull(rs);

--- a/cdap-explore-jdbc/src/test/java/co/cask/cdap/explore/jdbc/MockExploreClient.java
+++ b/cdap-explore-jdbc/src/test/java/co/cask/cdap/explore/jdbc/MockExploreClient.java
@@ -22,6 +22,7 @@ import co.cask.cdap.explore.client.ExploreExecutionResult;
 import co.cask.cdap.explore.service.ExploreException;
 import co.cask.cdap.explore.service.MetaDataInfo;
 import co.cask.cdap.proto.ColumnDesc;
+import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.QueryResult;
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.AbstractIdleService;
@@ -55,37 +56,37 @@ public class MockExploreClient extends AbstractIdleService implements ExploreCli
   }
 
   @Override
-  public ListenableFuture<Void> enableExploreDataset(String datasetInstance) {
+  public ListenableFuture<Void> enableExploreDataset(Id.DatasetInstance datasetInstance) {
     return null;
   }
 
   @Override
-  public ListenableFuture<Void> disableExploreDataset(String datasetInstance) {
+  public ListenableFuture<Void> disableExploreDataset(Id.DatasetInstance datasetInstance) {
     return null;
   }
 
   @Override
-  public ListenableFuture<Void> enableExploreStream(String streamName) {
+  public ListenableFuture<Void> enableExploreStream(Id.Stream stream) {
     return null;
   }
 
   @Override
-  public ListenableFuture<Void> disableExploreStream(String streamName) {
+  public ListenableFuture<Void> disableExploreStream(Id.Stream stream) {
     return null;
   }
 
   @Override
-  public ListenableFuture<Void> addPartition(String datasetName, PartitionKey key, String path) {
+  public ListenableFuture<Void> addPartition(Id.DatasetInstance datasetInstance, PartitionKey key, String path) {
     return null;
   }
 
   @Override
-  public ListenableFuture<Void> dropPartition(String datasetName, PartitionKey key) {
+  public ListenableFuture<Void> dropPartition(Id.DatasetInstance datasetInstance, PartitionKey key) {
     return null;
   }
 
   @Override
-  public ListenableFuture<ExploreExecutionResult> submit(final String statement) {
+  public ListenableFuture<ExploreExecutionResult> submit(Id.Namespace namespace, final String statement) {
     SettableFuture<ExploreExecutionResult> futureDelegate = SettableFuture.create();
     futureDelegate.set(new MockExploreExecutionResult(statementsToResults.get(statement).iterator(),
                                                       statementsToMetadata.get(statement)));
@@ -159,6 +160,16 @@ public class MockExploreClient extends AbstractIdleService implements ExploreCli
                                                       statementsToMetadata.get("dataTypes_stmt")));
     return new MockStatementExecutionFuture(futureDelegate, "dataTypes_stmt",
                                             statementsToMetadata, statementsToResults);
+  }
+
+  @Override
+  public ListenableFuture<ExploreExecutionResult> addNamespace(Id.Namespace namespace) {
+    return null;
+  }
+
+  @Override
+  public ListenableFuture<ExploreExecutionResult> removeNamespace(Id.Namespace namespace) {
+    return null;
   }
 
   @Override

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/executor/AbstractExploreMetadataHttpHandler.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/executor/AbstractExploreMetadataHttpHandler.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.explore.executor;
+
+import co.cask.cdap.explore.service.ExploreException;
+import co.cask.cdap.proto.QueryHandle;
+import co.cask.http.AbstractHttpHandler;
+import co.cask.http.HttpResponder;
+import com.google.common.base.Charsets;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSyntaxException;
+import org.jboss.netty.buffer.ChannelBuffer;
+import org.jboss.netty.buffer.ChannelBufferInputStream;
+import org.jboss.netty.handler.codec.http.HttpRequest;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.sql.SQLException;
+
+/**
+ * An abstract class that provides common functionality for namespaced and non-namespaced ExploreMetadata handlers.
+ */
+public class AbstractExploreMetadataHttpHandler extends AbstractHttpHandler {
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractExploreMetadataHttpHandler.class);
+  private static final Gson GSON = new Gson();
+
+  protected void handleResponseEndpointExecution(HttpRequest request, HttpResponder responder,
+                                                 final EndpointCoreExecution<QueryHandle> execution) {
+    genericEndpointExecution(request, responder, new EndpointCoreExecution<Void>() {
+      @Override
+      public Void execute(HttpRequest request, HttpResponder responder)
+        throws IllegalArgumentException, SQLException, ExploreException, IOException {
+        QueryHandle handle = execution.execute(request, responder);
+        JsonObject json = new JsonObject();
+        json.addProperty("handle", handle.getHandle());
+        responder.sendJson(HttpResponseStatus.OK, json);
+        return null;
+      }
+    });
+  }
+
+  protected void genericEndpointExecution(HttpRequest request, HttpResponder responder,
+                                          EndpointCoreExecution<Void> execution) {
+    try {
+      execution.execute(request, responder);
+    } catch (IllegalArgumentException e) {
+      LOG.debug("Got exception:", e);
+      responder.sendString(HttpResponseStatus.BAD_REQUEST, e.getMessage());
+    } catch (SQLException e) {
+      LOG.debug("Got exception:", e);
+      responder.sendString(HttpResponseStatus.BAD_REQUEST,
+                           String.format("[SQLState %s] %s", e.getSQLState(), e.getMessage()));
+    } catch (Throwable e) {
+      LOG.error("Got exception:", e);
+      responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  protected <T> T decodeArguments(HttpRequest request, Class<T> argsType, T defaultValue) throws IOException {
+    ChannelBuffer content = request.getContent();
+    if (!content.readable()) {
+      return defaultValue;
+    }
+    Reader reader = new InputStreamReader(new ChannelBufferInputStream(content), Charsets.UTF_8);
+    try {
+      T args = GSON.fromJson(reader, argsType);
+      return (args == null) ? defaultValue : args;
+    } catch (JsonSyntaxException e) {
+      LOG.info("Failed to parse runtime arguments on {}", request.getUri(), e);
+      throw e;
+    } finally {
+      reader.close();
+    }
+  }
+
+  /**
+   * Represents the core execution of an endpoint.
+   */
+  protected static interface EndpointCoreExecution<T> {
+    T execute(HttpRequest request, HttpResponder responder)
+      throws IllegalArgumentException, SQLException, ExploreException, IOException;
+  }
+
+}

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/executor/AbstractQueryExecutorHttpHandler.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/executor/AbstractQueryExecutorHttpHandler.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.explore.executor;
+
+import co.cask.cdap.explore.service.ExploreException;
+import co.cask.cdap.explore.service.HandleNotFoundException;
+import co.cask.cdap.proto.ColumnDesc;
+import co.cask.cdap.proto.QueryInfo;
+import co.cask.cdap.proto.QueryResult;
+import co.cask.http.AbstractHttpHandler;
+import com.google.common.base.Charsets;
+import com.google.common.base.Predicate;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.primitives.Longs;
+import com.google.common.reflect.TypeToken;
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+import org.jboss.netty.buffer.ChannelBuffer;
+import org.jboss.netty.buffer.ChannelBufferInputStream;
+import org.jboss.netty.handler.codec.http.HttpRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.lang.reflect.Type;
+import java.sql.SQLException;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * An abstract class that provides common functionality for namespaced and non-namespaced ExploreQuery handlers.
+ */
+public class AbstractQueryExecutorHttpHandler extends AbstractHttpHandler {
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractQueryExecutorHttpHandler.class);
+  protected static final Gson GSON = new Gson();
+  protected static final int DOWNLOAD_FETCH_CHUNK_SIZE = 1000;
+
+  protected static final Type STRING_MAP_TYPE = new TypeToken<Map<String, String>>() { }.getType();
+
+
+  protected List<QueryInfo> filterQueries(List<QueryInfo> queries, final long offset,
+                                          final boolean isForward, final int limit) {
+    // Reverse the list if the pagination is in the reverse from the offset until the max limit
+    if (!isForward) {
+      queries = Lists.reverse(queries);
+    }
+
+    return FluentIterable.from(queries)
+      .filter(new Predicate<QueryInfo>() {
+        @Override
+        public boolean apply(@Nullable QueryInfo queryInfo) {
+          if (isForward) {
+            return queryInfo.getTimestamp() < offset;
+          } else {
+            return queryInfo.getTimestamp() > offset;
+          }
+        }
+      })
+      .limit(limit)
+      .toSortedImmutableList(new Comparator<QueryInfo>() {
+        @Override
+        public int compare(QueryInfo first, QueryInfo second) {
+          //sort descending.
+          return Longs.compare(second.getTimestamp(), first.getTimestamp());
+        }
+      });
+  }
+
+  // get arguments contained in the request body
+  protected Map<String, String> decodeArguments(HttpRequest request) throws IOException {
+    ChannelBuffer content = request.getContent();
+    if (!content.readable()) {
+      return ImmutableMap.of();
+    }
+    Reader reader = new InputStreamReader(new ChannelBufferInputStream(content), Charsets.UTF_8);
+    try {
+      Map<String, String> args = GSON.fromJson(reader, STRING_MAP_TYPE);
+      return args == null ? ImmutableMap.<String, String>of() : args;
+    } catch (JsonSyntaxException e) {
+      LOG.info("Failed to parse runtime arguments on {}", request.getUri(), e);
+      throw e;
+    } finally {
+      reader.close();
+    }
+  }
+
+  protected String getCSVHeaders(List<ColumnDesc> schema)
+    throws HandleNotFoundException, SQLException, ExploreException {
+    StringBuffer sb = new StringBuffer();
+    boolean first = true;
+    for (ColumnDesc columnDesc : schema) {
+      if (first) {
+        first = false;
+      } else {
+        sb.append(',');
+      }
+      sb.append(columnDesc.getName());
+    }
+    return sb.toString();
+  }
+
+  protected String appendCSVRow(StringBuffer sb, QueryResult result)
+    throws HandleNotFoundException, SQLException, ExploreException {
+    boolean first = true;
+    for (Object o : result.getColumns()) {
+      if (first) {
+        first = false;
+      } else {
+        sb.append(',');
+      }
+      // Using GSON toJson will serialize objects - in particular, strings will be quoted
+      sb.append(GSON.toJson(o));
+    }
+    return sb.toString();
+  }
+
+}

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/executor/ExploreExecutorService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/executor/ExploreExecutorService.java
@@ -41,7 +41,7 @@ import java.net.InetSocketAddress;
 import java.util.Set;
 
 /**
- * Provides various REST endpoints to execute SQL commands via {@link QueryExecutorHttpHandler}.
+ * Provides various REST endpoints to execute SQL commands via {@link NamespacedQueryExecutorHttpHandler}.
  * In charge of starting and stopping the {@link co.cask.cdap.explore.service.ExploreService}.
  */
 public class ExploreExecutorService extends AbstractIdleService {

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/executor/ExploreMetadataHttpHandler.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/executor/ExploreMetadataHttpHandler.java
@@ -20,42 +20,30 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.explore.service.ExploreException;
 import co.cask.cdap.explore.service.ExploreService;
 import co.cask.cdap.explore.service.MetaDataInfo;
-import co.cask.cdap.explore.service.TableNotFoundException;
-import co.cask.cdap.explore.utils.ColumnsArgs;
-import co.cask.cdap.explore.utils.FunctionsArgs;
-import co.cask.cdap.explore.utils.SchemasArgs;
-import co.cask.cdap.explore.utils.TablesArgs;
+import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.QueryHandle;
-import co.cask.http.AbstractHttpHandler;
 import co.cask.http.HttpResponder;
-import com.google.common.base.Charsets;
-import com.google.gson.Gson;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonSyntaxException;
 import com.google.inject.Inject;
-import org.jboss.netty.buffer.ChannelBuffer;
-import org.jboss.netty.buffer.ChannelBufferInputStream;
 import org.jboss.netty.handler.codec.http.HttpRequest;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.Reader;
 import java.sql.SQLException;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 
 /**
  * Handler that implements explore metadata APIs.
  */
-@Path(Constants.Gateway.API_VERSION_3 + "/namespaces/{namespace-id}")
-public class ExploreMetadataHttpHandler extends AbstractHttpHandler {
-  private static final Logger LOG = LoggerFactory.getLogger(ExploreMetadataHttpHandler.class);
-  private static final Gson GSON = new Gson();
+@Path(Constants.Gateway.API_VERSION_3 + "/data/explore")
+public class ExploreMetadataHttpHandler extends AbstractExploreMetadataHttpHandler {
+  private static final Logger LOG = LoggerFactory.getLogger(NamespacedExploreMetadataHttpHandler.class);
 
   private final ExploreService exploreService;
 
@@ -64,78 +52,9 @@ public class ExploreMetadataHttpHandler extends AbstractHttpHandler {
     this.exploreService = exploreService;
   }
 
-  @GET
-  @Path("data/explore/tables")
-  public void getTables(HttpRequest request, HttpResponder responder, @PathParam("namespace-id") String namespaceId) {
-    LOG.trace("Received get tables for current user");
-    try {
-      responder.sendJson(HttpResponseStatus.OK, exploreService.getTables(namespaceId));
-    } catch (ExploreException e) {
-      LOG.error("Got exception:", e);
-      responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, e.getMessage());
-    }
-  }
-
-  @GET
-  @Path("data/explore/tables/{table}/info")
-  public void getTableSchema(HttpRequest request, HttpResponder responder,
-                             @PathParam("namespace-id") String namespaceId, @PathParam("table") String table) {
-    LOG.trace("Received get table info for table {}", table);
-    try {
-      int dbSepIdx = table.indexOf('.');
-      String dbName = null;
-      String tableName = table;
-      if (dbSepIdx >= 0) {
-        dbName = table.substring(0, dbSepIdx);
-        tableName = table.substring(dbSepIdx + 1);
-      }
-      responder.sendJson(HttpResponseStatus.OK, exploreService.getTableInfo(dbName, tableName));
-    } catch (TableNotFoundException e) {
-      LOG.error("Could not find table {}", table, e);
-      responder.sendStatus(HttpResponseStatus.NOT_FOUND);
-    } catch (ExploreException e) {
-      LOG.error("Got exception:", e);
-      responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, e.getMessage());
-    }
-  }
-
-
   @POST
-  @Path("data/explore/jdbc/tables")
-  public void getJDBCTables(HttpRequest request, HttpResponder responder,
-                            @PathParam("namespace-id") String namespaceId) {
-    handleResponseEndpointExecution(request, responder, new EndpointCoreExecution<QueryHandle>() {
-      @Override
-      public QueryHandle execute(HttpRequest request, HttpResponder responder)
-        throws IllegalArgumentException, SQLException, ExploreException, IOException {
-        TablesArgs args = decodeArguments(request, TablesArgs.class, new TablesArgs(null, null, "%", null));
-        LOG.trace("Received get tables with params: {}", args.toString());
-        return exploreService.getTables(args.getCatalog(), args.getSchemaPattern(),
-                                        args.getTableNamePattern(), args.getTableTypes());
-      }
-    });
-  }
-
-  @POST
-  @Path("data/explore/jdbc/columns")
-  public void getJDBCColumns(HttpRequest request, HttpResponder responder,
-                             @PathParam("namespace-id") String namespaceId) {
-    handleResponseEndpointExecution(request, responder, new EndpointCoreExecution<QueryHandle>() {
-      @Override
-      public QueryHandle execute(HttpRequest request, HttpResponder responder)
-        throws IllegalArgumentException, SQLException, ExploreException, IOException {
-        ColumnsArgs args = decodeArguments(request, ColumnsArgs.class, new ColumnsArgs(null, null, "%", "%"));
-        LOG.trace("Received get columns with params: {}", args.toString());
-        return exploreService.getColumns(args.getCatalog(), args.getSchemaPattern(),
-                                         args.getTableNamePattern(), args.getColumnNamePattern());
-      }
-    });
-  }
-
-  @POST
-  @Path("data/explore/jdbc/catalogs")
-  public void getJDBCCatalogs(HttpRequest request, HttpResponder responder,
-                              @PathParam("namespace-id") String namespaceId) {
+  @Path("jdbc/catalogs")
+  public void getJDBCCatalogs(HttpRequest request, HttpResponder responder) {
     handleResponseEndpointExecution(request, responder, new EndpointCoreExecution<QueryHandle>() {
       @Override
       public QueryHandle execute(HttpRequest request, HttpResponder responder)
@@ -146,69 +65,9 @@ public class ExploreMetadataHttpHandler extends AbstractHttpHandler {
     });
   }
 
-  @POST
-  @Path("data/explore/jdbc/schemas")
-  public void getJDBCSchemas(HttpRequest request, HttpResponder responder,
-                             @PathParam("namespace-id") String namespaceId) {
-    handleResponseEndpointExecution(request, responder, new EndpointCoreExecution<QueryHandle>() {
-      @Override
-      public QueryHandle execute(HttpRequest request, HttpResponder responder)
-        throws IllegalArgumentException, SQLException, ExploreException, IOException {
-        SchemasArgs args = decodeArguments(request, SchemasArgs.class, new SchemasArgs(null, null));
-        LOG.trace("Received get schemas with params: {}", args.toString());
-        return exploreService.getSchemas(args.getCatalog(), args.getSchemaPattern());
-      }
-    });
-  }
-
-  @POST
-  @Path("data/explore/jdbc/functions")
-  public void getJDBCFunctions(HttpRequest request, HttpResponder responder,
-                               @PathParam("namespace-id") String namespaceId) {
-    handleResponseEndpointExecution(request, responder, new EndpointCoreExecution<QueryHandle>() {
-      @Override
-      public QueryHandle execute(HttpRequest request, HttpResponder responder)
-        throws IllegalArgumentException, SQLException, ExploreException, IOException {
-        FunctionsArgs args = decodeArguments(request, FunctionsArgs.class, new FunctionsArgs(null, null, "%"));
-        LOG.trace("Received get functions with params: {}", args.toString());
-        return exploreService.getFunctions(args.getCatalog(), args.getSchemaPattern(),
-                                           args.getFunctionNamePattern());
-      }
-    });
-  }
-
-  @POST
-  @Path("data/explore/jdbc/tableTypes")
-  public void getJDBCTableTypes(HttpRequest request, HttpResponder responder,
-                                @PathParam("namespace-id") String namespaceId) {
-    handleResponseEndpointExecution(request, responder, new EndpointCoreExecution<QueryHandle>() {
-      @Override
-      public QueryHandle execute(HttpRequest request, HttpResponder responder)
-        throws IllegalArgumentException, SQLException, ExploreException, IOException {
-        LOG.trace("Received get table types query.");
-        return exploreService.getTableTypes();
-      }
-    });
-  }
-
-  @POST
-  @Path("data/explore/jdbc/types")
-  public void getJDBCTypes(HttpRequest request, HttpResponder responder,
-                           @PathParam("namespace-id") String namespaceId) {
-    handleResponseEndpointExecution(request, responder, new EndpointCoreExecution<QueryHandle>() {
-      @Override
-      public QueryHandle execute(HttpRequest request, HttpResponder responder)
-        throws IllegalArgumentException, SQLException, ExploreException, IOException {
-        LOG.trace("Received get type info query.");
-        return exploreService.getTypeInfo();
-      }
-    });
-  }
-
   @GET
-  @Path("data/explore/jdbc/info/{type}")
-  public void getJDBCInfo(HttpRequest request, HttpResponder responder,
-                          @PathParam("namespace-id") String namespaceId, @PathParam("type") final String type) {
+  @Path("jdbc/info/{type}")
+  public void getJDBCInfo(HttpRequest request, HttpResponder responder, @PathParam("type") final String type) {
     genericEndpointExecution(request, responder, new EndpointCoreExecution<Void>() {
       @Override
       public Void execute(HttpRequest request, HttpResponder responder)
@@ -222,60 +81,60 @@ public class ExploreMetadataHttpHandler extends AbstractHttpHandler {
     });
   }
 
-  private void handleResponseEndpointExecution(HttpRequest request, HttpResponder responder,
-                                               final EndpointCoreExecution<QueryHandle> execution) {
-    genericEndpointExecution(request, responder, new EndpointCoreExecution<Void>() {
+  @POST
+  @Path("jdbc/tableTypes")
+  public void getJDBCTableTypes(HttpRequest request, HttpResponder responder) {
+    handleResponseEndpointExecution(request, responder, new EndpointCoreExecution<QueryHandle>() {
       @Override
-      public Void execute(HttpRequest request, HttpResponder responder)
+      public QueryHandle execute(HttpRequest request, HttpResponder responder)
         throws IllegalArgumentException, SQLException, ExploreException, IOException {
-        QueryHandle handle = execution.execute(request, responder);
-        JsonObject json = new JsonObject();
-        json.addProperty("handle", handle.getHandle());
-        responder.sendJson(HttpResponseStatus.OK, json);
-        return null;
+        LOG.trace("Received get table types query.");
+        return exploreService.getTableTypes();
       }
     });
   }
 
-  private void genericEndpointExecution(HttpRequest request, HttpResponder responder,
-                                        EndpointCoreExecution<Void> execution) {
-    try {
-      execution.execute(request, responder);
-    } catch (IllegalArgumentException e) {
-      LOG.debug("Got exception:", e);
-      responder.sendString(HttpResponseStatus.BAD_REQUEST, e.getMessage());
-    } catch (SQLException e) {
-      LOG.debug("Got exception:", e);
-      responder.sendString(HttpResponseStatus.BAD_REQUEST,
-                           String.format("[SQLState %s] %s", e.getSQLState(), e.getMessage()));
-    } catch (Throwable e) {
-      LOG.error("Got exception:", e);
-      responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
-    }
+  @POST
+  @Path("jdbc/types")
+  public void getJDBCTypes(HttpRequest request, HttpResponder responder) {
+    handleResponseEndpointExecution(request, responder, new EndpointCoreExecution<QueryHandle>() {
+      @Override
+      public QueryHandle execute(HttpRequest request, HttpResponder responder)
+        throws IllegalArgumentException, SQLException, ExploreException, IOException {
+        LOG.trace("Received get type info query.");
+        return exploreService.getTypeInfo();
+      }
+    });
   }
 
-  private <T> T decodeArguments(HttpRequest request, Class<T> argsType, T defaultValue) throws IOException {
-    ChannelBuffer content = request.getContent();
-    if (!content.readable()) {
-      return defaultValue;
-    }
-    Reader reader = new InputStreamReader(new ChannelBufferInputStream(content), Charsets.UTF_8);
-    try {
-      T args = GSON.fromJson(reader, argsType);
-      return (args == null) ? defaultValue : args;
-    } catch (JsonSyntaxException e) {
-      LOG.info("Failed to parse runtime arguments on {}", request.getUri(), e);
-      throw e;
-    } finally {
-      reader.close();
-    }
+  // The following 2 endpoints are only for internal use and will be undocumented.
+  // They are called by UnderlyingSystemNamespaceAdmin to create/destroy a database in Hive when a namespace in
+  // CDAP is created/destroyed.
+  // TODO: Consider addings ACLs to these operations.
+
+  @PUT
+  @Path("namespaces/{namespace-id}")
+  public void create(HttpRequest request, HttpResponder responder,
+                     @PathParam("namespace-id") final String namespaceId) {
+    handleResponseEndpointExecution(request, responder, new EndpointCoreExecution<QueryHandle>() {
+      @Override
+      public QueryHandle execute(HttpRequest request, HttpResponder responder)
+        throws IllegalArgumentException, SQLException, ExploreException, IOException {
+        return exploreService.createNamespace(Id.Namespace.from(namespaceId));
+      }
+    });
   }
 
-  /**
-   * Represents the core execution of an endpoint.
-   */
-  private static interface EndpointCoreExecution<T> {
-    T execute(HttpRequest request, HttpResponder responder)
-      throws IllegalArgumentException, SQLException, ExploreException, IOException;
+  @DELETE
+  @Path("namespaces/{namespace-id}")
+  public void delete(HttpRequest request, HttpResponder responder,
+                     @PathParam("namespace-id") final String namespaceId) {
+    handleResponseEndpointExecution(request, responder, new EndpointCoreExecution<QueryHandle>() {
+      @Override
+      public QueryHandle execute(HttpRequest request, HttpResponder responder)
+        throws IllegalArgumentException, SQLException, ExploreException, IOException {
+        return exploreService.deleteNamespace(Id.Namespace.from(namespaceId));
+      }
+    });
   }
 }

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/executor/ExploreMetadataHttpHandlerV2.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/executor/ExploreMetadataHttpHandlerV2.java
@@ -18,7 +18,6 @@ package co.cask.cdap.explore.executor;
 
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.http.RESTMigrationUtils;
-import co.cask.http.AbstractHttpHandler;
 import co.cask.http.HttpResponder;
 import com.google.inject.Inject;
 import org.jboss.netty.handler.codec.http.HttpRequest;
@@ -32,82 +31,80 @@ import javax.ws.rs.PathParam;
  * Handler that implements V2 explore metadata APIs
  */
 @Path(Constants.Gateway.API_VERSION_2)
-public class ExploreMetadataHttpHandlerV2 extends AbstractHttpHandler {
+public class ExploreMetadataHttpHandlerV2 extends AbstractExploreMetadataHttpHandler {
+  private final NamespacedExploreMetadataHttpHandler namespacedExploreMetadataHttpHandler;
   private final ExploreMetadataHttpHandler exploreMetadataHttpHandler;
 
   @Inject
-  public ExploreMetadataHttpHandlerV2(ExploreMetadataHttpHandler exploreMetadataHttpHandler) {
+  public ExploreMetadataHttpHandlerV2(NamespacedExploreMetadataHttpHandler namespacedExploreMetadataHttpHandler,
+                                      ExploreMetadataHttpHandler exploreMetadataHttpHandler) {
+    this.namespacedExploreMetadataHttpHandler = namespacedExploreMetadataHttpHandler;
     this.exploreMetadataHttpHandler = exploreMetadataHttpHandler;
   }
 
   @GET
   @Path("data/explore/tables")
   public void getTables(HttpRequest request, HttpResponder responder) {
-    exploreMetadataHttpHandler.getTables(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
+    namespacedExploreMetadataHttpHandler.getTables(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
                                          Constants.DEFAULT_NAMESPACE);
   }
 
   @GET
   @Path("data/explore/tables/{table}/info")
   public void getTableSchema(HttpRequest request, HttpResponder responder, @PathParam("table") String table) {
-    exploreMetadataHttpHandler.getTableSchema(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
+    namespacedExploreMetadataHttpHandler.getTableSchema(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
                                               Constants.DEFAULT_NAMESPACE, table);
   }
-
 
   @POST
   @Path("data/explore/jdbc/tables")
   public void getJDBCTables(HttpRequest request, HttpResponder responder) {
-    exploreMetadataHttpHandler.getJDBCTables(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
+    namespacedExploreMetadataHttpHandler.getJDBCTables(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
                                              Constants.DEFAULT_NAMESPACE);
   }
 
   @POST
   @Path("data/explore/jdbc/columns")
   public void getJDBCColumns(HttpRequest request, HttpResponder responder) {
-    exploreMetadataHttpHandler.getJDBCColumns(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
+    namespacedExploreMetadataHttpHandler.getJDBCColumns(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
                                               Constants.DEFAULT_NAMESPACE);
   }
 
   @POST
   @Path("data/explore/jdbc/catalogs")
   public void getJDBCCatalogs(HttpRequest request, HttpResponder responder) {
-    exploreMetadataHttpHandler.getJDBCCatalogs(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
-                                               Constants.DEFAULT_NAMESPACE);
+    exploreMetadataHttpHandler.getJDBCCatalogs(RESTMigrationUtils.rewriteV2RequestToV3(request), responder);
   }
 
   @POST
   @Path("data/explore/jdbc/schemas")
   public void getJDBCSchemas(HttpRequest request, HttpResponder responder) {
-    exploreMetadataHttpHandler.getJDBCSchemas(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
+    namespacedExploreMetadataHttpHandler.getJDBCSchemas(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
                                               Constants.DEFAULT_NAMESPACE);
   }
 
   @POST
   @Path("data/explore/jdbc/functions")
   public void getJDBCFunctions(HttpRequest request, HttpResponder responder) {
-    exploreMetadataHttpHandler.getJDBCFunctions(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
+    namespacedExploreMetadataHttpHandler.getJDBCFunctions(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
                                                 Constants.DEFAULT_NAMESPACE);
   }
 
   @POST
   @Path("data/explore/jdbc/tableTypes")
   public void getJDBCTableTypes(HttpRequest request, HttpResponder responder) {
-    exploreMetadataHttpHandler.getJDBCTableTypes(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
-                                                 Constants.DEFAULT_NAMESPACE);
+    exploreMetadataHttpHandler.getJDBCTableTypes(RESTMigrationUtils.rewriteV2RequestToV3(request), responder);
   }
 
   @POST
   @Path("data/explore/jdbc/types")
   public void getJDBCTypes(HttpRequest request, HttpResponder responder) {
-    exploreMetadataHttpHandler.getJDBCTypes(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
-                                            Constants.DEFAULT_NAMESPACE);
+    exploreMetadataHttpHandler.getJDBCTypes(RESTMigrationUtils.rewriteV2RequestToV3(request), responder);
   }
 
   @GET
   @Path("data/explore/jdbc/info/{type}")
   public void getJDBCInfo(HttpRequest request, HttpResponder responder, @PathParam("type") String type) {
-    exploreMetadataHttpHandler.getJDBCInfo(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
-                                           Constants.DEFAULT_NAMESPACE, type);
+    exploreMetadataHttpHandler.getJDBCInfo(RESTMigrationUtils.rewriteV2RequestToV3(request), responder, type);
   }
 }

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/executor/ExploreStatusHandler.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/executor/ExploreStatusHandler.java
@@ -25,17 +25,16 @@ import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
 
 /**
- * Explore ping handler - reachable outside of CDAP.
+ * Explore status handler - reachable outside of CDAP.
  */
-@Path(Constants.Gateway.API_VERSION_3 + "/namespaces/{namespace-id}")
+@Path(Constants.Gateway.API_VERSION_3)
 public class ExploreStatusHandler extends AbstractHttpHandler {
 
-  @Path("/explore/status")
+  @Path("explore/status")
   @GET
-  public void status(HttpRequest request, HttpResponder responder, @PathParam("namespace-id") String namespaceId) {
+  public void status(HttpRequest request, HttpResponder responder) {
     JsonObject json = new JsonObject();
     json.addProperty("status", "OK");
     responder.sendJson(HttpResponseStatus.OK, json);

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/executor/ExploreStatusHandlerV2.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/executor/ExploreStatusHandlerV2.java
@@ -28,7 +28,7 @@ import javax.ws.rs.Path;
 
 
 /**
- * Explore ping handler - reachable outside of CDAP.
+ * Explore status handler - reachable outside of CDAP.
  */
 @Path(Constants.Gateway.API_VERSION_2)
 public class ExploreStatusHandlerV2 extends AbstractHttpHandler {
@@ -39,10 +39,9 @@ public class ExploreStatusHandlerV2 extends AbstractHttpHandler {
     this.exploreStatusHandler = exploreStatusHandler;
   }
 
-  @Path("/explore/status")
+  @Path("explore/status")
   @GET
   public void status(HttpRequest request, HttpResponder responder) {
-    exploreStatusHandler.status(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
-                                Constants.DEFAULT_NAMESPACE);
+    exploreStatusHandler.status(RESTMigrationUtils.rewriteV2RequestToV3(request), responder);
   }
 }

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/executor/NamespacedExploreMetadataHttpHandler.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/executor/NamespacedExploreMetadataHttpHandler.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright © 2014-2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.explore.executor;
+
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.explore.service.ExploreException;
+import co.cask.cdap.explore.service.ExploreService;
+import co.cask.cdap.explore.service.TableNotFoundException;
+import co.cask.cdap.explore.utils.ColumnsArgs;
+import co.cask.cdap.explore.utils.FunctionsArgs;
+import co.cask.cdap.explore.utils.SchemasArgs;
+import co.cask.cdap.explore.utils.TablesArgs;
+import co.cask.cdap.proto.QueryHandle;
+import co.cask.http.HttpResponder;
+import com.google.inject.Inject;
+import org.jboss.netty.handler.codec.http.HttpRequest;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+/**
+ * Handler that implements namespaced explore metadata APIs.
+ */
+@Path(Constants.Gateway.API_VERSION_3 + "/namespaces/{namespace-id}/data/explore")
+public class NamespacedExploreMetadataHttpHandler extends AbstractExploreMetadataHttpHandler {
+  private static final Logger LOG = LoggerFactory.getLogger(NamespacedExploreMetadataHttpHandler.class);
+
+  private final ExploreService exploreService;
+
+  @Inject
+  public NamespacedExploreMetadataHttpHandler(ExploreService exploreService) {
+    this.exploreService = exploreService;
+  }
+
+  @GET
+  @Path("tables")
+  public void getTables(HttpRequest request, HttpResponder responder, @PathParam("namespace-id") String namespaceId) {
+    LOG.trace("Received get tables for current user");
+    try {
+      responder.sendJson(HttpResponseStatus.OK, exploreService.getTables(namespaceId));
+    } catch (Throwable t) {
+      LOG.error("Got exception:", t);
+      responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, t.getMessage());
+    }
+  }
+
+  @GET
+  @Path("tables/{table}/info")
+  public void getTableSchema(HttpRequest request, HttpResponder responder,
+                             @PathParam("namespace-id") String namespaceId, @PathParam("table") String table) {
+    LOG.trace("Received get table info for table {}", table);
+    try {
+      responder.sendJson(HttpResponseStatus.OK, exploreService.getTableInfo(namespaceId, table));
+    } catch (TableNotFoundException e) {
+      LOG.error("Could not find table {}", table, e);
+      responder.sendStatus(HttpResponseStatus.NOT_FOUND);
+    } catch (Throwable t) {
+      LOG.error("Got exception:", t);
+      responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, t.getMessage());
+    }
+  }
+
+  @POST
+  @Path("jdbc/tables")
+  public void getJDBCTables(HttpRequest request, HttpResponder responder,
+                            @PathParam("namespace-id") final String namespaceId) {
+    handleResponseEndpointExecution(request, responder, new EndpointCoreExecution<QueryHandle>() {
+      @Override
+      public QueryHandle execute(HttpRequest request, HttpResponder responder)
+        throws IllegalArgumentException, SQLException, ExploreException, IOException {
+        TablesArgs args = decodeArguments(request, TablesArgs.class, new TablesArgs(null, namespaceId, "%", null));
+        LOG.trace("Received get tables with params: {}", args.toString());
+        return exploreService.getTables(args.getCatalog(), args.getSchemaPattern(),
+                                        args.getTableNamePattern(), args.getTableTypes());
+      }
+    });
+  }
+
+  @POST
+  @Path("jdbc/columns")
+  public void getJDBCColumns(HttpRequest request, HttpResponder responder,
+                             @PathParam("namespace-id") final String namespaceId) {
+    handleResponseEndpointExecution(request, responder, new EndpointCoreExecution<QueryHandle>() {
+      @Override
+      public QueryHandle execute(HttpRequest request, HttpResponder responder)
+        throws IllegalArgumentException, SQLException, ExploreException, IOException {
+        ColumnsArgs args = decodeArguments(request, ColumnsArgs.class, new ColumnsArgs(null, namespaceId, "%", "%"));
+        LOG.trace("Received get columns with params: {}", args.toString());
+        return exploreService.getColumns(args.getCatalog(), args.getSchemaPattern(),
+                                         args.getTableNamePattern(), args.getColumnNamePattern());
+      }
+    });
+  }
+
+  @POST
+  @Path("jdbc/schemas")
+  public void getJDBCSchemas(HttpRequest request, HttpResponder responder,
+                             @PathParam("namespace-id") final String namespaceId) {
+    handleResponseEndpointExecution(request, responder, new EndpointCoreExecution<QueryHandle>() {
+      @Override
+      public QueryHandle execute(HttpRequest request, HttpResponder responder)
+        throws IllegalArgumentException, SQLException, ExploreException, IOException {
+        SchemasArgs args = decodeArguments(request, SchemasArgs.class, new SchemasArgs(null, namespaceId));
+        LOG.trace("Received get schemas with params: {}", args.toString());
+        return exploreService.getSchemas(args.getCatalog(), args.getSchemaPattern());
+      }
+    });
+  }
+
+  @POST
+  @Path("jdbc/functions")
+  public void getJDBCFunctions(HttpRequest request, HttpResponder responder,
+                               @PathParam("namespace-id") final String namespaceId) {
+    handleResponseEndpointExecution(request, responder, new EndpointCoreExecution<QueryHandle>() {
+      @Override
+      public QueryHandle execute(HttpRequest request, HttpResponder responder)
+        throws IllegalArgumentException, SQLException, ExploreException, IOException {
+        FunctionsArgs args = decodeArguments(request, FunctionsArgs.class, new FunctionsArgs(null, namespaceId, "%"));
+        LOG.trace("Received get functions with params: {}", args.toString());
+        return exploreService.getFunctions(args.getCatalog(), args.getSchemaPattern(),
+                                           args.getFunctionNamePattern());
+      }
+    });
+  }
+}

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/executor/NamespacedQueryExecutorHttpHandler.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/executor/NamespacedQueryExecutorHttpHandler.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright © 2014-2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.explore.executor;
+
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.explore.service.ExploreService;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.QueryInfo;
+import co.cask.http.HttpResponder;
+import com.google.inject.Inject;
+import org.jboss.netty.handler.codec.http.HttpRequest;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
+
+/**
+ * Provides REST endpoints for {@link ExploreService} operations.
+ */
+@Path(Constants.Gateway.API_VERSION_3 + "/namespaces/{namespace-id}")
+public class NamespacedQueryExecutorHttpHandler extends AbstractQueryExecutorHttpHandler {
+  private static final Logger LOG = LoggerFactory.getLogger(NamespacedQueryExecutorHttpHandler.class);
+  private final ExploreService exploreService;
+
+  @Inject
+  public NamespacedQueryExecutorHttpHandler(ExploreService exploreService) {
+    this.exploreService = exploreService;
+  }
+
+  @POST
+  @Path("data/explore/queries")
+  public void query(HttpRequest request, HttpResponder responder, @PathParam("namespace-id") String namespaceId) {
+    try {
+      Map<String, String> args = decodeArguments(request);
+      String query = args.get("query");
+      LOG.trace("Received query: {}", query);
+      responder.sendJson(HttpResponseStatus.OK, exploreService.execute(Id.Namespace.from(namespaceId), query));
+    } catch (IllegalArgumentException e) {
+      LOG.debug("Got exception:", e);
+      responder.sendString(HttpResponseStatus.BAD_REQUEST, e.getMessage());
+    } catch (SQLException e) {
+      LOG.debug("Got exception:", e);
+      responder.sendString(HttpResponseStatus.BAD_REQUEST, String.format("[SQLState %s] %s",
+                                                                         e.getSQLState(), e.getMessage()));
+    } catch (Throwable e) {
+      LOG.error("Got exception:", e);
+      responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  @GET
+  @Path("data/explore/queries")
+  public void getQueryLiveHandles(HttpRequest request, HttpResponder responder,
+                                  @PathParam("namespace-id") String namespaceId,
+                                  @QueryParam("offset") @DefaultValue("9223372036854775807") long offset,
+                                  @QueryParam("cursor") @DefaultValue("next") String cursor,
+                                  @QueryParam("limit") @DefaultValue("50") int limit) {
+    try {
+      boolean isForward = "next".equals(cursor);
+
+      List<QueryInfo> queries = exploreService.getQueries(Id.Namespace.from(namespaceId));
+      // return the queries by after filtering (> offset) and limiting number of queries
+      responder.sendJson(HttpResponseStatus.OK, filterQueries(queries, offset, isForward, limit));
+    } catch (Exception e) {
+      LOG.error("Got exception:", e);
+      responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, "Error");
+    }
+  }
+}

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/executor/QueryExecutorHttpHandler.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/executor/QueryExecutorHttpHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,64 +17,38 @@
 package co.cask.cdap.explore.executor;
 
 import co.cask.cdap.common.conf.Constants;
-import co.cask.cdap.explore.service.ExploreException;
 import co.cask.cdap.explore.service.ExploreService;
 import co.cask.cdap.explore.service.HandleNotFoundException;
 import co.cask.cdap.proto.ColumnDesc;
 import co.cask.cdap.proto.QueryHandle;
-import co.cask.cdap.proto.QueryInfo;
 import co.cask.cdap.proto.QueryResult;
 import co.cask.cdap.proto.QueryStatus;
-import co.cask.http.AbstractHttpHandler;
 import co.cask.http.ChunkResponder;
 import co.cask.http.HttpResponder;
-import com.google.common.base.Charsets;
-import com.google.common.base.Predicate;
-import com.google.common.collect.FluentIterable;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.io.Closeables;
-import com.google.common.primitives.Longs;
-import com.google.common.reflect.TypeToken;
-import com.google.gson.Gson;
-import com.google.gson.JsonSyntaxException;
 import com.google.inject.Inject;
-import org.jboss.netty.buffer.ChannelBuffer;
-import org.jboss.netty.buffer.ChannelBufferInputStream;
 import org.jboss.netty.buffer.ChannelBuffers;
 import org.jboss.netty.handler.codec.http.HttpRequest;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.lang.reflect.Type;
 import java.sql.SQLException;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nullable;
 import javax.ws.rs.DELETE;
-import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
-import javax.ws.rs.QueryParam;
 
 /**
- * Provides REST endpoints for {@link co.cask.cdap.explore.service.ExploreService} operations.
+ *
  */
-@Path(Constants.Gateway.API_VERSION_2)
-public class QueryExecutorHttpHandler extends AbstractHttpHandler {
+@Path(Constants.Gateway.API_VERSION_3)
+public class QueryExecutorHttpHandler extends AbstractQueryExecutorHttpHandler {
   private static final Logger LOG = LoggerFactory.getLogger(QueryExecutorHttpHandler.class);
-  private static final Gson GSON = new Gson();
-  private static final int DOWNLOAD_FETCH_CHUNK_SIZE = 1000;
-
-  private static final Type STRING_MAP_TYPE = new TypeToken<Map<String, String>>() { }.getType();
-
   private final ExploreService exploreService;
 
   @Inject
@@ -82,31 +56,9 @@ public class QueryExecutorHttpHandler extends AbstractHttpHandler {
     this.exploreService = exploreService;
   }
 
-  @POST
-  @Path("data/explore/queries")
-  public void query(HttpRequest request, HttpResponder responder) {
-    try {
-      Map<String, String> args = decodeArguments(request);
-      String query = args.get("query");
-      LOG.trace("Received query: {}", query);
-      responder.sendJson(HttpResponseStatus.OK, exploreService.execute(query));
-    } catch (IllegalArgumentException e) {
-      LOG.debug("Got exception:", e);
-      responder.sendString(HttpResponseStatus.BAD_REQUEST, e.getMessage());
-    } catch (SQLException e) {
-      LOG.debug("Got exception:", e);
-      responder.sendString(HttpResponseStatus.BAD_REQUEST, String.format("[SQLState %s] %s",
-                                                                         e.getSQLState(), e.getMessage()));
-    } catch (Throwable e) {
-      LOG.error("Got exception:", e);
-      responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
-    }
-  }
-
   @DELETE
   @Path("data/explore/queries/{id}")
-  public void closeQuery(@SuppressWarnings("UnusedParameters") HttpRequest request, HttpResponder responder,
-                         @PathParam("id") final String id) {
+  public void closeQuery(HttpRequest request, HttpResponder responder, @PathParam("id") String id) {
     try {
       QueryHandle handle = QueryHandle.fromId(id);
       if (!handle.equals(QueryHandle.NO_OP)) {
@@ -126,8 +78,7 @@ public class QueryExecutorHttpHandler extends AbstractHttpHandler {
 
   @GET
   @Path("data/explore/queries/{id}/status")
-  public void getQueryStatus(@SuppressWarnings("UnusedParameters") HttpRequest request, HttpResponder responder,
-                             @PathParam("id") final String id) {
+  public void getQueryStatus(HttpRequest request, HttpResponder responder, @PathParam("id") String id) {
     try {
       QueryHandle handle = QueryHandle.fromId(id);
       QueryStatus status;
@@ -154,8 +105,7 @@ public class QueryExecutorHttpHandler extends AbstractHttpHandler {
 
   @GET
   @Path("data/explore/queries/{id}/schema")
-  public void getQueryResultsSchema(@SuppressWarnings("UnusedParameters") HttpRequest request, HttpResponder responder,
-                                    @PathParam("id") final String id) {
+  public void getQueryResultsSchema(HttpRequest request, HttpResponder responder, @PathParam("id") String id) {
     try {
       QueryHandle handle = QueryHandle.fromId(id);
       List<ColumnDesc> schema;
@@ -182,8 +132,7 @@ public class QueryExecutorHttpHandler extends AbstractHttpHandler {
 
   @POST
   @Path("data/explore/queries/{id}/next")
-  public void getQueryNextResults(HttpRequest request, HttpResponder responder,
-                                  @PathParam("id") final String id) {
+  public void getQueryNextResults(HttpRequest request, HttpResponder responder, @PathParam("id") String id) {
     // NOTE: this call is a POST because it is not idempotent: cursor of results is moved
     try {
       QueryHandle handle = QueryHandle.fromId(id);
@@ -211,27 +160,9 @@ public class QueryExecutorHttpHandler extends AbstractHttpHandler {
     }
   }
 
-  @GET
-  @Path("/data/explore/queries")
-  public void getQueryLiveHandles(HttpRequest request, HttpResponder responder,
-                                  @QueryParam("offset") @DefaultValue("9223372036854775807") long offset,
-                                  @QueryParam("cursor") @DefaultValue("next") String cursor,
-                                  @QueryParam("limit") @DefaultValue("50") int limit) {
-    try {
-      boolean isForward = "next".equals(cursor);
-
-      List<QueryInfo> queries = exploreService.getQueries();
-      // return the queries by after filtering (> offset) and limiting number of queries
-      responder.sendJson(HttpResponseStatus.OK, filterQueries(queries, offset, isForward, limit));
-    } catch (Exception e) {
-      LOG.error("Got exception:", e);
-      responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, "Error");
-    }
-  }
-
   @POST
-  @Path("/data/explore/queries/{id}/preview")
-  public void getQueryResultPreview(HttpRequest request, HttpResponder responder, @PathParam("id") final String id) {
+  @Path("data/explore/queries/{id}/preview")
+  public void getQueryResultPreview(HttpRequest request, HttpResponder responder, @PathParam("id") String id) {
     // NOTE: this call is a POST because it is not idempotent: cursor of results is moved
     try {
       QueryHandle handle = QueryHandle.fromId(id);
@@ -262,7 +193,7 @@ public class QueryExecutorHttpHandler extends AbstractHttpHandler {
   }
 
   @POST
-  @Path("/data/explore/queries/{id}/download")
+  @Path("data/explore/queries/{id}/download")
   public void downloadQueryResults(HttpRequest request, HttpResponder responder, @PathParam("id") final String id) {
     // NOTE: this call is a POST because it is not idempotent: cursor of results is moved
     boolean responseStarted = false;
@@ -324,80 +255,5 @@ public class QueryExecutorHttpHandler extends AbstractHttpHandler {
         responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
       }
     }
-  }
-
-  private List<QueryInfo> filterQueries(List<QueryInfo> queries, final long offset,
-                                        final boolean isForward, final int limit) {
-    // Reverse the list if the pagination is in the reverse from the offset until the max limit
-    if (!isForward) {
-      queries = Lists.reverse(queries);
-    }
-
-    return FluentIterable.from(queries)
-      .filter(new Predicate<QueryInfo>() {
-        @Override
-        public boolean apply(@Nullable QueryInfo queryInfo) {
-          if (isForward) {
-            return queryInfo.getTimestamp() < offset;
-          } else {
-            return queryInfo.getTimestamp() > offset;
-          }
-        }
-      })
-      .limit(limit)
-      .toSortedImmutableList(new Comparator<QueryInfo>() {
-        @Override
-        public int compare(QueryInfo first, QueryInfo second) {
-          //sort descending.
-          return Longs.compare(second.getTimestamp(), first.getTimestamp());
-        }
-      });
-  }
-
-  // get arguments contained in the request body
-  private Map<String, String> decodeArguments(HttpRequest request) throws IOException {
-    ChannelBuffer content = request.getContent();
-    if (!content.readable()) {
-      return ImmutableMap.of();
-    }
-    Reader reader = new InputStreamReader(new ChannelBufferInputStream(content), Charsets.UTF_8);
-    try {
-      Map<String, String> args = GSON.fromJson(reader, STRING_MAP_TYPE);
-      return args == null ? ImmutableMap.<String, String>of() : args;
-    } catch (JsonSyntaxException e) {
-      LOG.info("Failed to parse runtime arguments on {}", request.getUri(), e);
-      throw e;
-    } finally {
-      reader.close();
-    }
-  }
-
-  private String getCSVHeaders(List<ColumnDesc> schema) throws HandleNotFoundException, SQLException, ExploreException {
-    StringBuffer sb = new StringBuffer();
-    boolean first = true;
-    for (ColumnDesc columnDesc : schema) {
-      if (first) {
-        first = false;
-      } else {
-        sb.append(',');
-      }
-      sb.append(columnDesc.getName());
-    }
-    return sb.toString();
-  }
-
-  private String appendCSVRow(StringBuffer sb, QueryResult result)
-    throws HandleNotFoundException, SQLException, ExploreException {
-    boolean first = true;
-    for (Object o : result.getColumns()) {
-      if (first) {
-        first = false;
-      } else {
-        sb.append(',');
-      }
-      // Using GSON toJson will serialize objects - in particular, strings will be quoted
-      sb.append(GSON.toJson(o));
-    }
-    return sb.toString();
   }
 }

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/executor/QueryExecutorHttpHandlerV2.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/executor/QueryExecutorHttpHandlerV2.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.explore.executor;
+
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.http.RESTMigrationUtils;
+import co.cask.http.AbstractHttpHandler;
+import co.cask.http.HttpResponder;
+import com.google.inject.Inject;
+import org.jboss.netty.handler.codec.http.HttpRequest;
+
+import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
+
+/**
+ *
+ */
+@Path(Constants.Gateway.API_VERSION_2)
+public class QueryExecutorHttpHandlerV2 extends AbstractHttpHandler {
+  private final QueryExecutorHttpHandler queryExecutorHttpHandler;
+  private final NamespacedQueryExecutorHttpHandler namespacedQueryExecutorHttpHandler;
+
+  @Inject
+  public QueryExecutorHttpHandlerV2(NamespacedQueryExecutorHttpHandler namespacedQueryExecutorHttpHandler,
+                                    QueryExecutorHttpHandler queryExecutorHttpHandler) {
+    this.namespacedQueryExecutorHttpHandler = namespacedQueryExecutorHttpHandler;
+    this.queryExecutorHttpHandler = queryExecutorHttpHandler;
+  }
+
+  @DELETE
+  @Path("data/explore/queries/{id}")
+  public void closeQuery(HttpRequest request, HttpResponder responder, @PathParam("id") String id) {
+    queryExecutorHttpHandler.closeQuery(RESTMigrationUtils.rewriteV2RequestToV3(request), responder, id);
+  }
+
+  @GET
+  @Path("data/explore/queries/{id}/status")
+  public void getQueryStatus(HttpRequest request, HttpResponder responder, @PathParam("id") String id) {
+    queryExecutorHttpHandler.getQueryStatus(RESTMigrationUtils.rewriteV2RequestToV3(request), responder, id);
+  }
+
+  @GET
+  @Path("data/explore/queries/{id}/schema")
+  public void getQueryResultsSchema(HttpRequest request, HttpResponder responder, @PathParam("id") String id) {
+    queryExecutorHttpHandler.getQueryResultsSchema(RESTMigrationUtils.rewriteV2RequestToV3(request), responder, id);
+  }
+
+  @POST
+  @Path("data/explore/queries/{id}/next")
+  public void getQueryNextResults(HttpRequest request, HttpResponder responder, @PathParam("id") String id) {
+    queryExecutorHttpHandler.getQueryNextResults(RESTMigrationUtils.rewriteV2RequestToV3(request), responder, id);
+  }
+
+
+  @POST
+  @Path("/data/explore/queries/{id}/preview")
+  public void getQueryResultPreview(HttpRequest request, HttpResponder responder, @PathParam("id") String id) {
+    queryExecutorHttpHandler.getQueryResultPreview(RESTMigrationUtils.rewriteV2RequestToV3(request), responder, id);
+  }
+
+  @POST
+  @Path("/data/explore/queries/{id}/download")
+  public void downloadQueryResults(HttpRequest request, HttpResponder responder, @PathParam("id") String id) {
+    queryExecutorHttpHandler.downloadQueryResults(RESTMigrationUtils.rewriteV2RequestToV3(request), responder, id);
+  }
+
+  @POST
+  @Path("data/explore/queries")
+  public void query(HttpRequest request, HttpResponder responder) {
+    namespacedQueryExecutorHttpHandler.query(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
+                                             Constants.DEFAULT_NAMESPACE);
+  }
+
+  @GET
+  @Path("/data/explore/queries")
+  public void getQueryLiveHandles(HttpRequest request, HttpResponder responder,
+                                  @QueryParam("offset") @DefaultValue("9223372036854775807") long offset,
+                                  @QueryParam("cursor") @DefaultValue("next") String cursor,
+                                  @QueryParam("limit") @DefaultValue("50") int limit) {
+    namespacedQueryExecutorHttpHandler.getQueryLiveHandles(RESTMigrationUtils.rewriteV2RequestToV3(request), responder,
+                                                           Constants.DEFAULT_NAMESPACE, offset, cursor, limit);
+  }
+}

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/guice/ExploreRuntimeModule.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/guice/ExploreRuntimeModule.java
@@ -28,7 +28,10 @@ import co.cask.cdap.explore.executor.ExploreMetadataHttpHandler;
 import co.cask.cdap.explore.executor.ExploreMetadataHttpHandlerV2;
 import co.cask.cdap.explore.executor.ExploreStatusHandler;
 import co.cask.cdap.explore.executor.ExploreStatusHandlerV2;
+import co.cask.cdap.explore.executor.NamespacedExploreMetadataHttpHandler;
+import co.cask.cdap.explore.executor.NamespacedQueryExecutorHttpHandler;
 import co.cask.cdap.explore.executor.QueryExecutorHttpHandler;
+import co.cask.cdap.explore.executor.QueryExecutorHttpHandlerV2;
 import co.cask.cdap.explore.service.ExploreService;
 import co.cask.cdap.explore.service.ExploreServiceUtils;
 import co.cask.cdap.explore.service.hive.Hive13ExploreService;
@@ -98,13 +101,16 @@ public class ExploreRuntimeModule extends RuntimeModule {
       Named exploreSeriveName = Names.named(Constants.Service.EXPLORE_HTTP_USER_SERVICE);
       Multibinder<HttpHandler> handlerBinder =
           Multibinder.newSetBinder(binder(), HttpHandler.class, exploreSeriveName);
+      handlerBinder.addBinding().to(NamespacedQueryExecutorHttpHandler.class);
       handlerBinder.addBinding().to(QueryExecutorHttpHandler.class);
-      handlerBinder.addBinding().to(ExploreExecutorHttpHandler.class);
-      handlerBinder.addBinding().to(ExploreExecutorHttpHandlerV2.class);
-      handlerBinder.addBinding().to(ExploreStatusHandler.class);
-      handlerBinder.addBinding().to(ExploreStatusHandlerV2.class);
+      handlerBinder.addBinding().to(NamespacedExploreMetadataHttpHandler.class);
       handlerBinder.addBinding().to(ExploreMetadataHttpHandler.class);
+      handlerBinder.addBinding().to(ExploreExecutorHttpHandler.class);
+      handlerBinder.addBinding().to(ExploreStatusHandler.class);
+      handlerBinder.addBinding().to(QueryExecutorHttpHandlerV2.class);
       handlerBinder.addBinding().to(ExploreMetadataHttpHandlerV2.class);
+      handlerBinder.addBinding().to(ExploreExecutorHttpHandlerV2.class);
+      handlerBinder.addBinding().to(ExploreStatusHandlerV2.class);
       CommonHandlers.add(handlerBinder);
 
       bind(ExploreExecutorService.class).in(Scopes.SINGLETON);

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/datasets/DatasetSerDe.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/datasets/DatasetSerDe.java
@@ -59,8 +59,8 @@ public class DatasetSerDe implements SerDe {
     // It is then important that this schema be accurate and in the right order - the same order as
     // object inspectors will reflect them.
     String datasetName = properties.getProperty(Constants.Explore.DATASET_NAME);
-    // note: namespacing will come in later. Perhaps initialize this class with a namespace or get it in each method
-    Id.DatasetInstance datasetInstanceId = Id.DatasetInstance.from(Constants.DEFAULT_NAMESPACE, datasetName);
+    String namespace = properties.getProperty(Constants.Explore.DATASET_NAMESPACE);
+    Id.DatasetInstance datasetInstanceId = Id.DatasetInstance.from(namespace, datasetName);
     try {
       Schema schema = DatasetAccessor.getRecordSchema(entries, datasetInstanceId);
       this.deserializer = new ObjectDeserializer(properties, schema);

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/datasets/DatasetStorageHandler.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/datasets/DatasetStorageHandler.java
@@ -80,8 +80,10 @@ public class DatasetStorageHandler extends DefaultStorageHandler {
     // NOTE: the jobProperties map will be put in the jobConf passed to the DatasetOutputFormat/DatasetInputFormat.
     // Hive ensures that the properties of the right table will be passed at the right time to those classes.
     String datasetName = tableDesc.getProperties().getProperty(Constants.Explore.DATASET_NAME);
+    String namespce = tableDesc.getProperties().getProperty(Constants.Explore.DATASET_NAMESPACE);
     jobProperties.put(Constants.Explore.DATASET_NAME, datasetName);
-    LOG.debug("Got dataset {} for external table {}", datasetName, tableDesc.getTableName());
+    jobProperties.put(Constants.Explore.DATASET_NAMESPACE, namespce);
+    LOG.debug("Got dataset {} in namespace {} for external table {}", datasetName, namespce, tableDesc.getTableName());
   }
 
   private boolean writesEnabled() {

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/BaseHiveExploreServiceTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/BaseHiveExploreServiceTest.java
@@ -202,11 +202,11 @@ public class BaseHiveExploreServiceTest {
     return status;
   }
 
-  protected static void runCommand(String command, boolean expectedHasResult,
+  protected static void runCommand(Id.Namespace namespace, String command, boolean expectedHasResult,
                                    List<ColumnDesc> expectedColumnDescs, List<QueryResult> expectedResults)
     throws Exception {
 
-    ListenableFuture<ExploreExecutionResult> future = exploreClient.submit(command);
+    ListenableFuture<ExploreExecutionResult> future = exploreClient.submit(namespace, command);
     assertStatementResult(future, expectedHasResult, expectedColumnDescs, expectedResults);
   }
 

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreExtensiveSchemaTableTestRun.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreExtensiveSchemaTableTestRun.java
@@ -95,12 +95,12 @@ public class ExploreExtensiveSchemaTableTestRun extends BaseHiveExploreServiceTe
 
   @Test
   public void testExtensiveSchema() throws Exception {
-    runCommand("show tables",
+    runCommand(NAMESPACE_ID, "show tables",
                true,
                Lists.newArrayList(new ColumnDesc("tab_name", "STRING", 1, "from deserializer")),
                Lists.newArrayList(new QueryResult(Lists.<Object>newArrayList("my_table"))));
 
-    runCommand("describe my_table",
+    runCommand(NAMESPACE_ID, "describe my_table",
                true,
                Lists.newArrayList(
                  new ColumnDesc("col_name", "STRING", 1, "from deserializer"),
@@ -152,7 +152,7 @@ public class ExploreExtensiveSchemaTableTestRun extends BaseHiveExploreServiceTe
                )
     );
 
-    runCommand("select * from my_table",
+    runCommand(NAMESPACE_ID, "select * from my_table",
                true,
                Lists.newArrayList(new ColumnDesc("my_table.s", "STRING", 1, null),
                                   new ColumnDesc("my_table.i", "INT", 2, null),
@@ -262,6 +262,6 @@ public class ExploreExtensiveSchemaTableTestRun extends BaseHiveExploreServiceTe
                                          new TableInfo.ColumnInfo("vlist", "array<struct<s:string,i:int>>", null),
                                          new TableInfo.ColumnInfo("stovmap", "map<string,struct<s:string,i:int>>", null)
                         ),
-                        exploreService.getTableInfo("default", "my_table").getSchema());
+                        exploreService.getTableInfo(NAMESPACE_ID.getId(), "my_table").getSchema());
   }
 }

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreMetadataTestRun.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreMetadataTestRun.java
@@ -110,7 +110,7 @@ public class ExploreMetadataTestRun extends BaseHiveExploreServiceTest {
   public void testGetSchemas() throws Exception {
     ListenableFuture<ExploreExecutionResult> future;
 
-    future = getExploreClient().schemas(null, "");
+    future = getExploreClient().schemas(null, NAMESPACE_ID.getId());
     assertStatementResult(future, true,
                           Lists.newArrayList(
                             new ColumnDesc("TABLE_SCHEM", "STRING", 1, "Schema name."),

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceFileSetTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceFileSetTest.java
@@ -27,6 +27,7 @@ import co.cask.cdap.api.dataset.lib.PartitionedFileSetProperties;
 import co.cask.cdap.api.dataset.lib.Partitioning;
 import co.cask.cdap.api.dataset.lib.TimePartitionedFileSet;
 import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.data2.datafabric.DefaultDatasetNamespace;
 import co.cask.cdap.data2.dataset2.lib.partitioned.TimePartitionedFileSetDataset;
 import co.cask.cdap.proto.ColumnDesc;
 import co.cask.cdap.proto.Id;
@@ -58,6 +59,7 @@ public class HiveExploreServiceFileSetTest extends BaseHiveExploreServiceTest {
                                                        Schema.Field.of("key", Schema.of(Schema.Type.STRING)),
                                                        Schema.Field.of("value", Schema.of(Schema.Type.STRING)));
   private static final DateFormat DATE_FORMAT = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT);
+  private static final DefaultDatasetNamespace DATASET_NAMESPACE = new DefaultDatasetNamespace(CConfiguration.create());
 
   @BeforeClass
   public static void start() throws Exception {
@@ -91,7 +93,7 @@ public class HiveExploreServiceFileSetTest extends BaseHiveExploreServiceTest {
       .build());
 
     // verify that the hive table was created for this file set
-    runCommand("show tables", true,
+    runCommand(NAMESPACE_ID, "show tables", true,
                Lists.newArrayList(new ColumnDesc("tab_name", "STRING", 1, "from deserializer")),
                Lists.newArrayList(new QueryResult(Lists.<Object>newArrayList(tableName))));
 
@@ -103,7 +105,7 @@ public class HiveExploreServiceFileSetTest extends BaseHiveExploreServiceTest {
     AvroHelper.generateAvroFile(fileSet.getLocation("file1").getOutputStream(), "a", 0, 3);
 
     // verify that we can query the key-values in the file with Hive
-    runCommand("SELECT * FROM " + tableName, true,
+    runCommand(NAMESPACE_ID, "SELECT * FROM " + tableName, true,
                Lists.newArrayList(
                  new ColumnDesc("files.key", "STRING", 1, null),
                  new ColumnDesc("files.value", "STRING", 2, null)),
@@ -116,7 +118,7 @@ public class HiveExploreServiceFileSetTest extends BaseHiveExploreServiceTest {
     AvroHelper.generateAvroFile(fileSet.getLocation("file2").getOutputStream(), "b", 3, 5);
 
     // verify that we can query the key-values in the file with Hive
-    runCommand("SELECT count(*) AS count FROM " + tableName, true,
+    runCommand(NAMESPACE_ID, "SELECT count(*) AS count FROM " + tableName, true,
                Lists.newArrayList(new ColumnDesc("count", "BIGINT", 1, null)),
                Lists.newArrayList(new QueryResult(Lists.<Object>newArrayList(5L))));
 
@@ -124,7 +126,7 @@ public class HiveExploreServiceFileSetTest extends BaseHiveExploreServiceTest {
     datasetFramework.deleteInstance(datasetInstanceId);
 
     // verify the Hive table is gone
-    runCommand("show tables", false,
+    runCommand(NAMESPACE_ID, "show tables", false,
                Lists.newArrayList(new ColumnDesc("tab_name", "STRING", 1, "from deserializer")),
                Collections.<QueryResult>emptyList());
   }
@@ -132,12 +134,9 @@ public class HiveExploreServiceFileSetTest extends BaseHiveExploreServiceTest {
 
   @Test
   public void testPartitionedFileSet() throws Exception {
-
-    final String datasetName = "parted";
+    final String datasetName = DATASET_NAMESPACE.namespace(NAMESPACE_ID, "parted");
     final Id.DatasetInstance datasetInstanceId = Id.DatasetInstance.from(NAMESPACE_ID, datasetName);
-
-    @SuppressWarnings("UnnecessaryLocalVariable")
-    final String tableName = datasetName; // in this test context, the hive table name is the same as the dataset name
+    final String tableName = datasetName.replace(".", "_");
 
     // create a time partitioned file set
     datasetFramework.addInstance("partitionedFileSet", datasetInstanceId, PartitionedFileSetProperties.builder()
@@ -156,7 +155,7 @@ public class HiveExploreServiceFileSetTest extends BaseHiveExploreServiceTest {
       .build());
 
     // verify that the hive table was created for this file set
-    runCommand("show tables", true,
+    runCommand(NAMESPACE_ID, "show tables", true,
                Lists.newArrayList(new ColumnDesc("tab_name", "STRING", 1, "from deserializer")),
                Lists.newArrayList(new QueryResult(Lists.<Object>newArrayList(tableName))));
 
@@ -188,7 +187,7 @@ public class HiveExploreServiceFileSetTest extends BaseHiveExploreServiceTest {
     addPartition(partitioned, keyY2, "fileY2");
 
     // verify that the partitions were added to Hive
-    runCommand("show partitions " + tableName, true,
+    runCommand(NAMESPACE_ID, "show partitions " + tableName, true,
                Lists.newArrayList(new ColumnDesc("partition", "STRING", 1, "from deserializer")),
                Lists.newArrayList(
                  new QueryResult(Lists.<Object>newArrayList("str=x/num=1")),
@@ -197,12 +196,12 @@ public class HiveExploreServiceFileSetTest extends BaseHiveExploreServiceTest {
                  new QueryResult(Lists.<Object>newArrayList("str=y/num=2"))));
 
     // verify that we can query the key-values in the file with Hive
-    runCommand("SELECT count(*) AS count FROM " + tableName, true,
+    runCommand(NAMESPACE_ID, "SELECT count(*) AS count FROM " + tableName, true,
                Lists.newArrayList(new ColumnDesc("count", "BIGINT", 1, null)),
                Lists.newArrayList(new QueryResult(Lists.<Object>newArrayList(4L))));
 
     // verify that we can query the key-values in the file with Hive
-    runCommand("SELECT * FROM " + tableName + " ORDER BY key, value", true,
+    runCommand(NAMESPACE_ID, "SELECT * FROM " + tableName + " ORDER BY key, value", true,
                Lists.newArrayList(
                  new ColumnDesc(tableName + ".key", "STRING", 1, null),
                  new ColumnDesc(tableName + ".value", "STRING", 2, null),
@@ -215,7 +214,7 @@ public class HiveExploreServiceFileSetTest extends BaseHiveExploreServiceTest {
                  new QueryResult(Lists.<Object>newArrayList("y2", "#2", "y", 2))));
 
     // verify that we can query the key-values in the file with Hive
-    runCommand("SELECT * FROM " + tableName + " WHERE num = 2 ORDER BY key, value", true,
+    runCommand(NAMESPACE_ID, "SELECT * FROM " + tableName + " WHERE num = 2 ORDER BY key, value", true,
                Lists.newArrayList(
                  new ColumnDesc(tableName + ".key", "STRING", 1, null),
                  new ColumnDesc(tableName + ".value", "STRING", 2, null),
@@ -229,7 +228,7 @@ public class HiveExploreServiceFileSetTest extends BaseHiveExploreServiceTest {
     dropPartition(partitioned, keyX2);
 
     // verify that one value is gone now, namely x2
-    runCommand("SELECT key, value FROM " + tableName + " ORDER BY key, value", true,
+    runCommand(NAMESPACE_ID, "SELECT key, value FROM " + tableName + " ORDER BY key, value", true,
                Lists.newArrayList(
                  new ColumnDesc("key", "STRING", 1, null),
                  new ColumnDesc("value", "STRING", 2, null)),
@@ -242,19 +241,16 @@ public class HiveExploreServiceFileSetTest extends BaseHiveExploreServiceTest {
     datasetFramework.deleteInstance(datasetInstanceId);
 
     // verify the Hive table is gone
-    runCommand("show tables", false,
+    runCommand(NAMESPACE_ID, "show tables", false,
                Lists.newArrayList(new ColumnDesc("tab_name", "STRING", 1, "from deserializer")),
                Collections.<QueryResult>emptyList());
   }
 
   @Test
   public void testTimePartitionedFileSet() throws Exception {
-
-    final String datasetName = "parts";
+    final String datasetName = DATASET_NAMESPACE.namespace(NAMESPACE_ID, "parts");
     final Id.DatasetInstance datasetInstanceId = Id.DatasetInstance.from(NAMESPACE_ID, datasetName);
-
-    @SuppressWarnings("UnnecessaryLocalVariable")
-    final String tableName = datasetName; // in this test context, the hive table name is the same as the dataset name
+    final String tableName = datasetName.replace(".", "_");
 
     // create a time partitioned file set
     datasetFramework.addInstance("timePartitionedFileSet", datasetInstanceId, FileSetProperties.builder()
@@ -269,7 +265,7 @@ public class HiveExploreServiceFileSetTest extends BaseHiveExploreServiceTest {
       .build());
 
     // verify that the hive table was created for this file set
-    runCommand("show tables", true,
+    runCommand(NAMESPACE_ID, "show tables", true,
                Lists.newArrayList(new ColumnDesc("tab_name", "STRING", 1, "from deserializer")),
                Lists.newArrayList(new QueryResult(Lists.<Object>newArrayList(tableName))));
 
@@ -296,7 +292,7 @@ public class HiveExploreServiceFileSetTest extends BaseHiveExploreServiceTest {
     addTimePartition(tpfs, time3, "file3");
 
     // verify that the partitions were added to Hive
-    runCommand("show partitions " + tableName, true,
+    runCommand(NAMESPACE_ID, "show partitions " + tableName, true,
                Lists.newArrayList(new ColumnDesc("partition", "STRING", 1, "from deserializer")),
                Lists.newArrayList(
                  new QueryResult(Lists.<Object>newArrayList("year=2014/month=12/day=10/hour=1/minute=0")),
@@ -304,7 +300,7 @@ public class HiveExploreServiceFileSetTest extends BaseHiveExploreServiceTest {
                  new QueryResult(Lists.<Object>newArrayList("year=2014/month=12/day=10/hour=3/minute=0"))));
 
     // verify that we can query the key-values in the file with Hive
-    runCommand("SELECT key, value FROM " + tableName + " ORDER BY key, value", true,
+    runCommand(NAMESPACE_ID, "SELECT key, value FROM " + tableName + " ORDER BY key, value", true,
                Lists.newArrayList(
                  new ColumnDesc("key", "STRING", 1, null),
                  new ColumnDesc("value", "STRING", 2, null)),
@@ -314,7 +310,8 @@ public class HiveExploreServiceFileSetTest extends BaseHiveExploreServiceTest {
                  new QueryResult(Lists.<Object>newArrayList("y2", "#2"))));
 
     // verify that we can query the key-values in the file with Hive
-    runCommand("SELECT key, value FROM " + tableName + " WHERE hour = 2 ORDER BY key, value", true,
+    runCommand(NAMESPACE_ID, "SELECT key, value FROM " + tableName + " WHERE hour = 2 ORDER BY key, value",
+               true,
                Lists.newArrayList(
                  new ColumnDesc("key", "STRING", 1, null),
                  new ColumnDesc("value", "STRING", 2, null)),
@@ -325,7 +322,7 @@ public class HiveExploreServiceFileSetTest extends BaseHiveExploreServiceTest {
     dropTimePartition(tpfs, time2);
 
     // verify that we can query the key-values in the file with Hive
-    runCommand("SELECT key, value FROM " + tableName + " ORDER BY key, value", true,
+    runCommand(NAMESPACE_ID, "SELECT key, value FROM " + tableName + " ORDER BY key, value", true,
                Lists.newArrayList(
                  new ColumnDesc("key", "STRING", 1, null),
                  new ColumnDesc("value", "STRING", 2, null)),
@@ -335,7 +332,7 @@ public class HiveExploreServiceFileSetTest extends BaseHiveExploreServiceTest {
 
     // verify the partition was removed from Hive
     // verify that the partitions were added to Hive
-    runCommand("show partitions " + tableName, true,
+    runCommand(NAMESPACE_ID, "show partitions " + tableName, true,
                Lists.newArrayList(new ColumnDesc("partition", "STRING", 1, "from deserializer")),
                Lists.newArrayList(
                  new QueryResult(Lists.<Object>newArrayList("year=2014/month=12/day=10/hour=1/minute=0")),
@@ -345,7 +342,7 @@ public class HiveExploreServiceFileSetTest extends BaseHiveExploreServiceTest {
     datasetFramework.deleteInstance(datasetInstanceId);
 
     // verify the Hive table is gone
-    runCommand("show tables", false,
+    runCommand(NAMESPACE_ID, "show tables", false,
                Lists.newArrayList(new ColumnDesc("tab_name", "STRING", 1, "from deserializer")),
                Collections.<QueryResult>emptyList());
 
@@ -361,7 +358,7 @@ public class HiveExploreServiceFileSetTest extends BaseHiveExploreServiceTest {
       .build());
 
     // verify that the hive table was created for this file set
-    runCommand("show tables", true,
+    runCommand(NAMESPACE_ID, "show tables", true,
                Lists.newArrayList(new ColumnDesc("tab_name", "STRING", 1, "from deserializer")),
                Lists.newArrayList(new QueryResult(Lists.<Object>newArrayList(tableName))));
   }
@@ -369,12 +366,9 @@ public class HiveExploreServiceFileSetTest extends BaseHiveExploreServiceTest {
   // this tests that the TPFS is backward-compatible after upgrade to 2.8, and correctly manages partitions in Hive.
   @Test
   public void testTimePartitionedFileSetBackwardsCompatibility() throws Exception {
-
-    final String datasetName = "backward";
+    final String datasetName = DATASET_NAMESPACE.namespace(NAMESPACE_ID, "backward");
     final Id.DatasetInstance datasetInstanceId = Id.DatasetInstance.from(NAMESPACE_ID, datasetName);
-
-    @SuppressWarnings("UnnecessaryLocalVariable")
-    final String tableName = datasetName; // in this test context, the hive table name is the same as the dataset name
+    final String tableName = datasetName.replace(".", "_");
 
     // create a time partitioned file set
     datasetFramework.addInstance("timePartitionedFileSet", datasetInstanceId, FileSetProperties.builder()
@@ -389,7 +383,7 @@ public class HiveExploreServiceFileSetTest extends BaseHiveExploreServiceTest {
       .build());
 
     // verify that the hive table was created for this file set
-    runCommand("show tables", true,
+    runCommand(NAMESPACE_ID, "show tables", true,
                Lists.newArrayList(new ColumnDesc("tab_name", "STRING", 1, "from deserializer")),
                Lists.newArrayList(new QueryResult(Lists.<Object>newArrayList(tableName))));
 
@@ -419,14 +413,14 @@ public class HiveExploreServiceFileSetTest extends BaseHiveExploreServiceTest {
     addLegacyTimePartition(tpfs, time3, "file3");
 
     // verify that the partitions were added to Hive
-    runCommand("show partitions " + tableName, true,
+    runCommand(NAMESPACE_ID, "show partitions " + tableName, true,
                Lists.newArrayList(new ColumnDesc("partition", "STRING", 1, "from deserializer")),
                Lists.newArrayList(
                  new QueryResult(Lists.<Object>newArrayList("year=2014/month=12/day=10/hour=1/minute=0")),
                  new QueryResult(Lists.<Object>newArrayList("year=2014/month=12/day=10/hour=3/minute=0"))));
 
     // verify that we can query the key-values in the file with Hive
-    runCommand("SELECT key, value FROM " + tableName + " ORDER BY key, value", true,
+    runCommand(NAMESPACE_ID, "SELECT key, value FROM " + tableName + " ORDER BY key, value", true,
                Lists.newArrayList(
                  new ColumnDesc("key", "STRING", 1, null),
                  new ColumnDesc("value", "STRING", 2, null)),
@@ -438,14 +432,14 @@ public class HiveExploreServiceFileSetTest extends BaseHiveExploreServiceTest {
     addTimePartition(tpfs, time2, "file2");
 
     // verify that the partition was added to Hive and we can query across all three
-    runCommand("show partitions " + tableName, true,
+    runCommand(NAMESPACE_ID, "show partitions " + tableName, true,
                Lists.newArrayList(new ColumnDesc("partition", "STRING", 1, "from deserializer")),
                Lists.newArrayList(
                  new QueryResult(Lists.<Object>newArrayList("year=2014/month=12/day=10/hour=1/minute=0")),
                  new QueryResult(Lists.<Object>newArrayList("year=2014/month=12/day=10/hour=2/minute=0")),
                  new QueryResult(Lists.<Object>newArrayList("year=2014/month=12/day=10/hour=3/minute=0"))));
 
-    runCommand("SELECT key, value FROM " + tableName + " ORDER BY key, value", true,
+    runCommand(NAMESPACE_ID, "SELECT key, value FROM " + tableName + " ORDER BY key, value", true,
                Lists.newArrayList(
                  new ColumnDesc("key", "STRING", 1, null),
                  new ColumnDesc("value", "STRING", 2, null)),
@@ -458,14 +452,14 @@ public class HiveExploreServiceFileSetTest extends BaseHiveExploreServiceTest {
     dropTimePartition(tpfs, time3);
 
     // verify that the partition was added to Hive and we can query across all three
-    runCommand("show partitions " + tableName, true,
+    runCommand(NAMESPACE_ID, "show partitions " + tableName, true,
                Lists.newArrayList(new ColumnDesc("partition", "STRING", 1, "from deserializer")),
                Lists.newArrayList(
                  new QueryResult(Lists.<Object>newArrayList("year=2014/month=12/day=10/hour=1/minute=0")),
                  new QueryResult(Lists.<Object>newArrayList("year=2014/month=12/day=10/hour=2/minute=0"))));
 
     // verify that we can query the key-values in the file with Hive
-    runCommand("SELECT key, value FROM " + tableName + " ORDER BY key, value", true,
+    runCommand(NAMESPACE_ID, "SELECT key, value FROM " + tableName + " ORDER BY key, value", true,
                Lists.newArrayList(
                  new ColumnDesc("key", "STRING", 1, null),
                  new ColumnDesc("value", "STRING", 2, null)),
@@ -477,7 +471,7 @@ public class HiveExploreServiceFileSetTest extends BaseHiveExploreServiceTest {
     datasetFramework.deleteInstance(datasetInstanceId);
 
     // verify the Hive table is gone
-    runCommand("show tables", false,
+    runCommand(NAMESPACE_ID, "show tables", false,
                Lists.newArrayList(new ColumnDesc("tab_name", "STRING", 1, "from deserializer")),
                Collections.<QueryResult>emptyList());
   }

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceStopTestRun.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceStopTestRun.java
@@ -39,7 +39,7 @@ public class HiveExploreServiceStopTestRun extends BaseHiveExploreServiceTest {
     ExploreService exploreService = injector.getInstance(ExploreService.class);
     Set<Long> beforeTxns = transactionManager.getCurrentState().getInProgress().keySet();
 
-    exploreService.execute("show tables");
+    exploreService.execute(NAMESPACE_ID, "show tables");
 
     Set<Long> queryTxns = Sets.difference(transactionManager.getCurrentState().getInProgress().keySet(), beforeTxns);
     Assert.assertFalse(queryTxns.isEmpty());

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceStreamTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceStreamTest.java
@@ -21,7 +21,6 @@ import co.cask.cdap.api.data.format.FormatSpecification;
 import co.cask.cdap.api.data.format.Formats;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.common.conf.CConfiguration;
-import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.explore.client.ExploreExecutionResult;
 import co.cask.cdap.proto.ColumnDesc;
 import co.cask.cdap.proto.QueryResult;
@@ -79,7 +78,7 @@ public class HiveExploreServiceStreamTest extends BaseHiveExploreServiceTest {
 
   @Test
   public void testStreamDefaultSchema() throws Exception {
-    runCommand("describe " + streamTableName,
+    runCommand(NAMESPACE_ID, "describe " + streamTableName,
                true,
                Lists.newArrayList(
                  new ColumnDesc("col_name", "STRING", 1, "from deserializer"),
@@ -97,7 +96,7 @@ public class HiveExploreServiceStreamTest extends BaseHiveExploreServiceTest {
 
   @Test
   public void testSelectStarOnStream() throws Exception {
-    ExploreExecutionResult results = exploreClient.submit("select * from " + streamTableName).get();
+    ExploreExecutionResult results = exploreClient.submit(NAMESPACE_ID, "select * from " + streamTableName).get();
     // check schema
     List<ColumnDesc> expectedSchema = Lists.newArrayList(
       new ColumnDesc(streamTableName + ".ts", "BIGINT", 1, null),
@@ -125,7 +124,7 @@ public class HiveExploreServiceStreamTest extends BaseHiveExploreServiceTest {
 
   @Test
   public void testSelectFieldOnStream() throws Exception {
-    runCommand("select body from " + streamTableName,
+    runCommand(NAMESPACE_ID, "select body from " + streamTableName,
                true,
                Lists.newArrayList(new ColumnDesc("body", "STRING", 1, null)),
                Lists.newArrayList(
@@ -134,7 +133,8 @@ public class HiveExploreServiceStreamTest extends BaseHiveExploreServiceTest {
                  new QueryResult(Lists.<Object>newArrayList(body3)))
     );
 
-    runCommand("select headers[\"header1\"] as h1, headers[\"header2\"] as h2 from " + streamTableName,
+    runCommand(NAMESPACE_ID,
+               "select headers[\"header1\"] as h1, headers[\"header2\"] as h2 from " + streamTableName,
                true,
                Lists.newArrayList(new ColumnDesc("h1", "STRING", 1, null),
                                   new ColumnDesc("h2", "STRING", 2, null)),
@@ -147,7 +147,7 @@ public class HiveExploreServiceStreamTest extends BaseHiveExploreServiceTest {
 
   @Test
   public void testSelectAndFilterQueryOnStream() throws Exception {
-    runCommand("select body from " + streamTableName + " where ts > " + Long.MAX_VALUE,
+    runCommand(NAMESPACE_ID, "select body from " + streamTableName + " where ts > " + Long.MAX_VALUE,
                false,
                Lists.newArrayList(new ColumnDesc("body", "STRING", 1, null)),
                Lists.<QueryResult>newArrayList());
@@ -161,7 +161,7 @@ public class HiveExploreServiceStreamTest extends BaseHiveExploreServiceTest {
     // Streams with '-' are replaced with '_'
     String cleanStreamName = "stream_test";
 
-    runCommand("select body from " + getTableName(cleanStreamName), true,
+    runCommand(NAMESPACE_ID, "select body from " + getTableName(cleanStreamName), true,
                Lists.newArrayList(new ColumnDesc("body", "STRING", 1, null)),
                Lists.newArrayList(new QueryResult(Lists.<Object>newArrayList("Dummy"))));
   }
@@ -176,7 +176,8 @@ public class HiveExploreServiceStreamTest extends BaseHiveExploreServiceTest {
     sendStreamEvent("jointest2", Collections.<String, String>emptyMap(), Bytes.toBytes("ABC"));
     sendStreamEvent("jointest2", Collections.<String, String>emptyMap(), Bytes.toBytes("DEF"));
 
-    runCommand("select " + getTableName("jointest1") + ".body, " + getTableName("jointest2") + ".body" +
+    runCommand(NAMESPACE_ID,
+               "select " + getTableName("jointest1") + ".body, " + getTableName("jointest2") + ".body" +
                  " from " + getTableName("jointest1") + " join " + getTableName("jointest2") +
                  " on (" + getTableName("jointest1") + ".body = " + getTableName("jointest2") + ".body)",
                true,
@@ -188,7 +189,8 @@ public class HiveExploreServiceStreamTest extends BaseHiveExploreServiceTest {
 
   @Test(expected = ExecutionException.class)
   public void testWriteToStreamFails() throws Exception {
-    exploreClient.submit("insert into table " + streamTableName + " select * from " + streamTableName).get();
+    exploreClient.submit(NAMESPACE_ID,
+                         "insert into table " + streamTableName + " select * from " + streamTableName).get();
   }
 
   @Test
@@ -219,6 +221,7 @@ public class HiveExploreServiceStreamTest extends BaseHiveExploreServiceTest {
 
 
     ExploreExecutionResult result = exploreClient.submit(
+      NAMESPACE_ID,
       "SELECT user, sum(num) as total_num, sum(price * num) as total_price " +
         "FROM " + getTableName("avroStream") + " GROUP BY user ORDER BY total_price DESC").get();
 
@@ -254,7 +257,7 @@ public class HiveExploreServiceStreamTest extends BaseHiveExploreServiceTest {
   }
 
   private static String getTableName(String streamName) {
-    return String.format("cdap_stream_%s_%s", Constants.DEFAULT_NAMESPACE, streamName);
+    return String.format("cdap_stream_%s_%s", NAMESPACE_ID, streamName);
   }
 
   private byte[] createAvroEvent(org.apache.avro.Schema schema, Object... values) throws IOException {

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceTimeoutTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceTimeoutTest.java
@@ -110,7 +110,7 @@ public class HiveExploreServiceTimeoutTest extends BaseHiveExploreServiceTest {
   public void testTimeoutRunning() throws Exception {
     Set<Long> beforeTxns = transactionManager.getCurrentState().getInProgress().keySet();
 
-    QueryHandle handle = exploreService.execute("select key, value from my_table");
+    QueryHandle handle = exploreService.execute(NAMESPACE_ID, "select key, value from my_table");
 
     Set<Long> queryTxns = Sets.difference(transactionManager.getCurrentState().getInProgress().keySet(), beforeTxns);
     Assert.assertFalse(queryTxns.isEmpty());
@@ -137,7 +137,7 @@ public class HiveExploreServiceTimeoutTest extends BaseHiveExploreServiceTest {
   public void testTimeoutFetchAllResults() throws Exception {
     Set<Long> beforeTxns = transactionManager.getCurrentState().getInProgress().keySet();
 
-    QueryHandle handle = exploreService.execute("select key, value from my_table");
+    QueryHandle handle = exploreService.execute(NAMESPACE_ID, "select key, value from my_table");
 
     Set<Long> queryTxns = Sets.difference(transactionManager.getCurrentState().getInProgress().keySet(), beforeTxns);
     Assert.assertFalse(queryTxns.isEmpty());
@@ -182,7 +182,7 @@ public class HiveExploreServiceTimeoutTest extends BaseHiveExploreServiceTest {
   public void testTimeoutNoResults() throws Exception {
     Set<Long> beforeTxns = transactionManager.getCurrentState().getInProgress().keySet();
 
-    QueryHandle handle = exploreService.execute("drop table if exists not_existing_table_name");
+    QueryHandle handle = exploreService.execute(NAMESPACE_ID, "drop table if exists not_existing_table_name");
 
     Set<Long> queryTxns = Sets.difference(transactionManager.getCurrentState().getInProgress().keySet(), beforeTxns);
     Assert.assertFalse(queryTxns.isEmpty());
@@ -221,7 +221,7 @@ public class HiveExploreServiceTimeoutTest extends BaseHiveExploreServiceTest {
 
   @Test
   public void testCloseQuery() throws Exception {
-    QueryHandle handle = exploreService.execute("drop table if exists not_existing_table_name");
+    QueryHandle handle = exploreService.execute(NAMESPACE_ID, "drop table if exists not_existing_table_name");
     exploreService.close(handle);
     try {
       exploreService.getStatus(handle);

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/InMemoryExploreServiceTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/InMemoryExploreServiceTest.java
@@ -35,6 +35,7 @@ import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
 import co.cask.cdap.notifications.feeds.NotificationFeedManager;
 import co.cask.cdap.notifications.feeds.service.NoOpNotificationFeedManager;
 import co.cask.cdap.proto.ColumnDesc;
+import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.QueryHandle;
 import co.cask.cdap.proto.QueryResult;
 import co.cask.cdap.proto.QueryStatus;
@@ -191,7 +192,7 @@ public class InMemoryExploreServiceTest {
   private static void runCommand(String command, boolean expectedHasResult,
                                  List<ColumnDesc> expectedColumnDescs,
                                  List<QueryResult> expectedResults) throws Exception {
-    QueryHandle handle = exploreService.execute(command);
+    QueryHandle handle = exploreService.execute(Id.Namespace.from(Constants.DEFAULT_NAMESPACE), command);
 
     QueryStatus status = waitForCompletionStatus(handle);
     Assert.assertEquals(QueryStatus.OpStatus.FINISHED, status.getStatus());

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/WritableDatasetTestRun.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/WritableDatasetTestRun.java
@@ -99,7 +99,7 @@ public class WritableDatasetTestRun extends BaseHiveExploreServiceTest {
     try {
       initKeyValueTable(MY_TABLE, true);
       ListenableFuture<ExploreExecutionResult> future =
-        exploreClient.submit("insert into table my_table select * from my_table");
+        exploreClient.submit(NAMESPACE_ID, "insert into table my_table select * from my_table");
       ExploreExecutionResult result = future.get();
       result.close();
 
@@ -122,7 +122,7 @@ public class WritableDatasetTestRun extends BaseHiveExploreServiceTest {
       table.postTxCommit();
 
       // Make sure Hive also sees those values
-      result = exploreClient.submit("select * from my_table").get();
+      result = exploreClient.submit(NAMESPACE_ID, "select * from my_table").get();
       Assert.assertEquals("1", result.next().getColumns().get(0).toString());
       Assert.assertEquals("1_2", result.next().getColumns().get(0).toString());
       Assert.assertEquals("2", result.next().getColumns().get(0).toString());
@@ -144,12 +144,12 @@ public class WritableDatasetTestRun extends BaseHiveExploreServiceTest {
       initKeyValueTable(myTable1, true);
       initKeyValueTable(myTable2, true);
 
-      ExploreExecutionResult result = exploreClient.submit("select * from dot_table").get();
+      ExploreExecutionResult result = exploreClient.submit(NAMESPACE_ID, "select * from dot_table").get();
 
       Assert.assertEquals("1", result.next().getColumns().get(0).toString());
       result.close();
 
-      result = exploreClient.submit("select * from hyphen_table").get();
+      result = exploreClient.submit(NAMESPACE_ID, "select * from hyphen_table").get();
       Assert.assertEquals("1", result.next().getColumns().get(0).toString());
       result.close();
 
@@ -189,11 +189,11 @@ public class WritableDatasetTestRun extends BaseHiveExploreServiceTest {
       table.postTxCommit();
 
       ListenableFuture<ExploreExecutionResult> future =
-        exploreClient.submit("insert into table my_table select key,value from extended_table");
+        exploreClient.submit(NAMESPACE_ID, "insert into table my_table select key,value from extended_table");
       ExploreExecutionResult result = future.get();
       result.close();
 
-      result = exploreClient.submit("select * from my_table").get();
+      result = exploreClient.submit(NAMESPACE_ID, "select * from my_table").get();
       Assert.assertEquals("1", result.next().getColumns().get(0).toString());
       Assert.assertEquals("10_2", result.next().getColumns().get(0).toString());
       Assert.assertEquals("2", result.next().getColumns().get(0).toString());
@@ -201,9 +201,10 @@ public class WritableDatasetTestRun extends BaseHiveExploreServiceTest {
       result.close();
 
       // Test insert overwrite
-      result = exploreClient.submit("insert overwrite table my_table select key,value from extended_table").get();
+      result = exploreClient.submit(NAMESPACE_ID,
+                                    "insert overwrite table my_table select key,value from extended_table").get();
       result.close();
-      result = exploreClient.submit("select * from my_table").get();
+      result = exploreClient.submit(NAMESPACE_ID, "select * from my_table").get();
       result.hasNext();
 
     } finally {
@@ -246,7 +247,7 @@ public class WritableDatasetTestRun extends BaseHiveExploreServiceTest {
       table.postTxCommit();
 
       ListenableFuture<ExploreExecutionResult> future =
-        exploreClient.submit("insert into table writable_table select key,value from extended_table");
+        exploreClient.submit(NAMESPACE_ID, "insert into table writable_table select key,value from extended_table");
       ExploreExecutionResult result = future.get();
       result.close();
 
@@ -283,23 +284,24 @@ public class WritableDatasetTestRun extends BaseHiveExploreServiceTest {
       initKeyValueTable(myTable2, false);
       initKeyValueTable(myTable3, false);
       ListenableFuture<ExploreExecutionResult> future =
-        exploreClient.submit("from my_table insert into table my_table_1 select * where key='1'" +
+        exploreClient.submit(NAMESPACE_ID,
+                             "from my_table insert into table my_table_1 select * where key='1'" +
                                "insert into table my_table_2 select * where key='2'" +
                                "insert into table my_table_3 select *");
       ExploreExecutionResult result = future.get();
       result.close();
 
-      result = exploreClient.submit("select * from my_table_2").get();
+      result = exploreClient.submit(NAMESPACE_ID, "select * from my_table_2").get();
       Assert.assertEquals("2_2", result.next().getColumns().get(0).toString());
       Assert.assertFalse(result.hasNext());
       result.close();
 
-      result = exploreClient.submit("select * from my_table_1").get();
+      result = exploreClient.submit(NAMESPACE_ID, "select * from my_table_1").get();
       Assert.assertEquals("1_2", result.next().getColumns().get(0).toString());
       Assert.assertFalse(result.hasNext());
       result.close();
 
-      result = exploreClient.submit("select * from my_table_3").get();
+      result = exploreClient.submit(NAMESPACE_ID, "select * from my_table_3").get();
       Assert.assertEquals("1_2", result.next().getColumns().get(0).toString());
       Assert.assertEquals("2_2", result.next().getColumns().get(0).toString());
       Assert.assertFalse(result.hasNext());
@@ -321,14 +323,16 @@ public class WritableDatasetTestRun extends BaseHiveExploreServiceTest {
       URL loadFileUrl = getClass().getResource("/test_table.dat");
       Assert.assertNotNull(loadFileUrl);
 
-      exploreClient.submit("create table test (first INT, second STRING) ROW FORMAT " +
+      exploreClient.submit(NAMESPACE_ID,
+                           "create table test (first INT, second STRING) ROW FORMAT " +
                              "DELIMITED FIELDS TERMINATED BY '\\t'").get().close();
-      exploreClient.submit("LOAD DATA LOCAL INPATH '" + new File(loadFileUrl.toURI()).getAbsolutePath() +
+      exploreClient.submit(NAMESPACE_ID,
+                           "LOAD DATA LOCAL INPATH '" + new File(loadFileUrl.toURI()).getAbsolutePath() +
                              "' INTO TABLE test").get().close();
 
-      exploreClient.submit("insert into table simple_table select * from test").get().close();
+      exploreClient.submit(NAMESPACE_ID, "insert into table simple_table select * from test").get().close();
 
-      ExploreExecutionResult result = exploreClient.submit("select * from simple_table").get();
+      ExploreExecutionResult result = exploreClient.submit(NAMESPACE_ID, "select * from simple_table").get();
       Assert.assertEquals(ImmutableList.of(1, "one"), result.next().getColumns());
       Assert.assertEquals(ImmutableList.of(2, "two"), result.next().getColumns());
       Assert.assertEquals(ImmutableList.of(3, "three"), result.next().getColumns());
@@ -338,7 +342,7 @@ public class WritableDatasetTestRun extends BaseHiveExploreServiceTest {
       result.close();
 
     } finally {
-      exploreClient.submit("drop table if exists test").get().close();
+      exploreClient.submit(NAMESPACE_ID, "drop table if exists test").get().close();
       datasetFramework.deleteInstance(simpleTable);
       datasetFramework.deleteModule(kvTable);
     }
@@ -350,7 +354,7 @@ public class WritableDatasetTestRun extends BaseHiveExploreServiceTest {
     datasetFramework.addModule(kvTable, new KeyValueTableDefinition.KeyValueTableModule());
     datasetFramework.addInstance("kvTable", simpleTable, DatasetProperties.EMPTY);
     try {
-      exploreClient.submit("create table test (first INT, second STRING) ROW FORMAT " +
+      exploreClient.submit(NAMESPACE_ID, "create table test (first INT, second STRING) ROW FORMAT " +
                              "DELIMITED FIELDS TERMINATED BY '\\t'").get().close();
 
       // Accessing dataset instance to perform data operations
@@ -369,15 +373,15 @@ public class WritableDatasetTestRun extends BaseHiveExploreServiceTest {
       transactionManager.commit(tx1);
       table.postTxCommit();
 
-      exploreClient.submit("insert into table test select * from simple_table").get().close();
+      exploreClient.submit(NAMESPACE_ID, "insert into table test select * from simple_table").get().close();
 
-      ExploreExecutionResult result = exploreClient.submit("select * from test").get();
+      ExploreExecutionResult result = exploreClient.submit(NAMESPACE_ID, "select * from test").get();
       Assert.assertEquals(ImmutableList.of(10, "ten"), result.next().getColumns());
       Assert.assertFalse(result.hasNext());
       result.close();
 
     } finally {
-      exploreClient.submit("drop table if exists test").get().close();
+      exploreClient.submit(NAMESPACE_ID, "drop table if exists test").get().close();
       datasetFramework.deleteInstance(simpleTable);
       datasetFramework.deleteModule(kvTable);
     }

--- a/cdap-explore/src/test/java/co/cask/cdap/hive/objectinspector/StandardObjectInspectorsTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/hive/objectinspector/StandardObjectInspectorsTest.java
@@ -444,7 +444,6 @@ public class StandardObjectInspectorsTest {
 
     // Settable
     Object struct3 = soi1.create();
-    System.out.println(struct3);
     soi1.setStructFieldData(struct3, fields.get(0), 1);
     soi1.setStructFieldData(struct3, fields.get(1), "two");
     soi1.setStructFieldData(struct3, fields.get(2), true);

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterPathLookup.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterPathLookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -56,7 +56,7 @@ public final class RouterPathLookup extends AuthenticatedHttpHandler {
       //WebApp serves only static files (HTML, CSS, JS) and so /<appname> calls should go to WebApp
       //But procedure/stream calls issued by the UI should be routed to the appropriate CDAP service
       if (fallbackService.contains("$HOST") && (uriParts.length >= 1)
-                                            && (!(("/" + uriParts[0]).equals(Constants.Gateway.API_VERSION_2)))) {
+        && (!(("/" + uriParts[0]).equals(Constants.Gateway.API_VERSION_2)))) {
         return fallbackService;
       }
 
@@ -160,14 +160,16 @@ public final class RouterPathLookup extends AuthenticatedHttpHandler {
     } else if (uriParts.length >= 2 && uriParts[1].equals("metrics")) {
       //Metrics Search Handler Path /v3/metrics
       return Constants.Service.METRICS;
+    } else if (uriParts.length >= 5 && uriParts[1].equals("data") && uriParts[2].equals("explore") &&
+      (uriParts[3].equals("queries") || uriParts[3].equals("jdbc") || uriParts[3].equals("namespaces"))) {
+      // non-namespaced explore operations. For example, /v3/data/explore/queries/{id}
+      return Constants.Service.EXPLORE_HTTP_USER_SERVICE;
+    } else if (uriParts.length >= 6 && uriParts[3].equals("data") && uriParts[4].equals("explore") &&
+      (uriParts[5].equals("queries") || uriParts[5].equals("streams") || uriParts[5].equals("datasets")
+        || uriParts[5].equals("tables") || uriParts[5].equals("jdbc"))) {
+      // namespaced explore operations. For example, /v3/namespaces/{namespace-id}/data/explore/streams/{stream}/enable
+      return Constants.Service.EXPLORE_HTTP_USER_SERVICE;
     } else if ((uriParts.length >= 4) && uriParts[3].equals("data")) {
-      if ((uriParts.length >= 5) && uriParts[4].equals("explore")
-        && (uriParts[5].equals("queries") || uriParts[5].equals("jdbc") || uriParts[5].equals("tables"))) {
-        return Constants.Service.EXPLORE_HTTP_USER_SERVICE;
-      } else if ((uriParts.length == 8) && uriParts[4].equals("explore") && uriParts[5].equals("datasets")) {
-        // v3/namespaces/<namespace>/data/explore/datasets/<dataset>/schema
-        return Constants.Service.EXPLORE_HTTP_USER_SERVICE;
-      }
       return Constants.Service.DATASET_MANAGER;
     }
     return Constants.Service.APP_FABRIC_HTTP;

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/QueryHandle.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/QueryHandle.java
@@ -23,7 +23,7 @@ import java.util.UUID;
 /**
  * Represents a submitted query operation.
  */
-public class QueryHandle {
+public final class QueryHandle {
 
   private static final String NO_OP_ID = "NO_OP";
   public static final QueryHandle NO_OP = new QueryHandle(NO_OP_ID);
@@ -41,6 +41,10 @@ public class QueryHandle {
     return new QueryHandle(id);
   }
 
+  /**
+   * Create a new QueryHandle.
+   * @param handle handle of the query.
+   */
   private QueryHandle(String handle) {
     this.handle = handle;
   }

--- a/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
+++ b/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
@@ -113,7 +113,7 @@ public class StandaloneMain {
     serviceStore = injector.getInstance(ServiceStore.class);
     streamService = injector.getInstance(StreamService.class);
 
-    this.webCloudAppService = (webAppPath == null) ? null : injector.getInstance(WebCloudAppService.class);
+    webCloudAppService = (webAppPath == null) ? null : injector.getInstance(WebCloudAppService.class);
 
     sslEnabled = configuration.getBoolean(Constants.Security.SSL_ENABLED);
     securityEnabled = configuration.getBoolean(Constants.Security.ENABLED);
@@ -123,7 +123,7 @@ public class StandaloneMain {
 
     boolean exploreEnabled = configuration.getBoolean(Constants.Explore.EXPLORE_ENABLED);
     if (exploreEnabled) {
-      ExploreServiceUtils.checkHiveSupportWithoutSecurity(this.getClass().getClassLoader());
+      ExploreServiceUtils.checkHiveSupportWithoutSecurity(getClass().getClassLoader());
       exploreExecutorService = injector.getInstance(ExploreExecutorService.class);
     }
 

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/UnitTestManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/UnitTestManager.java
@@ -205,7 +205,8 @@ public class UnitTestManager implements TestManager {
     String host = address.getHostName();
     int port = address.getPort();
 
-    String connectString = String.format("%s%s:%d", Constants.Explore.Jdbc.URL_PREFIX, host, port);
+    String connectString = String.format("%s%s:%d?namespace=%s", Constants.Explore.Jdbc.URL_PREFIX, host, port,
+                                         Constants.DEFAULT_NAMESPACE);
 
     return DriverManager.getConnection(connectString);
   }


### PR DESCRIPTION
Major design choices: 
1. Split up the Explore handlers into 2 types - those that require a namespace and those that don't. For instance, to submit a query you need a namespace, but to get the status of that query you need only the `QueryHandle` since those are unique across namespaces. 
2. ~~`QueryHandle` now has a `namespaceId` that isn't used for equality checking (since some operations aren't namespaced and you don't have their namespace at that point). However, it is used when getting namespace-specific queries (such as `getQueries`).~~ => Resolved by moving the `namespace` to the value of the cache, which also significantly cleans up the logic.

TODO:
1. ~~PFS needs to be partitioned - sync up with @bdmogal on this. Relevant tests have been ignored.~~ => Fixed.
2. Add more tests for namespaced operations.