### PR TITLE
Fix dropping namespace issue

### DIFF
--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/common/ClientTestBase.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/common/ClientTestBase.java
@@ -21,7 +21,6 @@ import co.cask.cdap.cli.util.InstanceURIParser;
 import co.cask.cdap.client.ProgramClient;
 import co.cask.cdap.client.config.ClientConfig;
 import co.cask.cdap.client.config.ConnectionConfig;
-import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.exception.NotFoundException;
 import co.cask.cdap.common.exception.ProgramNotFoundException;
 import co.cask.cdap.common.exception.UnauthorizedException;

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/NoopStreamAdmin.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/NoopStreamAdmin.java
@@ -57,11 +57,6 @@ public class NoopStreamAdmin implements StreamAdmin {
   }
 
   @Override
-  public long fetchStreamSize(StreamConfig streamConfig) throws IOException {
-    return 0;
-  }
-
-  @Override
   public boolean exists(Id.Stream streamId) throws Exception {
     return false;
   }

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/service/StreamFileSizeFetcherTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/service/StreamFileSizeFetcherTest.java
@@ -62,7 +62,8 @@ public class StreamFileSizeFetcherTest {
     StreamConfig config = streamAdmin.getConfig(streamId);
 
     try {
-      StreamUtils.fetchStreamFilesSize(config);
+      StreamUtils.fetchStreamFilesSize(StreamUtils.createGenerationLocation(config.getLocation(),
+                                                                            StreamUtils.getGeneration(config)));
       Assert.fail("No stream file created yet");
     } catch (IOException e) {
       // Expected
@@ -83,7 +84,8 @@ public class StreamFileSizeFetcherTest {
 
     writer.close();
 
-    long size = streamAdmin.fetchStreamSize(config);
+    long size = StreamUtils.fetchStreamFilesSize(
+      StreamUtils.createGenerationLocation(config.getLocation(), StreamUtils.getGeneration(config)));
     Assert.assertTrue(size > 0);
     Assert.assertEquals(dataLocation.length(), size);
   }
@@ -109,11 +111,6 @@ public class StreamFileSizeFetcherTest {
     public StreamConfig getConfig(Id.Stream streamId) throws IOException {
       Location streamLocation = StreamFileTestUtils.getStreamBaseLocation(locationFactory, streamId);
       return new StreamConfig(streamId, partitionDuration, indexInterval, Long.MAX_VALUE, streamLocation, null, 1000);
-    }
-
-    @Override
-    public long fetchStreamSize(StreamConfig streamConfig) throws IOException {
-      return StreamUtils.fetchStreamFilesSize(streamConfig);
     }
   }
 

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/StreamAdminTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/StreamAdminTest.java
@@ -19,9 +19,11 @@ package co.cask.cdap.data2.transaction.stream;
 import co.cask.cdap.api.flow.flowlet.StreamEvent;
 import co.cask.cdap.data.file.FileWriter;
 import co.cask.cdap.data.stream.StreamFileWriterFactory;
+import co.cask.cdap.data.stream.StreamUtils;
 import co.cask.cdap.proto.Id;
 import com.google.common.base.Charsets;
 import com.google.common.collect.Lists;
+import org.apache.twill.filesystem.Location;
 import org.apache.twill.filesystem.LocationFactory;
 import org.junit.Assert;
 import org.junit.Test;
@@ -87,9 +89,9 @@ public abstract class StreamAdminTest {
 
     streamAdmin.dropAllInNamespace(Id.Namespace.from(FOO_NAMESPACE));
 
-    // All of the streams within the default namespace should have no data in them
+    // All of the streams within the default namespace should no longer exist
     for (Id.Stream defaultStream : fooStreams) {
-      Assert.assertEquals(0, getStreamSize(defaultStream));
+      Assert.assertFalse(streamAdmin.exists(defaultStream));
     }
     // otherStream isn't in the foo namespace so its data is not deleted in the above call to dropAllInNamespace.
     Assert.assertNotEquals(0, getStreamSize(otherStream));
@@ -102,7 +104,10 @@ public abstract class StreamAdminTest {
   private long getStreamSize(Id.Stream streamId) throws IOException {
     StreamAdmin streamAdmin = getStreamAdmin();
     StreamConfig config = streamAdmin.getConfig(streamId);
-    return streamAdmin.fetchStreamSize(config);
+
+    Location generationLocation = StreamUtils.createGenerationLocation(config.getLocation(),
+                                                                       StreamUtils.getGeneration(config));
+    return StreamUtils.fetchStreamFilesSize(generationLocation);
   }
 
   // simply writes a static string to a stream

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseFileStreamAdminTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseFileStreamAdminTest.java
@@ -29,6 +29,7 @@ import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;
 import co.cask.cdap.data.runtime.TransactionMetricsModule;
 import co.cask.cdap.data.stream.StreamAdminModules;
+import co.cask.cdap.data.stream.StreamCoordinatorClient;
 import co.cask.cdap.data.stream.StreamFileWriterFactory;
 import co.cask.cdap.data.stream.service.InMemoryStreamMetaStore;
 import co.cask.cdap.data.stream.service.StreamMetaStore;
@@ -70,6 +71,7 @@ public class HBaseFileStreamAdminTest extends StreamAdminTest {
   private static StreamAdmin streamAdmin;
   private static TransactionManager txManager;
   private static StreamFileWriterFactory fileWriterFactory;
+  private static StreamCoordinatorClient streamCoordinatorClient;
 
   @BeforeClass
   public static void init() throws Exception {
@@ -111,13 +113,16 @@ public class HBaseFileStreamAdminTest extends StreamAdminTest {
     streamAdmin = injector.getInstance(StreamAdmin.class);
     txManager = injector.getInstance(TransactionManager.class);
     fileWriterFactory = injector.getInstance(StreamFileWriterFactory.class);
+    streamCoordinatorClient = injector.getInstance(StreamCoordinatorClient.class);
 
     setupNamespaces(injector.getInstance(LocationFactory.class));
     txManager.startAndWait();
+    streamCoordinatorClient.startAndWait();
   }
 
   @AfterClass
   public static void finish() throws Exception {
+    streamCoordinatorClient.stopAndWait();
     txManager.stopAndWait();
     testHBase.stopHBase();
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/InMemoryStreamCoordinatorClient.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/InMemoryStreamCoordinatorClient.java
@@ -64,4 +64,9 @@ public final class InMemoryStreamCoordinatorClient extends AbstractStreamCoordin
   protected void streamCreated(Id.Stream streamId) {
     // Nothing to do
   }
+
+  @Override
+  protected void streamDeleted(Id.Stream streamId) {
+    // Nothing to do
+  }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamCoordinatorClient.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamCoordinatorClient.java
@@ -62,4 +62,15 @@ public interface StreamCoordinatorClient extends Service {
    * @throws Exception if failed to update properties
    */
   void updateProperties(Id.Stream streamId, Callable<CoordinatorStreamProperties> action) throws Exception;
+
+  /**
+   * Deletes a stream by performing the given action. The execution of the action is protected by a lock
+   * so that it is guaranteed that there is only only thread executing the given action for the given stream across
+   * the whole system.
+   *
+   * @param streamId name of the stream
+   * @param action action to perform.
+   * @throws Exception if the action throws Exception
+   */
+  void deleteStream(Id.Stream streamId, Callable<CoordinatorStreamProperties> action) throws Exception;
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamUtils.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamUtils.java
@@ -390,15 +390,13 @@ public final class StreamUtils {
   }
 
   /**
-   * Get the size of the data persisted for the stream which config is the {@code streamConfig}.
+   * Get the size of the data persisted for the stream under the given stream location.
    *
-   * @param streamConfig stream to get data size of
+   * @param streamLocation stream to get data size of
    * @return the size of the data persisted for the stream which config is the {@code streamName}
    * @throws IOException in case of any error in fetching the size
    */
-  public static long fetchStreamFilesSize(StreamConfig streamConfig) throws IOException {
-    Location streamPath = StreamUtils.createGenerationLocation(streamConfig.getLocation(), getGeneration(streamConfig));
-
+  public static long fetchStreamFilesSize(Location streamLocation) throws IOException {
     Processor<LocationStatus, Long> processor = new Processor<LocationStatus, Long>() {
       private long size = 0;
       @Override
@@ -415,7 +413,7 @@ public final class StreamUtils {
       }
     };
 
-    List<Location> locations = streamPath.list();
+    List<Location> locations = streamLocation.list();
     // All directories are partition directories
     for (Location location : locations) {
       if (!location.isDirectory() || !isPartition(location.getName())) {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/DistributedStreamService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/DistributedStreamService.java
@@ -34,7 +34,6 @@ import co.cask.cdap.data.stream.StreamPropertyListener;
 import co.cask.cdap.data.stream.service.heartbeat.HeartbeatPublisher;
 import co.cask.cdap.data.stream.service.heartbeat.StreamWriterHeartbeat;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
-import co.cask.cdap.data2.transaction.stream.StreamConfig;
 import co.cask.cdap.notifications.feeds.NotificationFeedException;
 import co.cask.cdap.notifications.feeds.NotificationFeedManager;
 import co.cask.cdap.notifications.feeds.NotificationFeedNotFoundException;
@@ -66,7 +65,6 @@ import org.apache.twill.zookeeper.ZKClients;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.Map;
@@ -222,15 +220,17 @@ public class DistributedStreamService extends AbstractStreamService {
         continue;
       }
 
-      StreamConfig config;
-      long eventsSize;
       while (true) {
         try {
-          config = streamAdmin.getConfig(streamId);
-          eventsSize = getStreamEventsSize(streamId);
+          if (!streamAdmin.exists(streamId)) {
+            break;
+          }
+          int threshold = streamAdmin.getConfig(streamId).getNotificationThresholdMB();
+          long eventsSize = getStreamEventsSize(streamId);
+          createSizeAggregator(streamId, eventsSize, threshold);
           LOG.debug("Size of the events ingested in stream {}: {}", streamId, eventsSize);
           break;
-        } catch (IOException e) {
+        } catch (Exception e) {
           LOG.info("Could not compute sizes of files for stream {}. Retrying in 1 sec.", streamId);
           try {
             TimeUnit.SECONDS.sleep(1);
@@ -240,7 +240,6 @@ public class DistributedStreamService extends AbstractStreamService {
           }
         }
       }
-      createSizeAggregator(streamId, eventsSize, config.getNotificationThresholdMB());
     }
 
     // Stop aggregating the heartbeats we used to listen to before the call to that method,

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseStreamAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseStreamAdmin.java
@@ -116,11 +116,6 @@ public class HBaseStreamAdmin extends HBaseQueueAdmin implements StreamAdmin {
   }
 
   @Override
-  public long fetchStreamSize(StreamConfig streamConfig) throws IOException {
-    return 0;
-  }
-
-  @Override
   public boolean exists(Id.Stream streamId) throws Exception {
     return exists(QueueName.fromStream(streamId));
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/inmemory/InMemoryStreamAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/inmemory/InMemoryStreamAdmin.java
@@ -66,11 +66,6 @@ public class InMemoryStreamAdmin extends InMemoryQueueAdmin implements StreamAdm
   }
 
   @Override
-  public long fetchStreamSize(StreamConfig streamConfig) throws IOException {
-    throw new UnsupportedOperationException("Not yet supported");
-  }
-
-  @Override
   public boolean exists(Id.Stream streamId) throws Exception {
     return exists(QueueName.fromStream(streamId));
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/leveldb/LevelDBStreamAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/leveldb/LevelDBStreamAdmin.java
@@ -93,11 +93,6 @@ public class LevelDBStreamAdmin extends LevelDBQueueAdmin implements StreamAdmin
   }
 
   @Override
-  public long fetchStreamSize(StreamConfig streamConfig) throws IOException {
-    throw new UnsupportedOperationException("Not yet supported");
-  }
-
-  @Override
   public boolean exists(Id.Stream streamId) throws Exception {
     return exists(QueueName.fromStream(streamId));
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/FileStreamAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/FileStreamAdmin.java
@@ -103,14 +103,14 @@ public class FileStreamAdmin implements StreamAdmin {
     // is done external to this class.
     List<Location> locations;
     try {
-      locations = getStreamsHomeLocation(namespace).list();
+      locations = getStreamBaseLocation(namespace).list();
     } catch (FileNotFoundException e) {
       // If the stream base doesn't exists, nothing need to be deleted
       locations = ImmutableList.of();
     }
 
     for (final Location streamLocation : locations) {
-      doTruncate(streamLocation);
+      doDrop(StreamUtils.getStreamIdFromLocation(streamLocation), streamLocation);
     }
 
     // Also drop the state table
@@ -204,14 +204,26 @@ public class FileStreamAdmin implements StreamAdmin {
 
   @Override
   public StreamConfig getConfig(Id.Stream streamId) throws IOException {
-    Location streamLocation = getStreamBaseLocation(streamId);
-    Preconditions.checkArgument(streamLocation.isDirectory(), "Stream '%s' does not exist.", streamId);
-    return loadConfig(streamLocation);
+    Location configLocation = getConfigLocation(streamId);
+    Preconditions.checkArgument(configLocation.exists(), "Stream '%s' does not exist.", streamId);
+
+    StreamConfig config = GSON.fromJson(
+      CharStreams.toString(CharStreams.newReaderSupplier(Locations.newInputSupplier(configLocation), Charsets.UTF_8)),
+      StreamConfig.class);
+
+    int threshold = config.getNotificationThresholdMB();
+    if (threshold <= 0) {
+      // Need to default it for existing configs that were created before notification threshold was added.
+      threshold = cConf.getInt(Constants.Stream.NOTIFICATION_THRESHOLD);
+    }
+
+    return new StreamConfig(streamId, config.getPartitionDuration(), config.getIndexInterval(),
+                            config.getTTL(), getStreamLocation(streamId), config.getFormat(), threshold);
   }
 
   @Override
   public void updateConfig(final Id.Stream streamId, final StreamProperties properties) throws IOException {
-    Location streamLocation = getStreamBaseLocation(streamId);
+    Location streamLocation = getStreamLocation(streamId);
     Preconditions.checkArgument(streamLocation.isDirectory(), "Stream '%s' does not exist.", streamId);
 
     try {
@@ -245,14 +257,9 @@ public class FileStreamAdmin implements StreamAdmin {
   }
 
   @Override
-  public long fetchStreamSize(StreamConfig streamConfig) throws IOException {
-    return StreamUtils.fetchStreamFilesSize(streamConfig);
-  }
-
-  @Override
   public boolean exists(Id.Stream streamId) throws Exception {
     try {
-      return getStreamConfigLocation(streamId).exists();
+      return getConfigLocation(streamId).exists();
     } catch (IOException e) {
       LOG.error("Exception when check for stream exist.", e);
       return false;
@@ -267,14 +274,13 @@ public class FileStreamAdmin implements StreamAdmin {
   @Override
   public void create(final Id.Stream streamId, @Nullable final Properties props) throws Exception {
     assertNamespaceHomeExists(streamId.getNamespace());
-    final Location streamLocation = getStreamBaseLocation(streamId);
+    final Location streamLocation = getStreamLocation(streamId);
     Locations.mkdirsIfNotExists(streamLocation);
 
     streamCoordinatorClient.createStream(streamId, new Callable<StreamConfig>() {
       @Override
       public StreamConfig call() throws Exception {
-        Location configLocation = getStreamConfigLocation(streamId);
-        if (configLocation.exists()) {
+        if (exists(streamId)) {
           return null;
         }
 
@@ -298,10 +304,9 @@ public class FileStreamAdmin implements StreamAdmin {
   }
 
   private void assertNamespaceHomeExists(Id.Namespace namespaceId) throws IOException {
-    Location namespaceHomeLocation = Locations.getParent(getStreamsHomeLocation(namespaceId));
-    Preconditions.checkArgument(namespaceHomeLocation.exists(),
-                                String.format("Home directory %s for namespace %s not found",
-                                              namespaceHomeLocation.toURI().getPath(), namespaceId));
+    Location namespaceHomeLocation = Locations.getParent(getStreamBaseLocation(namespaceId));
+    Preconditions.checkArgument(namespaceHomeLocation != null && namespaceHomeLocation.exists(),
+                                "Home directory %s for namespace %s not found", namespaceHomeLocation, namespaceId);
   }
 
   /**
@@ -326,42 +331,61 @@ public class FileStreamAdmin implements StreamAdmin {
 
   @Override
   public void truncate(Id.Stream streamId) throws Exception {
-    doTruncate(getStreamBaseLocation(streamId));
+    doTruncate(streamId, getStreamLocation(streamId));
   }
 
   @Override
   public void drop(Id.Stream streamId) throws Exception {
-    // Same as truncate
-    truncate(streamId);
+    doDrop(streamId, getStreamLocation(streamId));
   }
 
-  private Location getStreamConfigLocation(Id.Stream streamId) throws IOException {
-    return getStreamBaseLocation(streamId).append(CONFIG_FILE_NAME);
+  /**
+   * Returns the location that points the config file for the given stream.
+   */
+  private Location getConfigLocation(Id.Stream streamId) throws IOException {
+    return getStreamLocation(streamId).append(CONFIG_FILE_NAME);
   }
 
-  // Constructs path: /.../<namespace>/streams/<streamName>, as expected by StreamUtils#getStreamIdFromLocation
-  private Location getStreamBaseLocation(Id.Stream streamId) throws IOException {
-    return getStreamsHomeLocation(streamId.getNamespace()).append(streamId.getName());
+  /**
+   * Returns the location for the given stream.
+   */
+  private Location getStreamLocation(Id.Stream streamId) throws IOException {
+    return getStreamBaseLocation(streamId.getNamespace()).append(streamId.getName());
   }
 
-  private Location getStreamsHomeLocation(Id.Namespace namespace) throws IOException {
+  /**
+   * Returns the location for the given namespace that contains all streams belong to that namespace.
+   */
+  private Location getStreamBaseLocation(Id.Namespace namespace) throws IOException {
     return locationFactory.create(namespace.getId()).append(streamBaseDirPath);
   }
 
-  private void doTruncate(final Location streamLocation) {
-    final Id.Stream streamId = StreamUtils.getStreamIdFromLocation(streamLocation);
-    try {
-      streamCoordinatorClient.updateProperties(streamId, new Callable<CoordinatorStreamProperties>() {
-        @Override
-        public CoordinatorStreamProperties call() throws Exception {
-          int newGeneration = StreamUtils.getGeneration(streamLocation) + 1;
-          Locations.mkdirsIfNotExists(StreamUtils.createGenerationLocation(streamLocation, newGeneration));
-          return new CoordinatorStreamProperties(null, null, null, newGeneration);
+  private void doTruncate(Id.Stream streamId, final Location streamLocation) throws Exception {
+    streamCoordinatorClient.updateProperties(streamId, new Callable<CoordinatorStreamProperties>() {
+      @Override
+      public CoordinatorStreamProperties call() throws Exception {
+        int newGeneration = StreamUtils.getGeneration(streamLocation) + 1;
+        Locations.mkdirsIfNotExists(StreamUtils.createGenerationLocation(streamLocation, newGeneration));
+        return new CoordinatorStreamProperties(null, null, null, newGeneration);
+      }
+    });
+  }
+
+  private void doDrop(final Id.Stream streamId, final Location streamLocation) throws Exception {
+    streamCoordinatorClient.deleteStream(streamId, new Callable<CoordinatorStreamProperties>() {
+      @Override
+      public CoordinatorStreamProperties call() throws Exception {
+        Location configLocation = getConfigLocation(streamId);
+        if (!configLocation.exists()) {
+          return null;
         }
-      });
-    } catch (Exception e) {
-      LOG.error("Failed to truncate stream {}", streamId.getName(), e);
-    }
+        alterExploreStream(StreamUtils.getStreamIdFromLocation(streamLocation), false);
+        configLocation.delete();
+        int newGeneration = StreamUtils.getGeneration(streamLocation) + 1;
+        Locations.mkdirsIfNotExists(StreamUtils.createGenerationLocation(streamLocation, newGeneration));
+        return new CoordinatorStreamProperties(null, null, null, newGeneration);
+      }
+    });
   }
 
   private StreamProperties updateProperties(Id.Stream streamId, StreamProperties properties) throws IOException {
@@ -382,24 +406,6 @@ public class FileStreamAdmin implements StreamAdmin {
     return new StreamProperties(config.getTTL(), config.getFormat(), config.getNotificationThresholdMB());
   }
 
-  private StreamConfig loadConfig(Location streamLocation) throws IOException {
-    Location configLocation = streamLocation.append(CONFIG_FILE_NAME);
-
-    StreamConfig config = GSON.fromJson(
-      CharStreams.toString(CharStreams.newReaderSupplier(Locations.newInputSupplier(configLocation), Charsets.UTF_8)),
-      StreamConfig.class);
-
-    int threshold = config.getNotificationThresholdMB();
-    if (threshold <= 0) {
-      // Need to default it for existing configs that were created before notification threshold was added.
-      threshold = cConf.getInt(Constants.Stream.NOTIFICATION_THRESHOLD);
-    }
-
-    Id.Stream streamId = StreamUtils.getStreamIdFromLocation(streamLocation);
-    return new StreamConfig(streamId, config.getPartitionDuration(), config.getIndexInterval(),
-                            config.getTTL(), streamLocation, config.getFormat(), threshold);
-  }
-
   private void writeConfig(StreamConfig config) throws IOException {
     Location configLocation = config.getLocation().append(CONFIG_FILE_NAME);
     Location tmpConfigLocation = configLocation.getTempFile(null);
@@ -412,7 +418,7 @@ public class FileStreamAdmin implements StreamAdmin {
       if (OSDetector.isWindows()) {
         configLocation.delete();
       }
-      tmpConfigLocation.renameTo(getStreamConfigLocation(config.getStreamId()));
+      tmpConfigLocation.renameTo(getConfigLocation(config.getStreamId()));
     } finally {
       Locations.deleteQuietly(tmpConfigLocation);
     }
@@ -472,7 +478,7 @@ public class FileStreamAdmin implements StreamAdmin {
         }
       } catch (Exception e) {
         // at this time we want to still allow using stream even if it cannot be used for exploration
-        String msg = String.format("Cannot enable exploration of stream %s: %s", stream, e.getMessage());
+        String msg = String.format("Cannot alter exploration to %s for stream %s: %s", enable, stream, e.getMessage());
         LOG.error(msg, e);
       }
     }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/StreamAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/StreamAdmin.java
@@ -70,15 +70,6 @@ public interface StreamAdmin {
   void updateConfig(Id.Stream streamId, StreamProperties properties) throws IOException;
 
   /**
-   * Get the size of the data persisted for the stream with config {@code streamConfig}.
-   *
-   * @param streamConfig configuration of the stream to get the size of data for
-   * @return the size of the data persisted for the stream which config is the {@code streamId}
-   * @throws IOException in case of any error in fetching the size
-   */
-  long fetchStreamSize(StreamConfig streamConfig) throws IOException;
-
-  /**
    * @param streamId Id of the stream.
    * @return true if stream with given Id exists, otherwise false
    * @throws Exception if check fails

--- a/cdap-unit-test/src/test/java/co/cask/cdap/batch/stream/BatchStreamIntegrationTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/batch/stream/BatchStreamIntegrationTestRun.java
@@ -63,8 +63,8 @@ public class BatchStreamIntegrationTestRun extends TestFrameworkTestBase {
     submitAndVerifyStreamBatchJob(NoMapperApp.class, "nomapper", "NoMapperMapReduce", 120);
   }
 
-  private void submitAndVerifyStreamBatchJob(Class<? extends AbstractApplication> appClass, String streamWriter, String
-    mapReduceName, int timeout) throws Exception {
+  private void submitAndVerifyStreamBatchJob(Class<? extends AbstractApplication> appClass,
+                                             String streamWriter, String mapReduceName, int timeout) throws Exception {
     ApplicationManager applicationManager = deployApplication(appClass);
     StreamWriter writer = applicationManager.getStreamWriter(streamWriter);
     for (int i = 0; i < 50; i++) {

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/DummyBaseCloneTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/DummyBaseCloneTestRun.java
@@ -51,7 +51,6 @@ public class DummyBaseCloneTestRun extends TestFrameworkTestBase {
       Assert.assertEquals(expected, Sets.intersection(expected, tables));
     } finally {
       connection.close();
-
     }
   }
 }

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/DummyBaseTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/DummyBaseTestRun.java
@@ -30,7 +30,6 @@ import java.util.Set;
  * in particular, it makes sure that Explore is working properly.
  */
 public class DummyBaseTestRun extends TestFrameworkTestBase {
-
   @Test
   public void test() throws Exception {
     deployApplication(DummyApp.class);
@@ -45,6 +44,7 @@ public class DummyBaseTestRun extends TestFrameworkTestBase {
       } finally {
         resultSet.close();
       }
+
       // Since this test can runs in test suite that may contains other tests,
       // use intersect to verify to avoid seeing tables created by other tests
       Set<String> expected = Sets.newHashSet("stream_who", "dataset_whom");


### PR DESCRIPTION
- We should disable the stream table in Hive when dropping a stream
- Also fixed a annoying exception when StreamClient is used to fetch events.