### PR TITLE
Restrict 'root.prefix' values.

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/CConfigurationUtil.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/CConfigurationUtil.java
@@ -16,6 +16,8 @@
 
 package co.cask.cdap.common.conf;
 
+import com.google.common.base.Preconditions;
+
 import java.util.Properties;
 
 /**
@@ -32,5 +34,19 @@ public class CConfigurationUtil extends Configuration {
         destination.set(property, cConf.get(property));
       }
     }
+  }
+
+  public static void checkCConfValidity(CConfiguration cConf) {
+    // Checks to ensure that certain keys (e.g. "root.prefix") are valid as expected by CDAP.
+    checkAlphaNumberic(cConf, Constants.CFG_ROOT_NAMESPACE);
+    checkAlphaNumberic(cConf, Constants.Dataset.TABLE_PREFIX);
+  }
+
+  private static void checkAlphaNumberic(CConfiguration cConf, String key) {
+    String value = cConf.get(key);
+    Preconditions.checkNotNull(value, String.format("Entry of CConf with key: %s is null", key));
+    Preconditions.checkArgument(value.matches("[a-zA-Z0-9]+"),
+                                String.format("CConf entry with key: %s must consist " +
+                                                "of only alphanumeric characters; it is: %s", key, value));
   }
 }

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/CConfigurationUtil.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/CConfigurationUtil.java
@@ -36,17 +36,22 @@ public class CConfigurationUtil extends Configuration {
     }
   }
 
-  public static void checkCConfValidity(CConfiguration cConf) {
+  /**
+   * Asserts that the given CConfiguration has valid properties.
+   * @param cConf the CConfiguration object to check
+   * @throws IllegalArgumentException if the given cConf is invalid.
+   */
+  public static void verify(CConfiguration cConf) {
     // Checks to ensure that certain keys (e.g. "root.prefix") are valid as expected by CDAP.
-    checkAlphaNumberic(cConf, Constants.CFG_ROOT_NAMESPACE);
-    checkAlphaNumberic(cConf, Constants.Dataset.TABLE_PREFIX);
+    assertAlphanumeric(cConf, Constants.ROOT_NAMESPACE);
+    assertAlphanumeric(cConf, Constants.Dataset.TABLE_PREFIX);
   }
 
-  private static void checkAlphaNumberic(CConfiguration cConf, String key) {
+  private static void assertAlphanumeric(CConfiguration cConf, String key) {
     String value = cConf.get(key);
-    Preconditions.checkNotNull(value, String.format("Entry of CConf with key: %s is null", key));
+    Preconditions.checkNotNull(value, "Entry of CConf with key: {} is null", key);
     Preconditions.checkArgument(value.matches("[a-zA-Z0-9]+"),
-                                String.format("CConf entry with key: %s must consist " +
-                                                "of only alphanumeric characters; it is: %s", key, value));
+                                "CConf entry with key: {} must consist " +
+                                  "of only alphanumeric characters; it is: {}", key, value);
   }
 }

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -26,7 +26,7 @@ import java.util.concurrent.TimeUnit;
 public final class Constants {
 
   public static final String ARCHIVE_DIR = "archive";
-  public static final String CFG_ROOT_NAMESPACE = "root.namespace";
+  public static final String ROOT_NAMESPACE = "root.namespace";
 
   /**
    * Global Service names.

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 public final class Constants {
 
   public static final String ARCHIVE_DIR = "archive";
+  public static final String CFG_ROOT_NAMESPACE = "root.namespace";
 
   /**
    * Global Service names.

--- a/cdap-common/src/main/java/co/cask/cdap/common/guice/ConfigModule.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/guice/ConfigModule.java
@@ -49,6 +49,7 @@ public final class ConfigModule extends AbstractModule {
   }
 
   public ConfigModule(CConfiguration cConf, Configuration hConf, SConfiguration sConf) {
+    CConfigurationUtil.verify(cConf);
     this.cConf = cConf;
     this.hConf = hConf;
     this.sConf = sConf;

--- a/cdap-common/src/test/java/co/cask/cdap/common/conf/CConfigurationUtilTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/conf/CConfigurationUtilTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.conf;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CConfigurationUtilTest {
+
+  @Test
+  public void testCheckCConfValidity() throws Exception {
+    CConfiguration cConf = CConfiguration.create();
+    assertIsValidCConf(cConf);
+
+    // test some invalid values (and combinations)
+    cConf.set(Constants.CFG_ROOT_NAMESPACE, "invalid_root");
+    assertIsInvalidCConf(cConf);
+    cConf.set(Constants.CFG_ROOT_NAMESPACE, "invalid.root");
+    assertIsInvalidCConf(cConf);
+    cConf.set(Constants.Dataset.TABLE_PREFIX, "invalid/root");
+    assertIsInvalidCConf(cConf);
+    cConf.set(Constants.CFG_ROOT_NAMESPACE, "invalid\root");
+    assertIsInvalidCConf(cConf);
+
+    // set the invalid values back to valid values
+    cConf.set(Constants.CFG_ROOT_NAMESPACE, "cdap");
+    cConf.set(Constants.Dataset.TABLE_PREFIX, "dsprefix");
+    assertIsValidCConf(cConf);
+
+    cConf.set(Constants.CFG_ROOT_NAMESPACE, "cdap1");
+    assertIsValidCConf(cConf);
+
+    // test additional invalid values (and combinations)
+    cConf = CConfiguration.create();
+    cConf.set(Constants.Dataset.TABLE_PREFIX, "invalid.table.prefix");
+    assertIsInvalidCConf(cConf);
+
+    cConf.set(Constants.CFG_ROOT_NAMESPACE, "invalid/root/prefix");
+    assertIsInvalidCConf(cConf);
+  }
+
+  private void assertIsInvalidCConf(CConfiguration cConf) {
+    try {
+      CConfigurationUtil.checkCConfValidity(cConf);
+      Assert.fail("Expected cConf to be invalid");
+    } catch (IllegalArgumentException expected) {
+    }
+  }
+
+  private void assertIsValidCConf(CConfiguration cConf) {
+    CConfigurationUtil.checkCConfValidity(cConf);
+  }
+}

--- a/cdap-common/src/test/java/co/cask/cdap/common/conf/CConfigurationUtilTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/conf/CConfigurationUtilTest.java
@@ -27,21 +27,21 @@ public class CConfigurationUtilTest {
     assertIsValidCConf(cConf);
 
     // test some invalid values (and combinations)
-    cConf.set(Constants.CFG_ROOT_NAMESPACE, "invalid_root");
+    cConf.set(Constants.ROOT_NAMESPACE, "invalid_root");
     assertIsInvalidCConf(cConf);
-    cConf.set(Constants.CFG_ROOT_NAMESPACE, "invalid.root");
+    cConf.set(Constants.ROOT_NAMESPACE, "invalid.root");
     assertIsInvalidCConf(cConf);
     cConf.set(Constants.Dataset.TABLE_PREFIX, "invalid/root");
     assertIsInvalidCConf(cConf);
-    cConf.set(Constants.CFG_ROOT_NAMESPACE, "invalid\root");
+    cConf.set(Constants.ROOT_NAMESPACE, "invalid\root");
     assertIsInvalidCConf(cConf);
 
     // set the invalid values back to valid values
-    cConf.set(Constants.CFG_ROOT_NAMESPACE, "cdap");
+    cConf.set(Constants.ROOT_NAMESPACE, "cdap");
     cConf.set(Constants.Dataset.TABLE_PREFIX, "dsprefix");
     assertIsValidCConf(cConf);
 
-    cConf.set(Constants.CFG_ROOT_NAMESPACE, "cdap1");
+    cConf.set(Constants.ROOT_NAMESPACE, "cdap1");
     assertIsValidCConf(cConf);
 
     // test additional invalid values (and combinations)
@@ -49,19 +49,19 @@ public class CConfigurationUtilTest {
     cConf.set(Constants.Dataset.TABLE_PREFIX, "invalid.table.prefix");
     assertIsInvalidCConf(cConf);
 
-    cConf.set(Constants.CFG_ROOT_NAMESPACE, "invalid/root/prefix");
+    cConf.set(Constants.ROOT_NAMESPACE, "invalid/root/prefix");
     assertIsInvalidCConf(cConf);
   }
 
   private void assertIsInvalidCConf(CConfiguration cConf) {
     try {
-      CConfigurationUtil.checkCConfValidity(cConf);
+      CConfigurationUtil.verify(cConf);
       Assert.fail("Expected cConf to be invalid");
     } catch (IllegalArgumentException expected) {
     }
   }
 
   private void assertIsValidCConf(CConfiguration cConf) {
-    CConfigurationUtil.checkCConfValidity(cConf);
+    CConfigurationUtil.verify(cConf);
   }
 }

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
@@ -21,6 +21,7 @@ import co.cask.cdap.app.guice.ProgramRunnerRuntimeModule;
 import co.cask.cdap.app.guice.ServiceStoreModules;
 import co.cask.cdap.app.store.ServiceStore;
 import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.CConfigurationUtil;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
@@ -142,6 +143,7 @@ public class MasterServiceMain extends DaemonMain {
 
   @Override
   public void init(String[] args) {
+    CConfigurationUtil.checkCConfValidity(cConf);
     exploreEnabled = cConf.getBoolean(Constants.Explore.EXPLORE_ENABLED);
     serviceName = Constants.Service.MASTER_SERVICES;
     cConf.set(Constants.Dataset.Manager.ADDRESS, getLocalHost().getCanonicalHostName());
@@ -268,7 +270,10 @@ public class MasterServiceMain extends DaemonMain {
     LOG.info("Stopping {}", serviceName);
     stopFlag = true;
 
-    dsService.stopAndWait();
+    if (dsService != null) {
+      dsService.stopAndWait();
+    }
+
     if (isLeader.get() && twillController != null) {
       twillController.stopAndWait();
     }

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
@@ -21,7 +21,6 @@ import co.cask.cdap.app.guice.ProgramRunnerRuntimeModule;
 import co.cask.cdap.app.guice.ServiceStoreModules;
 import co.cask.cdap.app.store.ServiceStore;
 import co.cask.cdap.common.conf.CConfiguration;
-import co.cask.cdap.common.conf.CConfigurationUtil;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
@@ -143,7 +142,6 @@ public class MasterServiceMain extends DaemonMain {
 
   @Override
   public void init(String[] args) {
-    CConfigurationUtil.checkCConfValidity(cConf);
     exploreEnabled = cConf.getBoolean(Constants.Explore.EXPLORE_ENABLED);
     serviceName = Constants.Service.MASTER_SERVICES;
     cConf.set(Constants.Dataset.Manager.ADDRESS, getLocalHost().getCanonicalHostName());

--- a/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
+++ b/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
@@ -21,7 +21,6 @@ import co.cask.cdap.app.guice.ProgramRunnerRuntimeModule;
 import co.cask.cdap.app.guice.ServiceStoreModules;
 import co.cask.cdap.app.store.ServiceStore;
 import co.cask.cdap.common.conf.CConfiguration;
-import co.cask.cdap.common.conf.CConfigurationUtil;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
@@ -149,7 +148,6 @@ public class StandaloneMain {
    * Start the service.
    */
   public void startUp() throws Exception {
-    CConfigurationUtil.checkCConfValidity(configuration);
     // Start all the services.
     txService.startAndWait();
     metricsCollectionService.startAndWait();

--- a/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
+++ b/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
@@ -21,6 +21,7 @@ import co.cask.cdap.app.guice.ProgramRunnerRuntimeModule;
 import co.cask.cdap.app.guice.ServiceStoreModules;
 import co.cask.cdap.app.store.ServiceStore;
 import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.CConfigurationUtil;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
@@ -148,6 +149,7 @@ public class StandaloneMain {
    * Start the service.
    */
   public void startUp() throws Exception {
+    CConfigurationUtil.checkCConfValidity(configuration);
     // Start all the services.
     txService.startAndWait();
     metricsCollectionService.startAndWait();


### PR DESCRIPTION
StandaloneMain and MasterServiceMain do not start if the 'root.prefix' configured in CConfiguration is not strictly alphanumeric.

This is not a comprehensive list of all the checks we need to perform against the cConf, but it is a start - one that is necessary due to limitations on the characters that can be in hbase namespace, and assumptions we make about what values can be in the hbase namespace for cdap tables.
Note that our allowed values (strictly alphanumeric) are stricter than hbase's.

Build: http://builds.cask.co/browse/CDAP-DUT961-3

[Here is what happens in sdk when invalid root.prefix is given.](https://s3.amazonaws.com/uploads.hipchat.com/26476/1011205/ZJstMN1Qken9iDD/Screen%20Shot%202015-03-03%20at%203.03.57%20PM.png)

Things to consider:
I am not restricting the zookeeper value in cConf or a few other related ones that use 'root.prefix' by default, but can be overridden.