### PR TITLE
Changes to support backwards compatability for a flow's groupId (for str...

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowUtils.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowUtils.java
@@ -21,6 +21,7 @@ import co.cask.cdap.api.flow.FlowletDefinition;
 import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.queue.QueueSpecification;
 import co.cask.cdap.app.queue.QueueSpecificationGenerator;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.queue.QueueName;
 import co.cask.cdap.data2.transaction.ForwardingTransactionAware;
 import co.cask.cdap.data2.transaction.Transactions;
@@ -68,8 +69,13 @@ public final class FlowUtils {
    * Generates a queue consumer groupId for the given flowlet in the given program id.
    */
   public static long generateConsumerGroupId(Id.Program program, String flowletId) {
+    // Use 'developer' in place of a program's namespace for programs in the 'default' namespace
+    // to support backwards compatibility for queues and streams.
+    String namespace = program.getNamespaceId();
+    String backwardsCompatibleNamespace =
+      Constants.DEFAULT_NAMESPACE.equals(namespace) ? Constants.DEVELOPER_ACCOUNT : namespace;
     return Hashing.md5().newHasher()
-                  .putString(program.getNamespaceId())
+                  .putString(backwardsCompatibleNamespace)
                   .putString(program.getApplicationId())
                   .putString(program.getId())
                   .putString(flowletId).hash().asLong();

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -724,6 +724,11 @@ public final class Constants {
     new NamespaceMeta.Builder().setName(Constants.DEFAULT_NAMESPACE_ID).setDescription("Default Namespace").build();
 
   /**
+   * Used for upgrade and backwards compatability
+   */
+  public static final String DEVELOPER_ACCOUNT = "developer";
+
+  /**
    * 'system' reserved namespace name
    */
   public static final String SYSTEM_NAMESPACE = "system";

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/AbstractUpgrader.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/AbstractUpgrader.java
@@ -31,7 +31,6 @@ import javax.annotation.Nullable;
 public abstract class AbstractUpgrader {
 
   private static final Logger LOG = LoggerFactory.getLogger(AbstractUpgrader.class);
-  protected static final String DEVELOPER_ACCOUNT = "developer";
   protected final LocationFactory locationFactory;
 
   public AbstractUpgrader(LocationFactory locationFactory) {

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/ArchiveUpgrader.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/ArchiveUpgrader.java
@@ -73,7 +73,7 @@ public class ArchiveUpgrader extends AbstractUpgrader {
                      .append(cConf.get(LoggingConfiguration.LOG_BASE_DIR)));
     //TODO: This developer string in 2.7 is default so we need to handle that here when we improvise on this tool for
     //2.7 version
-    renameLocation(locationFactory.create(logBaseDir).append(DEVELOPER_ACCOUNT),
+    renameLocation(locationFactory.create(logBaseDir).append(Constants.DEVELOPER_ACCOUNT),
                    locationFactory.create(Constants.DEFAULT_NAMESPACE)
                      .append(cConf.get(LoggingConfiguration.LOG_BASE_DIR)));
   }

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/MDSUpgrader.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/MDSUpgrader.java
@@ -181,7 +181,7 @@ public class MDSUpgrader extends AbstractUpgrader {
    * @param programType the {@link ProgramType} of the program
    */
   private void handleProgramArgs(final String appId, final String programId, final ProgramType programType) {
-    final MDSKey partialKey = new MDSKey.Builder().add(AppMetadataStore.TYPE_PROGRAM_ARGS, DEVELOPER_ACCOUNT,
+    final MDSKey partialKey = new MDSKey.Builder().add(AppMetadataStore.TYPE_PROGRAM_ARGS, Constants.DEVELOPER_ACCOUNT,
                                                        appId, programId).build();
     appMDS.executeUnchecked(new TransactionExecutor.Function<AppMDS, Void>() {
       @Override
@@ -204,8 +204,9 @@ public class MDSUpgrader extends AbstractUpgrader {
    * @param programType the {@link ProgramType} of the program
    */
   private void handleRunRecordStarted(final String appId, final String programId, final ProgramType programType) {
-    final MDSKey partialKey = new MDSKey.Builder().add(AppMetadataStore.TYPE_RUN_RECORD_STARTED, DEVELOPER_ACCOUNT,
-                                                       appId, programId).build();
+    final MDSKey partialKey =
+      new MDSKey.Builder().add(AppMetadataStore.TYPE_RUN_RECORD_STARTED, Constants.DEVELOPER_ACCOUNT,
+                               appId, programId).build();
     appMDS.executeUnchecked(new TransactionExecutor.Function<AppMDS, Void>() {
       @Override
       public Void apply(AppMDS appMetaStore) throws Exception {
@@ -228,8 +229,9 @@ public class MDSUpgrader extends AbstractUpgrader {
    */
   private void handleRunRecordCompleted(final String appId, final String programId, final ProgramType programType) {
 
-    final MDSKey partialKey = new MDSKey.Builder().add(AppMetadataStore.TYPE_RUN_RECORD_COMPLETED, DEVELOPER_ACCOUNT,
-                                                       appId, programId).build();
+    final MDSKey partialKey =
+      new MDSKey.Builder().add(AppMetadataStore.TYPE_RUN_RECORD_COMPLETED, Constants.DEVELOPER_ACCOUNT,
+                               appId, programId).build();
     appMDS.executeUnchecked(new TransactionExecutor.Function<AppMDS, Void>() {
       @Override
       public Void apply(AppMDS appMetaStore) throws Exception {

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/QueueConfigUpgrader.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/QueueConfigUpgrader.java
@@ -84,7 +84,7 @@ public class QueueConfigUpgrader extends AbstractUpgrader {
       try {
         while ((result = resultScanner.next()) != null) {
           byte[] row = result.getRow();
-          String rowKey = Bytes.toStringBinary(row);
+          String rowKey = Bytes.toString(row);
           LOG.debug("Processing queue config for  {}", rowKey);
           NavigableMap<byte[], byte[]> columnsMap = result.getFamilyMap(QueueEntryRow.COLUMN_FAMILY);
           QueueName queueName = fromRowKey(row);

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/Id.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/Id.java
@@ -427,7 +427,8 @@ public final class Id  {
       Preconditions.checkNotNull(streamName, "Stream name cannot be null.");
 
       Preconditions.checkArgument(isId(streamName),
-                                  "Stream name can only contains alphanumeric, '-' and '_' characters only.");
+                                  String.format("Stream name can only contains alphanumeric, " +
+                                                  "'-' and '_' characters only: %s", streamName));
 
       this.namespace = namespace;
       this.streamName = streamName;

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/write/FileMetaDataManager.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/write/FileMetaDataManager.java
@@ -50,7 +50,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Arrays;
 import java.util.Map;
 import java.util.SortedMap;
 
@@ -62,7 +61,6 @@ public final class FileMetaDataManager {
 
   private static final byte[] ROW_KEY_PREFIX = Bytes.toBytes(200);
   private static final byte[] ROW_KEY_PREFIX_END = Bytes.toBytes(201);
-  private static final String DEVELOPER_STRING = "developer";
 
   private final TransactionExecutorFactory txExecutorFactory;
 
@@ -276,7 +274,7 @@ public final class FileMetaDataManager {
             String oldPath = Bytes.toString(entry.getValue());
             Location newPath;
             String newKey;
-            if (key.startsWith(Constants.CDAP_NAMESPACE) || key.startsWith(DEVELOPER_STRING)) {
+            if (key.startsWith(Constants.CDAP_NAMESPACE) || key.startsWith(Constants.DEVELOPER_ACCOUNT)) {
               newPath = upgradePath(key, oldPath);
               newKey = upgradeKey(key);
               try {
@@ -304,7 +302,7 @@ public final class FileMetaDataManager {
     if (key.startsWith(Constants.CDAP_NAMESPACE)) {
       return key.replace(Constants.CDAP_NAMESPACE, Constants.SYSTEM_NAMESPACE);
     }
-    return key.replace(DEVELOPER_STRING, Constants.DEFAULT_NAMESPACE);
+    return key.replace(Constants.DEVELOPER_ACCOUNT, Constants.DEFAULT_NAMESPACE);
   }
 
   /**
@@ -326,7 +324,7 @@ public final class FileMetaDataManager {
       newLocation = updateLogLocation(location, Constants.SYSTEM_NAMESPACE);
       // newLocation will be: hdfs://blah.blah.net/cdap/system/logs/avro/services/
       // service-appfabric/2015-02-26/1424988452088.avro
-    } else if (key.startsWith(DEVELOPER_STRING)) {
+    } else if (key.startsWith(Constants.DEVELOPER_ACCOUNT)) {
       // Example of this type: hdfs://blah.blah.net/cdap/logs/avro/developer/HelloWorld/
       // flow-WhoFlow/2015-02-26/1424988484082.avro
       newLocation = updateLogLocation(location, Constants.DEFAULT_NAMESPACE);


### PR DESCRIPTION
...eams/queues).

In FlowUtils#generateConsumerGroupId, use 'developer' instead of the program's namespace if the namespace is 'default'.

Data migration is less feasible because the groupId is used in the queue data tables, which can be quite large.

Helps to resolve: https://issues.cask.co/browse/CDAP-1823
Build: http://builds.cask.co/browse/CDAP-RBT161-2