### PR TITLE
Add a recommendation for Oracle JDKs on installation instructions

### DIFF
--- a/cdap-docs/admin-manual/source/installation/installation.rst
+++ b/cdap-docs/admin-manual/source/installation/installation.rst
@@ -111,7 +111,7 @@ You'll need this software installed:
 Java Runtime
 ++++++++++++
 The latest `JDK or JRE version 1.6.xx or 1.7.xx <http://www.java.com/en/download/manual.jsp>`__
-for Linux and Solaris must be installed in your environment.
+for Linux and Solaris must be installed in your environment; we recommend the Oracle JDK.
 
 To check the Java version installed, run the command::
 

--- a/cdap-docs/admin-manual/source/installation/quick-start.rst
+++ b/cdap-docs/admin-manual/source/installation/quick-start.rst
@@ -24,10 +24,9 @@ Software Prerequisites
 
 Install:
 
-- Java runtime (`JDK or JRE version 1.6.xx or 1.7.xx
-  <http://www.java.com/en/download/manual.jsp>`__) on CDAP and Hadoop nodes; we recommend
-  the Oracle JDK. Set the JAVA_HOME environment variable (:ref:`details
-  <install-java-runtime>`).
+- Java runtime (`JDK or JRE version 1.6.xx or 1.7.xx <http://www.java.com/en/download/manual.jsp>`__)
+  on CDAP and Hadoop nodes; we recommend the Oracle JDK. 
+- Set the JAVA_HOME environment variable (:ref:`details <install-java-runtime>`).
 - `Node.js <http://nodejs.org>`__ on CDAP nodes (:ref:`details <install-node.js>`).
 - Hadoop and HBase (and possibly Hive) environment to run against (:ref:`details <install-hadoop-hbase>`).
 - CDAP nodes require Hadoop and HBase client installation and configuration. 

--- a/cdap-docs/admin-manual/source/installation/quick-start.rst
+++ b/cdap-docs/admin-manual/source/installation/quick-start.rst
@@ -24,10 +24,12 @@ Software Prerequisites
 
 Install:
 
-- Java runtime (`JDK or JRE version 1.6.xx or 1.7.xx <http://www.java.com/en/download/manual.jsp>`__)
-  on CDAP and Hadoop nodes. Set the JAVA_HOME environment variable. (:ref:`details <install-java-runtime>`)
-- `Node.js <http://nodejs.org>`__ on CDAP nodes. (:ref:`details <install-node.js>`)
-- Hadoop and HBase (and possibly Hive) environment to run against. (:ref:`details <install-hadoop-hbase>`)
+- Java runtime (`JDK or JRE version 1.6.xx or 1.7.xx
+  <http://www.java.com/en/download/manual.jsp>`__) on CDAP and Hadoop nodes; we recommend
+  the Oracle JDK. Set the JAVA_HOME environment variable (:ref:`details
+  <install-java-runtime>`).
+- `Node.js <http://nodejs.org>`__ on CDAP nodes (:ref:`details <install-node.js>`).
+- Hadoop and HBase (and possibly Hive) environment to run against (:ref:`details <install-hadoop-hbase>`).
 - CDAP nodes require Hadoop and HBase client installation and configuration. 
   **Note:** No Hadoop services need to be running.
 

--- a/cdap-docs/reference-manual/source/faq.rst
+++ b/cdap-docs/reference-manual/source/faq.rst
@@ -79,7 +79,8 @@ CDAP currently supports Java for developing applications.
 
 .. rubric:: What Version of Java SDK is Required by CDAP?
 
-The latest version of the JDK or JRE version 6 or 7 must be installed in your environment.
+The latest version of the JDK or JRE version 6 or 7 (JDK/JRE 1.6 or 1.7) must be installed
+in your environment; we recommend the Oracle JDK.
 
 .. rubric:: What Version of Node.JS is Required by CDAP?
 


### PR DESCRIPTION
Fix for https://issues.cask.co/browse/CDAP-837

Staged at: 

- [FAQ](http://stg-web101.sw.joyent.continuuity.net/cdap/2.8.0-SNAPSHOT-r2.8_doc_java_version/en/reference-manual/faq.html#platforms-and-language)
- [Quick Start](http://stg-web101.sw.joyent.continuuity.net/cdap/2.8.0-SNAPSHOT-r2.8_doc_java_version/en/admin-manual/installation/quick-start.html#software-prerequisites)
- [Installation](http://stg-web101.sw.joyent.continuuity.net/cdap/2.8.0-SNAPSHOT-r2.8_doc_java_version/en/admin-manual/installation/installation.html#system-requirements)

For the last link, look at the "Java Runtime" section.