### PR TITLE
Use TableId for IncrementHandlerTest / IncrementSummingScannerTest

### DIFF
--- a/cdap-hbase-compat-0.94/src/test/java/co/cask/cdap/data2/increment/hbase94/IncrementSummingScannerTest.java
+++ b/cdap-hbase-compat-0.94/src/test/java/co/cask/cdap/data2/increment/hbase94/IncrementSummingScannerTest.java
@@ -16,8 +16,12 @@
 
 package co.cask.cdap.data2.increment.hbase94;
 
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.dataset2.lib.table.hbase.HBaseTable;
 import co.cask.cdap.data2.increment.hbase.IncrementHandlerState;
+import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.data2.util.hbase.HTable94NameConverter;
 import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -58,12 +62,15 @@ public class IncrementSummingScannerTest {
   private static final byte[] TRUE = Bytes.toBytes(true);
   private static HBaseTestingUtility testUtil;
   private static Configuration conf;
+  private static CConfiguration cConf;
+
 
   @BeforeClass
   public static void setupBeforeClass() throws Exception {
     testUtil = new HBaseTestingUtility();
     testUtil.startMiniCluster();
     conf = testUtil.getConfiguration();
+    cConf = CConfiguration.create();
   }
 
   @AfterClass
@@ -73,10 +80,10 @@ public class IncrementSummingScannerTest {
 
   @Test
   public void testIncrementScanning() throws Exception {
-    String tableName = "TestIncrementSummingScanner";
+    TableId tableId = TableId.from(Constants.DEFAULT_NAMESPACE, "TestIncrementSummingScanner");
     byte[] familyBytes = Bytes.toBytes("f");
     byte[] columnBytes = Bytes.toBytes("c");
-    HRegion region = createRegion(tableName, familyBytes);
+    HRegion region = createRegion(tableId, familyBytes);
     try {
       region.initialize();
 
@@ -212,10 +219,10 @@ public class IncrementSummingScannerTest {
 
   @Test
   public void testFlushAndCompact() throws Exception {
-    String tableName = "TestFlushAndCompact";
+    TableId tableId = TableId.from(Constants.DEFAULT_NAMESPACE, "TestFlushAndCompact");
     byte[] familyBytes = Bytes.toBytes("f");
     byte[] columnBytes = Bytes.toBytes("c");
-    HRegion region = createRegion(tableName, familyBytes);
+    HRegion region = createRegion(tableId, familyBytes);
     try {
       region.initialize();
 
@@ -305,10 +312,10 @@ public class IncrementSummingScannerTest {
 
   @Test
   public void testIncrementScanningWithBatchAndUVB() throws Exception {
-    String tableName = "TestIncrementSummingScannerWithUpperVisibilityBound";
+    TableId tableId = TableId.from(Constants.DEFAULT_NAMESPACE, "TestIncrementSummingScannerWithUpperVisibilityBound");
     byte[] familyBytes = Bytes.toBytes("f");
     byte[] columnBytes = Bytes.toBytes("c");
-    HRegion region = createRegion(tableName, familyBytes);
+    HRegion region = createRegion(tableId, familyBytes);
     try {
       region.initialize();
 
@@ -417,11 +424,13 @@ public class IncrementSummingScannerTest {
     assertFalse(hasMore);
   }
 
-  private HRegion createRegion(String tableName, byte[] family) throws Exception {
-    return createRegion(conf, tableName, new HColumnDescriptor(family));
+  private HRegion createRegion(TableId tableId, byte[] family) throws Exception {
+    return createRegion(conf, cConf, tableId, new HColumnDescriptor(family));
   }
 
-  static HRegion createRegion(Configuration hConf, String tableName, HColumnDescriptor cfd) throws Exception {
+  static HRegion createRegion(Configuration hConf, CConfiguration cConf, TableId tableId,
+                              HColumnDescriptor cfd) throws Exception {
+    String tableName = HTable94NameConverter.toTableName(cConf, tableId);
     HTableDescriptor htd = new HTableDescriptor(tableName);
     cfd.setMaxVersions(Integer.MAX_VALUE);
     cfd.setKeepDeletedCells(true);

--- a/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data2/increment/hbase96/IncrementHandlerTest.java
+++ b/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data2/increment/hbase96/IncrementHandlerTest.java
@@ -19,6 +19,8 @@ package co.cask.cdap.data2.increment.hbase96;
 import co.cask.cdap.data2.increment.hbase.AbstractIncrementHandlerTest;
 import co.cask.cdap.data2.increment.hbase.IncrementHandlerState;
 import co.cask.cdap.data2.increment.hbase.TimestampOracle;
+import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.data2.util.hbase.HTable96NameConverter;
 import co.cask.cdap.test.SlowTests;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
@@ -108,8 +110,8 @@ public class IncrementHandlerTest extends AbstractIncrementHandlerTest {
   }
 
   @Override
-  public void createTable(String tableName) throws Exception {
-    TableName table = TableName.valueOf(tableName);
+  public HTable createTable(TableId tableId) throws Exception {
+    TableName table = HTable96NameConverter.toTableName(cConf, tableId);
     HTableDescriptor tableDesc = new HTableDescriptor(table);
     HColumnDescriptor columnDesc = new HColumnDescriptor(FAMILY);
     columnDesc.setMaxVersions(Integer.MAX_VALUE);
@@ -117,19 +119,19 @@ public class IncrementHandlerTest extends AbstractIncrementHandlerTest {
     tableDesc.addFamily(columnDesc);
     tableDesc.addCoprocessor(IncrementHandler.class.getName());
     testUtil.getHBaseAdmin().createTable(tableDesc);
-    testUtil.waitUntilTableAvailable(Bytes.toBytes(tableName), 5000);
+    testUtil.waitUntilTableAvailable(table.getName(), 5000);
+    return new HTable(conf, table);
   }
 
   @Override
-  public RegionWrapper createRegion(String tableName, Map<String, String> familyProperties) throws Exception {
-    TableName table = TableName.valueOf(tableName);
+  public RegionWrapper createRegion(TableId tableId, Map<String, String> familyProperties) throws Exception {
     HColumnDescriptor columnDesc = new HColumnDescriptor(FAMILY);
     columnDesc.setMaxVersions(Integer.MAX_VALUE);
     for (Map.Entry<String, String> prop : familyProperties.entrySet()) {
       columnDesc.setValue(prop.getKey(), prop.getValue());
     }
     return new HBase96RegionWrapper(
-        IncrementSummingScannerTest.createRegion(testUtil.getConfiguration(), table, columnDesc));
+        IncrementSummingScannerTest.createRegion(testUtil.getConfiguration(), cConf, tableId, columnDesc));
   }
 
   public static ColumnCell convertCell(Cell cell) {

--- a/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data2/increment/hbase98/IncrementSummingScannerTest.java
+++ b/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data2/increment/hbase98/IncrementSummingScannerTest.java
@@ -16,8 +16,12 @@
 
 package co.cask.cdap.data2.increment.hbase98;
 
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.dataset2.lib.table.hbase.HBaseTable;
 import co.cask.cdap.data2.increment.hbase.IncrementHandlerState;
+import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.data2.util.hbase.HTable98NameConverter;
 import co.cask.cdap.data2.util.hbase.MockRegionServerServices;
 import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
@@ -60,12 +64,14 @@ public class IncrementSummingScannerTest {
   private static final byte[] TRUE = Bytes.toBytes(true);
   private static HBaseTestingUtility testUtil;
   private static Configuration conf;
+  private static CConfiguration cConf;
 
   @BeforeClass
   public static void setupBeforeClass() throws Exception {
     testUtil = new HBaseTestingUtility();
     testUtil.startMiniCluster();
     conf = testUtil.getConfiguration();
+    cConf = CConfiguration.create();
   }
 
   @AfterClass
@@ -75,10 +81,10 @@ public class IncrementSummingScannerTest {
 
   @Test
   public void testIncrementScanning() throws Exception {
-    TableName tableName = TableName.valueOf("TestIncrementSummingScanner");
+    TableId tableId = TableId.from(Constants.DEFAULT_NAMESPACE, "TestIncrementSummingScanner");
     byte[] familyBytes = Bytes.toBytes("f");
     byte[] columnBytes = Bytes.toBytes("c");
-    HRegion region = createRegion(tableName, familyBytes);
+    HRegion region = createRegion(tableId, familyBytes);
     try {
       region.initialize();
 
@@ -215,10 +221,10 @@ public class IncrementSummingScannerTest {
 
   @Test
   public void testFlushAndCompact() throws Exception {
-    TableName tableName = TableName.valueOf("TestFlushAndCompact");
+    TableId tableId = TableId.from(Constants.DEFAULT_NAMESPACE, "TestFlushAndCompact");
     byte[] familyBytes = Bytes.toBytes("f");
     byte[] columnBytes = Bytes.toBytes("c");
-    HRegion region = createRegion(tableName, familyBytes);
+    HRegion region = createRegion(tableId, familyBytes);
     try {
       region.initialize();
 
@@ -308,10 +314,10 @@ public class IncrementSummingScannerTest {
 
   @Test
   public void testIncrementScanningWithBatchAndUVB() throws Exception {
-    TableName tableName = TableName.valueOf("TestIncrementSummingScannerWithUpperVisibilityBound");
+    TableId tableId = TableId.from(Constants.DEFAULT_NAMESPACE, "TestIncrementSummingScannerWithUpperVisibilityBound");
     byte[] familyBytes = Bytes.toBytes("f");
     byte[] columnBytes = Bytes.toBytes("c");
-    HRegion region = createRegion(tableName, familyBytes);
+    HRegion region = createRegion(tableId, familyBytes);
     try {
       region.initialize();
 
@@ -420,11 +426,13 @@ public class IncrementSummingScannerTest {
     assertFalse(hasMore);
   }
 
-  private HRegion createRegion(TableName tableName, byte[] family) throws Exception {
-    return createRegion(conf, tableName, new HColumnDescriptor(family));
+  private HRegion createRegion(TableId tableId, byte[] family) throws Exception {
+    return createRegion(conf, cConf, tableId, new HColumnDescriptor(family));
   }
 
-  static HRegion createRegion(Configuration hConf, TableName tableName, HColumnDescriptor cfd) throws Exception {
+  static HRegion createRegion(Configuration hConf, CConfiguration cConf, TableId tableId,
+                              HColumnDescriptor cfd) throws Exception {
+    TableName tableName = HTable98NameConverter.toTableName(cConf, tableId);
     HTableDescriptor htd = new HTableDescriptor(tableName);
     cfd.setMaxVersions(Integer.MAX_VALUE);
     cfd.setKeepDeletedCells(true);
@@ -438,6 +446,6 @@ public class IncrementSummingScannerTest {
     HRegionInfo regionInfo = new HRegionInfo(tableName);
     HRegionFileSystem regionFS = HRegionFileSystem.createRegionOnFileSystem(hConf, fs, tablePath, regionInfo);
     return new HRegion(regionFS, hLog, hConf, htd,
-                                 new MockRegionServerServices(hConf, null));
+                       new MockRegionServerServices(hConf, null));
   }
 }


### PR DESCRIPTION
Need for this change arises due to the fact that the IncrementHandler coprocessor needs to read from the ConfigurationTable.
In order to do so, it needs to construct the configuration table name based off of the table the coprocessor instance is operating on, and so it needs the table prefix (which is 'cdap' by default).

In 2.7, this test case was fine, because of the following logic:
[release/2.7.0](https://github.com/caskdata/cdap/blob/release/2.7.0/cdap-data-fabric/src/main/java/co/cask/cdap/data2/increment/hbase/IncrementHandlerState.java#L78-L82)
So if it couldn't parse the root prefix, it improperly constructed the configuration table name, and so failed to talk to the ConfigurationTable.

Instead, the test cases should use a table name from which a root prefix can be computed (which this PR changes).

**Note**: The alternative to the changes in this PR is to simply use a table name such as "cdap.X", instead of just "X".

Build: http://builds.cask.co/browse/CDAP-DUT1026-4