### PR TITLE
Feature/r2.8 config rest api

### DIFF
--- a/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v3/configuration.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v3/configuration.rst
@@ -1,0 +1,61 @@
+.. meta::
+    :author: Cask Data, Inc.
+    :description: HTTP RESTful Interface to the Cask Data Application Platform
+    :copyright: Copyright © 2015 Cask Data, Inc.
+
+.. highlight:: console
+
+.. _http-restful-api-configuration:
+.. _http-restful-api-v3-configuration:
+
+======================================
+Configuration Service HTTP RESTful API
+======================================
+
+The configurations of CDAP and HBase are exposed via HTTP RESTful endpoints and are documented here.
+
+.. _http-restful-api-configuration-cdap:
+
+CDAP Configurations
+-------------------
+
+To retrieve all the configurations used by CDAP, issue an HTTP GET request::
+
+  GET <base-url>/config/cdap?format=<type>
+  
+.. list-table::
+   :widths: 20 80
+   :header-rows: 1
+
+   * - Parameter
+     - Description
+   * - ``<type>``
+     - Format for returned type, either ``json`` (default) or ``xml``
+  
+The response is a string in the specified format. For example, ::
+
+  { "": "" }
+
+
+.. _http-restful-api-configuration-hbase:
+
+HBase Configurations
+--------------------
+
+To retrieve all the configurations used by HBase, issue an HTTP GET request::
+
+  GET <base-url>/config/hbase?format=<type>
+  
+.. list-table::
+   :widths: 20 80
+   :header-rows: 1
+
+   * - Parameter
+     - Description
+   * - ``<type>``
+     - Format for returned type, either ``json`` (default) or ``xml``
+  
+The response is a string in the specified format. For example, ::
+
+  { "": "" }
+

--- a/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v3/configuration.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v3/configuration.rst
@@ -32,10 +32,15 @@ To retrieve all the configurations used by CDAP, issue an HTTP GET request::
    * - ``<type>``
      - Format for returned type, either ``json`` (default) or ``xml``
   
-The response is a string in the specified format. For example, ::
+The response is a string in the specified format. For example, using the default JSON
+format, the output would be similar to (showing the first portion, reformatted to fit)::
 
-  { "": "" }
-
+  {"security.enabled":"false","app.output.dir":"/programs","router.server.port":"10000","
+  metrics.kafka.partition.size":"10","data.tx.snapshot.local.dir":"data/tx.snapshot","
+  metrics.worker.threads":"10","security.server.maxthreads":"100","app.worker.threads":"10",
+  "security.token.digest.keylength":"128","metrics.memory.mb":"512","data.tx.server.io.
+  threads":"2","log.saver.num.instances":"1","notification.transport.system":"kafka","stream
+  .worker.threads":"10","metrics.data.table.ts.rollTime.60":"60","metrics.processor.num....
 
 .. _http-restful-api-configuration-hbase:
 
@@ -54,8 +59,37 @@ To retrieve all the configurations used by HBase, issue an HTTP GET request::
      - Description
    * - ``<type>``
      - Format for returned type, either ``json`` (default) or ``xml``
+
+.. highlight:: xml
+
+The response is a string in the specified format. For example, using the XML
+format, the output would be similar to (showing the first portion, reformatted to fit)::
+
+  <configuration>
+    <property>
+      <name>dfs.journalnode.rpc-address</name>
+        <value>0.0.0.0:8485</value>
+      <source>hdfs-default.xml</source>
+    </property>
+    <property>
+      <name>io.storefile.bloom.block.size</name>
+        <value>131072</value>
+      <source>hbase-default.xml</source>
+    </property>
+    <property>
+      <name>yarn.ipc.rpc.class</name>
+        <value>org.apache.hadoop.yarn.ipc.HadoopYarnProtoRPC</value>
+      <source>yarn-default.xml</source>
+    </property>
+    <property>
+      <name>mapreduce.job.maxtaskfailures.per.tracker</name>
+        <value>3</value>
+      <source>mapred-default.xml</source>
+    </property>
+    <property>
+      <name>hbase.rest.threads.min</name>
+        <value>2</value>
+      <source>hbase-default.xml</source>
+    </property>
+    ...
   
-The response is a string in the specified format. For example, ::
-
-  { "": "" }
-

--- a/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v3/configuration.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v3/configuration.rst
@@ -31,16 +31,28 @@ To retrieve all the configurations used by CDAP, issue an HTTP GET request::
      - Description
    * - ``<type>``
      - Format for returned type, either ``json`` (default) or ``xml``
-  
+
+.. highlight:: json
+
 The response is a string in the specified format. For example, using the default JSON
 format, the output would be similar to (showing the first portion, reformatted to fit)::
 
-  {"security.enabled":"false","app.output.dir":"/programs","router.server.port":"10000","
-  metrics.kafka.partition.size":"10","data.tx.snapshot.local.dir":"data/tx.snapshot","
-  metrics.worker.threads":"10","security.server.maxthreads":"100","app.worker.threads":"10",
-  "security.token.digest.keylength":"128","metrics.memory.mb":"512","data.tx.server.io.
-  threads":"2","log.saver.num.instances":"1","notification.transport.system":"kafka","stream
-  .worker.threads":"10","metrics.data.table.ts.rollTime.60":"60","metrics.processor.num....
+  {
+    "security.enabled": "false",
+    "app.output.dir": "\/programs",
+    "router.server.port": "10000",
+    "metrics.kafka.partition.size": "10",
+    "data.tx.snapshot.local.dir": "data\/tx.snapshot",
+    "metrics.worker.threads": "10",
+    "security.server.maxthreads": "100",
+    "app.worker.threads": "10",
+    "security.token.digest.keylength": "128",
+    "metrics.memory.mb": "256",
+    "data.tx.server.io.threads": "2",
+    ...
+  }
+
+.. highlight:: console
 
 .. _http-restful-api-configuration-hbase:
 
@@ -92,4 +104,4 @@ format, the output would be similar to (showing the first portion, reformatted t
       <source>hbase-default.xml</source>
     </property>
     ...
-  
+  </configuration>

--- a/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v3/configuration.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v3/configuration.rst
@@ -8,9 +8,9 @@
 .. _http-restful-api-configuration:
 .. _http-restful-api-v3-configuration:
 
-======================================
-Configuration Service HTTP RESTful API
-======================================
+==============================
+Configuration HTTP RESTful API
+==============================
 
 The configurations of CDAP and HBase are exposed via HTTP RESTful endpoints and are documented here.
 

--- a/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v3/index.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v3/index.rst
@@ -16,6 +16,7 @@ CDAP HTTP RESTful API v3
     Introduction <introduction>
     Namespace <namespace>
     Lifecycle <lifecycle>
+    Configuration <configuration>
     Preferences <preferences>
     Stream <stream>
     Dataset <dataset>
@@ -37,6 +38,7 @@ The Cask Data Application Platform (CDAP) has an HTTP interface for a multitude 
 - :doc:`Namespace: <namespace>` creating, listing, and deleting namespaces
 - :doc:`Lifecycle: <lifecycle>` deploying and managing Applications, and managing the lifecycle of Flows,
   MapReduce Programs, Spark Programs, Workflows, and Custom Services
+- :doc:`Configuration: <configuration>` retrieving the CDAP and HBase configurations
 - :doc:`Preferences: <preferences>` setting, retrieving, and deleting Preferences
 - :doc:`Stream: <stream>` sending data events to a Stream or to inspect the contents of a Stream
 - :doc:`Dataset: <dataset>` interacting with Datasets, Dataset Modules, and Dataset Types


### PR DESCRIPTION
Adds a "Configuration" API to the v3 RESTful APIs. 
Fix for https://issues.cask.co/browse/CDAP-1561?filter=10226

Staged at:

[Configuration API](http://stg-web101.sw.joyent.continuuity.net/cdap/2.8.0-SNAPSHOT-r2.8_config_rest_API/en/reference-manual/http-restful-api/http-restful-api-v3/configuration.html)