### PR TITLE
fix non-tx delete increments (metrics tables)

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseMetricsTable.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseMetricsTable.java
@@ -214,7 +214,7 @@ public class HBaseMetricsTable implements MetricsTable {
   public void delete(byte[] row, byte[][] columns) throws Exception {
     Delete delete = new Delete(row);
     for (byte[] column : columns) {
-      delete.deleteColumn(DATA_COLUMN_FAMILY, column);
+      delete.deleteColumns(DATA_COLUMN_FAMILY, column);
     }
     hTable.delete(delete);
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTable.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTable.java
@@ -190,7 +190,7 @@ public class HBaseTable extends BufferingTable {
           // TODO: hijacking timestamp... bad
           delete.deleteColumn(HBaseTableAdmin.DATA_COLUMN_FAMILY, column.getKey(), tx.getWritePointer());
         } else {
-          delete.deleteColumn(HBaseTableAdmin.DATA_COLUMN_FAMILY, column.getKey());
+          delete.deleteColumns(HBaseTableAdmin.DATA_COLUMN_FAMILY, column.getKey());
         }
       }
       deletes.add(delete);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBMetricsTable.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBMetricsTable.java
@@ -104,8 +104,7 @@ public class LevelDBMetricsTable implements MetricsTable {
   @Override
   public void delete(byte[] row, byte[][] columns) throws Exception {
     for (byte[] column : columns) {
-      // Bytes.EMPTY_BYTE_ARRAY is a delete marker
-      core.put(row, column, Bytes.EMPTY_BYTE_ARRAY, System.currentTimeMillis());
+      core.deleteColumn(row, column);
     }
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableCore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableCore.java
@@ -447,7 +447,7 @@ public class LevelDBTableCore {
     }
   }
 
-  private void deleteColumn(byte[] row, byte[] column) throws IOException {
+  public void deleteColumn(byte[] row, byte[] column) throws IOException {
     DB db = getDB();
     WriteBatch batch = db.createWriteBatch();
     DBIterator iterator = db.iterator();

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueConsumer.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueConsumer.java
@@ -109,7 +109,7 @@ abstract class HBaseQueueConsumer extends AbstractQueueConsumer {
     List<Row> ops = Lists.newArrayListWithCapacity(rowKeys.size());
     for (byte[] rowKey : rowKeys) {
       Delete delete = new Delete(queueStrategy.getActualRowKey(getConfig(), rowKey));
-      delete.deleteColumn(QueueEntryRow.COLUMN_FAMILY, stateColumnName);
+      delete.deleteColumns(QueueEntryRow.COLUMN_FAMILY, stateColumnName);
       ops.add(delete);
     }
     hTable.batch(ops);

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/MetricsTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/MetricsTableTest.java
@@ -21,13 +21,11 @@ import co.cask.cdap.api.dataset.table.Row;
 import co.cask.cdap.api.dataset.table.Scanner;
 import co.cask.cdap.common.utils.ImmutablePair;
 import co.cask.cdap.proto.Id;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Maps;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.Closeable;
@@ -285,6 +283,28 @@ public abstract class MetricsTableTest {
     table.deleteAll(new byte[0]);
     // verify everything is gone by counting all entries in a scan
     Assert.assertEquals(0, countRange(table, null, null));
+  }
+
+  @Test
+  public void testDeleteIncrements() throws Exception {
+    // note: this is pretty important test case for tables with counters, e.g. metrics
+
+    MetricsTable table = getTable("testDeleteIncrements");
+    // delete increment and increment again
+    table.increment(A, ImmutableMap.of(B, 5L));
+    table.increment(A, ImmutableMap.of(B, 2L));
+    table.increment(P, ImmutableMap.of(Q, 15L));
+    table.increment(P, ImmutableMap.of(Q, 12L));
+    Assert.assertEquals(7L, Bytes.toLong(table.get(A, B)));
+    Assert.assertEquals(27L, Bytes.toLong(table.get(P, Q)));
+    table.delete(A, new byte[][]{B});
+    table.deleteAll(P);
+    Assert.assertNull(table.get(A, B));
+    Assert.assertNull(table.get(P, Q));
+    table.increment(A, ImmutableMap.of(B, 3L));
+    table.increment(P, ImmutableMap.of(Q, 13L));
+    Assert.assertEquals(3L, Bytes.toLong(table.get(A, B)));
+    Assert.assertEquals(13L, Bytes.toLong(table.get(P, Q)));
   }
 
   private static int countRange(MetricsTable table, Integer start, Integer stop) throws Exception {

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/TableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/TableTest.java
@@ -471,6 +471,8 @@ public abstract class TableTest<T extends Table> {
     ((TransactionAware) myTable).startTx(tx);
 
     myTable.increment(R1, a(C1), la(-3L));
+    // we'll use this one to test that we can delete increment and increment again
+    myTable.increment(R2, a(C2), la(5L));
 
     commitAndAssertSuccess(tx, (TransactionAware) myTable);
 
@@ -482,6 +484,10 @@ public abstract class TableTest<T extends Table> {
     myTable.increment(R1, a(C1), la(-3L));
     verify(Bytes.toBytes(-6L), myTable.get(R1, C1));
 
+    verify(Bytes.toBytes(5L), myTable.get(R2, C2));
+    myTable.delete(R2, C2);
+    verify(null, myTable.get(R2, C2));
+
     commitAndAssertSuccess(tx, (TransactionAware) myTable);
 
     // start 3rd tx
@@ -490,7 +496,20 @@ public abstract class TableTest<T extends Table> {
 
     verify(Bytes.toBytes(-6L), myTable.get(R1, C1));
 
+    verify(null, myTable.get(R2, C2));
+    myTable.increment(R2, a(C2), la(7L));
+    verify(Bytes.toBytes(7L), myTable.get(R2, C2));
+
     commitAndAssertSuccess(tx, (TransactionAware) myTable);
+
+    // start 4rd tx
+    tx = txClient.startShort();
+    ((TransactionAware) myTable).startTx(tx);
+
+    verify(Bytes.toBytes(7L), myTable.get(R2, C2));
+
+    commitAndAssertSuccess(tx, (TransactionAware) myTable);
+
     admin.drop();
   }
 


### PR DESCRIPTION
Two issues fixed:
* in level db case, in non-tx, we should not write empty byte array delete tombstone
* in hbase case, in non-txt, when deleting a column, Delete.deleteColumnS method must be called to delete all versions

Just in case also added unit-test for transactional table.
