### PR TITLE
CDAP-1843 fix NaN issue on start time after upgrade

### DIFF
--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/MDSUpgrader.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/MDSUpgrader.java
@@ -263,7 +263,7 @@ public class MDSUpgrader extends AbstractUpgrader {
   private void writeTempRunRecordStart(String appId, ProgramType programType, String programId, String pId,
                                        long startTs) {
     store.setStart(Id.Program.from(Id.Application.from(Constants.DEFAULT_NAMESPACE, appId), programType, programId),
-                   pId, Long.MAX_VALUE - startTs);
+                   pId, startTs);
   }
 
   /**


### PR DESCRIPTION
The start time is just a part of the key in runRecordCompleted so get it from there 

Issue: https://issues.cask.co/browse/CDAP-1843
Build: http://builds.cask.co/browse/CDAP-RBT172-1