### PR TITLE
CDAP-1722 Fix/namespace name

### DIFF
--- a/cdap-ui/app/features/admin/controllers/NamespaceCreateController.js
+++ b/cdap-ui/app/features/admin/controllers/NamespaceCreateController.js
@@ -11,7 +11,7 @@ angular.module(PKG.name + '.feature.admin')
         _cdapPath: '/namespaces/' + $scope.model.id,
         body: {
           id: $scope.model.id,
-          name: $scope.model.name || $scope.model.id,
+          name: $scope.model.name || null,
           description: $scope.model.description
         }
       })

--- a/cdap-ui/app/features/admin/controllers/NamespaceCreateController.js
+++ b/cdap-ui/app/features/admin/controllers/NamespaceCreateController.js
@@ -11,7 +11,7 @@ angular.module(PKG.name + '.feature.admin')
         _cdapPath: '/namespaces/' + $scope.model.id,
         body: {
           id: $scope.model.id,
-          name: $scope.model.name,
+          name: $scope.model.name || $scope.model.id,
           description: $scope.model.description
         }
       })


### PR DESCRIPTION
angular initialize $scope.model.name with empty string and it's causing the backend to process name to empty string.