### PR TITLE
fix upgrade tool filset key prefix

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/mds/DatasetInstanceMDSUpgrader.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/mds/DatasetInstanceMDSUpgrader.java
@@ -122,7 +122,7 @@ public final class DatasetInstanceMDSUpgrader {
       List<DatasetSpecification>>() {
       @Override
       public List<DatasetSpecification> apply(UpgradeMDSStores<DatasetInstanceMDS> ctx) throws Exception {
-        MDSKey key = new MDSKey(Bytes.toBytes(DatasetInstanceMDS.INSTANCE_PREFIX));
+        MDSKey key = new MDSKey.Builder().add(DatasetInstanceMDS.INSTANCE_PREFIX).build();
         List<DatasetSpecification> dsSpecs = ctx.getNewMds().list(key, DatasetSpecification.class);
         List<DatasetSpecification> fileSetSpecs = Lists.newArrayList();
         for (DatasetSpecification dsSpec : dsSpecs) {


### PR DESCRIPTION
We read the new meta table to get the filesets which is written with new key format. So read it in that way. 
I had this fixed during the review process but looks like it got lost some where :/
