### PR TITLE
Hotfix/revert comma

### DIFF
--- a/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
+++ b/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
@@ -372,10 +372,10 @@ public class CLIMainTest extends StandaloneTestBase {
   public void testPreferences() throws Exception {
     testPreferencesOutput(cli, "get preferences instance", ImmutableMap.<String, String>of());
     Map<String, String> propMap = Maps.newHashMap();
-    propMap.put("key", "new instance");
+    propMap.put("key", "newinstance");
     propMap.put("k1", "v1");
     testCommandOutputContains(cli, "delete preferences instance", "successfully");
-    testCommandOutputContains(cli, String.format("set preferences instance 'key=new instance, k1=v1'"),
+    testCommandOutputContains(cli, String.format("set preferences instance 'key=newinstance k1=v1'"),
                               "successfully");
     testPreferencesOutput(cli, "get preferences instance", propMap);
     testPreferencesOutput(cli, "get resolved preferences instance", propMap);

--- a/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
+++ b/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
@@ -64,7 +64,6 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
@@ -425,7 +424,6 @@ public class CLIMainTest extends StandaloneTestBase {
   }
 
   @Test
-  @Ignore
   public void testNamespaces() throws Exception {
     final String name = PREFIX + "testNamespace";
     final String description = "testDescription";
@@ -434,7 +432,7 @@ public class CLIMainTest extends StandaloneTestBase {
 
     // initially only default namespace should be present
     NamespaceMeta defaultNs = new NamespaceMeta.Builder()
-      .setName("default").setDescription("default").build();
+      .setName("default").setDescription("Default Namespace").build();
     List<NamespaceMeta> expectedNamespaces = Lists.newArrayList(defaultNs);
     testNamespacesOutput(cli, "list namespaces", expectedNamespaces);
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetPreferencesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetPreferencesCommand.java
@@ -65,6 +65,6 @@ public class SetPreferencesCommand extends AbstractSetPreferencesCommand {
   @Override
   public String getDescription() {
     return "Sets the preferences of a " + type.getPluralPrettyName() + "." +
-      " <" + ArgumentName.RUNTIME_ARGS + "> is specified in the format \"key1=v1, key2=v2\".";
+      " <" + ArgumentName.RUNTIME_ARGS + "> is specified in the format \"key1=v1 key2=v2\".";
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetStreamFormatCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetStreamFormatCommand.java
@@ -102,7 +102,7 @@ public class SetStreamFormatCommand extends AbstractAuthCommand {
       .append(ArgumentName.SCHEMA)
       .append("> is a sql-like schema \"column_name data_type, ...\" or avro-like json schema and <")
       .append(ArgumentName.SETTINGS)
-      .append("> is specified in the format \"key1=v1, key2=v2\".")
+      .append("> is specified in the format \"key1=v1 key2=v2\".")
       .toString();
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/util/ArgumentParser.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/util/ArgumentParser.java
@@ -38,7 +38,7 @@ import static co.cask.common.cli.util.Parser.OPTIONAL_PART_ENDING;
 public class ArgumentParser {
 
   /**
-   * Parses a map in the format: "key1=a, key2=b, .."
+   * Parses a map in the format: "key1=a key2=b .."
    *
    * @param mapString {@link String} representation of the map
    * @return the map
@@ -47,7 +47,7 @@ public class ArgumentParser {
     if (mapString == null || mapString.isEmpty()) {
       return ImmutableMap.of();
     }
-    return Splitter.on(",").omitEmptyStrings().trimResults().withKeyValueSeparator("=").split(mapString);
+    return Splitter.on(" ").omitEmptyStrings().trimResults().withKeyValueSeparator("=").split(mapString);
   }
 
   /**


### PR DESCRIPTION
* Preferences/RuntimeArguments CLI will use ' ' (space) as the separator between key-value pairs instead of ','.
* Enabling Namespace CLI Test.

Bamboo : http://builds.cask.co/browse/CDAP-DUT1204-1

Opened JIRA to address this in 3.0 : https://issues.cask.co/browse/CDAP-1886

