### PR TITLE
Bugfix/default ns

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/NamespaceHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/NamespaceHttpHandler.java
@@ -125,7 +125,7 @@ public class NamespaceHttpHandler extends AbstractAppFabricHttpHandler {
 
     if (isReserved(namespaceId)) {
       responder.sendString(HttpResponseStatus.BAD_REQUEST,
-                           String.format("Cannot delete the namespace '%s'. '%s' is a reserved namespace.",
+                           String.format("Cannot create the namespace '%s'. '%s' is a reserved namespace.",
                                          namespaceId, namespaceId));
       return;
     }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdmin.java
@@ -34,7 +34,6 @@ import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.ProgramType;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
-import com.google.common.base.Throwables;
 import com.google.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -71,27 +70,6 @@ public final class DefaultNamespaceAdmin implements NamespaceAdmin {
   }
 
   /**
-   * This should be removed once we stop support for v2 APIs, since 'default' namespace is only reserved for v2 APIs.
-   */
-  private void createDefaultNamespace() {
-    NamespaceMeta.Builder builder = new NamespaceMeta.Builder();
-    NamespaceMeta defaultNamespace = builder
-      .setName(Constants.DEFAULT_NAMESPACE)
-      .setDescription("Default Namespace")
-      .build();
-
-    try {
-      createNamespace(defaultNamespace);
-      LOG.info("Successfully created 'default' namespace.");
-    } catch (AlreadyExistsException e) {
-      LOG.info("'default' namespace already exists.");
-    } catch (NamespaceCannotBeCreatedException e) {
-      LOG.error("Error while creating default namespace", e);
-      Throwables.propagate(e);
-    }
-  }
-
-  /**
    * Lists all namespaces
    *
    * @return a list of {@link NamespaceMeta} for all namespaces
@@ -122,18 +100,12 @@ public final class DefaultNamespaceAdmin implements NamespaceAdmin {
    * @return true, if the specifed namespace exists, false otherwise
    */
   public boolean hasNamespace(Id.Namespace namespaceId) {
-    boolean exists = true;
     try {
       getNamespace(namespaceId);
     } catch (NotFoundException e) {
-      // TODO: CDAP-1213 do this better
-      if (Constants.DEFAULT_NAMESPACE.equals(namespaceId.getId())) {
-        createDefaultNamespace();
-      } else {
-        exists = false;
-      }
+      return false;
     }
-    return exists;
+    return true;
   }
 
   /**
@@ -145,8 +117,7 @@ public final class DefaultNamespaceAdmin implements NamespaceAdmin {
   public void createNamespace(NamespaceMeta metadata) throws NamespaceCannotBeCreatedException, AlreadyExistsException {
     // TODO: CDAP-1427 - This should be transactional, but we don't support transactions on files yet
     Preconditions.checkArgument(metadata != null, "Namespace metadata should not be null.");
-    NamespaceMeta existing = store.getNamespace(Id.Namespace.from(metadata.getName()));
-    if (existing != null) {
+    if (hasNamespace(Id.Namespace.from(metadata.getName()))) {
       throw new AlreadyExistsException(NAMESPACE_ELEMENT_TYPE, metadata.getName());
     }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceEnsurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceEnsurer.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.namespace;
+
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.exception.AlreadyExistsException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Thread that ensures that the default namespace exists
+ */
+public final class DefaultNamespaceEnsurer implements Runnable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultNamespaceEnsurer.class);
+
+  private final NamespaceAdmin namespaceAdmin;
+  private final int waitBetweenRetries;
+  private final TimeUnit waitUnit;
+
+  public DefaultNamespaceEnsurer(NamespaceAdmin namespaceAdmin, int waitBetweenRetries, TimeUnit waitUnit) {
+    this.namespaceAdmin = namespaceAdmin;
+    this.waitBetweenRetries = waitBetweenRetries;
+    this.waitUnit = waitUnit;
+  }
+
+  @Override
+  public void run() {
+    Thread.currentThread().setName("default-namespace-ensurer");
+    int retries = 0;
+    while (true) {
+      try {
+        namespaceAdmin.createNamespace(Constants.DEFAULT_NAMESPACE_META);
+        // if there is no exception, assume successfully created and break
+        LOG.info("Created default namespace successfully.");
+        break;
+      } catch (AlreadyExistsException e) {
+        // default namespace already exists, break the retry loop
+        LOG.info("Default namespace already exists.");
+        break;
+      } catch (Exception e) {
+        retries++;
+        LOG.warn("Error during retry# {} - {}", retries, e.getMessage());
+        try {
+          waitUnit.sleep(waitBetweenRetries);
+        } catch (InterruptedException e1) {
+          LOG.warn("Interrupted during retry# {} - {}", retries, e1.getMessage());
+        }
+      }
+    }
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AppFabricServer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AppFabricServer.java
@@ -24,6 +24,8 @@ import co.cask.cdap.common.http.CommonNettyHttpServiceBuilder;
 import co.cask.cdap.common.logging.LoggingContextAccessor;
 import co.cask.cdap.common.logging.ServiceLoggingContext;
 import co.cask.cdap.common.metrics.MetricsCollectionService;
+import co.cask.cdap.internal.app.namespace.DefaultNamespaceEnsurer;
+import co.cask.cdap.internal.app.namespace.NamespaceAdmin;
 import co.cask.cdap.internal.app.runtime.adapter.AdapterService;
 import co.cask.cdap.internal.app.runtime.schedule.SchedulerService;
 import co.cask.cdap.notifications.service.NotificationService;
@@ -49,6 +51,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
 /**
@@ -66,6 +69,7 @@ public final class AppFabricServer extends AbstractIdleService {
   private final NotificationService notificationService;
   private final Set<String> servicesNames;
   private final Set<String> handlerHookNames;
+  private final NamespaceAdmin namespaceAdmin;
 
   private NettyHttpService httpService;
   private Set<HttpHandler> handlers;
@@ -83,7 +87,8 @@ public final class AppFabricServer extends AbstractIdleService {
                          @Nullable MetricsCollectionService metricsCollectionService,
                          ProgramRuntimeService programRuntimeService, AdapterService adapterService,
                          @Named("appfabric.services.names") Set<String> servicesNames,
-                         @Named("appfabric.handler.hooks") Set<String> handlerHookNames) {
+                         @Named("appfabric.handler.hooks") Set<String> handlerHookNames,
+                         NamespaceAdmin namespaceAdmin) {
     this.hostname = hostname;
     this.discoveryService = discoveryService;
     this.schedulerService = schedulerService;
@@ -95,6 +100,7 @@ public final class AppFabricServer extends AbstractIdleService {
     this.notificationService = notificationService;
     this.servicesNames = servicesNames;
     this.handlerHookNames = handlerHookNames;
+    this.namespaceAdmin = namespaceAdmin;
   }
 
   /**
@@ -186,6 +192,9 @@ public final class AppFabricServer extends AbstractIdleService {
     }, Threads.SAME_THREAD_EXECUTOR);
 
     httpService.startAndWait();
+
+    Thread defaultNamespaceEnsurer = new Thread(new DefaultNamespaceEnsurer(namespaceAdmin, 1, TimeUnit.SECONDS));
+    defaultNamespaceEnsurer.start();
   }
 
   @Override

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/SchedulerTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/SchedulerTestBase.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.schedule;
+
+import co.cask.cdap.app.runtime.ProgramRuntimeService;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.ProgramType;
+import com.google.common.base.Predicate;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Base class for scheduler tests
+ */
+public class SchedulerTestBase {
+  protected void waitUntilFinished(ProgramRuntimeService runtimeService,
+                                   Id.Program program, int maxWaitSeconds) throws InterruptedException {
+    int retries = 0;
+    while (isProgramRunning(runtimeService, program) && retries < maxWaitSeconds) {
+      TimeUnit.SECONDS.sleep(1);
+      retries++;
+    }
+  }
+
+  private boolean isProgramRunning(ProgramRuntimeService runtimeService, final Id.Program program) {
+    return runtimeService.checkAnyRunning(new Predicate<Id.Program>() {
+      @Override
+      public boolean apply(Id.Program programId) {
+        return programId.equals(program);
+      }
+    }, ProgramType.values());
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/StreamSizeSchedulerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/StreamSizeSchedulerTest.java
@@ -23,14 +23,16 @@ import co.cask.cdap.api.metrics.MetricValue;
 import co.cask.cdap.api.schedule.SchedulableProgramType;
 import co.cask.cdap.api.schedule.Schedule;
 import co.cask.cdap.api.schedule.Schedules;
+import co.cask.cdap.app.runtime.ProgramRuntimeService;
 import co.cask.cdap.app.store.Store;
 import co.cask.cdap.app.store.StoreFactory;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.exception.NotFoundException;
 import co.cask.cdap.common.stream.notification.StreamSizeNotification;
 import co.cask.cdap.config.PreferencesStore;
-import co.cask.cdap.data2.transaction.stream.StreamAdmin;
+import co.cask.cdap.internal.app.namespace.NamespaceAdmin;
+import co.cask.cdap.internal.app.namespace.NamespaceCannotBeDeletedException;
 import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
-import co.cask.cdap.notifications.feeds.NotificationFeedManager;
 import co.cask.cdap.notifications.service.NotificationService;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramRunStatus;
@@ -38,6 +40,7 @@ import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.test.XSlowTests;
 import co.cask.cdap.test.internal.AppFabricTestHelper;
 import com.google.common.collect.ImmutableMap;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -50,21 +53,21 @@ import java.util.concurrent.TimeUnit;
  *
  */
 @Category(XSlowTests.class)
-public class StreamSizeSchedulerTest {
-  public static StreamSizeScheduler streamSizeScheduler;
-  public static NotificationFeedManager notificationFeedManager;
-  public static NotificationService notificationService;
-  public static StreamAdmin streamAdmin;
-  public static Store store;
-  public static MetricStore metricStore;
+public class StreamSizeSchedulerTest extends SchedulerTestBase {
+  private static StreamSizeScheduler streamSizeScheduler;
+  private static NotificationService notificationService;
+  private static Store store;
+  private static MetricStore metricStore;
+  private static NamespaceAdmin namespaceAdmin;
+  private static ProgramRuntimeService runtimeService;
 
-  private static final Id.Namespace NAMESPACE = new Id.Namespace(Constants.DEFAULT_NAMESPACE);
-  private static final Id.Application APP_ID = new Id.Application(NAMESPACE, "AppWithStreamSizeSchedule");
+  private static final Id.Application APP_ID = new Id.Application(Constants.DEFAULT_NAMESPACE_ID,
+                                                                  "AppWithStreamSizeSchedule");
   private static final Id.Program PROGRAM_ID = new Id.Program(APP_ID, ProgramType.WORKFLOW, "SampleWorkflow");
   private static final String SCHEDULE_NAME_1 = "SampleSchedule1";
   private static final String SCHEDULE_NAME_2 = "SampleSchedule2";
   private static final SchedulableProgramType PROGRAM_TYPE = SchedulableProgramType.WORKFLOW;
-  private static final Id.Stream STREAM_ID = Id.Stream.from(NAMESPACE, "stream");
+  private static final Id.Stream STREAM_ID = Id.Stream.from(Constants.DEFAULT_NAMESPACE_ID, "stream");
   private static final Id.NotificationFeed FEED = new Id.NotificationFeed.Builder()
     .setNamespaceId(STREAM_ID.getNamespaceId())
     .setCategory(Constants.Notification.Stream.STREAM_FEED_CATEGORY)
@@ -77,20 +80,20 @@ public class StreamSizeSchedulerTest {
   public static void set() throws Exception {
     PreferencesStore preferencesStore = AppFabricTestHelper.getInjector().getInstance(PreferencesStore.class);
     Map<String, String> properties = ImmutableMap.of(ProgramOptionConstants.CONCURRENT_RUNS_ENABLED, "true");
-    preferencesStore.setProperties(NAMESPACE.getId(), APP_ID.getId(), properties);
-    notificationFeedManager = AppFabricTestHelper.getInjector().getInstance(NotificationFeedManager.class);
+    preferencesStore.setProperties(Constants.DEFAULT_NAMESPACE_ID.getId(), APP_ID.getId(), properties);
     notificationService = AppFabricTestHelper.getInjector().getInstance(NotificationService.class);
     streamSizeScheduler = AppFabricTestHelper.getInjector().getInstance(StreamSizeScheduler.class);
     StoreFactory storeFactory = AppFabricTestHelper.getInjector().getInstance(StoreFactory.class);
     store = storeFactory.create();
-    streamAdmin = AppFabricTestHelper.getInjector().getInstance(StreamAdmin.class);
     metricStore = AppFabricTestHelper.getInjector().getInstance(MetricStore.class);
+    namespaceAdmin = AppFabricTestHelper.getInjector().getInstance(NamespaceAdmin.class);
+    namespaceAdmin.createNamespace(Constants.DEFAULT_NAMESPACE_META);
+    runtimeService = AppFabricTestHelper.getInjector().getInstance(ProgramRuntimeService.class);
   }
 
   @Test
   public void testStreamSizeSchedule() throws Exception {
     // Test the StreamSizeScheduler behavior using notifications
-
     AppFabricTestHelper.deployApplication(AppWithStreamSizeSchedule.class);
     Assert.assertEquals(Scheduler.ScheduleState.SCHEDULED,
                         streamSizeScheduler.scheduleState(PROGRAM_ID, PROGRAM_TYPE, SCHEDULE_NAME_1));
@@ -160,6 +163,11 @@ public class StreamSizeSchedulerTest {
                                     1024 * 1024, MetricType.COUNTER));
     notificationService.publish(FEED, new StreamSizeNotification(System.currentTimeMillis(), 5 * 1024 * 1025));
     waitForRuns(PROGRAM_ID, 8);
+
+    streamSizeScheduler.suspendSchedule(PROGRAM_ID, PROGRAM_TYPE, SCHEDULE_NAME_1);
+    streamSizeScheduler.suspendSchedule(PROGRAM_ID, PROGRAM_TYPE, SCHEDULE_NAME_2);
+    streamSizeScheduler.deleteSchedules(PROGRAM_ID, PROGRAM_TYPE);
+    waitUntilFinished(runtimeService, PROGRAM_ID, 10);
   }
 
   private void waitForRuns(Id.Program programId, int expectedRuns) throws Exception {
@@ -175,5 +183,10 @@ public class StreamSizeSchedulerTest {
       }
     }
     Assert.fail("Time out");
+  }
+
+  @AfterClass
+  public static void tearDown() throws NotFoundException, NamespaceCannotBeDeletedException {
+    namespaceAdmin.deleteNamespace(Constants.DEFAULT_NAMESPACE_ID);
   }
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/NamespaceHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/NamespaceHttpHandlerTest.java
@@ -324,10 +324,11 @@ public class NamespaceHttpHandlerTest extends AppFabricTestBase {
   public void testNamespaceClient() throws Exception {
     // tests the NamespaceClient's ability to interact with Namespace service/handlers.
     AbstractNamespaceClient namespaceClient = getInjector().getInstance(AbstractNamespaceClient.class);
-    // test setup creates two namespaces in @BeforeClass
+    // test setup creates two namespaces in @BeforeClass, apart from the default namespace which always exists.
     List<NamespaceMeta> namespaces = namespaceClient.list();
-    Assert.assertEquals(2, namespaces.size());
-    Set<NamespaceMeta> expectedNamespaces = ImmutableSet.of(TEST_NAMESPACE_META1, TEST_NAMESPACE_META2);
+    Assert.assertEquals(3, namespaces.size());
+    Set<NamespaceMeta> expectedNamespaces = ImmutableSet.of(Constants.DEFAULT_NAMESPACE_META, TEST_NAMESPACE_META1,
+                                                            TEST_NAMESPACE_META2);
     Assert.assertEquals(expectedNamespaces, Sets.newHashSet(namespaces));
 
     NamespaceMeta namespaceMeta = namespaceClient.get(TEST_NAMESPACE1);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/DefaultStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/DefaultStoreTest.java
@@ -54,8 +54,10 @@ import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.internal.app.Specifications;
+import co.cask.cdap.internal.app.namespace.NamespaceAdmin;
 import co.cask.cdap.proto.AdapterSpecification;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.RunRecord;
@@ -97,6 +99,8 @@ public class DefaultStoreTest {
     store.clear();
     LocationFactory locationFactory = AppFabricTestHelper.getInjector().getInstance(LocationFactory.class);
     locationFactory.create(Constants.DEFAULT_NAMESPACE).delete(true);
+    NamespaceAdmin admin = AppFabricTestHelper.getInjector().getInstance(NamespaceAdmin.class);
+    admin.createNamespace(Constants.DEFAULT_NAMESPACE_META);
   }
 
   @Test

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/NamespaceClientTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/NamespaceClientTestRun.java
@@ -27,11 +27,11 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Tests for {@link NamespaceClient}
@@ -39,10 +39,7 @@ import java.util.List;
 public class NamespaceClientTestRun extends ClientTestBase {
   private NamespaceClient namespaceClient;
   private static final Id.Namespace DOES_NOT_EXIST = Id.Namespace.from("doesnotexist");
-  private static final Id.Namespace DEFAULT = Id.Namespace.from("default");
-  private static final Id.Namespace SYSTEM = Id.Namespace.from("system");
-  private static final Id.Namespace TEST_NAMESPACE_ID = Id.Namespace.from("testnamespace");
-  private static final String TEST_NAME = "testname";
+  private static final Id.Namespace TEST_NAMESPACE_NAME = Id.Namespace.from("testnamespace");
   private static final String TEST_DESCRIPTION = "testdescription";
   private static final Id.Namespace TEST_DEFAULT_FIELDS = Id.Namespace.from("testdefaultfields");
 
@@ -52,45 +49,37 @@ public class NamespaceClientTestRun extends ClientTestBase {
   }
 
   @Test
-  @Ignore
   public void testNamespaces() throws Exception {
     List<NamespaceMeta> namespaces = namespaceClient.list();
     int initialNamespaceCount = namespaces.size();
 
-    if (namespaces.size() == 1) {
-      Assert.assertEquals(Constants.DEFAULT_NAMESPACE, namespaces.get(0).getName());
-    } else {
-      Assert.assertEquals(0, namespaces.size());
-    }
-
     verifyDoesNotExist(DOES_NOT_EXIST);
     verifyReservedCreate();
     verifyReservedDelete();
-    // include default namespace
-    initialNamespaceCount++;
 
     // create a valid namespace
     NamespaceMeta.Builder builder = new NamespaceMeta.Builder();
-    builder.setName(TEST_NAMESPACE_ID).setDescription(TEST_DESCRIPTION);
+    builder.setName(TEST_NAMESPACE_NAME).setDescription(TEST_DESCRIPTION);
     namespaceClient.create(builder.build());
+    waitForNamespaceCreation(TEST_NAMESPACE_NAME.getId());
 
     // verify that the namespace got created correctly
     namespaces = namespaceClient.list();
     Assert.assertEquals(initialNamespaceCount + 1, namespaces.size());
-    NamespaceMeta meta = namespaceClient.get(TEST_NAMESPACE_ID.getId());
-    Assert.assertEquals(TEST_NAMESPACE_ID.getId(), meta.getName());
+    NamespaceMeta meta = namespaceClient.get(TEST_NAMESPACE_NAME.getId());
+    Assert.assertEquals(TEST_NAMESPACE_NAME.getId(), meta.getName());
     Assert.assertEquals(TEST_DESCRIPTION, meta.getDescription());
 
     // try creating a namespace with the same id again
-    builder.setName("existing").setDescription("existing");
+    builder.setName(TEST_NAMESPACE_NAME).setDescription("existing");
     try {
       namespaceClient.create(builder.build());
       Assert.fail("Should not be able to re-create an existing namespace");
     } catch (AlreadyExistsException e) {
     }
     // verify that the existing namespace was not updated
-    meta = namespaceClient.get(TEST_NAMESPACE_ID.getId());
-    Assert.assertEquals(TEST_NAMESPACE_ID.getId(), meta.getName());
+    meta = namespaceClient.get(TEST_NAMESPACE_NAME.getId());
+    Assert.assertEquals(TEST_NAMESPACE_NAME.getId(), meta.getName());
     Assert.assertEquals(TEST_DESCRIPTION, meta.getDescription());
 
     // create and verify namespace without name and description
@@ -104,7 +93,7 @@ public class NamespaceClientTestRun extends ClientTestBase {
     Assert.assertEquals("", meta.getDescription());
 
     // cleanup
-    namespaceClient.delete(TEST_NAMESPACE_ID.getId());
+    namespaceClient.delete(TEST_NAMESPACE_NAME.getId());
     namespaceClient.delete(TEST_DEFAULT_FIELDS.getId());
 
     Assert.assertEquals(initialNamespaceCount, namespaceClient.list().size());
@@ -128,16 +117,16 @@ public class NamespaceClientTestRun extends ClientTestBase {
 
   private void verifyReservedCreate() throws AlreadyExistsException, IOException, UnauthorizedException {
     NamespaceMeta.Builder builder = new NamespaceMeta.Builder();
-    builder.setName(DEFAULT);
+    builder.setName(Constants.DEFAULT_NAMESPACE_ID);
     try {
       namespaceClient.create(builder.build());
-      Assert.fail(String.format("Must not create '%s' namespace", DEFAULT));
+      Assert.fail(String.format("Must not create '%s' namespace", Constants.DEFAULT_NAMESPACE_ID));
     } catch (BadRequestException e) {
     }
-    builder.setName(SYSTEM);
+    builder.setName(Constants.SYSTEM_NAMESPACE_ID);
     try {
       namespaceClient.create(builder.build());
-      Assert.fail(String.format("Must not create '%s' namespace", SYSTEM));
+      Assert.fail(String.format("Must not create '%s' namespace", Constants.SYSTEM_NAMESPACE_ID));
     } catch (BadRequestException e) {
     }
   }
@@ -145,12 +134,26 @@ public class NamespaceClientTestRun extends ClientTestBase {
   private void verifyReservedDelete() throws Exception {
     // For the purposes of NamespaceClientTestRun, deleting default namespace has no effect.
     // Its lifecycle is already tested in NamespaceHttpHandlerTest
-    namespaceClient.delete(DEFAULT.getId());
-    namespaceClient.get(DEFAULT.getId());
+    namespaceClient.delete(Constants.DEFAULT_NAMESPACE);
+    namespaceClient.get(Constants.DEFAULT_NAMESPACE);
     try {
-      namespaceClient.delete(SYSTEM.getId());
-      Assert.fail(String.format("'%s' namespace must not exist", SYSTEM));
+      namespaceClient.delete(Constants.SYSTEM_NAMESPACE);
+      Assert.fail(String.format("'%s' namespace must not exist", Constants.SYSTEM_NAMESPACE));
     } catch (NotFoundException e) {
+    }
+  }
+
+  private void waitForNamespaceCreation(String namespace) throws IOException, UnauthorizedException,
+    InterruptedException {
+    int count = 0;
+    while (count < 10) {
+      try {
+        namespaceClient.get(namespace);
+        return;
+      } catch (Throwable t) {
+        count++;
+        TimeUnit.SECONDS.sleep(1);
+      }
     }
   }
 }

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.common.conf;
 
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.NamespaceMeta;
 
 import java.util.concurrent.TimeUnit;
 
@@ -719,6 +720,8 @@ public final class Constants {
    */
   public static final String DEFAULT_NAMESPACE = "default";
   public static final Id.Namespace DEFAULT_NAMESPACE_ID = Id.Namespace.from(DEFAULT_NAMESPACE);
+  public static final NamespaceMeta DEFAULT_NAMESPACE_META =
+    new NamespaceMeta.Builder().setName(Constants.DEFAULT_NAMESPACE_ID).setDescription("Default Namespace").build();
 
   /**
    * 'system' reserved namespace name

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
@@ -702,8 +702,6 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
 
   @Test(timeout = 60000L)
   public void testDatasetWithoutApp() throws Exception {
-    // TODO: Although this has nothing to do with this testcase, deploying a dummy app to create the default namespace
-    deployApplication(DummyApp.class);
     deployDatasetModule("my-kv", AppsWithDataset.KeyValueTableDefinition.Module.class);
     addDatasetInstance("myKeyValueTable", "myTable", DatasetProperties.EMPTY).create();
     DataSetManager<AppsWithDataset.KeyValueTableDefinition.KeyValueTable> dataSetManager = getDataset("myTable");


### PR DESCRIPTION
- [x] Ensures that the default namespace exists asynchronously during ``AppFabricServer`` startup.
- [x] Creates default namespace in tests that do not start ``AppFabricServer``

Jira: [CDAP-1213](https://issues.cask.co/browse/CDAP-1213)
Build: http://builds.cask.co/browse/CDAP-RBT144-2