### PR TITLE
[CDAP-870] Namespace Delete

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/ProgramRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/ProgramRuntimeService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -20,6 +20,7 @@ import co.cask.cdap.app.program.Program;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramLiveInfo;
 import co.cask.cdap.proto.ProgramType;
+import com.google.common.base.Predicate;
 import com.google.common.util.concurrent.Service;
 import org.apache.twill.api.RunId;
 
@@ -72,4 +73,14 @@ public interface ProgramRuntimeService extends Service {
    * YARN application id and the container information for each runnable. For in-memory, it may be empty.
    */
   ProgramLiveInfo getLiveInfo(Id.Program programId, ProgramType type);
+
+  /**
+   * Check if any program that satisfy the given {@link Predicate} is running.
+   * Protected only to support v2 APIs
+   *
+   * @param predicate Get call on each running {@link Id.Program}.
+   * @param types Types of program to check
+   * returns True if a program is running as defined by the predicate.
+   */
+  boolean checkAnyRunning(Predicate<Id.Program> predicate, ProgramType... types);
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/NamespaceHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/NamespaceHttpHandler.java
@@ -16,20 +16,19 @@
 
 package co.cask.cdap.gateway.handlers;
 
+import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.exception.AlreadyExistsException;
 import co.cask.cdap.common.exception.NotFoundException;
 import co.cask.cdap.gateway.auth.Authenticator;
 import co.cask.cdap.gateway.handlers.util.AbstractAppFabricHttpHandler;
 import co.cask.cdap.internal.app.namespace.NamespaceAdmin;
+import co.cask.cdap.internal.app.namespace.NamespaceCannotBeDeletedException;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.http.HttpHandler;
 import co.cask.http.HttpResponder;
 import com.google.common.base.CharMatcher;
-import com.google.common.base.Charsets;
-import com.google.common.reflect.TypeToken;
-import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 import com.google.inject.Inject;
 import org.jboss.netty.handler.codec.http.HttpRequest;
@@ -38,8 +37,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.lang.reflect.Type;
-import java.util.Map;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.PUT;
@@ -52,14 +49,14 @@ import javax.ws.rs.PathParam;
 @Path(Constants.Gateway.API_VERSION_3)
 public class NamespaceHttpHandler extends AbstractAppFabricHttpHandler {
   private static final Logger LOG = LoggerFactory.getLogger(NamespaceHttpHandler.class);
-  private static final Gson GSON = new Gson();
-  private static final Type STRING_MAP_TYPE = new TypeToken<Map<String, String>>() { }.getType();
 
+  private final CConfiguration cConf;
   private final NamespaceAdmin namespaceAdmin;
 
   @Inject
-  public NamespaceHttpHandler(Authenticator authenticator, NamespaceAdmin namespaceAdmin) {
+  public NamespaceHttpHandler(Authenticator authenticator, CConfiguration cConf, NamespaceAdmin namespaceAdmin) {
     super(authenticator);
+    this.cConf = cConf;
     this.namespaceAdmin = namespaceAdmin;
   }
 
@@ -164,13 +161,15 @@ public class NamespaceHttpHandler extends AbstractAppFabricHttpHandler {
     }
   }
 
+  /**
+   * DO NOT DOCUMENT THIS API
+   */
   @DELETE
-  @Path("/namespaces/{namespace-id}")
+  @Path("/unrecoverable/namespaces/{namespace-id}")
   public void delete(HttpRequest request, HttpResponder responder, @PathParam("namespace-id") String namespace) {
-    if (isReserved(namespace)) {
-      responder.sendString(HttpResponseStatus.FORBIDDEN,
-                           String.format("Cannot delete the namespace '%s'. '%s' is a reserved namespace.",
-                                         namespace, namespace));
+    // NOTE: DO NOT DOCUMENT
+    if (!cConf.getBoolean(Constants.Dangerous.UNRECOVERABLE_RESET, Constants.Dangerous.DEFAULT_UNRECOVERABLE_RESET)) {
+      responder.sendStatus(HttpResponseStatus.FORBIDDEN);
       return;
     }
     Id.Namespace namespaceId = Id.Namespace.from(namespace);
@@ -179,6 +178,33 @@ public class NamespaceHttpHandler extends AbstractAppFabricHttpHandler {
       responder.sendStatus(HttpResponseStatus.OK);
     } catch (NotFoundException e) {
       responder.sendString(HttpResponseStatus.NOT_FOUND, String.format("Namespace %s not found.", namespace));
+    } catch (NamespaceCannotBeDeletedException e) {
+      responder.sendString(HttpResponseStatus.FORBIDDEN, e.getMessage());
+    } catch (Exception e) {
+      LOG.error("Internal error while deleting namespace.", e);
+      responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, e.getMessage());
+    }
+  }
+
+  /**
+   * DO NOT DOCUMENT THIS API
+   */
+  @DELETE
+  @Path("/unrecoverable/namespaces/{namespace-id}/datasets")
+  public void deleteDatasets(HttpRequest request, HttpResponder responder,
+                             @PathParam("namespace-id") String namespace) {
+    if (!cConf.getBoolean(Constants.Dangerous.UNRECOVERABLE_RESET, Constants.Dangerous.DEFAULT_UNRECOVERABLE_RESET)) {
+      responder.sendStatus(HttpResponseStatus.FORBIDDEN);
+      return;
+    }
+    Id.Namespace namespaceId = Id.Namespace.from(namespace);
+    try {
+      namespaceAdmin.deleteDatasets(namespaceId);
+      responder.sendStatus(HttpResponseStatus.OK);
+    } catch (NotFoundException e) {
+      responder.sendString(HttpResponseStatus.NOT_FOUND, String.format("Namespace %s not found.", namespace));
+    } catch (NamespaceCannotBeDeletedException e) {
+      responder.sendString(HttpResponseStatus.FORBIDDEN, e.getMessage());
     } catch (Exception e) {
       LOG.error("Internal error while deleting namespace.", e);
       responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, e.getMessage());
@@ -186,7 +212,7 @@ public class NamespaceHttpHandler extends AbstractAppFabricHttpHandler {
   }
 
   private boolean isValid(String namespaceId) {
-    // TODO: This is copied from StreamVerification in app-fabric as this handler is in data-fabric module.
+    // TODO: Re-use from proto.Id
     return CharMatcher.inRange('A', 'Z')
       .or(CharMatcher.inRange('a', 'z'))
       .or(CharMatcher.is('-'))

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/NamespaceAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/NamespaceAdmin.java
@@ -72,6 +72,15 @@ public interface NamespaceAdmin {
   public void deleteNamespace(Id.Namespace namespaceId) throws NotFoundException, NamespaceCannotBeDeletedException;
 
   /**
+   * Deletes all datasets in the specified namespace
+   *
+   * @param namespaceId the {@link Id.Namespace} of the specified namespace
+   * @throws NotFoundException if the specified namespace does not exist
+   * @throws NamespaceCannotBeDeletedException if the deletion operation was unsuccessful
+   */
+  public void deleteDatasets(Id.Namespace namespaceId) throws NotFoundException, NamespaceCannotBeDeletedException;
+
+  /**
    * Update namespace properties for a given namespace.
    *
    * @param namespaceId  the {@link Id.Namespace} of the namespace to be updated

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/gateway/handlers/AppFabricDataHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/gateway/handlers/AppFabricDataHttpHandlerTest.java
@@ -16,7 +16,6 @@
 
 package co.cask.cdap.gateway.handlers;
 
-import co.cask.cdap.AppWithDataset;
 import co.cask.cdap.AppWithMR;
 import co.cask.cdap.AppWithWorker;
 import co.cask.cdap.WordCountApp;

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AppFabricTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AppFabricTestBase.java
@@ -506,10 +506,11 @@ public abstract class AppFabricTestBase {
   }
 
   private static void deleteNamespaces() throws Exception {
-    HttpResponse response = doDelete(String.format("%s/namespaces/%s", Constants.Gateway.API_VERSION_3,
+    HttpResponse response = doDelete(String.format("%s/unrecoverable/namespaces/%s", Constants.Gateway.API_VERSION_3,
                                                    TEST_NAMESPACE1));
     Assert.assertEquals(200, response.getStatusLine().getStatusCode());
-    response = doDelete(String.format("%s/namespaces/%s", Constants.Gateway.API_VERSION_3, TEST_NAMESPACE2));
+    response = doDelete(String.format("%s/unrecoverable/namespaces/%s", Constants.Gateway.API_VERSION_3,
+                                      TEST_NAMESPACE2));
     Assert.assertEquals(200, response.getStatusLine().getStatusCode());
   }
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/NamespaceHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/NamespaceHttpHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,13 +16,21 @@
 
 package co.cask.cdap.internal.app.services.http.handlers;
 
+import co.cask.cdap.AppWithDataset;
+import co.cask.cdap.AppWithServices;
+import co.cask.cdap.AppWithStreamSizeSchedule;
+import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.exception.NotFoundException;
 import co.cask.cdap.common.namespace.AbstractNamespaceClient;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.gateway.handlers.NamespaceHttpHandler;
 import co.cask.cdap.internal.app.services.http.AppFabricTestBase;
+import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceConfig;
 import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.proto.ProgramType;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
@@ -30,6 +38,8 @@ import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
 import org.apache.http.HttpResponse;
+import org.apache.twill.filesystem.Location;
+import org.apache.twill.filesystem.LocationFactory;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -57,6 +67,7 @@ public class NamespaceHttpHandlerTest extends AppFabricTestBase {
   private static final String METADATA_EMPTY_FIELDS = "{\"name\":\"\", \"description\":\"\"}";
   private static final String METADATA_INVALID_JSON = "invalid";
   private static final String INVALID_ID = "!nv@l*d/";
+  private static final String OTHER_ID = "test1";
   private static final Gson GSON = new Gson();
 
   private HttpResponse createNamespace(String id) throws Exception {
@@ -77,7 +88,11 @@ public class NamespaceHttpHandlerTest extends AppFabricTestBase {
   }
 
   private HttpResponse deleteNamespace(String name) throws Exception {
-    return doDelete(String.format("%s/namespaces/%s", Constants.Gateway.API_VERSION_3, name));
+    return doDelete(String.format("%s/unrecoverable/namespaces/%s", Constants.Gateway.API_VERSION_3, name));
+  }
+
+  private HttpResponse deleteNamespaceData(String name) throws Exception {
+    return doDelete(String.format("%s/unrecoverable/namespaces/%s/datasets", Constants.Gateway.API_VERSION_3, name));
   }
 
   private HttpResponse setProperties(String id, NamespaceMeta meta) throws Exception {
@@ -160,10 +175,16 @@ public class NamespaceHttpHandlerTest extends AppFabricTestBase {
     assertResponseCode(400, response);
     response = createNamespace(METADATA_VALID, Constants.SYSTEM_NAMESPACE);
     assertResponseCode(400, response);
+    // we allow deleting the contents in default namespace. However, the namespace itself should never be deleted
+    deploy(AppWithDataset.class, Constants.Gateway.API_VERSION_3_TOKEN, Constants.DEFAULT_NAMESPACE, "AppWithDataSet");
     response = deleteNamespace(Constants.DEFAULT_NAMESPACE);
-    assertResponseCode(403, response);
+    assertResponseCode(200, response);
+    response = getNamespace(Constants.DEFAULT_NAMESPACE);
+    Assert.assertEquals(0, getAppList(Constants.DEFAULT_NAMESPACE).size());
+    assertResponseCode(200, response);
+    // there is no system namespace
     response = deleteNamespace(Constants.SYSTEM_NAMESPACE);
-    assertResponseCode(403, response);
+    assertResponseCode(404, response);
   }
 
   @Test
@@ -222,10 +243,89 @@ public class NamespaceHttpHandlerTest extends AppFabricTestBase {
   }
 
   @Test
-  public void testDeleteMissingNamespace() throws Exception {
+  public void testDeleteAll() throws Exception {
+    CConfiguration cConf = getInjector().getInstance(CConfiguration.class);
     // test deleting non-existent namespace
-    HttpResponse response = deleteNamespace("doesnotexist");
-    assertResponseCode(404, response);
+    assertResponseCode(404, deleteNamespace("doesnotexist"));
+    assertResponseCode(200, createNamespace(ID));
+    assertResponseCode(200, getNamespace(ID));
+    assertResponseCode(200, createNamespace(OTHER_ID));
+    assertResponseCode(200, getNamespace(OTHER_ID));
+
+    LocationFactory locationFactory = getInjector().getInstance(LocationFactory.class);
+    Location nsLocation = locationFactory.create(ID);
+    Assert.assertTrue(nsLocation.exists());
+
+    DatasetFramework dsFramework = getInjector().getInstance(DatasetFramework.class);
+    StreamAdmin streamAdmin = getInjector().getInstance(StreamAdmin.class);
+
+    deploy(AppWithServices.class, Constants.Gateway.API_VERSION_3_TOKEN, ID);
+    deploy(AppWithDataset.class, Constants.Gateway.API_VERSION_3_TOKEN, ID);
+    deploy(AppWithStreamSizeSchedule.class, Constants.Gateway.API_VERSION_3_TOKEN, OTHER_ID);
+
+    Id.DatasetInstance myDataset = Id.DatasetInstance.from(ID, "myds");
+    Id.Stream myStream = Id.Stream.from(OTHER_ID, "stream");
+
+    Assert.assertTrue(dsFramework.hasInstance(myDataset));
+    Assert.assertTrue(streamAdmin.exists(myStream));
+    getRunnableStartStop(ID, "AppWithServices", ProgramType.SERVICE.getCategoryName(), "NoOpService", "start");
+    boolean resetEnabled = cConf.getBoolean(Constants.Dangerous.UNRECOVERABLE_RESET);
+    cConf.setBoolean(Constants.Dangerous.UNRECOVERABLE_RESET, false);
+    // because unrecoverable reset is disabled
+    assertResponseCode(403, deleteNamespace(ID));
+    cConf.setBoolean(Constants.Dangerous.UNRECOVERABLE_RESET, resetEnabled);
+    // because service is running
+    assertResponseCode(403, deleteNamespace(ID));
+    Assert.assertTrue(nsLocation.exists());
+    getRunnableStartStop(ID, "AppWithServices", ProgramType.SERVICE.getCategoryName(), "NoOpService", "stop");
+    // delete should work now
+    assertResponseCode(200, deleteNamespace(ID));
+    Assert.assertFalse(nsLocation.exists());
+    Assert.assertFalse(dsFramework.hasInstance(myDataset));
+    Assert.assertTrue(streamAdmin.exists(myStream));
+    assertResponseCode(200, deleteNamespace(OTHER_ID));
+    Assert.assertFalse(streamAdmin.exists(myStream));
+  }
+
+  @Test
+  public void testDeleteDatasetsOnly() throws Exception {
+    CConfiguration cConf = getInjector().getInstance(CConfiguration.class);
+    // test deleting non-existent namespace
+    assertResponseCode(200, createNamespace(ID));
+    assertResponseCode(200, getNamespace(ID));
+
+    LocationFactory locationFactory = getInjector().getInstance(LocationFactory.class);
+    Location nsLocation = locationFactory.create(ID);
+    Assert.assertTrue(nsLocation.exists());
+
+    DatasetFramework dsFramework = getInjector().getInstance(DatasetFramework.class);
+
+    deploy(AppWithServices.class, Constants.Gateway.API_VERSION_3_TOKEN, ID);
+    deploy(AppWithDataset.class, Constants.Gateway.API_VERSION_3_TOKEN, ID);
+
+    Id.DatasetInstance myDataset = Id.DatasetInstance.from(ID, "myds");
+
+    Assert.assertTrue(dsFramework.hasInstance(myDataset));
+    getRunnableStartStop(ID, "AppWithServices", ProgramType.SERVICE.getCategoryName(), "NoOpService", "start");
+    boolean resetEnabled = cConf.getBoolean(Constants.Dangerous.UNRECOVERABLE_RESET);
+    cConf.setBoolean(Constants.Dangerous.UNRECOVERABLE_RESET, false);
+    // because reset is not enabled
+    assertResponseCode(403, deleteNamespaceData(ID));
+    Assert.assertTrue(nsLocation.exists());
+    cConf.setBoolean(Constants.Dangerous.UNRECOVERABLE_RESET, resetEnabled);
+    // because service is running
+    assertResponseCode(403, deleteNamespace(ID));
+    Assert.assertTrue(nsLocation.exists());
+    getRunnableStartStop(ID, "AppWithServices", ProgramType.SERVICE.getCategoryName(), "NoOpService", "stop");
+    assertResponseCode(200, deleteNamespaceData(ID));
+    Assert.assertTrue(nsLocation.exists());
+    Assert.assertTrue(getAppList(ID).size() == 2);
+    Assert.assertTrue(getAppDetails(ID, "AppWithServices").get("name").getAsString().equals("AppWithServices"));
+    Assert.assertTrue(getAppDetails(ID, "AppWithDataSet").get("name").getAsString().equals("AppWithDataSet"));
+    assertResponseCode(200, getNamespace(ID));
+    Assert.assertFalse(dsFramework.hasInstance(myDataset));
+    assertResponseCode(200, deleteNamespace(ID));
+    assertResponseCode(404, getNamespace(ID));
   }
 
   @Test

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/NamespaceClientTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/NamespaceClientTestRun.java
@@ -54,9 +54,7 @@ public class NamespaceClientTestRun extends ClientTestBase {
   }
 
   @Test
-  public void testNamespaces() throws IOException, UnauthorizedException, CannotBeDeletedException,
-    NotFoundException, AlreadyExistsException, BadRequestException {
-
+  public void testNamespaces() throws Exception {
     List<NamespaceMeta> namespaces = namespaceClient.list();
     int initialNamespaceCount = namespaces.size();
 
@@ -69,6 +67,8 @@ public class NamespaceClientTestRun extends ClientTestBase {
     verifyDoesNotExist(DOES_NOT_EXIST);
     verifyReservedCreate();
     verifyReservedDelete();
+    // include default namespace
+    initialNamespaceCount++;
 
     // create a valid namespace
     NamespaceMeta.Builder builder = new NamespaceMeta.Builder();
@@ -146,16 +146,15 @@ public class NamespaceClientTestRun extends ClientTestBase {
     }
   }
 
-  private void verifyReservedDelete() throws NotFoundException, IOException, UnauthorizedException {
-    try {
-      namespaceClient.delete(DEFAULT.getId());
-      Assert.fail(String.format("Must not delete '%s' namespace", DEFAULT));
-    } catch (CannotBeDeletedException e) {
-    }
+  private void verifyReservedDelete() throws Exception {
+    // For the purposes of NamespaceClientTestRun, deleting default namespace has no effect.
+    // Its lifecycle is already tested in NamespaceHttpHandlerTest
+    namespaceClient.delete(DEFAULT.getId());
+    namespaceClient.get(DEFAULT.getId());
     try {
       namespaceClient.delete(SYSTEM.getId());
-      Assert.fail(String.format("Must not delete '%s' namespace", SYSTEM));
-    } catch (CannotBeDeletedException e) {
+      Assert.fail(String.format("'%s' namespace must not exist", SYSTEM));
+    } catch (NotFoundException e) {
     }
   }
 }

--- a/cdap-common/src/main/java/co/cask/cdap/common/namespace/AbstractNamespaceClient.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/namespace/AbstractNamespaceClient.java
@@ -64,7 +64,8 @@ public abstract class AbstractNamespaceClient {
 
   public void delete(String namespaceId) throws NotFoundException, CannotBeDeletedException, IOException,
     UnauthorizedException {
-    HttpResponse response = execute(HttpRequest.delete(resolve(String.format("namespaces/%s", namespaceId))).build());
+    URL url = resolve(String.format("unrecoverable/namespaces/%s", namespaceId));
+    HttpResponse response = execute(HttpRequest.delete(url).build());
     if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
       throw new NotFoundException(NAMESPACE_ENTITY_TYPE, namespaceId);
     } else if (HttpURLConnection.HTTP_FORBIDDEN == response.getResponseCode()) {

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgraderMain.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgraderMain.java
@@ -16,6 +16,7 @@
 package co.cask.cdap.data.tools;
 
 import co.cask.cdap.api.dataset.module.DatasetDefinitionRegistry;
+import co.cask.cdap.app.guice.ProgramRunnerRuntimeModule;
 import co.cask.cdap.app.store.Store;
 import co.cask.cdap.app.store.StoreFactory;
 import co.cask.cdap.common.conf.CConfiguration;
@@ -23,6 +24,7 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
 import co.cask.cdap.common.guice.LocationRuntimeModule;
+import co.cask.cdap.common.guice.TwillModule;
 import co.cask.cdap.common.guice.ZKClientModule;
 import co.cask.cdap.common.metrics.MetricsCollectionService;
 import co.cask.cdap.common.metrics.NoOpMetricsCollectionService;
@@ -30,6 +32,7 @@ import co.cask.cdap.common.utils.ProjectInfo;
 import co.cask.cdap.config.ConfigStore;
 import co.cask.cdap.config.DefaultConfigStore;
 import co.cask.cdap.data.runtime.DataFabricDistributedModule;
+import co.cask.cdap.data.stream.StreamAdminModules;
 import co.cask.cdap.data2.datafabric.dataset.DatasetMetaTableUtil;
 import co.cask.cdap.data2.datafabric.dataset.RemoteDatasetFramework;
 import co.cask.cdap.data2.datafabric.dataset.type.DatasetTypeClassLoaderFactory;
@@ -50,6 +53,7 @@ import co.cask.cdap.internal.app.store.DefaultStore;
 import co.cask.cdap.logging.save.LogSaverTableUtil;
 import co.cask.cdap.logging.write.FileMetaDataManager;
 import co.cask.cdap.metrics.store.DefaultMetricDatasetFactory;
+import co.cask.cdap.notifications.feeds.client.NotificationFeedClientModule;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.tephra.TransactionExecutorFactory;
@@ -132,6 +136,10 @@ public class UpgraderMain {
       new LocationRuntimeModule().getDistributedModules(),
       new ZKClientModule(),
       new DiscoveryRuntimeModule().getDistributedModules(),
+      new StreamAdminModules().getDistributedModules(),
+      new NotificationFeedClientModule(),
+      new TwillModule(),
+      new ProgramRunnerRuntimeModule().getDistributedModules(),
       new AbstractModule() {
         @Override
         protected void configure() {

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultApplicationManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultApplicationManager.java
@@ -17,7 +17,6 @@
 package co.cask.cdap.test.internal;
 
 import co.cask.cdap.api.schedule.ScheduleSpecification;
-import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.lang.ProgramClassLoader;
 import co.cask.cdap.common.lang.jar.BundleJarUtil;
 import co.cask.cdap.data.dataset.DatasetInstantiator;


### PR DESCRIPTION
Summary
- [x] Added ``DELETE /v3/unrecoverable/namespaces/{namespace-id}`` API to delete a namespace. This is the equivalent of today's unrecoverable reset API, for a particular namespace.
- [x] Added ``DELETE /v3/unrecoverable/namespaces/{namespace-id}/datasets`` API to delete all datasets in a namespace. This is the equivalent of today's unrecoverable reset datasets API, for a particular namespace
- [x] Both the above APIs are governed by the ``UNRECOVERABLE_RESET_ENABLED`` option.
- [x] Removed ``DELETE /v3/namespaces/{namespace-id}`` API, so as to make deletion that much harder (you need to add the unrecoverable path param and set the unrecoverable configuration).
- [x] Moved the ``checkAnyRunning`` method from ``AppLifecycleHttpHandler`` to ``ProgramRuntimeService``, so it can be used from ``NamespaceAdmin`` and any other class that needs it.
- [x] Added tests in ``NamespaceHttpHandlerTest`` to illustrate how delete is supposed to work.
- [x] The v2 unrecoverable reset API calls namespace delete (on *default* namespace) apart from a bunch of other operations that are not namespace specific. This operation clears all the CDAP data in the default namespace, however, does not percolate the delete to Hive DB or HBase namespace. It also does not delete the default namespace from the MDS.


Issues Addressed:
* [CDAP-870](https://issues.cask.co/browse/CDAP-870)
* [CDAP-1501](https://issues.cask.co/browse/CDAP-1501)

Build:
* http://builds.cask.co/browse/CDAP-DUT1027-JOB1-1/