### PR TITLE
(CDAP-1395) Log rotation of containers

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractDistributedProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractDistributedProgramRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -57,6 +57,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
 import java.io.Writer;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -112,6 +115,33 @@ public abstract class AbstractDistributedProgramRunner implements ProgramRunner 
       throw Throwables.propagate(e);
     }
 
+    final File tempDir = Files.createTempDir();
+    URI logbackURI = null;
+    try {
+      // TODO: When CDAP-1273 is fixed you can get the resource directly from the program classloader.
+      // Make an unused call to getClassloader() to ensure that the jar is expanded into programDir.
+      copiedProgram.getClassLoader();
+      File logbackFile = new File(programDir, "logback.xml");
+      if (logbackFile.exists()) {
+        logbackURI = logbackFile.toURI();
+      } else {
+        URL containerLogbackURL = getClass().getResource("/logback-container.xml");
+        if (containerLogbackURL != null) {
+          File file = new File(tempDir.getPath(), "logback.xml");
+
+          try {
+            Files.copy(new File(containerLogbackURL.toURI()), file);
+            logbackURI = file.toURI();
+          } catch (IOException e) {
+            LOG.error("Error copying container logback.", e);
+          }
+        }
+      }
+    } catch (URISyntaxException e) {
+      LOG.error("Error getting logback for program.", e);
+    }
+
+    final URI programLogbackURI = logbackURI;
     final String programOptions = GSON.toJson(options);
 
     // Obtains and add the HBase delegation token as well (if in non-secure mode, it's a no-op)
@@ -120,11 +150,14 @@ public abstract class AbstractDistributedProgramRunner implements ProgramRunner 
     return launch(copiedProgram, options, hConfFile, cConfFile, new ApplicationLauncher() {
       @Override
       public TwillController launch(TwillApplication twillApplication) {
-        TwillPreparer twillPreparer = twillRunner
-          .prepare(twillApplication);
+        TwillPreparer twillPreparer = twillRunner.prepare(twillApplication);
         if (options.isDebug()) {
-          LOG.info("Starting {} with debugging enabled.", program.getId());
+          LOG.info("Starting {} with debugging enabled, programOptions: {}, and logback: {}",
+                   program.getId(), programOptions, programLogbackURI);
           twillPreparer.enableDebugging();
+        }
+        if (programLogbackURI != null) {
+          twillPreparer.withResources(programLogbackURI);
         }
         TwillController twillController = twillPreparer
           .withDependencies(HBaseTableUtilFactory.getHBaseTableUtilClass())
@@ -134,7 +167,7 @@ public abstract class AbstractDistributedProgramRunner implements ProgramRunner 
             String.format("--%s", RunnableOptions.JAR), copiedProgram.getJarLocation().getName(),
             String.format("--%s", RunnableOptions.PROGRAM_OPTIONS), programOptions
           ).start();
-        return addCleanupListener(twillController, hConfFile, cConfFile, copiedProgram, programDir);
+        return addCleanupListener(twillController, hConfFile, cConfFile, tempDir, copiedProgram, programDir);
       }
     });
   }
@@ -191,7 +224,8 @@ public abstract class AbstractDistributedProgramRunner implements ProgramRunner 
    * @return The same TwillController instance.
    */
   private TwillController addCleanupListener(TwillController controller, final File hConfFile,
-                                             final File cConfFile, final Program program, final File programDir) {
+                                             final File cConfFile, final File tempDir,
+                                             final Program program, final File programDir) {
 
     final AtomicBoolean deleted = new AtomicBoolean(false);
     controller.addListener(new ServiceListenerAdapter() {
@@ -216,6 +250,7 @@ public abstract class AbstractDistributedProgramRunner implements ProgramRunner 
                     program.getName(), hConfFile, cConfFile, program.getJarLocation().toURI());
           hConfFile.delete();
           cConfFile.delete();
+          tempDir.delete();
           try {
             program.getJarLocation().delete();
           } catch (IOException e) {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseVersion.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -62,7 +62,7 @@ public class HBaseVersion {
         currentVersion = Version.UNKNOWN;
       }
     } catch (Throwable e) {
-      // must be a class loading exception, HBasde is not there
+      // must be a class loading exception, HBase is not there
       currentVersion = Version.UNKNOWN;
     }
   }

--- a/cdap-distributions/src/etc/cdap/conf.dist/logback-container.xml
+++ b/cdap-distributions/src/etc/cdap/conf.dist/logback-container.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Copyright © 2015 Cask Data, Inc.
+    
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+    
+  http://www.apache.org/licenses/LICENSE-2.0
+    
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+  -->
+
+<!--
+  Logback used by containers that run in YARN eg. Flows, MR, Explore
+-->
+<configuration>
+
+  <!--
+    Disabling some chatty loggers.
+  -->
+  <logger name="org.apache.commons.beanutils" level="ERROR"/>
+  <logger name="org.apache.zookeeper.server" level="ERROR"/>
+  <logger name="org.apache.zookeeper" level="ERROR"/>
+  <logger name="com.ning" level="WARN"/>
+  <logger name="org.apache.hadoop" level="WARN"/>
+  <logger name="org.apache.hive" level="WARN"/>
+  <logger name="org.quartz.core" level="WARN"/>
+  <logger name="co.cask.cdap" level="INFO"/>
+  <!-- Redirected stdout and stderr of Hive operations -->
+  <logger name="Explore.stdout" level="INFO"/>
+  <logger name="Explore.stderr" level="INFO"/>
+
+    <appender name="Rolling" class="ch.qos.logback.core.rolling.RollingFileAppender">
+      <!-- LOG_DIRS is the environment variable set by YARN for container logs -->
+      <file>${LOG_DIRS}/program.log</file>
+      <encoder>
+        <pattern>%d{ISO8601} - %-5p [%t:%logger{1}@%L] - %m%n</pattern>
+      </encoder>
+      <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+        <!-- Daily rollover at midnight-->
+        <fileNamePattern>${LOG_DIRS}/program.%d.log</fileNamePattern>
+
+        <!-- Keep 2 weeks of history -->
+        <maxHistory>14</maxHistory>
+      </rollingPolicy>
+    </appender>
+
+  <root level="ERROR">
+    <appender-ref ref="Rolling"/>
+  </root>
+
+</configuration>
+

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/HiveStreamRedirector.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/HiveStreamRedirector.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.explore.service;
+
+import co.cask.cdap.api.common.Bytes;
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.hadoop.hive.ql.session.SessionState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.FilterOutputStream;
+import java.io.PrintStream;
+import javax.annotation.Nullable;
+
+/**
+ * Sets the output streams of a {@link SessionState} to a logger instead of Hive's default System.out and System.err
+ */
+public final class HiveStreamRedirector {
+  private static final String LINE_SEPARATOR = System.getProperty("line.separator");
+
+  public static void redirectToLogger(SessionState sessionState) {
+    redirectToLogger(sessionState, null);
+  }
+
+  @VisibleForTesting
+  static void redirectToLogger(SessionState sessionState, Logger logger) {
+    sessionState.err = new PrintStream(new RedirectedPrintStream(true, logger), true);
+    sessionState.out = new PrintStream(new RedirectedPrintStream(false, logger), true);
+
+    sessionState.childErr = new PrintStream(new RedirectedPrintStream(true, logger), true);
+    sessionState.childOut = new PrintStream(new RedirectedPrintStream(false, logger), true);
+  }
+
+  private static final class RedirectedPrintStream extends FilterOutputStream {
+    private static final Logger LOG_OUT = LoggerFactory.getLogger("Explore.stdout");
+    private static final Logger LOG_ERR = LoggerFactory.getLogger("Explore.stderr");
+
+    private final ByteArrayOutputStream byteArrayOutputStream;
+    private final boolean errorStream;
+    private final Logger logger;
+
+    RedirectedPrintStream(boolean errorStream, @Nullable Logger logger) {
+      super(new ByteArrayOutputStream());
+      // Safe cast as we know what outputStream we've created.
+      byteArrayOutputStream = (ByteArrayOutputStream) super.out;
+      this.errorStream = errorStream;
+      this.logger = logger == null ? getLogger() : logger;
+    }
+
+    private Logger getLogger() {
+      return errorStream ? LOG_ERR : LOG_OUT;
+    }
+
+    @Override
+    public void flush() {
+      String msg = Bytes.toString(byteArrayOutputStream.toByteArray());
+      if (msg == null || msg.isEmpty()) {
+        byteArrayOutputStream.reset();
+        return;
+      }
+
+      if (msg.endsWith(LINE_SEPARATOR)) {
+        msg = msg.substring(0, msg.length() - LINE_SEPARATOR.length());
+      }
+
+      if (msg.isEmpty()) {
+        byteArrayOutputStream.reset();
+        return;
+      }
+
+      logger.info(msg);
+
+      byteArrayOutputStream.reset();
+    }
+
+    @Override
+    public void write(int i) {
+      byteArrayOutputStream.write(i);
+    }
+  }
+
+  private HiveStreamRedirector() {
+  }
+}

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive12ExploreService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive12ExploreService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -29,7 +29,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hive.service.cli.CLIService;
 import org.apache.hive.service.cli.HiveSQLException;
 import org.apache.hive.service.cli.OperationHandle;
@@ -54,10 +53,9 @@ public class Hive12ExploreService extends BaseHiveExploreService {
 
   @Inject
   public Hive12ExploreService(TransactionSystemClient txClient, DatasetFramework datasetFramework,
-                              CConfiguration cConf, Configuration hConf, HiveConf hiveConf,
-                              StreamAdmin streamAdmin,
+                              CConfiguration cConf, Configuration hConf, StreamAdmin streamAdmin,
                               @Named(Constants.Explore.PREVIEWS_DIR_NAME) File previewsDir) {
-    super(txClient, datasetFramework, cConf, hConf, hiveConf, previewsDir, streamAdmin);
+    super(txClient, datasetFramework, cConf, hConf, previewsDir, streamAdmin);
   }
 
   @Override

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive13ExploreService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive13ExploreService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -50,10 +50,9 @@ public class Hive13ExploreService extends BaseHiveExploreService {
 
   @Inject
   public Hive13ExploreService(TransactionSystemClient txClient, DatasetFramework datasetFramework,
-                              CConfiguration cConf, Configuration hConf, HiveConf hiveConf,
-                              StreamAdmin streamAdmin,
+                              CConfiguration cConf, Configuration hConf, StreamAdmin streamAdmin,
                               @Named(Constants.Explore.PREVIEWS_DIR_NAME) File previewsDir) {
-    super(txClient, datasetFramework, cConf, hConf, hiveConf, previewsDir, streamAdmin);
+    super(txClient, datasetFramework, cConf, hConf, previewsDir, streamAdmin);
     // This config sets the time Hive CLI getOperationStatus method will wait for the status of
     // a running query.
     System.setProperty(HiveConf.ConfVars.HIVE_SERVER2_LONG_POLLING_TIMEOUT.toString(), "50");

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/HiveCDH4ExploreService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/HiveCDH4ExploreService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -30,7 +30,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hive.service.cli.HiveSQLException;
 import org.apache.hive.service.cli.OperationHandle;
 import org.apache.hive.service.cli.OperationState;
@@ -61,10 +60,9 @@ public class HiveCDH4ExploreService extends BaseHiveExploreService {
 
   @Inject
   protected HiveCDH4ExploreService(TransactionSystemClient txClient, DatasetFramework datasetFramework,
-                                   CConfiguration cConf, Configuration hConf, HiveConf hiveConf,
-                                   StreamAdmin streamAdmin,
+                                   CConfiguration cConf, Configuration hConf, StreamAdmin streamAdmin,
                                    @Named(Constants.Explore.PREVIEWS_DIR_NAME) File previewsDir) {
-    super(txClient, datasetFramework, cConf, hConf, hiveConf, previewsDir, streamAdmin);
+    super(txClient, datasetFramework, cConf, hConf, previewsDir, streamAdmin);
     System.setProperty("hive.server2.blocking.query", "false");
     if (cConf.getBoolean(Constants.Explore.WRITES_ENABLED)) {
       LOG.warn("Writing to datasets through Hive is not supported in CDH4.x, overriding {} setting to false.",

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/HiveCDH5ExploreService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/HiveCDH5ExploreService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -28,7 +28,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hive.service.cli.HiveSQLException;
 import org.apache.hive.service.cli.OperationHandle;
 import org.apache.hive.service.cli.OperationStatus;
@@ -48,10 +47,9 @@ public class HiveCDH5ExploreService extends BaseHiveExploreService {
 
   @Inject
   protected HiveCDH5ExploreService(TransactionSystemClient txClient, DatasetFramework datasetFramework,
-                                   CConfiguration cConf, Configuration hConf, HiveConf hiveConf,
-                                   StreamAdmin streamAdmin,
+                                   CConfiguration cConf, Configuration hConf, StreamAdmin streamAdmin,
                                    @Named(Constants.Explore.PREVIEWS_DIR_NAME) File previewsDir) {
-    super(txClient, datasetFramework, cConf, hConf, hiveConf, previewsDir, streamAdmin);
+    super(txClient, datasetFramework, cConf, hConf, previewsDir, streamAdmin);
   }
 
   @Override

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveStreamRedirectorTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveStreamRedirectorTest.java
@@ -1,0 +1,361 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.explore.service;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.ql.session.SessionState;
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.Marker;
+
+/**
+ *
+ */
+public class HiveStreamRedirectorTest {
+
+  @Test
+  public void testLoggerRedirector() throws Exception {
+    CountingLogger logger = new CountingLogger();
+    SessionState sessionState = new SessionState(new HiveConf());
+
+    HiveStreamRedirector.redirectToLogger(sessionState, logger);
+
+    for (int i = 0; i < 5; i++) {
+      sessionState.out.print("testInfoLog" + i);
+    }
+
+    Assert.assertEquals(5, logger.getInfoLogs());
+  }
+
+  /**
+   * A logger that increments counters for simple info logs.
+   */
+  private static final class CountingLogger implements Logger {
+    private int infoLogs = 0;
+
+    public int getInfoLogs() {
+      return infoLogs;
+    }
+
+    @Override
+    public String getName() {
+      return "CountingLogger";
+    }
+
+    @Override
+    public boolean isTraceEnabled() {
+      return false;
+    }
+
+    @Override
+    public void trace(String msg) {
+      // no-op
+    }
+
+    @Override
+    public void trace(String format, Object arg) {
+      // no-op
+    }
+
+    @Override
+    public void trace(String format, Object arg1, Object arg2) {
+      // no-op
+    }
+
+    @Override
+    public void trace(String format, Object... arguments) {
+      // no-op
+    }
+
+    @Override
+    public void trace(String msg, Throwable t) {
+      // no-op
+    }
+
+    @Override
+    public boolean isTraceEnabled(Marker marker) {
+      return false;
+    }
+
+    @Override
+    public void trace(Marker marker, String msg) {
+      // no-op
+    }
+
+    @Override
+    public void trace(Marker marker, String format, Object arg) {
+      // no-op
+    }
+
+    @Override
+    public void trace(Marker marker, String format, Object arg1, Object arg2) {
+      // no-op
+    }
+
+    @Override
+    public void trace(Marker marker, String format, Object... argArray) {
+      // no-op
+    }
+
+    @Override
+    public void trace(Marker marker, String msg, Throwable t) {
+      // no-op
+    }
+
+    @Override
+    public boolean isDebugEnabled() {
+      return false;
+    }
+
+    @Override
+    public void debug(String msg) {
+      // no-op
+    }
+
+    @Override
+    public void debug(String format, Object arg) {
+      // no-op
+    }
+
+    @Override
+    public void debug(String format, Object arg1, Object arg2) {
+      // no-op
+    }
+
+    @Override
+    public void debug(String format, Object... arguments) {
+      // no-op
+    }
+
+    @Override
+    public void debug(String msg, Throwable t) {
+      // no-op
+    }
+
+    @Override
+    public boolean isDebugEnabled(Marker marker) {
+      return false;
+    }
+
+    @Override
+    public void debug(Marker marker, String msg) {
+      // no-op
+    }
+
+    @Override
+    public void debug(Marker marker, String format, Object arg) {
+      // no-op
+    }
+
+    @Override
+    public void debug(Marker marker, String format, Object arg1, Object arg2) {
+      // no-op
+    }
+
+    @Override
+    public void debug(Marker marker, String format, Object... arguments) {
+      // no-op
+    }
+
+    @Override
+    public void debug(Marker marker, String msg, Throwable t) {
+      // no-op
+    }
+
+    @Override
+    public boolean isInfoEnabled() {
+      return true;
+    }
+
+    @Override
+    public void info(String msg) {
+      infoLogs++;
+    }
+
+    @Override
+    public void info(String format, Object arg) {
+      // no-op
+    }
+
+    @Override
+    public void info(String format, Object arg1, Object arg2) {
+      // no-op
+    }
+
+    @Override
+    public void info(String format, Object... arguments) {
+      // no-op
+    }
+
+    @Override
+    public void info(String msg, Throwable t) {
+      // no-op
+    }
+
+    @Override
+    public boolean isInfoEnabled(Marker marker) {
+      return false;
+    }
+
+    @Override
+    public void info(Marker marker, String msg) {
+      // no-op
+    }
+
+    @Override
+    public void info(Marker marker, String format, Object arg) {
+      // no-op
+    }
+
+    @Override
+    public void info(Marker marker, String format, Object arg1, Object arg2) {
+      // no-op
+    }
+
+    @Override
+    public void info(Marker marker, String format, Object... arguments) {
+      // no-op
+    }
+
+    @Override
+    public void info(Marker marker, String msg, Throwable t) {
+      // no-op
+    }
+
+    @Override
+    public boolean isWarnEnabled() {
+      return false;
+    }
+
+    @Override
+    public void warn(String msg) {
+      // no-op
+    }
+
+    @Override
+    public void warn(String format, Object arg) {
+      // no-op
+    }
+
+    @Override
+    public void warn(String format, Object... arguments) {
+      // no-op
+    }
+
+    @Override
+    public void warn(String format, Object arg1, Object arg2) {
+      // no-op
+    }
+
+    @Override
+    public void warn(String msg, Throwable t) {
+      // no-op
+    }
+
+    @Override
+    public boolean isWarnEnabled(Marker marker) {
+      return false;
+    }
+
+    @Override
+    public void warn(Marker marker, String msg) {
+      // no-op
+    }
+
+    @Override
+    public void warn(Marker marker, String format, Object arg) {
+      // no-op
+    }
+
+    @Override
+    public void warn(Marker marker, String format, Object arg1, Object arg2) {
+      // no-op
+    }
+
+    @Override
+    public void warn(Marker marker, String format, Object... arguments) {
+      // no-op
+    }
+
+    @Override
+    public void warn(Marker marker, String msg, Throwable t) {
+      // no-op
+    }
+
+    @Override
+    public boolean isErrorEnabled() {
+      return false;
+    }
+
+    @Override
+    public void error(String msg) {
+      // no-op
+    }
+
+    @Override
+    public void error(String format, Object arg) {
+      // no-op
+    }
+
+    @Override
+    public void error(String format, Object arg1, Object arg2) {
+      // no-op
+    }
+
+    @Override
+    public void error(String format, Object... arguments) {
+      // no-op
+    }
+
+    @Override
+    public void error(String msg, Throwable t) {
+      // no-op
+    }
+
+    @Override
+    public boolean isErrorEnabled(Marker marker) {
+      return false;
+    }
+
+    @Override
+    public void error(Marker marker, String msg) {
+      // no-op
+    }
+
+    @Override
+    public void error(Marker marker, String format, Object arg) {
+      // no-op
+    }
+
+    @Override
+    public void error(Marker marker, String format, Object arg1, Object arg2) {
+      // no-op
+    }
+
+    @Override
+    public void error(Marker marker, String format, Object... arguments) {
+      // no-op
+    }
+
+    @Override
+    public void error(Marker marker, String msg, Throwable t) {
+      // no-op
+    }
+  }
+
+}

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterMain.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -32,7 +32,6 @@ import com.google.common.util.concurrent.Futures;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.apache.twill.common.Services;
-import org.apache.twill.discovery.DiscoveryService;
 import org.apache.twill.zookeeper.ZKClientService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,7 +44,6 @@ public class RouterMain extends DaemonMain {
 
   private ZKClientService zkClientService;
   private NettyRouter router;
-  private DiscoveryService discoveryService;
 
   public static void main(String[] args) {
     try {
@@ -79,9 +77,6 @@ public class RouterMain extends DaemonMain {
 
       // Get the Router
       router = injector.getInstance(NettyRouter.class);
-
-      //Get the discovery service
-      discoveryService = injector.getInstance(DiscoveryService.class);
 
       LOG.info("Router initialized.");
     } catch (Throwable t) {

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
@@ -87,6 +87,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Writer;
 import java.net.InetAddress;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.UnknownHostException;
@@ -548,17 +549,37 @@ public class MasterServiceMain extends DaemonMain {
     TwillPreparer preparer = twillRunnerService.prepare(twillApplication)
       .addLogHandler(new PrinterLogHandler(new PrintWriter(System.out)));
 
-    // Add system logback file to the preparer
-    URL logbackUrl = getClass().getResource("/logback.xml");
-    if (logbackUrl == null) {
-      LOG.warn("Cannot find logback.xml to pass onto Twill Runnables!");
-    } else {
+    URL containerLogbackURL = getClass().getResource("/logback-container.xml");
+    if (containerLogbackURL != null) {
       try {
-        preparer.withResources(logbackUrl.toURI());
+        File tempDir = Files.createTempDir();
+        tempDir.deleteOnExit();
+        File file = new File(tempDir.getPath(), "logback.xml");
+
+        Files.copy(new File(containerLogbackURL.toURI()), file);
+        URI copiedLogbackURI = file.toURI();
+        preparer.withResources(copiedLogbackURI);
+      } catch (IOException e) {
+        LOG.error("Got exception while copying logback-container.xml", e);
       } catch (URISyntaxException e) {
-        LOG.error("Got exception while getting URI for logback.xml - {}", logbackUrl);
+        LOG.error("Got exception while getting URI for logback-container.xml - {}", containerLogbackURL, e);
+      }
+    } else {
+      // Default to system logback if the container logback is not found.
+      LOG.debug("Could not load logback specific for containers. Defaulting to system logback.");
+
+      containerLogbackURL = getClass().getResource("/logback.xml");
+      if (containerLogbackURL == null) {
+        LOG.warn("Cannot find logback.xml to pass onto Twill Runnables!");
+      } else {
+        try {
+          preparer.withResources(containerLogbackURL.toURI());
+        } catch (URISyntaxException e) {
+          LOG.error("Got exception while getting URI for logback.xml - {}", containerLogbackURL, e);
+        }
       }
     }
+
     preparer = prepareExploreContainer(preparer);
     return prepare(preparer);
   }


### PR DESCRIPTION
- [x] Log rotation of containers spawned by master service
- [x] Ability for user to specify a `logback.xml` in their application jar.
- [x] Hive logs are now redirected to the `program.log` of the explore container.
- [x] Minor cleanup of the `ExploreService` constructors to not take an un-needed `hiveConf`.