### PR TITLE
remove QueueAdmin#dropAll and update queue data table (put namespace in ...

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/AbstractQueueAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/AbstractQueueAdmin.java
@@ -33,8 +33,8 @@ public abstract class AbstractQueueAdmin implements QueueAdmin {
   public AbstractQueueAdmin(CConfiguration conf, QueueConstants.QueueType type) {
     // todo: we have to do that because queues do not follow dataset semantic fully (yet)
     // system scope
-    unqualifiedTableNamePrefix = Constants.SYSTEM_NAMESPACE + "." + type.toString();
-    namespace = new DefaultDatasetNamespace(conf);
+    this.unqualifiedTableNamePrefix = Constants.SYSTEM_NAMESPACE + "." + type.toString();
+    this.namespace = new DefaultDatasetNamespace(conf);
   }
 
   /**

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/AbstractQueueAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/AbstractQueueAdmin.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.transaction.queue;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.queue.QueueName;
+import co.cask.cdap.data2.datafabric.DefaultDatasetNamespace;
+import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
+import co.cask.cdap.proto.Id;
+
+/**
+ * Common implementation of table-based QueueAdmin
+ */
+public abstract class AbstractQueueAdmin implements QueueAdmin {
+  private final String unqualifiedTableNamePrefix;
+  protected final DefaultDatasetNamespace namespace;
+
+  public AbstractQueueAdmin(CConfiguration conf, QueueConstants.QueueType type) {
+    // todo: we have to do that because queues do not follow dataset semantic fully (yet)
+    // system scope
+    unqualifiedTableNamePrefix = Constants.SYSTEM_NAMESPACE + "." + type.toString();
+    namespace = new DefaultDatasetNamespace(conf);
+  }
+
+  /**
+   * @param queueTableName actual queue table name
+   * @return namespace id that this queue belongs to
+   */
+  public static String getNamespaceId(String queueTableName) {
+    // last three parts are namespaceId, appName and flow
+    String[] parts = queueTableName.split("\\.");
+    String namespaceId;
+    if (parts.length == 6) {
+      // cdap.<namespace>.system.queue.<app>.<flow>
+      namespaceId = parts[1];
+    } else {
+      throw new IllegalArgumentException(String.format("Unexpected format for queue table name. " +
+                                                         "Expected 'cdap.<namespace>.system.queue.<app>.<flow>'" +
+                                                         "Received '%s'",
+                                                       queueTableName));
+    }
+    return namespaceId;
+  }
+
+  /**
+   * @param queueTableName actual queue table name
+   * @return app name this queue belongs to
+   */
+  public static String getApplicationName(String queueTableName) {
+    // last three parts are namespaceId (optional - in which case it will be the default namespace), appName and flow
+    String[] parts = queueTableName.split("\\.");
+    return parts[parts.length - 2];
+  }
+
+  /**
+   * @param queueTableName actual queue table name
+   * @return flow name this queue belongs to
+   */
+  public static String getFlowName(String queueTableName) {
+    // last three parts are namespaceId (optional - in which case it will be the default namespace), appName and flow
+    String[] parts = queueTableName.split("\\.");
+    return parts[parts.length - 1];
+  }
+
+
+  /**
+   * This determines the actual table name from the table name prefix and the name of the queue.
+   * @param queueName The name of the queue.
+   * @return the full name of the table that holds this queue.
+   */
+  public String getActualTableName(QueueName queueName) {
+    if (queueName.isQueue()) {
+      // <root namespace>.<queue namespace>.system.queue.<app>.<flow>
+      return getTableNameForFlow(queueName.getFirstComponent(),
+                                 queueName.getSecondComponent(),
+                                 queueName.getThirdComponent());
+    } else {
+      throw new IllegalArgumentException("'" + queueName + "' is not a valid name for a queue.");
+    }
+  }
+
+  protected String getTableNameForFlow(String namespaceId, String app, String flow) {
+    String tablePrefix = getTableNamePrefix(namespaceId);
+    String tableName = tablePrefix + "." + app + "." + flow;
+    return HBaseTableUtil.getHBaseTableName(tableName);
+  }
+
+  public String getTableNamePrefix(String namespaceId) {
+    // returns String with format:  '<root namespace>.<namespaceId>.system.(stream|queue)'
+    String tablePrefix = namespace.namespace(Id.DatasetInstance.from(namespaceId,
+                                                                     unqualifiedTableNamePrefix)).getId();
+    return HBaseTableUtil.getHBaseTableName(tablePrefix);
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/QueueAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/QueueAdmin.java
@@ -28,11 +28,6 @@ import javax.annotation.Nullable;
 public interface QueueAdmin {
 
   /**
-   * Deletes all entries for all queues.
-   */
-  void dropAll() throws Exception;
-
-  /**
    * Deletes all queues in a namespace
    * @param namespaceId the namespace to delete flows in
    */

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/QueueUtils.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/QueueUtils.java
@@ -21,7 +21,7 @@ package co.cask.cdap.data2.transaction.queue;
 public final class QueueUtils {
 
   public static String determineQueueConfigTableName(String queueTableName) {
-    // the name of this table has the form: <cdap name space>.<system name space>.(queue|stream).*
+    // the name of this table has the form: <cdap root namespace>.<system namespace>.(queue|stream).<queue namespace>.*
     // beware that the cdap name space may also contain ., but there must be at least two .
 
     int firstDot = queueTableName.indexOf('.');
@@ -48,7 +48,11 @@ public final class QueueUtils {
       throw new IllegalArgumentException(
         "Unable to determine config table name from queue table name '" + queueTableName + "'");
     }
-    return queueTableName.substring(0, pos) + QueueConstants.QUEUE_CONFIG_TABLE_NAME;
+
+    // this will be reverted once queue config table is also namespaced
+    String[] parts = queueTableName.split("\\.");
+    return parts[0] + "." + parts[2] + "." + QueueConstants.QUEUE_CONFIG_TABLE_NAME;
+//    return queueTableName.substring(0, pos) + QueueConstants.QUEUE_CONFIG_TABLE_NAME;
   }
 
   private QueueUtils() { }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/QueueUtils.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/QueueUtils.java
@@ -21,7 +21,7 @@ package co.cask.cdap.data2.transaction.queue;
 public final class QueueUtils {
 
   public static String determineQueueConfigTableName(String queueTableName) {
-    // the name of this table has the form: <cdap root namespace>.<system namespace>.(queue|stream).<queue namespace>.*
+    // the name of this table has the form: <cdap root namespace>.<queue namespace>.<system namespace>.(queue|stream).*
     // beware that the cdap name space may also contain ., but there must be at least two .
 
     int firstDot = queueTableName.indexOf('.');

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueAdmin.java
@@ -28,6 +28,7 @@ import co.cask.cdap.data2.transaction.queue.QueueEntryRow;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.hbase.wd.AbstractRowKeyDistributor;
 import co.cask.cdap.hbase.wd.RowKeyDistributorByHashPrefix;
+import co.cask.cdap.proto.Id;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -95,9 +96,10 @@ public class HBaseQueueAdmin implements QueueAdmin {
   private final CConfiguration cConf;
   private final Configuration hConf;
   private final LocationFactory locationFactory;
-  private final String tableNamePrefix;
   private final String configTableName;
   private final QueueConstants.QueueType type;
+  private final String unqualifiedTableNamePrefix;
+  private final DefaultDatasetNamespace namespace;
 
   private HBaseAdmin admin;
 
@@ -118,11 +120,10 @@ public class HBaseQueueAdmin implements QueueAdmin {
     this.cConf = cConf;
     this.tableUtil = tableUtil;
     // todo: we have to do that because queues do not follow dataset semantic fully (yet)
-    String unqualifiedTableNamePrefix = type.toString();
+    // system scope
+    unqualifiedTableNamePrefix = Constants.SYSTEM_NAMESPACE + "." + type.toString();
     this.type = type;
-    DefaultDatasetNamespace namespace = new DefaultDatasetNamespace(cConf);
-    this.tableNamePrefix =
-      HBaseTableUtil.getHBaseTableName(namespace.namespace(unqualifiedTableNamePrefix).getId());
+    namespace = new DefaultDatasetNamespace(cConf);
     this.configTableName =
       HBaseTableUtil.getHBaseTableName(namespace.namespace(QueueConstants.QUEUE_CONFIG_TABLE_NAME).getId());
     this.locationFactory = locationFactory;
@@ -142,7 +143,7 @@ public class HBaseQueueAdmin implements QueueAdmin {
    */
   public String getActualTableName(QueueName queueName) {
     if (queueName.isQueue()) {
-      // <cdap namespace>.system.queue.<namespace>.<app>.<flow>
+      // <root namespace>.<queue namespace>.system.queue.<app>.<flow>
       return getTableNameForFlow(queueName.getFirstComponent(),
                                  queueName.getSecondComponent(),
                                  queueName.getThirdComponent());
@@ -152,11 +153,9 @@ public class HBaseQueueAdmin implements QueueAdmin {
   }
 
   private String getTableNameForFlow(String namespaceId, String app, String flow) {
-    StringBuilder tableName = new StringBuilder(tableNamePrefix).append(".");
-    if (!Constants.DEFAULT_NAMESPACE.equals(namespaceId)) {
-      tableName.append(namespaceId).append(".");
-    }
-    return tableName.append(app).append(".").append(flow).toString();
+    String tablePrefix = getTableNamePrefix(namespaceId);
+    String tableName = tablePrefix + "." + app + "." + flow;
+    return HBaseTableUtil.getHBaseTableName(tableName);
   }
 
   /**
@@ -197,15 +196,12 @@ public class HBaseQueueAdmin implements QueueAdmin {
    * @return namespace id that this queue belongs to
    */
   public static String getNamespaceId(String queueTableName) {
-    // last three parts are namespaceId (optional - in which case it will be the default namespace), appName and flow
+    // last three parts are namespaceId, appName and flow
     String[] parts = queueTableName.split("\\.");
     String namespaceId;
-    if (parts.length == 5) {
-      // cdap.system.queue.<app>.<flow>
-      namespaceId = Constants.DEFAULT_NAMESPACE;
-    } else if (parts.length == 6) {
-      // cdap.system.queue.<namespace>.<app>.<flow>
-      namespaceId = parts[parts.length - 3];
+    if (parts.length == 6) {
+      // cdap.<namespace>.system.queue.<app>.<flow>
+      namespaceId = parts[1];
     } else {
       throw new IllegalArgumentException(String.format("Unexpected format for queue table name. " +
                                                          "Expected 'cdap.system.queue.<app>.<flow>' or " +
@@ -439,16 +435,9 @@ public class HBaseQueueAdmin implements QueueAdmin {
   }
 
   @Override
-  public void dropAll() throws Exception {
-    dropTablesWithPrefix(tableNamePrefix);
-    // drop config table last
-    drop(Bytes.toBytes(configTableName));
-  }
-
-  @Override
   public void dropAllInNamespace(String namespaceId) throws Exception {
     // Note: The trailing "." is crucial, since otherwise nsId could match nsId1, nsIdx etc
-    dropTablesWithPrefix(String.format("%s.%s.", tableNamePrefix, namespaceId));
+    dropTablesWithPrefix(String.format("%s.", getTableNamePrefix(namespaceId)));
     deleteConsumerConfigurations(namespaceId);
   }
 
@@ -567,7 +556,7 @@ public class HBaseQueueAdmin implements QueueAdmin {
     for (HTableDescriptor desc : getHBaseAdmin().listTables()) {
       String tableName = Bytes.toString(desc.getName());
       // It's important to skip config table enabled.
-      if (tableName.startsWith(tableNamePrefix) && !tableName.equals(configTableName)) {
+      if (isDataTable(tableName) && !tableName.equals(configTableName)) {
         LOG.info(String.format("Upgrading queue hbase table: %s", tableName));
         Properties properties = new Properties();
         if (desc.getValue(HBaseQueueAdmin.PROPERTY_PREFIX_BYTES) == null) {
@@ -578,6 +567,16 @@ public class HBaseQueueAdmin implements QueueAdmin {
         LOG.info(String.format("Upgraded queue hbase table: %s", tableName));
       }
     }
+  }
+
+  private boolean isDataTable(String tableName) {
+    String[] parts = tableName.split("\\.");
+    if (parts.length != 6) {
+      return false;
+    }
+    String namespace = parts[1];
+    String tableNamePrefix = getTableNamePrefix(namespace);
+    return tableName.startsWith(tableNamePrefix);
   }
 
   private void dropTablesWithPrefix(String tableNamePrefix) throws IOException {
@@ -660,8 +659,11 @@ public class HBaseQueueAdmin implements QueueAdmin {
     return mutations;
   }
 
-  protected String getTableNamePrefix() {
-    return tableNamePrefix;
+  protected String getTableNamePrefix(String namespaceId) {
+    // returns String with format:  '<root namespace>.<namespaceId>.system.(stream|queue)'
+    String tablePrefix = namespace.namespace(Id.DatasetInstance.from(namespaceId,
+                                                                     unqualifiedTableNamePrefix)).getId();
+    return HBaseTableUtil.getHBaseTableName(tablePrefix);
   }
 
   public String getConfigTableName() {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueAdmin.java
@@ -18,17 +18,15 @@ package co.cask.cdap.data2.transaction.queue.hbase;
 
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.common.conf.CConfiguration;
-import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.queue.QueueName;
 import co.cask.cdap.data2.datafabric.DefaultDatasetNamespace;
 import co.cask.cdap.data2.dataset2.lib.hbase.AbstractHBaseDataSetAdmin;
-import co.cask.cdap.data2.transaction.queue.QueueAdmin;
+import co.cask.cdap.data2.transaction.queue.AbstractQueueAdmin;
 import co.cask.cdap.data2.transaction.queue.QueueConstants;
 import co.cask.cdap.data2.transaction.queue.QueueEntryRow;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.hbase.wd.AbstractRowKeyDistributor;
 import co.cask.cdap.hbase.wd.RowKeyDistributorByHashPrefix;
-import co.cask.cdap.proto.Id;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -77,7 +75,7 @@ import static co.cask.cdap.data2.transaction.queue.QueueConstants.QueueType.QUEU
  * admin for queues in hbase.
  */
 @Singleton
-public class HBaseQueueAdmin implements QueueAdmin {
+public class HBaseQueueAdmin extends AbstractQueueAdmin {
 
   private static final Logger LOG = LoggerFactory.getLogger(HBaseQueueAdmin.class);
 
@@ -98,8 +96,6 @@ public class HBaseQueueAdmin implements QueueAdmin {
   private final LocationFactory locationFactory;
   private final String configTableName;
   private final QueueConstants.QueueType type;
-  private final String unqualifiedTableNamePrefix;
-  private final DefaultDatasetNamespace namespace;
 
   private HBaseAdmin admin;
 
@@ -116,14 +112,11 @@ public class HBaseQueueAdmin implements QueueAdmin {
                             LocationFactory locationFactory,
                             HBaseTableUtil tableUtil,
                             QueueConstants.QueueType type) throws IOException {
+    super(cConf, type);
     this.hConf = hConf;
     this.cConf = cConf;
     this.tableUtil = tableUtil;
-    // todo: we have to do that because queues do not follow dataset semantic fully (yet)
-    // system scope
-    unqualifiedTableNamePrefix = Constants.SYSTEM_NAMESPACE + "." + type.toString();
     this.type = type;
-    namespace = new DefaultDatasetNamespace(cConf);
     this.configTableName =
       HBaseTableUtil.getHBaseTableName(namespace.namespace(QueueConstants.QUEUE_CONFIG_TABLE_NAME).getId());
     this.locationFactory = locationFactory;
@@ -134,28 +127,6 @@ public class HBaseQueueAdmin implements QueueAdmin {
       admin = new HBaseAdmin(hConf);
     }
     return admin;
-  }
-
-  /**
-   * This determines the actual table name from the table name prefix and the name of the queue.
-   * @param queueName The name of the queue.
-   * @return the full name of the table that holds this queue.
-   */
-  public String getActualTableName(QueueName queueName) {
-    if (queueName.isQueue()) {
-      // <root namespace>.<queue namespace>.system.queue.<app>.<flow>
-      return getTableNameForFlow(queueName.getFirstComponent(),
-                                 queueName.getSecondComponent(),
-                                 queueName.getThirdComponent());
-    } else {
-      throw new IllegalArgumentException("'" + queueName + "' is not a valid name for a queue.");
-    }
-  }
-
-  private String getTableNameForFlow(String namespaceId, String app, String flow) {
-    String tablePrefix = getTableNamePrefix(namespaceId);
-    String tableName = tablePrefix + "." + app + "." + flow;
-    return HBaseTableUtil.getHBaseTableName(tableName);
   }
 
   /**
@@ -188,48 +159,6 @@ public class HBaseQueueAdmin implements QueueAdmin {
     Bytes.putLong(column, 0, groupId);
     Bytes.putInt(column, Longs.BYTES, instanceId);
     return column;
-  }
-
-  // TODO: CDAP-1177 Move these functions to an abstract base class to share with LevelDBQueueAdmin
-  /**
-   * @param queueTableName actual queue table name
-   * @return namespace id that this queue belongs to
-   */
-  public static String getNamespaceId(String queueTableName) {
-    // last three parts are namespaceId, appName and flow
-    String[] parts = queueTableName.split("\\.");
-    String namespaceId;
-    if (parts.length == 6) {
-      // cdap.<namespace>.system.queue.<app>.<flow>
-      namespaceId = parts[1];
-    } else {
-      throw new IllegalArgumentException(String.format("Unexpected format for queue table name. " +
-                                                         "Expected 'cdap.system.queue.<app>.<flow>' or " +
-                                                         "'cdap.system.queue.<namespace>.<app>.<flow>'. " +
-                                                         "Received '%s'",
-                                                       queueTableName));
-    }
-    return namespaceId;
-  }
-
-  /**
-   * @param queueTableName actual queue table name
-   * @return app name this queue belongs to
-   */
-  public static String getApplicationName(String queueTableName) {
-    // last three parts are namespaceId (optional - in which case it will be the default namespace), appName and flow
-    String[] parts = queueTableName.split("\\.");
-    return parts[parts.length - 2];
-  }
-
-  /**
-   * @param queueTableName actual queue table name
-   * @return flow name this queue belongs to
-   */
-  public static String getFlowName(String queueTableName) {
-    // last three parts are namespaceId (optional - in which case it will be the default namespace), appName and flow
-    String[] parts = queueTableName.split("\\.");
-    return parts[parts.length - 1];
   }
 
   @Override
@@ -657,13 +586,6 @@ public class HBaseQueueAdmin implements QueueAdmin {
     }
 
     return mutations;
-  }
-
-  protected String getTableNamePrefix(String namespaceId) {
-    // returns String with format:  '<root namespace>.<namespaceId>.system.(stream|queue)'
-    String tablePrefix = namespace.namespace(Id.DatasetInstance.from(namespaceId,
-                                                                     unqualifiedTableNamePrefix)).getId();
-    return HBaseTableUtil.getHBaseTableName(tablePrefix);
   }
 
   public String getConfigTableName() {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseStreamAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseStreamAdmin.java
@@ -52,9 +52,8 @@ public class HBaseStreamAdmin extends HBaseQueueAdmin implements StreamAdmin {
   @Override
   public String getActualTableName(QueueName queueName) {
     if (queueName.isStream()) {
-      // TODO: don't prefix with namespace if ('default' == namespace).
-      // <cdap namespace>.system.stream.<namespace>.<stream name>
-      return getTableNamePrefix() + "." + queueName.getFirstComponent() + "." + queueName.getSecondComponent();
+      // <root namespace>.<stream namespace>.system.stream.<stream name>
+      return getTableNamePrefix(queueName.getFirstComponent()) + "." + queueName.getSecondComponent();
     } else {
       throw new IllegalArgumentException("'" + queueName + "' is not a valid name for a stream.");
     }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/inmemory/InMemoryQueueAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/inmemory/InMemoryQueueAdmin.java
@@ -74,11 +74,6 @@ public class InMemoryQueueAdmin implements QueueAdmin {
   }
 
   @Override
-  public void dropAll() throws Exception {
-    queueService.resetQueues();
-  }
-
-  @Override
   public void dropAllInNamespace(String namespaceId) throws Exception {
     queueService.resetQueuesWithPrefix(QueueName.prefixForNamespacedQueue(namespaceId));
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/leveldb/LevelDBQueueAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/leveldb/LevelDBQueueAdmin.java
@@ -18,9 +18,7 @@ package co.cask.cdap.data2.transaction.queue.leveldb;
 
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.queue.QueueName;
-import co.cask.cdap.data2.datafabric.DefaultDatasetNamespace;
 import co.cask.cdap.data2.dataset2.lib.table.leveldb.LevelDBTableService;
-import co.cask.cdap.data2.transaction.queue.QueueAdmin;
 import co.cask.cdap.data2.transaction.queue.AbstractQueueAdmin;
 import co.cask.cdap.data2.transaction.queue.QueueConstants;
 import com.google.inject.Inject;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/leveldb/LevelDBStreamAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/leveldb/LevelDBStreamAdmin.java
@@ -46,8 +46,8 @@ public class LevelDBStreamAdmin extends LevelDBQueueAdmin implements StreamAdmin
   @Override
   public String getActualTableName(QueueName queueName) {
     if (queueName.isStream()) {
-      // <cdap namespace>.system.stream.<namespace>.<stream name>
-      return getTableNamePrefix() + "." + queueName.getFirstComponent() + "." + queueName.getSecondComponent();
+      // <cdap namespace>.<namespace>.system.stream.<stream name>
+      return getTableNamePrefix(queueName.getFirstComponent()) + "." + queueName.getSecondComponent();
     } else {
       throw new IllegalArgumentException("'" + queueName + "' is not a valid name for a stream.");
     }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/queue/QueueTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/queue/QueueTest.java
@@ -117,7 +117,7 @@ public abstract class QueueTest {
                      }
                    });
     // drop all queues
-    queueAdmin.dropAll();
+    queueAdmin.dropAllInNamespace(Constants.DEFAULT_NAMESPACE);
     // verify that queue is gone and stream is still there
     final QueueConsumer qConsumer = queueClientFactory.createConsumer(
       queueName, new ConsumerConfig(0, 0, 1, DequeueStrategy.FIFO, null), 1);
@@ -466,13 +466,13 @@ public abstract class QueueTest {
 
   @Test
   public void testClearAllForFlowWithNoQueues() throws Exception {
-    queueAdmin.dropAll();
+    queueAdmin.dropAllInNamespace(Constants.DEFAULT_NAMESPACE);
     queueAdmin.clearAllForFlow(Constants.DEFAULT_NAMESPACE, "app", "flow");
   }
 
   @Test
   public void testDropAllForFlowWithNoQueues() throws Exception {
-    queueAdmin.dropAll();
+    queueAdmin.dropAllInNamespace(Constants.DEFAULT_NAMESPACE);
     queueAdmin.dropAllForFlow(Constants.DEFAULT_NAMESPACE, "app", "flow");
   }
 
@@ -588,7 +588,7 @@ public abstract class QueueTest {
     txContext.finish();
 
     // Reset queues
-    queueAdmin.dropAll();
+    queueAdmin.dropAllInNamespace(Constants.DEFAULT_NAMESPACE);
 
     // we gonna need another one to check again to avoid caching side-affects
     QueueConsumer consumer2 = queueClientFactory.createConsumer(

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueTest.java
@@ -187,14 +187,14 @@ public abstract class HBaseQueueTest extends QueueTest {
     QueueName queueName = QueueName.fromFlowlet(Constants.DEFAULT_NAMESPACE, "application1", "flow1", "flowlet1",
                                                 "output1");
     String tableName = ((HBaseQueueAdmin) queueAdmin).getActualTableName(queueName);
-    Assert.assertEquals("test.system.queue.application1.flow1", tableName);
+    Assert.assertEquals("test.default.system.queue.application1.flow1", tableName);
     Assert.assertEquals(Constants.DEFAULT_NAMESPACE, HBaseQueueAdmin.getNamespaceId(tableName));
     Assert.assertEquals("application1", HBaseQueueAdmin.getApplicationName(tableName));
     Assert.assertEquals("flow1", HBaseQueueAdmin.getFlowName(tableName));
 
     queueName = QueueName.fromFlowlet("testNamespace", "application1", "flow1", "flowlet1", "output1");
     tableName = ((HBaseQueueAdmin) queueAdmin).getActualTableName(queueName);
-    Assert.assertEquals("test.system.queue.testNamespace.application1.flow1", tableName);
+    Assert.assertEquals("test.testNamespace.system.queue.application1.flow1", tableName);
     Assert.assertEquals("testNamespace", HBaseQueueAdmin.getNamespaceId(tableName));
     Assert.assertEquals("application1", HBaseQueueAdmin.getApplicationName(tableName));
     Assert.assertEquals("flow1", HBaseQueueAdmin.getFlowName(tableName));
@@ -282,7 +282,7 @@ public abstract class HBaseQueueTest extends QueueTest {
 
     } finally {
       hTable.close();
-      queueAdmin.dropAll();
+      queueAdmin.dropAllInNamespace(Constants.DEFAULT_NAMESPACE);
     }
   }
 
@@ -311,7 +311,7 @@ public abstract class HBaseQueueTest extends QueueTest {
 
   @Test
   public void testPrefix() {
-    String queueTablename = ((HBaseQueueAdmin) queueAdmin).getTableNamePrefix();
+    String queueTablename = ((HBaseQueueAdmin) queueAdmin).getTableNamePrefix(Constants.DEFAULT_NAMESPACE);
     Assert.assertTrue(queueTablename.startsWith("test."));
   }
 

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/queue/leveldb/LevelDBQueueTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/queue/leveldb/LevelDBQueueTest.java
@@ -30,8 +30,6 @@ import co.cask.cdap.data2.queue.QueueClientFactory;
 import co.cask.cdap.data2.transaction.queue.QueueAdmin;
 import co.cask.cdap.data2.transaction.queue.QueueTest;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
-import co.cask.cdap.notifications.feeds.NotificationFeedManager;
-import co.cask.cdap.notifications.feeds.service.NoOpNotificationFeedManager;
 import co.cask.tephra.TransactionExecutorFactory;
 import co.cask.tephra.TransactionManager;
 import co.cask.tephra.TransactionSystemClient;
@@ -89,14 +87,14 @@ public class LevelDBQueueTest extends QueueTest {
     QueueName queueName = QueueName.fromFlowlet(Constants.DEFAULT_NAMESPACE, "application1", "flow1", "flowlet1",
                                                 "output1");
     String tableName = ((LevelDBQueueAdmin) queueAdmin).getActualTableName(queueName);
-    Assert.assertEquals("test.system.queue.application1.flow1", tableName);
+    Assert.assertEquals("test.default.system.queue.application1.flow1", tableName);
     Assert.assertEquals(Constants.DEFAULT_NAMESPACE, LevelDBQueueAdmin.getNamespaceId(tableName));
     Assert.assertEquals("application1", LevelDBQueueAdmin.getApplicationName(tableName));
     Assert.assertEquals("flow1", LevelDBQueueAdmin.getFlowName(tableName));
 
     queueName = QueueName.fromFlowlet("testNamespace", "application1", "flow1", "flowlet1", "output1");
     tableName = ((LevelDBQueueAdmin) queueAdmin).getActualTableName(queueName);
-    Assert.assertEquals("test.system.queue.testNamespace.application1.flow1", tableName);
+    Assert.assertEquals("test.testNamespace.system.queue.application1.flow1", tableName);
     Assert.assertEquals("testNamespace", LevelDBQueueAdmin.getNamespaceId(tableName));
     Assert.assertEquals("application1", LevelDBQueueAdmin.getApplicationName(tableName));
     Assert.assertEquals("flow1", LevelDBQueueAdmin.getFlowName(tableName));


### PR DESCRIPTION
...the prefix).

In preparation of using hbase namespaces, changes queue data table name from:
`<root namespace>.system.queue.<queue namespace><app>.<flow>`
to:
`<root namespace>.<queue namespace>.system.queue.<app>.<flow>`
Note that it still maintains a `system` component, to avoid conflicting with user tables.
Additionally, the table name no longer does special casing for the default namespace. That logic will be done by the component responsible for translating this table name into hbase namespace + table name.

Also removes QueueAdmin#dropAll method (replaced by QueueAdmin#dropAllInNamespace.

Also resolves: https://issues.cask.co/browse/CDAP-1177

Build:
http://builds.cask.co/browse/CDAP-DUT870-8