### PR TITLE
Add TTL configuring for Datasets.

### DIFF
--- a/cdap-docs/developers-manual/source/building-blocks/datasets/index.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/datasets/index.rst
@@ -84,6 +84,23 @@ interface or by extending existing Dataset types. See the
 :ref:`Purchase Example<examples-purchase>` for an implementation of a Custom Dataset.
 For more details, refer to :ref:`Custom Datasets. <custom-datasets>`
 
+.. rubric::  Dataset Time-To-Live (TTL)
+
+Datasets, like :ref:`Streams <streams>`, can have a Time-To-Live (TTL) property that
+governs how long data will be persisted in a specific Dataset.
+
+When you create a Dataset, you can configure its TTL as part of the creation::
+
+  public void configure() {
+      createDataset("myCounters", Table.class, 
+                    DatasetProperties.builder().add(Table.PROPERTY_TTL, 
+                                                    "<age in milliseconds>").build());
+      ...
+  }
+
+The default TTL for all Datasets is infinite, meaning that data will never expire. The TTL
+property of an existing Dataset can be changed using the :ref:`http-restful-api-dataset`.
+
 .. rubric:: Types of Datasets
 
 A Dataset abstraction is defined by a Java class that implements the ``DatasetDefinition`` interface.

--- a/cdap-docs/developers-manual/source/building-blocks/datasets/index.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/datasets/index.rst
@@ -87,7 +87,8 @@ For more details, refer to :ref:`Custom Datasets. <custom-datasets>`
 .. rubric::  Dataset Time-To-Live (TTL)
 
 Datasets, like :ref:`Streams <streams>`, can have a Time-To-Live (TTL) property that
-governs how long data will be persisted in a specific Dataset.
+governs how long data will be persisted in a specific Dataset. TTL is configured as the
+maximum age (in milliseconds) that data should be retained.
 
 When you create a Dataset, you can configure its TTL as part of the creation::
 

--- a/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v3/dataset.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v3/dataset.rst
@@ -100,9 +100,9 @@ with JSON-formatted name of the dataset type and properties in a body::
    * - HTTP Request
      - ``PUT <base-url>/namespaces/default/data/datasets/mydataset``
    * - Body
-     - ``{"typeName":"co.cask.cdap.api.dataset.table.Table",`` ``"properties":{"ttl":"3600"}}``
+     - ``{"typeName":"co.cask.cdap.api.dataset.table.Table",`` ``"properties":{"dataset.table.ttl":"3600"}}``
    * - Description
-     - Creates a Dataset named "mydataset" of the type "table" in the namespace *default*
+     - Creates a Dataset named *mydataset* of the type ``Table`` in the namespace *default*
        with the time-to-live property set to 1 hour
 
 
@@ -159,9 +159,9 @@ with JSON-formatted name of the dataset type and properties in the body::
    * - HTTP Request
      - ``PUT <base-url>/namespaces/default/data/datasets/mydataset/properties``
    * - Body
-     - ``{"typeName":"co.cask.cdap.api.dataset.table.Table",`` ``"properties":{"ttl":"7200"}}``
+     - ``{"typeName":"co.cask.cdap.api.dataset.table.Table",`` ``"properties":{"dataset.table.ttl":"7200"}}``
    * - Description
-     - For the "mydataset" of type "Table" of the namespace *default*, update the Dataset
+     - For the *mydataset* of type ``Table`` of the namespace *default*, update the Dataset
        and its time-to-live property to 2 hours
 
 


### PR DESCRIPTION
Fix for https://issues.cask.co/browse/CDAP-406

Staged at:

- [Datasets](http://stg-web101.sw.joyent.continuuity.net/cdap/2.8.0-SNAPSHOT-r2.8_doc_ttl_config/en/developers-manual/building-blocks/datasets/index.html) (see "Dataset Time-To-Live (TTL)")
- [RESTful API: Creating a Dataset](http://stg-web101.sw.joyent.continuuity.net/cdap/2.8.0-SNAPSHOT-r2.8_doc_ttl_config/en/reference-manual/http-restful-api/http-restful-api-v3/dataset.html#creating-a-dataset) (see Example Body and Description)
- [RESTful API: Updating a Dataset](http://stg-web101.sw.joyent.continuuity.net/cdap/2.8.0-SNAPSHOT-r2.8_doc_ttl_config/en/reference-manual/http-restful-api/http-restful-api-v3/dataset.html#updating-an-existing-dataset) (see Example Body and Description)

The latter two links were updated as to the example showing use of the TTL property.