### PR TITLE
Document Supported Characters

### DIFF
--- a/cdap-docs/reference-manual/source/characters.rst
+++ b/cdap-docs/reference-manual/source/characters.rst
@@ -17,9 +17,9 @@ Streams
 
 Stream names can have these characters:
 
-- Alphanumeric characters ('a-zA-Z0-9')
-- Hyphens '-'
-- Underscores '_''
+- Alphanumeric characters (``a-z A-Z 0-9``)
+- Hyphens (``-``)
+- Underscores (``_``)
 
 
 Datasets
@@ -27,23 +27,36 @@ Datasets
 
 Dataset names can have these characters:
 
-- Alphanumeric characters ('a-zA-Z0-9')
-- Hyphens '-'
-- Underscores '_''
-- Periods '.'
+- Alphanumeric characters (``a-z A-Z 0-9``)
+- Hyphens (``-``)
+- Underscores (``_``)
+- Periods (``.``)
 
 
 Hive Limitation and Conversion
 ------------------------------
 
 `Hive 0.12 <https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL>`__
-only supports alphanumeric characters ('a-zA-Z0-9') and underscores '_' . 
+only supports alphanumeric characters (``a-z A-Z 0-9``) and underscores (``_``). 
 
 As a consequence, any hyphens in Stream names and any hyphens or periods in Dataset names
 will be converted to underscores while creating Hive tables. 
 
-For instance: the Streams ``my-ingest`` and ``my_ingest`` will both be converted to
-``cdap_stream_my_ingest``; the Datasets ``my-dataset``, ``my_dataset``, and ``my.dataset``
-will all be converted to ``cdap_dataset_my_dataset``.
+Examples: 
+
+- The Streams
+
+    - ``my-ingest``
+    - ``my_ingest``
+  
+  will both be converted to ``cdap_stream_my_ingest``
+
+- The Datasets
+
+    - ``my-dataset``
+    - ``my_dataset``
+    - ``my.dataset``
+    
+  will all be converted to ``cdap_dataset_my_dataset``
 
 Names should be carefully constructed to avoid any collisions as a result of conversion.

--- a/cdap-docs/reference-manual/source/characters.rst
+++ b/cdap-docs/reference-manual/source/characters.rst
@@ -1,0 +1,49 @@
+.. meta::
+    :author: Cask Data, Inc.
+    :copyright: Copyright © 2015 Cask Data, Inc.
+
+.. highlight:: console
+
+.. _supported-characters:
+
+============================================
+Supported Characters
+============================================
+
+The Cask Data Application Platform (CDAP) has naming conventions for different elements of CDAP.
+
+Streams
+----------------
+
+Stream names can have these characters:
+
+- Alphanumeric characters ('a-zA-Z0-9')
+- Hyphens '-'
+- Underscores '_''
+
+
+Datasets
+----------
+
+Dataset names can have these characters:
+
+- Alphanumeric characters ('a-zA-Z0-9')
+- Hyphens '-'
+- Underscores '_''
+- Periods '.'
+
+
+Hive Limitation and Conversion
+------------------------------
+
+`Hive 0.12 <https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL>`__
+only supports alphanumeric characters ('a-zA-Z0-9') and underscores '_' . 
+
+As a consequence, any hyphens in Stream names and any hyphens or periods in Dataset names
+will be converted to underscores while creating Hive tables. 
+
+For instance: the Streams ``my-ingest`` and ``my_ingest`` will both be converted to
+``cdap_stream_my_ingest``; the Datasets ``my-dataset``, ``my_dataset``, and ``my.dataset``
+will all be converted to ``cdap_dataset_my_dataset``.
+
+Names should be carefully constructed to avoid any collisions as a result of conversion.

--- a/cdap-docs/reference-manual/source/index.rst
+++ b/cdap-docs/reference-manual/source/index.rst
@@ -8,6 +8,13 @@
 CDAP Reference Manual: APIs, Licenses, and Dependencies
 =======================================================
 
+
+.. |characters| replace:: **Supported Characters:**
+.. _characters: characters.html
+
+- |characters|_ Accepted naming conventions for CDAP elements.
+
+
 .. |http| replace:: **HTTP RESTful API:**
 .. _http: http-restful-api/index.html
 

--- a/cdap-docs/reference-manual/source/table-of-contents.rst
+++ b/cdap-docs/reference-manual/source/table-of-contents.rst
@@ -10,6 +10,7 @@ CDAP Reference Manual Table of Contents
    :maxdepth: 5
 
     Introduction <index>
+    Supported Characters <characters>
     HTTP RESTful API <http-restful-api/index>
     Javadocs <javadocs/index>
     Java Client API <java-client-api>


### PR DESCRIPTION
Fix for https://issues.cask.co/browse/CDAP-1565

Staged at: [Supported Characters](http://stg-web101.sw.joyent.continuuity.net/cdap/2.8.0-SNAPSHOT-r2.8_suported_characters/en/reference-manual/characters.html)