### PR TITLE
add job in spark programs which runs in test

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/WorkflowApp.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/WorkflowApp.java
@@ -30,13 +30,15 @@ import co.cask.cdap.internal.app.runtime.batch.WordCount;
 import co.cask.cdap.runtime.WorkflowTest;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
-import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.mapreduce.Job;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -110,10 +112,13 @@ public class WorkflowApp extends AbstractApplication {
       File successFile = new File(outputDir, "_SUCCESS");
       Preconditions.checkState(successFile.exists());
       try {
-        FileUtils.deleteDirectory(successFile);
-      } catch (IOException e) {
+        successFile.delete();
+      } catch (Exception e) {
         Throwables.propagate(e);
       }
+      List<Integer> data = Arrays.asList(1, 2, 3, 4, 5);
+      JavaRDD<Integer> distData = ((JavaSparkContext) context.getOriginalSparkContext()).parallelize(data);
+      distData.collect();
       Preconditions.checkState(!successFile.exists());
     }
   }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/WorkflowAppWithScopedParameters.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/WorkflowAppWithScopedParameters.java
@@ -27,7 +27,11 @@ import co.cask.cdap.api.workflow.AbstractWorkflow;
 import co.cask.cdap.internal.app.runtime.batch.WordCount;
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.mapreduce.Job;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -125,7 +129,9 @@ public class WorkflowAppWithScopedParameters extends AbstractApplication {
   public static class SparkTestProgram implements JavaSparkProgram {
     @Override
     public void run(SparkContext context) {
-      // no-op
+      List<Integer> data = Arrays.asList(1, 2, 3, 4, 5);
+      JavaRDD<Integer> distData = ((JavaSparkContext) context.getOriginalSparkContext()).parallelize(data);
+      distData.collect();
     }
   }
 


### PR DESCRIPTION
We collect spark program success status through the listener which list to job completion in spark. So we have to have a job in dummy programs. 

Opened a jira to find out if the improvement is possible: https://issues.cask.co/browse/CDAP-1806