### PR TITLE
[CDAP-1369] Namespaced log dir

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/NamespaceHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/NamespaceHttpHandler.java
@@ -222,6 +222,6 @@ public class NamespaceHttpHandler extends AbstractAppFabricHttpHandler {
 
   private boolean isReserved(String namespaceId) {
     return Constants.DEFAULT_NAMESPACE.equals(namespaceId) || Constants.SYSTEM_NAMESPACE.equals(namespaceId) ||
-      Constants.Logging.SYSTEM_NAME.equals(namespaceId);
+      Constants.CDAP_NAMESPACE.equals(namespaceId);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AppFabricServer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AppFabricServer.java
@@ -102,7 +102,7 @@ public final class AppFabricServer extends AbstractIdleService {
    */
   @Override
   protected void startUp() throws Exception {
-    LoggingContextAccessor.setLoggingContext(new ServiceLoggingContext(Constants.Logging.SYSTEM_NAME,
+    LoggingContextAccessor.setLoggingContext(new ServiceLoggingContext(Constants.SYSTEM_NAMESPACE,
                                                                        Constants.Logging.COMPONENT_NAME,
                                                                        Constants.Service.APP_FABRIC_HTTP));
     // Delete app fabric temp directory

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -483,7 +483,6 @@ public final class Constants {
    * Logging constants.
    */
   public static final class Logging {
-    public static final String SYSTEM_NAME = "cdap";
     public static final String COMPONENT_NAME = "services";
   }
 
@@ -726,6 +725,11 @@ public final class Constants {
    */
   public static final String SYSTEM_NAMESPACE = "system";
   public static final Id.Namespace SYSTEM_NAMESPACE_ID = Id.Namespace.from(SYSTEM_NAMESPACE);
+
+  /**
+   * 'cdap' reserved namespace name. Unused right now (other than in logging. Reserved in case we need it in future.
+   */
+  public static final String CDAP_NAMESPACE = "cdap";
 
   /**
    * Constants related to external systems.

--- a/cdap-common/src/main/java/co/cask/cdap/common/logging/AbstractLoggingContext.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/logging/AbstractLoggingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -30,6 +30,14 @@ import java.util.Map;
 public abstract class AbstractLoggingContext implements LoggingContext {
   // Map looks not efficient here, it might be better to use set
   private Map<String, SystemTag> systemTags = Maps.newHashMap();
+
+  /**
+   * Returns the base dir for logs under the namespace directory
+   *
+   * @param logBaseDir the base dir
+   * @return log base dir in the namespace directory
+   */
+  protected abstract String getNamespacedLogBaseDir(String logBaseDir);
 
   /**
    * Sets system tag.

--- a/cdap-common/src/main/java/co/cask/cdap/common/logging/ApplicationLoggingContext.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/logging/ApplicationLoggingContext.java
@@ -38,7 +38,7 @@ public abstract class ApplicationLoggingContext extends NamespaceLoggingContext 
   }
 
   @Override
-  public String getLogPathFragment() {
-    return String.format("%s/%s", super.getLogPathFragment(), getSystemTag(TAG_APPLICATION_ID));
+  public String getLogPathFragment(String logBaseDir) {
+    return String.format("%s/%s", super.getLogPathFragment(logBaseDir), getSystemTag(TAG_APPLICATION_ID));
   }
 }

--- a/cdap-common/src/main/java/co/cask/cdap/common/logging/ComponentLoggingContext.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/logging/ComponentLoggingContext.java
@@ -38,7 +38,7 @@ public class ComponentLoggingContext extends SystemLoggingContext {
   }
 
   @Override
-  public String getLogPathFragment() {
-    return String.format("%s/%s", super.getLogPathFragment(), getSystemTag(TAG_COMPONENT_ID));
+  public String getLogPathFragment(String logBaseDir) {
+    return String.format("%s/%s", super.getLogPathFragment(logBaseDir), getSystemTag(TAG_COMPONENT_ID));
   }
 }

--- a/cdap-common/src/main/java/co/cask/cdap/common/logging/LoggingContext.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/logging/LoggingContext.java
@@ -46,8 +46,9 @@ public interface LoggingContext {
    * Returns the path fragment that will be part of the log file name. The grouping of log messages into partitions
    * should be consistent with the value returned as path fragment.
    * @return the path fragment that will be part of the log file name.
+   * @param logBaseDir base dir for logs
    */
-  String getLogPathFragment();
+  String getLogPathFragment(String logBaseDir);
 
   /**
    * Defines the interface for the system tag associated with LoggingContext.

--- a/cdap-common/src/main/java/co/cask/cdap/common/logging/NamespaceLoggingContext.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/logging/NamespaceLoggingContext.java
@@ -23,11 +23,18 @@ public abstract class NamespaceLoggingContext extends AbstractLoggingContext {
   public static final String TAG_NAMESPACE_ID = ".namespaceId";
 
   /**
-   * Constructs AccountLoggingContext.
+   * Constructs NamespaceLoggingContext.
    * @param namespaceId namespace id
    */
   public NamespaceLoggingContext(final String namespaceId) {
     setSystemTag(TAG_NAMESPACE_ID, namespaceId);
+  }
+
+  @Override
+  public String getNamespacedLogBaseDir(String logBaseDir) {
+    // cannot just call #getLogPathFragment here, because if called on a subclass' object, that would return
+    // a wrong value
+    return String.format("%s/%s", getSystemTag(TAG_NAMESPACE_ID), logBaseDir);
   }
 
   @Override
@@ -36,7 +43,7 @@ public abstract class NamespaceLoggingContext extends AbstractLoggingContext {
   }
 
   @Override
-  public String getLogPathFragment() {
-    return String.format("%s", getSystemTag(TAG_NAMESPACE_ID));
+  public String getLogPathFragment(String logBaseDir) {
+    return String.format("%s/%s", getSystemTag(TAG_NAMESPACE_ID), logBaseDir);
   }
 }

--- a/cdap-common/src/main/java/co/cask/cdap/common/logging/ServiceLoggingContext.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/logging/ServiceLoggingContext.java
@@ -39,8 +39,8 @@ public class ServiceLoggingContext extends ComponentLoggingContext {
   }
 
   @Override
-  public String getLogPathFragment() {
-    return String.format("%s/service-%s", super.getLogPathFragment(), getSystemTag(TAG_SERVICE_ID));
+  public String getLogPathFragment(String logBaseDir) {
+    return String.format("%s/service-%s", super.getLogPathFragment(logBaseDir), getSystemTag(TAG_SERVICE_ID));
   }
 
 }

--- a/cdap-common/src/main/java/co/cask/cdap/common/logging/SystemLoggingContext.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/logging/SystemLoggingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -31,12 +31,19 @@ public abstract class SystemLoggingContext extends AbstractLoggingContext {
   }
 
   @Override
+  public String getNamespacedLogBaseDir(String logBaseDir) {
+    // cannot just call #getLogPathFragment here, because if called on a subclass' object, that would return
+    // a wrong value
+    return String.format("%s/%s", getSystemTag(TAG_SYSTEM_ID), logBaseDir);
+  }
+
+  @Override
   public String getLogPartition() {
     return String.format("%s", getSystemTag(TAG_SYSTEM_ID));
   }
 
   @Override
-  public String getLogPathFragment() {
-    return String.format("%s", getSystemTag(TAG_SYSTEM_ID));
+  public String getLogPathFragment(String logBaseDir) {
+    return String.format("%s/%s", getSystemTag(TAG_SYSTEM_ID), logBaseDir);
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamHttpService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamHttpService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -71,7 +71,7 @@ public final class StreamHttpService extends AbstractIdleService implements Supp
 
   @Override
   protected void startUp() throws Exception {
-    LoggingContextAccessor.setLoggingContext(new ServiceLoggingContext(Constants.Logging.SYSTEM_NAME,
+    LoggingContextAccessor.setLoggingContext(new ServiceLoggingContext(Constants.SYSTEM_NAMESPACE,
                                                                        Constants.Logging.COMPONENT_NAME,
                                                                        Constants.Service.STREAMS));
     httpService.startAndWait();

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/DatasetOpExecutorService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/DatasetOpExecutorService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -73,7 +73,7 @@ public class DatasetOpExecutorService extends AbstractIdleService {
 
   @Override
   protected void startUp() throws Exception {
-    LoggingContextAccessor.setLoggingContext(new ServiceLoggingContext(Constants.Logging.SYSTEM_NAME,
+    LoggingContextAccessor.setLoggingContext(new ServiceLoggingContext(Constants.SYSTEM_NAMESPACE,
                                                                        Constants.Logging.COMPONENT_NAME,
                                                                        Constants.Service.DATASET_EXECUTOR));
     LOG.info("Starting DatasetOpExecutorService...");

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/executor/ExploreExecutorService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/executor/ExploreExecutorService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -79,7 +79,7 @@ public class ExploreExecutorService extends AbstractIdleService {
 
   @Override
   protected void startUp() throws Exception {
-    LoggingContextAccessor.setLoggingContext(new ServiceLoggingContext(Constants.Logging.SYSTEM_NAME,
+    LoggingContextAccessor.setLoggingContext(new ServiceLoggingContext(Constants.SYSTEM_NAMESPACE,
                                                                        Constants.Logging.COMPONENT_NAME,
                                                                        Constants.Service.EXPLORE_HTTP_USER_SERVICE));
 

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/log/LogHandlerTestRun.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/log/LogHandlerTestRun.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/DatasetOpExecutorServerTwillRunnable.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/DatasetOpExecutorServerTwillRunnable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -88,7 +88,7 @@ public class DatasetOpExecutorServerTwillRunnable extends AbstractMasterTwillRun
       new ExploreClientModule());
 
     injector.getInstance(LogAppenderInitializer.class).initialize();
-    LoggingContextAccessor.setLoggingContext(new ServiceLoggingContext(Constants.Logging.SYSTEM_NAME,
+    LoggingContextAccessor.setLoggingContext(new ServiceLoggingContext(Constants.SYSTEM_NAMESPACE,
                                                                        Constants.Logging.COMPONENT_NAME,
                                                                        Constants.Service.DATASET_EXECUTOR));
   }

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/ExploreServiceTwillRunnable.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/ExploreServiceTwillRunnable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -104,7 +104,7 @@ public class ExploreServiceTwillRunnable extends AbstractMasterTwillRunnable {
 
     injector.getInstance(LogAppenderInitializer.class).initialize();
 
-    LoggingContextAccessor.setLoggingContext(new ServiceLoggingContext(Constants.Logging.SYSTEM_NAME,
+    LoggingContextAccessor.setLoggingContext(new ServiceLoggingContext(Constants.SYSTEM_NAMESPACE,
                                                                        Constants.Logging.COMPONENT_NAME,
                                                                        Constants.Service.EXPLORE_HTTP_USER_SERVICE));
     LOG.info("Initializing runnable {}", name);

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/StreamHandlerRunnable.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/StreamHandlerRunnable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -96,7 +96,7 @@ public class StreamHandlerRunnable extends AbstractMasterTwillRunnable {
       );
 
       injector.getInstance(LogAppenderInitializer.class).initialize();
-      LoggingContextAccessor.setLoggingContext(new ServiceLoggingContext(Constants.Logging.SYSTEM_NAME,
+      LoggingContextAccessor.setLoggingContext(new ServiceLoggingContext(Constants.SYSTEM_NAMESPACE,
                                                                          Constants.Logging.COMPONENT_NAME,
                                                                          Constants.Service.STREAMS));
 

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/TransactionServiceTwillRunnable.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/TransactionServiceTwillRunnable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -79,7 +79,7 @@ public class TransactionServiceTwillRunnable extends AbstractMasterTwillRunnable
 
       Injector injector = createGuiceInjector(getCConfiguration(), getConfiguration());
       injector.getInstance(LogAppenderInitializer.class).initialize();
-      LoggingContextAccessor.setLoggingContext(new ServiceLoggingContext(Constants.Logging.SYSTEM_NAME,
+      LoggingContextAccessor.setLoggingContext(new ServiceLoggingContext(Constants.SYSTEM_NAMESPACE,
                                                                          Constants.Logging.COMPONENT_NAME,
                                                                          Constants.Service.TRANSACTION));
 

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/ArchiveUpgrader.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/ArchiveUpgrader.java
@@ -68,7 +68,7 @@ public class ArchiveUpgrader extends AbstractUpgrader {
   private void upgradeLogs() throws IOException {
     LOG.info("Upgrading log files ...");
     String logBaseDir = cConf.get(LoggingConfiguration.LOG_BASE_DIR);
-    renameLocation(locationFactory.create(logBaseDir).append(Constants.Logging.SYSTEM_NAME),
+    renameLocation(locationFactory.create(logBaseDir).append(Constants.CDAP_NAMESPACE),
                    locationFactory.create(Constants.SYSTEM_NAMESPACE)
                      .append(cConf.get(LoggingConfiguration.LOG_BASE_DIR)));
     //TODO: This developer string in 2.7 is default so we need to handle that here when we improvise on this tool for

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgraderMain.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgraderMain.java
@@ -200,7 +200,7 @@ public class UpgraderMain {
                                                           @Named("dsFramework") DatasetFramework dsFramework,
                                                           TransactionExecutorFactory txExecutorFactory,
                                                           LocationFactory locationFactory) {
-          return new FileMetaDataManager(tableUtil, txExecutorFactory, locationFactory, dsFramework);
+          return new FileMetaDataManager(tableUtil, txExecutorFactory, locationFactory, dsFramework, cConf);
         }
       });
   }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/FlowletLoggingContext.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/FlowletLoggingContext.java
@@ -48,7 +48,7 @@ public class FlowletLoggingContext extends ApplicationLoggingContext {
   }
 
   @Override
-  public String getLogPathFragment() {
-    return String.format("%s/flow-%s", super.getLogPathFragment(), getSystemTag(TAG_FLOW_ID));
+  public String getLogPathFragment(String logBaseDir) {
+    return String.format("%s/flow-%s", super.getLogPathFragment(logBaseDir), getSystemTag(TAG_FLOW_ID));
   }
 }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/GenericLoggingContext.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/GenericLoggingContext.java
@@ -31,8 +31,8 @@ public class GenericLoggingContext extends ApplicationLoggingContext {
    * @param entityId flow entity id
    */
   public GenericLoggingContext(final String namespaceId,
-                                 final String applicationId,
-                                 final String entityId) {
+                               final String applicationId,
+                               final String entityId) {
     super(namespaceId, applicationId);
     setSystemTag(TAG_ENTITY_ID, entityId);
   }
@@ -43,7 +43,7 @@ public class GenericLoggingContext extends ApplicationLoggingContext {
   }
 
   @Override
-  public String getLogPathFragment() {
+  public String getLogPathFragment(String logBaseDir) {
     throw new UnsupportedOperationException("GenericLoggingContext does not support this");
   }
 }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/LoggingContextHelper.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/LoggingContextHelper.java
@@ -27,6 +27,7 @@ import co.cask.cdap.logging.filter.Filter;
 import co.cask.cdap.logging.filter.MdcExpression;
 import co.cask.cdap.logging.filter.OrFilter;
 import co.cask.cdap.proto.ProgramType;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 import java.util.Map;
@@ -36,6 +37,17 @@ import java.util.Map;
  */
 public final class LoggingContextHelper {
   private LoggingContextHelper() {}
+
+  public static String getNamespacedBaseDir(String logBaseDir, String logPartition) {
+    Preconditions.checkArgument(logBaseDir != null, "Log Base dir cannot be null");
+    Preconditions.checkArgument(logPartition != null, "Log partition cannot be null");
+    String [] partitions = logPartition.split(":");
+    Preconditions.checkArgument(partitions.length == 3,
+                                "Expected log partition to be in the format <ns>:<entity>:<sub-entity>");
+    // don't care about the app or the program, only need the namespace
+    GenericLoggingContext loggingContext = new GenericLoggingContext(partitions[0], partitions[1], partitions[2]);
+    return loggingContext.getNamespacedLogBaseDir(logBaseDir);
+  }
 
   public static LoggingContext getLoggingContext(Map<String, String> tags) {
     // Tags are empty, cannot determine logging context.

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/MapReduceLoggingContext.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/MapReduceLoggingContext.java
@@ -42,7 +42,7 @@ public class MapReduceLoggingContext extends ApplicationLoggingContext {
   }
 
   @Override
-  public String getLogPathFragment() {
-    return String.format("%s/mapred-%s", super.getLogPathFragment(), getSystemTag(TAG_MAP_REDUCE_JOB_ID));
+  public String getLogPathFragment(String logBaseDir) {
+    return String.format("%s/mapred-%s", super.getLogPathFragment(logBaseDir), getSystemTag(TAG_MAP_REDUCE_JOB_ID));
   }
 }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/ProcedureLoggingContext.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/ProcedureLoggingContext.java
@@ -44,7 +44,7 @@ public class ProcedureLoggingContext extends ApplicationLoggingContext {
   }
 
   @Override
-  public String getLogPathFragment() {
-    return String.format("%s/procedure-%s", super.getLogPathFragment(), getSystemTag(TAG_PROCEDURE_ID));
+  public String getLogPathFragment(String logBaseDir) {
+    return String.format("%s/procedure-%s", super.getLogPathFragment(logBaseDir), getSystemTag(TAG_PROCEDURE_ID));
   }
 }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/SparkLoggingContext.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/SparkLoggingContext.java
@@ -43,7 +43,7 @@ public class SparkLoggingContext extends ApplicationLoggingContext {
   }
 
   @Override
-  public String getLogPathFragment() {
-    return String.format("%s/spark-%s", super.getLogPathFragment(), getSystemTag(TAG_SPARK_JOB_ID));
+  public String getLogPathFragment(String logBaseDir) {
+    return String.format("%s/spark-%s", super.getLogPathFragment(logBaseDir), getSystemTag(TAG_SPARK_JOB_ID));
   }
 }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/UserServiceLoggingContext.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/UserServiceLoggingContext.java
@@ -41,8 +41,8 @@ public class UserServiceLoggingContext extends ApplicationLoggingContext {
   }
 
   @Override
-  public String getLogPathFragment() {
-    return String.format("%s/userservice-%s", super.getLogPathFragment(), getSystemTag(TAG_USERSERVICE_ID));
+  public String getLogPathFragment(String logBaseDir) {
+    return String.format("%s/userservice-%s", super.getLogPathFragment(logBaseDir), getSystemTag(TAG_USERSERVICE_ID));
   }
 
 }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/WorkerLoggingContext.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/WorkerLoggingContext.java
@@ -37,7 +37,7 @@ public class WorkerLoggingContext extends ApplicationLoggingContext {
   }
 
   @Override
-  public String getLogPathFragment() {
-    return String.format("%s/worker-%s", super.getLogPathFragment(), getSystemTag(TAG_WORKER_ID));
+  public String getLogPathFragment(String logBaseDir) {
+    return String.format("%s/worker-%s", super.getLogPathFragment(logBaseDir), getSystemTag(TAG_WORKER_ID));
   }
 }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/LogHandler.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/LogHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -171,7 +171,7 @@ public class LogHandler extends AuthenticatedHttpHandler {
         return;
       }
 
-      LoggingContext loggingContext = LoggingContextHelper.getLoggingContext(Constants.Logging.SYSTEM_NAME, componentId,
+      LoggingContext loggingContext = LoggingContextHelper.getLoggingContext(Constants.SYSTEM_NAMESPACE, componentId,
                                                                              serviceId);
       ChunkedLogReaderCallback logCallback = new ChunkedLogReaderCallback(responder, logPattern, escape);
       logReader.getLog(loggingContext, fromTimeMs, toTimeMs, filter, logCallback);
@@ -193,7 +193,7 @@ public class LogHandler extends AuthenticatedHttpHandler {
     try {
       Filter filter = FilterParser.parse(filterStr);
 
-      LoggingContext loggingContext = LoggingContextHelper.getLoggingContext(Constants.Logging.SYSTEM_NAME, componentId,
+      LoggingContext loggingContext = LoggingContextHelper.getLoggingContext(Constants.SYSTEM_NAMESPACE, componentId,
                                                                              serviceId);
       LogReaderCallback logCallback = new LogReaderCallback(responder, logPattern, escape);
       logReader.getLogNext(loggingContext, fromOffset, maxEvents, filter, logCallback);
@@ -215,7 +215,7 @@ public class LogHandler extends AuthenticatedHttpHandler {
     try {
       Filter filter = FilterParser.parse(filterStr);
 
-      LoggingContext loggingContext = LoggingContextHelper.getLoggingContext(Constants.Logging.SYSTEM_NAME, componentId,
+      LoggingContext loggingContext = LoggingContextHelper.getLoggingContext(Constants.SYSTEM_NAMESPACE, componentId,
                                                                              serviceId);
       LogReaderCallback logCallback = new LogReaderCallback(responder, logPattern, escape);
       logReader.getLogPrev(loggingContext, fromOffset, maxEvents, filter, logCallback);

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/service/LogSaverStatusService.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/service/LogSaverStatusService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -59,7 +59,7 @@ public class LogSaverStatusService extends AbstractIdleService {
 
   @Override
   protected void startUp() throws Exception {
-    LoggingContextAccessor.setLoggingContext(new ServiceLoggingContext(Constants.Logging.SYSTEM_NAME,
+    LoggingContextAccessor.setLoggingContext(new ServiceLoggingContext(Constants.SYSTEM_NAMESPACE,
                                                                        Constants.Logging.COMPONENT_NAME,
                                                                        Constants.Service.LOGSAVER));
     httpService.startAndWait();

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/process/MetricsProcessorStatusService.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/process/MetricsProcessorStatusService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -64,7 +64,7 @@ public class MetricsProcessorStatusService extends AbstractIdleService {
 
   @Override
   protected void startUp() throws Exception {
-    LoggingContextAccessor.setLoggingContext(new ServiceLoggingContext(Constants.Logging.SYSTEM_NAME,
+    LoggingContextAccessor.setLoggingContext(new ServiceLoggingContext(Constants.SYSTEM_NAMESPACE,
                                                                        Constants.Logging.COMPONENT_NAME,
                                                                        Constants.Service.METRICS_PROCESSOR));
     httpService.startAndWait();

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/MetricsQueryService.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/MetricsQueryService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -85,7 +85,7 @@ public class MetricsQueryService extends AbstractIdleService {
 
   @Override
   protected void startUp() throws Exception {
-    LoggingContextAccessor.setLoggingContext(new ServiceLoggingContext(Constants.Logging.SYSTEM_NAME,
+    LoggingContextAccessor.setLoggingContext(new ServiceLoggingContext(Constants.SYSTEM_NAMESPACE,
                                                                        Constants.Logging.COMPONENT_NAME,
                                                                        Constants.Service.METRICS));
 

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/runtime/MetricsProcessorTwillRunnable.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/runtime/MetricsProcessorTwillRunnable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -80,7 +80,7 @@ public final class MetricsProcessorTwillRunnable extends AbstractMasterTwillRunn
       getCConfiguration().set(Constants.MetricsProcessor.ADDRESS, context.getHost().getCanonicalHostName());
       Injector injector = createGuiceInjector(getCConfiguration(), getConfiguration());
       injector.getInstance(LogAppenderInitializer.class).initialize();
-      LoggingContextAccessor.setLoggingContext(new ServiceLoggingContext(Constants.Logging.SYSTEM_NAME,
+      LoggingContextAccessor.setLoggingContext(new ServiceLoggingContext(Constants.SYSTEM_NAMESPACE,
                                                                          Constants.Logging.COMPONENT_NAME,
                                                                          Constants.Service.METRICS_PROCESSOR));
 

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/runtime/MetricsTwillRunnable.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/runtime/MetricsTwillRunnable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -73,7 +73,7 @@ public class MetricsTwillRunnable extends AbstractMasterTwillRunnable {
       Injector injector = createGuiceInjector(getCConfiguration(), getConfiguration());
       injector.getInstance(LogAppenderInitializer.class).initialize();
 
-      LoggingContextAccessor.setLoggingContext(new ServiceLoggingContext(Constants.Logging.SYSTEM_NAME,
+      LoggingContextAccessor.setLoggingContext(new ServiceLoggingContext(Constants.SYSTEM_NAMESPACE,
                                                                          Constants.Logging.COMPONENT_NAME,
                                                                          Constants.Service.METRICS));
 

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/kafka/TestKafkaLogging.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/kafka/TestKafkaLogging.java
@@ -24,7 +24,6 @@ import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.LocationRuntimeModule;
 import co.cask.cdap.common.logging.LoggingContext;
 import co.cask.cdap.common.logging.LoggingContextAccessor;
-import co.cask.cdap.data.runtime.DataSetServiceModules;
 import co.cask.cdap.data2.datafabric.dataset.InMemoryDefinitionRegistryFactory;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.InMemoryDatasetFramework;

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/write/LogCleanupTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/write/LogCleanupTest.java
@@ -24,12 +24,12 @@ import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.LocationRuntimeModule;
 import co.cask.cdap.common.io.Locations;
 import co.cask.cdap.common.logging.LoggingContext;
-import co.cask.cdap.data2.datafabric.dataset.InMemoryDefinitionRegistryFactory;
 import co.cask.cdap.data2.dataset2.DatasetDefinitionRegistryFactory;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.DefaultDatasetDefinitionRegistry;
 import co.cask.cdap.data2.dataset2.InMemoryDatasetFramework;
 import co.cask.cdap.data2.dataset2.module.lib.inmemory.InMemoryTableModule;
+import co.cask.cdap.logging.LoggingConfiguration;
 import co.cask.cdap.logging.context.FlowletLoggingContext;
 import co.cask.cdap.proto.Id;
 import co.cask.tephra.TransactionManager;
@@ -78,7 +78,7 @@ public class LogCleanupTest {
 
   private static Injector injector;
   private static TransactionManager txManager;
-
+  private static String logBaseDir;
 
   @BeforeClass
   public static void init() throws Exception {
@@ -107,6 +107,7 @@ public class LogCleanupTest {
     DatasetFramework dsFramework = injector.getInstance(DatasetFramework.class);
     dsFramework.addModule(Id.DatasetModule.from(Constants.SYSTEM_NAMESPACE_ID, "table"),
                           new InMemoryTableModule());
+    logBaseDir = injector.getInstance(CConfiguration.class).get(LoggingConfiguration.LOG_BASE_DIR);
   }
 
   @AfterClass
@@ -127,9 +128,10 @@ public class LogCleanupTest {
     LOG.info("deletionBoundary = {}", deletionBoundary);
 
     // Setup directories
-    LoggingContext dummyContext = new FlowletLoggingContext("act", "app", "flw", "flwt");
+    LoggingContext dummyContext = new FlowletLoggingContext("ns", "app", "flw", "flwt");
 
-    Location contextDir = baseDir.append("act/app/flw");
+    Location namespacedLogsDir = baseDir.append("ns").append(logBaseDir);
+    Location contextDir = namespacedLogsDir.append("app").append("flw");
     List<Location> toDelete = Lists.newArrayList();
     for (int i = 0; i < 5; ++i) {
       toDelete.add(contextDir.append("2012-12-1" + i + "/del-1"));
@@ -190,43 +192,48 @@ public class LogCleanupTest {
   public void testDeleteEmptyDir1() throws Exception {
     // Create base dir
     Location baseDir = injector.getInstance(LocationFactory.class).create(TEMP_FOLDER.newFolder().toURI());
+    // Create namespaced logs dirs
+    Location namespacedLogsDir1 = baseDir.append("ns1").append(logBaseDir);
+    Location namespacedLogsDir2 = baseDir.append("ns2").append(logBaseDir);
 
     // Create dirs with files
     Set<Location> files = Sets.newHashSet();
     Set<Location> nonEmptyDirs = Sets.newHashSet();
-    for (int i = 0; i < 5; ++i) {
-      files.add(createFile(baseDir.append(String.valueOf(i))));
+    for (int i = 0; i < 1; ++i) {
+      String name = String.valueOf(i);
+      files.add(createFile(namespacedLogsDir1.append(name)));
 
-      Location dir1 = createDir(baseDir.append("abc"));
+      Location dir1 = createDir(namespacedLogsDir1.append("abc"));
       files.add(dir1);
       nonEmptyDirs.add(dir1);
-      files.add(createFile(baseDir.append("abc/" + i)));
-      files.add(createFile(baseDir.append("abc/def/" + i)));
+      files.add(createFile(namespacedLogsDir1.append("abc").append(name)));
+      files.add(createFile(namespacedLogsDir1.append("abc").append("def").append(name)));
 
-      Location dir2 = createDir(baseDir.append("def"));
+      Location dir2 = createDir(namespacedLogsDir2.append("def"));
       files.add(dir2);
       nonEmptyDirs.add(dir2);
-      files.add(createFile(baseDir.append("def/" + i)));
-      files.add(createFile(baseDir.append("def/hij/" + i)));
+      files.add(createFile(namespacedLogsDir2.append("def").append(name)));
+      files.add(createFile(namespacedLogsDir2.append("def").append("hij").append(name)));
     }
 
     // Create empty dirs
     Set<Location> emptyDirs = Sets.newHashSet();
-    for (int i = 0; i < 5; ++i) {
-      emptyDirs.add(createDir(baseDir.append("dir_" + i)));
-      emptyDirs.add(createDir(baseDir.append("dir_" + i + "/emptyDir1")));
-      emptyDirs.add(createDir(baseDir.append("dir_" + i + "/emptyDir2")));
+    for (int i = 0; i < 1; ++i) {
+      emptyDirs.add(createDir(namespacedLogsDir1.append("dir_" + i)));
+      emptyDirs.add(createDir(namespacedLogsDir1.append("dir_" + i).append("emptyDir1")));
+      emptyDirs.add(createDir(namespacedLogsDir1.append("dir_" + i).append("emptyDir2")));
 
-      emptyDirs.add(createDir(baseDir.append("abc/dir_" + i)));
-      emptyDirs.add(createDir(baseDir.append("abc/def/dir_" + i)));
+      emptyDirs.add(createDir(namespacedLogsDir1.append("abc").append("dir_" + i)));
+      emptyDirs.add(createDir(namespacedLogsDir1.append("abc").append("def").append("dir_" + i)));
 
-      emptyDirs.add(createDir(baseDir.append("def/dir_" + i)));
-      emptyDirs.add(createDir(baseDir.append("def/hij/dir_" + i)));
+      emptyDirs.add(createDir(namespacedLogsDir2.append("def").append("dir_" + i)));
+      emptyDirs.add(createDir(namespacedLogsDir2.append("def").append("hij").append("dir_" + i)));
     }
 
     LogCleanup logCleanup = new LogCleanup(null, baseDir, RETENTION_DURATION_MS);
     for (Location location : Sets.newHashSet(Iterables.concat(nonEmptyDirs, emptyDirs))) {
-      logCleanup.deleteEmptyDir(location);
+      logCleanup.deleteEmptyDir("ns1/" + logBaseDir, location);
+      logCleanup.deleteEmptyDir("ns2/" + logBaseDir, location);
     }
 
     // Assert non-empty dirs (and their files) are still present
@@ -239,8 +246,10 @@ public class LogCleanupTest {
       Assert.assertFalse("Dir " + location.toURI() + " is still present!", location.exists());
     }
 
-    // Assert base dir exists
+    // Assert base dir and namespaced log dirs exist
     Assert.assertTrue(baseDir.exists());
+    Assert.assertTrue(namespacedLogsDir1.exists());
+    Assert.assertTrue(namespacedLogsDir2.exists());
   }
 
   @Test
@@ -251,21 +260,28 @@ public class LogCleanupTest {
 
     LogCleanup logCleanup = new LogCleanup(null, baseDir, RETENTION_DURATION_MS);
 
-    logCleanup.deleteEmptyDir(baseDir);
+    logCleanup.deleteEmptyDir("ns/" + logBaseDir, baseDir);
     // Assert base dir exists
     Assert.assertTrue(baseDir.exists());
 
-    Location rootPath = locationFactory.create("/");
-    rootPath.mkdirs();
-    Assert.assertTrue(rootPath.exists());
-    logCleanup.deleteEmptyDir(rootPath);
+    baseDir.mkdirs();
+    // Assert root exists
+    Assert.assertTrue(baseDir.exists());
+    logCleanup.deleteEmptyDir("ns/" + logBaseDir, baseDir);
     // Assert root still exists
-    Assert.assertTrue(rootPath.exists());
+    Assert.assertTrue(baseDir.exists());
+
+    Location namespaceDir = baseDir.append("ns");
+    namespaceDir.mkdirs();
+    Assert.assertTrue(namespaceDir.exists());
+    logCleanup.deleteEmptyDir("ns/" + logBaseDir, namespaceDir);
+    // Assert root still exists
+    Assert.assertTrue(namespaceDir.exists());
 
     Location tmpPath = locationFactory.create("/tmp");
     tmpPath.mkdirs();
     Assert.assertTrue(tmpPath.exists());
-    logCleanup.deleteEmptyDir(tmpPath);
+    logCleanup.deleteEmptyDir("ns/" + logBaseDir, tmpPath);
     // Assert tmp still exists
     Assert.assertTrue(tmpPath.exists());
   }


### PR DESCRIPTION
Summary:
- [x] Moved all CDAP logs under ``/<root>/[namespace]/${log.base.dir}`` directory
- [x] System services logs use **system** namespace rather than **cdap** namespace.

Impacts a large number of files only because of the change from "cdap" to "system" for system services.

Most of the functional changes are in ``AvroFileWriter`` and ``LogCleanup``.

Issue: https://issues.cask.co/browse/CDAP-1369
Build: http://builds.cask.co/browse/CDAP-DUT1025-1/
 