### PR TITLE
(CDAP-1648) Remove deprecated instances endpoint for services

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
@@ -66,8 +66,6 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Lists;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.SettableFuture;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
@@ -1097,16 +1095,8 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
     getServiceInstances(request, responder, namespaceId, appId, serviceId, serviceId);
   }
 
-  /**
-   * Return the number of instances for the given runnable of a service.
-   */
-  @GET
-  @Path("/apps/{app-id}/services/{service-id}/runnables/{runnable-name}/instances")
-  public void getServiceInstances(HttpRequest request, HttpResponder responder,
-                                  @PathParam("namespace-id") String namespaceId,
-                                  @PathParam("app-id") String appId,
-                                  @PathParam("service-id") String serviceId,
-                                  @PathParam("runnable-name") String runnableName) {
+  void getServiceInstances(HttpRequest request, HttpResponder responder,
+                           String namespaceId, String appId, String serviceId, String runnableName) {
     try {
       Id.Program programId = Id.Program.from(namespaceId, appId, ProgramType.SERVICE, serviceId);
       if (!store.programExists(programId, ProgramType.SERVICE)) {
@@ -1158,16 +1148,8 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
     setServiceInstances(request, responder, namespaceId, appId, serviceId, serviceId);
   }
 
-  /**
-   * Set instances.
-   */
-  @PUT
-  @Path("/apps/{app-id}/services/{service-id}/runnables/{runnable-name}/instances")
-  public void setServiceInstances(HttpRequest request, HttpResponder responder,
-                                  @PathParam("namespace-id") String namespaceId,
-                                  @PathParam("app-id") String appId,
-                                  @PathParam("service-id") String serviceId,
-                                  @PathParam("runnable-name") String runnableName) {
+  void setServiceInstances(HttpRequest request, HttpResponder responder,
+                           String namespaceId, String appId, String serviceId, String runnableName) {
 
     try {
       Id.Program programId = Id.Program.from(namespaceId, appId, ProgramType.SERVICE, serviceId);


### PR DESCRIPTION
Addresses: https://issues.cask.co/browse/CDAP-1648

Steps 2 and 3 of the JIRA have already been done during the separation of workers and services by @gokulavasan. The only problem was that the old endpoints also got transferred to v3.