### PR TITLE
Update usage of Trademarks

### DIFF
--- a/cdap-docs/_common/_source/index.rst
+++ b/cdap-docs/_common/_source/index.rst
@@ -20,8 +20,9 @@ application abstractions to simplify and accelerate application development, add
 broader range of real-time and batch use cases, and deploy applications into production
 while satisfying enterprise requirements.
 
-CDAP is a layer of software running on top of Apache |(TM)| Hadoop |(R)| platforms such as the
-Cloudera Enterprise Data Hub or the Hortonworks Data Platform. CDAP provides these essential capabilities:
+CDAP is a layer of software running on top of Apache Hadoop |(R)| platforms such as the
+Cloudera Enterprise Data Hub or the Hortonworks |(R)| Data Platform. CDAP provides these 
+essential capabilities:
 
 - Abstraction of data in the Hadoop environment through logical representations of underlying
   data;
@@ -97,7 +98,7 @@ on the installation, monitoring and diagnosing fully distributed CDAP in a Hadoo
   - **Javadocs:** The Java APIs for writing CDAP Applications
   - **Java Client API:** Methods for interacting with CDAP from external Java applications
   - **Command Line Interface API:** Methods for interacting with a CDAP instance from within a shell
-  - **Licenses and Dependencies:** License information for the CDAP and list of CDAP Dependent Packages
+  - **Trademarks, Licenses, and Dependencies:** Trademark and License information for CDAP and lists of CDAP Dependent Packages
 
 
 .. |release-notes| replace:: **Release Notes:**
@@ -122,10 +123,3 @@ on the installation, monitoring and diagnosing fully distributed CDAP in a Hadoo
 .. _search: search.html
 
 - |search|_ Search this documentation using *Quick Search*
-
-
-.. |(TM)| unicode:: U+2122 .. trademark sign
-   :ltrim:
-
-.. |(R)| unicode:: U+00AE .. registered trademark sign
-   :ltrim:

--- a/cdap-docs/_common/common_conf.py
+++ b/cdap-docs/_common/common_conf.py
@@ -134,7 +134,19 @@ rst_epilog = """
 
 .. |http:| replace:: http:
 
-""" % {'version': version, 'short_version': short_version, 'release': release}
+.. |(TM)| unicode:: U+2122 .. trademark sign
+   :ltrim:
+
+.. |(R)| unicode:: U+00AE .. registered trademark sign
+   :ltrim:
+
+.. |copyright| replace:: %(copyright)s
+
+""" % {'version': version, 
+       'short_version': short_version, 
+       'release': release,
+       'copyright': copyright,
+       }
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/cdap-docs/admin-manual/source/index.rst
+++ b/cdap-docs/admin-manual/source/index.rst
@@ -88,10 +88,3 @@ introduces the CDAP Console.**
 .. _troubleshooting: operations/troubleshooting.html
 
 - |troubleshooting|_ Selected examples of potential **problems and possible resolutions.**
-
-
-.. |(TM)| unicode:: U+2122 .. trademark sign
-   :ltrim:
-
-.. |(R)| unicode:: U+00AE .. registered trademark sign
-   :ltrim:

--- a/cdap-docs/developers-manual/source/building-blocks/transaction-system.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/transaction-system.rst
@@ -34,7 +34,7 @@ object can be reattempted. This ensures "exactly-once" processing of each object
 OCC: Optimistic Concurrency Control
 -----------------------------------
 
-The Cask Data Application Platform uses `Cask's Tephra, <http://tephra.io>`__ which uses
+The Cask Data Application Platform uses `Cask's Tephra™ <http://tephra.io>`__, which uses
 *Optimistic Concurrency Control* (OCC) to implement transactions. Unlike most relational
 databases that use locks to prevent conflicting operations between transactions, under OCC
 we allow these conflicting writes to happen. When the transaction is committed, we can

--- a/cdap-docs/developers-manual/source/index.rst
+++ b/cdap-docs/developers-manual/source/index.rst
@@ -70,10 +70,3 @@ CDAP Developers’ Manual
 - |advanced|_ Covers **advanced topics on CDAP** that will be of interest to
   developers who want a deeper dive into CDAP, with presentations on 
   **Best Practices for CDAP development** and **Adapters**.
-  
-
-.. |(TM)| unicode:: U+2122 .. trademark sign
-   :ltrim:
-
-.. |(R)| unicode:: U+00AE .. registered trademark sign
-   :ltrim:

--- a/cdap-docs/developers-manual/source/overview/abstractions.rst
+++ b/cdap-docs/developers-manual/source/overview/abstractions.rst
@@ -30,8 +30,8 @@ In CDAP applications, you interact with data through Datasets. Datasets provide 
 - Abstraction of the actual representation of data in storage. You can write your code or queries without
   having to know where and how your data is stored—be it in HBase, LevelDB or a relational database.
 - Encapsulation of data access patterns and business logic as reusable, managed Java code.
-- Consistency of your data under highly concurrent access using Cask's
-  `Tephra transaction system. <https://github.com/caskdata/tephra/>`__
+- Consistency of your data under highly concurrent access using Cask's 
+  `Tephra™ transaction system <https://github.com/caskdata/tephra/>`__.
 - Injection of datasets into different programming paradigms and runtimes. As soon as your data is in a
   dataset, you can immediately use it: in real-time programs; in batch processing applications such as Map/Reduce
   and Spark; in ad-hoc SQL queries.

--- a/cdap-docs/reference-manual/source/glossary.rst
+++ b/cdap-docs/reference-manual/source/glossary.rst
@@ -94,7 +94,7 @@ Glossary
       for *Ubuntu 12* and *CentOS 6*.
 
    Hadoop
-      Refers to the `Apache™ Hadoop® <http://hadoop.apache.org>`__ project, which describes
+      Refers to the `Apache Hadoop® <http://hadoop.apache.org>`__ project, which describes
       itself as:
 
       *"The Apache Hadoop software library is a framework that allows for the distributed
@@ -122,14 +122,6 @@ Glossary
       Refers to the `Apache Avro™ <http://avro.apache.org>`__ project, which is a
       data serialization system that provides rich data structures and a compact, fast, binary data format.
 
-
-
-.. |(TM)| unicode:: U+2122 .. trademark sign
-   :ltrim:
-
-.. |(R)| unicode:: U+00AE .. registered trademark sign
-   :ltrim:
-
-.. Apache |(TM)| Hadoop |(R)|
-.. Apache™ Hadoop®
+.. Apache Hadoop |(R)|
+.. Apache Hadoop®
 

--- a/cdap-docs/reference-manual/source/index.rst
+++ b/cdap-docs/reference-manual/source/index.rst
@@ -37,8 +37,8 @@ CDAP Reference Manual: APIs, Licenses, and Dependencies
 - |cli|_ methods for interacting with a CDAP instance from within a shell.
 
 
-.. |licenses| replace:: **Licenses and Dependencies:**
+.. |licenses| replace:: **Trademarks, Licenses, and Dependencies:**
 .. _licenses: licenses/index.html
 
-- |licenses|_ License information for the CDAP Product and Documentation and CDAP
-  Dependent Packages, Licenses, and License URLs.
+- |licenses|_ Trademark and License information for the CDAP Product and Documentation, and lists of
+  CDAP Dependent Packages, Licenses, and License URLs.

--- a/cdap-docs/reference-manual/source/licenses/index.rst
+++ b/cdap-docs/reference-manual/source/licenses/index.rst
@@ -55,12 +55,14 @@ Other product and company names mentioned herein, within our documentation or we
 be the trademarks of their respective owners. Where the ownership or registration is known,
 the addition of appropriate symbols has been made.
 
-Apache®, Apache Hadoop, and Hadoop® are either registered trademarks or trademarks of the
-Apache Software Foundation in the United States and/or other countries.
+Apache®, `Apache Hadoop <http://hadoop.apache.org>`__, and `Hadoop®
+<http://hadoop.apache.org>`__ are either registered trademarks or trademarks of the
+`Apache Software Foundation <http://www.apache.org>`__ in the United States and/or other
+countries.
 
-Cloudera, Cloudera Impala, and Impala are trademarks of Cloudera, Inc. 
+Cloudera, Cloudera Impala, and Impala are trademarks of `Cloudera, Inc. <http://www.cloudera.com>`__ 
 
-Hortonworks is a registered trademark of Hortonworks, Inc.
+Hortonworks is a registered trademark of `Hortonworks, Inc. <http://hortonworks.com>`__
 
 CDAP Product License
 --------------------

--- a/cdap-docs/reference-manual/source/licenses/index.rst
+++ b/cdap-docs/reference-manual/source/licenses/index.rst
@@ -3,7 +3,7 @@
     :description: Cask Data Application Platform Dependencies
 
 ========================================================
-Cask Data Application Platform Licenses and Dependencies
+Trademarks, Licenses, and Dependencies
 ========================================================
 
 .. toctree::
@@ -13,12 +13,61 @@ Cask Data Application Platform Licenses and Dependencies
     <cdap-level-1-dependencies>
     <cdap-standalone-dependencies>
 
+Trademarks, Logos, and Trade Dress
+----------------------------------
+
+The following are word trademarks and service marks ("Word Marks", "Service Marks") of
+Cask Data, Inc.:
+
+.. list-table::
+   :widths: 20 80
+   :header-rows: 1
+
+   * - Mark
+     - Common descriptive name for the goods or services
+   * - Cask
+     - Computer software and related services
+   * - CDAP
+     - Computer software and related services
+   * - Coopr
+     - Computer software and related services
+   * - Coopr Cloud
+     - Computer software and related services
+   * - Tephra
+     - Computer software and related services
+   * - Tigon
+     - Computer software and related services
+
+
+Our logos ("Logos") include any logos or illustrations used on these webpages.
+The unique visual styling of our website and packaging is referred to as the "Trade Dress".
+
+This encompasses all trademarks and service marks, whether Word Marks, Logos or Trade
+Dress, whether registered or not, which are collectively referred to as the “Marks.” 
+
+All marks are trademarks of Cask Data, Inc. All rights reserved.
+
+
+Other Products and Trademarks
+-----------------------------
+
+Other product and company names mentioned herein, within our documentation or webpages, may
+be the trademarks of their respective owners. Where the ownership or registration is known,
+the addition of appropriate symbols has been made.
+
+Apache®, Apache Hadoop, and Hadoop® are either registered trademarks or trademarks of the
+Apache Software Foundation in the United States and/or other countries.
+
+Cloudera, Cloudera Impala, and Impala are trademarks of Cloudera, Inc. 
+
+Hortonworks is a registered trademark of Hortonworks, Inc.
+
 CDAP Product License
 --------------------
 
 The Cask Data Application Platform (CDAP) product is copyright and licensed as follows:
 
-   Copyright © 2014-2015 Cask Data, Inc.
+   Copyright © |copyright|
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -39,7 +88,7 @@ CDAP Documentation License
 
 The Cask Data Application Platform (CDAP) documentation is copyright and licensed as follows:
 
-   Copyright © 2014-2015 Cask Data, Inc.
+   Copyright © |copyright|
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/cdap-docs/reference-manual/source/release-notes.rst
+++ b/cdap-docs/reference-manual/source/release-notes.rst
@@ -239,7 +239,7 @@ Known Issues
 CDAP Bug Fixes
 --------------
 
-- Fixed a problem with a Coopr-provisioned secure cluster failing to start due to a classpath
+- Fixed a problem with a Coopr |(TM)|\ -provisioned secure cluster failing to start due to a classpath
   issue (`CDAP-478 <https://issues.cask.co/browse/CDAP-478>`__).
 - Fixed a problem with the WISE app zip distribution not packaged correctly; a new version
   (0.2.1) has been released (`CDAP-533 <https://issues.cask.co/browse/CDAP-533>`__).

--- a/cdap-docs/reference-manual/source/table-of-contents.rst
+++ b/cdap-docs/reference-manual/source/table-of-contents.rst
@@ -14,5 +14,5 @@ CDAP Reference Manual Table of Contents
     Javadocs <javadocs/index>
     Java Client API <java-client-api>
     Command Line Interface API <cli-api>
-    License and Dependencies <licenses/index>
+    Trademarks, Licenses, and Dependencies <licenses/index>
 


### PR DESCRIPTION
Adds info on Trademarks, adds trademark symbols, moves the trademark symbol replace directives to the common file, so they are available in all files.

Corrects some usages of trademarks. Makes the copyright string available as a replace directive, and uses it on the License page.

Staged at: [2.8.0-SNAPSHOT-2.8.0_trademarks](http://stg-web101.sw.joyent.continuuity.net/cdap/2.8.0-SNAPSHOT-2.8.0_trademarks/en/index.html)