### PR TITLE
(CDAP-1627) No-op default database creation in Hive

### DIFF
--- a/cdap-explore/src/main/java/co/cask/cdap/explore/executor/ExploreExecutorHttpHandler.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/executor/ExploreExecutorHttpHandler.java
@@ -470,9 +470,9 @@ public class ExploreExecutorHttpHandler extends AbstractHttpHandler {
     throws UnsupportedTypeException {
     String hiveSchema = hiveSchemaFor(dataset);
     String tableName = getHiveTableName(datasetInstance.getId());
-    return String.format("CREATE EXTERNAL TABLE IF NOT EXISTS %s %s COMMENT \"CDAP Dataset\" " +
-                           "STORED BY \"%s\" WITH SERDEPROPERTIES(\"%s\" = \"%s\")" +
-                           "TBLPROPERTIES ('%s'='%s', '%s'='%s')",
+    return String.format("CREATE EXTERNAL TABLE IF NOT EXISTS %s %s COMMENT 'CDAP Dataset' " +
+                           "STORED BY '%s' WITH SERDEPROPERTIES('%s'='%s', '%s'='%s')" +
+                           "TBLPROPERTIES ('%s'='%s')",
                          tableName, hiveSchema, Constants.Explore.DATASET_STORAGE_HANDLER_CLASS,
                          Constants.Explore.DATASET_NAME, datasetInstance.getId(),
                          Constants.Explore.DATASET_NAMESPACE, datasetInstance.getNamespaceId(),

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceTestRun.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceTestRun.java
@@ -358,7 +358,9 @@ public class HiveExploreServiceTestRun extends BaseHiveExploreServiceTest {
                           tableInfo.getLocation(), DatasetInputFormat.class.getName(),
                           "org.apache.hadoop.hive.ql.io.HivePassThroughOutputFormat", false, -1,
                           DatasetSerDe.class.getName(),
-                          ImmutableMap.of("serialization.format", "1", "explore.dataset.name", "my_table"),
+                          ImmutableMap.of("serialization.format", "1",
+                                          Constants.Explore.DATASET_NAME, "my_table",
+                                          Constants.Explore.DATASET_NAMESPACE, NAMESPACE_ID.getId()),
                           true
                         ),
                         tableInfo);
@@ -377,7 +379,9 @@ public class HiveExploreServiceTestRun extends BaseHiveExploreServiceTest {
                           tableInfo.getLocation(), DatasetInputFormat.class.getName(),
                           "org.apache.hadoop.hive.ql.io.HivePassThroughOutputFormat", false, -1,
                           DatasetSerDe.class.getName(),
-                          ImmutableMap.of("serialization.format", "1", "explore.dataset.name", "my_table"),
+                          ImmutableMap.of("serialization.format", "1",
+                                          Constants.Explore.DATASET_NAME, "my_table",
+                                          Constants.Explore.DATASET_NAMESPACE, NAMESPACE_ID.getId()),
                           true
                         ),
                         tableInfo);


### PR DESCRIPTION
Two small changes:
1. No-op the creation of the "default" namespace in Hive. This prevents an additional log warning.
2. Database creation and usage is now "cdap_<namespace-id>".