### PR TITLE
Exclude slf4j-log4j from hadoop-mapreduce-client-jobclient & hbase-testing-util

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1171,6 +1171,12 @@
         <artifactId>hbase-testing-util</artifactId>
         <version>${hbase96.version}</version>
         <scope>test</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.hsqldb</groupId>
@@ -1222,6 +1228,12 @@
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-mapreduce-client-jobclient</artifactId>
         <version>${hadoop.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Sometimes error appear in `LogAppenderInitializer` since there are multiple logging jars in the classpath. This explicitly excludes `slf4j-log4j12`.

I also built the rpms and ran: `find . -name "*.rpm" | xargs -I '{}' rpm -qlp '{}' | grep slf4j-log4j12`. This gave no output.