### PR TITLE
Feature/cdap 1823 stream state store upgrade

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowUtils.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowUtils.java
@@ -21,6 +21,7 @@ import co.cask.cdap.api.flow.FlowletDefinition;
 import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.queue.QueueSpecification;
 import co.cask.cdap.app.queue.QueueSpecificationGenerator;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.queue.QueueName;
 import co.cask.cdap.data2.transaction.ForwardingTransactionAware;
 import co.cask.cdap.data2.transaction.Transactions;
@@ -68,8 +69,13 @@ public final class FlowUtils {
    * Generates a queue consumer groupId for the given flowlet in the given program id.
    */
   public static long generateConsumerGroupId(Id.Program program, String flowletId) {
+    // Use 'developer' in place of a program's namespace for programs in the 'default' namespace
+    // to support backwards compatibility for queues and streams.
+    String namespace = program.getNamespaceId();
+    String backwardsCompatibleNamespace =
+      Constants.DEFAULT_NAMESPACE.equals(namespace) ? Constants.DEVELOPER_ACCOUNT : namespace;
     return Hashing.md5().newHasher()
-                  .putString(program.getNamespaceId())
+                  .putString(backwardsCompatibleNamespace)
                   .putString(program.getApplicationId())
                   .putString(program.getId())
                   .putString(flowletId).hash().asLong();

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -724,6 +724,11 @@ public final class Constants {
     new NamespaceMeta.Builder().setName(Constants.DEFAULT_NAMESPACE_ID).setDescription("Default Namespace").build();
 
   /**
+   * Used for upgrade and backwards compatability
+   */
+  public static final String DEVELOPER_ACCOUNT = "developer";
+
+  /**
    * 'system' reserved namespace name
    */
   public static final String SYSTEM_NAMESPACE = "system";

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/AbstractQueueUpgrader.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/AbstractQueueUpgrader.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data.tools;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.data2.transaction.queue.QueueEntryRow;
+import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
+import com.google.common.base.Throwables;
+import com.google.common.collect.Lists;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.HBaseAdmin;
+import org.apache.hadoop.hbase.client.HTable;
+import org.apache.hadoop.hbase.client.Mutation;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.ResultScanner;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.twill.filesystem.LocationFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.NavigableMap;
+import javax.annotation.Nullable;
+
+/**
+ * Upgrades row keys of a queue table
+ */
+public abstract class AbstractQueueUpgrader extends AbstractUpgrader {
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractQueueUpgrader.class);
+  protected final HBaseTableUtil tableUtil;
+  protected final Configuration conf;
+
+  protected AbstractQueueUpgrader(LocationFactory locationFactory, HBaseTableUtil tableUtil, Configuration conf) {
+    super(locationFactory);
+    this.tableUtil = tableUtil;
+    this.conf = conf;
+  }
+
+  /**
+   * @return TableId of the table to upgrade
+   */
+  protected abstract TableId getTableId();
+
+  /**
+   * @param oldRowKey the old row key of the row to migrate
+   * @return row key for the row to migrate, or null if the row is not to be migrated
+   */
+  @Nullable
+  protected abstract byte[] processRowKey(byte[] oldRowKey);
+
+  @Override
+  void upgrade() throws Exception {
+    TableId tableId = getTableId();
+    if (!tableUtil.tableExists(new HBaseAdmin(conf), tableId)) {
+      LOG.info("Table does not exist: {}. No upgrade necessary.", tableId);
+      return;
+    }
+    HTable hTable = tableUtil.createHTable(conf, tableId);
+    LOG.info("Starting upgrade for table {}", Bytes.toString(hTable.getTableName()));
+    try {
+      Scan scan = new Scan();
+      scan.setTimeRange(0, HConstants.LATEST_TIMESTAMP);
+      scan.addFamily(QueueEntryRow.COLUMN_FAMILY);
+      scan.setMaxVersions(1); // we only need to see one version of each row
+      List<Mutation> mutations = Lists.newArrayList();
+      Result result;
+      ResultScanner resultScanner = hTable.getScanner(scan);
+      try {
+        while ((result = resultScanner.next()) != null) {
+          byte[] row = result.getRow();
+          String rowKeyString = Bytes.toString(row);
+          byte[] newKey = processRowKey(row);
+          NavigableMap<byte[], byte[]> columnsMap = result.getFamilyMap(QueueEntryRow.COLUMN_FAMILY);
+          if (newKey != null) {
+            Put put = new Put(newKey);
+            for (NavigableMap.Entry<byte[], byte[]> entry : columnsMap.entrySet()) {
+              LOG.debug("Adding entry {} -> {} for upgrade",
+                        Bytes.toString(entry.getKey()), Bytes.toString(entry.getValue()));
+              put.add(QueueEntryRow.COLUMN_FAMILY, entry.getKey(), entry.getValue());
+              mutations.add(put);
+            }
+            LOG.debug("Marking old key {} for deletion", rowKeyString);
+            mutations.add(new Delete(row));
+          }
+          LOG.info("Finished processing row key {}", rowKeyString);
+        }
+      } finally {
+        resultScanner.close();
+      }
+
+      hTable.batch(mutations);
+
+      LOG.info("Successfully completed upgrade for table {}", Bytes.toString(hTable.getTableName()));
+    } catch (Exception e) {
+      LOG.error("Error while upgrading table: {}", tableId, e);
+      throw Throwables.propagate(e);
+    } finally {
+      hTable.close();
+    }
+  }
+}

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/AbstractUpgrader.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/AbstractUpgrader.java
@@ -31,7 +31,6 @@ import javax.annotation.Nullable;
 public abstract class AbstractUpgrader {
 
   private static final Logger LOG = LoggerFactory.getLogger(AbstractUpgrader.class);
-  protected static final String DEVELOPER_ACCOUNT = "developer";
   protected final LocationFactory locationFactory;
 
   public AbstractUpgrader(LocationFactory locationFactory) {

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/ArchiveUpgrader.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/ArchiveUpgrader.java
@@ -73,7 +73,7 @@ public class ArchiveUpgrader extends AbstractUpgrader {
                      .append(cConf.get(LoggingConfiguration.LOG_BASE_DIR)));
     //TODO: This developer string in 2.7 is default so we need to handle that here when we improvise on this tool for
     //2.7 version
-    renameLocation(locationFactory.create(logBaseDir).append(DEVELOPER_ACCOUNT),
+    renameLocation(locationFactory.create(logBaseDir).append(Constants.DEVELOPER_ACCOUNT),
                    locationFactory.create(Constants.DEFAULT_NAMESPACE)
                      .append(cConf.get(LoggingConfiguration.LOG_BASE_DIR)));
   }

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/MDSUpgrader.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/MDSUpgrader.java
@@ -181,7 +181,7 @@ public class MDSUpgrader extends AbstractUpgrader {
    * @param programType the {@link ProgramType} of the program
    */
   private void handleProgramArgs(final String appId, final String programId, final ProgramType programType) {
-    final MDSKey partialKey = new MDSKey.Builder().add(AppMetadataStore.TYPE_PROGRAM_ARGS, DEVELOPER_ACCOUNT,
+    final MDSKey partialKey = new MDSKey.Builder().add(AppMetadataStore.TYPE_PROGRAM_ARGS, Constants.DEVELOPER_ACCOUNT,
                                                        appId, programId).build();
     appMDS.executeUnchecked(new TransactionExecutor.Function<AppMDS, Void>() {
       @Override
@@ -204,8 +204,9 @@ public class MDSUpgrader extends AbstractUpgrader {
    * @param programType the {@link ProgramType} of the program
    */
   private void handleRunRecordStarted(final String appId, final String programId, final ProgramType programType) {
-    final MDSKey partialKey = new MDSKey.Builder().add(AppMetadataStore.TYPE_RUN_RECORD_STARTED, DEVELOPER_ACCOUNT,
-                                                       appId, programId).build();
+    final MDSKey partialKey =
+      new MDSKey.Builder().add(AppMetadataStore.TYPE_RUN_RECORD_STARTED, Constants.DEVELOPER_ACCOUNT,
+                               appId, programId).build();
     appMDS.executeUnchecked(new TransactionExecutor.Function<AppMDS, Void>() {
       @Override
       public Void apply(AppMDS appMetaStore) throws Exception {
@@ -228,8 +229,9 @@ public class MDSUpgrader extends AbstractUpgrader {
    */
   private void handleRunRecordCompleted(final String appId, final String programId, final ProgramType programType) {
 
-    final MDSKey partialKey = new MDSKey.Builder().add(AppMetadataStore.TYPE_RUN_RECORD_COMPLETED, DEVELOPER_ACCOUNT,
-                                                       appId, programId).build();
+    final MDSKey partialKey =
+      new MDSKey.Builder().add(AppMetadataStore.TYPE_RUN_RECORD_COMPLETED, Constants.DEVELOPER_ACCOUNT,
+                               appId, programId).build();
     appMDS.executeUnchecked(new TransactionExecutor.Function<AppMDS, Void>() {
       @Override
       public Void apply(AppMDS appMetaStore) throws Exception {

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/QueueConfigUpgrader.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/QueueConfigUpgrader.java
@@ -20,102 +20,41 @@ import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.queue.QueueName;
 import co.cask.cdap.data2.transaction.queue.QueueConstants;
-import co.cask.cdap.data2.transaction.queue.QueueEntryRow;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
-import co.cask.cdap.proto.Id;
 import com.google.common.base.Joiner;
-import com.google.common.base.Throwables;
-import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hbase.HBaseConfiguration;
-import org.apache.hadoop.hbase.HConstants;
-import org.apache.hadoop.hbase.client.Delete;
-import org.apache.hadoop.hbase.client.HBaseAdmin;
-import org.apache.hadoop.hbase.client.HTable;
-import org.apache.hadoop.hbase.client.Mutation;
-import org.apache.hadoop.hbase.client.Put;
-import org.apache.hadoop.hbase.client.Result;
-import org.apache.hadoop.hbase.client.ResultScanner;
-import org.apache.hadoop.hbase.client.Scan;
 import org.apache.twill.filesystem.LocationFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.List;
-import java.util.NavigableMap;
 import javax.annotation.Nullable;
 
 /**
  * Upgrades queue.config table
  */
-public class QueueConfigUpgrader extends AbstractUpgrader {
+public class QueueConfigUpgrader extends AbstractQueueUpgrader {
   private static final Logger LOG = LoggerFactory.getLogger(QueueConfigUpgrader.class);
-  private final HBaseTableUtil tableUtil;
-  private final Configuration conf;
 
   @Inject
   public QueueConfigUpgrader(LocationFactory locationFactory, HBaseTableUtil tableUtil, Configuration conf) {
-    super(locationFactory);
-    this.tableUtil = tableUtil;
-    this.conf = conf;
+    super(locationFactory, tableUtil, conf);
   }
 
   @Override
-  void upgrade() throws Exception {
+  protected TableId getTableId() {
     String dsName = Joiner.on(".").join(Constants.SYSTEM_NAMESPACE, QueueConstants.QUEUE_CONFIG_TABLE_NAME);
-    Id.DatasetInstance datasetId = Id.DatasetInstance.from(Constants.DEFAULT_NAMESPACE_ID, dsName);
-    TableId queueConfigTableId = TableId.from(datasetId.getNamespaceId(), dsName);
-    if (!tableUtil.tableExists(new HBaseAdmin(conf), queueConfigTableId)) {
-      LOG.info("Queue config table does not exist: {}. No upgrade necessary.", queueConfigTableId);
-      return;
-    }
-    HTable queueConfigTable = tableUtil.createHTable(conf, queueConfigTableId);
-    LOG.info("Starting upgrade for queue config table {}", Bytes.toString(queueConfigTable.getTableName()));
-    try {
-      Scan scan = new Scan();
-      scan.setTimeRange(0, HConstants.LATEST_TIMESTAMP);
-      scan.addFamily(QueueEntryRow.COLUMN_FAMILY);
-      scan.setMaxVersions(1); // we only need to see one version of each row
-      List<Mutation> mutations = Lists.newArrayList();
-      Result result;
-      ResultScanner resultScanner = queueConfigTable.getScanner(scan);
-      try {
-        while ((result = resultScanner.next()) != null) {
-          byte[] row = result.getRow();
-          String rowKey = Bytes.toString(row);
-          LOG.debug("Processing queue config for  {}", rowKey);
-          NavigableMap<byte[], byte[]> columnsMap = result.getFamilyMap(QueueEntryRow.COLUMN_FAMILY);
-          QueueName queueName = fromRowKey(row);
-          if (queueName != null) {
-            Put put = new Put(queueName.toBytes());
-            LOG.debug("Upgrading queue name: {}", queueName);
-            for (NavigableMap.Entry<byte[], byte[]> entry : columnsMap.entrySet()) {
-              LOG.debug("Adding entry {} -> {} for upgrade",
-                        Bytes.toString(entry.getKey()), Bytes.toString(entry.getValue()));
-              put.add(QueueEntryRow.COLUMN_FAMILY, entry.getKey(), entry.getValue());
-              mutations.add(put);
-            }
-            LOG.debug("Marking old key {} for deletion", rowKey);
-            mutations.add(new Delete(row));
-          }
-          LOG.info("Finished processing queue config for {}", rowKey);
-        }
-      } finally {
-        resultScanner.close();
-      }
+    return TableId.from(Constants.DEFAULT_NAMESPACE, dsName);
+  }
 
-      queueConfigTable.batch(mutations);
-
-      LOG.info("Successfully completed upgrade for queue config table {}",
-               Bytes.toString(queueConfigTable.getTableName()));
-    } catch (Exception e) {
-      LOG.error("Error while upgrading queue config table: {}", datasetId, e);
-      throw Throwables.propagate(e);
-    } finally {
-      queueConfigTable.close();
-    }
+  @Nullable
+  @Override
+  protected byte[] processRowKey(byte[] oldRowKey) {
+    LOG.debug("Processing queue config for: {}", Bytes.toString(oldRowKey));
+    QueueName queueName = fromRowKey(oldRowKey);
+    LOG.debug("Processing row key for  queue name: {}", queueName);
+    return queueName == null ? null : queueName.toBytes();
   }
 
   @Nullable

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/QueueConfigUpgrader.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/QueueConfigUpgrader.java
@@ -84,7 +84,7 @@ public class QueueConfigUpgrader extends AbstractUpgrader {
       try {
         while ((result = resultScanner.next()) != null) {
           byte[] row = result.getRow();
-          String rowKey = Bytes.toStringBinary(row);
+          String rowKey = Bytes.toString(row);
           LOG.debug("Processing queue config for  {}", rowKey);
           NavigableMap<byte[], byte[]> columnsMap = result.getFamilyMap(QueueEntryRow.COLUMN_FAMILY);
           QueueName queueName = fromRowKey(row);

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/StreamStateStoreUpgrader.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/StreamStateStoreUpgrader.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data.tools;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.queue.QueueName;
+import co.cask.cdap.data.stream.StreamUtils;
+import co.cask.cdap.data2.transaction.queue.QueueEntryRow;
+import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
+import co.cask.cdap.proto.Id;
+import com.google.common.base.Throwables;
+import com.google.common.collect.Lists;
+import com.google.inject.Inject;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.HBaseAdmin;
+import org.apache.hadoop.hbase.client.HTable;
+import org.apache.hadoop.hbase.client.Mutation;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.ResultScanner;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.twill.filesystem.LocationFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.NavigableMap;
+import javax.annotation.Nullable;
+
+/**
+ * Upgrades stream state store table
+ */
+public class StreamStateStoreUpgrader extends AbstractUpgrader {
+  private static final Logger LOG = LoggerFactory.getLogger(StreamStateStoreUpgrader.class);
+  private final HBaseTableUtil tableUtil;
+  private final Configuration conf;
+
+  @Inject
+  public StreamStateStoreUpgrader(LocationFactory locationFactory, HBaseTableUtil tableUtil) {
+    super(locationFactory);
+    this.tableUtil = tableUtil;
+    this.conf = HBaseConfiguration.create();
+  }
+
+  @Override
+  void upgrade() throws Exception {
+    TableId streamStateStoreTableId = StreamUtils.getStateStoreTableId(Constants.DEFAULT_NAMESPACE_ID);
+    if (!tableUtil.tableExists(new HBaseAdmin(conf), streamStateStoreTableId)) {
+      LOG.info("Stream state store table does not exist: {}. No upgrade necessary.", streamStateStoreTableId);
+      return;
+    }
+    HTable streamStateStoreHTable = tableUtil.createHTable(conf, streamStateStoreTableId);
+    LOG.info("Starting upgrade for stream state store table: {}",
+             Bytes.toString(streamStateStoreHTable.getTableName()));
+    try {
+      Scan scan = new Scan();
+      scan.setTimeRange(0, HConstants.LATEST_TIMESTAMP);
+      scan.addFamily(QueueEntryRow.COLUMN_FAMILY);
+      scan.setMaxVersions(1); // we only need to see one version of each row
+      List<Mutation> mutations = Lists.newArrayList();
+      Result result;
+      ResultScanner resultScanner = streamStateStoreHTable.getScanner(scan);
+      try {
+        while ((result = resultScanner.next()) != null) {
+          byte[] row = result.getRow();
+          String rowKey = Bytes.toString(row);
+          LOG.debug("Processing stream state for {}", rowKey);
+          NavigableMap<byte[], byte[]> columnsMap = result.getFamilyMap(QueueEntryRow.COLUMN_FAMILY);
+          Id.Stream streamId = fromRowKey(row);
+          if (streamId != null) {
+            Put put = new Put(streamId.toBytes());
+            LOG.debug("Upgrading stream: {}", streamId);
+            for (NavigableMap.Entry<byte[], byte[]> entry : columnsMap.entrySet()) {
+              LOG.debug("Adding entry {} -> {} for upgrade",
+                        Bytes.toString(entry.getKey()), Bytes.toString(entry.getValue()));
+              put.add(QueueEntryRow.COLUMN_FAMILY, entry.getKey(), entry.getValue());
+              mutations.add(put);
+            }
+            LOG.debug("Marking old key {} for deletion", rowKey);
+            mutations.add(new Delete(row));
+          }
+          LOG.info("Finished processing stream state for {}", rowKey);
+        }
+      } finally {
+        resultScanner.close();
+      }
+
+      streamStateStoreHTable.batch(mutations);
+
+      LOG.info("Successfully completed upgrade for stream state store table {}",
+               Bytes.toString(streamStateStoreHTable.getTableName()));
+    } catch (Exception e) {
+      LOG.error("Error while upgrading stream state store table: {}", streamStateStoreHTable, e);
+      throw Throwables.propagate(e);
+    } finally {
+      streamStateStoreHTable.close();
+    }
+  }
+
+  @Nullable
+  private Id.Stream fromRowKey(byte[] oldRowKey) {
+    QueueName queueName = QueueName.from(oldRowKey);
+
+    if (queueName.isStream() && queueName.getNumComponents() == 1) {
+      LOG.debug("Found old stream state {}. Upgrading.", queueName);
+      return Id.Stream.from(Constants.DEFAULT_NAMESPACE, queueName.getFirstComponent());
+    } else {
+      LOG.warn("Unknown format for queueName: {}. Skipping.", queueName);
+    }
+
+    // skip unknown rows or rows that may already have a namespace in the QueueName
+    return null;
+  }
+}

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/StreamStateStoreUpgrader.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/StreamStateStoreUpgrader.java
@@ -20,100 +20,40 @@ import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.queue.QueueName;
 import co.cask.cdap.data.stream.StreamUtils;
-import co.cask.cdap.data2.transaction.queue.QueueEntryRow;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.proto.Id;
-import com.google.common.base.Throwables;
-import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hbase.HBaseConfiguration;
-import org.apache.hadoop.hbase.HConstants;
-import org.apache.hadoop.hbase.client.Delete;
-import org.apache.hadoop.hbase.client.HBaseAdmin;
-import org.apache.hadoop.hbase.client.HTable;
-import org.apache.hadoop.hbase.client.Mutation;
-import org.apache.hadoop.hbase.client.Put;
-import org.apache.hadoop.hbase.client.Result;
-import org.apache.hadoop.hbase.client.ResultScanner;
-import org.apache.hadoop.hbase.client.Scan;
 import org.apache.twill.filesystem.LocationFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.List;
-import java.util.NavigableMap;
 import javax.annotation.Nullable;
 
 /**
  * Upgrades stream state store table
  */
-public class StreamStateStoreUpgrader extends AbstractUpgrader {
+public class StreamStateStoreUpgrader extends AbstractQueueUpgrader {
   private static final Logger LOG = LoggerFactory.getLogger(StreamStateStoreUpgrader.class);
-  private final HBaseTableUtil tableUtil;
-  private final Configuration conf;
 
   @Inject
-  public StreamStateStoreUpgrader(LocationFactory locationFactory, HBaseTableUtil tableUtil) {
-    super(locationFactory);
-    this.tableUtil = tableUtil;
-    this.conf = HBaseConfiguration.create();
+  public StreamStateStoreUpgrader(LocationFactory locationFactory, HBaseTableUtil tableUtil, Configuration conf) {
+    super(locationFactory, tableUtil, conf);
   }
 
   @Override
-  void upgrade() throws Exception {
-    TableId streamStateStoreTableId = StreamUtils.getStateStoreTableId(Constants.DEFAULT_NAMESPACE_ID);
-    if (!tableUtil.tableExists(new HBaseAdmin(conf), streamStateStoreTableId)) {
-      LOG.info("Stream state store table does not exist: {}. No upgrade necessary.", streamStateStoreTableId);
-      return;
-    }
-    HTable streamStateStoreHTable = tableUtil.createHTable(conf, streamStateStoreTableId);
-    LOG.info("Starting upgrade for stream state store table: {}",
-             Bytes.toString(streamStateStoreHTable.getTableName()));
-    try {
-      Scan scan = new Scan();
-      scan.setTimeRange(0, HConstants.LATEST_TIMESTAMP);
-      scan.addFamily(QueueEntryRow.COLUMN_FAMILY);
-      scan.setMaxVersions(1); // we only need to see one version of each row
-      List<Mutation> mutations = Lists.newArrayList();
-      Result result;
-      ResultScanner resultScanner = streamStateStoreHTable.getScanner(scan);
-      try {
-        while ((result = resultScanner.next()) != null) {
-          byte[] row = result.getRow();
-          String rowKey = Bytes.toString(row);
-          LOG.debug("Processing stream state for {}", rowKey);
-          NavigableMap<byte[], byte[]> columnsMap = result.getFamilyMap(QueueEntryRow.COLUMN_FAMILY);
-          Id.Stream streamId = fromRowKey(row);
-          if (streamId != null) {
-            Put put = new Put(streamId.toBytes());
-            LOG.debug("Upgrading stream: {}", streamId);
-            for (NavigableMap.Entry<byte[], byte[]> entry : columnsMap.entrySet()) {
-              LOG.debug("Adding entry {} -> {} for upgrade",
-                        Bytes.toString(entry.getKey()), Bytes.toString(entry.getValue()));
-              put.add(QueueEntryRow.COLUMN_FAMILY, entry.getKey(), entry.getValue());
-              mutations.add(put);
-            }
-            LOG.debug("Marking old key {} for deletion", rowKey);
-            mutations.add(new Delete(row));
-          }
-          LOG.info("Finished processing stream state for {}", rowKey);
-        }
-      } finally {
-        resultScanner.close();
-      }
+  protected TableId getTableId() {
+    return StreamUtils.getStateStoreTableId(Constants.DEFAULT_NAMESPACE_ID);
+  }
 
-      streamStateStoreHTable.batch(mutations);
-
-      LOG.info("Successfully completed upgrade for stream state store table {}",
-               Bytes.toString(streamStateStoreHTable.getTableName()));
-    } catch (Exception e) {
-      LOG.error("Error while upgrading stream state store table: {}", streamStateStoreHTable, e);
-      throw Throwables.propagate(e);
-    } finally {
-      streamStateStoreHTable.close();
-    }
+  @Nullable
+  @Override
+  protected byte[] processRowKey(byte[] oldRowKey) {
+    LOG.debug("Processing stream state for: {}", Bytes.toString(oldRowKey));
+    Id.Stream streamId = fromRowKey(oldRowKey);
+    LOG.debug("Upgrading stream state for: {}", streamId);
+    return streamId == null ? null : streamId.toBytes();
   }
 
   @Nullable

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
@@ -301,6 +301,10 @@ public class UpgradeTool {
     LOG.info("Upgrading logs meta data ...");
     getFileMetaDataManager().upgrade();
 
+    LOG.info("Upgrading stream state store table ...");
+    StreamStateStoreUpgrader streamStateStoreUpgrader = injector.getInstance(StreamStateStoreUpgrader.class);
+    streamStateStoreUpgrader.upgrade();
+
     LOG.info("Upgrading queue.config table ...");
     QueueConfigUpgrader queueConfigUpgrader = injector.getInstance(QueueConfigUpgrader.class);
     queueConfigUpgrader.upgrade();

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/Id.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/Id.java
@@ -427,7 +427,7 @@ public final class Id  {
       Preconditions.checkNotNull(streamName, "Stream name cannot be null.");
 
       Preconditions.checkArgument(isId(streamName),
-                                  String.format("Stream name can only contains alphanumeric, " +
+                                  String.format("Stream name can only contain alphanumeric, " +
                                                   "'-' and '_' characters only: %s", streamName));
 
       this.namespace = namespace;

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/Id.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/Id.java
@@ -427,7 +427,8 @@ public final class Id  {
       Preconditions.checkNotNull(streamName, "Stream name cannot be null.");
 
       Preconditions.checkArgument(isId(streamName),
-                                  "Stream name can only contains alphanumeric, '-' and '_' characters only.");
+                                  String.format("Stream name can only contains alphanumeric, " +
+                                                  "'-' and '_' characters only: %s", streamName));
 
       this.namespace = namespace;
       this.streamName = streamName;

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/write/FileMetaDataManager.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/write/FileMetaDataManager.java
@@ -50,7 +50,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Arrays;
 import java.util.Map;
 import java.util.SortedMap;
 
@@ -62,7 +61,6 @@ public final class FileMetaDataManager {
 
   private static final byte[] ROW_KEY_PREFIX = Bytes.toBytes(200);
   private static final byte[] ROW_KEY_PREFIX_END = Bytes.toBytes(201);
-  private static final String DEVELOPER_STRING = "developer";
 
   private final TransactionExecutorFactory txExecutorFactory;
 
@@ -276,7 +274,7 @@ public final class FileMetaDataManager {
             String oldPath = Bytes.toString(entry.getValue());
             Location newPath;
             String newKey;
-            if (key.startsWith(Constants.CDAP_NAMESPACE) || key.startsWith(DEVELOPER_STRING)) {
+            if (key.startsWith(Constants.CDAP_NAMESPACE) || key.startsWith(Constants.DEVELOPER_ACCOUNT)) {
               newPath = upgradePath(key, oldPath);
               newKey = upgradeKey(key);
               try {
@@ -304,7 +302,7 @@ public final class FileMetaDataManager {
     if (key.startsWith(Constants.CDAP_NAMESPACE)) {
       return key.replace(Constants.CDAP_NAMESPACE, Constants.SYSTEM_NAMESPACE);
     }
-    return key.replace(DEVELOPER_STRING, Constants.DEFAULT_NAMESPACE);
+    return key.replace(Constants.DEVELOPER_ACCOUNT, Constants.DEFAULT_NAMESPACE);
   }
 
   /**
@@ -326,7 +324,7 @@ public final class FileMetaDataManager {
       newLocation = updateLogLocation(location, Constants.SYSTEM_NAMESPACE);
       // newLocation will be: hdfs://blah.blah.net/cdap/system/logs/avro/services/
       // service-appfabric/2015-02-26/1424988452088.avro
-    } else if (key.startsWith(DEVELOPER_STRING)) {
+    } else if (key.startsWith(Constants.DEVELOPER_ACCOUNT)) {
       // Example of this type: hdfs://blah.blah.net/cdap/logs/avro/developer/HelloWorld/
       // flow-WhoFlow/2015-02-26/1424988484082.avro
       newLocation = updateLogLocation(location, Constants.DEFAULT_NAMESPACE);


### PR DESCRIPTION
Depends on: https://github.com/caskdata/cdap/pull/1652

This follows a similar pattern as queue config table upgrade (row key migration), but I have kept this separate/independent, because queue config table migration may need to be changed to go through dataset APIs instead of HBase Table APIs.

JIRA: https://issues.cask.co/browse/CDAP-1823
Build: http://builds.cask.co/browse/CDAP-RBT162-3