### PR TITLE
Fix CDAP-1619

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/upload/FileContentWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/upload/FileContentWriter.java
@@ -54,8 +54,8 @@ final class FileContentWriter implements ContentWriter {
     this.streamEvent = new MutableStreamEvent();
 
     directory.mkdirs();
-    this.eventFile = directory.append(String.format("upload.%s.dat", streamConfig.getStreamId()));
-    this.indexFile = directory.append(String.format("upload.%s.idx", streamConfig.getStreamId()));
+    this.eventFile = directory.append("upload.dat");
+    this.indexFile = directory.append("upload.idx");
 
     Map<String, String> properties = createStreamFileProperties(headers);
     properties.put(StreamDataFileConstants.Property.Key.UNI_TIMESTAMP,


### PR DESCRIPTION
Using the toString of Id.Stream object in file path is not good. Also, streamId is not necessary in the path in this case as the directory it is passed is already namespaced for the stream it is writing to.

Alternative: namespace (for a particular stream) the eventFile/indexFile in this class (instead of namespacing the directory and then passing it in - from FileContentWriterFactory).

Resolves: https://issues.cask.co/browse/CDAP-1619
Build: http://builds.cask.co/browse/CDAP-RBT133-1