### PR TITLE
Document new UI

### DIFF
--- a/cdap-docs/admin-manual/source/operations/cdap-console.rst
+++ b/cdap-docs/admin-manual/source/operations/cdap-console.rst
@@ -25,8 +25,27 @@ managing each of these CDAP components.
 In the far upper-right are two buttons: the *Metrics* and *Services* buttons, which take
 you to their respective explorers.
 
-A detailed *How-To Guide* covering using the CDAP Console 
-will be available
-at `Guides and Tutorials for CDAP. <http://cask.co/guides/>`__
-
+.. A detailed *How-To Guide* covering using the CDAP Console will be available
+.. at `Guides and Tutorials for CDAP. <http://cask.co/guides/>`__
 .. is available
+
+
+New User Interface
+------------------
+As part of release 2.8.0, a new alpha User Interface (UI) for the CDAP Console was introduced.
+
+To try out the new UI, changes are required before CDAP is started.
+
+- For CDAP Standalone SDK, pass an additional argument when starting CDAP::
+
+    $ ./bin/cdap.sh start --enable-alpha-ui
+    
+- For CDAP Distributed, modify the :ref:`command used to start CDAP <install-starting-services>`.
+  Before starting the service, an environmental variable needs to be set::
+  
+    export ENABLE_ALPHA_UI=true 
+    for i in `ls /etc/init.d/ | grep cdap` ; do sudo service $i restart ; done
+    
+  To restart just the CDAP Web App (the UI) in the new UI::
+  
+    export ENABLE_ALPHA_UI=true sudo /etc/init.d/cdap-web-app restart

--- a/cdap-docs/admin-manual/source/operations/cdap-console.rst
+++ b/cdap-docs/admin-manual/source/operations/cdap-console.rst
@@ -40,7 +40,7 @@ To try out the new UI, changes are required before CDAP is started.
 
     $ ./bin/cdap.sh start --enable-alpha-ui
     
-- For CDAP Distributed, modify the `command used to start CDAP </admin-manual/installation.html#starting-services>`.
+- For CDAP Distributed, modify the `command used to start CDAP <../installation/installation.html#starting-services>`__.
   Before starting the service, an environmental variable needs to be set::
   
     export ENABLE_ALPHA_UI=true 

--- a/cdap-docs/admin-manual/source/operations/cdap-console.rst
+++ b/cdap-docs/admin-manual/source/operations/cdap-console.rst
@@ -36,11 +36,11 @@ As part of release 2.8.0, a new alpha User Interface (UI) for the CDAP Console w
 
 To try out the new UI, changes are required before CDAP is started.
 
-- For CDAP Standalone SDK, pass an additional argument when starting CDAP::
+- For CDAP Standalone SDK, pass an additional argument :ref:`when starting CDAP <start-stop-cdap>`::
 
     $ ./bin/cdap.sh start --enable-alpha-ui
     
-- For CDAP Distributed, modify the :ref:`command used to start CDAP <install-starting-services>`.
+- For CDAP Distributed, modify the `command used to start CDAP </admin-manual/installation.html#starting-services>`.
   Before starting the service, an environmental variable needs to be set::
   
     export ENABLE_ALPHA_UI=true 
@@ -49,3 +49,4 @@ To try out the new UI, changes are required before CDAP is started.
   To restart just the CDAP Web App (the UI) in the new UI::
   
     export ENABLE_ALPHA_UI=true sudo /etc/init.d/cdap-web-app restart
+


### PR DESCRIPTION
Provides documentation on starting the new UI.

Staged at: [CDAP Console](http://stg-web101.sw.joyent.continuuity.net/cdap/2.8.0-SNAPSHOT-r2.8_doc_new_gui/en/admin-manual/operations/cdap-console.html) or http://stg-web101.sw.joyent.continuuity.net/cdap/2.8.0-SNAPSHOT-r2.8_doc_new_gui/en/admin-manual/operations/cdap-console.html