### PR TITLE
Failure of the program should move it to KILLED instead of COMPLETED.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/ProgramControllerServiceAdapter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/ProgramControllerServiceAdapter.java
@@ -64,7 +64,7 @@ public class ProgramControllerServiceAdapter extends AbstractProgramController {
   /**
    * Returns {@code true} if service error is propagated as error for this controller state.
    * If this method returns {@code false}, service error is just getting logged and state will just change
-   * to {@link State#COMPLETED}. This method returns {@code true} by default.
+   * to {@link State#KILLED}. This method returns {@code true} by default.
    */
   protected boolean propagateServiceError() {
     return true;
@@ -83,8 +83,6 @@ public class ProgramControllerServiceAdapter extends AbstractProgramController {
         if (propagateServiceError()) {
           error(failure);
         } else if (getState() != State.STOPPING) {
-          complete();
-        } else {
           stop();
         }
       }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/ProgramControllerServiceAdapter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/ProgramControllerServiceAdapter.java
@@ -61,15 +61,6 @@ public class ProgramControllerServiceAdapter extends AbstractProgramController {
 
   }
 
-  /**
-   * Returns {@code true} if service error is propagated as error for this controller state.
-   * If this method returns {@code false}, service error is just getting logged and state will just change
-   * to {@link State#KILLED}. This method returns {@code true} by default.
-   */
-  protected boolean propagateServiceError() {
-    return true;
-  }
-
   private void listenToRuntimeState(Service service) {
     service.addListener(new ServiceListenerAdapter() {
       @Override
@@ -80,11 +71,7 @@ public class ProgramControllerServiceAdapter extends AbstractProgramController {
       @Override
       public void failed(Service.State from, Throwable failure) {
         LOG.error("Program terminated with exception", failure);
-        if (propagateServiceError()) {
-          error(failure);
-        } else if (getState() != State.STOPPING) {
-          stop();
-        }
+        error(failure);
       }
 
       @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramController.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramController.java
@@ -32,12 +32,6 @@ public final class MapReduceProgramController extends ProgramControllerServiceAd
     this.context = context;
   }
 
-  @Override
-  protected boolean propagateServiceError() {
-    // Don't propagate MR failure as failure. Quick fix for CDAP-749.
-    return false;
-  }
-
   /**
    * Returns the {@link MapReduceContext} for MapReduce run represented by this controller.
    */

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractProgramTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractProgramTwillRunnable.java
@@ -239,6 +239,15 @@ public abstract class AbstractProgramTwillRunnable<T extends ProgramRunner> impl
     }
   }
 
+  /**
+   * Returns {@code true} if service error is propagated as error for this controller state.
+   * If this method returns {@code false}, service error is just getting logged and state will just change
+   * to {@link ProgramController.State#KILLED}. This method returns {@code true} by default.
+   */
+  protected boolean propagateServiceError() {
+    return true;
+  }
+
   @Override
   public void run() {
     LOG.info("Starting metrics service");
@@ -275,7 +284,9 @@ public abstract class AbstractProgramTwillRunnable<T extends ProgramRunner> impl
       LOG.warn("Program interrupted.", e);
     } catch (ExecutionException e) {
       LOG.error("Program execution failed.", e);
-      throw Throwables.propagate(Throwables.getRootCause(e));
+      if (propagateServiceError()) {
+        throw Throwables.propagate(Throwables.getRootCause(e));
+      }
     }
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/MapReduceTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/MapReduceTwillRunnable.java
@@ -30,6 +30,12 @@ final class MapReduceTwillRunnable extends AbstractProgramTwillRunnable<MapReduc
   }
 
   @Override
+  protected boolean propagateServiceError() {
+    // Don't propagate MR failure as failure. Quick fix for CDAP-749.
+    return false;
+  }
+
+  @Override
   protected Class<MapReduceProgramRunner> getProgramClass() {
     return MapReduceProgramRunner.class;
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/WorkflowTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/WorkflowTwillRunnable.java
@@ -69,6 +69,12 @@ final class WorkflowTwillRunnable extends AbstractProgramTwillRunnable<WorkflowP
     });
   }
 
+  @Override
+  protected boolean propagateServiceError() {
+    // Don't propagate Workflow failure as failure. Quick fix for CDAP-749.
+    return false;
+  }
+
   @Singleton
   private static final class WorkflowProgramRunnerFactory implements ProgramRunnerFactory {
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkProgramController.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkProgramController.java
@@ -35,12 +35,6 @@ public final class SparkProgramController extends ProgramControllerServiceAdapte
     this.context = context;
   }
 
-  @Override
-  protected boolean propagateServiceError() {
-    // Don't propagate Spark failure as failure. Similar reason as in MapReduce case (CDAP-749).
-    return false;
-  }
-
   /**
    * Returns the {@link SparkContext} for Spark run represented by this controller.
    */


### PR DESCRIPTION
Jira: https://issues.cask.co/browse/CDAP-1744
Failure of a program was incorrectly attempting to mark them as COMPLETED. It should be marked KILLED.