### PR TITLE
CDAP-1817 Run kinit on secure clusters so "hive -e" works

### DIFF
--- a/cdap-distributions/src/debian/init.d/cdap-service
+++ b/cdap-distributions/src/debian/init.d/cdap-service
@@ -33,6 +33,24 @@
 
 SVC_COMMAND="/opt/cdap/@package.name@/bin/svc-@service.name@ $*"
 
+# source configuration, if it exists
+if [[ -r /etc/default/cdap-@service.name@ ]]; then
+  . /etc/default/cdap-@service.name@
+fi
+
+KRB_COMMAND="kinit -kt $CDAP_KEYTAB $CDAP_PRINCIPAL"
+
+# check for kerberos
+if [[ -r $CDAP_KEYTAB ]] && [[ -n $CDAP_PRINCIPAL ]]; then
+  if [[ $1 =~ "start" ]]; then
+    if [[ $UID -eq 0 ]]; then
+      su cdap -c "$KRB_COMMAND"
+    else
+      $KRB_COMMAND
+    fi
+  fi
+fi
+
 # drop permissions to cdap user and run service script
 
 if [[ $UID -eq 0 ]]; then

--- a/cdap-distributions/src/etc/default/cdap-master
+++ b/cdap-distributions/src/etc/default/cdap-master
@@ -1,0 +1,20 @@
+#
+# Copyright © 2014-2015 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
+# Uncomment the following and set them to the correct values for running on a Kerberos-enabled Hadoop cluster
+#
+#CDAP_KEYTAB="/etc/security/keytabs/cdap.keytab"
+#CDAP_PRINCIPAL="yarn@EXAMPLE.REALM.COM"

--- a/cdap-distributions/src/rpm/init.d/cdap-service
+++ b/cdap-distributions/src/rpm/init.d/cdap-service
@@ -33,6 +33,24 @@
 
 SVC_COMMAND="/opt/cdap/@package.name@/bin/svc-@service.name@ $*"
 
+# source configuration, if it exists
+if [[ -r /etc/default/cdap-@service.name@ ]]; then
+  . /etc/default/cdap-@service.name@
+fi
+
+KRB_COMMAND="kinit -kt $CDAP_KEYTAB $CDAP_PRINCIPAL"
+
+# check for kerberos
+if [[ -r $CDAP_KEYTAB ]] && [[ -n $CDAP_PRINCIPAL ]]; then
+  if [[ $1 =~ "start" ]]; then
+    if [[ $UID -eq 0 ]]; then
+      su cdap -c "$KRB_COMMAND"
+    else
+      $KRB_COMMAND
+    fi
+  fi
+fi
+
 # drop permissions to cdap user and run service script
 
 if [[ $UID -eq 0 ]]; then

--- a/cdap-docs/admin-manual/source/installation/installation.rst
+++ b/cdap-docs/admin-manual/source/installation/installation.rst
@@ -427,6 +427,9 @@ In order to configure CDAP Master for Kerberos authentication:
 - Generate a keytab file for each CDAP Master Kerberos principal, and place the file as
   ``/etc/security/keytabs/cdap.keytab`` on the corresponding CDAP Master host.  The file should
   be readable only by the user running the CDAP Master process.
+- Edit ``/etc/default/cdap-master``, substituting the Kerberos principal for ``<cdap-principal>``::
+    CDAP_KEYTAB="/etc/security/keytabs/cdap.keytab"
+    CDAP_PRINCIPAL="<cdap-principal>@EXAMPLE.REALM.COM"
 - Edit ``/etc/cdap/conf/cdap-site.xml``, substituting the Kerberos principal for
   ``<cdap-principal>`` when adding these two properties::
 


### PR DESCRIPTION
This is a semi-reversal of #996 for CDAP-1171 which allows Explore to run on secure clusters by detecting the Hive CLASSPATH properly.