### PR TITLE
Fix documentation build.

### DIFF
--- a/cdap-docs/_common/common-build.sh
+++ b/cdap-docs/_common/common-build.sh
@@ -310,14 +310,17 @@ function build_dependencies() {
 }
 
 function version() {
+  local current_directory=`pwd`
   cd $PROJECT_PATH
   PROJECT_VERSION=`grep "<version>" pom.xml`
   PROJECT_VERSION=${PROJECT_VERSION#*<version>}
   PROJECT_VERSION=${PROJECT_VERSION%%</version>*}
+  PROJECT_LONG_VERSION=`expr "$PROJECT_VERSION" : '\([0-9]*\.[0-9]*\.[0-9]*\)'`
   PROJECT_SHORT_VERSION=`expr "$PROJECT_VERSION" : '\([0-9]*\.[0-9]*\)'`
   IFS=/ read -a branch <<< "`git rev-parse --abbrev-ref HEAD`"
   GIT_BRANCH_TYPE="${branch[0]}"
   GIT_BRANCH="${branch[1]}"
+  cd $current_directory
 }
 
 function display_version() {
@@ -325,6 +328,7 @@ function display_version() {
   echo ""
   echo "PROJECT_PATH: $PROJECT_PATH"
   echo "PROJECT_VERSION: $PROJECT_VERSION"
+  echo "PROJECT_LONG_VERSION: $PROJECT_LONG_VERSION"
   echo "PROJECT_SHORT_VERSION: $PROJECT_SHORT_VERSION"
   echo "GIT_BRANCH_TYPE: $GIT_BRANCH_TYPE"
   echo "GIT_BRANCH: $GIT_BRANCH"

--- a/cdap-docs/examples-manual/build.sh
+++ b/cdap-docs/examples-manual/build.sh
@@ -27,18 +27,24 @@ CHECK_INCLUDES=$TRUE
 function guide_rewrite_sed() {
   echo "Re-writing using sed $1 $2"
   # Re-writes the links in the RST file to point to a local copy of any image links.
-  INCLUDES_DIR=$1
-  GUIDE=$2
-  REDIRECT_S="../../../../.." # Source, 5 redirects
-  REDIRECT_T="\.\./\.\./\.\./\.\./\.\." # Target, 5 redirects, escaped
+  local includes_dir=$1
+  local guide=$2
+  local project_version=$PROJECT_LONG_VERSION
   
-  mkdir $INCLUDES_DIR/$GUIDE
-  sed -e "s|image:: docs/images|image:: $REDIRECT_T/$GUIDE/docs/images|g" -e "s|.. code:: |.. code-block:: |g" $INCLUDES_DIR/$REDIRECT_S/$GUIDE/README.rst > $INCLUDES_DIR/$GUIDE/README.rst
+  local source1="https://raw.githubusercontent.com/cdap-guides"
+  local source2="release/cdap-$project_version-compatible/README.rst"
+
+  local redirect="\.\./\.\./\.\./\.\./\.\." # Target, 5 redirects, escaped
+  
+  mkdir $includes_dir/$guide
+  curl --silent $source1/$guide/$source2 --output $includes_dir/$guide/README_SOURCE.rst  
+  sed -e "s|image:: docs/images|image:: $redirect/$guide/docs/images|g" -e "s|.. code:: |.. code-block:: |g" $includes_dir/$guide/README_SOURCE.rst > $includes_dir/$guide/README.rst
 }
 
 function pandoc_includes() {
-  # Re-writes all the image links...
-  guide_rewrite_sed $1 cdap-bi-guide
+  echo "Re-writes all the image links..."
+  version
+  guide_rewrite_sed $1 cdap-bi-guide 
   guide_rewrite_sed $1 cdap-flow-guide
   guide_rewrite_sed $1 cdap-flume-guide
   guide_rewrite_sed $1 cdap-kafka-ingest-guide


### PR DESCRIPTION
Fix the Build to use curl to download example documentation and set the version based on the release.

It doesn't depend on the example documentation to be locally available; instead, it downloads it from GitHub.