### PR TITLE
CDAP-73 Add multi-get operation to Table

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/IndexedTable.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/IndexedTable.java
@@ -152,6 +152,11 @@ public class IndexedTable extends AbstractDataset implements Table {
     return table.get(row, startColumn, stopColumn, limit);
   }
 
+  @Override
+  public List<Row> get(List<Get> gets) {
+    return table.get(gets);
+  }
+
   /**
    * Reads table rows by the given secondary index key.  If no rows are indexed by the given key, then a
    * {@link co.cask.cdap.api.dataset.table.Scanner} with no results will be returned.

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/KeyValueTable.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/KeyValueTable.java
@@ -25,15 +25,19 @@ import co.cask.cdap.api.data.batch.RecordWritable;
 import co.cask.cdap.api.data.batch.Scannables;
 import co.cask.cdap.api.data.batch.Split;
 import co.cask.cdap.api.data.batch.SplitReader;
+import co.cask.cdap.api.dataset.table.Get;
 import co.cask.cdap.api.dataset.table.Row;
 import co.cask.cdap.api.dataset.table.Scanner;
 import co.cask.cdap.api.dataset.table.Table;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.common.reflect.TypeToken;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.List;
+import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
@@ -73,6 +77,27 @@ public class KeyValueTable extends AbstractDataset implements
   @Nullable
   public byte[] read(byte[] key) {
     return table.get(key, KEY_COLUMN);
+  }
+
+  /**
+   * Reads the values for an array of given keys.
+   *
+   * @param keys the keys to be read
+   * @return a map of the stored values, keyed by key
+   */
+  public Map<byte[], byte[]> readAll(byte[][] keys) {
+    List<Get> gets = Lists.newArrayListWithCapacity(keys.length);
+    for (byte[] key : keys) {
+      gets.add(new Get(key).add(KEY_COLUMN));
+    }
+    List<Row> results = table.get(gets);
+    Map<byte[], byte[]> values = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
+    for (Row row : results) {
+      if (row.get(KEY_COLUMN) != null) {
+        values.put(row.getRow(), row.get(KEY_COLUMN));
+      }
+    }
+    return values;
   }
 
   /**

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/Table.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/Table.java
@@ -100,6 +100,17 @@ public interface Table extends BatchReadable<byte[], Row>, BatchWritable<byte[],
    */
   Row get(Get get);
 
+
+  /**
+   * Reads values for the rows and columns defined by the {@link Get} parameters.  When running in distributed mode,
+   * and retrieving multiple rows at the same time, this method should be preferred to multiple {@link Table#get(Get)}
+   * calls, as the operations will be batched into a single remote call per server.
+   *
+   * @param gets defines the rows and columns to read
+   * @return a list of {@link Row} instances
+   */
+  List<Row> get(List<Get> gets);
+
   /**
    * Writes the specified value for the specified column of the specified row.
    *

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/AbstractTable.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/AbstractTable.java
@@ -32,6 +32,7 @@ import co.cask.cdap.api.dataset.table.TableSplit;
 import co.cask.tephra.TransactionAware;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,6 +63,15 @@ public abstract class AbstractTable implements Table, TransactionAware {
     return get.getColumns().isEmpty() ?
         get(get.getRow()) :
         get(get.getRow(), get.getColumns().toArray(new byte[get.getColumns().size()][]));
+  }
+
+  @Override
+  public List<Row> get(List<Get> gets) {
+    List<Row> results = Lists.newArrayListWithCapacity(gets.size());
+    for (Get get : gets) {
+      results.add(get(get));
+    }
+    return results;
   }
 
   @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTable.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTable.java
@@ -17,7 +17,9 @@
 package co.cask.cdap.data2.dataset2.lib.table.hbase;
 
 import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.dataset.DataSetException;
 import co.cask.cdap.api.dataset.table.ConflictDetection;
+import co.cask.cdap.api.dataset.table.Row;
 import co.cask.cdap.api.dataset.table.Scanner;
 import co.cask.cdap.data2.dataset2.lib.table.BufferingTable;
 import co.cask.cdap.data2.dataset2.lib.table.IncrementValue;
@@ -26,7 +28,10 @@ import co.cask.cdap.data2.dataset2.lib.table.Update;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.tephra.Transaction;
 import co.cask.tephra.TransactionCodec;
+import com.google.common.base.Function;
 import com.google.common.base.Objects;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.apache.hadoop.conf.Configuration;
@@ -41,9 +46,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
+import java.util.TreeMap;
 import javax.annotation.Nullable;
 
 /**
@@ -88,6 +95,33 @@ public class HBaseTable extends BufferingTable {
   public void startTx(Transaction tx) {
     super.startTx(tx);
     this.tx = tx;
+  }
+
+  @Override
+  public List<Row> get(List<co.cask.cdap.api.dataset.table.Get> gets) {
+    List<Get> hbaseGets = Lists.transform(gets, new Function<co.cask.cdap.api.dataset.table.Get, Get>() {
+      @Nullable
+      @Override
+      public Get apply(@Nullable co.cask.cdap.api.dataset.table.Get get) {
+        List<byte[]> cols = get.getColumns();
+        return createGet(get.getRow(), cols == null ? null : cols.toArray(new byte[cols.size()][]));
+      }
+    });
+    try {
+      Result[] results = hTable.get(hbaseGets);
+      List<Row> rows = Lists.transform(Arrays.asList(results), new Function<Result, Row>() {
+        @Nullable
+        @Override
+        public Row apply(@Nullable Result result) {
+          Map<byte[], byte[]> familyMap = result.getFamilyMap(HBaseTableAdmin.DATA_COLUMN_FAMILY);
+          return new co.cask.cdap.api.dataset.table.Result(result.getRow(),
+              familyMap != null ? familyMap : ImmutableMap.<byte[], byte[]>of());
+        }
+      });
+      return rows;
+    } catch (IOException ioe) {
+      throw new DataSetException("Multi-get failed on table " + hTableName, ioe);
+    }
   }
 
   @Override
@@ -200,16 +234,32 @@ public class HBaseTable extends BufferingTable {
     return new HBaseScanner(resultScanner);
   }
 
-  private NavigableMap<byte[], byte[]> getInternal(byte[] row, @Nullable byte[][] columns) throws IOException {
+  private Get createGet(byte[] row, @Nullable byte[][] columns) {
     Get get = new Get(row);
-    // todo: uncomment when doing caching fetching data in-memory
-    // get.setCacheBlocks(false);
     get.addFamily(HBaseTableAdmin.DATA_COLUMN_FAMILY);
-    if (columns != null) {
+    if (columns != null && columns.length > 0) {
       for (byte[] column : columns) {
         get.addColumn(HBaseTableAdmin.DATA_COLUMN_FAMILY, column);
       }
+    } else {
+      get.addFamily(HBaseTableAdmin.DATA_COLUMN_FAMILY);
     }
+
+    try {
+      // no tx logic needed
+      if (tx == null) {
+        get.setMaxVersions(1);
+      } else {
+        txCodec.addToOperation(get, tx);
+      }
+    } catch (IOException ioe) {
+      throw Throwables.propagate(ioe);
+    }
+    return get;
+  }
+
+  private NavigableMap<byte[], byte[]> getInternal(byte[] row, @Nullable byte[][] columns) throws IOException {
+    Get get = createGet(row, columns);
 
     // no tx logic needed
     if (tx == null) {

--- a/cdap-docs/developers-manual/source/building-blocks/datasets/table.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/datasets/table.rst
@@ -92,6 +92,24 @@ the corresponding methods accept a default value to be returned when the column 
   // Get column value as a primitive type or 0 if column is absent
   long valueAsLong = row.getLong("column1", 0);
 
+Multiple rows can be requested together using a variation of the ``get`` operation that takes a
+list of ``Get`` objects to be retrieved::
+
+  Table t;
+
+  // Define the rows to retrieve
+  List<Get> gets = Lists.newArrayList();
+  gets.add(new Get("row1"));
+  // Separate columns can be requested for each row
+  gets.add(new Get("row2").add("column1").add("column2"));
+  gets.add(new Get("row3"));
+
+  List<Row> rows = t.get(gets);
+
+Each ``Row`` object in the returned list will contain the results for one of the requested row
+keys.  When multiple rows must be retrieved together, this version of the ``get`` operation
+allows the storage provider to perform more efficient batching of the operations, if supported.
+
 Scan
 ====
 A ``scan`` operation fetches a subset of rows or all of the rows of a Table::


### PR DESCRIPTION
Adds a multi-get operation to Table, IndexedTable and KeyValueTable.  This also adds sample usage of the multi-get operation to the WordCount example app, and some minor documentation to the datasets guide.