### PR TITLE
CDAP-1861 bump the kafka topic version and parition  of logging for ns

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -853,7 +853,7 @@
 
     <property>
         <name>log.publish.num.partitions</name>
-        <value>10</value>
+        <value>50</value>
         <description>Number of Kafka partitions to publish the logs to</description>
     </property>
 

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/appender/kafka/KafkaTopic.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/appender/kafka/KafkaTopic.java
@@ -24,7 +24,7 @@ import java.io.IOException;
 public final class KafkaTopic {
   // Kafka topic on which log messages will get published.
   // If there is an incompatible log schema change, then the topic version needs to be updated.
-  private static final String KAFKA_TOPIC = "logs.user-v1";
+  private static final String KAFKA_TOPIC = "logs.user-v2";
 
   /**
    * @return Kafka topic with schema.

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/write/FileMetaDataManager.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/write/FileMetaDataManager.java
@@ -263,7 +263,7 @@ public final class FileMetaDataManager {
     oldLogMDS.execute(new TransactionExecutor.Function<DatasetContext<Table>, Void>() {
       @Override
       public Void apply(DatasetContext<Table> ctx) throws Exception {
-        Scanner rows = ctx.get().scan(null, null);
+        Scanner rows = ctx.get().scan(ROW_KEY_PREFIX, Bytes.stopKeyForPrefix(ROW_KEY_PREFIX));
         Row row;
         while ((row = rows.next()) != null) {
           String key = Bytes.toString(row.getRow(), ROW_KEY_PREFIX.length,


### PR DESCRIPTION
- Bump the version of kafka topic for new schema with namespace
- Increase the number of partitions

Issues: https://issues.cask.co/browse/CDAP-1861

Build: http://builds.cask.co/browse/CDAP-RBT189-1