### PR TITLE
CDAP-1715: Upgrade tool now reads the old metatable again

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/config/DefaultConfigStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/config/DefaultConfigStore.java
@@ -31,6 +31,7 @@ import co.cask.cdap.data2.dataset2.tx.Transactional;
 import co.cask.cdap.proto.Id;
 import co.cask.tephra.TransactionExecutor;
 import co.cask.tephra.TransactionExecutorFactory;
+import com.google.common.base.Joiner;
 import com.google.common.base.Supplier;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Iterators;
@@ -80,7 +81,10 @@ public class DefaultConfigStore implements ConfigStore {
   }
 
   public static void setupDatasets(DatasetFramework dsFramework) throws DatasetManagementException, IOException {
-    dsFramework.addInstance(Table.class.getName(), configStoreDatasetInstanceId, DatasetProperties.EMPTY);
+    dsFramework.addInstance(Table.class.getName(), Id.DatasetInstance.from(
+                              Constants.DEFAULT_NAMESPACE_ID, Joiner.on(".").join(Constants.SYSTEM_NAMESPACE,
+                                                                                  Constants.ConfigStore.CONFIG_TABLE)),
+                            DatasetProperties.EMPTY);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/store/ScheduleStoreTableUtil.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/store/ScheduleStoreTableUtil.java
@@ -19,10 +19,12 @@ package co.cask.cdap.internal.app.runtime.schedule.store;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.DatasetManagementException;
 import co.cask.cdap.data2.dataset2.lib.table.MetaTableUtil;
 import co.cask.cdap.proto.Id;
+import com.google.common.base.Joiner;
 import com.google.inject.Inject;
 
 import java.io.IOException;
@@ -46,11 +48,13 @@ public class ScheduleStoreTableUtil extends MetaTableUtil {
 
   /**
    * Adds datasets and types to the given {@link DatasetFramework} used by schedule mds.
+   *
    * @param datasetFramework framework to add types and datasets to
    */
   public static void setupDatasets(DatasetFramework datasetFramework) throws IOException, DatasetManagementException {
     Id.DatasetInstance scheduleStoreDatasetInstance =
-      Id.DatasetInstance.from(SYSTEM_NAMESPACE, SCHEDULE_STORE_DATASET_NAME);
+      Id.DatasetInstance.from(Constants.DEFAULT_NAMESPACE_ID, (Joiner.on(".").join(Constants.SYSTEM_NAMESPACE,
+                                                                                   SCHEDULE_STORE_DATASET_NAME)));
     datasetFramework.addInstance(Table.class.getName(), scheduleStoreDatasetInstance, DatasetProperties.EMPTY);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
@@ -125,10 +125,14 @@ public class DefaultStore implements Store {
 
   /**
    * Adds datasets and types to the given {@link DatasetFramework} used by app mds.
+   *
    * @param framework framework to add types and datasets to
    */
   public static void setupDatasets(DatasetFramework framework) throws IOException, DatasetManagementException {
-    framework.addInstance(Table.class.getName(), appMetaDatasetInstanceId, DatasetProperties.EMPTY);
+    framework.addInstance(Table.class.getName(), Id.DatasetInstance.from(
+                            Constants.DEFAULT_NAMESPACE_ID, (Joiner.on(".").join(Constants.SYSTEM_NAMESPACE,
+                                                                                 APP_META_TABLE))),
+                          DatasetProperties.EMPTY);
   }
 
   @Nullable
@@ -176,7 +180,6 @@ public class DefaultStore implements Store {
         return null;
       }
     });
-
 
 
     // todo: delete old history data

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetMetaTableUtil.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetMetaTableUtil.java
@@ -24,6 +24,7 @@ import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.DatasetManagementException;
 import co.cask.cdap.data2.dataset2.SingleTypeModule;
 import co.cask.cdap.proto.Id;
+import com.google.common.base.Joiner;
 
 import java.io.IOException;
 
@@ -35,7 +36,7 @@ public class DatasetMetaTableUtil {
   public static final String INSTANCE_TABLE_NAME = "datasets.instance";
 
   private static final Id.DatasetInstance metaTableInstanceId =
-    Id.DatasetInstance.from(Constants.SYSTEM_NAMESPACE_ID,  META_TABLE_NAME);
+    Id.DatasetInstance.from(Constants.SYSTEM_NAMESPACE_ID, META_TABLE_NAME);
   private static final Id.DatasetInstance instanceTableInstanceId =
     Id.DatasetInstance.from(Constants.SYSTEM_NAMESPACE_ID, INSTANCE_TABLE_NAME);
 
@@ -63,12 +64,19 @@ public class DatasetMetaTableUtil {
 
   /**
    * Adds datasets and types to the given {@link DatasetFramework} used by dataset service mds.
+   *
    * @param datasetFramework framework to add types and datasets to
    */
   public static void setupDatasets(DatasetFramework datasetFramework) throws IOException, DatasetManagementException {
     addTypes(datasetFramework);
-    datasetFramework.addInstance(DatasetTypeMDS.class.getName(), metaTableInstanceId, DatasetProperties.EMPTY);
-    datasetFramework.addInstance(DatasetInstanceMDS.class.getName(), instanceTableInstanceId, DatasetProperties.EMPTY);
+    datasetFramework.addInstance(DatasetTypeMDS.class.getName(), Id.DatasetInstance.from(
+                                   Constants.DEFAULT_NAMESPACE_ID, Joiner.on(".").join(Constants.SYSTEM_NAMESPACE,
+                                                                                       META_TABLE_NAME)),
+                                 DatasetProperties.EMPTY);
+    datasetFramework.addInstance(DatasetInstanceMDS.class.getName(), Id.DatasetInstance.from(
+                                   Constants.DEFAULT_NAMESPACE_ID, Joiner.on(".").join(Constants.SYSTEM_NAMESPACE,
+                                                                                       INSTANCE_TABLE_NAME)),
+                                 DatasetProperties.EMPTY);
   }
 
   private static void addTypes(DatasetFramework framework) throws DatasetManagementException {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/hbase/AbstractHBaseDataSetAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/hbase/AbstractHBaseDataSetAdmin.java
@@ -104,7 +104,7 @@ public abstract class AbstractHBaseDataSetAdmin implements DatasetAdmin {
    * @throws IOException If upgrade failed.
    */
   protected void upgradeTable(TableId tableId) throws IOException {
-    HTableDescriptor tableDescriptor = tableUtil.createHTableDescriptor(tableId);
+    HTableDescriptor tableDescriptor = tableUtil.getHTableDescriptor(getAdmin(), tableId);
 
     // Upgrade any table properties if necessary
     boolean needUpgrade = upgradeTable(tableDescriptor);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HTableNameConverter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HTableNameConverter.java
@@ -86,6 +86,14 @@ public abstract class HTableNameConverter {
    */
   public abstract String getSysConfigTablePrefix(String hTableName);
 
+  /**
+   * Returns the {@link TableId} for the given hbase tablename
+   * Note: Sub-classes should override this method for their version specific implementation.
+   * @param hTableName the table name
+   * @return {@link TableId} for the table
+   */
+  public abstract TableId from(String hTableName);
+
   @VisibleForTesting
   protected static String toHBaseNamespace(Id.Namespace namespace) {
     // Handle backward compatibility to not add the prefix for default namespace

--- a/cdap-hbase-compat-0.94/src/main/java/co/cask/cdap/data2/util/hbase/HTable94NameConverter.java
+++ b/cdap-hbase-compat-0.94/src/main/java/co/cask/cdap/data2/util/hbase/HTable94NameConverter.java
@@ -31,6 +31,11 @@ public class HTable94NameConverter extends HTableNameConverter {
     return HBASE_NAMESPACE_PREFIX + Constants.SYSTEM_NAMESPACE + ".";
   }
 
+  @Override
+  public TableId from(String hTableName) {
+    return fromTableName(hTableName);
+  }
+
   public static String toTableName(CConfiguration cConf, TableId tableId) {
     Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
     // backward compatibility

--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/util/hbase/HTable96NameConverter.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/util/hbase/HTable96NameConverter.java
@@ -30,6 +30,11 @@ public class HTable96NameConverter extends HTableNameConverter {
     return HBASE_NAMESPACE_PREFIX + Constants.SYSTEM_NAMESPACE + ":";
   }
 
+  @Override
+  public TableId from(String hTableName) {
+    return fromTableName(TableName.valueOf(hTableName));
+  }
+
   public static TableName toTableName(CConfiguration cConf, TableId tableId) {
     return TableName.valueOf(toHBaseNamespace(tableId.getNamespace()),
                              getHBaseTableName(cConf, tableId));

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/util/hbase/HTable98NameConverter.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/util/hbase/HTable98NameConverter.java
@@ -30,6 +30,11 @@ public class HTable98NameConverter extends HTableNameConverter {
     return HBASE_NAMESPACE_PREFIX + Constants.SYSTEM_NAMESPACE + ":";
   }
 
+  @Override
+  public TableId from(String hTableName) {
+    return fromTableName(TableName.valueOf(hTableName));
+  }
+
   public static TableName toTableName(CConfiguration cConf, TableId tableId) {
     return TableName.valueOf(toHBaseNamespace(tableId.getNamespace()),
                              getHBaseTableName(cConf, tableId));

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/DatasetUpgrader.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/DatasetUpgrader.java
@@ -54,7 +54,7 @@ public class DatasetUpgrader extends AbstractUpgrader {
   private final QueueAdmin queueAdmin;
   private final HBaseTableUtil hBaseTableUtil;
   private final DatasetFramework namespacedFramework;
-  private static final Pattern USER_TABLE_PREFIX = Pattern.compile("cdap\\.user\\..*");
+  private static final Pattern USER_TABLE_PREFIX = Pattern.compile("^cdap\\.user\\..*");
 
   @Inject
   private DatasetUpgrader(CConfiguration cConf, Configuration hConf, LocationFactory locationFactory,

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/DatasetUpgrader.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/DatasetUpgrader.java
@@ -19,13 +19,14 @@ package co.cask.cdap.data.tools;
 import co.cask.cdap.api.dataset.DatasetAdmin;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
-import co.cask.cdap.data2.datafabric.DefaultDatasetNamespace;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.lib.hbase.AbstractHBaseDataSetAdmin;
 import co.cask.cdap.data2.dataset2.lib.table.hbase.HBaseTableAdmin;
 import co.cask.cdap.data2.transaction.queue.QueueAdmin;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
+import co.cask.cdap.data2.util.hbase.HTableNameConverter;
+import co.cask.cdap.data2.util.hbase.HTableNameConverterFactory;
 import co.cask.cdap.proto.DatasetSpecificationSummary;
 import co.cask.cdap.proto.Id;
 import com.google.inject.Inject;
@@ -38,6 +39,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.regex.Pattern;
 
 /**
  * Handles upgrade for System and User Datasets
@@ -52,6 +54,7 @@ public class DatasetUpgrader extends AbstractUpgrader {
   private final QueueAdmin queueAdmin;
   private final HBaseTableUtil hBaseTableUtil;
   private final DatasetFramework namespacedFramework;
+  private static final Pattern USER_TABLE_PREFIX = Pattern.compile("cdap\\.user\\..*");
 
   @Inject
   private DatasetUpgrader(CConfiguration cConf, Configuration hConf, LocationFactory locationFactory,
@@ -82,10 +85,10 @@ public class DatasetUpgrader extends AbstractUpgrader {
   private void upgradeSystemDatasets(DatasetFramework framework) throws Exception {
 
     // Upgrade all datasets in system namespace
-    Id.Namespace systemNamespace = Constants.SYSTEM_NAMESPACE_ID;
-    for (DatasetSpecificationSummary spec : framework.getInstances(systemNamespace)) {
+    for (DatasetSpecificationSummary spec : framework.getInstances(Constants.DEFAULT_NAMESPACE_ID)) {
       LOG.info("Upgrading dataset: {}, spec: {}", spec.getName(), spec.toString());
-      DatasetAdmin admin = framework.getAdmin(Id.DatasetInstance.from(systemNamespace, spec.getName()), null);
+      DatasetAdmin admin = framework.getAdmin(Id.DatasetInstance.from(Constants.DEFAULT_NAMESPACE_ID, spec.getName()),
+                                              null);
       // we know admin is not null, since we are looping over existing datasets
       admin.upgrade();
       LOG.info("Upgraded dataset: {}", spec.getName());
@@ -93,45 +96,40 @@ public class DatasetUpgrader extends AbstractUpgrader {
   }
 
   private void upgradeUserTables() throws Exception {
-    DefaultDatasetNamespace namespace = new DefaultDatasetNamespace(cConf);
     HBaseAdmin hAdmin = new HBaseAdmin(hConf);
 
-
-    for (HTableDescriptor desc : hAdmin.listTables()) {
+    for (HTableDescriptor desc : hAdmin.listTables(USER_TABLE_PREFIX)) {
       String tableName = desc.getNameAsString();
-      TableId tableId = TableId.from(tableName);
-      Id.DatasetInstance datasetInstanceId = Id.DatasetInstance.from(tableId.getNamespace(), tableId.getTableName());
-      // todo: it works now, but we will want to change it if namespacing of datasets in HBase is more than +prefix
-      if (namespace.fromNamespaced(datasetInstanceId) != null) {
-        LOG.info("Upgrading hbase table: {}, desc: {}", tableName, desc);
+      HTableNameConverter hTableNameConverter = new HTableNameConverterFactory().get();
+      TableId tableId = hTableNameConverter.from(tableName);
+      LOG.info("Upgrading hbase table: {}, desc: {}", tableName, desc);
 
-        final boolean supportsIncrement = HBaseTableAdmin.supportsReadlessIncrements(desc);
-        final boolean transactional = HBaseTableAdmin.isTransactional(desc);
-        DatasetAdmin admin = new AbstractHBaseDataSetAdmin(tableId, hConf, hBaseTableUtil) {
-          @Override
-          protected CoprocessorJar createCoprocessorJar() throws IOException {
-            return HBaseTableAdmin.createCoprocessorJarInternal(cConf,
-                                                                locationFactory,
-                                                                hBaseTableUtil,
-                                                                transactional,
-                                                                supportsIncrement);
-          }
+      final boolean supportsIncrement = HBaseTableAdmin.supportsReadlessIncrements(desc);
+      final boolean transactional = HBaseTableAdmin.isTransactional(desc);
+      DatasetAdmin admin = new AbstractHBaseDataSetAdmin(tableId, hConf, hBaseTableUtil) {
+        @Override
+        protected CoprocessorJar createCoprocessorJar() throws IOException {
+          return HBaseTableAdmin.createCoprocessorJarInternal(cConf,
+                                                              locationFactory,
+                                                              hBaseTableUtil,
+                                                              transactional,
+                                                              supportsIncrement);
+        }
 
-          @Override
-          protected boolean upgradeTable(HTableDescriptor tableDescriptor) {
-            // we don't do any other changes apart from coprocessors upgrade
-            return false;
-          }
+        @Override
+        protected boolean upgradeTable(HTableDescriptor tableDescriptor) {
+          // we don't do any other changes apart from coprocessors upgrade
+          return false;
+        }
 
-          @Override
-          public void create() throws IOException {
-            // no-op
-            throw new UnsupportedOperationException("This DatasetAdmin is only used for upgrade() operation");
-          }
-        };
-        admin.upgrade();
-        LOG.info("Upgraded hbase table: {}", tableName);
-      }
+        @Override
+        public void create() throws IOException {
+          // no-op
+          throw new UnsupportedOperationException("This DatasetAdmin is only used for upgrade() operation");
+        }
+      };
+      admin.upgrade();
+      LOG.info("Upgraded hbase table: {}", tableName);
     }
   }
 }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/LogSaverTableUtil.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/LogSaverTableUtil.java
@@ -19,11 +19,13 @@ package co.cask.cdap.logging.save;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.DatasetManagementException;
 import co.cask.cdap.data2.dataset2.lib.table.MetaTableUtil;
 import co.cask.cdap.logging.LoggingConfiguration;
 import co.cask.cdap.proto.Id;
+import com.google.common.base.Joiner;
 import com.google.inject.Inject;
 
 import java.io.IOException;
@@ -46,10 +48,13 @@ public class LogSaverTableUtil extends MetaTableUtil {
 
   /**
    * Adds datasets and types to the given {@link DatasetFramework} used by logging system mds.
+   *
    * @param datasetFramework framework to add types and datasets to
    */
   public static void setupDatasets(DatasetFramework datasetFramework) throws IOException, DatasetManagementException {
-    Id.DatasetInstance logMetaDatasetInstance = Id.DatasetInstance.from(SYSTEM_NAMESPACE, TABLE_NAME);
+    Id.DatasetInstance logMetaDatasetInstance = Id.DatasetInstance.from(Constants.DEFAULT_NAMESPACE_ID,
+                                                                        (Joiner.on(".").join(Constants.SYSTEM_NAMESPACE,
+                                                                                             TABLE_NAME)));
     datasetFramework.addInstance(Table.class.getName(), logMetaDatasetInstance, DatasetProperties.EMPTY);
   }
 }


### PR DESCRIPTION
Fixes the CDAP-1715 and enables the upgrade tool to read the old meta data tables again 

Build : http://builds.cask.co/browse/CDAP-DUT1019-1