### PR TITLE
Remove root prefix from TableId class. Instead, HBaseTableUtil has a CCo...

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
@@ -651,7 +651,7 @@ final class MapReduceRuntimeService extends AbstractExecutionThreadService {
       // Ignore
     }
     try {
-      Class<?> hbaseTableUtilClass = new HBaseTableUtilFactory().get().getClass();
+      Class<?> hbaseTableUtilClass = new HBaseTableUtilFactory().getHBaseTableUtilClass();
       classes.add(hbaseTableUtilClass);
     } catch (ProvisionException e) {
       LOG.warn("Not including HBaseTableUtil classes in submitted Job Jar since they are not available");

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
@@ -651,7 +651,7 @@ final class MapReduceRuntimeService extends AbstractExecutionThreadService {
       // Ignore
     }
     try {
-      Class<?> hbaseTableUtilClass = new HBaseTableUtilFactory().getHBaseTableUtilClass();
+      Class<?> hbaseTableUtilClass = HBaseTableUtilFactory.getHBaseTableUtilClass();
       classes.add(hbaseTableUtilClass);
     } catch (ProvisionException e) {
       LOG.warn("Not including HBaseTableUtil classes in submitted Job Jar since they are not available");

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/distributed/DistributedMapReduceContextBuilder.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/distributed/DistributedMapReduceContextBuilder.java
@@ -29,8 +29,6 @@ import co.cask.cdap.data2.datafabric.dataset.type.DistributedDatasetTypeClassLoa
 import co.cask.cdap.data2.dataset2.DatasetDefinitionRegistryFactory;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.DefaultDatasetDefinitionRegistry;
-import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
-import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
 import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.gateway.auth.AuthModule;
 import co.cask.cdap.internal.app.runtime.batch.AbstractMapReduceContextBuilder;
@@ -76,9 +74,6 @@ public class DistributedMapReduceContextBuilder extends AbstractMapReduceContext
       new AbstractModule() {
         @Override
         protected void configure() {
-
-          // Data-fabric bindings
-          bind(HBaseTableUtil.class).toProvider(HBaseTableUtilFactory.class);
 
           // txds2
           install(new FactoryModuleBuilder()

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/distributed/DistributedMapReduceContextBuilder.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/distributed/DistributedMapReduceContextBuilder.java
@@ -29,6 +29,8 @@ import co.cask.cdap.data2.datafabric.dataset.type.DistributedDatasetTypeClassLoa
 import co.cask.cdap.data2.dataset2.DatasetDefinitionRegistryFactory;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.DefaultDatasetDefinitionRegistry;
+import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
+import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
 import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.gateway.auth.AuthModule;
 import co.cask.cdap.internal.app.runtime.batch.AbstractMapReduceContextBuilder;
@@ -74,6 +76,9 @@ public class DistributedMapReduceContextBuilder extends AbstractMapReduceContext
       new AbstractModule() {
         @Override
         protected void configure() {
+
+          // Data-fabric bindings
+          bind(HBaseTableUtil.class).toProvider(HBaseTableUtilFactory.class);
 
           // txds2
           install(new FactoryModuleBuilder()

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractDistributedProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractDistributedProgramRunner.java
@@ -127,7 +127,7 @@ public abstract class AbstractDistributedProgramRunner implements ProgramRunner 
           twillPreparer.enableDebugging();
         }
         TwillController twillController = twillPreparer
-          .withDependencies(new HBaseTableUtilFactory().get().getClass())
+          .withDependencies(new HBaseTableUtilFactory().getHBaseTableUtilClass())
           .addLogHandler(new PrinterLogHandler(new PrintWriter(System.out)))
           .addSecureStore(YarnSecureStore.create(HBaseTokenUtils.obtainToken(hConf, new Credentials())))
           .withApplicationArguments(

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractDistributedProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractDistributedProgramRunner.java
@@ -127,7 +127,7 @@ public abstract class AbstractDistributedProgramRunner implements ProgramRunner 
           twillPreparer.enableDebugging();
         }
         TwillController twillController = twillPreparer
-          .withDependencies(new HBaseTableUtilFactory().getHBaseTableUtilClass())
+          .withDependencies(HBaseTableUtilFactory.getHBaseTableUtilClass())
           .addLogHandler(new PrinterLogHandler(new PrintWriter(System.out)))
           .addSecureStore(YarnSecureStore.create(HBaseTokenUtils.obtainToken(hConf, new Credentials())))
           .withApplicationArguments(

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/kv/HBaseKVTableTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/kv/HBaseKVTableTest.java
@@ -18,6 +18,7 @@ package co.cask.cdap.data2.dataset2.lib.kv;
 
 import co.cask.cdap.api.dataset.DatasetAdmin;
 import co.cask.cdap.api.dataset.DatasetDefinition;
+import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.data.hbase.HBaseTestBase;
 import co.cask.cdap.data.hbase.HBaseTestFactory;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
@@ -42,7 +43,7 @@ public class HBaseKVTableTest extends NoTxKeyValueTableTest {
   public static TemporaryFolder tmpFolder = new TemporaryFolder();
 
   private static HBaseTestBase testHBase;
-  private static HBaseTableUtil hBaseTableUtil = new HBaseTableUtilFactory().get();
+  private static HBaseTableUtil hBaseTableUtil = new HBaseTableUtilFactory().get(CConfiguration.create());
 
   @BeforeClass
   public static void beforeClass() throws Exception {
@@ -53,7 +54,7 @@ public class HBaseKVTableTest extends NoTxKeyValueTableTest {
 
   @AfterClass
   public static void afterClass() throws Exception {
-    testHBase.deleteTables(hBaseTableUtil.toHBaseNamespace(NAMESPACE_ID));
+    hBaseTableUtil.deleteAllInNamespace(testHBase.getHBaseAdmin(), NAMESPACE_ID);
     hBaseTableUtil.deleteNamespaceIfExists(testHBase.getHBaseAdmin(), NAMESPACE_ID);
     testHBase.stopHBase();
   }
@@ -64,7 +65,6 @@ public class HBaseKVTableTest extends NoTxKeyValueTableTest {
       @Override
       protected void configure() {
         bind(Configuration.class).toInstance(testHBase.getConfiguration());
-        bind(HBaseTableUtil.class).toInstance(hBaseTableUtil);
       }
     });
 

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/kv/HBaseKVTableTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/kv/HBaseKVTableTest.java
@@ -43,7 +43,7 @@ public class HBaseKVTableTest extends NoTxKeyValueTableTest {
   public static TemporaryFolder tmpFolder = new TemporaryFolder();
 
   private static HBaseTestBase testHBase;
-  private static HBaseTableUtil hBaseTableUtil = new HBaseTableUtilFactory().get(CConfiguration.create());
+  private static HBaseTableUtil hBaseTableUtil = new HBaseTableUtilFactory(CConfiguration.create()).get();
 
   @BeforeClass
   public static void beforeClass() throws Exception {
@@ -65,6 +65,7 @@ public class HBaseKVTableTest extends NoTxKeyValueTableTest {
       @Override
       protected void configure() {
         bind(Configuration.class).toInstance(testHBase.getConfiguration());
+        bind(HBaseTableUtil.class).toInstance(hBaseTableUtil);
       }
     });
 

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseMetricsTableTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseMetricsTableTest.java
@@ -39,7 +39,6 @@ import co.cask.cdap.data2.dataset2.lib.table.MetricsTable;
 import co.cask.cdap.data2.dataset2.lib.table.MetricsTableTest;
 import co.cask.cdap.data2.dataset2.module.lib.hbase.HBaseMetricsTableModule;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
-import co.cask.cdap.data2.util.hbase.HTableNameConverter;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.test.SlowTests;
 import com.google.common.collect.ImmutableList;
@@ -100,7 +99,7 @@ public class HBaseMetricsTableTest extends MetricsTableTest {
 
   @AfterClass
   public static void tearDown() throws Exception {
-    testHBase.deleteTables(HTableNameConverter.toHBaseNamespace(Constants.SYSTEM_NAMESPACE_ID));
+    tableUtil.deleteAllInNamespace(testHBase.getHBaseAdmin(), Constants.SYSTEM_NAMESPACE_ID);
     tableUtil.deleteNamespaceIfExists(testHBase.getHBaseAdmin(), Constants.SYSTEM_NAMESPACE_ID);
     testHBase.stopHBase();
   }

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseMetricsTableTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseMetricsTableTest.java
@@ -40,6 +40,7 @@ import co.cask.cdap.data2.dataset2.lib.table.MetricsTableTest;
 import co.cask.cdap.data2.dataset2.module.lib.hbase.HBaseMetricsTableModule;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
+import co.cask.cdap.data2.util.hbase.HTableNameConverter;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.test.SlowTests;
 import com.google.common.collect.ImmutableList;
@@ -94,13 +95,13 @@ public class HBaseMetricsTableTest extends MetricsTableTest {
     dsFramework = new InMemoryDatasetFramework(injector.getInstance(DatasetDefinitionRegistryFactory.class), conf);
     dsFramework.addModule(Id.DatasetModule.from(Constants.SYSTEM_NAMESPACE_ID, "metrics-hbase"),
                           new HBaseMetricsTableModule());
-    tableUtil = new HBaseTableUtilFactory().get();
+    tableUtil = new HBaseTableUtilFactory().get(conf);
     tableUtil.createNamespaceIfNotExists(testHBase.getHBaseAdmin(), Constants.SYSTEM_NAMESPACE_ID);
   }
 
   @AfterClass
   public static void tearDown() throws Exception {
-    testHBase.deleteTables(tableUtil.toHBaseNamespace(Constants.SYSTEM_NAMESPACE_ID));
+    testHBase.deleteTables(HTableNameConverter.toHBaseNamespace(Constants.SYSTEM_NAMESPACE_ID));
     tableUtil.deleteNamespaceIfExists(testHBase.getHBaseAdmin(), Constants.SYSTEM_NAMESPACE_ID);
     testHBase.stopHBase();
   }

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseMetricsTableTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseMetricsTableTest.java
@@ -39,7 +39,6 @@ import co.cask.cdap.data2.dataset2.lib.table.MetricsTable;
 import co.cask.cdap.data2.dataset2.lib.table.MetricsTableTest;
 import co.cask.cdap.data2.dataset2.module.lib.hbase.HBaseMetricsTableModule;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
-import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
 import co.cask.cdap.data2.util.hbase.HTableNameConverter;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.test.SlowTests;
@@ -95,7 +94,7 @@ public class HBaseMetricsTableTest extends MetricsTableTest {
     dsFramework = new InMemoryDatasetFramework(injector.getInstance(DatasetDefinitionRegistryFactory.class), conf);
     dsFramework.addModule(Id.DatasetModule.from(Constants.SYSTEM_NAMESPACE_ID, "metrics-hbase"),
                           new HBaseMetricsTableModule());
-    tableUtil = new HBaseTableUtilFactory().get(conf);
+    tableUtil = injector.getInstance(HBaseTableUtil.class);
     tableUtil.createNamespaceIfNotExists(testHBase.getHBaseAdmin(), Constants.SYSTEM_NAMESPACE_ID);
   }
 

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableTest.java
@@ -87,7 +87,7 @@ public class HBaseTableTest extends BufferingTableTest<BufferingTable> {
     testHBase = new HBaseTestFactory().get();
     testHBase.startHBase();
     cConf = CConfiguration.create();
-    hBaseTableUtil = new HBaseTableUtilFactory().get(cConf);
+    hBaseTableUtil = new HBaseTableUtilFactory(cConf).get();
     // TODO: CDAP-1634 - Explore a way to not have every HBase test class do this.
     hBaseTableUtil.createNamespaceIfNotExists(testHBase.getHBaseAdmin(), NAMESPACE_ID);
   }
@@ -103,7 +103,8 @@ public class HBaseTableTest extends BufferingTableTest<BufferingTable> {
   protected BufferingTable getTable(String name, ConflictDetection conflictLevel) throws Exception {
     // ttl=-1 means "keep data forever"
     return
-      new HBaseTable(name, ConflictDetection.valueOf(conflictLevel.name()), testHBase.getConfiguration(), cConf, true);
+      new HBaseTable(name, ConflictDetection.valueOf(conflictLevel.name()), testHBase.getConfiguration(),
+                     hBaseTableUtil, true);
   }
 
   @Override
@@ -122,7 +123,8 @@ public class HBaseTableTest extends BufferingTableTest<BufferingTable> {
     String noTtlTable = DS_NAMESPACE.namespace(NAMESPACE_ID, "nottl");
     DatasetProperties props = DatasetProperties.builder().add(Table.PROPERTY_TTL, String.valueOf(ttl)).build();
     getTableAdmin(ttlTable, props).create();
-    HBaseTable table = new HBaseTable(ttlTable, ConflictDetection.ROW, testHBase.getConfiguration(), cConf, false);
+    HBaseTable table = new HBaseTable(ttlTable, ConflictDetection.ROW, testHBase.getConfiguration(),
+                                      hBaseTableUtil, false);
 
     DetachedTxSystemClient txSystemClient = new DetachedTxSystemClient();
     Transaction tx = txSystemClient.startShort();
@@ -151,7 +153,8 @@ public class HBaseTableTest extends BufferingTableTest<BufferingTable> {
     DatasetProperties props2 = DatasetProperties.builder()
       .add(Table.PROPERTY_TTL, String.valueOf(Tables.NO_TTL)).build();
     getTableAdmin(noTtlTable, props2).create();
-    HBaseTable table2 = new HBaseTable(noTtlTable, ConflictDetection.ROW, testHBase.getConfiguration(), cConf, false);
+    HBaseTable table2 = new HBaseTable(noTtlTable, ConflictDetection.ROW, testHBase.getConfiguration(),
+                                       hBaseTableUtil, false);
 
     tx = txSystemClient.startShort();
     table2.startTx(tx);

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableTest.java
@@ -32,7 +32,6 @@ import co.cask.cdap.data2.increment.hbase96.IncrementHandler;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
-import co.cask.cdap.data2.util.hbase.HTableNameConverter;
 import co.cask.cdap.test.SlowTests;
 import co.cask.tephra.Transaction;
 import co.cask.tephra.inmemory.DetachedTxSystemClient;
@@ -94,7 +93,7 @@ public class HBaseTableTest extends BufferingTableTest<BufferingTable> {
 
   @AfterClass
   public static void afterClass() throws Exception {
-    testHBase.deleteTables(HTableNameConverter.toHBaseNamespace(NAMESPACE_ID));
+    hBaseTableUtil.deleteAllInNamespace(testHBase.getHBaseAdmin(), NAMESPACE_ID);
     hBaseTableUtil.deleteNamespaceIfExists(testHBase.getHBaseAdmin(), NAMESPACE_ID);
     testHBase.stopHBase();
   }

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/MetricHBaseTableUtilTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/MetricHBaseTableUtilTest.java
@@ -24,9 +24,9 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data.hbase.HBaseTestBase;
 import co.cask.cdap.data.hbase.HBaseTestFactory;
+import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
-import co.cask.cdap.data2.util.hbase.TableId;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.HBaseAdmin;
@@ -46,15 +46,16 @@ public class MetricHBaseTableUtilTest {
   public static TemporaryFolder tmpFolder = new TemporaryFolder();
 
   private static HBaseTestBase testHBase;
-  private static HBaseTableUtil hBaseTableUtil = new HBaseTableUtilFactory().get();
-  private static HBaseTableUtil tableUtil;
+  private static HBaseTableUtil hBaseTableUtil;
+  private static CConfiguration cConf;
 
   @BeforeClass
   public static void beforeClass() throws Exception {
     testHBase = new HBaseTestFactory().get();
     testHBase.startHBase();
-    tableUtil = new HBaseTableUtilFactory().get();
-    tableUtil.createNamespaceIfNotExists(testHBase.getHBaseAdmin(), Constants.SYSTEM_NAMESPACE_ID);
+    cConf = CConfiguration.create();
+    hBaseTableUtil = new HBaseTableUtilFactory().get(cConf);
+    hBaseTableUtil.createNamespaceIfNotExists(testHBase.getHBaseAdmin(), Constants.SYSTEM_NAMESPACE_ID);
   }
 
   @AfterClass
@@ -67,7 +68,7 @@ public class MetricHBaseTableUtilTest {
     // Verify new metric datasets are properly recognized as 2.8+ version from now on
     HBaseMetricsTableDefinition definition =
       new HBaseMetricsTableDefinition("foo", testHBase.getConfiguration(), hBaseTableUtil,
-                                      new LocalLocationFactory(tmpFolder.newFolder()), CConfiguration.create());
+                                      new LocalLocationFactory(tmpFolder.newFolder()), cConf);
     DatasetSpecification spec = definition.configure("cdap.system.metricV2.8", DatasetProperties.EMPTY);
 
     DatasetAdmin admin = definition.getAdmin(DatasetContext.from(Constants.SYSTEM_NAMESPACE), spec, null);
@@ -75,7 +76,7 @@ public class MetricHBaseTableUtilTest {
 
     MetricHBaseTableUtil util = new MetricHBaseTableUtil(hBaseTableUtil);
     HBaseAdmin hAdmin = testHBase.getHBaseAdmin();
-    HTableDescriptor desc = tableUtil.getHTableDescriptor(hAdmin, TableId.from(spec.getName()));
+    HTableDescriptor desc = hBaseTableUtil.getHTableDescriptor(hAdmin, TableId.from(spec.getName()));
     Assert.assertEquals(MetricHBaseTableUtil.Version.VERSION_2_8_OR_HIGHER, util.getVersion(desc));
 
     // Verify HBase table without coprocessor is properly recognized as 2.6- version

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/MetricHBaseTableUtilTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/MetricHBaseTableUtilTest.java
@@ -54,7 +54,7 @@ public class MetricHBaseTableUtilTest {
     testHBase = new HBaseTestFactory().get();
     testHBase.startHBase();
     cConf = CConfiguration.create();
-    hBaseTableUtil = new HBaseTableUtilFactory().get(cConf);
+    hBaseTableUtil = new HBaseTableUtilFactory(cConf).get();
     hBaseTableUtil.createNamespaceIfNotExists(testHBase.getHBaseAdmin(), Constants.SYSTEM_NAMESPACE_ID);
   }
 

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseConsumerStateTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseConsumerStateTest.java
@@ -34,7 +34,6 @@ import co.cask.cdap.data2.transaction.stream.StreamConsumerStateStore;
 import co.cask.cdap.data2.transaction.stream.StreamConsumerStateStoreFactory;
 import co.cask.cdap.data2.transaction.stream.StreamConsumerStateTestBase;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
-import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
 import co.cask.cdap.data2.util.hbase.HTableNameConverter;
 import co.cask.cdap.notifications.feeds.NotificationFeedManager;
 import co.cask.cdap.notifications.feeds.service.NoOpNotificationFeedManager;
@@ -105,7 +104,7 @@ public class HBaseConsumerStateTest extends StreamConsumerStateTestBase {
     streamAdmin = injector.getInstance(StreamAdmin.class);
     stateStoreFactory = injector.getInstance(StreamConsumerStateStoreFactory.class);
 
-    tableUtil = new HBaseTableUtilFactory().get(cConf);
+    tableUtil = injector.getInstance(HBaseTableUtil.class);
     tableUtil.createNamespaceIfNotExists(testHBase.getHBaseAdmin(), TEST_NAMESPACE);
     tableUtil.createNamespaceIfNotExists(testHBase.getHBaseAdmin(), OTHER_NAMESPACE);
   }

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseConsumerStateTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseConsumerStateTest.java
@@ -35,6 +35,7 @@ import co.cask.cdap.data2.transaction.stream.StreamConsumerStateStoreFactory;
 import co.cask.cdap.data2.transaction.stream.StreamConsumerStateTestBase;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
+import co.cask.cdap.data2.util.hbase.HTableNameConverter;
 import co.cask.cdap.notifications.feeds.NotificationFeedManager;
 import co.cask.cdap.notifications.feeds.service.NoOpNotificationFeedManager;
 import co.cask.cdap.proto.Id;
@@ -104,7 +105,7 @@ public class HBaseConsumerStateTest extends StreamConsumerStateTestBase {
     streamAdmin = injector.getInstance(StreamAdmin.class);
     stateStoreFactory = injector.getInstance(StreamConsumerStateStoreFactory.class);
 
-    tableUtil = new HBaseTableUtilFactory().get();
+    tableUtil = new HBaseTableUtilFactory().get(cConf);
     tableUtil.createNamespaceIfNotExists(testHBase.getHBaseAdmin(), TEST_NAMESPACE);
     tableUtil.createNamespaceIfNotExists(testHBase.getHBaseAdmin(), OTHER_NAMESPACE);
   }
@@ -119,7 +120,7 @@ public class HBaseConsumerStateTest extends StreamConsumerStateTestBase {
   }
 
   private static void deleteNamespace(Id.Namespace namespace) throws IOException {
-    testHBase.deleteTables(tableUtil.toHBaseNamespace(namespace));
+    testHBase.deleteTables(HTableNameConverter.toHBaseNamespace(namespace));
     tableUtil.deleteNamespaceIfExists(testHBase.getHBaseAdmin(), namespace);
   }
 

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseConsumerStateTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseConsumerStateTest.java
@@ -34,7 +34,6 @@ import co.cask.cdap.data2.transaction.stream.StreamConsumerStateStore;
 import co.cask.cdap.data2.transaction.stream.StreamConsumerStateStoreFactory;
 import co.cask.cdap.data2.transaction.stream.StreamConsumerStateTestBase;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
-import co.cask.cdap.data2.util.hbase.HTableNameConverter;
 import co.cask.cdap.notifications.feeds.NotificationFeedManager;
 import co.cask.cdap.notifications.feeds.service.NoOpNotificationFeedManager;
 import co.cask.cdap.proto.Id;
@@ -119,7 +118,7 @@ public class HBaseConsumerStateTest extends StreamConsumerStateTestBase {
   }
 
   private static void deleteNamespace(Id.Namespace namespace) throws IOException {
-    testHBase.deleteTables(HTableNameConverter.toHBaseNamespace(namespace));
+    tableUtil.deleteAllInNamespace(testHBase.getHBaseAdmin(), namespace);
     tableUtil.deleteNamespaceIfExists(testHBase.getHBaseAdmin(), namespace);
   }
 

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseStreamConsumerTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseStreamConsumerTest.java
@@ -34,7 +34,6 @@ import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.data2.transaction.stream.StreamConsumerFactory;
 import co.cask.cdap.data2.transaction.stream.StreamConsumerTestBase;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
-import co.cask.cdap.data2.util.hbase.HTableNameConverter;
 import co.cask.cdap.notifications.feeds.NotificationFeedManager;
 import co.cask.cdap.notifications.feeds.service.NoOpNotificationFeedManager;
 import co.cask.cdap.proto.Id;
@@ -142,7 +141,7 @@ public class HBaseStreamConsumerTest extends StreamConsumerTestBase {
   }
 
   private static void deleteNamespace(Id.Namespace namespace) throws IOException {
-    testHBase.deleteTables(HTableNameConverter.toHBaseNamespace(namespace));
+    tableUtil.deleteAllInNamespace(testHBase.getHBaseAdmin(), namespace);
     tableUtil.deleteNamespaceIfExists(testHBase.getHBaseAdmin(), namespace);
   }
 

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseStreamConsumerTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseStreamConsumerTest.java
@@ -35,6 +35,7 @@ import co.cask.cdap.data2.transaction.stream.StreamConsumerFactory;
 import co.cask.cdap.data2.transaction.stream.StreamConsumerTestBase;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
+import co.cask.cdap.data2.util.hbase.HTableNameConverter;
 import co.cask.cdap.notifications.feeds.NotificationFeedManager;
 import co.cask.cdap.notifications.feeds.service.NoOpNotificationFeedManager;
 import co.cask.cdap.proto.Id;
@@ -126,7 +127,7 @@ public class HBaseStreamConsumerTest extends StreamConsumerTestBase {
 
     txManager.startAndWait();
 
-    tableUtil = new HBaseTableUtilFactory().get();
+    tableUtil = new HBaseTableUtilFactory().get(cConf);
     tableUtil.createNamespaceIfNotExists(testHBase.getHBaseAdmin(), Constants.SYSTEM_NAMESPACE_ID);
     tableUtil.createNamespaceIfNotExists(testHBase.getHBaseAdmin(), TEST_NAMESPACE);
     tableUtil.createNamespaceIfNotExists(testHBase.getHBaseAdmin(), OTHER_NAMESPACE);
@@ -142,7 +143,7 @@ public class HBaseStreamConsumerTest extends StreamConsumerTestBase {
   }
 
   private static void deleteNamespace(Id.Namespace namespace) throws IOException {
-    testHBase.deleteTables(tableUtil.toHBaseNamespace(namespace));
+    testHBase.deleteTables(HTableNameConverter.toHBaseNamespace(namespace));
     tableUtil.deleteNamespaceIfExists(testHBase.getHBaseAdmin(), namespace);
   }
 

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseStreamConsumerTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseStreamConsumerTest.java
@@ -34,7 +34,6 @@ import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.data2.transaction.stream.StreamConsumerFactory;
 import co.cask.cdap.data2.transaction.stream.StreamConsumerTestBase;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
-import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
 import co.cask.cdap.data2.util.hbase.HTableNameConverter;
 import co.cask.cdap.notifications.feeds.NotificationFeedManager;
 import co.cask.cdap.notifications.feeds.service.NoOpNotificationFeedManager;
@@ -127,7 +126,7 @@ public class HBaseStreamConsumerTest extends StreamConsumerTestBase {
 
     txManager.startAndWait();
 
-    tableUtil = new HBaseTableUtilFactory().get(cConf);
+    tableUtil = injector.getInstance(HBaseTableUtil.class);
     tableUtil.createNamespaceIfNotExists(testHBase.getHBaseAdmin(), Constants.SYSTEM_NAMESPACE_ID);
     tableUtil.createNamespaceIfNotExists(testHBase.getHBaseAdmin(), TEST_NAMESPACE);
     tableUtil.createNamespaceIfNotExists(testHBase.getHBaseAdmin(), OTHER_NAMESPACE);

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/util/hbase/ConfigurationTableTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/util/hbase/ConfigurationTableTest.java
@@ -44,7 +44,7 @@ public class ConfigurationTableTest {
   @BeforeClass
   public static void setupBeforeClass() throws Exception {
     testHBase.startHBase();
-    tableUtil = new HBaseTableUtilFactory().get(cConf);
+    tableUtil = new HBaseTableUtilFactory(cConf).get();
     tableUtil.createNamespaceIfNotExists(testHBase.getHBaseAdmin(), Constants.SYSTEM_NAMESPACE_ID);
   }
 

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/util/hbase/ConfigurationTableTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/util/hbase/ConfigurationTableTest.java
@@ -50,7 +50,7 @@ public class ConfigurationTableTest {
 
   @AfterClass
   public static void teardownAfterClass() throws Exception {
-    testHBase.deleteTables(HTableNameConverter.toHBaseNamespace(Constants.SYSTEM_NAMESPACE_ID));
+    tableUtil.deleteAllInNamespace(testHBase.getHBaseAdmin(), Constants.SYSTEM_NAMESPACE_ID);
     tableUtil.deleteNamespaceIfExists(testHBase.getHBaseAdmin(), Constants.SYSTEM_NAMESPACE_ID);
     testHBase.stopHBase();
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataFabricDistributedModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataFabricDistributedModule.java
@@ -22,6 +22,8 @@ import co.cask.cdap.data2.transaction.metrics.TransactionManagerMetricsCollector
 import co.cask.cdap.data2.transaction.queue.QueueAdmin;
 import co.cask.cdap.data2.transaction.queue.hbase.HBaseQueueAdmin;
 import co.cask.cdap.data2.transaction.queue.hbase.HBaseQueueClientFactory;
+import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
+import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
 import co.cask.tephra.TxConstants;
 import co.cask.tephra.distributed.PooledClientProvider;
 import co.cask.tephra.distributed.ThreadLocalClientProvider;
@@ -54,6 +56,7 @@ public class DataFabricDistributedModule extends AbstractModule {
     bind(ThriftClientProvider.class).toProvider(ThriftClientProviderSupplier.class);
     bind(QueueClientFactory.class).to(HBaseQueueClientFactory.class).in(Singleton.class);
     bind(QueueAdmin.class).to(HBaseQueueAdmin.class).in(Singleton.class);
+    bind(HBaseTableUtil.class).toProvider(HBaseTableUtilFactory.class);
 
     // bind transactions
     bind(TxMetricsCollector.class).to(TransactionManagerMetricsCollector.class).in(Scopes.SINGLETON);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataFabricDistributedModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataFabricDistributedModule.java
@@ -22,8 +22,6 @@ import co.cask.cdap.data2.transaction.metrics.TransactionManagerMetricsCollector
 import co.cask.cdap.data2.transaction.queue.QueueAdmin;
 import co.cask.cdap.data2.transaction.queue.hbase.HBaseQueueAdmin;
 import co.cask.cdap.data2.transaction.queue.hbase.HBaseQueueClientFactory;
-import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
-import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
 import co.cask.tephra.TxConstants;
 import co.cask.tephra.distributed.PooledClientProvider;
 import co.cask.tephra.distributed.ThreadLocalClientProvider;
@@ -56,7 +54,6 @@ public class DataFabricDistributedModule extends AbstractModule {
     bind(ThriftClientProvider.class).toProvider(ThriftClientProviderSupplier.class);
     bind(QueueClientFactory.class).to(HBaseQueueClientFactory.class).in(Singleton.class);
     bind(QueueAdmin.class).to(HBaseQueueAdmin.class).in(Singleton.class);
-    bind(HBaseTableUtil.class).toProvider(HBaseTableUtilFactory.class);
 
     // bind transactions
     bind(TxMetricsCollector.class).to(TransactionManagerMetricsCollector.class).in(Scopes.SINGLETON);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DistributedUnderlyingSystemNamespaceAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DistributedUnderlyingSystemNamespaceAdmin.java
@@ -45,7 +45,7 @@ public final class DistributedUnderlyingSystemNamespaceAdmin extends UnderlyingS
                                                    ExploreFacade exploreFacade) {
     super(cConf, locationFactory, exploreFacade);
     this.hConf = HBaseConfiguration.create();
-    this.tableUtil = new HBaseTableUtilFactory().get();
+    this.tableUtil = new HBaseTableUtilFactory().get(cConf);
   }
 
   @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DistributedUnderlyingSystemNamespaceAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DistributedUnderlyingSystemNamespaceAdmin.java
@@ -18,7 +18,6 @@ package co.cask.cdap.data2.datafabric.dataset.service;
 
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
-import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
 import co.cask.cdap.explore.client.ExploreFacade;
 import co.cask.cdap.explore.service.ExploreException;
 import co.cask.cdap.proto.Id;
@@ -42,10 +41,10 @@ public final class DistributedUnderlyingSystemNamespaceAdmin extends UnderlyingS
 
   @Inject
   public DistributedUnderlyingSystemNamespaceAdmin(CConfiguration cConf, LocationFactory locationFactory,
-                                                   ExploreFacade exploreFacade) {
+                                                   ExploreFacade exploreFacade, HBaseTableUtil tableUtil) {
     super(cConf, locationFactory, exploreFacade);
     this.hConf = HBaseConfiguration.create();
-    this.tableUtil = new HBaseTableUtilFactory().get(cConf);
+    this.tableUtil = tableUtil;
   }
 
   @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/hbase/AbstractHBaseDataSetAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/hbase/AbstractHBaseDataSetAdmin.java
@@ -17,8 +17,8 @@ package co.cask.cdap.data2.dataset2.lib.hbase;
 
 import co.cask.cdap.api.dataset.DatasetAdmin;
 import co.cask.cdap.common.utils.ProjectInfo;
+import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
-import co.cask.cdap.data2.util.hbase.TableId;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -82,16 +82,12 @@ public abstract class AbstractHBaseDataSetAdmin implements DatasetAdmin {
 
   @Override
   public void truncate() throws IOException {
-    HTableDescriptor tableDescriptor = tableUtil.getHTableDescriptor(getAdmin(), tableId);
-    tableUtil.disableTable(getAdmin(), tableId);
-    tableUtil.deleteTable(getAdmin(), tableId);
-    tableUtil.createTableIfNotExists(getAdmin(), tableId, tableDescriptor);
+    tableUtil.truncateTable(getAdmin(), tableId);
   }
 
   @Override
   public void drop() throws IOException {
-    tableUtil.disableTable(getAdmin(), tableId);
-    tableUtil.deleteTable(getAdmin(), tableId);
+    tableUtil.dropTable(getAdmin(), tableId);
   }
 
   @Override
@@ -108,7 +104,7 @@ public abstract class AbstractHBaseDataSetAdmin implements DatasetAdmin {
    * @throws IOException If upgrade failed.
    */
   protected void upgradeTable(TableId tableId) throws IOException {
-    HTableDescriptor tableDescriptor = tableUtil.getHTableDescriptor(tableId);
+    HTableDescriptor tableDescriptor = tableUtil.createHTableDescriptor(tableId);
 
     // Upgrade any table properties if necessary
     boolean needUpgrade = upgradeTable(tableDescriptor);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/kv/HBaseKVTableDefinition.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/kv/HBaseKVTableDefinition.java
@@ -24,8 +24,8 @@ import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.dataset.lib.AbstractDatasetDefinition;
 import co.cask.cdap.api.dataset.module.DatasetDefinitionRegistry;
 import co.cask.cdap.api.dataset.module.DatasetModule;
+import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
-import co.cask.cdap.data2.util.hbase.TableId;
 import com.google.common.base.Throwables;
 import com.google.inject.Inject;
 import org.apache.hadoop.conf.Configuration;
@@ -98,23 +98,19 @@ public class HBaseKVTableDefinition extends AbstractDatasetDefinition<NoTxKeyVal
       columnDescriptor.setMaxVersions(1);
       tableUtil.setBloomFilter(columnDescriptor, HBaseTableUtil.BloomType.ROW);
 
-      HTableDescriptor tableDescriptor = tableUtil.getHTableDescriptor(tableId);
+      HTableDescriptor tableDescriptor = tableUtil.createHTableDescriptor(tableId);
       tableDescriptor.addFamily(columnDescriptor);
       tableUtil.createTableIfNotExists(admin, tableId, tableDescriptor);
     }
 
     @Override
     public void drop() throws IOException {
-      tableUtil.disableTable(admin, tableId);
-      tableUtil.deleteTable(admin, tableId);
+      tableUtil.dropTable(admin, tableId);
     }
 
     @Override
     public void truncate() throws IOException {
-      HTableDescriptor tableDescriptor = tableUtil.getHTableDescriptor(tableId);
-      tableUtil.disableTable(admin, tableId);
-      tableUtil.deleteTable(admin, tableId);
-      tableUtil.createTableIfNotExists(admin, tableId, tableDescriptor);
+      tableUtil.truncateTable(admin, tableId);
     }
 
     @Override
@@ -136,7 +132,7 @@ public class HBaseKVTableDefinition extends AbstractDatasetDefinition<NoTxKeyVal
 
     public KVTableImpl(String tableName, Configuration hConf, HBaseTableUtil tableUtil) throws IOException {
       this.tableUtil = tableUtil;
-      this.table = this.tableUtil.getHTable(hConf, TableId.from(tableName));
+      this.table = this.tableUtil.createHTable(hConf, TableId.from(tableName));
     }
 
     @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseMetricsTable.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseMetricsTable.java
@@ -24,7 +24,6 @@ import co.cask.cdap.data2.dataset2.lib.table.FuzzyRowFilter;
 import co.cask.cdap.data2.dataset2.lib.table.MetricsTable;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
-import co.cask.cdap.data2.util.hbase.HTableNameConverter;
 import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HConstants;
@@ -54,10 +53,9 @@ public class HBaseMetricsTable implements MetricsTable {
 
   private final HTable hTable;
 
-  public HBaseMetricsTable(String name, Configuration hConf, CConfiguration cConf,
+  public HBaseMetricsTable(String tableName, Configuration hConf, CConfiguration cConf,
                            HBaseTableUtil tableUtil) throws IOException {
-    String hTableName = HTableNameConverter.getHBaseTableName(name);
-    HTable hTable = tableUtil.createHTable(hConf, TableId.from(hTableName));
+    HTable hTable = tableUtil.createHTable(hConf, TableId.from(tableName));
     // todo: make configurable
     hTable.setWriteBufferSize(HBaseTableUtil.DEFAULT_WRITE_BUFFER_SIZE);
     hTable.setAutoFlush(false);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseMetricsTable.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseMetricsTable.java
@@ -24,7 +24,6 @@ import co.cask.cdap.data2.dataset2.lib.table.FuzzyRowFilter;
 import co.cask.cdap.data2.dataset2.lib.table.MetricsTable;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
-import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
 import co.cask.cdap.data2.util.hbase.HTableNameConverter;
 import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
@@ -55,9 +54,9 @@ public class HBaseMetricsTable implements MetricsTable {
 
   private final HTable hTable;
 
-  public HBaseMetricsTable(String name, Configuration hConf, CConfiguration cConf) throws IOException {
+  public HBaseMetricsTable(String name, Configuration hConf, CConfiguration cConf,
+                           HBaseTableUtil tableUtil) throws IOException {
     String hTableName = HTableNameConverter.getHBaseTableName(name);
-    HBaseTableUtil tableUtil = new HBaseTableUtilFactory().get(cConf);
     HTable hTable = tableUtil.createHTable(hConf, TableId.from(hTableName));
     // todo: make configurable
     hTable.setWriteBufferSize(HBaseTableUtil.DEFAULT_WRITE_BUFFER_SIZE);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseMetricsTable.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseMetricsTable.java
@@ -18,12 +18,14 @@ package co.cask.cdap.data2.dataset2.lib.table.hbase;
 
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.dataset.table.Scanner;
+import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.utils.ImmutablePair;
 import co.cask.cdap.data2.dataset2.lib.table.FuzzyRowFilter;
 import co.cask.cdap.data2.dataset2.lib.table.MetricsTable;
+import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
-import co.cask.cdap.data2.util.hbase.TableId;
+import co.cask.cdap.data2.util.hbase.HTableNameConverter;
 import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HConstants;
@@ -53,10 +55,10 @@ public class HBaseMetricsTable implements MetricsTable {
 
   private final HTable hTable;
 
-  public HBaseMetricsTable(String name, Configuration hConf) throws IOException {
-    String hTableName = HBaseTableUtil.getHBaseTableName(name);
-    HBaseTableUtil tableUtil = new HBaseTableUtilFactory().get();
-    HTable hTable = tableUtil.getHTable(hConf, TableId.from(hTableName));
+  public HBaseMetricsTable(String name, Configuration hConf, CConfiguration cConf) throws IOException {
+    String hTableName = HTableNameConverter.getHBaseTableName(name);
+    HBaseTableUtil tableUtil = new HBaseTableUtilFactory().get(cConf);
+    HTable hTable = tableUtil.createHTable(hConf, TableId.from(hTableName));
     // todo: make configurable
     hTable.setWriteBufferSize(HBaseTableUtil.DEFAULT_WRITE_BUFFER_SIZE);
     hTable.setAutoFlush(false);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseMetricsTableDefinition.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseMetricsTableDefinition.java
@@ -44,7 +44,7 @@ public class HBaseMetricsTableDefinition extends AbstractDatasetDefinition<Metri
   @Inject
   private LocationFactory locationFactory;
   @Inject
-  private CConfiguration conf;
+  private CConfiguration cConf;
 
   public HBaseMetricsTableDefinition(String name) {
     super(name);
@@ -52,12 +52,12 @@ public class HBaseMetricsTableDefinition extends AbstractDatasetDefinition<Metri
 
   // for unit-test purposes only
   HBaseMetricsTableDefinition(String name, Configuration hConf, HBaseTableUtil hBaseTableUtil,
-                                     LocationFactory locationFactory, CConfiguration conf) {
+                                     LocationFactory locationFactory, CConfiguration cConf) {
     super(name);
     this.hConf = hConf;
     this.hBaseTableUtil = hBaseTableUtil;
     this.locationFactory = locationFactory;
-    this.conf = conf;
+    this.cConf = cConf;
   }
 
   @Override
@@ -72,12 +72,12 @@ public class HBaseMetricsTableDefinition extends AbstractDatasetDefinition<Metri
   @Override
   public MetricsTable getDataset(DatasetContext datasetContext, DatasetSpecification spec,
                                  Map<String, String> arguments, ClassLoader classLoader) throws IOException {
-    return new HBaseMetricsTable(spec.getName(), hConf);
+    return new HBaseMetricsTable(spec.getName(), hConf, cConf);
   }
 
   @Override
   public DatasetAdmin getAdmin(DatasetContext datasetContext, DatasetSpecification spec,
                                ClassLoader classLoader) throws IOException {
-    return new HBaseTableAdmin(spec, hConf, hBaseTableUtil, conf, locationFactory);
+    return new HBaseTableAdmin(spec, hConf, hBaseTableUtil, cConf, locationFactory);
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseMetricsTableDefinition.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseMetricsTableDefinition.java
@@ -72,7 +72,7 @@ public class HBaseMetricsTableDefinition extends AbstractDatasetDefinition<Metri
   @Override
   public MetricsTable getDataset(DatasetContext datasetContext, DatasetSpecification spec,
                                  Map<String, String> arguments, ClassLoader classLoader) throws IOException {
-    return new HBaseMetricsTable(spec.getName(), hConf, cConf);
+    return new HBaseMetricsTable(spec.getName(), hConf, cConf, hBaseTableUtil);
   }
 
   @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTable.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTable.java
@@ -21,13 +21,15 @@ import co.cask.cdap.api.dataset.DataSetException;
 import co.cask.cdap.api.dataset.table.ConflictDetection;
 import co.cask.cdap.api.dataset.table.Row;
 import co.cask.cdap.api.dataset.table.Scanner;
+import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.data2.dataset2.lib.table.BufferingTable;
 import co.cask.cdap.data2.dataset2.lib.table.IncrementValue;
 import co.cask.cdap.data2.dataset2.lib.table.PutValue;
 import co.cask.cdap.data2.dataset2.lib.table.Update;
+import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
-import co.cask.cdap.data2.util.hbase.TableId;
+import co.cask.cdap.data2.util.hbase.HTableNameConverter;
 import co.cask.tephra.Transaction;
 import co.cask.tephra.TransactionCodec;
 import com.google.common.base.Function;
@@ -71,13 +73,14 @@ public class HBaseTable extends BufferingTable {
 
   private final TransactionCodec txCodec;
 
-  public HBaseTable(String name, ConflictDetection level, Configuration hConf, boolean enableReadlessIncrements)
+  public HBaseTable(String name, ConflictDetection level, Configuration hConf, CConfiguration cConf,
+                    boolean enableReadlessIncrements)
     throws IOException {
     super(name, level, enableReadlessIncrements);
-    hTableName = HBaseTableUtil.getHBaseTableName(name);
-    HBaseTableUtil tableUtil = new HBaseTableUtilFactory().get();
+    hTableName = HTableNameConverter.getHBaseTableName(name);
+    HBaseTableUtil tableUtil = new HBaseTableUtilFactory().get(cConf);
     TableId tableId = TableId.from(name);
-    HTable hTable = tableUtil.getHTable(hConf, tableId);
+    HTable hTable = tableUtil.createHTable(hConf, tableId);
     // todo: make configurable
     hTable.setWriteBufferSize(HBaseTableUtil.DEFAULT_WRITE_BUFFER_SIZE);
     hTable.setAutoFlush(false);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTable.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTable.java
@@ -21,14 +21,12 @@ import co.cask.cdap.api.dataset.DataSetException;
 import co.cask.cdap.api.dataset.table.ConflictDetection;
 import co.cask.cdap.api.dataset.table.Row;
 import co.cask.cdap.api.dataset.table.Scanner;
-import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.data2.dataset2.lib.table.BufferingTable;
 import co.cask.cdap.data2.dataset2.lib.table.IncrementValue;
 import co.cask.cdap.data2.dataset2.lib.table.PutValue;
 import co.cask.cdap.data2.dataset2.lib.table.Update;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
-import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
 import co.cask.cdap.data2.util.hbase.HTableNameConverter;
 import co.cask.tephra.Transaction;
 import co.cask.tephra.TransactionCodec;
@@ -73,12 +71,10 @@ public class HBaseTable extends BufferingTable {
 
   private final TransactionCodec txCodec;
 
-  public HBaseTable(String name, ConflictDetection level, Configuration hConf, CConfiguration cConf,
-                    boolean enableReadlessIncrements)
-    throws IOException {
+  public HBaseTable(String name, ConflictDetection level, Configuration hConf,
+                    HBaseTableUtil tableUtil, boolean enableReadlessIncrements) throws IOException {
     super(name, level, enableReadlessIncrements);
     hTableName = HTableNameConverter.getHBaseTableName(name);
-    HBaseTableUtil tableUtil = new HBaseTableUtilFactory().get(cConf);
     TableId tableId = TableId.from(name);
     HTable hTable = tableUtil.createHTable(hConf, tableId);
     // todo: make configurable

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTable.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTable.java
@@ -27,7 +27,6 @@ import co.cask.cdap.data2.dataset2.lib.table.PutValue;
 import co.cask.cdap.data2.dataset2.lib.table.Update;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
-import co.cask.cdap.data2.util.hbase.HTableNameConverter;
 import co.cask.tephra.Transaction;
 import co.cask.tephra.TransactionCodec;
 import com.google.common.base.Function;
@@ -65,17 +64,17 @@ public class HBaseTable extends BufferingTable {
 
   public static final String DELTA_WRITE = "d";
   private final HTable hTable;
-  private final String hTableName;
+  private final String tableName;
 
   private Transaction tx;
 
   private final TransactionCodec txCodec;
 
-  public HBaseTable(String name, ConflictDetection level, Configuration hConf,
+  public HBaseTable(String tableName, ConflictDetection level, Configuration hConf,
                     HBaseTableUtil tableUtil, boolean enableReadlessIncrements) throws IOException {
-    super(name, level, enableReadlessIncrements);
-    hTableName = HTableNameConverter.getHBaseTableName(name);
-    TableId tableId = TableId.from(name);
+    super(tableName, level, enableReadlessIncrements);
+    this.tableName = tableName;
+    TableId tableId = TableId.from(tableName);
     HTable hTable = tableUtil.createHTable(hConf, tableId);
     // todo: make configurable
     hTable.setWriteBufferSize(HBaseTableUtil.DEFAULT_WRITE_BUFFER_SIZE);
@@ -88,7 +87,7 @@ public class HBaseTable extends BufferingTable {
   public String toString() {
     return Objects.toStringHelper(this)
                   .add("hTable", hTable)
-                  .add("hTableName", hTableName)
+                  .add("tableName", tableName)
                   .toString();
   }
 
@@ -121,7 +120,7 @@ public class HBaseTable extends BufferingTable {
       });
       return rows;
     } catch (IOException ioe) {
-      throw new DataSetException("Multi-get failed on table " + hTableName, ioe);
+      throw new DataSetException("Multi-get failed on table " + tableName, ioe);
     }
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableAdmin.java
@@ -22,8 +22,8 @@ import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.dataset2.lib.hbase.AbstractHBaseDataSetAdmin;
+import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
-import co.cask.cdap.data2.util.hbase.TableId;
 import co.cask.tephra.TxConstants;
 import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
@@ -84,7 +84,7 @@ public class HBaseTableAdmin extends AbstractHBaseDataSetAdmin {
       }
     }
 
-    final HTableDescriptor tableDescriptor = tableUtil.getHTableDescriptor(tableId);
+    final HTableDescriptor tableDescriptor = tableUtil.createHTableDescriptor(tableId);
     setVersion(tableDescriptor);
     tableDescriptor.addFamily(columnDescriptor);
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableDefinition.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableDefinition.java
@@ -66,7 +66,7 @@ public class HBaseTableDefinition
     // NOTE: ttl property is applied on server-side in CPs
     // check if read-less increment operations are supported
     boolean supportsIncrements = HBaseTableAdmin.supportsReadlessIncrements(spec);
-    return new HBaseTable(spec.getName(), conflictDetection, hConf, cConf, supportsIncrements);
+    return new HBaseTable(spec.getName(), conflictDetection, hConf, hBaseTableUtil, supportsIncrements);
   }
 
   @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableDefinition.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableDefinition.java
@@ -45,7 +45,7 @@ public class HBaseTableDefinition
   private LocationFactory locationFactory;
   // todo: datasets should not depend on cdap configuration!
   @Inject
-  private CConfiguration conf;
+  private CConfiguration cConf;
 
   public HBaseTableDefinition(String name) {
     super(name);
@@ -66,12 +66,12 @@ public class HBaseTableDefinition
     // NOTE: ttl property is applied on server-side in CPs
     // check if read-less increment operations are supported
     boolean supportsIncrements = HBaseTableAdmin.supportsReadlessIncrements(spec);
-    return new HBaseTable(spec.getName(), conflictDetection, hConf, supportsIncrements);
+    return new HBaseTable(spec.getName(), conflictDetection, hConf, cConf, supportsIncrements);
   }
 
   @Override
   public HBaseTableAdmin getAdmin(DatasetContext datasetContext, DatasetSpecification spec,
                                   ClassLoader classLoader) throws IOException {
-    return new HBaseTableAdmin(spec, hConf, hBaseTableUtil, conf, locationFactory);
+    return new HBaseTableAdmin(spec, hConf, hBaseTableUtil, cConf, locationFactory);
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metrics/HBaseDatasetMetricsReporter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metrics/HBaseDatasetMetricsReporter.java
@@ -23,6 +23,7 @@ import co.cask.cdap.common.metrics.MetricsCollector;
 import co.cask.cdap.data2.datafabric.DefaultDatasetNamespace;
 import co.cask.cdap.data2.dataset2.DatasetNamespace;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
+import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
 import co.cask.cdap.proto.Id;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.AbstractScheduledService;
@@ -53,13 +54,13 @@ public class HBaseDatasetMetricsReporter extends AbstractScheduledService implem
   private HBaseAdmin hAdmin;
 
   @Inject
-  public HBaseDatasetMetricsReporter(MetricsCollectionService metricsService, HBaseTableUtil hBaseTableUtil,
-                                     Configuration hConf, CConfiguration conf) {
+  public HBaseDatasetMetricsReporter(MetricsCollectionService metricsService,
+                                     Configuration hConf, CConfiguration cConf) {
     this.metricsService = metricsService;
-    this.hBaseTableUtil = hBaseTableUtil;
+    this.hBaseTableUtil = new HBaseTableUtilFactory().get(cConf);
     this.hConf = hConf;
-    this.reportIntervalInSec = conf.getInt(Constants.Metrics.Dataset.HBASE_STATS_REPORT_INTERVAL);
-    this.userDsNamespace = new DefaultDatasetNamespace(conf);
+    this.reportIntervalInSec = cConf.getInt(Constants.Metrics.Dataset.HBASE_STATS_REPORT_INTERVAL);
+    this.userDsNamespace = new DefaultDatasetNamespace(cConf);
   }
 
   @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metrics/HBaseDatasetMetricsReporter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metrics/HBaseDatasetMetricsReporter.java
@@ -23,7 +23,6 @@ import co.cask.cdap.common.metrics.MetricsCollector;
 import co.cask.cdap.data2.datafabric.DefaultDatasetNamespace;
 import co.cask.cdap.data2.dataset2.DatasetNamespace;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
-import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
 import co.cask.cdap.proto.Id;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.AbstractScheduledService;
@@ -54,10 +53,10 @@ public class HBaseDatasetMetricsReporter extends AbstractScheduledService implem
   private HBaseAdmin hAdmin;
 
   @Inject
-  public HBaseDatasetMetricsReporter(MetricsCollectionService metricsService,
+  public HBaseDatasetMetricsReporter(MetricsCollectionService metricsService, HBaseTableUtil hBaseTableUtil,
                                      Configuration hConf, CConfiguration cConf) {
     this.metricsService = metricsService;
-    this.hBaseTableUtil = new HBaseTableUtilFactory().get(cConf);
+    this.hBaseTableUtil = hBaseTableUtil;
     this.hConf = hConf;
     this.reportIntervalInSec = cConf.getInt(Constants.Metrics.Dataset.HBASE_STATS_REPORT_INTERVAL);
     this.userDsNamespace = new DefaultDatasetNamespace(cConf);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/AbstractQueueAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/AbstractQueueAdmin.java
@@ -20,7 +20,6 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.queue.QueueName;
 import co.cask.cdap.data2.datafabric.DefaultDatasetNamespace;
-import co.cask.cdap.data2.util.hbase.HTableNameConverter;
 import co.cask.cdap.proto.Id;
 
 /**
@@ -97,15 +96,12 @@ public abstract class AbstractQueueAdmin implements QueueAdmin {
 
   protected String getTableNameForFlow(String namespaceId, String app, String flow) {
     String tablePrefix = getTableNamePrefix(namespaceId);
-    String tableName = tablePrefix + "." + app + "." + flow;
-    return HTableNameConverter.getHBaseTableName(tableName);
+    return tablePrefix + "." + app + "." + flow;
   }
 
   public String getTableNamePrefix(String namespaceId) {
     // returns String with format:  '<root namespace>.<namespaceId>.system.(stream|queue)'
-    String tablePrefix = namespace.namespace(Id.DatasetInstance.from(namespaceId,
-                                                                     unqualifiedTableNamePrefix)).getId();
-    return HTableNameConverter.getHBaseTableName(tablePrefix);
+    return namespace.namespace(Id.DatasetInstance.from(namespaceId, unqualifiedTableNamePrefix)).getId();
   }
 
   public String getConfigTableName(QueueName queueName) {
@@ -114,8 +110,6 @@ public abstract class AbstractQueueAdmin implements QueueAdmin {
 
   protected String getConfigTableName(String namespaceId) {
     // returns String with format:  '<root namespace>.<namespaceId>.system.queue.config'
-    String tablePrefix = namespace.namespace(Id.DatasetInstance.from(namespaceId,
-                                                                     unqualifiedConfigTableNameSuffix)).getId();
-    return HTableNameConverter.getHBaseTableName(tablePrefix);
+    return namespace.namespace(Id.DatasetInstance.from(namespaceId, unqualifiedConfigTableNameSuffix)).getId();
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/AbstractQueueAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/AbstractQueueAdmin.java
@@ -20,7 +20,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.queue.QueueName;
 import co.cask.cdap.data2.datafabric.DefaultDatasetNamespace;
-import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
+import co.cask.cdap.data2.util.hbase.HTableNameConverter;
 import co.cask.cdap.proto.Id;
 
 /**
@@ -98,14 +98,14 @@ public abstract class AbstractQueueAdmin implements QueueAdmin {
   protected String getTableNameForFlow(String namespaceId, String app, String flow) {
     String tablePrefix = getTableNamePrefix(namespaceId);
     String tableName = tablePrefix + "." + app + "." + flow;
-    return HBaseTableUtil.getHBaseTableName(tableName);
+    return HTableNameConverter.getHBaseTableName(tableName);
   }
 
   public String getTableNamePrefix(String namespaceId) {
     // returns String with format:  '<root namespace>.<namespaceId>.system.(stream|queue)'
     String tablePrefix = namespace.namespace(Id.DatasetInstance.from(namespaceId,
                                                                      unqualifiedTableNamePrefix)).getId();
-    return HBaseTableUtil.getHBaseTableName(tablePrefix);
+    return HTableNameConverter.getHBaseTableName(tablePrefix);
   }
 
   public String getConfigTableName(QueueName queueName) {
@@ -116,6 +116,6 @@ public abstract class AbstractQueueAdmin implements QueueAdmin {
     // returns String with format:  '<root namespace>.<namespaceId>.system.queue.config'
     String tablePrefix = namespace.namespace(Id.DatasetInstance.from(namespaceId,
                                                                      unqualifiedConfigTableNameSuffix)).getId();
-    return HBaseTableUtil.getHBaseTableName(tablePrefix);
+    return HTableNameConverter.getHBaseTableName(tablePrefix);
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueAdmin.java
@@ -25,7 +25,6 @@ import co.cask.cdap.data2.transaction.queue.QueueConstants;
 import co.cask.cdap.data2.transaction.queue.QueueEntryRow;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
-import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
 import co.cask.cdap.hbase.wd.AbstractRowKeyDistributor;
 import co.cask.cdap.hbase.wd.RowKeyDistributorByHashPrefix;
 import com.google.common.base.Objects;
@@ -102,18 +101,20 @@ public class HBaseQueueAdmin extends AbstractQueueAdmin {
   @Inject
   public HBaseQueueAdmin(Configuration hConf,
                          CConfiguration cConf,
-                         LocationFactory locationFactory) throws IOException {
-    this(hConf, cConf, locationFactory, QUEUE);
+                         LocationFactory locationFactory,
+                         HBaseTableUtil tableUtil) throws IOException {
+    this(hConf, cConf, locationFactory, tableUtil, QUEUE);
   }
 
   protected HBaseQueueAdmin(Configuration hConf,
                             CConfiguration cConf,
                             LocationFactory locationFactory,
+                            HBaseTableUtil tableUtil,
                             QueueConstants.QueueType type) throws IOException {
     super(cConf, type);
     this.hConf = hConf;
     this.cConf = cConf;
-    this.tableUtil = new HBaseTableUtilFactory().get(cConf);
+    this.tableUtil = tableUtil;
     this.type = type;
     this.locationFactory = locationFactory;
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueAdmin.java
@@ -23,8 +23,9 @@ import co.cask.cdap.data2.dataset2.lib.hbase.AbstractHBaseDataSetAdmin;
 import co.cask.cdap.data2.transaction.queue.AbstractQueueAdmin;
 import co.cask.cdap.data2.transaction.queue.QueueConstants;
 import co.cask.cdap.data2.transaction.queue.QueueEntryRow;
+import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
-import co.cask.cdap.data2.util.hbase.TableId;
+import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
 import co.cask.cdap.hbase.wd.AbstractRowKeyDistributor;
 import co.cask.cdap.hbase.wd.RowKeyDistributorByHashPrefix;
 import com.google.common.base.Objects;
@@ -101,20 +102,18 @@ public class HBaseQueueAdmin extends AbstractQueueAdmin {
   @Inject
   public HBaseQueueAdmin(Configuration hConf,
                          CConfiguration cConf,
-                         LocationFactory locationFactory,
-                         HBaseTableUtil tableUtil) throws IOException {
-    this(hConf, cConf, locationFactory, tableUtil, QUEUE);
+                         LocationFactory locationFactory) throws IOException {
+    this(hConf, cConf, locationFactory, QUEUE);
   }
 
   protected HBaseQueueAdmin(Configuration hConf,
                             CConfiguration cConf,
                             LocationFactory locationFactory,
-                            HBaseTableUtil tableUtil,
                             QueueConstants.QueueType type) throws IOException {
     super(cConf, type);
     this.hConf = hConf;
     this.cConf = cConf;
-    this.tableUtil = tableUtil;
+    this.tableUtil = new HBaseTableUtilFactory().get(cConf);
     this.type = type;
     this.locationFactory = locationFactory;
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseStreamAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseStreamAdmin.java
@@ -44,9 +44,9 @@ import javax.annotation.Nullable;
 public class HBaseStreamAdmin extends HBaseQueueAdmin implements StreamAdmin {
 
   @Inject
-  public HBaseStreamAdmin(Configuration hConf, CConfiguration cConf, LocationFactory locationFactory,
-                          HBaseTableUtil tableUtil) throws IOException {
-    super(hConf, cConf, locationFactory, tableUtil, QueueConstants.QueueType.STREAM);
+  public HBaseStreamAdmin(Configuration hConf, CConfiguration cConf,
+                          LocationFactory locationFactory) throws IOException {
+    super(hConf, cConf, locationFactory, QueueConstants.QueueType.STREAM);
   }
 
   @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseStreamAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseStreamAdmin.java
@@ -44,9 +44,9 @@ import javax.annotation.Nullable;
 public class HBaseStreamAdmin extends HBaseQueueAdmin implements StreamAdmin {
 
   @Inject
-  public HBaseStreamAdmin(Configuration hConf, CConfiguration cConf,
-                          LocationFactory locationFactory) throws IOException {
-    super(hConf, cConf, locationFactory, QueueConstants.QueueType.STREAM);
+  public HBaseStreamAdmin(Configuration hConf, CConfiguration cConf, LocationFactory locationFactory,
+                          HBaseTableUtil tableUtil) throws IOException {
+    super(hConf, cConf, locationFactory, tableUtil, QueueConstants.QueueType.STREAM);
   }
 
   @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/coprocessor/ConsumerConfigCache.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/coprocessor/ConsumerConfigCache.java
@@ -47,7 +47,7 @@ import javax.annotation.Nullable;
  */
 public class ConsumerConfigCache {
   private static final Logger LOG = LoggerFactory.getLogger(ConsumerConfigCache.class);
-  
+
   private static final int LONG_BYTES = Long.SIZE / Byte.SIZE;
   // update interval for CConfiguration
   private static final long CONFIG_UPDATE_FREQUENCY = 300 * 1000L;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseStreamConsumerStateStoreFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseStreamConsumerStateStoreFactory.java
@@ -15,6 +15,7 @@
  */
 package co.cask.cdap.data2.transaction.stream.hbase;
 
+import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data.stream.StreamUtils;
 import co.cask.cdap.data2.transaction.queue.QueueConstants;
@@ -22,8 +23,10 @@ import co.cask.cdap.data2.transaction.queue.QueueEntryRow;
 import co.cask.cdap.data2.transaction.stream.StreamConfig;
 import co.cask.cdap.data2.transaction.stream.StreamConsumerStateStore;
 import co.cask.cdap.data2.transaction.stream.StreamConsumerStateStoreFactory;
+import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
-import co.cask.cdap.data2.util.hbase.TableId;
+import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
+import co.cask.cdap.data2.util.hbase.HTableNameConverter;
 import co.cask.cdap.proto.Id;
 import com.google.inject.Inject;
 import org.apache.hadoop.conf.Configuration;
@@ -43,9 +46,9 @@ public final class HBaseStreamConsumerStateStoreFactory implements StreamConsume
   private final HBaseTableUtil tableUtil;
 
   @Inject
-  HBaseStreamConsumerStateStoreFactory(Configuration hConf, HBaseTableUtil tableUtil) {
+  HBaseStreamConsumerStateStoreFactory(Configuration hConf, CConfiguration cConf) {
     this.hConf = hConf;
-    this.tableUtil = tableUtil;
+    this.tableUtil = new HBaseTableUtilFactory().get(cConf);
   }
 
   @Override
@@ -55,7 +58,7 @@ public final class HBaseStreamConsumerStateStoreFactory implements StreamConsume
     HBaseAdmin admin = new HBaseAdmin(hConf);
     if (!tableUtil.tableExists(admin, streamStateStoreTableId)) {
       try {
-        HTableDescriptor htd = tableUtil.getHTableDescriptor(streamStateStoreTableId);
+        HTableDescriptor htd = tableUtil.createHTableDescriptor(streamStateStoreTableId);
 
         HColumnDescriptor hcd = new HColumnDescriptor(QueueEntryRow.COLUMN_FAMILY);
         htd.addFamily(hcd);
@@ -68,7 +71,7 @@ public final class HBaseStreamConsumerStateStoreFactory implements StreamConsume
       }
     }
 
-    HTable hTable = tableUtil.getHTable(hConf, streamStateStoreTableId);
+    HTable hTable = tableUtil.createHTable(hConf, streamStateStoreTableId);
     hTable.setWriteBufferSize(Constants.Stream.HBASE_WRITE_BUFFER_SIZE);
     hTable.setAutoFlush(false);
     return new HBaseStreamConsumerStateStore(streamConfig, hTable);
@@ -80,8 +83,7 @@ public final class HBaseStreamConsumerStateStoreFactory implements StreamConsume
     try {
       TableId tableId = TableId.from(getTableName(namespace));
       if (tableUtil.tableExists(admin, tableId)) {
-        tableUtil.disableTable(admin, tableId);
-        tableUtil.deleteTable(admin, tableId);
+        tableUtil.dropTable(admin, tableId);
       }
     } finally {
       admin.close();
@@ -89,6 +91,6 @@ public final class HBaseStreamConsumerStateStoreFactory implements StreamConsume
   }
 
   private String getTableName(Id.Namespace namespace) {
-    return HBaseTableUtil.getHBaseTableName(StreamUtils.getStateStoreTableName(namespace));
+    return HTableNameConverter.getHBaseTableName(StreamUtils.getStateStoreTableName(namespace));
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseStreamConsumerStateStoreFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseStreamConsumerStateStoreFactory.java
@@ -15,7 +15,6 @@
  */
 package co.cask.cdap.data2.transaction.stream.hbase;
 
-import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data.stream.StreamUtils;
 import co.cask.cdap.data2.transaction.queue.QueueConstants;
@@ -25,7 +24,6 @@ import co.cask.cdap.data2.transaction.stream.StreamConsumerStateStore;
 import co.cask.cdap.data2.transaction.stream.StreamConsumerStateStoreFactory;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
-import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
 import co.cask.cdap.data2.util.hbase.HTableNameConverter;
 import co.cask.cdap.proto.Id;
 import com.google.inject.Inject;
@@ -46,9 +44,9 @@ public final class HBaseStreamConsumerStateStoreFactory implements StreamConsume
   private final HBaseTableUtil tableUtil;
 
   @Inject
-  HBaseStreamConsumerStateStoreFactory(Configuration hConf, CConfiguration cConf) {
+  HBaseStreamConsumerStateStoreFactory(Configuration hConf, HBaseTableUtil tableUtil) {
     this.hConf = hConf;
-    this.tableUtil = new HBaseTableUtilFactory().get(cConf);
+    this.tableUtil = tableUtil;
   }
 
   @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseStreamConsumerStateStoreFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseStreamConsumerStateStoreFactory.java
@@ -24,7 +24,6 @@ import co.cask.cdap.data2.transaction.stream.StreamConsumerStateStore;
 import co.cask.cdap.data2.transaction.stream.StreamConsumerStateStoreFactory;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
-import co.cask.cdap.data2.util.hbase.HTableNameConverter;
 import co.cask.cdap.proto.Id;
 import com.google.inject.Inject;
 import org.apache.hadoop.conf.Configuration;
@@ -89,6 +88,6 @@ public final class HBaseStreamConsumerStateStoreFactory implements StreamConsume
   }
 
   private String getTableName(Id.Namespace namespace) {
-    return HTableNameConverter.getHBaseTableName(StreamUtils.getStateStoreTableName(namespace));
+    return StreamUtils.getStateStoreTableName(namespace);
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseStreamFileConsumerFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseStreamFileConsumerFactory.java
@@ -34,7 +34,6 @@ import co.cask.cdap.data2.transaction.stream.StreamConsumerStateStore;
 import co.cask.cdap.data2.transaction.stream.StreamConsumerStateStoreFactory;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
-import co.cask.cdap.data2.util.hbase.HTableNameConverter;
 import com.google.inject.Inject;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HColumnDescriptor;
@@ -72,8 +71,7 @@ public final class HBaseStreamFileConsumerFactory extends AbstractStreamFileCons
                                   FileReader<StreamEventOffset, Iterable<StreamFileOffset>> reader,
                                   @Nullable ReadFilter extraFilter) throws IOException {
 
-    String hBaseTableName = HTableNameConverter.getHBaseTableName(tableName);
-    TableId tableId = TableId.from(hBaseTableName);
+    TableId tableId = TableId.from(tableName);
     HTableDescriptor htd = tableUtil.createHTableDescriptor(tableId);
 
     HColumnDescriptor hcd = new HColumnDescriptor(QueueEntryRow.COLUMN_FAMILY);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseStreamFileConsumerFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseStreamFileConsumerFactory.java
@@ -34,7 +34,6 @@ import co.cask.cdap.data2.transaction.stream.StreamConsumerStateStore;
 import co.cask.cdap.data2.transaction.stream.StreamConsumerStateStoreFactory;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
-import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
 import co.cask.cdap.data2.util.hbase.HTableNameConverter;
 import com.google.inject.Inject;
 import org.apache.hadoop.conf.Configuration;
@@ -60,11 +59,11 @@ public final class HBaseStreamFileConsumerFactory extends AbstractStreamFileCons
 
   @Inject
   HBaseStreamFileConsumerFactory(StreamAdmin streamAdmin, StreamConsumerStateStoreFactory stateStoreFactory,
-                                 CConfiguration cConf, Configuration hConf) {
+                                 CConfiguration cConf, Configuration hConf, HBaseTableUtil tableUtil) {
     super(cConf, streamAdmin, stateStoreFactory);
     this.hConf = hConf;
     this.cConf = cConf;
-    this.tableUtil = new HBaseTableUtilFactory().get(cConf);
+    this.tableUtil = tableUtil;
   }
 
   @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseStreamFileConsumerFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseStreamFileConsumerFactory.java
@@ -15,7 +15,6 @@
  */
 package co.cask.cdap.data2.transaction.stream.hbase;
 
-import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data.file.FileReader;
@@ -33,8 +32,10 @@ import co.cask.cdap.data2.transaction.stream.StreamConsumer;
 import co.cask.cdap.data2.transaction.stream.StreamConsumerState;
 import co.cask.cdap.data2.transaction.stream.StreamConsumerStateStore;
 import co.cask.cdap.data2.transaction.stream.StreamConsumerStateStoreFactory;
+import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
-import co.cask.cdap.data2.util.hbase.TableId;
+import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
+import co.cask.cdap.data2.util.hbase.HTableNameConverter;
 import com.google.inject.Inject;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HColumnDescriptor;
@@ -58,13 +59,12 @@ public final class HBaseStreamFileConsumerFactory extends AbstractStreamFileCons
   private HBaseAdmin admin;
 
   @Inject
-  HBaseStreamFileConsumerFactory(StreamAdmin streamAdmin,
-                                 StreamConsumerStateStoreFactory stateStoreFactory,
-                                 CConfiguration cConf, Configuration hConf, HBaseTableUtil tableUtil) {
+  HBaseStreamFileConsumerFactory(StreamAdmin streamAdmin, StreamConsumerStateStoreFactory stateStoreFactory,
+                                 CConfiguration cConf, Configuration hConf) {
     super(cConf, streamAdmin, stateStoreFactory);
     this.hConf = hConf;
     this.cConf = cConf;
-    this.tableUtil = tableUtil;
+    this.tableUtil = new HBaseTableUtilFactory().get(cConf);
   }
 
   @Override
@@ -73,9 +73,9 @@ public final class HBaseStreamFileConsumerFactory extends AbstractStreamFileCons
                                   FileReader<StreamEventOffset, Iterable<StreamFileOffset>> reader,
                                   @Nullable ReadFilter extraFilter) throws IOException {
 
-    String hBaseTableName = HBaseTableUtil.getHBaseTableName(tableName);
+    String hBaseTableName = HTableNameConverter.getHBaseTableName(tableName);
     TableId tableId = TableId.from(hBaseTableName);
-    HTableDescriptor htd = tableUtil.getHTableDescriptor(tableId);
+    HTableDescriptor htd = tableUtil.createHTableDescriptor(tableId);
 
     HColumnDescriptor hcd = new HColumnDescriptor(QueueEntryRow.COLUMN_FAMILY);
     htd.addFamily(hcd);
@@ -87,7 +87,7 @@ public final class HBaseStreamFileConsumerFactory extends AbstractStreamFileCons
     tableUtil.createTableIfNotExists(getAdmin(), tableId, htd, splitKeys,
                                      QueueConstants.MAX_CREATE_TABLE_WAIT, TimeUnit.MILLISECONDS);
 
-    HTable hTable = tableUtil.getHTable(hConf, tableId);
+    HTable hTable = tableUtil.createHTable(hConf, tableId);
     hTable.setWriteBufferSize(Constants.Stream.HBASE_WRITE_BUFFER_SIZE);
     hTable.setAutoFlush(false);
     return new HBaseStreamFileConsumer(cConf, streamConfig, consumerConfig, hTable, reader,
@@ -100,8 +100,7 @@ public final class HBaseStreamFileConsumerFactory extends AbstractStreamFileCons
     HBaseAdmin admin = getAdmin();
     TableId tableId = TableId.from(tableName);
     if (tableUtil.tableExists(admin, tableId)) {
-      tableUtil.disableTable(admin, tableId);
-      tableUtil.deleteTable(admin, tableId);
+      tableUtil.dropTable(admin, tableId);
     }
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/TableId.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/TableId.java
@@ -14,66 +14,37 @@
  * the License.
  */
 
-package co.cask.cdap.data2.util.hbase;
+package co.cask.cdap.data2.util;
 
 import co.cask.cdap.api.dataset.DatasetSpecification;
-import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.proto.Id;
-import com.google.common.base.Joiner;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
 /**
- * Identifier for an HBase tables that contains a table prefix, a namespace and a table name
+ * Identifier for an HBase tables that contains a namespace and a table name
  */
 public class TableId {
-  private final String tablePrefix;
   private final Id.Namespace namespace;
   private final String tableName;
 
-  private TableId(String tablePrefix, Id.Namespace namespace, String tableName) {
-    this.tablePrefix = tablePrefix;
+  private TableId(Id.Namespace namespace, String tableName) {
     this.namespace = namespace;
     this.tableName = tableName;
-  }
-
-  public String getTablePrefix() {
-    return tablePrefix;
   }
 
   public Id.Namespace getNamespace() {
     return namespace;
   }
 
-  /**
-   *@return Backward compatible, ASCII encoded table name
-   */
   public String getTableName() {
-    return HBaseTableUtil.getHBaseTableName(getBackwardCompatibleTableName());
-  }
-
-  private String getBackwardCompatibleTableName() {
-    // handle table names in default namespace so we do not have to worry about upgrades
-    if (Constants.DEFAULT_NAMESPACE_ID.equals(namespace)) {
-      // if the table name starts with 'system.', then its a queue or stream table. Do not add namespace to table name
-      // e.g. namespace = default, tableName = system.queue.config. Resulting table name = cdap.system.queue.config
-      if (tableName.startsWith(String.format("%s.", Constants.SYSTEM_NAMESPACE))) {
-        return Joiner.on(".").join(tablePrefix, tableName);
-      }
-      // if the table name does not start with 'system.', then its a user dataset. Add 'user' to the table name to
-      // maintain backward compatibility. Also, do not add namespace to the table name
-      // e.g. namespace = default, tableName = purchases. Resulting table name = cdap.user.purchases
-      return Joiner.on(".").join(tablePrefix, "user", tableName);
-    }
-    // if the namespace is not default, do not need to change anything
     return tableName;
   }
 
-  public static TableId from(String tablePrefix, String namespace, String tableName) {
-    Preconditions.checkArgument(tablePrefix != null, "Table prefix should not be null.");
+  public static TableId from(String namespace, String tableName) {
     Preconditions.checkArgument(tableName != null, "Table name should not be null.");
     // Id.Namespace already checks for non-null namespace
-    return new TableId(tablePrefix, Id.Namespace.from(namespace), tableName);
+    return new TableId(Id.Namespace.from(namespace), tableName);
   }
 
   /**
@@ -92,7 +63,8 @@ public class TableId {
                                                 "Expected - <table-prefix>.<namespace>.<dataset/table-name>", name);
     String [] parts = name.split("\\.", 3);
     Preconditions.checkArgument(parts.length == 3, invalidFormatError);
-    return new TableId(parts[0], Id.Namespace.from(parts[1]), parts[2]);
+    // Ignore the prefix in the input name.
+    return new TableId(Id.Namespace.from(parts[1]), parts[2]);
   }
 
   @Override
@@ -105,20 +77,18 @@ public class TableId {
     }
 
     TableId that = (TableId) o;
-    return Objects.equal(tablePrefix, that.getTablePrefix()) &&
-      Objects.equal(namespace, that.getNamespace()) &&
+    return Objects.equal(namespace, that.getNamespace()) &&
       Objects.equal(tableName, that.getTableName());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(tablePrefix, namespace, tableName);
+    return Objects.hashCode(namespace, tableName);
   }
 
   @Override
   public String toString() {
     return Objects.toStringHelper(this)
-      .add("tablePrefix", tablePrefix)
       .add("namespace", namespace)
       .add("tableName", tableName)
       .toString();

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/ConfigurationTable.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/ConfigurationTable.java
@@ -75,7 +75,7 @@ public class ConfigurationTable {
     HBaseAdmin admin = new HBaseAdmin(hbaseConf);
     HTable table = null;
     try {
-      HBaseTableUtil tableUtil = new HBaseTableUtilFactory().get(cConf);
+      HBaseTableUtil tableUtil = new HBaseTableUtilFactory(cConf).get();
       HTableDescriptor htd = tableUtil.createHTableDescriptor(tableId);
       htd.addFamily(new HColumnDescriptor(FAMILY));
       tableUtil.createTableIfNotExists(admin, tableId, htd);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseTableUtil.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseTableUtil.java
@@ -18,7 +18,6 @@ package co.cask.cdap.data2.util.hbase;
 
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.common.conf.CConfiguration;
-import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.transaction.queue.hbase.HBaseQueueAdmin;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.hbase.wd.AbstractRowKeyDistributor;
@@ -95,11 +94,9 @@ public abstract class HBaseTableUtil {
 
 
   protected CConfiguration cConf;
-  private String tableNamePrefix;
 
   public void setCConf(CConfiguration cConf) {
     this.cConf = cConf;
-    this.tableNamePrefix = cConf.get(Constants.Dataset.TABLE_PREFIX);
   }
 
   /**

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseTableUtilFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseTableUtilFactory.java
@@ -16,22 +16,43 @@
 
 package co.cask.cdap.data2.util.hbase;
 
+import co.cask.cdap.common.conf.CConfiguration;
+
 /**
  * Factory for HBase version-specific {@link HBaseTableUtil} instances.
  */
-public class HBaseTableUtilFactory extends HBaseVersionSpecificFactory<HBaseTableUtil> {
-  @Override
-  protected String getHBase94Classname() {
-    return "co.cask.cdap.data2.util.hbase.HBase94TableUtil";
+public class HBaseTableUtilFactory {
+  private final HBaseVersionSpecificFactory<HBaseTableUtil> delegate;
+
+  public HBaseTableUtilFactory() {
+    delegate = new HBaseVersionSpecificFactory<HBaseTableUtil>() {
+      @Override
+      protected String getHBase94Classname() {
+        return "co.cask.cdap.data2.util.hbase.HBase94TableUtil";
+      }
+
+      @Override
+      protected String getHBase96Classname() {
+        return "co.cask.cdap.data2.util.hbase.HBase96TableUtil";
+      }
+
+      @Override
+      protected String getHBase98Classname() {
+        return "co.cask.cdap.data2.util.hbase.HBase98TableUtil";
+      }
+    };
   }
 
-  @Override
-  protected String getHBase96Classname() {
-    return "co.cask.cdap.data2.util.hbase.HBase96TableUtil";
+  // There are a few places where we only need the class of the HBaseTableUtil, and so it does not need to be configured
+  // with a CConfiguration
+  public Class<? extends HBaseTableUtil> getHBaseTableUtilClass() {
+    return delegate.get().getClass();
   }
 
-  @Override
-  protected String getHBase98Classname() {
-    return "co.cask.cdap.data2.util.hbase.HBase98TableUtil";
+  public HBaseTableUtil get(CConfiguration cConf) {
+    HBaseTableUtil hBaseTableUtil = delegate.get();
+    hBaseTableUtil.setCConf(cConf);
+    return hBaseTableUtil;
   }
+
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseTableUtilFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseTableUtilFactory.java
@@ -17,42 +17,45 @@
 package co.cask.cdap.data2.util.hbase;
 
 import co.cask.cdap.common.conf.CConfiguration;
+import com.google.inject.Inject;
 
 /**
  * Factory for HBase version-specific {@link HBaseTableUtil} instances.
  */
-public class HBaseTableUtilFactory {
-  private final HBaseVersionSpecificFactory<HBaseTableUtil> delegate;
+public class HBaseTableUtilFactory extends HBaseVersionSpecificFactory<HBaseTableUtil> {
 
-  public HBaseTableUtilFactory() {
-    delegate = new HBaseVersionSpecificFactory<HBaseTableUtil>() {
-      @Override
-      protected String getHBase94Classname() {
-        return "co.cask.cdap.data2.util.hbase.HBase94TableUtil";
-      }
+  private final CConfiguration cConf;
 
-      @Override
-      protected String getHBase96Classname() {
-        return "co.cask.cdap.data2.util.hbase.HBase96TableUtil";
-      }
-
-      @Override
-      protected String getHBase98Classname() {
-        return "co.cask.cdap.data2.util.hbase.HBase98TableUtil";
-      }
-    };
+  @Inject
+  public HBaseTableUtilFactory(CConfiguration cConf) {
+    this.cConf = cConf;
   }
 
-  // There are a few places where we only need the class of the HBaseTableUtil, and so it does not need to be configured
-  // with a CConfiguration
-  public Class<? extends HBaseTableUtil> getHBaseTableUtilClass() {
-    return delegate.get().getClass();
-  }
-
-  public HBaseTableUtil get(CConfiguration cConf) {
-    HBaseTableUtil hBaseTableUtil = delegate.get();
+  @Override
+  protected HBaseTableUtil createInstance(String className) throws ClassNotFoundException {
+    HBaseTableUtil hBaseTableUtil = super.createInstance(className);
     hBaseTableUtil.setCConf(cConf);
     return hBaseTableUtil;
   }
 
+  public static Class<? extends HBaseTableUtil> getHBaseTableUtilClass() {
+    // Since we only need the class name, it is fine to have a null CConfiguration, since we do not use the
+    // tableUtil instance
+    return new HBaseTableUtilFactory(null).get().getClass();
+  }
+
+  @Override
+  protected String getHBase94Classname() {
+    return "co.cask.cdap.data2.util.hbase.HBase94TableUtil";
+  }
+
+  @Override
+  protected String getHBase96Classname() {
+    return "co.cask.cdap.data2.util.hbase.HBase96TableUtil";
+  }
+
+  @Override
+  protected String getHBase98Classname() {
+    return "co.cask.cdap.data2.util.hbase.HBase98TableUtil";
+  }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseVersionSpecificFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseVersionSpecificFactory.java
@@ -50,7 +50,7 @@ public abstract class HBaseVersionSpecificFactory<T> implements Provider<T> {
     return instance;
   }
 
-  private T createInstance(String className) throws ClassNotFoundException {
+  protected T createInstance(String className) throws ClassNotFoundException {
     Class clz = Class.forName(className);
     return (T) Instances.newInstance(clz);
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HTableNameConverter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HTableNameConverter.java
@@ -33,11 +33,11 @@ import java.net.URLEncoder;
 public abstract class HTableNameConverter {
   protected static final String HBASE_NAMESPACE_PREFIX = "cdap_";
 
-  public static String getHBaseTableName(String tableName) {
+  private static String getHBaseTableName(String tableName) {
     return encodeTableName(tableName);
   }
 
-  public static String encodeTableName(String tableName) {
+  private static String encodeTableName(String tableName) {
     try {
       return URLEncoder.encode(tableName, "ASCII");
     } catch (UnsupportedEncodingException e) {
@@ -46,7 +46,7 @@ public abstract class HTableNameConverter {
     }
   }
 
-  public static String getBackwardCompatibleTableName(String tablePrefix, TableId tableId) {
+  private static String getBackwardCompatibleTableName(String tablePrefix, TableId tableId) {
     String tableName = tableId.getTableName();
     // handle table names in default namespace so we do not have to worry about upgrades
     if (Constants.DEFAULT_NAMESPACE_ID.equals(tableId.getNamespace())) {
@@ -70,7 +70,7 @@ public abstract class HTableNameConverter {
   /**
    * @return Backward compatible, ASCII encoded table name
    */
-  public static String getHBaseTableName(CConfiguration cConf, TableId tableId) {
+  protected static String getHBaseTableName(CConfiguration cConf, TableId tableId) {
     String tablePrefix = cConf.get(Constants.Dataset.TABLE_PREFIX);
     Preconditions.checkArgument(tablePrefix != null, "Table prefix should not be null.");
     return getHBaseTableName(getBackwardCompatibleTableName(tablePrefix, tableId));
@@ -86,10 +86,10 @@ public abstract class HTableNameConverter {
    */
   public abstract String getSysConfigTablePrefix(String hTableName);
 
-  public abstract TableId fromTableName(String hTableName);
+  protected abstract TableId fromTableName(String hTableName);
 
   @VisibleForTesting
-  public static String toHBaseNamespace(Id.Namespace namespace) {
+  protected static String toHBaseNamespace(Id.Namespace namespace) {
     // Handle backward compatibility to not add the prefix for default namespace
     // TODO: CDAP-1601 - Conditional should be removed when we have a way to upgrade user datasets
     return HTableNameConverter.getHBaseTableName(Constants.DEFAULT_NAMESPACE_ID.equals(namespace) ? namespace.getId() :

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HTableNameConverter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HTableNameConverter.java
@@ -16,18 +16,113 @@
 
 package co.cask.cdap.data2.util.hbase;
 
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.proto.Id;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+
 /**
  * Common utility methods for dealing with HBase table name conversions.
  */
 public abstract class HTableNameConverter {
+  protected static final String HBASE_NAMESPACE_PREFIX = "cdap_";
+
+  public static String getHBaseTableName(String tableName) {
+    return encodeTableName(tableName);
+  }
+
+  public static String encodeTableName(String tableName) {
+    try {
+      return URLEncoder.encode(tableName, "ASCII");
+    } catch (UnsupportedEncodingException e) {
+      // this can never happen - we know that ASCII is a supported character set!
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static String getBackwardCompatibleTableName(String tablePrefix, TableId tableId) {
+    String tableName = tableId.getTableName();
+    // handle table names in default namespace so we do not have to worry about upgrades
+    if (Constants.DEFAULT_NAMESPACE_ID.equals(tableId.getNamespace())) {
+      // if the table name starts with 'system.', then its a queue or stream table. Do not add namespace to table name
+      // e.g. namespace = default, tableName = system.queue.config. Resulting table name = cdap.system.queue.config
+      // also no need to prepend the table name if it already starts with 'user'.
+      // TODO: the 'user' should be prepended by the HBaseTableAdmin.
+      if (tableName.startsWith(String.format("%s.", Constants.SYSTEM_NAMESPACE)) ||
+          tableName.startsWith("user.")) {
+        return Joiner.on(".").join(tablePrefix, tableName);
+      }
+      // if the table name does not start with 'system.', then its a user dataset. Add 'user' to the table name to
+      // maintain backward compatibility. Also, do not add namespace to the table name
+      // e.g. namespace = default, tableName = purchases. Resulting table name = cdap.user.purchases
+      return Joiner.on(".").join(tablePrefix, "user", tableName);
+    }
+    // if the namespace is not default, do not need to change anything
+    return tableName;
+  }
+
+  /**
+   * @return Backward compatible, ASCII encoded table name
+   */
+  public static String getHBaseTableName(CConfiguration cConf, TableId tableId) {
+    String tablePrefix = cConf.get(Constants.Dataset.TABLE_PREFIX);
+    Preconditions.checkArgument(tablePrefix != null, "Table prefix should not be null.");
+    return getHBaseTableName(getBackwardCompatibleTableName(tablePrefix, tableId));
+  }
+
   /**
    * Gets the system configuration table prefix
-   * @param tableName Full table name.
+   * @param hTableName Full HBase table name.
    * @return System configuration table prefix (full table name minus the table qualifier).
    * Example input: "cdap_ns.table.name"  -->  output: "cdap_system."   (hbase 94)
    * Example input: "cdap.table.name"     -->  output: "cdap_system."   (hbase 94. input table is in default namespace)
    * Example input: "cdap_ns:table.name"  -->  output: "cdap_system:"   (hbase 96, 98)
    */
-  public abstract String getSysConfigTablePrefix(String tableName);
+  public abstract String getSysConfigTablePrefix(String hTableName);
 
+  public abstract TableId fromTableName(String hTableName);
+
+  @VisibleForTesting
+  public static String toHBaseNamespace(Id.Namespace namespace) {
+    // Handle backward compatibility to not add the prefix for default namespace
+    // TODO: CDAP-1601 - Conditional should be removed when we have a way to upgrade user datasets
+    return HTableNameConverter.getHBaseTableName(Constants.DEFAULT_NAMESPACE_ID.equals(namespace) ? namespace.getId() :
+                                                   HBASE_NAMESPACE_PREFIX + namespace.getId());
+  }
+
+  protected static TableId from(String hBaseNamespace, String hTableName) {
+    Preconditions.checkArgument(hBaseNamespace != null, "Table namespace should not be null.");
+    Preconditions.checkArgument(hTableName != null, "Table name should not be null.");
+
+    String namespace;
+    String prefix;
+
+    // Handle backward compatibility to not add the prefix for default namespace
+    if (Constants.DEFAULT_NAMESPACE.equals(hBaseNamespace)) {
+      namespace = hBaseNamespace;
+      // in Default namespace, hTableName is something like 'cdap.foo.table'
+      String[] parts = hTableName.split("\\.", 2);
+      Preconditions.checkArgument(parts.length == 2,
+                                  String.format("expected table name to contain '.': %s", hTableName));
+      // prefix is parts[0], but it is not needed
+      hTableName = parts[1];
+      return TableId.from(namespace, hTableName);
+    }
+
+
+    String[] parts = hBaseNamespace.split("_");
+    Preconditions.checkArgument(parts.length == 2,
+                                String.format("expected hbase namespace to have a '_': %s", hBaseNamespace));
+    // prefix is parts[0], but it is not needed
+    namespace = parts[1];
+
+    // Id.Namespace already checks for non-null namespace
+    return TableId.from(namespace, hTableName);
+  }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HTableNameConverter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HTableNameConverter.java
@@ -86,8 +86,6 @@ public abstract class HTableNameConverter {
    */
   public abstract String getSysConfigTablePrefix(String hTableName);
 
-  protected abstract TableId fromTableName(String hTableName);
-
   @VisibleForTesting
   protected static String toHBaseNamespace(Id.Namespace namespace) {
     // Handle backward compatibility to not add the prefix for default namespace

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data/hbase/HBaseTestBase.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data/hbase/HBaseTestBase.java
@@ -50,9 +50,9 @@ public abstract class HBaseTestBase {
   }
 
   // TODO: This method should be removed in favor of HBaseTableUtil#createHTable. Currently only used in Queue Tests
-    public HTable createHTable(byte[] tableName) throws IOException {
-      return new HTable(getConfiguration(), tableName);
-    }
+  public HTable createHTable(byte[] tableName) throws IOException {
+    return new HTable(getConfiguration(), tableName);
+  }
 
   // TODO: This method should be removed in favor of HBaseTableUtil#deleteAllInNamespace - AGREED.
   public void deleteTables(String prefix) throws IOException {

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data/hbase/HBaseTestBase.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data/hbase/HBaseTestBase.java
@@ -33,9 +33,7 @@ import java.util.regex.Pattern;
  *
  * To use, simply extend this class and create your tests like normal.  From
  * within your tests, you can access the underlying HBase cluster through
- * {@link #getConfiguration()}, {@link #getHBaseAdmin()}, and
- * {@link #getHTable(byte[])}.
- *
+ * {@link #getConfiguration()}, {@link #getHBaseAdmin()}
  * Alternatively, you can call the {@link #startHBase()} and {@link #stopHBase()}
  * methods directly from within your own BeforeClass/AfterClass methods.
  *
@@ -51,19 +49,17 @@ public abstract class HBaseTestBase {
     return new HBaseAdmin(getConfiguration());
   }
 
-  // TODO: This method should be removed in favor of HBaseTableUtil#getHTable. Currently only used in Queue Tests
-  public HTable getHTable(byte [] tableName) throws IOException {
-    return new HTable(getConfiguration(), tableName);
-  }
+  // TODO: This method should be removed in favor of HBaseTableUtil#createHTable. Currently only used in Queue Tests
+    public HTable createHTable(byte[] tableName) throws IOException {
+      return new HTable(getConfiguration(), tableName);
+    }
 
-  // TODO: This method should be removed in favor of HBaseTableUtil#deleteAllInNamespace
+  // TODO: This method should be removed in favor of HBaseTableUtil#deleteAllInNamespace - AGREED.
   public void deleteTables(String prefix) throws IOException {
     Pattern pattern = Pattern.compile(prefix + ".*");
     getHBaseAdmin().disableTables(pattern);
     getHBaseAdmin().deleteTables(pattern);
   }
-
-  // Temporary directories
 
   public String getZkConnectionString() {
     return "localhost:" + getZKClientPort();

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data/hbase/HBaseTestBase.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data/hbase/HBaseTestBase.java
@@ -54,13 +54,6 @@ public abstract class HBaseTestBase {
     return new HTable(getConfiguration(), tableName);
   }
 
-  // TODO: This method should be removed in favor of HBaseTableUtil#deleteAllInNamespace - AGREED.
-  public void deleteTables(String prefix) throws IOException {
-    Pattern pattern = Pattern.compile(prefix + ".*");
-    getHBaseAdmin().disableTables(pattern);
-    getHBaseAdmin().deleteTables(pattern);
-  }
-
   public String getZkConnectionString() {
     return "localhost:" + getZKClientPort();
   }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueTest.java
@@ -129,7 +129,7 @@ public abstract class HBaseQueueTest extends QueueTest {
       });
 
     //create HBase namespace
-    tableUtil = new HBaseTableUtilFactory().get();
+    tableUtil = new HBaseTableUtilFactory().get(cConf);
     tableUtil.createNamespaceIfNotExists(testHBase.getHBaseAdmin(), Constants.SYSTEM_NAMESPACE_ID);
 
     ConfigurationTable configTable = new ConfigurationTable(hConf);
@@ -180,7 +180,6 @@ public abstract class HBaseQueueTest extends QueueTest {
     queueAdmin = injector.getInstance(QueueAdmin.class);
     streamAdmin = injector.getInstance(StreamAdmin.class);
     executorFactory = injector.getInstance(TransactionExecutorFactory.class);
-    tableUtil = new HBaseTableUtilFactory().get();
   }
 
   // TODO: CDAP-1177 Should move to QueueTest after making getNamespaceId() etc instance methods in a base class
@@ -219,7 +218,7 @@ public abstract class HBaseQueueTest extends QueueTest {
     if (!admin.exists(queueName.toString())) {
       admin.create(queueName.toString());
     }
-    HTable hTable = testHBase.getHTable(Bytes.toBytes(tableName));
+    HTable hTable = testHBase.createHTable(Bytes.toBytes(tableName));
     Assert.assertEquals("Failed for " + admin.getClass().getName(),
                         QueueConstants.DEFAULT_QUEUE_TABLE_PRESPLITS,
                         hTable.getRegionsInRange(new byte[]{0}, new byte[]{(byte) 0xff}).size());
@@ -233,7 +232,7 @@ public abstract class HBaseQueueTest extends QueueTest {
     // Set a group info
     queueAdmin.configureGroups(queueName, ImmutableMap.of(1L, 1, 2L, 2, 3L, 3));
 
-    HTable hTable = testHBase.getHTable(Bytes.toBytes(tableName));
+    HTable hTable = testHBase.createHTable(Bytes.toBytes(tableName));
     try {
       byte[] rowKey = queueName.toBytes();
       Result result = hTable.get(new Get(rowKey));

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueTest.java
@@ -39,7 +39,6 @@ import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.ConsumerConfigCach
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.data2.util.hbase.ConfigurationTable;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
-import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
 import co.cask.cdap.data2.util.hbase.HTableNameConverterFactory;
 import co.cask.cdap.notifications.feeds.NotificationFeedManager;
 import co.cask.cdap.notifications.feeds.service.NoOpNotificationFeedManager;
@@ -128,14 +127,7 @@ public abstract class HBaseQueueTest extends QueueTest {
         }
       });
 
-    //create HBase namespace
-    tableUtil = new HBaseTableUtilFactory().get(cConf);
-    tableUtil.createNamespaceIfNotExists(testHBase.getHBaseAdmin(), Constants.SYSTEM_NAMESPACE_ID);
-
-    ConfigurationTable configTable = new ConfigurationTable(hConf);
-    configTable.write(ConfigurationTable.Type.DEFAULT, cConf);
-
-    final Injector injector = Guice.createInjector(
+        final Injector injector = Guice.createInjector(
       dataFabricModule,
       new ConfigModule(cConf, hConf),
       new ZKClientModule(),
@@ -162,6 +154,13 @@ public abstract class HBaseQueueTest extends QueueTest {
         }
       })
     );
+
+    //create HBase namespace
+    tableUtil = injector.getInstance(HBaseTableUtil.class);
+    tableUtil.createNamespaceIfNotExists(testHBase.getHBaseAdmin(), Constants.SYSTEM_NAMESPACE_ID);
+
+    ConfigurationTable configTable = new ConfigurationTable(hConf);
+    configTable.write(ConfigurationTable.Type.DEFAULT, cConf);
 
     zkClientService = injector.getInstance(ZKClientService.class);
     zkClientService.startAndWait();

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/guice/ExploreRuntimeModule.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/guice/ExploreRuntimeModule.java
@@ -272,7 +272,7 @@ public class ExploreRuntimeModule extends RuntimeModule {
     Set<String> bootstrapClassPaths = ExploreServiceUtils.getBoostrapClasses();
 
     Set<File> hBaseTableDeps = ExploreServiceUtils.traceDependencies(
-      HBaseTableUtilFactory.getHBaseTableUtilClass().getCanonicalName(),
+      HBaseTableUtilFactory.getHBaseTableUtilClass().getName(),
       bootstrapClassPaths, null);
 
     // Note the order of dependency jars is important so that HBase jars come first in the classpath order

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/guice/ExploreRuntimeModule.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/guice/ExploreRuntimeModule.java
@@ -272,7 +272,7 @@ public class ExploreRuntimeModule extends RuntimeModule {
     Set<String> bootstrapClassPaths = ExploreServiceUtils.getBoostrapClasses();
 
     Set<File> hBaseTableDeps = ExploreServiceUtils.traceDependencies(
-      new HBaseTableUtilFactory().getHBaseTableUtilClass().getCanonicalName(),
+      HBaseTableUtilFactory.getHBaseTableUtilClass().getCanonicalName(),
       bootstrapClassPaths, null);
 
     // Note the order of dependency jars is important so that HBase jars come first in the classpath order

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/guice/ExploreRuntimeModule.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/guice/ExploreRuntimeModule.java
@@ -272,7 +272,7 @@ public class ExploreRuntimeModule extends RuntimeModule {
     Set<String> bootstrapClassPaths = ExploreServiceUtils.getBoostrapClasses();
 
     Set<File> hBaseTableDeps = ExploreServiceUtils.traceDependencies(
-      new HBaseTableUtilFactory().get().getClass().getCanonicalName(),
+      new HBaseTableUtilFactory().getHBaseTableUtilClass().getCanonicalName(),
       bootstrapClassPaths, null);
 
     // Note the order of dependency jars is important so that HBase jars come first in the classpath order

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/ExploreServiceUtils.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/ExploreServiceUtils.java
@@ -263,7 +263,7 @@ public class ExploreServiceUtils {
     }
     Set<String> bootstrapClassPaths = getBoostrapClasses();
 
-    Set<File> hBaseTableDeps = traceDependencies(HBaseTableUtilFactory.getHBaseTableUtilClass().getCanonicalName(),
+    Set<File> hBaseTableDeps = traceDependencies(HBaseTableUtilFactory.getHBaseTableUtilClass().getName(),
                                                  bootstrapClassPaths, usingCL);
 
     // Note the order of dependency jars is important so that HBase jars come first in the classpath order

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/ExploreServiceUtils.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/ExploreServiceUtils.java
@@ -263,8 +263,9 @@ public class ExploreServiceUtils {
     }
     Set<String> bootstrapClassPaths = getBoostrapClasses();
 
-    Set<File> hBaseTableDeps = traceDependencies(new HBaseTableUtilFactory().get().getClass().getCanonicalName(),
-                                                 bootstrapClassPaths, usingCL);
+    Set<File> hBaseTableDeps =
+      traceDependencies(new HBaseTableUtilFactory().getHBaseTableUtilClass().getCanonicalName(),
+                        bootstrapClassPaths, usingCL);
 
     // Note the order of dependency jars is important so that HBase jars come first in the classpath order
     // LinkedHashSet maintains insertion order while removing duplicate entries.

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/ExploreServiceUtils.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/ExploreServiceUtils.java
@@ -263,9 +263,8 @@ public class ExploreServiceUtils {
     }
     Set<String> bootstrapClassPaths = getBoostrapClasses();
 
-    Set<File> hBaseTableDeps =
-      traceDependencies(new HBaseTableUtilFactory().getHBaseTableUtilClass().getCanonicalName(),
-                        bootstrapClassPaths, usingCL);
+    Set<File> hBaseTableDeps = traceDependencies(HBaseTableUtilFactory.getHBaseTableUtilClass().getCanonicalName(),
+                                                 bootstrapClassPaths, usingCL);
 
     // Note the order of dependency jars is important so that HBase jars come first in the classpath order
     // LinkedHashSet maintains insertion order while removing duplicate entries.

--- a/cdap-hbase-compat-0.94/src/main/java/co/cask/cdap/data2/util/hbase/HBase94TableUtil.java
+++ b/cdap-hbase-compat-0.94/src/main/java/co/cask/cdap/data2/util/hbase/HBase94TableUtil.java
@@ -127,7 +127,7 @@ public class HBase94TableUtil extends HBaseTableUtil {
   public void deleteAllInNamespace(HBaseAdmin admin, Id.Namespace namespaceId, String tablePrefix) throws IOException {
     HTableDescriptor[] hTableDescriptors = admin.listTables();
     for (HTableDescriptor hTableDescriptor : hTableDescriptors) {
-      TableId tableId = new HTable94NameConverter().fromTableName(hTableDescriptor.getNameAsString());
+      TableId tableId = HTable94NameConverter.fromTableName(hTableDescriptor.getNameAsString());
       if (namespaceId.equals(tableId.getNamespace()) && tableId.getTableName().startsWith(tablePrefix)) {
         dropTable(admin, tableId);
       }

--- a/cdap-hbase-compat-0.94/src/main/java/co/cask/cdap/data2/util/hbase/HBase94TableUtil.java
+++ b/cdap-hbase-compat-0.94/src/main/java/co/cask/cdap/data2/util/hbase/HBase94TableUtil.java
@@ -17,13 +17,12 @@
 package co.cask.cdap.data2.util.hbase;
 
 import co.cask.cdap.api.common.Bytes;
-import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.increment.hbase94.IncrementHandler;
 import co.cask.cdap.data2.transaction.coprocessor.hbase94.DefaultTransactionProcessor;
 import co.cask.cdap.data2.transaction.queue.coprocessor.hbase94.DequeueScanObserver;
 import co.cask.cdap.data2.transaction.queue.coprocessor.hbase94.HBaseQueueRegionObserver;
+import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.proto.Id;
-import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import org.apache.hadoop.conf.Configuration;
@@ -49,22 +48,22 @@ import java.util.Map;
 public class HBase94TableUtil extends HBaseTableUtil {
 
   @Override
-  public HTable getHTable(Configuration conf, TableId tableId) throws IOException {
+  public HTable createHTable(Configuration conf, TableId tableId) throws IOException {
     Preconditions.checkArgument(tableId != null, "Table id should not be null");
-    return new HTable(conf, toTableName(tableId));
+    return new HTable(conf, HTable94NameConverter.toTableName(cConf, tableId));
   }
 
   @Override
-  public HTableDescriptor getHTableDescriptor(TableId tableId) {
+  public HTableDescriptor createHTableDescriptor(TableId tableId) {
     Preconditions.checkArgument(tableId != null, "Table id should not be null");
-    return new HTableDescriptor(toTableName(tableId));
+    return new HTableDescriptor(HTable94NameConverter.toTableName(cConf, tableId));
   }
 
   @Override
   public HTableDescriptor getHTableDescriptor(HBaseAdmin admin, TableId tableId) throws IOException {
     Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
     Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    return admin.getTableDescriptor(Bytes.toBytes(toTableName(tableId)));
+    return admin.getTableDescriptor(Bytes.toBytes(HTable94NameConverter.toTableName(cConf, tableId)));
   }
 
   @Override
@@ -86,28 +85,28 @@ public class HBase94TableUtil extends HBaseTableUtil {
   public void disableTable(HBaseAdmin admin, TableId tableId) throws IOException {
     Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
     Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    admin.disableTable(toTableName(tableId));
+    admin.disableTable(HTable94NameConverter.toTableName(cConf, tableId));
   }
 
   @Override
   public void enableTable(HBaseAdmin admin, TableId tableId) throws IOException {
     Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
     Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    admin.enableTable(toTableName(tableId));
+    admin.enableTable(HTable94NameConverter.toTableName(cConf, tableId));
   }
 
   @Override
   public boolean tableExists(HBaseAdmin admin, TableId tableId) throws IOException {
     Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
     Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    return admin.tableExists(toTableName(tableId));
+    return admin.tableExists(HTable94NameConverter.toTableName(cConf, tableId));
   }
 
   @Override
   public void deleteTable(HBaseAdmin admin, TableId tableId) throws IOException {
     Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
     Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    admin.deleteTable(toTableName(tableId));
+    admin.deleteTable(HTable94NameConverter.toTableName(cConf, tableId));
   }
 
   @Override
@@ -121,7 +120,18 @@ public class HBase94TableUtil extends HBaseTableUtil {
   public List<HRegionInfo> getTableRegions(HBaseAdmin admin, TableId tableId) throws IOException {
     Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
     Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    return admin.getTableRegions(Bytes.toBytes(toTableName(tableId)));
+    return admin.getTableRegions(Bytes.toBytes(HTable94NameConverter.toTableName(cConf, tableId)));
+  }
+
+  @Override
+  public void deleteAllInNamespace(HBaseAdmin admin, Id.Namespace namespaceId, String tablePrefix) throws IOException {
+    HTableDescriptor[] hTableDescriptors = admin.listTables();
+    for (HTableDescriptor hTableDescriptor : hTableDescriptors) {
+      TableId tableId = new HTable94NameConverter().fromTableName(hTableDescriptor.getNameAsString());
+      if (namespaceId.equals(tableId.getNamespace()) && tableId.getTableName().startsWith(tablePrefix)) {
+        dropTable(admin, tableId);
+      }
+    }
   }
 
   @Override
@@ -237,14 +247,5 @@ public class HBase94TableUtil extends HBaseTableUtil {
       }
     }
     return datasetStat;
-  }
-
-  private String toTableName(TableId tableId) {
-    Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    // backward compatibility
-    if (Constants.DEFAULT_NAMESPACE_ID.equals(tableId.getNamespace())) {
-      return tableId.getTableName();
-    }
-    return Joiner.on(".").join(toHBaseNamespace(tableId.getNamespace()), tableId.getTableName());
   }
 }

--- a/cdap-hbase-compat-0.94/src/main/java/co/cask/cdap/data2/util/hbase/HTable94NameConverter.java
+++ b/cdap-hbase-compat-0.94/src/main/java/co/cask/cdap/data2/util/hbase/HTable94NameConverter.java
@@ -16,13 +16,48 @@
 
 package co.cask.cdap.data2.util.hbase;
 
+import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.data2.util.TableId;
+import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
 
 /**
  * Utility methods for dealing with HBase table name conversions in HBase 0.94.
  */
 public class HTable94NameConverter extends HTableNameConverter {
-  public String getSysConfigTablePrefix(String tableName) {
-    return HBaseTableUtil.HBASE_NAMESPACE_PREFIX + Constants.SYSTEM_NAMESPACE + ".";
+  @Override
+  public String getSysConfigTablePrefix(String hTableName) {
+    return HBASE_NAMESPACE_PREFIX + Constants.SYSTEM_NAMESPACE + ".";
+  }
+
+  public static String toTableName(CConfiguration cConf, TableId tableId) {
+    Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
+    // backward compatibility
+    if (Constants.DEFAULT_NAMESPACE_ID.equals(tableId.getNamespace())) {
+      return getHBaseTableName(cConf, tableId);
+    }
+    return Joiner.on(".").join(toHBaseNamespace(tableId.getNamespace()),
+                               getHBaseTableName(cConf, tableId));
+  }
+
+  // Assumptions made:
+  // 1) root prefix can not have '.' or '_'.
+  // 2) namespace can not have '.'
+  @Override
+  public TableId fromTableName(String hTableName) {
+    Preconditions.checkArgument(hTableName != null, "HBase table name should not be null.");
+    String[] parts = hTableName.split("\\.", 2);
+    String hBaseNamespace;
+    String hBaseQualifier;
+
+    if (!parts[0].contains("_")) {
+      hBaseNamespace = Constants.DEFAULT_NAMESPACE;
+      hBaseQualifier = hTableName;
+    } else {
+      hBaseNamespace = parts[0];
+      hBaseQualifier = parts[1];
+    }
+    return HTableNameConverter.from(hBaseNamespace, hBaseQualifier);
   }
 }

--- a/cdap-hbase-compat-0.94/src/main/java/co/cask/cdap/data2/util/hbase/HTable94NameConverter.java
+++ b/cdap-hbase-compat-0.94/src/main/java/co/cask/cdap/data2/util/hbase/HTable94NameConverter.java
@@ -44,8 +44,7 @@ public class HTable94NameConverter extends HTableNameConverter {
   // Assumptions made:
   // 1) root prefix can not have '.' or '_'.
   // 2) namespace can not have '.'
-  @Override
-  public TableId fromTableName(String hTableName) {
+  public static TableId fromTableName(String hTableName) {
     Preconditions.checkArgument(hTableName != null, "HBase table name should not be null.");
     String[] parts = hTableName.split("\\.", 2);
     String hBaseNamespace;

--- a/cdap-hbase-compat-0.94/src/test/java/co/cask/cdap/data2/util/hbase/HBase94TableUtilTest.java
+++ b/cdap-hbase-compat-0.94/src/test/java/co/cask/cdap/data2/util/hbase/HBase94TableUtilTest.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.data2.util.hbase;
 
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.test.XSlowTests;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
@@ -30,16 +31,19 @@ public class HBase94TableUtilTest extends AbstractHBaseTableUtilTest {
 
   @Override
   protected HBaseTableUtil getTableUtil() {
-    return new HBase94TableUtil();
+    HBase94TableUtil hBaseTableUtil = new HBase94TableUtil();
+    hBaseTableUtil.setCConf(cConf);
+    return hBaseTableUtil;
   }
 
   @Override
   protected String getTableNameAsString(TableId tableId) {
     Preconditions.checkArgument(tableId != null, "TableId should not be null.");
     if (Constants.DEFAULT_NAMESPACE_ID.equals(tableId.getNamespace())) {
-      return tableId.getTableName();
+      return HTableNameConverter.getHBaseTableName(cConf, tableId);
     }
-    return Joiner.on(".").join(getTableUtil().toHBaseNamespace(tableId.getNamespace()), tableId.getTableName());
+    return Joiner.on(".").join(HTableNameConverter.toHBaseNamespace(tableId.getNamespace()),
+                               HTableNameConverter.getHBaseTableName(cConf, tableId));
   }
 
   @Override

--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/util/hbase/HBase96TableUtil.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/util/hbase/HBase96TableUtil.java
@@ -144,12 +144,12 @@ public class HBase96TableUtil extends HBaseTableUtil {
 
   @Override
   public void deleteAllInNamespace(HBaseAdmin admin, Id.Namespace namespaceId, String tablePrefix) throws IOException {
-    TableName[] tableNames = admin.listTableNamesByNamespace(HTableNameConverter.toHBaseNamespace(namespaceId));
-    for (TableName tableName : tableNames) {
-      String name = HTable96NameConverter.fromTableName(tableName).getTableName();
-      if (name.startsWith(tablePrefix)) {
-        admin.disableTable(tableName);
-        admin.deleteTable(tableName);
+    TableName[] hTableNames = admin.listTableNamesByNamespace(HTableNameConverter.toHBaseNamespace(namespaceId));
+    for (TableName hTableName : hTableNames) {
+      String tableName = HTable96NameConverter.fromTableName(hTableName).getTableName();
+      if (tableName.startsWith(tablePrefix)) {
+        admin.disableTable(hTableName);
+        admin.deleteTable(hTableName);
       }
     }
   }

--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/util/hbase/HTable96NameConverter.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/util/hbase/HTable96NameConverter.java
@@ -30,11 +30,6 @@ public class HTable96NameConverter extends HTableNameConverter {
     return HBASE_NAMESPACE_PREFIX + Constants.SYSTEM_NAMESPACE + ":";
   }
 
-  @Override
-  public TableId fromTableName(String hTableName) {
-    return fromTableName(TableName.valueOf(hTableName));
-  }
-
   public static TableName toTableName(CConfiguration cConf, TableId tableId) {
     return TableName.valueOf(toHBaseNamespace(tableId.getNamespace()),
                              getHBaseTableName(cConf, tableId));

--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/util/hbase/HTable96NameConverter.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/util/hbase/HTable96NameConverter.java
@@ -16,13 +16,31 @@
 
 package co.cask.cdap.data2.util.hbase;
 
+import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.data2.util.TableId;
+import org.apache.hadoop.hbase.TableName;
 
 /**
  * Utility methods for dealing with HBase table name conversions in HBase 0.96.
  */
 public class HTable96NameConverter extends HTableNameConverter {
-  public String getSysConfigTablePrefix(String tableName) {
-    return HBaseTableUtil.HBASE_NAMESPACE_PREFIX + Constants.SYSTEM_NAMESPACE + ":";
+  @Override
+  public String getSysConfigTablePrefix(String hTableName) {
+    return HBASE_NAMESPACE_PREFIX + Constants.SYSTEM_NAMESPACE + ":";
+  }
+
+  @Override
+  public TableId fromTableName(String hTableName) {
+    return fromTableName(TableName.valueOf(hTableName));
+  }
+
+  public static TableName toTableName(CConfiguration cConf, TableId tableId) {
+    return TableName.valueOf(toHBaseNamespace(tableId.getNamespace()),
+                             getHBaseTableName(cConf, tableId));
+  }
+
+  public static TableId fromTableName(TableName tableName) {
+    return HTableNameConverter.from(tableName.getNamespaceAsString(), tableName.getQualifierAsString());
   }
 }

--- a/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data2/util/hbase/HBase96TableUtilTest.java
+++ b/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data2/util/hbase/HBase96TableUtilTest.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.data2.util.hbase;
 
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.test.XSlowTests;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
@@ -30,16 +31,19 @@ public class HBase96TableUtilTest extends AbstractHBaseTableUtilTest {
 
   @Override
   protected HBaseTableUtil getTableUtil() {
-    return new HBase96TableUtil();
+    HBase96TableUtil hBaseTableUtil = new HBase96TableUtil();
+    hBaseTableUtil.setCConf(cConf);
+    return hBaseTableUtil;
   }
 
   @Override
   protected String getTableNameAsString(TableId tableId) {
     Preconditions.checkArgument(tableId != null, "TableId should not be null.");
     if (Constants.DEFAULT_NAMESPACE_ID.equals(tableId.getNamespace())) {
-      return tableId.getTableName();
+      return HTableNameConverter.getHBaseTableName(cConf, tableId);
     }
-    return Joiner.on(':').join(getTableUtil().toHBaseNamespace(tableId.getNamespace()), tableId.getTableName());
+    return Joiner.on(':').join(HTableNameConverter.toHBaseNamespace(tableId.getNamespace()),
+                               HTableNameConverter.getHBaseTableName(cConf, tableId));
   }
 
   @Override

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/util/hbase/HBase98TableUtil.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/util/hbase/HBase98TableUtil.java
@@ -21,6 +21,7 @@ import co.cask.cdap.data2.increment.hbase98.IncrementHandler;
 import co.cask.cdap.data2.transaction.coprocessor.hbase98.DefaultTransactionProcessor;
 import co.cask.cdap.data2.transaction.queue.coprocessor.hbase98.DequeueScanObserver;
 import co.cask.cdap.data2.transaction.queue.coprocessor.hbase98.HBaseQueueRegionObserver;
+import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.proto.Id;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
@@ -49,22 +50,22 @@ import java.util.Map;
 public class HBase98TableUtil extends HBaseTableUtil {
 
   @Override
-  public HTable getHTable(Configuration conf, TableId tableId) throws IOException {
+  public HTable createHTable(Configuration conf, TableId tableId) throws IOException {
     Preconditions.checkArgument(tableId != null, "Table id should not be null");
-    return new HTable(conf, toTableName(tableId));
+    return new HTable(conf, HTable98NameConverter.toTableName(cConf, tableId));
   }
 
   @Override
-  public HTableDescriptor getHTableDescriptor(TableId tableId) {
+  public HTableDescriptor createHTableDescriptor(TableId tableId) {
     Preconditions.checkArgument(tableId != null, "Table id should not be null");
-    return new HTableDescriptor(toTableName(tableId));
+    return new HTableDescriptor(HTable98NameConverter.toTableName(cConf, tableId));
   }
 
   @Override
   public HTableDescriptor getHTableDescriptor(HBaseAdmin admin, TableId tableId) throws IOException {
     Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
     Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    return admin.getTableDescriptor(toTableName(tableId));
+    return admin.getTableDescriptor(HTable98NameConverter.toTableName(cConf, tableId));
   }
 
   @Override
@@ -72,7 +73,7 @@ public class HBase98TableUtil extends HBaseTableUtil {
     Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
     Preconditions.checkArgument(namespace != null, "Namespace should not be null.");
     try {
-      admin.getNamespaceDescriptor(toHBaseNamespace(namespace));
+      admin.getNamespaceDescriptor(HTableNameConverter.toHBaseNamespace(namespace));
       return true;
     } catch (NamespaceNotFoundException e) {
       return false;
@@ -85,7 +86,7 @@ public class HBase98TableUtil extends HBaseTableUtil {
     Preconditions.checkArgument(namespace != null, "Namespace should not be null.");
     if (!hasNamespace(admin, namespace)) {
       NamespaceDescriptor namespaceDescriptor =
-        NamespaceDescriptor.create(toHBaseNamespace(namespace)).build();
+        NamespaceDescriptor.create(HTableNameConverter.toHBaseNamespace(namespace)).build();
       admin.createNamespace(namespaceDescriptor);
     }
   }
@@ -95,7 +96,7 @@ public class HBase98TableUtil extends HBaseTableUtil {
     Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
     Preconditions.checkArgument(namespace != null, "Namespace should not be null.");
     if (hasNamespace(admin, namespace)) {
-      admin.deleteNamespace(toHBaseNamespace(namespace));
+      admin.deleteNamespace(HTableNameConverter.toHBaseNamespace(namespace));
     }
   }
 
@@ -103,28 +104,28 @@ public class HBase98TableUtil extends HBaseTableUtil {
   public void disableTable(HBaseAdmin admin, TableId tableId) throws IOException {
     Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
     Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    admin.disableTable(toTableName(tableId));
+    admin.disableTable(HTable98NameConverter.toTableName(cConf, tableId));
   }
 
   @Override
   public void enableTable(HBaseAdmin admin, TableId tableId) throws IOException {
     Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
     Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    admin.enableTable(toTableName(tableId));
+    admin.enableTable(HTable98NameConverter.toTableName(cConf, tableId));
   }
 
   @Override
   public boolean tableExists(HBaseAdmin admin, TableId tableId) throws IOException {
     Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
     Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    return admin.tableExists(toTableName(tableId));
+    return admin.tableExists(HTable98NameConverter.toTableName(cConf, tableId));
   }
 
   @Override
   public void deleteTable(HBaseAdmin admin, TableId tableId) throws IOException {
     Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
     Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    admin.deleteTable(toTableName(tableId));
+    admin.deleteTable(HTable98NameConverter.toTableName(cConf, tableId));
   }
 
   @Override
@@ -138,7 +139,18 @@ public class HBase98TableUtil extends HBaseTableUtil {
   public List<HRegionInfo> getTableRegions(HBaseAdmin admin, TableId tableId) throws IOException {
     Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
     Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    return admin.getTableRegions(toTableName(tableId));
+    return admin.getTableRegions(HTable98NameConverter.toTableName(cConf, tableId));
+  }
+
+  @Override
+  public void deleteAllInNamespace(HBaseAdmin admin, Id.Namespace namespaceId, String tablePrefix) throws IOException {
+    TableName[] tableNames = admin.listTableNamesByNamespace(HTableNameConverter.toHBaseNamespace(namespaceId));
+    for (TableName tableName : tableNames) {
+      if (HTable98NameConverter.fromTableName(tableName).getTableName().startsWith(tablePrefix)) {
+        admin.disableTable(tableName);
+        admin.deleteTable(tableName);
+      }
+    }
   }
 
   @Override
@@ -253,9 +265,5 @@ public class HBase98TableUtil extends HBaseTableUtil {
       }
     }
     return datasetStat;
-  }
-
-  private TableName toTableName(TableId tableId) {
-    return TableName.valueOf(toHBaseNamespace(tableId.getNamespace()), tableId.getTableName());
   }
 }

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/util/hbase/HTable98NameConverter.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/util/hbase/HTable98NameConverter.java
@@ -30,11 +30,6 @@ public class HTable98NameConverter extends HTableNameConverter {
     return HBASE_NAMESPACE_PREFIX + Constants.SYSTEM_NAMESPACE + ":";
   }
 
-  @Override
-  public TableId fromTableName(String hTableName) {
-    return fromTableName(TableName.valueOf(hTableName));
-  }
-
   public static TableName toTableName(CConfiguration cConf, TableId tableId) {
     return TableName.valueOf(toHBaseNamespace(tableId.getNamespace()),
                              getHBaseTableName(cConf, tableId));

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/util/hbase/HTable98NameConverter.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/util/hbase/HTable98NameConverter.java
@@ -16,13 +16,31 @@
 
 package co.cask.cdap.data2.util.hbase;
 
+import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.data2.util.TableId;
+import org.apache.hadoop.hbase.TableName;
 
 /**
  * Utility methods for dealing with HBase table name conversions in HBase 0.98.
  */
 public class HTable98NameConverter extends HTableNameConverter {
-  public String getSysConfigTablePrefix(String tableName) {
-    return HBaseTableUtil.HBASE_NAMESPACE_PREFIX + Constants.SYSTEM_NAMESPACE + ":";
+  @Override
+  public String getSysConfigTablePrefix(String hTableName) {
+    return HBASE_NAMESPACE_PREFIX + Constants.SYSTEM_NAMESPACE + ":";
+  }
+
+  @Override
+  public TableId fromTableName(String hTableName) {
+    return fromTableName(TableName.valueOf(hTableName));
+  }
+
+  public static TableName toTableName(CConfiguration cConf, TableId tableId) {
+    return TableName.valueOf(toHBaseNamespace(tableId.getNamespace()),
+                             getHBaseTableName(cConf, tableId));
+  }
+
+  public static TableId fromTableName(TableName tableName) {
+    return HTableNameConverter.from(tableName.getNamespaceAsString(), tableName.getQualifierAsString());
   }
 }

--- a/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data2/util/hbase/HBase98TableUtilTest.java
+++ b/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data2/util/hbase/HBase98TableUtilTest.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.data2.util.hbase;
 
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.test.XSlowTests;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
@@ -30,16 +31,19 @@ public class HBase98TableUtilTest extends AbstractHBaseTableUtilTest {
 
   @Override
   protected HBaseTableUtil getTableUtil() {
-    return new HBase98TableUtil();
+    HBase98TableUtil hBaseTableUtil = new HBase98TableUtil();
+    hBaseTableUtil.setCConf(cConf);
+    return hBaseTableUtil;
   }
 
   @Override
   protected String getTableNameAsString(TableId tableId) {
     Preconditions.checkArgument(tableId != null, "TableId should not be null.");
     if (Constants.DEFAULT_NAMESPACE_ID.equals(tableId.getNamespace())) {
-      return tableId.getTableName();
+      return HTableNameConverter.getHBaseTableName(cConf, tableId);
     }
-    return Joiner.on(':').join(getTableUtil().toHBaseNamespace(tableId.getNamespace()), tableId.getTableName());
+    return Joiner.on(':').join(HTableNameConverter.toHBaseNamespace(tableId.getNamespace()),
+                               HTableNameConverter.getHBaseTableName(cConf, tableId));
   }
 
   @Override

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
@@ -39,7 +39,6 @@ import co.cask.cdap.data.stream.StreamAdminModules;
 import co.cask.cdap.data2.datafabric.dataset.service.DatasetService;
 import co.cask.cdap.data2.util.hbase.ConfigurationTable;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
-import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
 import co.cask.cdap.explore.client.ExploreClient;
 import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.explore.service.ExploreServiceUtils;
@@ -196,7 +195,7 @@ public class MasterServiceMain extends DaemonMain {
   }
 
   private void createSystemHBaseNamespace() {
-    HBaseTableUtil tableUtil = new HBaseTableUtilFactory().get(cConf);
+    HBaseTableUtil tableUtil = baseInjector.getInstance(HBaseTableUtil.class);
     try {
       HBaseAdmin admin = new HBaseAdmin(hConf);
       tableUtil.createNamespaceIfNotExists(admin, Constants.SYSTEM_NAMESPACE_ID);
@@ -394,7 +393,7 @@ public class MasterServiceMain extends DaemonMain {
   }
 
   private TwillPreparer prepare(TwillPreparer preparer) {
-    return preparer.withDependencies(new HBaseTableUtilFactory().getHBaseTableUtilClass())
+    return preparer.withDependencies(baseInjector.getInstance(HBaseTableUtil.class).getClass())
       // TokenSecureStoreUpdater.update() ignores parameters
       .addSecureStore(secureStoreUpdater.update(null, null));
   }

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
@@ -50,7 +50,6 @@ import co.cask.cdap.logging.guice.LoggingModules;
 import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
 import co.cask.cdap.notifications.feeds.guice.NotificationFeedServiceRuntimeModule;
 import co.cask.cdap.notifications.guice.NotificationServiceRuntimeModule;
-import co.cask.cdap.proto.Id;
 import com.google.common.base.Charsets;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
@@ -197,7 +196,7 @@ public class MasterServiceMain extends DaemonMain {
   }
 
   private void createSystemHBaseNamespace() {
-    HBaseTableUtil tableUtil = new HBaseTableUtilFactory().get();
+    HBaseTableUtil tableUtil = new HBaseTableUtilFactory().get(cConf);
     try {
       HBaseAdmin admin = new HBaseAdmin(hConf);
       tableUtil.createNamespaceIfNotExists(admin, Constants.SYSTEM_NAMESPACE_ID);
@@ -395,7 +394,7 @@ public class MasterServiceMain extends DaemonMain {
   }
 
   private TwillPreparer prepare(TwillPreparer preparer) {
-    return preparer.withDependencies(new HBaseTableUtilFactory().get().getClass())
+    return preparer.withDependencies(new HBaseTableUtilFactory().getHBaseTableUtilClass())
       // TokenSecureStoreUpdater.update() ignores parameters
       .addSecureStore(secureStoreUpdater.update(null, null));
   }

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/DatasetUpgrader.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/DatasetUpgrader.java
@@ -24,8 +24,9 @@ import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.lib.hbase.AbstractHBaseDataSetAdmin;
 import co.cask.cdap.data2.dataset2.lib.table.hbase.HBaseTableAdmin;
 import co.cask.cdap.data2.transaction.queue.QueueAdmin;
+import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
-import co.cask.cdap.data2.util.hbase.TableId;
+import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
 import co.cask.cdap.proto.DatasetSpecificationSummary;
 import co.cask.cdap.proto.Id;
 import com.google.inject.Inject;
@@ -55,7 +56,7 @@ public class DatasetUpgrader extends AbstractUpgrader {
 
   @Inject
   private DatasetUpgrader(CConfiguration cConf, Configuration hConf, LocationFactory locationFactory,
-                          QueueAdmin queueAdmin, HBaseTableUtil hBaseTableUtil,
+                          QueueAdmin queueAdmin,
                           @Named("namespacedDSFramework") DatasetFramework namespacedFramework) {
 
     super(locationFactory);
@@ -63,7 +64,7 @@ public class DatasetUpgrader extends AbstractUpgrader {
     this.hConf = hConf;
     this.locationFactory = locationFactory;
     this.queueAdmin = queueAdmin;
-    this.hBaseTableUtil = hBaseTableUtil;
+    this.hBaseTableUtil = new HBaseTableUtilFactory().get(cConf);
     this.namespacedFramework = namespacedFramework;
   }
 

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/DatasetUpgrader.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/DatasetUpgrader.java
@@ -26,7 +26,6 @@ import co.cask.cdap.data2.dataset2.lib.table.hbase.HBaseTableAdmin;
 import co.cask.cdap.data2.transaction.queue.QueueAdmin;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
-import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
 import co.cask.cdap.proto.DatasetSpecificationSummary;
 import co.cask.cdap.proto.Id;
 import com.google.inject.Inject;
@@ -56,7 +55,7 @@ public class DatasetUpgrader extends AbstractUpgrader {
 
   @Inject
   private DatasetUpgrader(CConfiguration cConf, Configuration hConf, LocationFactory locationFactory,
-                          QueueAdmin queueAdmin,
+                          QueueAdmin queueAdmin, HBaseTableUtil hBaseTableUtil,
                           @Named("namespacedDSFramework") DatasetFramework namespacedFramework) {
 
     super(locationFactory);
@@ -64,7 +63,7 @@ public class DatasetUpgrader extends AbstractUpgrader {
     this.hConf = hConf;
     this.locationFactory = locationFactory;
     this.queueAdmin = queueAdmin;
-    this.hBaseTableUtil = new HBaseTableUtilFactory().get(cConf);
+    this.hBaseTableUtil = hBaseTableUtil;
     this.namespacedFramework = namespacedFramework;
   }
 


### PR DESCRIPTION
...nfiguration from which it derives the table prefix.

Build: http://builds.cask.co/browse/CDAP-DUT990-12