### PR TITLE
Refactor HTableNameConverter

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/coprocessor/CConfigurationReader.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/coprocessor/CConfigurationReader.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.transaction.queue.hbase.coprocessor;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.data2.util.hbase.ConfigurationTable;
+import org.apache.hadoop.conf.Configuration;
+
+import java.io.IOException;
+
+/**
+ * This class helps abstract out reading of CConfiguration from {@link ConfigurationTable} from different HBase version.
+ */
+public final class CConfigurationReader {
+
+  private final ConfigurationTable configTable;
+  private final String configTablePrefix;
+
+  public CConfigurationReader(Configuration hConf, String configTablePrefix) {
+    this.configTable = new ConfigurationTable(hConf);
+    this.configTablePrefix = configTablePrefix;
+  }
+
+  public CConfiguration read() throws IOException {
+    return configTable.read(ConfigurationTable.Type.DEFAULT, configTablePrefix);
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/coprocessor/ConsumerConfigCache.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/coprocessor/ConsumerConfigCache.java
@@ -19,8 +19,6 @@ package co.cask.cdap.data2.transaction.queue.hbase.coprocessor;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.data2.transaction.queue.QueueConstants;
 import co.cask.cdap.data2.transaction.queue.QueueEntryRow;
-import co.cask.cdap.data2.util.hbase.ConfigurationTable;
-import co.cask.cdap.data2.util.hbase.HTableNameConverter;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 import org.apache.hadoop.conf.Configuration;
@@ -57,23 +55,20 @@ public class ConsumerConfigCache {
 
   private final byte[] queueConfigTableName;
   private final Configuration hConf;
+  private final CConfigurationReader cConfReader;
 
   private Thread refreshThread;
   private long lastUpdated;
   private volatile Map<byte[], QueueConsumerConfig> configCache = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
   private long configCacheUpdateFrequency = QueueConstants.DEFAULT_QUEUE_CONFIG_UPDATE_FREQUENCY;
-  private ConfigurationTable configTable;
-  // hBase namespace + namespace separator
-  private String tablePrefix;
   private CConfiguration conf;
   // timestamp of the last update from the configuration table
   private long lastConfigUpdate;
 
-  ConsumerConfigCache(Configuration hConf, byte[] queueConfigTableName, HTableNameConverter hTableNameConverter) {
+  ConsumerConfigCache(Configuration hConf, byte[] queueConfigTableName, CConfigurationReader cConfReader) {
     this.hConf = hConf;
     this.queueConfigTableName = queueConfigTableName;
-    this.tablePrefix = hTableNameConverter.getSysConfigTablePrefix(Bytes.toString(queueConfigTableName));
-    this.configTable = new ConfigurationTable(hConf);
+    this.cConfReader = cConfReader;
   }
 
   private void init() {
@@ -93,7 +88,7 @@ public class ConsumerConfigCache {
     long now = System.currentTimeMillis();
     if (this.conf == null || now > (lastConfigUpdate + CONFIG_UPDATE_FREQUENCY)) {
       try {
-        this.conf = configTable.read(ConfigurationTable.Type.DEFAULT, tablePrefix);
+        this.conf = cConfReader.read();
         if (this.conf != null) {
           LOG.info("Reloaded CConfiguration at {}", now);
           this.lastConfigUpdate = now;
@@ -207,10 +202,10 @@ public class ConsumerConfigCache {
   }
 
   public static ConsumerConfigCache getInstance(Configuration hConf, byte[] tableName,
-                                                HTableNameConverter hTableNameConverter) {
+                                                CConfigurationReader cConfReader) {
     ConsumerConfigCache cache = instances.get(tableName);
     if (cache == null) {
-      cache = new ConsumerConfigCache(hConf, tableName, hTableNameConverter);
+      cache = new ConsumerConfigCache(hConf, tableName, cConfReader);
       if (instances.putIfAbsent(tableName, cache) == null) {
         // if another thread created an instance for the same table, that's ok, we only init the one saved
         cache.init();

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HTableNameConverter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HTableNameConverter.java
@@ -115,7 +115,7 @@ public abstract class HTableNameConverter {
       return new PrefixedTableId(prefix, namespace, qualifier);
     }
 
-    // If HBase namespace is used, namespace is something like 'cdap_userNS'
+    // If non-default HBase namespace is used, namespace is something like 'cdap_userNS'
     String[] parts = namespace.split("_");
     Preconditions.checkArgument(parts.length == 2,
                                 String.format("expected hbase namespace to have a '_': %s", namespace));

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/util/hbase/AbstractHBaseTableUtilTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/util/hbase/AbstractHBaseTableUtilTest.java
@@ -72,6 +72,8 @@ public abstract class AbstractHBaseTableUtilTest {
 
   protected abstract HBaseTableUtil getTableUtil();
 
+  protected abstract HTableNameConverter getNameConverter();
+
   protected abstract String getTableNameAsString(TableId tableId);
 
   protected abstract boolean namespacesSupported();
@@ -172,26 +174,26 @@ public abstract class AbstractHBaseTableUtilTest {
     String tablePrefix = cConf.get(Constants.Dataset.TABLE_PREFIX);
     TableId tableId = TableId.from("default", "my.dataset");
     create(tableId);
-    Assert.assertEquals("default", HTableNameConverter.toHBaseNamespace(tablePrefix, tableId.getNamespace()));
+    Assert.assertEquals("default", getNameConverter().toHBaseNamespace(tablePrefix, tableId.getNamespace()));
     Assert.assertEquals("cdap.user.my.dataset",
-                        HTableNameConverter.getHBaseTableName(tablePrefix, tableId));
+                        getNameConverter().getHBaseTableName(tablePrefix, tableId));
     Assert.assertEquals(getTableNameAsString(tableId),
                         Bytes.toString(tableUtil.createHTable(testHBase.getConfiguration(), tableId).getTableName()));
     drop(tableId);
     tableId = TableId.from("default", "system.queue.config");
     create(tableId);
-    Assert.assertEquals("default", HTableNameConverter.toHBaseNamespace(tablePrefix, tableId.getNamespace()));
+    Assert.assertEquals("default", getNameConverter().toHBaseNamespace(tablePrefix, tableId.getNamespace()));
     Assert.assertEquals("cdap.system.queue.config",
-                        HTableNameConverter.getHBaseTableName(tablePrefix, tableId));
+                        getNameConverter().getHBaseTableName(tablePrefix, tableId));
     Assert.assertEquals(getTableNameAsString(tableId),
                         Bytes.toString(tableUtil.createHTable(testHBase.getConfiguration(), tableId).getTableName()));
     drop(tableId);
     tableId = TableId.from("myspace", "could.be.any.table.name");
     createNamespace("myspace");
     create(tableId);
-    Assert.assertEquals("cdap_myspace", HTableNameConverter.toHBaseNamespace(tablePrefix, tableId.getNamespace()));
+    Assert.assertEquals("cdap_myspace", getNameConverter().toHBaseNamespace(tablePrefix, tableId.getNamespace()));
     Assert.assertEquals("could.be.any.table.name",
-                        HTableNameConverter.getHBaseTableName(tablePrefix, tableId));
+                        getNameConverter().getHBaseTableName(tablePrefix, tableId));
     Assert.assertEquals(getTableNameAsString(tableId),
                         Bytes.toString(tableUtil.createHTable(testHBase.getConfiguration(), tableId).getTableName()));
     drop(tableId);

--- a/cdap-hbase-compat-0.94/src/main/java/co/cask/cdap/data2/increment/hbase94/IncrementHandler.java
+++ b/cdap-hbase-compat-0.94/src/main/java/co/cask/cdap/data2/increment/hbase94/IncrementHandler.java
@@ -23,8 +23,6 @@ import co.cask.cdap.data2.util.hbase.HTable94NameConverter;
 import co.cask.tephra.hbase94.Filters;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.hbase.CoprocessorEnvironment;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
@@ -69,7 +67,6 @@ import java.util.TreeMap;
  * all the successfully committed delta values.</p>
  */
 public class IncrementHandler extends BaseRegionObserver {
-  private static final Log LOG = LogFactory.getLog(IncrementHandler.class);
 
   private HRegion region;
   private IncrementHandlerState state;
@@ -79,7 +76,8 @@ public class IncrementHandler extends BaseRegionObserver {
     if (e instanceof RegionCoprocessorEnvironment) {
       RegionCoprocessorEnvironment env = (RegionCoprocessorEnvironment) e;
       this.region = ((RegionCoprocessorEnvironment) e).getRegion();
-      this.state = new IncrementHandlerState(env.getConfiguration(), env.getRegion().getTableDesc().getNameAsString(),
+      this.state = new IncrementHandlerState(env.getConfiguration(),
+                                             env.getRegion().getTableDesc(),
                                              new HTable94NameConverter());
 
       HTableDescriptor tableDesc = env.getRegion().getTableDesc();

--- a/cdap-hbase-compat-0.94/src/main/java/co/cask/cdap/data2/transaction/coprocessor/hbase94/DefaultTransactionProcessor.java
+++ b/cdap-hbase-compat-0.94/src/main/java/co/cask/cdap/data2/transaction/coprocessor/hbase94/DefaultTransactionProcessor.java
@@ -37,8 +37,7 @@ public class DefaultTransactionProcessor extends TransactionProcessor {
 
   @Override
   protected Supplier<TransactionStateCache> getTransactionStateCacheSupplier(RegionCoprocessorEnvironment env) {
-    String sysConfigTablePrefix
-      = new HTable94NameConverter().getSysConfigTablePrefix(env.getRegion().getTableDesc().getNameAsString());
+    String sysConfigTablePrefix = new HTable94NameConverter().getSysConfigTablePrefix(env.getRegion().getTableDesc());
     return new DefaultTransactionStateCacheSupplier(sysConfigTablePrefix, env.getConfiguration());
   }
 

--- a/cdap-hbase-compat-0.94/src/main/java/co/cask/cdap/data2/util/hbase/HBase94TableUtil.java
+++ b/cdap-hbase-compat-0.94/src/main/java/co/cask/cdap/data2/util/hbase/HBase94TableUtil.java
@@ -48,23 +48,25 @@ import java.util.Map;
  */
 public class HBase94TableUtil extends HBaseTableUtil {
 
+  private final HTable94NameConverter nameConverter = new HTable94NameConverter();
+
   @Override
   public HTable createHTable(Configuration conf, TableId tableId) throws IOException {
     Preconditions.checkArgument(tableId != null, "Table id should not be null");
-    return new HTable(conf, HTable94NameConverter.toTableName(tablePrefix, tableId));
+    return new HTable(conf, nameConverter.toTableName(tablePrefix, tableId));
   }
 
   @Override
   public HTableDescriptor createHTableDescriptor(TableId tableId) {
     Preconditions.checkArgument(tableId != null, "Table id should not be null");
-    return new HTableDescriptor(HTable94NameConverter.toTableName(tablePrefix, tableId));
+    return new HTableDescriptor(nameConverter.toTableName(tablePrefix, tableId));
   }
 
   @Override
   public HTableDescriptor getHTableDescriptor(HBaseAdmin admin, TableId tableId) throws IOException {
     Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
     Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    return admin.getTableDescriptor(Bytes.toBytes(HTable94NameConverter.toTableName(tablePrefix, tableId)));
+    return admin.getTableDescriptor(Bytes.toBytes(nameConverter.toTableName(tablePrefix, tableId)));
   }
 
   @Override
@@ -86,28 +88,28 @@ public class HBase94TableUtil extends HBaseTableUtil {
   public void disableTable(HBaseAdmin admin, TableId tableId) throws IOException {
     Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
     Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    admin.disableTable(HTable94NameConverter.toTableName(tablePrefix, tableId));
+    admin.disableTable(nameConverter.toTableName(tablePrefix, tableId));
   }
 
   @Override
   public void enableTable(HBaseAdmin admin, TableId tableId) throws IOException {
     Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
     Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    admin.enableTable(HTable94NameConverter.toTableName(tablePrefix, tableId));
+    admin.enableTable(nameConverter.toTableName(tablePrefix, tableId));
   }
 
   @Override
   public boolean tableExists(HBaseAdmin admin, TableId tableId) throws IOException {
     Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
     Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    return admin.tableExists(HTable94NameConverter.toTableName(tablePrefix, tableId));
+    return admin.tableExists(nameConverter.toTableName(tablePrefix, tableId));
   }
 
   @Override
   public void deleteTable(HBaseAdmin admin, TableId tableId) throws IOException {
     Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
     Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    admin.deleteTable(HTable94NameConverter.toTableName(tablePrefix, tableId));
+    admin.deleteTable(nameConverter.toTableName(tablePrefix, tableId));
   }
 
   @Override
@@ -121,7 +123,7 @@ public class HBase94TableUtil extends HBaseTableUtil {
   public List<HRegionInfo> getTableRegions(HBaseAdmin admin, TableId tableId) throws IOException {
     Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
     Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    return admin.getTableRegions(Bytes.toBytes(HTable94NameConverter.toTableName(tablePrefix, tableId)));
+    return admin.getTableRegions(Bytes.toBytes(nameConverter.toTableName(tablePrefix, tableId)));
   }
 
   @Override
@@ -141,8 +143,7 @@ public class HBase94TableUtil extends HBaseTableUtil {
     HTableDescriptor[] hTableDescriptors = admin.listTables();
     for (HTableDescriptor hTableDescriptor : hTableDescriptors) {
       if (isCDAPTable(hTableDescriptor)) {
-        String hTableName = hTableDescriptor.getNameAsString();
-        tableIds.add(HTable94NameConverter.fromTableName(hTableName));
+        tableIds.add(nameConverter.from(hTableDescriptor));
       }
     }
     return tableIds;

--- a/cdap-hbase-compat-0.94/src/main/java/co/cask/cdap/data2/util/hbase/HTable94NameConverter.java
+++ b/cdap-hbase-compat-0.94/src/main/java/co/cask/cdap/data2/util/hbase/HTable94NameConverter.java
@@ -16,53 +16,48 @@
 
 package co.cask.cdap.data2.util.hbase;
 
-import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.util.TableId;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
+import org.apache.hadoop.hbase.HTableDescriptor;
 
 /**
  * Utility methods for dealing with HBase table name conversions in HBase 0.94.
  */
 public class HTable94NameConverter extends HTableNameConverter {
   @Override
-  public String getSysConfigTablePrefix(String hTableName) {
-    return getHbaseNamespacePrefix(hTableName) + "_" + Constants.SYSTEM_NAMESPACE + ".";
+  public String getSysConfigTablePrefix(HTableDescriptor htd) {
+    return getNamespacePrefix(htd) + "_" + Constants.SYSTEM_NAMESPACE + ".";
   }
 
   @Override
-  public TableId from(String hTableName) {
-    return fromTableName(hTableName);
+  public TableId from(HTableDescriptor htd) {
+    return prefixedTableIdFromTableName(htd.getNameAsString()).getTableId();
   }
 
-  public static String toTableName(CConfiguration cConf, TableId tableId) {
-    String tablePrefix = cConf.get(Constants.Dataset.TABLE_PREFIX);
-    return toTableName(tablePrefix, tableId);
+  @Override
+  public String getNamespacePrefix(HTableDescriptor htd) {
+    return prefixedTableIdFromTableName(htd.getNameAsString()).getTablePrefix();
   }
 
-  public static String toTableName(String tablePrefix, TableId tableId) {
+  /**
+   * Returns the actual HBase table name.
+   */
+  public String toTableName(String namespacePrefix, TableId tableId) {
     Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
     // backward compatibility
     if (Constants.DEFAULT_NAMESPACE_ID.equals(tableId.getNamespace())) {
-      return getHBaseTableName(tablePrefix, tableId);
+      return getHBaseTableName(namespacePrefix, tableId);
     }
-    return Joiner.on(".").join(toHBaseNamespace(tablePrefix, tableId.getNamespace()),
-                               getHBaseTableName(tablePrefix, tableId));
-  }
-
-  public static TableId fromTableName(String hTableName) {
-    return prefixedTableIdFromTableName(hTableName).getTableId();
-  }
-
-  public static String getHbaseNamespacePrefix(String hTableName) {
-    return prefixedTableIdFromTableName(hTableName).getTablePrefix();
+    return Joiner.on(".").join(toHBaseNamespace(namespacePrefix, tableId.getNamespace()),
+                               getHBaseTableName(namespacePrefix, tableId));
   }
 
   // Assumptions made:
   // 1) root prefix can not have '.' or '_'.
   // 2) namespace can not have '.'
-  private static PrefixedTableId prefixedTableIdFromTableName(String hTableName) {
+  private PrefixedTableId prefixedTableIdFromTableName(String hTableName) {
     Preconditions.checkArgument(hTableName != null, "HBase table name should not be null.");
     String[] parts = hTableName.split("\\.", 2);
     String hBaseNamespace;
@@ -75,6 +70,6 @@ public class HTable94NameConverter extends HTableNameConverter {
       hBaseNamespace = parts[0];
       hBaseQualifier = parts[1];
     }
-    return HTableNameConverter.from(hBaseNamespace, hBaseQualifier);
+    return fromHBaseTableName(hBaseNamespace, hBaseQualifier);
   }
 }

--- a/cdap-hbase-compat-0.94/src/test/java/co/cask/cdap/data2/util/hbase/HBase94TableUtilTest.java
+++ b/cdap-hbase-compat-0.94/src/test/java/co/cask/cdap/data2/util/hbase/HBase94TableUtilTest.java
@@ -29,6 +29,8 @@ import org.junit.experimental.categories.Category;
 @Category(XSlowTests.class)
 public class HBase94TableUtilTest extends AbstractHBaseTableUtilTest {
 
+  private final HTableNameConverter nameConverter = new HTable94NameConverter();
+
   @Override
   protected HBaseTableUtil getTableUtil() {
     HBase94TableUtil hBaseTableUtil = new HBase94TableUtil();
@@ -37,14 +39,19 @@ public class HBase94TableUtilTest extends AbstractHBaseTableUtilTest {
   }
 
   @Override
+  protected HTableNameConverter getNameConverter() {
+    return nameConverter;
+  }
+
+  @Override
   protected String getTableNameAsString(TableId tableId) {
     Preconditions.checkArgument(tableId != null, "TableId should not be null.");
     String tablePrefix = cConf.get(Constants.Dataset.TABLE_PREFIX);
     if (Constants.DEFAULT_NAMESPACE_ID.equals(tableId.getNamespace())) {
-      return HTableNameConverter.getHBaseTableName(tablePrefix, tableId);
+      return nameConverter.getHBaseTableName(tablePrefix, tableId);
     }
-    return Joiner.on(".").join(HTableNameConverter.toHBaseNamespace(tablePrefix, tableId.getNamespace()),
-                               HTableNameConverter.getHBaseTableName(tablePrefix, tableId));
+    return Joiner.on(".").join(nameConverter.toHBaseNamespace(tablePrefix, tableId.getNamespace()),
+                               nameConverter.getHBaseTableName(tablePrefix, tableId));
   }
 
   @Override

--- a/cdap-hbase-compat-0.94/src/test/java/co/cask/cdap/data2/util/hbase/HTable94NameConverterTest.java
+++ b/cdap-hbase-compat-0.94/src/test/java/co/cask/cdap/data2/util/hbase/HTable94NameConverterTest.java
@@ -16,14 +16,25 @@
 
 package co.cask.cdap.data2.util.hbase;
 
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.data2.util.TableId;
+import org.apache.hadoop.hbase.HTableDescriptor;
 import org.junit.Assert;
 import org.junit.Test;
 
 public class HTable94NameConverterTest {
   @Test
   public void testGetSysConfigTablePrefix() throws Exception {
-    HTable94NameConverter hBaseNameConversionUtil = new HTable94NameConverter();
-    Assert.assertEquals("cdap_system.", hBaseNameConversionUtil.getSysConfigTablePrefix("cdap_user.some_table"));
-    Assert.assertEquals("cdap_system.", hBaseNameConversionUtil.getSysConfigTablePrefix("cdap.table_in_default_ns"));
+    CConfiguration cConf = CConfiguration.create();
+    String tablePrefix = cConf.get(Constants.Dataset.TABLE_PREFIX);
+
+    HBaseTableUtil tableUtil = new HBaseTableUtilFactory(cConf).get();
+    HTableNameConverter hBaseNameConversionUtil = new HTableNameConverterFactory().get();
+
+    HTableDescriptor htd = tableUtil.createHTableDescriptor(TableId.from("user", "some_table"));
+    Assert.assertEquals(tablePrefix + "_system.", hBaseNameConversionUtil.getSysConfigTablePrefix(htd));
+    htd = tableUtil.createHTableDescriptor(TableId.from(Constants.DEFAULT_NAMESPACE_ID, "table_in_default_ns"));
+    Assert.assertEquals(tablePrefix + "_system.", hBaseNameConversionUtil.getSysConfigTablePrefix(htd));
   }
 }

--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/increment/hbase96/IncrementHandler.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/increment/hbase96/IncrementHandler.java
@@ -23,8 +23,6 @@ import co.cask.cdap.data2.util.hbase.HTable96NameConverter;
 import co.cask.tephra.hbase96.Filters;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.CoprocessorEnvironment;
@@ -71,7 +69,6 @@ import java.util.TreeMap;
  * all the successfully committed delta values.</p>
  */
 public class IncrementHandler extends BaseRegionObserver {
-  private static final Log LOG = LogFactory.getLog(IncrementHandler.class);
 
   private HRegion region;
   private IncrementHandlerState state;
@@ -81,7 +78,8 @@ public class IncrementHandler extends BaseRegionObserver {
     if (e instanceof RegionCoprocessorEnvironment) {
       RegionCoprocessorEnvironment env = (RegionCoprocessorEnvironment) e;
       this.region = ((RegionCoprocessorEnvironment) e).getRegion();
-      this.state = new IncrementHandlerState(env.getConfiguration(), env.getRegion().getTableDesc().getNameAsString(),
+      this.state = new IncrementHandlerState(env.getConfiguration(),
+                                             env.getRegion().getTableDesc(),
                                              new HTable96NameConverter());
 
       HTableDescriptor tableDesc = env.getRegion().getTableDesc();

--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/transaction/coprocessor/hbase96/DefaultTransactionProcessor.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/transaction/coprocessor/hbase96/DefaultTransactionProcessor.java
@@ -36,8 +36,7 @@ import org.apache.hadoop.hbase.regionserver.ScanType;
 public class DefaultTransactionProcessor extends TransactionProcessor {
   @Override
   protected Supplier<TransactionStateCache> getTransactionStateCacheSupplier(RegionCoprocessorEnvironment env) {
-    String sysConfigTablePrefix
-      = new HTable96NameConverter().getSysConfigTablePrefix(env.getRegion().getTableDesc().getNameAsString());
+    String sysConfigTablePrefix = new HTable96NameConverter().getSysConfigTablePrefix(env.getRegion().getTableDesc());
     return new DefaultTransactionStateCacheSupplier(sysConfigTablePrefix, env.getConfiguration());
   }
 

--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/util/hbase/HBase96TableUtil.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/util/hbase/HBase96TableUtil.java
@@ -49,23 +49,25 @@ import java.util.Map;
  */
 public class HBase96TableUtil extends HBaseTableUtil {
 
+  private final HTable96NameConverter nameConverter = new HTable96NameConverter();
+
   @Override
   public HTable createHTable(Configuration conf, TableId tableId) throws IOException {
     Preconditions.checkArgument(tableId != null, "Table id should not be null");
-    return new HTable(conf, HTable96NameConverter.toTableName(tablePrefix, tableId));
+    return new HTable(conf, nameConverter.toTableName(tablePrefix, tableId));
   }
 
   @Override
   public HTableDescriptor createHTableDescriptor(TableId tableId) {
     Preconditions.checkArgument(tableId != null, "Table id should not be null");
-    return new HTableDescriptor(HTable96NameConverter.toTableName(tablePrefix, tableId));
+    return new HTableDescriptor(nameConverter.toTableName(tablePrefix, tableId));
   }
 
   @Override
   public HTableDescriptor getHTableDescriptor(HBaseAdmin admin, TableId tableId) throws IOException {
     Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
     Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    return admin.getTableDescriptor(HTable96NameConverter.toTableName(tablePrefix, tableId));
+    return admin.getTableDescriptor(nameConverter.toTableName(tablePrefix, tableId));
   }
 
   @Override
@@ -73,7 +75,7 @@ public class HBase96TableUtil extends HBaseTableUtil {
     Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
     Preconditions.checkArgument(namespace != null, "Namespace should not be null.");
     try {
-      admin.getNamespaceDescriptor(HTableNameConverter.toHBaseNamespace(tablePrefix, namespace));
+      admin.getNamespaceDescriptor(nameConverter.toHBaseNamespace(tablePrefix, namespace));
       return true;
     } catch (NamespaceNotFoundException e) {
       return false;
@@ -86,7 +88,7 @@ public class HBase96TableUtil extends HBaseTableUtil {
     Preconditions.checkArgument(namespace != null, "Namespace should not be null.");
     if (!hasNamespace(admin, namespace)) {
       NamespaceDescriptor namespaceDescriptor =
-        NamespaceDescriptor.create(HTableNameConverter.toHBaseNamespace(tablePrefix, namespace)).build();
+        NamespaceDescriptor.create(nameConverter.toHBaseNamespace(tablePrefix, namespace)).build();
       admin.createNamespace(namespaceDescriptor);
     }
   }
@@ -96,7 +98,7 @@ public class HBase96TableUtil extends HBaseTableUtil {
     Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
     Preconditions.checkArgument(namespace != null, "Namespace should not be null.");
     if (hasNamespace(admin, namespace)) {
-      admin.deleteNamespace(HTableNameConverter.toHBaseNamespace(tablePrefix, namespace));
+      admin.deleteNamespace(nameConverter.toHBaseNamespace(tablePrefix, namespace));
     }
   }
 
@@ -104,28 +106,28 @@ public class HBase96TableUtil extends HBaseTableUtil {
   public void disableTable(HBaseAdmin admin, TableId tableId) throws IOException {
     Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
     Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    admin.disableTable(HTable96NameConverter.toTableName(tablePrefix, tableId));
+    admin.disableTable(nameConverter.toTableName(tablePrefix, tableId));
   }
 
   @Override
   public void enableTable(HBaseAdmin admin, TableId tableId) throws IOException {
     Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
     Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    admin.enableTable(HTable96NameConverter.toTableName(tablePrefix, tableId));
+    admin.enableTable(nameConverter.toTableName(tablePrefix, tableId));
   }
 
   @Override
   public boolean tableExists(HBaseAdmin admin, TableId tableId) throws IOException {
     Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
     Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    return admin.tableExists(HTable96NameConverter.toTableName(tablePrefix, tableId));
+    return admin.tableExists(nameConverter.toTableName(tablePrefix, tableId));
   }
 
   @Override
   public void deleteTable(HBaseAdmin admin, TableId tableId) throws IOException {
     Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
     Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    admin.deleteTable(HTable96NameConverter.toTableName(tablePrefix, tableId));
+    admin.deleteTable(nameConverter.toTableName(tablePrefix, tableId));
   }
 
   @Override
@@ -139,17 +141,17 @@ public class HBase96TableUtil extends HBaseTableUtil {
   public List<HRegionInfo> getTableRegions(HBaseAdmin admin, TableId tableId) throws IOException {
     Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
     Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    return admin.getTableRegions(HTable96NameConverter.toTableName(tablePrefix, tableId));
+    return admin.getTableRegions(nameConverter.toTableName(tablePrefix, tableId));
   }
 
   @Override
   public List<TableId> listTablesInNamespace(HBaseAdmin admin, Id.Namespace namespaceId) throws IOException {
     List<TableId> tableIds = Lists.newArrayList();
     HTableDescriptor[] hTableDescriptors =
-      admin.listTableDescriptorsByNamespace(HTableNameConverter.toHBaseNamespace(tablePrefix, namespaceId));
+      admin.listTableDescriptorsByNamespace(nameConverter.toHBaseNamespace(tablePrefix, namespaceId));
     for (HTableDescriptor hTableDescriptor : hTableDescriptors) {
       if (isCDAPTable(hTableDescriptor)) {
-        tableIds.add(HTable96NameConverter.fromTableName(hTableDescriptor.getTableName()));
+        tableIds.add(nameConverter.from(hTableDescriptor));
       }
     }
     return tableIds;
@@ -161,7 +163,7 @@ public class HBase96TableUtil extends HBaseTableUtil {
     HTableDescriptor[] hTableDescriptors = admin.listTables();
     for (HTableDescriptor hTableDescriptor : hTableDescriptors) {
       if (isCDAPTable(hTableDescriptor)) {
-        tableIds.add(HTable96NameConverter.fromTableName(hTableDescriptor.getTableName()));
+        tableIds.add(nameConverter.from(hTableDescriptor));
       }
     }
     return tableIds;

--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/util/hbase/HTable96NameConverter.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/util/hbase/HTable96NameConverter.java
@@ -16,44 +16,37 @@
 
 package co.cask.cdap.data2.util.hbase;
 
-import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.util.TableId;
+import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.TableName;
 
 /**
  * Utility methods for dealing with HBase table name conversions in HBase 0.96.
  */
 public class HTable96NameConverter extends HTableNameConverter {
-  @Override
-  public String getSysConfigTablePrefix(String hTableName) {
-    return getHbaseNamespacePrefix(TableName.valueOf(hTableName)) + "_" + Constants.SYSTEM_NAMESPACE + ":";
-  }
 
   @Override
-  public TableId from(String hTableName) {
-    return fromTableName(TableName.valueOf(hTableName));
+  public String getSysConfigTablePrefix(HTableDescriptor htd) {
+    return getNamespacePrefix(htd) + "_" + Constants.SYSTEM_NAMESPACE + ":";
   }
 
-  public static TableName toTableName(CConfiguration cConf, TableId tableId) {
-    String tablePrefix = cConf.get(Constants.Dataset.TABLE_PREFIX);
-    return toTableName(tablePrefix, tableId);
+  @Override
+  public TableId from(HTableDescriptor htd) {
+    return prefixedTableIdFromTableName(htd.getTableName()).getTableId();
   }
 
-  public static TableName toTableName(String tablePrefix, TableId tableId) {
+  @Override
+  public String getNamespacePrefix(HTableDescriptor htd) {
+    return prefixedTableIdFromTableName(htd.getTableName()).getTablePrefix();
+  }
+
+  public TableName toTableName(String tablePrefix, TableId tableId) {
     return TableName.valueOf(toHBaseNamespace(tablePrefix, tableId.getNamespace()),
                              getHBaseTableName(tablePrefix, tableId));
   }
 
-  public static TableId fromTableName(TableName tableName) {
-    return prefixedTableIdFromTableName(tableName).getTableId();
-  }
-
-  public static String getHbaseNamespacePrefix(TableName tableName) {
-    return prefixedTableIdFromTableName(tableName).getTablePrefix();
-  }
-
-  private static PrefixedTableId prefixedTableIdFromTableName(TableName tableName) {
-    return HTableNameConverter.from(tableName.getNamespaceAsString(), tableName.getQualifierAsString());
+  private PrefixedTableId prefixedTableIdFromTableName(TableName tableName) {
+    return fromHBaseTableName(tableName.getNamespaceAsString(), tableName.getQualifierAsString());
   }
 }

--- a/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data2/increment/hbase96/IncrementHandlerTest.java
+++ b/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data2/increment/hbase96/IncrementHandlerTest.java
@@ -20,14 +20,14 @@ import co.cask.cdap.data2.increment.hbase.AbstractIncrementHandlerTest;
 import co.cask.cdap.data2.increment.hbase.IncrementHandlerState;
 import co.cask.cdap.data2.increment.hbase.TimestampOracle;
 import co.cask.cdap.data2.util.TableId;
-import co.cask.cdap.data2.util.hbase.HTable96NameConverter;
+import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
+import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
 import co.cask.cdap.test.SlowTests;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.Coprocessor;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
-import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.HTable;
 import org.apache.hadoop.hbase.client.Put;
@@ -111,16 +111,16 @@ public class IncrementHandlerTest extends AbstractIncrementHandlerTest {
 
   @Override
   public HTable createTable(TableId tableId) throws Exception {
-    TableName table = HTable96NameConverter.toTableName(cConf, tableId);
-    HTableDescriptor tableDesc = new HTableDescriptor(table);
+    HBaseTableUtil tableUtil = new HBaseTableUtilFactory(cConf).get();
+    HTableDescriptor tableDesc = tableUtil.createHTableDescriptor(tableId);
     HColumnDescriptor columnDesc = new HColumnDescriptor(FAMILY);
     columnDesc.setMaxVersions(Integer.MAX_VALUE);
     columnDesc.setValue(IncrementHandlerState.PROPERTY_TRANSACTIONAL, "false");
     tableDesc.addFamily(columnDesc);
     tableDesc.addCoprocessor(IncrementHandler.class.getName());
     testUtil.getHBaseAdmin().createTable(tableDesc);
-    testUtil.waitUntilTableAvailable(table.getName(), 5000);
-    return new HTable(conf, table);
+    testUtil.waitUntilTableAvailable(tableDesc.getName(), 5000);
+    return tableUtil.createHTable(conf, tableId);
   }
 
   @Override

--- a/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data2/util/hbase/HBase96TableUtilTest.java
+++ b/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data2/util/hbase/HBase96TableUtilTest.java
@@ -29,6 +29,8 @@ import org.junit.experimental.categories.Category;
 @Category(XSlowTests.class)
 public class HBase96TableUtilTest extends AbstractHBaseTableUtilTest {
 
+  private final HTableNameConverter nameConverter = new HTable96NameConverter();
+
   @Override
   protected HBaseTableUtil getTableUtil() {
     HBase96TableUtil hBaseTableUtil = new HBase96TableUtil();
@@ -37,14 +39,19 @@ public class HBase96TableUtilTest extends AbstractHBaseTableUtilTest {
   }
 
   @Override
+  protected HTableNameConverter getNameConverter() {
+    return nameConverter;
+  }
+
+  @Override
   protected String getTableNameAsString(TableId tableId) {
     Preconditions.checkArgument(tableId != null, "TableId should not be null.");
     String tablePrefix = cConf.get(Constants.Dataset.TABLE_PREFIX);
     if (Constants.DEFAULT_NAMESPACE_ID.equals(tableId.getNamespace())) {
-      return HTableNameConverter.getHBaseTableName(tablePrefix, tableId);
+      return nameConverter.getHBaseTableName(tablePrefix, tableId);
     }
-    return Joiner.on(':').join(HTableNameConverter.toHBaseNamespace(tablePrefix, tableId.getNamespace()),
-                               HTableNameConverter.getHBaseTableName(tablePrefix, tableId));
+    return Joiner.on(':').join(nameConverter.toHBaseNamespace(tablePrefix, tableId.getNamespace()),
+                               nameConverter.getHBaseTableName(tablePrefix, tableId));
   }
 
   @Override

--- a/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data2/util/hbase/HTable96NameConverterTest.java
+++ b/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data2/util/hbase/HTable96NameConverterTest.java
@@ -16,14 +16,25 @@
 
 package co.cask.cdap.data2.util.hbase;
 
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.data2.util.TableId;
+import org.apache.hadoop.hbase.HTableDescriptor;
 import org.junit.Assert;
 import org.junit.Test;
 
 public class HTable96NameConverterTest {
   @Test
   public void testGetSysConfigTablePrefix() throws Exception {
-    HTable96NameConverter hBaseNameConversionUtil = new HTable96NameConverter();
-    Assert.assertEquals("cdap_system:", hBaseNameConversionUtil.getSysConfigTablePrefix("cdap_user:some_table"));
-    Assert.assertEquals("cdap_system:", hBaseNameConversionUtil.getSysConfigTablePrefix("cdap.table_in_default_ns"));
+    CConfiguration cConf = CConfiguration.create();
+    String tablePrefix = cConf.get(Constants.Dataset.TABLE_PREFIX);
+
+    HBaseTableUtil tableUtil = new HBaseTableUtilFactory(cConf).get();
+    HTableNameConverter hBaseNameConversionUtil = new HTableNameConverterFactory().get();
+
+    HTableDescriptor htd = tableUtil.createHTableDescriptor(TableId.from("user", "some_table"));
+    Assert.assertEquals(tablePrefix + "_system:", hBaseNameConversionUtil.getSysConfigTablePrefix(htd));
+    htd = tableUtil.createHTableDescriptor(TableId.from(Constants.DEFAULT_NAMESPACE_ID, "table_in_default_ns"));
+    Assert.assertEquals(tablePrefix + "_system:", hBaseNameConversionUtil.getSysConfigTablePrefix(htd));
   }
 }

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/increment/hbase98/IncrementHandler.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/increment/hbase98/IncrementHandler.java
@@ -23,8 +23,6 @@ import co.cask.cdap.data2.util.hbase.HTable98NameConverter;
 import co.cask.tephra.hbase98.Filters;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.CoprocessorEnvironment;
@@ -71,7 +69,6 @@ import java.util.TreeMap;
  * all the successfully committed delta values.</p>
  */
 public class IncrementHandler extends BaseRegionObserver {
-  private static final Log LOG = LogFactory.getLog(IncrementHandler.class);
 
   private HRegion region;
   private IncrementHandlerState state;
@@ -82,7 +79,8 @@ public class IncrementHandler extends BaseRegionObserver {
     if (e instanceof RegionCoprocessorEnvironment) {
       RegionCoprocessorEnvironment env = (RegionCoprocessorEnvironment) e;
       this.region = ((RegionCoprocessorEnvironment) e).getRegion();
-      this.state = new IncrementHandlerState(env.getConfiguration(), env.getRegion().getTableDesc().getNameAsString(),
+      this.state = new IncrementHandlerState(env.getConfiguration(),
+                                             env.getRegion().getTableDesc(),
                                              new HTable98NameConverter());
 
       HTableDescriptor tableDesc = env.getRegion().getTableDesc();

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/transaction/coprocessor/hbase98/DefaultTransactionProcessor.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/transaction/coprocessor/hbase98/DefaultTransactionProcessor.java
@@ -36,8 +36,7 @@ import org.apache.hadoop.hbase.regionserver.ScanType;
 public class DefaultTransactionProcessor extends TransactionProcessor {
   @Override
   protected Supplier<TransactionStateCache> getTransactionStateCacheSupplier(RegionCoprocessorEnvironment env) {
-    String sysConfigTablePrefix
-      = new HTable98NameConverter().getSysConfigTablePrefix(env.getRegion().getTableDesc().getNameAsString());
+    String sysConfigTablePrefix = new HTable98NameConverter().getSysConfigTablePrefix(env.getRegion().getTableDesc());
     return new DefaultTransactionStateCacheSupplier(sysConfigTablePrefix, env.getConfiguration());
   }
 

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/util/hbase/HBase98TableUtil.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/util/hbase/HBase98TableUtil.java
@@ -49,23 +49,25 @@ import java.util.Map;
  */
 public class HBase98TableUtil extends HBaseTableUtil {
 
+  private final HTable98NameConverter nameConverter = new HTable98NameConverter();
+
   @Override
   public HTable createHTable(Configuration conf, TableId tableId) throws IOException {
     Preconditions.checkArgument(tableId != null, "Table id should not be null");
-    return new HTable(conf, HTable98NameConverter.toTableName(tablePrefix, tableId));
+    return new HTable(conf, nameConverter.toTableName(tablePrefix, tableId));
   }
 
   @Override
   public HTableDescriptor createHTableDescriptor(TableId tableId) {
     Preconditions.checkArgument(tableId != null, "Table id should not be null");
-    return new HTableDescriptor(HTable98NameConverter.toTableName(tablePrefix, tableId));
+    return new HTableDescriptor(nameConverter.toTableName(tablePrefix, tableId));
   }
 
   @Override
   public HTableDescriptor getHTableDescriptor(HBaseAdmin admin, TableId tableId) throws IOException {
     Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
     Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    return admin.getTableDescriptor(HTable98NameConverter.toTableName(tablePrefix, tableId));
+    return admin.getTableDescriptor(nameConverter.toTableName(tablePrefix, tableId));
   }
 
   @Override
@@ -73,7 +75,7 @@ public class HBase98TableUtil extends HBaseTableUtil {
     Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
     Preconditions.checkArgument(namespace != null, "Namespace should not be null.");
     try {
-      admin.getNamespaceDescriptor(HTableNameConverter.toHBaseNamespace(tablePrefix, namespace));
+      admin.getNamespaceDescriptor(nameConverter.toHBaseNamespace(tablePrefix, namespace));
       return true;
     } catch (NamespaceNotFoundException e) {
       return false;
@@ -86,7 +88,7 @@ public class HBase98TableUtil extends HBaseTableUtil {
     Preconditions.checkArgument(namespace != null, "Namespace should not be null.");
     if (!hasNamespace(admin, namespace)) {
       NamespaceDescriptor namespaceDescriptor =
-        NamespaceDescriptor.create(HTableNameConverter.toHBaseNamespace(tablePrefix, namespace)).build();
+        NamespaceDescriptor.create(nameConverter.toHBaseNamespace(tablePrefix, namespace)).build();
       admin.createNamespace(namespaceDescriptor);
     }
   }
@@ -96,7 +98,7 @@ public class HBase98TableUtil extends HBaseTableUtil {
     Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
     Preconditions.checkArgument(namespace != null, "Namespace should not be null.");
     if (hasNamespace(admin, namespace)) {
-      admin.deleteNamespace(HTableNameConverter.toHBaseNamespace(tablePrefix, namespace));
+      admin.deleteNamespace(nameConverter.toHBaseNamespace(tablePrefix, namespace));
     }
   }
 
@@ -104,28 +106,28 @@ public class HBase98TableUtil extends HBaseTableUtil {
   public void disableTable(HBaseAdmin admin, TableId tableId) throws IOException {
     Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
     Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    admin.disableTable(HTable98NameConverter.toTableName(tablePrefix, tableId));
+    admin.disableTable(nameConverter.toTableName(tablePrefix, tableId));
   }
 
   @Override
   public void enableTable(HBaseAdmin admin, TableId tableId) throws IOException {
     Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
     Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    admin.enableTable(HTable98NameConverter.toTableName(tablePrefix, tableId));
+    admin.enableTable(nameConverter.toTableName(tablePrefix, tableId));
   }
 
   @Override
   public boolean tableExists(HBaseAdmin admin, TableId tableId) throws IOException {
     Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
     Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    return admin.tableExists(HTable98NameConverter.toTableName(tablePrefix, tableId));
+    return admin.tableExists(nameConverter.toTableName(tablePrefix, tableId));
   }
 
   @Override
   public void deleteTable(HBaseAdmin admin, TableId tableId) throws IOException {
     Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
     Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    admin.deleteTable(HTable98NameConverter.toTableName(tablePrefix, tableId));
+    admin.deleteTable(nameConverter.toTableName(tablePrefix, tableId));
   }
 
   @Override
@@ -139,17 +141,17 @@ public class HBase98TableUtil extends HBaseTableUtil {
   public List<HRegionInfo> getTableRegions(HBaseAdmin admin, TableId tableId) throws IOException {
     Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
     Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    return admin.getTableRegions(HTable98NameConverter.toTableName(tablePrefix, tableId));
+    return admin.getTableRegions(nameConverter.toTableName(tablePrefix, tableId));
   }
 
   @Override
   public List<TableId> listTablesInNamespace(HBaseAdmin admin, Id.Namespace namespaceId) throws IOException {
     List<TableId> tableIds = Lists.newArrayList();
     HTableDescriptor[] hTableDescriptors =
-      admin.listTableDescriptorsByNamespace(HTableNameConverter.toHBaseNamespace(tablePrefix, namespaceId));
+      admin.listTableDescriptorsByNamespace(nameConverter.toHBaseNamespace(tablePrefix, namespaceId));
     for (HTableDescriptor hTableDescriptor : hTableDescriptors) {
       if (isCDAPTable(hTableDescriptor)) {
-        tableIds.add(HTable98NameConverter.fromTableName(hTableDescriptor.getTableName()));
+        tableIds.add(nameConverter.from(hTableDescriptor));
       }
     }
     return tableIds;
@@ -161,7 +163,7 @@ public class HBase98TableUtil extends HBaseTableUtil {
     HTableDescriptor[] hTableDescriptors = admin.listTables();
     for (HTableDescriptor hTableDescriptor : hTableDescriptors) {
       if (isCDAPTable(hTableDescriptor)) {
-        tableIds.add(HTable98NameConverter.fromTableName(hTableDescriptor.getTableName()));
+        tableIds.add(nameConverter.from(hTableDescriptor));
       }
     }
     return tableIds;

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/util/hbase/HTable98NameConverter.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/util/hbase/HTable98NameConverter.java
@@ -16,44 +16,37 @@
 
 package co.cask.cdap.data2.util.hbase;
 
-import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.util.TableId;
+import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.TableName;
 
 /**
  * Utility methods for dealing with HBase table name conversions in HBase 0.98.
  */
 public class HTable98NameConverter extends HTableNameConverter {
-  @Override
-  public String getSysConfigTablePrefix(String hTableName) {
-    return getHbaseNamespacePrefix(TableName.valueOf(hTableName)) + "_" + Constants.SYSTEM_NAMESPACE + ":";
-  }
 
   @Override
-  public TableId from(String hTableName) {
-    return fromTableName(TableName.valueOf(hTableName));
+  public String getSysConfigTablePrefix(HTableDescriptor htd) {
+    return getNamespacePrefix(htd) + "_" + Constants.SYSTEM_NAMESPACE + ":";
   }
 
-  public static TableName toTableName(CConfiguration cConf, TableId tableId) {
-    String tablePrefix = cConf.get(Constants.Dataset.TABLE_PREFIX);
-    return toTableName(tablePrefix, tableId);
+  @Override
+  public TableId from(HTableDescriptor htd) {
+    return prefixedTableIdFromTableName(htd.getTableName()).getTableId();
   }
 
-  public static TableName toTableName(String tablePrefix, TableId tableId) {
+  @Override
+  public String getNamespacePrefix(HTableDescriptor htd) {
+    return prefixedTableIdFromTableName(htd.getTableName()).getTablePrefix();
+  }
+
+  public TableName toTableName(String tablePrefix, TableId tableId) {
     return TableName.valueOf(toHBaseNamespace(tablePrefix, tableId.getNamespace()),
                              getHBaseTableName(tablePrefix, tableId));
   }
 
-  public static TableId fromTableName(TableName tableName) {
-    return prefixedTableIdFromTableName(tableName).getTableId();
-  }
-
-  public static String getHbaseNamespacePrefix(TableName tableName) {
-    return prefixedTableIdFromTableName(tableName).getTablePrefix();
-  }
-
-  private static PrefixedTableId prefixedTableIdFromTableName(TableName tableName) {
-    return HTableNameConverter.from(tableName.getNamespaceAsString(), tableName.getQualifierAsString());
+  private PrefixedTableId prefixedTableIdFromTableName(TableName tableName) {
+    return fromHBaseTableName(tableName.getNamespaceAsString(), tableName.getQualifierAsString());
   }
 }

--- a/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data2/increment/hbase98/IncrementHandlerTest.java
+++ b/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data2/increment/hbase98/IncrementHandlerTest.java
@@ -20,14 +20,14 @@ import co.cask.cdap.data2.increment.hbase.AbstractIncrementHandlerTest;
 import co.cask.cdap.data2.increment.hbase.IncrementHandlerState;
 import co.cask.cdap.data2.increment.hbase.TimestampOracle;
 import co.cask.cdap.data2.util.TableId;
-import co.cask.cdap.data2.util.hbase.HTable98NameConverter;
+import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
+import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
 import co.cask.cdap.test.SlowTests;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.Coprocessor;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
-import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.HTable;
 import org.apache.hadoop.hbase.client.Put;
@@ -107,16 +107,16 @@ public class IncrementHandlerTest extends AbstractIncrementHandlerTest {
 
   @Override
   public HTable createTable(TableId tableId) throws Exception {
-    TableName table = HTable98NameConverter.toTableName(cConf, tableId);
-    HTableDescriptor tableDesc = new HTableDescriptor(table);
+    HBaseTableUtil tableUtil = new HBaseTableUtilFactory(cConf).get();
+    HTableDescriptor tableDesc = tableUtil.createHTableDescriptor(tableId);
     HColumnDescriptor columnDesc = new HColumnDescriptor(FAMILY);
     columnDesc.setMaxVersions(Integer.MAX_VALUE);
     columnDesc.setValue(IncrementHandlerState.PROPERTY_TRANSACTIONAL, "false");
     tableDesc.addFamily(columnDesc);
     tableDesc.addCoprocessor(IncrementHandler.class.getName());
     testUtil.getHBaseAdmin().createTable(tableDesc);
-    testUtil.waitUntilTableAvailable(table.getName(), 5000);
-    return new HTable(conf, table);
+    testUtil.waitUntilTableAvailable(tableDesc.getName(), 5000);
+    return tableUtil.createHTable(conf, tableId);
   }
 
   @Override

--- a/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data2/increment/hbase98/IncrementSummingScannerTest.java
+++ b/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data2/increment/hbase98/IncrementSummingScannerTest.java
@@ -21,7 +21,8 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.dataset2.lib.table.hbase.HBaseTable;
 import co.cask.cdap.data2.increment.hbase.IncrementHandlerState;
 import co.cask.cdap.data2.util.TableId;
-import co.cask.cdap.data2.util.hbase.HTable98NameConverter;
+import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
+import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
 import co.cask.cdap.data2.util.hbase.MockRegionServerServices;
 import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
@@ -33,7 +34,6 @@ import org.apache.hadoop.hbase.HBaseTestingUtility;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HRegionInfo;
 import org.apache.hadoop.hbase.HTableDescriptor;
-import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.Put;
@@ -432,18 +432,20 @@ public class IncrementSummingScannerTest {
 
   static HRegion createRegion(Configuration hConf, CConfiguration cConf, TableId tableId,
                               HColumnDescriptor cfd) throws Exception {
-    TableName tableName = HTable98NameConverter.toTableName(cConf, tableId);
-    HTableDescriptor htd = new HTableDescriptor(tableName);
+    HBaseTableUtil tableUtil = new HBaseTableUtilFactory(cConf).get();
+    HTableDescriptor htd = tableUtil.createHTableDescriptor(tableId);
     cfd.setMaxVersions(Integer.MAX_VALUE);
     cfd.setKeepDeletedCells(true);
     htd.addFamily(cfd);
     htd.addCoprocessor(IncrementHandler.class.getName());
-    Path tablePath = new Path("/tmp/" + tableName.getNameAsString());
-    Path hlogPath = new Path("/tmp/hlog-" + tableName.getNameAsString());
+
+    String tableName = htd.getNameAsString();
+    Path tablePath = new Path("/tmp/" + tableName);
+    Path hlogPath = new Path("/tmp/hlog-" + tableName);
     FileSystem fs = FileSystem.get(hConf);
     assertTrue(fs.mkdirs(tablePath));
-    HLog hLog = HLogFactory.createHLog(fs, hlogPath, tableName.getNameAsString(), hConf);
-    HRegionInfo regionInfo = new HRegionInfo(tableName);
+    HLog hLog = HLogFactory.createHLog(fs, hlogPath, tableName, hConf);
+    HRegionInfo regionInfo = new HRegionInfo(htd.getTableName());
     HRegionFileSystem regionFS = HRegionFileSystem.createRegionOnFileSystem(hConf, fs, tablePath, regionInfo);
     return new HRegion(regionFS, hLog, hConf, htd,
                        new MockRegionServerServices(hConf, null));

--- a/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data2/util/hbase/HBase98TableUtilTest.java
+++ b/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data2/util/hbase/HBase98TableUtilTest.java
@@ -29,6 +29,8 @@ import org.junit.experimental.categories.Category;
 @Category(XSlowTests.class)
 public class HBase98TableUtilTest extends AbstractHBaseTableUtilTest {
 
+  private final HTableNameConverter nameConverter = new HTable98NameConverter();
+
   @Override
   protected HBaseTableUtil getTableUtil() {
     HBase98TableUtil hBaseTableUtil = new HBase98TableUtil();
@@ -37,14 +39,19 @@ public class HBase98TableUtilTest extends AbstractHBaseTableUtilTest {
   }
 
   @Override
+  protected HTableNameConverter getNameConverter() {
+    return nameConverter;
+  }
+
+  @Override
   protected String getTableNameAsString(TableId tableId) {
     Preconditions.checkArgument(tableId != null, "TableId should not be null.");
     String tablePrefix = cConf.get(Constants.Dataset.TABLE_PREFIX);
     if (Constants.DEFAULT_NAMESPACE_ID.equals(tableId.getNamespace())) {
-      return HTableNameConverter.getHBaseTableName(tablePrefix, tableId);
+      return nameConverter.getHBaseTableName(tablePrefix, tableId);
     }
-    return Joiner.on(':').join(HTableNameConverter.toHBaseNamespace(tablePrefix, tableId.getNamespace()),
-                               HTableNameConverter.getHBaseTableName(tablePrefix, tableId));
+    return Joiner.on(':').join(nameConverter.toHBaseNamespace(tablePrefix, tableId.getNamespace()),
+                               nameConverter.getHBaseTableName(tablePrefix, tableId));
   }
 
   @Override

--- a/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data2/util/hbase/HTable98NameConverterTest.java
+++ b/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data2/util/hbase/HTable98NameConverterTest.java
@@ -16,14 +16,25 @@
 
 package co.cask.cdap.data2.util.hbase;
 
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.data2.util.TableId;
+import org.apache.hadoop.hbase.HTableDescriptor;
 import org.junit.Assert;
 import org.junit.Test;
 
 public class HTable98NameConverterTest {
   @Test
   public void testGetSysConfigTablePrefix() throws Exception {
-    HTable98NameConverter hBaseNameConversionUtil = new HTable98NameConverter();
-    Assert.assertEquals("cdap_system:", hBaseNameConversionUtil.getSysConfigTablePrefix("cdap_user:some_table"));
-    Assert.assertEquals("cdap_system:", hBaseNameConversionUtil.getSysConfigTablePrefix("cdap.table_in_default_ns"));
+    CConfiguration cConf = CConfiguration.create();
+    String tablePrefix = cConf.get(Constants.Dataset.TABLE_PREFIX);
+
+    HBaseTableUtil tableUtil = new HBaseTableUtilFactory(cConf).get();
+    HTableNameConverter hBaseNameConversionUtil = new HTableNameConverterFactory().get();
+
+    HTableDescriptor htd = tableUtil.createHTableDescriptor(TableId.from("user", "some_table"));
+    Assert.assertEquals(tablePrefix + "_system:", hBaseNameConversionUtil.getSysConfigTablePrefix(htd));
+    htd = tableUtil.createHTableDescriptor(TableId.from(Constants.DEFAULT_NAMESPACE_ID, "table_in_default_ns"));
+    Assert.assertEquals(tablePrefix + "_system:", hBaseNameConversionUtil.getSysConfigTablePrefix(htd));
   }
 }

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/DatasetUpgrader.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/DatasetUpgrader.java
@@ -99,10 +99,9 @@ public class DatasetUpgrader extends AbstractUpgrader {
     HBaseAdmin hAdmin = new HBaseAdmin(hConf);
 
     for (HTableDescriptor desc : hAdmin.listTables(USER_TABLE_PREFIX)) {
-      String tableName = desc.getNameAsString();
       HTableNameConverter hTableNameConverter = new HTableNameConverterFactory().get();
-      TableId tableId = hTableNameConverter.from(tableName);
-      LOG.info("Upgrading hbase table: {}, desc: {}", tableName, desc);
+      TableId tableId = hTableNameConverter.from(desc);
+      LOG.info("Upgrading hbase table: {}, desc: {}", tableId, desc);
 
       final boolean supportsIncrement = HBaseTableAdmin.supportsReadlessIncrements(desc);
       final boolean transactional = HBaseTableAdmin.isTransactional(desc);
@@ -129,7 +128,7 @@ public class DatasetUpgrader extends AbstractUpgrader {
         }
       };
       admin.upgrade();
-      LOG.info("Upgraded hbase table: {}", tableName);
+      LOG.info("Upgraded hbase table: {}", tableId);
     }
   }
 }


### PR DESCRIPTION
- Get rid of unnecessary static
  - Static is really evil
- Cleanup code, remove unneeded methods
- Simplify the HTableNameConverter and sub-classes