### PR TITLE
remove confusing info log

### DIFF
--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgraderMain.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgraderMain.java
@@ -194,7 +194,6 @@ public class UpgraderMain {
    * Stop services and
    */
   private void stop() {
-    LOG.info("Stopping Upgrade ...");
     try {
       txService.stopAndWait();
       zkClientService.stopAndWait();


### PR DESCRIPTION
The stopping message can be confusing in ideal case when upgrade runs well as its basically completing and not stopping. Just getting rid of it. 