### PR TITLE
Feature/cli packaging fixes

### DIFF
--- a/cdap-cli/pom.xml
+++ b/cdap-cli/pom.xml
@@ -155,39 +155,12 @@
               <!-- Copy CLI scripts -->
               <execution>
                 <id>copy-cli-scripts</id>
-                <phase>prepare-package</phase>
+                <phase>process-resources</phase>
                 <goals>
                   <goal>copy-resources</goal>
                 </goals>
                 <configuration combine.self="override">
                   <outputDirectory>${stage.opt.dir}</outputDirectory>
-                  <useDefaultDelimiters>false</useDefaultDelimiters>
-                  <delimiters>
-                    <delimiter>@@</delimiter>
-                  </delimiters>
-                  <resources>
-                    <resource>
-                      <directory>${project.parent.basedir}/cdap-cli/bin</directory>
-                      <targetPath>bin</targetPath>
-                      <includes>
-                        <include>cdap-cli.sh</include>
-                        <include>cdap-cli.bat</include>
-                      </includes>
-                      <filtering>true</filtering>
-                    </resource>
-                  </resources>
-                </configuration>
-              </execution>
-              <!-- Copy CLI scripts for .deb -->
-              <execution>
-                <id>copy-cli-scripts-deb</id>
-                <phase>prepare-package</phase>
-                <goals>
-                  <goal>copy-resources</goal>
-                </goals>
-                <configuration combine.self="override">
-                  <outputDirectory>${stage.opt.dir}</outputDirectory>
-                  <outputDirectory>${stage.dir}-deb/opt/cdap/${package.name}</outputDirectory>
                   <useDefaultDelimiters>false</useDefaultDelimiters>
                   <delimiters>
                     <delimiter>@@</delimiter>

--- a/cdap-cli/pom.xml
+++ b/cdap-cli/pom.xml
@@ -1,4 +1,4 @@
-?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   Copyright © 2012-2014 Cask Data, Inc.
 

--- a/cdap-cli/pom.xml
+++ b/cdap-cli/pom.xml
@@ -116,6 +116,10 @@
   <profiles>
     <profile>
       <id>dist</id>
+      <!-- Override to not package non-existent etc dir for cdap-cli -->
+      <properties>
+        <package.dirs>opt</package.dirs>
+      </properties>
       <build>
         <plugins>
           <plugin>

--- a/cdap-cli/pom.xml
+++ b/cdap-cli/pom.xml
@@ -151,33 +151,60 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-resources-plugin</artifactId>
             <version>2.6</version>
-              <executions>
-                <!-- Copy CLI scripts -->
-                <execution>
-                  <id>copy-cli-scripts</id>
-                  <phase>prepare-package</phase>
-                  <goals>
-                    <goal>copy-resources</goal>
-                  </goals>
-                  <configuration combine.self="override">
-                    <outputDirectory>${stage.opt.dir}</outputDirectory>
-                    <useDefaultDelimiters>false</useDefaultDelimiters>
-                    <delimiters>
-                      <delimiter>@@</delimiter>
-                    </delimiters>
-                    <resources>
-                      <resource>
-                        <directory>${project.parent.basedir}/cdap-cli/bin</directory>
-                        <targetPath>bin</targetPath>
-                        <includes>
-                          <include>cdap-cli.sh</include>
-                          <include>cdap-cli.bat</include>
-                        </includes>
-                        <filtering>true</filtering>
-                      </resource>
-                    </resources>
-                  </configuration>
-                </execution>
+            <executions>
+              <!-- Copy CLI scripts -->
+              <execution>
+                <id>copy-cli-scripts</id>
+                <phase>prepare-package</phase>
+                <goals>
+                  <goal>copy-resources</goal>
+                </goals>
+                <configuration combine.self="override">
+                  <outputDirectory>${stage.opt.dir}</outputDirectory>
+                  <useDefaultDelimiters>false</useDefaultDelimiters>
+                  <delimiters>
+                    <delimiter>@@</delimiter>
+                  </delimiters>
+                  <resources>
+                    <resource>
+                      <directory>${project.parent.basedir}/cdap-cli/bin</directory>
+                      <targetPath>bin</targetPath>
+                      <includes>
+                        <include>cdap-cli.sh</include>
+                        <include>cdap-cli.bat</include>
+                      </includes>
+                      <filtering>true</filtering>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
+              <!-- Copy CLI scripts for .deb -->
+              <execution>
+                <id>copy-cli-scripts-deb</id>
+                <phase>prepare-package</phase>
+                <goals>
+                  <goal>copy-resources</goal>
+                </goals>
+                <configuration combine.self="override">
+                  <outputDirectory>${stage.opt.dir}</outputDirectory>
+                  <outputDirectory>${stage.dir}-deb/opt/cdap/${package.name}</outputDirectory>
+                  <useDefaultDelimiters>false</useDefaultDelimiters>
+                  <delimiters>
+                    <delimiter>@@</delimiter>
+                  </delimiters>
+                  <resources>
+                    <resource>
+                      <directory>${project.parent.basedir}/cdap-cli/bin</directory>
+                      <targetPath>bin</targetPath>
+                      <includes>
+                        <include>cdap-cli.sh</include>
+                        <include>cdap-cli.bat</include>
+                      </includes>
+                      <filtering>true</filtering>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
             </executions>
           </plugin>
           <plugin>

--- a/cdap-cli/pom.xml
+++ b/cdap-cli/pom.xml
@@ -170,23 +170,6 @@
                   <goal>run</goal>
                 </goals>
               </execution>
-              <!-- Override parent to not generate init.d service script -->
-              <execution>
-                <id>rename-rpm-service</id>
-                <phase></phase>
-              </execution>
-              <execution>
-                <id>rpm-init-permission</id>
-                <phase></phase>
-              </execution>
-              <execution>
-                <id>renmae-deb-service</id>
-                <phase></phase>
-              </execution>
-              <execution>
-                <id>deb-init-permission</id>
-                <phase></phase>
-              </execution>
             </executions>
           </plugin>
         </plugins>
@@ -206,6 +189,17 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-antrun-plugin</artifactId>
             <version>1.7</version>
+            <executions>
+              <!-- Override parent to not generate init.d service script -->
+              <execution>
+                <id>rename-rpm-service</id>
+                <phase></phase>
+              </execution>
+              <execution>
+                <id>rpm-init-permission</id>
+                <phase></phase>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>
@@ -224,6 +218,17 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-antrun-plugin</artifactId>
             <version>1.7</version>
+            <executions>
+              <!-- Override parent to not generate init.d service script -->
+              <execution>
+                <id>rename-deb-service</id>
+                <phase></phase>
+              </execution>
+              <execution>
+                <id>deb-init-permission</id>
+                <phase></phase>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>

--- a/cdap-cli/pom.xml
+++ b/cdap-cli/pom.xml
@@ -151,6 +151,34 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-resources-plugin</artifactId>
             <version>2.6</version>
+              <executions>
+                <!-- Copy CLI scripts -->
+                <execution>
+                  <id>copy-cli-scripts</id>
+                  <phase>prepare-package</phase>
+                  <goals>
+                    <goal>copy-resources</goal>
+                  </goals>
+                  <configuration combine.self="override">
+                    <outputDirectory>${stage.opt.dir}</outputDirectory>
+                    <useDefaultDelimiters>false</useDefaultDelimiters>
+                    <delimiters>
+                      <delimiter>@@</delimiter>
+                    </delimiters>
+                    <resources>
+                      <resource>
+                        <directory>${project.parent.basedir}/cdap-cli/bin</directory>
+                        <targetPath>bin</targetPath>
+                        <includes>
+                          <include>cdap-cli.sh</include>
+                          <include>cdap-cli.bat</include>
+                        </includes>
+                        <filtering>true</filtering>
+                      </resource>
+                    </resources>
+                  </configuration>
+                </execution>
+            </executions>
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>

--- a/cdap-cli/pom.xml
+++ b/cdap-cli/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+?xml version="1.0" encoding="UTF-8"?>
 <!--
   Copyright © 2012-2014 Cask Data, Inc.
 
@@ -165,6 +165,23 @@
                 <goals>
                   <goal>run</goal>
                 </goals>
+              </execution>
+              <!-- Override parent to not generate init.d service script -->
+              <execution>
+                <id>rename-rpm-service</id>
+                <phase></phase>
+              </execution>
+              <execution>
+                <id>rpm-init-permission</id>
+                <phase></phase>
+              </execution>
+              <execution>
+                <id>renmae-deb-service</id>
+                <phase></phase>
+              </execution>
+              <execution>
+                <id>deb-init-permission</id>
+                <phase></phase>
               </execution>
             </executions>
           </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1626,32 +1626,6 @@
                     </resources>
                   </configuration>
                 </execution>
-                <!-- Copy CLI scripts -->
-                <execution>
-                  <id>copy-cli-scripts</id>
-                  <phase>prepare-package</phase>
-                  <goals>
-                    <goal>copy-resources</goal>
-                  </goals>
-                  <configuration combine.self="override">
-                    <outputDirectory>${stage.opt.dir}</outputDirectory>
-                    <useDefaultDelimiters>false</useDefaultDelimiters>
-                    <delimiters>
-                      <delimiter>@@</delimiter>
-                    </delimiters>
-                    <resources>
-                      <resource>
-                        <directory>${project.parent.basedir}/cdap-cli/bin</directory>
-                        <targetPath>bin</targetPath>
-                        <includes>
-                          <include>cdap-cli.sh</include>
-                          <include>cdap-cli.bat</include>
-                        </includes>
-                        <filtering>true</filtering>
-                      </resource>
-                    </resources>
-                  </configuration>
-                </execution>
               </executions>
             </plugin>
             <plugin>


### PR DESCRIPTION
This PR fixes https://issues.cask.co/browse/CDAP-1397

- [x] removes ``cdap-cli.{sh,bat}`` from non-cli packages by moving the ``copy-cli-scripts`` plugin execution from the parent pom.xml dist profile, to that of cdap-cli/pom.xml.  
   - [x] I also had to split it into two separate executions, one for each rpm/deb, since some ordering of resources changed.  Previously ``copy-cli-scripts`` would run and substitute tokens in ``stage-package`` before it is copied to ``stage-package-deb``.  Now, ``copy-cli-scripts`` gets run after ``stage-package-deb`` is already created, so the token substitution needs to be run for each.
- [x] prevents ``/etc/init.d/cdap-cli`` from getting created in the ``cdap-cli`` packages by overriding the relevant parent plugin executions into no-ops.