### PR TITLE
Source backwards compatability

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/service/ServiceWorkerContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/service/ServiceWorkerContext.java
@@ -41,6 +41,12 @@ public interface ServiceWorkerContext extends RuntimeContext, ServiceDiscoverer 
   void execute(TxRunnable runnable);
 
   /**
+   * Execute a set of operations on datasets via a {@link TxRunnable} that are committed as a single transaction.
+   * @param runnable The runnable to be executed in the transaction
+   */
+  void execute(co.cask.cdap.api.service.TxRunnable runnable);
+
+  /**
    * @return Number of instances of this worker.
    */
   int getInstanceCount();

--- a/cdap-api/src/main/java/co/cask/cdap/api/service/TxRunnable.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/service/TxRunnable.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.api.service;
+
+import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.api.dataset.Dataset;
+
+/**
+ * A runnable that provides a {@link DatasetContext} to programs which may be used to get
+ * access to and use datasets.
+ * @deprecated As of version 2.8.0, replaced by {@link co.cask.cdap.api.TxRunnable}
+ */
+public interface TxRunnable {
+
+  /**
+   * Provides a {@link DatasetContext} to get instances of {@link Dataset}s.
+   *
+   * <p>
+   *   Operations executed on a dataset within the execution of this method are committed as a single transaction.
+   *   The transaction is started before this method is invoked and is committed upon successful execution.
+   *   Exceptions thrown while committing the transaction or thrown by user-code result in a rollback of the
+   *   transaction.
+   * </p>
+   * @param context to get datasets from.
+   * @throws Exception
+   */
+  void run(DatasetContext context) throws Exception;
+
+}

--- a/cdap-api/src/main/java/co/cask/cdap/api/service/TxRunnable.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/service/TxRunnable.java
@@ -24,6 +24,7 @@ import co.cask.cdap.api.dataset.Dataset;
  * access to and use datasets.
  * @deprecated As of version 2.8.0, replaced by {@link co.cask.cdap.api.TxRunnable}
  */
+@Deprecated
 public interface TxRunnable {
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/BasicServiceWorkerContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/BasicServiceWorkerContext.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.internal.app.runtime.service;
 
 import co.cask.cdap.api.TxRunnable;
+import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.service.ServiceWorkerContext;
@@ -175,6 +176,16 @@ public class BasicServiceWorkerContext extends AbstractContext implements Servic
     } catch (Exception e) {
       abortTransaction(e, "Exception occurred running user code. Aborting transaction.", context);
     }
+  }
+
+  @Override
+  public void execute(final co.cask.cdap.api.service.TxRunnable runnable) {
+    execute(new TxRunnable() {
+      @Override
+      public void run(DatasetContext context) throws Exception {
+       runnable.run(context);
+      }
+    });
   }
 
   @Override

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
@@ -157,6 +157,7 @@ public class TestBase {
    * @param applicationClz The application class
    * @return An {@link co.cask.cdap.test.ApplicationManager} to manage the deployed application.
    */
+  @Deprecated
   protected ApplicationManager deployApplication(Class<? extends Application> applicationClz,
                                                  File... bundleEmbeddedJars) {
     TestManager testManager = getTestManager();
@@ -171,13 +172,14 @@ public class TestBase {
    *
    * @deprecated Use {@link TestManager#clear()} from {@link #getTestManager()}.
    */
+  @Deprecated
   protected void clear() {
     try {
       TestManager testManager = getTestManager();
       testManager.clear();
     } catch (Exception e) {
       // Unchecked exception to maintain compatibility until we remove this method
-      Throwables.propagate(e);
+      throw Throwables.propagate(e);
     }
   }
 
@@ -393,6 +395,7 @@ public class TestBase {
    * @param datasetModule module class
    * @throws Exception
    */
+  @Deprecated
   protected final void deployDatasetModule(String moduleName, Class<? extends DatasetModule> datasetModule)
     throws Exception {
     TestManager testManager = getTestManager();
@@ -410,6 +413,7 @@ public class TestBase {
    * @param props properties
    * @param <T> type of the dataset admin
    */
+  @Deprecated
   protected final <T extends DatasetAdmin> T addDatasetInstance(String datasetTypeName,
                                                        String datasetInstanceName,
                                                        DatasetProperties props) throws Exception {
@@ -426,6 +430,7 @@ public class TestBase {
    * @param datasetInstanceName instance name
    * @param <T> type of the dataset admin
    */
+  @Deprecated
   protected final <T extends DatasetAdmin> T addDatasetInstance(String datasetTypeName,
                                                                 String datasetInstanceName) throws Exception {
     TestManager testManager = getTestManager();
@@ -434,10 +439,12 @@ public class TestBase {
 
   /**
    * Gets Dataset manager of Dataset instance of type <T>
+   * @deprecated Use {@link TestManager#getDataset(String)} ()} from {@link #getTestManager()}.
    * @param datasetInstanceName - instance name of dataset
    * @return Dataset Manager of Dataset instance of type <T>
    * @throws Exception
    */
+  @Deprecated
   protected final <T> DataSetManager<T> getDataset(String datasetInstanceName) throws Exception {
     TestManager testManager = getTestManager();
     return testManager.getDataset(datasetInstanceName);

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
@@ -171,9 +171,14 @@ public class TestBase {
    *
    * @deprecated Use {@link TestManager#clear()} from {@link #getTestManager()}.
    */
-  protected void clear() throws Exception {
-    TestManager testManager = getTestManager();
-    testManager.clear();
+  protected void clear() {
+    try {
+      TestManager testManager = getTestManager();
+      testManager.clear();
+    } catch (Exception e) {
+      // Unchecked exception to maintain compatibility until we remove this method
+      Throwables.propagate(e);
+    }
   }
 
   @Before

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/AppWithServices.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/AppWithServices.java
@@ -16,7 +16,6 @@
 
 package co.cask.cdap.test.app;
 
-import co.cask.cdap.api.TxRunnable;
 import co.cask.cdap.api.annotation.Handle;
 import co.cask.cdap.api.annotation.Property;
 import co.cask.cdap.api.annotation.UseDataSet;
@@ -33,6 +32,7 @@ import co.cask.cdap.api.service.AbstractService;
 import co.cask.cdap.api.service.AbstractServiceWorker;
 import co.cask.cdap.api.service.BasicService;
 import co.cask.cdap.api.service.ServiceWorkerContext;
+import co.cask.cdap.api.service.TxRunnable;
 import co.cask.cdap.api.service.http.AbstractHttpServiceHandler;
 import co.cask.cdap.api.service.http.HttpServiceContext;
 import co.cask.cdap.api.service.http.HttpServiceRequest;


### PR DESCRIPTION
Users should have to modify as little code as possible when they upgrade CDAP versions (marking it as deprecated first so they have plenty of time to modify the code to new APIs).

Brought back a copy of TxRunnable in cdap.api.service package, and changed AppWithServices to use it to test it. Simply delegates execution to the TxRunnable in cdap.api package.
Also removed the checked Exception from TestBase#clear method (it has been deprecated for 2.8, so we should support it as is in previous version, until we remove it).

Unsure how to handler RuntimeStats#clearStats(String). Perhaps we can't do anything but remove that method and require the user to modify their code.

http://builds.cask.co/browse/CDAP-DUT904-5