### PR TITLE
CDAP-1682: CLI option to provide a script containing CLI commands

### DIFF
--- a/cdap-cli/src/main/java/co/cask/cdap/cli/CLIConfig.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/CLIConfig.java
@@ -96,7 +96,7 @@ public class CLIConfig {
       setSSLEnabled(connectionInfo.isSSLEnabled());
       setAccessToken(accessToken);
 
-      output.printf("Successfully connected CDAP instance at %s:%d\n",
+      output.printf("Successfully connected to CDAP instance at %s:%d\n",
                     connectionInfo.getHostname(), connectionInfo.getPort());
     } catch (IOException e) {
       throw new IOException(String.format("Host %s on port %d could not be reached: %s",

--- a/cdap-docs/reference-manual/source/cli-api.rst
+++ b/cdap-docs/reference-manual/source/cli-api.rst
@@ -73,17 +73,20 @@ Options
 The CLI may be started with command-line options, as detailed below::
 
   usage: cdap-cli.sh [--autoconnect <true|false>] [--debug] [--help]
-                     [--verify-ssl <true|false>] [--uri <arg>]
+                     [--verify-ssl <true|false>] [--uri <uri>][--script
+                     <script-file>]
    -a,--autoconnect <arg>   If "true", try provided connection (from uri)
                             upon launch or try default connection if none
                             provided. Defaults to "true".
    -d,--debug               Print exception stack traces.
    -h,--help                Print the usage message.
-   -s,--verify-ssl <arg>    If "true", verify SSL certificate when making
-                            requests. Defaults to "true".
+   -s,--script <arg>        Execute a file containing a series of CLI
+                            commands, line-by-line.
    -u,--uri <arg>           CDAP instance URI to interact with in the format
                             "[http[s]://]<hostname>[:<port>[/<namespace>]]".
                             Defaults to "http://127.0.0.1:10000/default".
+   -v,--verify-ssl <arg>    If "true", verify SSL certificate when making
+                            requests. Defaults to "true".
 
 .. _cli-available-commands:
 


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-1682

Very basic implementation. Would like some functionality to allow the user to press ENTER on each command, to control the pace. Issue for that: https://issues.cask.co/browse/CDAP-1748

Example:

```
cdap-cli.sh -s cli.script

17:45:57.796 [main] DEBUG c.c.c.s.a.c.AbstractAuthenticationClient - Try to get the authentication URI from the gateway server: http://127.0.0.1:10000/v2/ping.
17:45:57.883 [main] DEBUG c.c.c.s.a.c.AbstractAuthenticationClient - Got response 200 - OK from http://127.0.0.1:10000/v2/ping
Successfully connected CDAP instance at 127.0.0.1:10000
cdap (http://127.0.0.1:10000/default)> list apps
+=====================================================================================+
| id                                       | description                              |
+=====================================================================================+
| PurchaseHistory                          | Purchase history application.            |
+=====================================================================================+

cdap (http://127.0.0.1:10000/default)> list workflows
+========================================================================================+
| app                        | id                         | description                  |
+========================================================================================+
| PurchaseHistory            | PurchaseHistoryWorkflow    | PurchaseHistoryWorkflow desc |
|                            |                            | ription                      |
+========================================================================================+

cdap (http://127.0.0.1:10000/default)> get workflow status NoApp.NoWorkflow
Error: workflows 'NoApp/NoWorkflow' was not found

cdap (http://127.0.0.1:10000/default)> version
2.8.0-SNAPSHOT
````