### PR TITLE
CDAP-1830: Use terminal width as max allowable line width in CLI

### DIFF
--- a/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
+++ b/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
@@ -582,7 +582,7 @@ public class CLIMainTest extends StandaloneTestBase {
   private static void testNamespacesOutput(CLI cli, String command, final List<NamespaceMeta> expected)
     throws Exception {
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-    PrintStream printStream = new PrintStream(outputStream);
+    PrintStream output = new PrintStream(outputStream);
     Table table = Table.builder()
       .setHeader("name", "description")
       .setRows(expected, new RowMaker<NamespaceMeta>() {
@@ -591,7 +591,7 @@ public class CLIMainTest extends StandaloneTestBase {
           return Lists.newArrayList(object.getName(), object.getDescription());
         }
       }).build();
-    cliMain.getTableRenderer().render(cliConfig, table);
+    cliMain.getTableRenderer().render(cliConfig, output, table);
     final String expectedOutput = outputStream.toString();
 
     testCommand(cli, command, new Function<String, Void>() {

--- a/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
+++ b/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
@@ -591,7 +591,7 @@ public class CLIMainTest extends StandaloneTestBase {
           return Lists.newArrayList(object.getName(), object.getDescription());
         }
       }).build();
-    cliMain.getTableRenderer().render(printStream, table);
+    cliMain.getTableRenderer().render(cliConfig, table);
     final String expectedOutput = outputStream.toString();
 
     testCommand(cli, command, new Function<String, Void>() {

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/CLIMain.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/CLIMain.java
@@ -40,6 +40,7 @@ import com.google.common.collect.Iterables;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import jline.TerminalFactory;
 import jline.console.completer.Completer;
 import org.apache.commons.cli.BasicParser;
 import org.apache.commons.cli.CommandLine;
@@ -113,8 +114,8 @@ public class CLIMain {
     this.commands = ImmutableList.of(
       injector.getInstance(DefaultCommands.class),
       new CommandSet<Command>(ImmutableList.<Command>of(
-        new HelpCommand(getCommandsSupplier()),
-        new SearchCommandsCommand(getCommandsSupplier())
+        new HelpCommand(getCommandsSupplier(), cliConfig),
+        new SearchCommandsCommand(getCommandsSupplier(), cliConfig)
       )));
     Map<String, Completer> completers = injector.getInstance(DefaultCompleters.class).get();
     cli = new CLI<Command>(Iterables.concat(commands), completers);

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/CallServiceCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/CallServiceCommand.java
@@ -124,7 +124,7 @@ public class CallServiceCommand extends AbstractCommand implements Categorized {
                                     bodySize, getBody(byteBuffer));
         }
       }).build();
-    cliConfig.getTableRenderer().render(cliConfig, table);
+    cliConfig.getTableRenderer().render(cliConfig, output, table);
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/CallServiceCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/CallServiceCommand.java
@@ -124,7 +124,7 @@ public class CallServiceCommand extends AbstractCommand implements Categorized {
                                     bodySize, getBody(byteBuffer));
         }
       }).build();
-    cliConfig.getTableRenderer().render(output, table);
+    cliConfig.getTableRenderer().render(cliConfig, table);
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/DescribeAppCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/DescribeAppCommand.java
@@ -57,7 +57,7 @@ public class DescribeAppCommand extends AbstractAuthCommand {
           return Lists.newArrayList(object.getType().getPrettyName(), object.getName(), object.getDescription());
         }
       }).build();
-    cliConfig.getTableRenderer().render(output, table);
+    cliConfig.getTableRenderer().render(cliConfig, table);
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/DescribeAppCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/DescribeAppCommand.java
@@ -57,7 +57,7 @@ public class DescribeAppCommand extends AbstractAuthCommand {
           return Lists.newArrayList(object.getType().getPrettyName(), object.getName(), object.getDescription());
         }
       }).build();
-    cliConfig.getTableRenderer().render(cliConfig, table);
+    cliConfig.getTableRenderer().render(cliConfig, output, table);
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/DescribeDatasetModuleCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/DescribeDatasetModuleCommand.java
@@ -62,7 +62,7 @@ public class DescribeDatasetModuleCommand extends AbstractAuthCommand {
                                     Joiner.on(", ").join(object.getUsedByModules()));
         }
       }).build();
-    cliConfig.getTableRenderer().render(cliConfig, table);
+    cliConfig.getTableRenderer().render(cliConfig, output, table);
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/DescribeDatasetModuleCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/DescribeDatasetModuleCommand.java
@@ -22,7 +22,6 @@ import co.cask.cdap.cli.ElementType;
 import co.cask.cdap.cli.util.AbstractAuthCommand;
 import co.cask.cdap.cli.util.RowMaker;
 import co.cask.cdap.cli.util.table.Table;
-import co.cask.cdap.cli.util.table.TableRenderer;
 import co.cask.cdap.client.DatasetModuleClient;
 import co.cask.cdap.proto.DatasetModuleMeta;
 import co.cask.common.cli.Arguments;
@@ -63,7 +62,7 @@ public class DescribeDatasetModuleCommand extends AbstractAuthCommand {
                                     Joiner.on(", ").join(object.getUsedByModules()));
         }
       }).build();
-    cliConfig.getTableRenderer().render(output, table);
+    cliConfig.getTableRenderer().render(cliConfig, table);
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/DescribeDatasetTypeCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/DescribeDatasetTypeCommand.java
@@ -22,7 +22,6 @@ import co.cask.cdap.cli.ElementType;
 import co.cask.cdap.cli.util.AbstractAuthCommand;
 import co.cask.cdap.cli.util.RowMaker;
 import co.cask.cdap.cli.util.table.Table;
-import co.cask.cdap.cli.util.table.TableRenderer;
 import co.cask.cdap.client.DatasetTypeClient;
 import co.cask.cdap.proto.DatasetTypeMeta;
 import co.cask.common.cli.Arguments;
@@ -60,7 +59,7 @@ public class DescribeDatasetTypeCommand extends AbstractAuthCommand {
           return Lists.newArrayList(object.getName(), Joiner.on(", ").join(object.getModules()));
         }
       }).build();
-    cliConfig.getTableRenderer().render(output, table);
+    cliConfig.getTableRenderer().render(cliConfig, table);
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/DescribeDatasetTypeCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/DescribeDatasetTypeCommand.java
@@ -59,7 +59,7 @@ public class DescribeDatasetTypeCommand extends AbstractAuthCommand {
           return Lists.newArrayList(object.getName(), Joiner.on(", ").join(object.getModules()));
         }
       }).build();
-    cliConfig.getTableRenderer().render(cliConfig, table);
+    cliConfig.getTableRenderer().render(cliConfig, output, table);
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/DescribeNamespaceCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/DescribeNamespaceCommand.java
@@ -58,7 +58,7 @@ public class DescribeNamespaceCommand extends AbstractCommand {
           return ImmutableList.of(object.getName(), object.getDescription());
         }
       }).build();
-    cliConfig.getTableRenderer().render(cliConfig, table);
+    cliConfig.getTableRenderer().render(cliConfig, output, table);
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/DescribeNamespaceCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/DescribeNamespaceCommand.java
@@ -58,7 +58,7 @@ public class DescribeNamespaceCommand extends AbstractCommand {
           return ImmutableList.of(object.getName(), object.getDescription());
         }
       }).build();
-    cliConfig.getTableRenderer().render(output, table);
+    cliConfig.getTableRenderer().render(cliConfig, table);
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/DescribeStreamCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/DescribeStreamCommand.java
@@ -61,7 +61,7 @@ public class DescribeStreamCommand extends AbstractAuthCommand {
                                     object.getNotificationThresholdMB());
         }
       }).build();
-    cliConfig.getTableRenderer().render(cliConfig, table);
+    cliConfig.getTableRenderer().render(cliConfig, output, table);
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/DescribeStreamCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/DescribeStreamCommand.java
@@ -61,7 +61,7 @@ public class DescribeStreamCommand extends AbstractAuthCommand {
                                     object.getNotificationThresholdMB());
         }
       }).build();
-    cliConfig.getTableRenderer().render(output, table);
+    cliConfig.getTableRenderer().render(cliConfig, table);
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/ExecuteQueryCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/ExecuteQueryCommand.java
@@ -91,7 +91,7 @@ public class ExecuteQueryCommand extends AbstractAuthCommand implements Categori
             return object.getColumns();
           }
         }).build();
-      cliConfig.getTableRenderer().render(cliConfig, table);
+      cliConfig.getTableRenderer().render(cliConfig, output, table);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
     } catch (ExecutionException e) {

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/ExecuteQueryCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/ExecuteQueryCommand.java
@@ -91,7 +91,7 @@ public class ExecuteQueryCommand extends AbstractAuthCommand implements Categori
             return object.getColumns();
           }
         }).build();
-      cliConfig.getTableRenderer().render(output, table);
+      cliConfig.getTableRenderer().render(cliConfig, table);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
     } catch (ExecutionException e) {

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramLiveInfoCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramLiveInfoCommand.java
@@ -71,7 +71,7 @@ public class GetProgramLiveInfoCommand extends AbstractAuthCommand {
                                     object.getRuntime(), object.getYarnAppId());
         }
       }).build();
-    cliConfig.getTableRenderer().render(cliConfig, table);
+    cliConfig.getTableRenderer().render(cliConfig, output, table);
 
     if (liveInfo.getContainers() != null) {
       Table containersTable = Table.builder()
@@ -83,7 +83,7 @@ public class GetProgramLiveInfoCommand extends AbstractAuthCommand {
               object.getMemory(), object.getVirtualCores(), object.getDebugPort());
           }
         }).build();
-      cliConfig.getTableRenderer().render(cliConfig, containersTable);
+      cliConfig.getTableRenderer().render(cliConfig, output, containersTable);
     }
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramLiveInfoCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramLiveInfoCommand.java
@@ -71,7 +71,7 @@ public class GetProgramLiveInfoCommand extends AbstractAuthCommand {
                                     object.getRuntime(), object.getYarnAppId());
         }
       }).build();
-    cliConfig.getTableRenderer().render(output, table);
+    cliConfig.getTableRenderer().render(cliConfig, table);
 
     if (liveInfo.getContainers() != null) {
       Table containersTable = Table.builder()
@@ -83,7 +83,7 @@ public class GetProgramLiveInfoCommand extends AbstractAuthCommand {
               object.getMemory(), object.getVirtualCores(), object.getDebugPort());
           }
         }).build();
-      cliConfig.getTableRenderer().render(output, containersTable);
+      cliConfig.getTableRenderer().render(cliConfig, containersTable);
     }
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramRunsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramRunsCommand.java
@@ -82,7 +82,7 @@ public class GetProgramRunsCommand extends AbstractCommand {
           return Lists.newArrayList(object.getPid(), object.getStatus(), object.getStartTs(), object.getStopTs());
         }
       }).build();
-    cliConfig.getTableRenderer().render(cliConfig, table);
+    cliConfig.getTableRenderer().render(cliConfig, output, table);
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramRunsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramRunsCommand.java
@@ -82,7 +82,7 @@ public class GetProgramRunsCommand extends AbstractCommand {
           return Lists.newArrayList(object.getPid(), object.getStatus(), object.getStartTs(), object.getStopTs());
         }
       }).build();
-    cliConfig.getTableRenderer().render(output, table);
+    cliConfig.getTableRenderer().render(cliConfig, table);
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetServiceEndpointsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetServiceEndpointsCommand.java
@@ -67,7 +67,7 @@ public class GetServiceEndpointsCommand extends AbstractAuthCommand implements C
           return Lists.newArrayList(endpoint.getMethod(), endpoint.getPath());
         }
       }).build();
-    cliConfig.getTableRenderer().render(cliConfig, table);
+    cliConfig.getTableRenderer().render(cliConfig, output, table);
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetServiceEndpointsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetServiceEndpointsCommand.java
@@ -67,7 +67,7 @@ public class GetServiceEndpointsCommand extends AbstractAuthCommand implements C
           return Lists.newArrayList(endpoint.getMethod(), endpoint.getPath());
         }
       }).build();
-    cliConfig.getTableRenderer().render(output, table);
+    cliConfig.getTableRenderer().render(cliConfig, table);
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetStreamEventsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetStreamEventsCommand.java
@@ -67,7 +67,7 @@ public class GetStreamEventsCommand extends AbstractCommand {
                                     bodySize, getBody(event.getBody()));
         }
       }).build();
-    cliConfig.getTableRenderer().render(output, table);
+    cliConfig.getTableRenderer().render(cliConfig, table);
 
     output.printf("Fetched %d events from stream %s", events.size(), streamId);
     output.println();

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetStreamEventsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetStreamEventsCommand.java
@@ -67,7 +67,7 @@ public class GetStreamEventsCommand extends AbstractCommand {
                                     bodySize, getBody(event.getBody()));
         }
       }).build();
-    cliConfig.getTableRenderer().render(cliConfig, table);
+    cliConfig.getTableRenderer().render(cliConfig, output, table);
 
     output.printf("Fetched %d events from stream %s", events.size(), streamId);
     output.println();

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetStreamStatsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetStreamStatsCommand.java
@@ -188,7 +188,7 @@ public class GetStreamStatsCommand extends AbstractCommand {
     }
 
     if (isInt || isLong || isFloat || isDouble) {
-      result.add(new HistogramProcessor());
+      result.add(new HistogramProcessor(cliConfig));
     }
 
     return result.build();
@@ -261,11 +261,15 @@ public class GetStreamStatsCommand extends AbstractCommand {
   private static final class HistogramProcessor implements StatsProcessor {
 
     private static final int MIN_BAR_WIDTH = 5;
-    private static final int MAX_PRINT_WIDTH = 80;
 
     // 0 -> [0, 99], 1 -> [100, 199], etc. (bucket size is BUCKET_SIZE)
     private final Multiset<Integer> buckets = HashMultiset.create();
     private static final int BUCKET_SIZE = 100;
+    private final CLIConfig cliConfig;
+
+    public HistogramProcessor(CLIConfig cliConfig) {
+      this.cliConfig = cliConfig;
+    }
 
     @Override
     public void process(Object element) {
@@ -286,7 +290,7 @@ public class GetStreamStatsCommand extends AbstractCommand {
         int maxCount = getBiggestBucket().getCount();
         int longestPrefix = getLongestBucketPrefix();
         // max length of the bar
-        int maxBarLength = Math.max(MIN_BAR_WIDTH, MAX_PRINT_WIDTH - longestPrefix);
+        int maxBarLength = Math.max(MIN_BAR_WIDTH, cliConfig.getLineWidth() - longestPrefix);
 
         for (Integer bucketIndex : sortedBuckets) {
           Bucket bucket = new Bucket(bucketIndex, buckets.count(bucketIndex));

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListAdaptersCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListAdaptersCommand.java
@@ -61,7 +61,7 @@ public class ListAdaptersCommand extends AbstractAuthCommand {
                                     GSON.toJson(object.getProperties()));
         }
       }).build();
-    cliConfig.getTableRenderer().render(output, table);
+    cliConfig.getTableRenderer().render(cliConfig, table);
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListAdaptersCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListAdaptersCommand.java
@@ -61,7 +61,7 @@ public class ListAdaptersCommand extends AbstractAuthCommand {
                                     GSON.toJson(object.getProperties()));
         }
       }).build();
-    cliConfig.getTableRenderer().render(cliConfig, table);
+    cliConfig.getTableRenderer().render(cliConfig, output, table);
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListAllProgramsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListAllProgramsCommand.java
@@ -64,7 +64,7 @@ public class ListAllProgramsCommand extends AbstractAuthCommand implements Categ
                                     object.getName(), object.getDescription());
         }
       }).build();
-    cliConfig.getTableRenderer().render(output, table);
+    cliConfig.getTableRenderer().render(cliConfig, table);
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListAllProgramsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListAllProgramsCommand.java
@@ -64,7 +64,7 @@ public class ListAllProgramsCommand extends AbstractAuthCommand implements Categ
                                     object.getName(), object.getDescription());
         }
       }).build();
-    cliConfig.getTableRenderer().render(cliConfig, table);
+    cliConfig.getTableRenderer().render(cliConfig, output, table);
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListAppsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListAppsCommand.java
@@ -53,7 +53,7 @@ public class ListAppsCommand extends AbstractAuthCommand {
           return Lists.newArrayList(object.getName(), object.getDescription());
         }
       }).build();
-    cliConfig.getTableRenderer().render(cliConfig, table);
+    cliConfig.getTableRenderer().render(cliConfig, output, table);
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListAppsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListAppsCommand.java
@@ -53,7 +53,7 @@ public class ListAppsCommand extends AbstractAuthCommand {
           return Lists.newArrayList(object.getName(), object.getDescription());
         }
       }).build();
-    cliConfig.getTableRenderer().render(output, table);
+    cliConfig.getTableRenderer().render(cliConfig, table);
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListDatasetInstancesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListDatasetInstancesCommand.java
@@ -55,7 +55,7 @@ public class ListDatasetInstancesCommand extends AbstractAuthCommand {
           return Lists.newArrayList(object.getName(), object.getType());
         }
       }).build();
-    cliConfig.getTableRenderer().render(cliConfig, table);
+    cliConfig.getTableRenderer().render(cliConfig, output, table);
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListDatasetInstancesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListDatasetInstancesCommand.java
@@ -55,7 +55,7 @@ public class ListDatasetInstancesCommand extends AbstractAuthCommand {
           return Lists.newArrayList(object.getName(), object.getType());
         }
       }).build();
-    cliConfig.getTableRenderer().render(output, table);
+    cliConfig.getTableRenderer().render(cliConfig, table);
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListDatasetModulesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListDatasetModulesCommand.java
@@ -54,7 +54,7 @@ public class ListDatasetModulesCommand extends AbstractAuthCommand {
           return Lists.newArrayList(object.getName(), object.getClassName());
         }
       }).build();
-    cliConfig.getTableRenderer().render(output, table);
+    cliConfig.getTableRenderer().render(cliConfig, table);
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListDatasetModulesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListDatasetModulesCommand.java
@@ -54,7 +54,7 @@ public class ListDatasetModulesCommand extends AbstractAuthCommand {
           return Lists.newArrayList(object.getName(), object.getClassName());
         }
       }).build();
-    cliConfig.getTableRenderer().render(cliConfig, table);
+    cliConfig.getTableRenderer().render(cliConfig, output, table);
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListDatasetTypesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListDatasetTypesCommand.java
@@ -61,7 +61,7 @@ public class ListDatasetTypesCommand extends AbstractAuthCommand {
           return Lists.newArrayList(object.getName(), Joiner.on(", ").join(modulesStrings));
         }
       }).build();
-    cliConfig.getTableRenderer().render(output, table);
+    cliConfig.getTableRenderer().render(cliConfig, table);
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListDatasetTypesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListDatasetTypesCommand.java
@@ -61,7 +61,7 @@ public class ListDatasetTypesCommand extends AbstractAuthCommand {
           return Lists.newArrayList(object.getName(), Joiner.on(", ").join(modulesStrings));
         }
       }).build();
-    cliConfig.getTableRenderer().render(cliConfig, table);
+    cliConfig.getTableRenderer().render(cliConfig, output, table);
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListNamespacesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListNamespacesCommand.java
@@ -54,7 +54,7 @@ public class ListNamespacesCommand extends AbstractCommand {
           return Lists.newArrayList(object.getName(), object.getDescription());
         }
       }).build();
-    cliConfig.getTableRenderer().render(output, table);
+    cliConfig.getTableRenderer().render(cliConfig, table);
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListNamespacesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListNamespacesCommand.java
@@ -54,7 +54,7 @@ public class ListNamespacesCommand extends AbstractCommand {
           return Lists.newArrayList(object.getName(), object.getDescription());
         }
       }).build();
-    cliConfig.getTableRenderer().render(cliConfig, table);
+    cliConfig.getTableRenderer().render(cliConfig, output, table);
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListProgramsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListProgramsCommand.java
@@ -56,7 +56,7 @@ public class ListProgramsCommand extends AbstractAuthCommand {
           return Lists.newArrayList(object.getApp(), object.getName(), object.getDescription());
         }
       }).build();
-    cliConfig.getTableRenderer().render(output, table);
+    cliConfig.getTableRenderer().render(cliConfig, table);
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListProgramsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListProgramsCommand.java
@@ -56,7 +56,7 @@ public class ListProgramsCommand extends AbstractAuthCommand {
           return Lists.newArrayList(object.getApp(), object.getName(), object.getDescription());
         }
       }).build();
-    cliConfig.getTableRenderer().render(cliConfig, table);
+    cliConfig.getTableRenderer().render(cliConfig, output, table);
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListStreamsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListStreamsCommand.java
@@ -53,7 +53,7 @@ public class ListStreamsCommand extends AbstractAuthCommand {
           return Lists.newArrayList(object.getName());
         }
       }).build();
-    cliConfig.getTableRenderer().render(cliConfig, table);
+    cliConfig.getTableRenderer().render(cliConfig, output, table);
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListStreamsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListStreamsCommand.java
@@ -53,7 +53,7 @@ public class ListStreamsCommand extends AbstractAuthCommand {
           return Lists.newArrayList(object.getName());
         }
       }).build();
-    cliConfig.getTableRenderer().render(output, table);
+    cliConfig.getTableRenderer().render(cliConfig, table);
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/system/HelpCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/system/HelpCommand.java
@@ -20,6 +20,7 @@ import co.cask.cdap.cli.ArgumentName;
 import co.cask.cdap.cli.Categorized;
 import co.cask.cdap.cli.CommandCategory;
 import co.cask.cdap.cli.util.StringStyler;
+import co.cask.cdap.cli.util.table.TableRendererConfig;
 import co.cask.common.cli.Arguments;
 import co.cask.common.cli.Command;
 import co.cask.common.cli.CommandSet;
@@ -43,12 +44,13 @@ import java.util.List;
  */
 public class HelpCommand implements Command {
 
-  static final int COL_WIDTH = 80;
-
   protected final Supplier<Iterable<CommandSet<Command>>> commands;
 
-  public HelpCommand(Supplier<Iterable<CommandSet<Command>>> commands) {
+  private final TableRendererConfig tableRendererConfig;
+
+  public HelpCommand(Supplier<Iterable<CommandSet<Command>>> commands, TableRendererConfig tableRendererConfig) {
     this.commands = commands;
+    this.tableRendererConfig = tableRendererConfig;
   }
 
   @Override
@@ -99,8 +101,8 @@ public class HelpCommand implements Command {
     output.println();
 
     for (Command command : commandList) {
-      printPattern(command.getPattern(), output, COL_WIDTH, 2);
-      wrappedPrint(command.getDescription(), output, COL_WIDTH, 4);
+      printPattern(command.getPattern(), output, tableRendererConfig.getLineWidth(), 2);
+      wrappedPrint(command.getDescription(), output, tableRendererConfig.getLineWidth(), 4);
       output.println();
     }
   }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/system/SearchCommandsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/system/SearchCommandsCommand.java
@@ -18,6 +18,7 @@ package co.cask.cdap.cli.command.system;
 
 import co.cask.cdap.cli.ArgumentName;
 import co.cask.cdap.cli.CommandCategory;
+import co.cask.cdap.cli.util.table.TableRendererConfig;
 import co.cask.common.cli.Arguments;
 import co.cask.common.cli.Command;
 import co.cask.common.cli.CommandSet;
@@ -37,8 +38,9 @@ public class SearchCommandsCommand extends HelpCommand {
 
   private final Supplier<Iterable<CommandSet<Command>>> commands;
 
-  public SearchCommandsCommand(Supplier<Iterable<CommandSet<Command>>> commands) {
-    super(commands);
+  public SearchCommandsCommand(Supplier<Iterable<CommandSet<Command>>> commands,
+                               TableRendererConfig tableRendererConfig) {
+    super(commands, tableRendererConfig);
     this.commands = commands;
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/commandset/ScheduleCommands.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/commandset/ScheduleCommands.java
@@ -188,7 +188,7 @@ public class ScheduleCommands extends CommandSet<Command> implements Categorized
     }
 
     @Override
-    public void perform(Arguments arguments, PrintStream printStream) throws Exception {
+    public void perform(Arguments arguments, PrintStream output) throws Exception {
       String[] programIdParts = arguments.get(ElementType.WORKFLOW.getArgumentName().toString()).split("\\.");
       if (programIdParts.length < 2) {
         throw new CommandInputError(this);
@@ -213,7 +213,7 @@ public class ScheduleCommands extends CommandSet<Command> implements Categorized
                                       GSON.toJson(object.getProperties()));
           }
         }).build();
-      cliConfig.getTableRenderer().render(cliConfig, table);
+      cliConfig.getTableRenderer().render(cliConfig, output, table);
     }
 
     private String getScheduleType(Schedule schedule) {

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/commandset/ScheduleCommands.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/commandset/ScheduleCommands.java
@@ -213,7 +213,7 @@ public class ScheduleCommands extends CommandSet<Command> implements Categorized
                                       GSON.toJson(object.getProperties()));
           }
         }).build();
-      cliConfig.getTableRenderer().render(printStream, table);
+      cliConfig.getTableRenderer().render(cliConfig, table);
     }
 
     private String getScheduleType(Schedule schedule) {

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/docs/GenerateCLIDocsTable.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/docs/GenerateCLIDocsTable.java
@@ -51,7 +51,8 @@ public class GenerateCLIDocsTable {
         bind(TableRenderer.class).toInstance(new CsvTableRenderer());
       }
     });
-    this.printDocsCommand = new GenerateCLIDocsTableCommand(injector.getInstance(DefaultCommands.class));
+    this.printDocsCommand = new GenerateCLIDocsTableCommand(injector.getInstance(DefaultCommands.class),
+                                                            injector.getInstance(CLIConfig.class));
   }
 
   public static void main(String[] args) throws Exception {

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/docs/GenerateCLIDocsTableCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/docs/GenerateCLIDocsTableCommand.java
@@ -18,6 +18,7 @@ package co.cask.cdap.cli.docs;
 
 import co.cask.cdap.cli.CommandCategory;
 import co.cask.cdap.cli.command.system.HelpCommand;
+import co.cask.cdap.cli.util.table.TableRendererConfig;
 import co.cask.common.cli.Arguments;
 import co.cask.common.cli.Command;
 import co.cask.common.cli.CommandSet;
@@ -30,6 +31,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
+import com.google.inject.Inject;
 
 import java.io.PrintStream;
 import java.util.Collections;
@@ -43,8 +45,9 @@ import javax.annotation.Nullable;
  */
 public class GenerateCLIDocsTableCommand extends HelpCommand {
 
-  public GenerateCLIDocsTableCommand(CommandSet commands) {
-    super(Suppliers.<Iterable<CommandSet<Command>>>ofInstance(ImmutableList.<CommandSet<Command>>of(commands)));
+  public GenerateCLIDocsTableCommand(CommandSet commands, TableRendererConfig tableRendererConfig) {
+    super(Suppliers.<Iterable<CommandSet<Command>>>ofInstance(ImmutableList.<CommandSet<Command>>of(commands)),
+          tableRendererConfig);
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/util/table/AltStyleTableRenderer.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/util/table/AltStyleTableRenderer.java
@@ -88,6 +88,7 @@ public class AltStyleTableRenderer implements TableRenderer {
   @Override
   public void render(TableRendererConfig config, Table table) {
     PrintStream output = config.getOutput();
+    // outer table width
     int width = config.getLineWidth();
 
     List<String> header = table.getHeader();
@@ -95,6 +96,7 @@ public class AltStyleTableRenderer implements TableRenderer {
 
     // Collects all output cells for all records.
     // If any record has multiple lines output, a row divider is printed between each row.
+    // inner column widths
     int[] columnWidths = calculateColumnWidths(table.getHeader(), table.getRows(), width);
 
     boolean useRowDivider = false;
@@ -221,14 +223,14 @@ public class AltStyleTableRenderer implements TableRenderer {
   }
 
   /**
-   * Calculates the maximum columns' widths.
+   * Calculates the maximum inner column widths.
    *
    * @param header The table header.
    * @param rows All rows that is going to display.
-   * @param maxTableWidth Maximum width of the table.
+   * @param maxOuterTableWidth Maximum outer width of the table.
    * @return An array of integers, with contains maximum width for each column.
    */
-  private int[] calculateColumnWidths(List<String> header, Iterable<List<String>> rows, int maxTableWidth) {
+  private int[] calculateColumnWidths(List<String> header, Iterable<List<String>> rows, int maxOuterTableWidth) {
     int[] widths;
     if (!header.isEmpty()) {
       widths = new int[header.size()];
@@ -238,10 +240,14 @@ public class AltStyleTableRenderer implements TableRenderer {
       return new int[0];
     }
 
-    // distribute maxTableWidth equally to each column
-    int remainingWidth = maxTableWidth;
+    int maxInnerTableWidth = maxOuterTableWidth
+      - (widths.length + 1) // for the '|' borders
+      - (2 * widths.length); // for the spaces within each column
+
+    // distribute maxInnerTableWidth equally to each column
+    int remainingWidth = maxInnerTableWidth;
     for (int i = 0; i < header.size(); i++) {
-      widths[i] = (int) (maxTableWidth * 1.0 / header.size());
+      widths[i] = (int) (maxInnerTableWidth * 1.0 / header.size());
       remainingWidth -= widths[i];
     }
     // fix any rounding issues by resizing the last column width

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/util/table/AltStyleTableRenderer.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/util/table/AltStyleTableRenderer.java
@@ -86,8 +86,7 @@ public class AltStyleTableRenderer implements TableRenderer {
   }
 
   @Override
-  public void render(TableRendererConfig config, Table table) {
-    PrintStream output = config.getOutput();
+  public void render(TableRendererConfig config, PrintStream output, Table table) {
     // outer table width
     int width = config.getLineWidth();
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/util/table/AltStyleTableRenderer.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/util/table/AltStyleTableRenderer.java
@@ -69,27 +69,27 @@ import java.util.List;
  */
 public class AltStyleTableRenderer implements TableRenderer {
 
-  private static final int DEFAULT_WIDTH = 80;
   private static final int DEFAULT_MIN_COLUMN_WIDTH = 5;
   private static final String DEFAULT_NEWLINE = System.getProperty("line.separator");
 
-  private final int width;
   private final int minColumnWidth;
   private final Splitter newlineSplitter;
 
   @Inject
   public AltStyleTableRenderer() {
-    this(DEFAULT_WIDTH, DEFAULT_MIN_COLUMN_WIDTH, DEFAULT_NEWLINE);
+    this(DEFAULT_MIN_COLUMN_WIDTH, DEFAULT_NEWLINE);
   }
 
-  public AltStyleTableRenderer(int width, int minColumnWidth, String newline) {
-    this.width = width;
+  public AltStyleTableRenderer(int minColumnWidth, String newline) {
     this.minColumnWidth = minColumnWidth;
     this.newlineSplitter = Splitter.on(newline);
   }
 
   @Override
-  public void render(PrintStream output, Table table) {
+  public void render(TableRendererConfig config, Table table) {
+    PrintStream output = config.getOutput();
+    int width = config.getLineWidth();
+
     List<String> header = table.getHeader();
     List<Row> rows = Lists.newArrayList();
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/util/table/CsvTableRenderer.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/util/table/CsvTableRenderer.java
@@ -38,9 +38,7 @@ public class CsvTableRenderer implements TableRenderer {
   private static final Joiner CSV_JOINER = Joiner.on(",");
 
   @Override
-  public void render(TableRendererConfig config, Table table) {
-    PrintStream output = config.getOutput();
-
+  public void render(TableRendererConfig config, PrintStream output, Table table) {
     if (table.getHeader() != null) {
       output.println(CSV_JOINER.useForNull("").join(table.getHeader()));
     }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/util/table/CsvTableRenderer.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/util/table/CsvTableRenderer.java
@@ -38,7 +38,9 @@ public class CsvTableRenderer implements TableRenderer {
   private static final Joiner CSV_JOINER = Joiner.on(",");
 
   @Override
-  public void render(PrintStream output, Table table) {
+  public void render(TableRendererConfig config, Table table) {
+    PrintStream output = config.getOutput();
+
     if (table.getHeader() != null) {
       output.println(CSV_JOINER.useForNull("").join(table.getHeader()));
     }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/util/table/TableRenderer.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/util/table/TableRenderer.java
@@ -15,6 +15,8 @@
  */
 package co.cask.cdap.cli.util.table;
 
+import java.io.PrintStream;
+
 /**
  * Renders a {@link Table}.
  */
@@ -22,8 +24,9 @@ public interface TableRenderer {
   /**
    * Renders the table to the output.
    *
-   * @param config specifies the output to render to and the width of the table
+   * @param config specifies the width of the table
+   * @param output the output to render to
    * @param table the table to render
    */
-  void render(TableRendererConfig config, Table table);
+  void render(TableRendererConfig config, PrintStream output, Table table);
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/util/table/TableRendererConfig.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/util/table/TableRendererConfig.java
@@ -15,12 +15,9 @@
  */
 package co.cask.cdap.cli.util.table;
 
-import java.io.PrintStream;
-
 /**
- * Configures {@link TableRenderer#render(co.cask.cdap.cli.CLIConfig, Table)}
+ * Configures {@link TableRenderer#render(TableRendererConfig, PrintStream, Table)}
  */
 public interface TableRendererConfig {
-  PrintStream getOutput();
   int getLineWidth();
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/util/table/TableRendererConfig.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/util/table/TableRendererConfig.java
@@ -15,15 +15,12 @@
  */
 package co.cask.cdap.cli.util.table;
 
+import java.io.PrintStream;
+
 /**
- * Renders a {@link Table}.
+ * Configures {@link TableRenderer#render(co.cask.cdap.cli.CLIConfig, Table)}
  */
-public interface TableRenderer {
-  /**
-   * Renders the table to the output.
-   *
-   * @param config specifies the output to render to and the width of the table
-   * @param table the table to render
-   */
-  void render(TableRendererConfig config, Table table);
+public interface TableRendererConfig {
+  PrintStream getOutput();
+  int getLineWidth();
 }

--- a/cdap-cli/src/test/java/co/cask/cdap/cli/util/table/AltStyleTableRendererTest.java
+++ b/cdap-cli/src/test/java/co/cask/cdap/cli/util/table/AltStyleTableRendererTest.java
@@ -27,4 +27,5 @@ public class AltStyleTableRendererTest extends TableRendererTest {
   public TableRenderer getRenderer() {
     return new AltStyleTableRenderer();
   }
+  
 }

--- a/cdap-cli/src/test/java/co/cask/cdap/cli/util/table/TableRendererTest.java
+++ b/cdap-cli/src/test/java/co/cask/cdap/cli/util/table/TableRendererTest.java
@@ -28,12 +28,8 @@ import java.io.PrintStream;
 public abstract class TableRendererTest {
 
   private static final int LINE_WIDTH = 80;
+  private static final PrintStream OUTPUT = System.out;
   private static final TableRendererConfig TEST_CONFIG = new TableRendererConfig() {
-    @Override
-    public PrintStream getOutput() {
-      return System.out;
-    }
-
     @Override
     public int getLineWidth() {
       return LINE_WIDTH;
@@ -52,7 +48,7 @@ public abstract class TableRendererTest {
                  .add("r3333", "r3", "r3\n1")
                  .build())
       .build();
-    getRenderer().render(TEST_CONFIG, table);
+    getRenderer().render(TEST_CONFIG, OUTPUT, table);
   }
 
   @Test
@@ -65,7 +61,7 @@ public abstract class TableRendererTest {
                  .add("r3333", "r3", "r3\n1")
                  .build())
       .build();
-    getRenderer().render(TEST_CONFIG, table);
+    getRenderer().render(TEST_CONFIG, OUTPUT, table);
   }
 
   @Test
@@ -78,7 +74,7 @@ public abstract class TableRendererTest {
                  .add("r3333", "r3", "r3\n1")
                  .build())
       .build();
-    getRenderer().render(TEST_CONFIG, table);
+    getRenderer().render(TEST_CONFIG, OUTPUT, table);
   }
 
   @Test
@@ -91,7 +87,7 @@ public abstract class TableRendererTest {
                  .add("r3333", "r3", "r3\n1")
                  .build())
       .build();
-    getRenderer().render(TEST_CONFIG, table);
+    getRenderer().render(TEST_CONFIG, OUTPUT, table);
   }
 
   @Test
@@ -104,6 +100,6 @@ public abstract class TableRendererTest {
                  .add("r3333", "r3", "r3\n1")
                  .build())
       .build();
-    getRenderer().render(TEST_CONFIG, table);
+    getRenderer().render(TEST_CONFIG, OUTPUT, table);
   }
 }

--- a/cdap-cli/src/test/java/co/cask/cdap/cli/util/table/TableRendererTest.java
+++ b/cdap-cli/src/test/java/co/cask/cdap/cli/util/table/TableRendererTest.java
@@ -19,11 +19,26 @@ import com.google.common.base.Strings;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.io.PrintStream;
+
 /**
  *
  */
 @Ignore
 public abstract class TableRendererTest {
+
+  private static final int LINE_WIDTH = 80;
+  private static final TableRendererConfig TEST_CONFIG = new TableRendererConfig() {
+    @Override
+    public PrintStream getOutput() {
+      return System.out;
+    }
+
+    @Override
+    public int getLineWidth() {
+      return LINE_WIDTH;
+    }
+  };
 
   public abstract TableRenderer getRenderer();
 
@@ -37,7 +52,7 @@ public abstract class TableRendererTest {
                  .add("r3333", "r3", "r3\n1")
                  .build())
       .build();
-    getRenderer().render(System.out, table);
+    getRenderer().render(TEST_CONFIG, table);
   }
 
   @Test
@@ -50,7 +65,7 @@ public abstract class TableRendererTest {
                  .add("r3333", "r3", "r3\n1")
                  .build())
       .build();
-    getRenderer().render(System.out, table);
+    getRenderer().render(TEST_CONFIG, table);
   }
 
   @Test
@@ -63,7 +78,7 @@ public abstract class TableRendererTest {
                  .add("r3333", "r3", "r3\n1")
                  .build())
       .build();
-    getRenderer().render(System.out, table);
+    getRenderer().render(TEST_CONFIG, table);
   }
 
   @Test
@@ -76,7 +91,7 @@ public abstract class TableRendererTest {
                  .add("r3333", "r3", "r3\n1")
                  .build())
       .build();
-    getRenderer().render(System.out, table);
+    getRenderer().render(TEST_CONFIG, table);
   }
 
   @Test
@@ -89,6 +104,6 @@ public abstract class TableRendererTest {
                  .add("r3333", "r3", "r3\n1")
                  .build())
       .build();
-    getRenderer().render(System.out, table);
+    getRenderer().render(TEST_CONFIG, table);
   }
 }


### PR DESCRIPTION
`AltStyleTableRenderer` was not rendering tables with correct outer width, so this PR fixes that bug. Also, this PR makes `AltStyleTableRenderer` and the output from `help` use up the entire terminal width.

https://issues.cask.co/browse/CDAP-1830
http://builds.cask.co/browse/CDAP-RBT165