### PR TITLE
[CADP-1837] Fix stream table name in get stream-stats command

### DIFF
--- a/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
+++ b/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
@@ -210,7 +210,7 @@ public class CLIMainTest extends StandaloneTestBase {
     BufferedWriter writer = Files.newWriter(file, Charsets.UTF_8);
     try {
       for (int i = 0; i < 10; i++) {
-        writer.write("Event " + i);
+        writer.write(String.format("%s, Event %s", i, i));
         writer.newLine();
       }
     } finally {
@@ -218,7 +218,16 @@ public class CLIMainTest extends StandaloneTestBase {
     }
     testCommandOutputContains(cli, "load stream " + streamId + " " + file.getAbsolutePath(),
                               "Successfully send stream event to stream");
-    testCommandOutputContains(cli, "get stream " + streamId, "Event 9");
+    testCommandOutputContains(cli, "get stream " + streamId, "9, Event 9");
+    testCommandOutputContains(cli, "get stream-stats " + streamId,
+                              String.format("No schema found for Stream '%s'", streamId));
+    testCommandOutputContains(cli, "set stream format " + streamId + " csv",
+                              String.format("Successfully set format of stream '%s'", streamId));
+    testCommandOutputContains(cli, "execute 'show tables'", String.format("stream_%s", streamId));
+    testCommandOutputContains(cli, "get stream-stats " + streamId,
+                              "Analyzing 100 Stream events in the time range [0, 9223372036854775807]");
+    testCommandOutputContains(cli, "get stream-stats " + streamId + " limit 50 start 50 end 500",
+                              "Analyzing 50 Stream events in the time range [50, 500]");
   }
 
   @Test

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetStreamStatsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetStreamStatsCommand.java
@@ -24,7 +24,6 @@ import co.cask.cdap.cli.ElementType;
 import co.cask.cdap.cli.util.AbstractCommand;
 import co.cask.cdap.client.QueryClient;
 import co.cask.cdap.client.StreamClient;
-import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.explore.client.ExploreExecutionResult;
 import co.cask.cdap.proto.ColumnDesc;
 import co.cask.cdap.proto.QueryResult;
@@ -165,7 +164,7 @@ public class GetStreamStatsCommand extends AbstractCommand {
   }
 
   private String getHiveTableName(String streamId) {
-    return String.format("cdap_stream_%s_%s", Constants.DEFAULT_NAMESPACE, streamId);
+    return String.format("stream_%s", streamId);
   }
 
   private String cdapSchemaColumName2HiveColumnName(String streamId, String schemaColumName) {


### PR DESCRIPTION
- [x] Quick fix for stream table name in ``get stream-stats`` command
- [x] Added missing verifications for ``get stream-stats`` command in ``CLIMainTest#testStream``
- [ ] Overall fix for standardizing stream/dataset table names in Hive - this may not get done in 2.8 

Jira: [CDAP-1837](https://issues.cask.co/browse/CDAP-1837)
Build: http://builds.cask.co/browse/CDAP-RBT168-2

