### PR TITLE
Feature/r2.8 yarn queue docs

### DIFF
--- a/cdap-docs/admin-manual/source/index.rst
+++ b/cdap-docs/admin-manual/source/index.rst
@@ -56,8 +56,8 @@ monitoring.** Appendices cover the XML files used to configure the CDAP installa
 .. |operations| replace:: **Operations:**
 .. _operations: installation/index.html
 
-|operations|_ Covers **logging, metrics, preferences, scaling instances and
-introduces the CDAP Console.** 
+|operations|_ Covers **logging, metrics, preferences, scaling instances, resource guarantees, 
+and introduces the CDAP Console.** 
 
 .. |logging| replace:: **Logging:**
 .. _logging: operations/logging.html
@@ -78,6 +78,11 @@ introduces the CDAP Console.**
 .. _scaling-instances: operations/scaling-instances.html
 
 - |scaling-instances|_ Covers **querying and setting the number of instances of Flowlets and Procedures.** 
+
+.. |resource-guarantees| replace:: **Resource Guarantees:**
+.. _resource-guarantees: operations/resource-guarantees.html
+
+- |resource-guarantees|_ Providing resource guarantees **for CDAP Programs in YARN.**
 
 .. |cdap-console| replace:: **CDAP Console:**
 .. _cdap-console: operations/cdap-console.html

--- a/cdap-docs/admin-manual/source/operations/index.rst
+++ b/cdap-docs/admin-manual/source/operations/index.rst
@@ -17,6 +17,7 @@ Operations
     Metrics <metrics>
     Preferences and Runtime Arguments <preferences>
     Scaling Instances <scaling-instances>
+    Resource Guarantees in YARN <resource-guarantees>
     CDAP Console <cdap-console>
     Troubleshooting <troubleshooting>
 
@@ -42,6 +43,12 @@ Operations
 .. _scaling-instances: scaling-instances.html
 
 - |scaling-instances|_ Covers **querying and setting the number of instances of Flowlets and Procedures.** 
+
+
+.. |resource-guarantees| replace:: **Resource Guarantees:**
+.. _resource-guarantees: resource-guarantees.html
+
+- |resource-guarantees|_ Providing resource guarantees **for CDAP Programs in YARN.**
 
 
 .. |cdap-console| replace:: **CDAP Console:**

--- a/cdap-docs/admin-manual/source/operations/resource-guarantees.rst
+++ b/cdap-docs/admin-manual/source/operations/resource-guarantees.rst
@@ -40,14 +40,14 @@ Configurations for submitting to non-default YARN queues can be specified in two
 2. Using a Namespace-level property: 
 
    The queue name to submit programs and Hive queries in YARN can be specified at a
-   Namespace-level by using the RESTful API to configure the property
-   ``scheduler.queue.name``.
+   Namespace-level by using the :ref:`RESTful API <http-restful-api-lifecycle>` to
+   configure the property ``scheduler.queue.name``.
    
    The configuration specified at the Namespace-level will override the configuration
    specified in ``cdap-site.xml``.
 
    For example, to set ``A`` as the queue name to be used for the namespace
-   *<namespace-id>*, you use this command::
+   *<namespace-id>*, you use this HTTP PUT method::
    
       PUT <base-url>/v3/namespaces/<namespace-id>/properties
    

--- a/cdap-docs/admin-manual/source/operations/resource-guarantees.rst
+++ b/cdap-docs/admin-manual/source/operations/resource-guarantees.rst
@@ -53,7 +53,7 @@ Configurations for submitting to non-default YARN queues can be specified in two
    
    with the property as a JSON string in the body::
    
-      {"config": {"scheduler.queue.name": "A"}'
+      {"config": {"scheduler.queue.name": "A"}
 
     
    **Note:** The configuration at the Namespace level can only be set for CDAP programs and

--- a/cdap-docs/admin-manual/source/operations/resource-guarantees.rst
+++ b/cdap-docs/admin-manual/source/operations/resource-guarantees.rst
@@ -1,0 +1,66 @@
+.. meta::
+    :author: Cask Data, Inc.
+    :copyright: Copyright © 2015 Cask Data, Inc.
+
+.. highlight:: xml
+
+.. _resource-guarantees:
+
+=============================================
+Resource Guarantees For CDAP Programs In YARN
+=============================================
+
+CDAP Master Services |---| Transaction, Twill, CDAP Programs (Flows, MapReduce, Services,
+Workers) and Explore Queries |---| run in YARN on default YARN queues. 
+
+YARN provides capabilites for resource guarantees via Capacity Schedulers and Fair
+Schedulers. CDAP provides capabilities to submit CDAP programs and Explore Queries to
+non-default YARN queues.
+
+Configurations for submitting to non-default YARN queues can be specified in two levels.
+
+1. Using the CDAP site configuration ``cdap-site.xml``:
+
+   The configuration parameter of the queue name for Master Services, CDAP Programs and
+   Explore Queries can be specified at the CDAP instance level. This is then applied for
+   all programs and Hive queries::
+
+    <property>
+      <name>master.services.scheduler.queue</name>
+      <value>sys</value>
+      <description>Scheduler queue for CDAP master services</description>
+    </property>
+
+    <property>
+      <name>app.scheduler.queue</name>
+      <value>app</value>
+      <description>Scheduler queue for CDAP Programs and Explore Queries </description>
+    </property>
+
+2. Using a Namespace-level property: 
+
+   The queue name to submit programs and Hive queries in YARN can be specified at a
+   Namespace-level by using the RESTful API to configure the property
+   ``scheduler.queue.name``.
+   
+   The configuration specified at the Namespace-level will override the configuration
+   specified in ``cdap-site.xml``.
+
+   For example, to set ``A`` as the queue name to be used for the namespace
+   *<namespace-id>*, you use this command::
+   
+      PUT <base-url>/v3/namespaces/<namespace-id>/properties
+   
+   with the property as a JSON string in the body::
+   
+      {"config": {"scheduler.queue.name": "A"}'
+
+    
+   **Note:** The configuration at the Namespace level can only be set for CDAP programs and
+   Explore queries. This configuration cannot be applied for Master Services, since
+   Master Services are not tied to a namespace level.
+
+   **Note:** If the configuration is not specified at either the Namespace or
+   ``cdap-site`` levels, then all the Master Services, CDAP programs and Explore queries
+   will be submitted to default YARN queues.
+


### PR DESCRIPTION
"Resource Guarantees for CDAP Programs in YARN"

Staged at:

- [Admin Manual index](http://stg-web101.sw.joyent.continuuity.net/cdap/2.8.0-SNAPSHOT-r2.8_yarn_queue_docs/en/admin-manual/index.html)
- [Operations Section index](http://stg-web101.sw.joyent.continuuity.net/cdap/2.8.0-SNAPSHOT-r2.8_yarn_queue_docs/en/admin-manual/operations/index.html)
- [Resource Guarantees](http://stg-web101.sw.joyent.continuuity.net/cdap/2.8.0-SNAPSHOT-r2.8_yarn_queue_docs/en/admin-manual/operations/resource-guarantees.html)
