### PR TITLE
Removed soft delete until we come up with a good way of managing trash

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -701,9 +701,6 @@ public final class Constants {
   public static final String SYSTEM_NAMESPACE = "system";
   public static final Id.Namespace SYSTEM_NAMESPACE_ID = Id.Namespace.from(SYSTEM_NAMESPACE);
 
-  public static final String TRASH_LOCATION = "fs.trash.location";
-  public static final String DEFAULT_TRASH_LOCATION = ".Trash";
-
   /**
    * Constants related to external systems.
    */

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/UnderlyingSystemNamespaceAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/UnderlyingSystemNamespaceAdmin.java
@@ -65,22 +65,18 @@ public class UnderlyingSystemNamespaceAdmin {
   /**
    * Delete a namespace from the underlying system
    * Can perform operations such as deleting directories, deleting namespaces, etc.
-   * The default implementation soft deletes the namespace directory on the filesystem.
+   * The default implementation deletes the namespace directory on the filesystem.
    * Subclasses can override to add more logic such as delete namespaces in HBase, etc.
    *
    * @param namespaceId {@link Id.Namespace} for the namespace to delete
    * @throws IOException if there are errors while deleting the namespace
    */
   protected void delete(Id.Namespace namespaceId) throws IOException {
+    // TODO: CDAP-1581: Implement soft delete
     Location namespaceHome = locationFactory.create(namespaceId.getId());
-    Location trashLocation = locationFactory.create(cConf.get(Constants.TRASH_LOCATION,
-                                                              Constants.DEFAULT_TRASH_LOCATION));
-    Locations.mkdirsIfNotExists(trashLocation);
-    if (namespaceHome.exists()) {
-      if (namespaceHome.renameTo(trashLocation.append(namespaceId.getId())) == null) {
+    if (namespaceHome.exists() && !namespaceHome.delete(true)) {
         throw new IOException(String.format("Error while deleting home directory '%s' for namespace '%s'",
                                             namespaceHome.toURI().toString(), namespaceId.getId()));
-      }
     } else {
       // warn that namespace home was not found and skip delete step
       LOG.warn(String.format("Home directory '%s' for namespace '%s' does not exist.",


### PR DESCRIPTION
The soft delete would not work if you deleted multiple times. 

We can implement soft delete separately in a better way (with a janitor) as a separate PR. 

Until then, using delete because this will cause build failures the next time develop builds.

Build: https://builds.cask.co/browse/CDAP-DUT872