### PR TITLE
Streams V3 API changes

### DIFF
--- a/cdap-client/src/main/java/co/cask/cdap/client/StreamClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/StreamClient.java
@@ -83,7 +83,7 @@ public class StreamClient {
    */
   public StreamProperties getConfig(String streamId) throws IOException, StreamNotFoundException,
     UnAuthorizedAccessTokenException {
-    URL url = config.resolveNamespacedURLV3(String.format("streams/%s/info", streamId));
+    URL url = config.resolveNamespacedURLV3(String.format("streams/%s", streamId));
     HttpResponse response = restClient.execute(HttpMethod.GET, url, config.getAccessToken(),
                                                HttpURLConnection.HTTP_NOT_FOUND);
     if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
@@ -104,7 +104,7 @@ public class StreamClient {
    */
   public void setStreamProperties(String streamId, StreamProperties properties) throws IOException,
     UnAuthorizedAccessTokenException, BadRequestException, StreamNotFoundException {
-    URL url = config.resolveNamespacedURLV3(String.format("streams/%s/config", streamId));
+    URL url = config.resolveNamespacedURLV3(String.format("streams/%s/properties", streamId));
 
     HttpRequest request = HttpRequest.put(url).withBody(GSON.toJson(properties)).build();
     HttpResponse response = restClient.execute(request, config.getAccessToken(),
@@ -226,7 +226,7 @@ public class StreamClient {
    */
   public void setTTL(String streamId, long ttlInSeconds) throws IOException, StreamNotFoundException,
     UnAuthorizedAccessTokenException {
-    URL url = config.resolveNamespacedURLV3(String.format("streams/%s/config", streamId));
+    URL url = config.resolveNamespacedURLV3(String.format("streams/%s/properties", streamId));
     HttpRequest request = HttpRequest.put(url).withBody(GSON.toJson(ImmutableMap.of("ttl", ttlInSeconds))).build();
 
     HttpResponse response = restClient.execute(request, config.getAccessToken(), HttpURLConnection.HTTP_NOT_FOUND);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamHandler.java
@@ -169,7 +169,7 @@ public final class StreamHandler extends AuthenticatedHttpHandler {
   }
 
   @GET
-  @Path("/{stream}/info")
+  @Path("/{stream}")
   public void getInfo(HttpRequest request, HttpResponder responder,
                       @PathParam("namespace-id") String namespaceId,
                       @PathParam("stream") String stream) throws Exception {
@@ -278,7 +278,7 @@ public final class StreamHandler extends AuthenticatedHttpHandler {
   }
 
   @PUT
-  @Path("/{stream}/config")
+  @Path("/{stream}/properties")
   public void setConfig(HttpRequest request, HttpResponder responder,
                         @PathParam("namespace-id") String namespaceId,
                         @PathParam("stream") String stream) throws Exception {

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/StreamHandlerTestV2.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/StreamHandlerTestV2.java
@@ -28,4 +28,14 @@ public class StreamHandlerTestV2 extends StreamHandlerTest {
   protected URL createURL(String path) throws URISyntaxException, MalformedURLException {
     return getEndPoint(String.format("/v2/%s", path)).toURL();
   }
+
+  @Override
+  protected URL createStreamInfoURL(String streamName) throws URISyntaxException, MalformedURLException {
+    return createURL(String.format("streams/%s/info", streamName));
+  }
+
+  @Override
+  protected URL createPropertiesURL(String streamName) throws URISyntaxException, MalformedURLException {
+    return createURL(String.format("streams/%s/config", streamName));
+  }
 }

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/StreamHandlerTestV3.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/StreamHandlerTestV3.java
@@ -45,6 +45,17 @@ public class StreamHandlerTestV3 extends StreamHandlerTest {
     return createURL(Constants.DEFAULT_NAMESPACE, path);
   }
 
+  @Override
+  protected URL createStreamInfoURL(String streamName) throws URISyntaxException, MalformedURLException {
+    return createURL(String.format("streams/%s", streamName));
+  }
+
+  @Override
+  protected URL createPropertiesURL(String streamName) throws URISyntaxException, MalformedURLException {
+    return createURL(String.format("streams/%s/properties", streamName));
+  }
+
+
   private URL createURL(String namespace, String path) throws URISyntaxException, MalformedURLException {
     return getEndPoint(String.format("/v3/namespaces/%s/%s", namespace, path)).toURL();
   }
@@ -52,7 +63,7 @@ public class StreamHandlerTestV3 extends StreamHandlerTest {
   @Test
   public void testNamespacedStreamEvents() throws Exception {
     // Create two streams with the same name, in different namespaces.
-    String streamName = "testNamespacedMetrics";
+    String streamName = "testNamespacedEvents";
     Id.Stream streamId1 = Id.Stream.from("namespace1", streamName);
     Id.Stream streamId2 = Id.Stream.from("namespace2", streamName);
 


### PR DESCRIPTION
PR contains the following changes
* Removed v3/namespaces/{id}/streams/{id}/info endpoint
* Added v3/namespaces/{id}/streams/{id} endpoint
* Removed v3/namespaces/{id}/streams/{id}/config endpoint
* Added v3/namespaces/{id}/streams/{id}/properties endpoint
* Corresponding Stream Client changes for CLI

Related JIRA: https://issues.cask.co/browse/CDAP-1641

Build: http://builds.cask.co/browse/CDAP-DUT936-2