### PR TITLE
CDAP-1540 Port to 2.6 - Exposing transaction manager APIs to truncate invalid list through Router

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/MonitorHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/MonitorHandler.java
@@ -26,6 +26,7 @@ import co.cask.http.HttpResponder;
 import com.google.common.collect.Lists;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonSyntaxException;
 import com.google.inject.Inject;
 import org.jboss.netty.handler.codec.http.HttpRequest;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
@@ -98,7 +99,16 @@ public class MonitorHandler extends AbstractAppFabricHttpHandler {
       }
 
       MasterServiceManager serviceManager = serviceManagementMap.get(serviceName);
-      int instance = getInstances(request);
+      int instance = 0;
+      try {
+        instance = getInstances(request);
+      } catch (IllegalArgumentException e) {
+        responder.sendString(HttpResponseStatus.BAD_REQUEST, "Invalid instance value in request");
+        return;
+      } catch (JsonSyntaxException e) {
+        responder.sendString(HttpResponseStatus.BAD_REQUEST, "Invalid JSON in request");
+        return;
+      }
       if (!serviceManager.isServiceEnabled()) {
         responder.sendString(HttpResponseStatus.FORBIDDEN, String.format("Service %s is not enabled", serviceName));
         return;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ServiceHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ServiceHttpHandler.java
@@ -36,8 +36,7 @@ import co.cask.cdap.proto.ServiceInstances;
 import co.cask.http.HttpHandler;
 import co.cask.http.HttpResponder;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
+import com.google.gson.JsonSyntaxException;
 import com.google.inject.Inject;
 import org.jboss.netty.handler.codec.http.HttpRequest;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
@@ -154,7 +153,16 @@ public class ServiceHttpHandler extends AbstractAppFabricHttpHandler {
         return;
       }
 
-      int instances = getInstances(request);
+      int instances;
+      try {
+        instances = getInstances(request);
+      } catch (IllegalArgumentException e) {
+        responder.sendString(HttpResponseStatus.BAD_REQUEST, "Invalid instance value in request");
+        return;
+      } catch (JsonSyntaxException e) {
+        responder.sendString(HttpResponseStatus.BAD_REQUEST, "Invalid JSON in request");
+        return;
+      }
       if (instances < 1) {
         responder.sendString(HttpResponseStatus.BAD_REQUEST, "Instance count should be greater than 0");
         return;

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/distributed/TransactionServiceClientTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/distributed/TransactionServiceClientTest.java
@@ -41,6 +41,7 @@ import org.apache.twill.internal.zookeeper.InMemoryZKServer;
 import org.apache.twill.zookeeper.ZKClientService;
 import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -123,6 +124,12 @@ public class TransactionServiceClientTest extends TransactionSystemTest {
       zkServer.stopAndWait();
       txStateStorage.stopAndWait();
     }
+  }
+
+  @Before
+  public void resetState() throws Exception {
+    TransactionSystemClient txClient = getClient();
+    txClient.resetState();
   }
 
   @Test

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseOrderedTable.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseOrderedTable.java
@@ -26,6 +26,7 @@ import co.cask.cdap.data2.dataset2.lib.table.ordered.Update;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.tephra.Transaction;
 import co.cask.tephra.TransactionCodec;
+import co.cask.tephra.TxConstants;
 import com.google.common.base.Objects;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -33,6 +34,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.HTable;
+import org.apache.hadoop.hbase.client.OperationWithAttributes;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
@@ -194,7 +196,7 @@ public class HBaseOrderedTable extends BufferingOrderedTable {
       scan.setStopRow(stopRow);
     }
 
-    txCodec.addToOperation(scan, tx);
+    addToOperation(scan, tx);
 
     ResultScanner resultScanner = hTable.getScanner(scan);
     return new HBaseScanner(resultScanner);
@@ -218,7 +220,7 @@ public class HBaseOrderedTable extends BufferingOrderedTable {
       return result.isEmpty() ? EMPTY_ROW_MAP : result.getFamilyMap(HBaseOrderedTableAdmin.DATA_COLUMN_FAMILY);
     }
 
-    txCodec.addToOperation(get, tx);
+    addToOperation(get, tx);
 
     Result result = hTable.get(get);
     return getRowMap(result);
@@ -239,5 +241,9 @@ public class HBaseOrderedTable extends BufferingOrderedTable {
     }
 
     return unwrapDeletes(rowMap);
+  }
+
+  private void addToOperation(OperationWithAttributes op, Transaction tx) throws IOException {
+    op.setAttribute(TxConstants.TX_OPERATION_ATTRIBUTE_KEY, txCodec.encode(tx));
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/DequeueScanAttributes.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/DequeueScanAttributes.java
@@ -21,6 +21,7 @@ import co.cask.cdap.data2.queue.ConsumerConfig;
 import co.cask.cdap.data2.queue.DequeueStrategy;
 import co.cask.cdap.data2.transaction.queue.QueueEntryRow;
 import co.cask.tephra.Transaction;
+import co.cask.tephra.TransactionType;
 import com.google.common.io.ByteArrayDataInput;
 import com.google.common.io.ByteArrayDataOutput;
 import com.google.common.io.ByteStreams;
@@ -143,7 +144,8 @@ public class DequeueScanAttributes {
     long firstShortInProgress = dataInput.readLong();
     long[] inProgress = readLongArray(dataInput);
     long[] invalids = readLongArray(dataInput);
-    return new Transaction(readPointer, writePointer, invalids, inProgress, firstShortInProgress);
+    return new Transaction(readPointer, writePointer, invalids, inProgress, firstShortInProgress,
+                           TransactionType.SHORT);
   }
 
   private static void write(DataOutput dataOutput, long[] array) throws IOException {

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
     <servlet.api.version>3.0.1</servlet.api.version>
     <shiro.version>1.2.1</shiro.version>
     <slf4j.version>1.7.5</slf4j.version>
-    <tephra.version>0.3.4</tephra.version>
+    <tephra.version>0.3.5-SNAPSHOT</tephra.version>
     <thrift.version>0.9.0</thrift.version>
     <twill.version>0.4.0-incubating</twill.version>
     <unboundid.version>2.3.6</unboundid.version>


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-1540

Porting from https://github.com/caskdata/cdap/pull/1571