### PR TITLE
remove redundant per app agg for metrics

### DIFF
--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/store/DefaultMetricStore.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/store/DefaultMetricStore.java
@@ -80,12 +80,6 @@ public class DefaultMetricStore implements MetricStore {
     aggs.add(new DefaultAggregation(ImmutableList.of(
       Constants.Metrics.Tag.NAMESPACE)));
 
-    // Applications:
-    aggs.add(new DefaultAggregation(
-      ImmutableList.of(Constants.Metrics.Tag.NAMESPACE, Constants.Metrics.Tag.APP, Constants.Metrics.Tag.DATASET),
-      // i.e. for programs only
-      ImmutableList.of(Constants.Metrics.Tag.NAMESPACE, Constants.Metrics.Tag.APP)));
-
     // Programs:
 
     // Note that dataset tag goes before runId and such. This is a trade-off between efficiency of two query types:

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/store/DefaultMetricStore.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/store/DefaultMetricStore.java
@@ -80,6 +80,12 @@ public class DefaultMetricStore implements MetricStore {
     aggs.add(new DefaultAggregation(ImmutableList.of(
       Constants.Metrics.Tag.NAMESPACE)));
 
+    // Applications:
+    aggs.add(new DefaultAggregation(
+      ImmutableList.of(Constants.Metrics.Tag.NAMESPACE, Constants.Metrics.Tag.APP),
+      // i.e. for programs only
+      ImmutableList.of(Constants.Metrics.Tag.NAMESPACE, Constants.Metrics.Tag.APP)));
+
     // Programs:
 
     // Note that dataset tag goes before runId and such. This is a trade-off between efficiency of two query types:


### PR DESCRIPTION
It is a premature optimization. After changing aggregations yesterday there's even less obvious reasons to keep it