### PR TITLE
Upgrade docs

### DIFF
--- a/cdap-docs/admin-manual/source/installation/installation.rst
+++ b/cdap-docs/admin-manual/source/installation/installation.rst
@@ -639,14 +639,14 @@ and then restart CDAP.
 
      for i in `ls /etc/init.d/ | grep cdap` ; do sudo service $i start ; done
      
-#. You should recompile and redeploy your application. This will allow you to see your old
-   run history, logs, and |---| if you migrated your old metrics with the 
-   :ref:`metric migration tool <>` |---| metrics.
+#. This will allow you to see your old run history, logs, and |---| if you migrated your 
+   old metrics with the :ref:`metric migration tool <>` |---| metrics.
 
    **Note:** You will no longer be able to see your previous logs in the CDAP Console (UI). 
    To access your previous logs, please see the section on downloading logs in the
    :ref:`Logging HTTP RESTful API <http-restful-api-logging>`.
 
+#. You must recompile and then redeploy your applications. 
 
 .. _install-troubleshooting:
 

--- a/cdap-docs/admin-manual/source/installation/installation.rst
+++ b/cdap-docs/admin-manual/source/installation/installation.rst
@@ -634,8 +634,8 @@ and then restart CDAP.
 
      for i in `ls /etc/init.d/ | grep cdap` ; do sudo service $i start ; done
      
-#. You should recompile and redeploy your application. This will allow you to see your old run history, logs,
-   and |---| if you migrated your old metrics with the 
+#. You should recompile and redeploy your application. This will allow you to see your old
+   run history, logs, and |---| if you migrated your old metrics with the 
    :ref:`metric migration tool <>` |---| metrics.
 
    **Note:** You will no longer be able to see your previous logs in the CDAP Console (UI). 

--- a/cdap-docs/admin-manual/source/installation/installation.rst
+++ b/cdap-docs/admin-manual/source/installation/installation.rst
@@ -601,7 +601,7 @@ and then restart CDAP.
 
 .. highlight:: console
 
-1. Stop all Flows, Services, and Programs in all your applications.
+1. Stop all Flows, Services, and other Programs in all your applications.
 
 #. Stop all CDAP processes::
 
@@ -626,6 +626,11 @@ and then restart CDAP.
 #. Copy the ``logback-container.xml`` into your ``conf`` directory. 
    Please see :ref:`Configuration <install-configuration>`.
 
+#. If you are upgrading a secure Hadoop cluster, you should authenticate with ``kinit``
+   before the next step (upgrade tool)::
+
+     kinit -kt <keytab> <principle>
+
 #. Run the upgrade tool::
 
      /opt/cdap/master/bin/svc-master run co.cask.cdap.data.tools.UpgradeTool upgrade
@@ -641,13 +646,7 @@ and then restart CDAP.
    **Note:** You will no longer be able to see your previous logs in the CDAP Console (UI). 
    To access your previous logs, please see the section on downloading logs in the
    :ref:`Logging HTTP RESTful API <http-restful-api-logging>`.
-     
-#. If you are upgrading a secure Hadoop cluster, see the notes above about
-   :ref:`configuring secure Hadoop <install-secure-hadoop>`.
 
-   To upgrade a secure cluster, you should use ``kinit``::
-
-     kinit -kt <keytab> <principle>
 
 .. _install-troubleshooting:
 

--- a/cdap-docs/admin-manual/source/installation/installation.rst
+++ b/cdap-docs/admin-manual/source/installation/installation.rst
@@ -635,19 +635,19 @@ and then restart CDAP.
 
      /opt/cdap/master/bin/svc-master run co.cask.cdap.data.tools.UpgradeTool upgrade
 
-#. Run the Data Migration tool for metrics::
+#. Run the Data Migration Tool for metrics::
 
      /opt/cdap/master/bin/svc-master run co.cask.cdap.data.tools.DataMigration metrics  [--keep-old-metrics-data]
 
-This will migrate aggregate metrics data from CDAP 2.6 table to CDAP-2.8 metrics system. The old metrics tables
-are deleted by default unless the optional field --keep-old-metrics-data is specified.
+   This will migrate aggregate metrics data from the CDAP 2.6.x tables to the CDAP 2.8 metrics system. 
+   The old metrics tables are deleted by default unless the optional field ``--keep-old-metrics-data`` is specified.
 
 #. Restart the CDAP processes::
 
      for i in `ls /etc/init.d/ | grep cdap` ; do sudo service $i start ; done
      
 #. This will allow you to see your old run history, logs, and |---| if you migrated your 
-   old metrics with the :ref:`metric migration tool <>` |---| metrics.
+   old metrics with the *Data Migration Tool* |---| metrics.
 
    **Note:** You will no longer be able to see your previous logs in the CDAP Console (UI). 
    To access your previous logs, please see the section on downloading logs in the

--- a/cdap-docs/admin-manual/source/installation/installation.rst
+++ b/cdap-docs/admin-manual/source/installation/installation.rst
@@ -472,7 +472,7 @@ In order to configure CDAP Master for Kerberos authentication:
 
 - When CDAP Master is started, it will login using the configured keytab file and principal.
 
-**Note:** CDAP support for secure Hadoop clusters is limited to CDH 5.0 or higher and HDP 2.0 or higher
+**Note:** CDAP support for secure Hadoop clusters is limited to CDH 5.0 or higher and HDP 2.0 or higher.
 
 .. _install-ulimit:
 

--- a/cdap-docs/admin-manual/source/installation/installation.rst
+++ b/cdap-docs/admin-manual/source/installation/installation.rst
@@ -601,7 +601,9 @@ and then restart CDAP.
 
 .. highlight:: console
 
-1. Stop all CDAP processes::
+1. Stop all Flows, Services, and Programs in all your applications.
+
+#. Stop all CDAP processes::
 
      for i in `ls /etc/init.d/ | grep cdap` ; do sudo service $i stop ; done
 
@@ -621,6 +623,9 @@ and then restart CDAP.
                             cdap-hbase-compat-0.98 cdap-kafka cdap-master
                             cdap-security cdap-web-app
 
+#. Copy the ``logback-container.xml`` into your ``conf`` directory. 
+   Please see :ref:`Configuration <install-configuration>`.
+
 #. Run the upgrade tool::
 
      /opt/cdap/master/bin/svc-master run co.cask.cdap.data.tools.UpgradeTool upgrade
@@ -629,8 +634,20 @@ and then restart CDAP.
 
      for i in `ls /etc/init.d/ | grep cdap` ; do sudo service $i start ; done
      
-If you are upgrading a secure Hadoop cluster, see the notes above about
-:ref:`configuring secure Hadoop <install-secure-hadoop>`. 
+#. You should recompile and redeploy your application. This will allow you to see your old run history, logs,
+   and |---| if you migrated your old metrics with the 
+   :ref:`metric migration tool <>` |---| metrics.
+
+   **Note:** You will no longer be able to see your previous logs in the CDAP Console (UI). 
+   To access your previous logs, please see the section on downloading logs in the
+   :ref:`Logging HTTP RESTful API <http-restful-api-logging>`.
+     
+#. If you are upgrading a secure Hadoop cluster, see the notes above about
+   :ref:`configuring secure Hadoop <install-secure-hadoop>`.
+
+   To upgrade a secure cluster, you should use ``kinit``::
+
+     kinit -kt <keytab> <principle>
 
 .. _install-troubleshooting:
 

--- a/cdap-docs/developers-manual/source/advanced/adapters.rst
+++ b/cdap-docs/developers-manual/source/advanced/adapters.rst
@@ -81,7 +81,7 @@ events as partitioned Avro files. With this adapter running, you will be able to
 over the output fileset, which will contain the ``ts``, ``ticker``, ``trades``, and ``price`` fields as well
 as the partition fields::
 
-  cdap (http://127.0.0.1:10000)> execute 'describe cdap_user_tickers_converted'
+  cdap (http://127.0.0.1:10000)> execute 'describe dataset_tickers_converted'
   +=======================================================================+
   | col_name: STRING        | data_type: STRING    | comment: STRING      |
   +=======================================================================+

--- a/cdap-docs/developers-manual/source/data-exploration/custom-datasets.rst
+++ b/cdap-docs/developers-manual/source/data-exploration/custom-datasets.rst
@@ -239,7 +239,7 @@ Writing to Datasets with SQL
 Data can be inserted into Datasets using SQL. For example, you can write to a Dataset named
 ``ProductCatalog`` with this SQL query::
 
-  INSERT INTO TABLE cdap_user_productcatalog SELECT ...
+  INSERT INTO TABLE dataset_productcatalog SELECT ...
 
 In order for a Dataset to enable record insertion from SQL query, it simply has to expose a way to write records
 into itself.
@@ -302,8 +302,8 @@ When creating your queries, keep these limitations in mind:
 - The query syntax of CDAP is a subset of the variant of SQL that was first defined by Apache Hive.
 - The SQL commands ``UPDATE`` and ``DELETE`` are not allowed on CDAP Datasets.
 - When addressing your datasets in queries, you need to prefix the data set name with the CDAP
-  namespace ``cdap_user_``. For example, if your Dataset is named ``ProductCatalog``, then the corresponding table
-  name is ``cdap_user_productcatalog``. Note that the table name is lower-case.
+  namespace ``dataset_``. For example, if your Dataset is named ``ProductCatalog``, then the corresponding table
+  name is ``dataset_productcatalog``. Note that the table name is lower-case.
 
 For more examples of queries, please refer to the `Hive language manual
 <https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DML#LanguageManualDML-InsertingdataintoHiveTablesfromqueries>`__.

--- a/cdap-docs/developers-manual/source/data-exploration/custom-datasets.rst
+++ b/cdap-docs/developers-manual/source/data-exploration/custom-datasets.rst
@@ -301,9 +301,10 @@ When creating your queries, keep these limitations in mind:
 
 - The query syntax of CDAP is a subset of the variant of SQL that was first defined by Apache Hive.
 - The SQL commands ``UPDATE`` and ``DELETE`` are not allowed on CDAP Datasets.
-- When addressing your datasets in queries, you need to prefix the data set name with the CDAP
-  namespace ``dataset_``. For example, if your Dataset is named ``ProductCatalog``, then the corresponding table
-  name is ``dataset_productcatalog``. Note that the table name is lower-case.
+- When addressing your datasets in queries, you need to prefix the data set name with
+  ``dataset_``. For example, if your Dataset is named ``ProductCatalog``, then the
+  corresponding table name is ``dataset_productcatalog``. Note that the table name is
+  lower-case.
 
 For more examples of queries, please refer to the `Hive language manual
 <https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DML#LanguageManualDML-InsertingdataintoHiveTablesfromqueries>`__.

--- a/cdap-docs/developers-manual/source/data-exploration/filesets.rst
+++ b/cdap-docs/developers-manual/source/data-exploration/filesets.rst
@@ -46,7 +46,7 @@ For example, in the configure method of your application::
 These Dataset properties map directly to table properties in Hive. 
 For example, the Dataset above would result in the following "create table" statement being generated::
 
-  CREATE EXTERNAL TABLE cdap_user_myfiles(
+  CREATE EXTERNAL TABLE dataset_myfiles(
     user string,
     item_id int,
     price double)

--- a/cdap-docs/developers-manual/source/data-exploration/object-mapped-tables.rst
+++ b/cdap-docs/developers-manual/source/data-exploration/object-mapped-tables.rst
@@ -115,8 +115,8 @@ When creating your queries, keep these limitations in mind:
 - The query syntax of CDAP is a subset of the variant of SQL that was first defined by Apache Hive.
 - The SQL commands ``UPDATE`` and ``DELETE`` are not allowed on CDAP Datasets.
 - When addressing your datasets in queries, you need to prefix the data set name with the CDAP
-  namespace ``cdap_user_``. For example, if your Dataset is named ``Purchases``, then the corresponding table
-  name is ``cdap_user_purchases``. Note that the table name is lower-case.
+  namespace ``dataset_``. For example, if your Dataset is named ``Purchases``, then the corresponding table
+  name is ``dataset_purchases``. Note that the table name is lower-case.
 
 For more examples of queries, please refer to the `Hive language manual
 <https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DML>`__.

--- a/cdap-docs/developers-manual/source/data-exploration/streams.rst
+++ b/cdap-docs/developers-manual/source/data-exploration/streams.rst
@@ -199,8 +199,8 @@ When creating your queries, keep these limitations in mind:
 - The query syntax of CDAP is a subset of the variant of SQL that was first defined by Apache Hive.
 - Writing into a Stream using SQL is not supported.
 - The SQL command ``DELETE`` is not supported.
-- When addressing your streams in queries, you need to prefix the stream name with the CDAP
-  namespace ``stream_``. For example, if your Stream is named ``Purchases``, then the corresponding table
+- When addressing your streams in queries, you need to prefix the stream name with
+  ``stream_``. For example, if your Stream is named ``Purchases``, then the corresponding table
   name is ``stream_purchases``. Note that the table name is all lower-case, regardless of how it was defined.
 - CDAP uses a custom storage handler to read Streams through Hive. This means that queries must be run through
   CDAP and not directly through Hive unless you place CDAP jars in your Hive classpath. This also means that

--- a/cdap-docs/developers-manual/source/data-exploration/streams.rst
+++ b/cdap-docs/developers-manual/source/data-exploration/streams.rst
@@ -169,22 +169,22 @@ and send some data to it as comma-delimited text::
 
 If we run a query over the Stream, we can see each event as text::
 
-  > execute "select * from cdap_stream_trades"
-  +==================================================================================================================+
-  | cdap_stream_trades.ts: BIGINT | cdap_stream_trades.headers: map<string,string> | cdap_stream_trades.body: STRING |
-  +==================================================================================================================+
-  | 1422493022983                 | {}                                             | AAPL,50,112.98                  |
-  | 1422493027358                 | {}                                             | AAPL,100,112.87                 |
-  | 1422493031802                 | {}                                             | AAPL,8,113.02                   |
-  | 1422493036080                 | {}                                             | NFLX,10,437.45                  |
-  +==================================================================================================================+
+  > execute "select * from stream_trades"
+  +===================================================================================================+
+  | stream_trades.ts: BIGINT | stream_trades.headers: map<string,string> | stream_trades.body: STRING |
+  +===================================================================================================+
+  | 1422493022983            | {}                                        | AAPL,50,112.98             |
+  | 1422493027358            | {}                                        | AAPL,100,112.87            |
+  | 1422493031802            | {}                                        | AAPL,8,113.02              |
+  | 1422493036080            | {}                                        | NFLX,10,437.45             |
+  +===================================================================================================+
 
 Since we know the body of every event is comma separated text and that each event
 contains three fields, we can set a format and schema on the stream to allow us to run more
 complicated queries::
 
   > set stream format trades csv "ticker string, num_traded int, price double"
-  > execute "select ticker, count(*) as transactions, sum(num_traded) as volume from cdap_stream_trades group by ticker order by volume desc" 
+  > execute "select ticker, count(*) as transactions, sum(num_traded) as volume from stream_trades group by ticker order by volume desc" 
   +========================================================+
   | ticker: STRING | transactions: BIGINT | volume: BIGINT |
   +========================================================+
@@ -200,8 +200,8 @@ When creating your queries, keep these limitations in mind:
 - Writing into a Stream using SQL is not supported.
 - The SQL command ``DELETE`` is not supported.
 - When addressing your streams in queries, you need to prefix the stream name with the CDAP
-  namespace ``cdap_stream_``. For example, if your Stream is named ``Purchases``, then the corresponding table
-  name is ``cdap_stream_purchases``. Note that the table name is all lower-case, regardless of how it was defined.
+  namespace ``stream_``. For example, if your Stream is named ``Purchases``, then the corresponding table
+  name is ``stream_purchases``. Note that the table name is all lower-case, regardless of how it was defined.
 - CDAP uses a custom storage handler to read Streams through Hive. This means that queries must be run through
   CDAP and not directly through Hive unless you place CDAP jars in your Hive classpath. This also means that
   Streams cannot be queried directly by Impala. If you wish to use Impala to explore data in a Stream, you can

--- a/cdap-docs/developers-manual/source/getting-started/quick-start.rst
+++ b/cdap-docs/developers-manual/source/getting-started/quick-start.rst
@@ -259,14 +259,14 @@ convenient to send it as the body of a POST request.
 We can also use SQL to bypass the service and query the raw contents of the underlying
 table (reformatted to fit)::
 
-  $ <path-to-CDAP-SDK>/bin/cdap-cli.sh execute "\"SELECT * FROM cdap_user_pageviewstore WHERE key = '255.255.255.249'\""
-  +===============================================================================================+
-  | cdap_user_pageviewstore.key: STRING | cdap_user_pageviewstore.value: map<string,bigint>       |
-  +===============================================================================================+
-  | 255.255.255.249                     | {"/about.html":2,"/world.html":4,"/index.html":14,      |
-  |                                     |  "/news.html":4,"/team.html":2,"/cdap.html":4,          |
-  |                                     |  "/contact.html":2,"/home.html":6,"/developers.html":4} |
-  +===============================================================================================+
+  $ <path-to-CDAP-SDK>/bin/cdap-cli.sh execute "\"SELECT * FROM dataset_pageviewstore WHERE key = '255.255.255.249'\""
+  +===========================================================================================+
+  | dataset_pageviewstore.key: STRING | dataset_pageviewstore.value: map<string,bigint>       |
+  +===========================================================================================+
+  | 255.255.255.249                 | {"/about.html":2,"/world.html":4,"/index.html":14,      |
+  |                                 |  "/news.html":4,"/team.html":2,"/cdap.html":4,          |
+  |                                 |  "/contact.html":2,"/home.html":6,"/developers.html":4} |
+  +===========================================================================================+
 
 Here we can see that the storage format is one table row per IP address, with a column for
 each URL that was requested from that IP address. This is an implementation detail that
@@ -308,7 +308,7 @@ We can inquire as to the status of the MapReduce::
 When the job has finished, the returned status will be *STOPPED*. Now we can query the
 bounce counts with SQL. Let's take a look at the schema first::
 
-  $ <path-to-CDAP-SDK>/bin/cdap-cli.sh execute "\"DESCRIBE cdap_user_bouncecountstore\""
+  $ <path-to-CDAP-SDK>/bin/cdap-cli.sh execute "\"DESCRIBE dataset_bouncecountstore\""
   Successfully connected CDAP instance at 127.0.0.1:10000
   +==========================================================+
   | col_name: STRING | data_type: STRING | comment: STRING   |
@@ -321,7 +321,7 @@ bounce counts with SQL. Let's take a look at the schema first::
 For example, to get the five URLs with the highest bounce-to-visit ratio (or bounce rate)::
 
   $ <path-to-CDAP-SDK>/bin/cdap-cli.sh execute "\"SELECT uri, bounces/totalvisits AS ratio \
-    FROM cdap_user_bouncecountstore ORDER BY ratio DESC LIMIT 5\""
+    FROM dataset_bouncecountstore ORDER BY ratio DESC LIMIT 5\""
   +===================================+
   | uri: STRING | ratio: DOUBLE       |
   +===================================+
@@ -339,7 +339,7 @@ We can also use the full power of the `Hive query language
 queries. For example, Hive allows us to explode the page view counts into a table with
 fixed columns::
 
-  $ <path-to-CDAP-SDK>/bin/cdap-cli.sh execute "\"SELECT key AS ip, uri, count FROM cdap_user_pageviewstore \
+  $ <path-to-CDAP-SDK>/bin/cdap-cli.sh execute "\"SELECT key AS ip, uri, count FROM dataset_pageviewstore \
     LATERAL VIEW explode(value) t AS uri,count ORDER BY count DESC LIMIT 10\""
   +====================================================+
   | ip: STRING      | uri: STRING      | count: BIGINT |
@@ -366,9 +366,9 @@ pages?
 
   $ <path-to-CDAP-SDK>/bin/cdap-cli.sh execute "\"SELECT views.uri, ratio, ip, count FROM \
        (SELECT uri, totalvisits/bounces AS ratio \
-          FROM cdap_user_bouncecountstore ORDER BY ratio DESC LIMIT 3) bounce, \
+          FROM dataset_bouncecountstore ORDER BY ratio DESC LIMIT 3) bounce, \
        (SELECT key AS ip, uri, count \
-          FROM cdap_user_pageviewstore LATERAL VIEW explode(value) t AS uri,count) views \
+          FROM dataset_pageviewstore LATERAL VIEW explode(value) t AS uri,count) views \
     WHERE views.uri = bounce.uri AND views.count >= 3\""
   +=========================================================================+
   | views.uri: STRING | ratio: DOUBLE     | ip: STRING      | count: BIGINT |

--- a/cdap-docs/examples-manual/source/examples/stream-conversion.rst
+++ b/cdap-docs/examples-manual/source/examples/stream-conversion.rst
@@ -125,7 +125,7 @@ to send 10000 events at a rate of roughly two per second::
 You can now wait for the Workflow to run, after which you can query the partitions in the
 ``converted`` dataset::
 
-  $ cdap-cli.sh execute \"show partitions cdap_user_converted\"
+  $ cdap-cli.sh execute \"show partitions dataset_converted\"
   +============================================+
   | partition: STRING                          |
   +============================================+
@@ -139,7 +139,7 @@ than the time since the Epoch: the year, month, day of the month, hour and minut
 
 You can also query the data in the dataset. For example, to find the five most frequent body texts, issue::
 
-  $ cdap-cli.sh execute '"select count(*) as count, body from cdap_user_converted group by body order by count desc limit 5"'
+  $ cdap-cli.sh execute '"select count(*) as count, body from dataset_converted group by body order by count desc limit 5"'
   +==============================+
   | count: BIGINT | body: STRING |
   +==============================+
@@ -153,7 +153,7 @@ You can also query the data in the dataset. For example, to find the five most f
 Because this dataset is time-partitioned, you can use the partitioning keys to restrict the scope
 of the query. For example, to run the same query for only the month of January, use the query::
 
-  select count(*) as count, body from cdap_user_converted where month=1 group by body order by count desc limit 5
+  select count(*) as count, body from dataset_converted where month=1 group by body order by count desc limit 5
 
 Stopping the Application
 ------------------------

--- a/cdap-docs/examples-manual/source/examples/web-analytics.rst
+++ b/cdap-docs/examples-manual/source/examples/web-analytics.rst
@@ -177,7 +177,7 @@ Dataset:
 You can then run SQL queries against the Dataset. Let's try to find the top five IP
 addresses that visited the site by running a SQL query::
 
-  SELECT * FROM cdap_user_uniquevisitcount ORDER BY value DESC LIMIT 5
+  SELECT * FROM dataset_uniquevisitcount ORDER BY value DESC LIMIT 5
 
 You can copy and paste the above SQL into the **Query** box as shown below (replacing the
 default query that is there) and click the **Execute** button to run it. It may take a

--- a/cdap-docs/integrations/source/jdbc.rst
+++ b/cdap-docs/integrations/source/jdbc.rst
@@ -58,7 +58,7 @@ and executes a query over a CDAP dataset ``mydataset``::
   Connection connection = DriverManager.getConnection(connectionUrl);
 
   // Execute a query over CDAP Datasets and retrieve the results
-  ResultSet resultSet = connection.prepareStatement("select * from cdap_user_mydataset").executeQuery();
+  ResultSet resultSet = connection.prepareStatement("select * from dataset_mydataset").executeQuery();
   ...
 
 JDBC drivers are a standard in the Java ecosystem, with many `resources about them available

--- a/cdap-docs/integrations/source/partners/cloudera/ingesting.rst
+++ b/cdap-docs/integrations/source/partners/cloudera/ingesting.rst
@@ -65,21 +65,21 @@ the top of this page.
 
 You can now examine the contents of your stream by executing a SQL query::
 
-  > execute 'select * from cdap_stream_trades limit 5'
-  +==================================================================================================================+
-  | cdap_stream_trades.ts: BIGINT | cdap_stream_trades.headers: map<string,string> | cdap_stream_trades.body: STRING |
-  +==================================================================================================================+
-  | 1422924257559                 | {}                                             | NFLX,441.07,50                  |
-  | 1422924261588                 | {}                                             | AAPL,118.63,100                 |
-  | 1422924265441                 | {}                                             | GOOG,528.48,10                  |
-  | 1422924291009                 | {"content.type":"text/csv"}                    | GOOG,538.53,18230               |
-  | 1422924291009                 | {"content.type":"text/csv"}                    | GOOG,538.17,100                 |
-  +==================================================================================================================+
+  > execute 'select * from stream_trades limit 5'
+  +===================================================================================================+
+  | stream_trades.ts: BIGINT | stream_trades.headers: map<string,string> | stream_trades.body: STRING |
+  +===================================================================================================+
+  | 1422493022983            | {}                                        | NFLX,441.07,50             |
+  | 1422493027358            | {}                                        | AAPL,118.63,100            |
+  | 1422493031802            | {}                                        | GOOG,528.48,10             |
+  | 1422493036080            | {"content.type":"text/csv"}               | GOOG,538.53,18230          |
+  | 1422493036080            | {"content.type":"text/csv"}               | GOOG,538.17,100            |
+  +===================================================================================================+
 
 You can also attach a schema to your stream to enable more powerful queries::
 
   > set stream format trades csv 'ticker string, price double, trades int'
-  > execute 'select ticker, sum(price * trades) / 1000000 as millions from cdap_stream_trades group by ticker order by millions desc'
+  > execute 'select ticker, sum(price * trades) / 1000000 as millions from stream_trades group by ticker order by millions desc'
   +=====================================+
   | ticker: STRING | millions: DOUBLE   |
   +=====================================+
@@ -110,7 +110,7 @@ cluster, use the Impala shell to connect to Impala::
 
   $ impala-shell -i <impala-host>
   > invalidate metadata
-  > select ticker, sum(price * trades) / 1000000 as millions from cdap_user_trades_converted group by ticker order by millions desc
+  > select ticker, sum(price * trades) / 1000000 as millions from dataset_trades_converted group by ticker order by millions desc
   +--------+-------------------+
   | ticker | millions          |
   +--------+-------------------+

--- a/cdap-docs/reference-manual/source/characters.rst
+++ b/cdap-docs/reference-manual/source/characters.rst
@@ -49,7 +49,7 @@ Examples:
     - ``my-ingest``
     - ``my_ingest``
   
-  will both be converted to ``cdap_stream_my_ingest``
+  will both be converted to ``stream_my_ingest``
 
 - The Datasets
 
@@ -57,6 +57,6 @@ Examples:
     - ``my_dataset``
     - ``my.dataset``
     
-  will all be converted to ``cdap_dataset_my_dataset``
+  will all be converted to ``dataset_my_dataset``
 
 Names should be carefully constructed to avoid any collisions as a result of conversion.

--- a/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v2/query.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v2/query.rst
@@ -65,7 +65,7 @@ Example
    * - HTTP Request
      - ``PUT <base-url>/data/explore/queries``
    * - HTTP Body
-     - ``{"query":"SELECT * FROM cdap_user_mydataset LIMIT 5"}``
+     - ``{"query":"SELECT * FROM dataset_mydataset LIMIT 5"}``
    * - HTTP Response
      - ``{"handle":"57cf1b01-8dba-423a-a8b4-66cd29dd75e2"}``
    * - Description
@@ -179,8 +179,8 @@ Example
    * - HTTP Request
      - ``GET <base-url>/data/explore/queries/57cf1b01-8dba-423a-a8b4-66cd29dd75e2/schema``
    * - HTTP Response
-     - ``[{"name":"cdap_user_mydataset.key","type":"array<tinyint>","position":1},``
-       ``{"name":"cdap_user_mydataset.value","type":"array<tinyint>","position":2}]``
+     - ``[{"name":"dataset_mydataset.key","type":"array<tinyint>","position":1},``
+       ``{"name":"dataset_mydataset.value","type":"array<tinyint>","position":2}]``
    * - Description
      - Retrieve the schema of the result of the query which has the handle 57cf1b01-8dba-423a-a8b4-66cd29dd75e2
 
@@ -347,7 +347,7 @@ Example
    * - HTTP Response
      - ``[{``
        ``   "timestamp": 1411266478717,``
-       ``   "statement": "SELECT * FROM cdap_user_mydataset",``
+       ``   "statement": "SELECT * FROM dataset_mydataset",``
        ``   "status": "FINISHED",``
        ``   "query_handle": "57cf1b01-8dba-423a-a8b4-66cd29dd75e2",
        ``   "has_results": true,

--- a/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v3/query.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v3/query.rst
@@ -70,7 +70,7 @@ used to identify the query in subsequent requests::
    * - HTTP Request
      - ``PUT <base-url>/namespaces/default/data/explore/queries``
    * - HTTP Body
-     - ``{"query":"SELECT * FROM cdap_user_mydataset LIMIT 5"}``
+     - ``{"query":"SELECT * FROM dataset_mydataset LIMIT 5"}``
    * - HTTP Response
      - ``{"handle":"57cf1b01-8dba-423a-a8b4-66cd29dd75e2"}``
    * - Description
@@ -186,8 +186,8 @@ The type of each column is a data type as defined in the `Hive language manual
    * - HTTP Request
      - ``GET <base-url>/namespaces/default/data/explore/queries/57cf1b01-8dba-423a-a8b4-66cd29dd75e2/schema``
    * - HTTP Response
-     - ``[{"name":"cdap_user_mydataset.key","type":"array<tinyint>","position":1},``
-       ``{"name":"cdap_user_mydataset.value","type":"array<tinyint>","position":2}]``
+     - ``[{"name":"dataset_mydataset.key","type":"array<tinyint>","position":1},``
+       ``{"name":"dataset_mydataset.value","type":"array<tinyint>","position":2}]``
    * - Description
      - Retrieve the schema of the result of the query in the namespace *default* which has
        the handle 57cf1b01-8dba-423a-a8b4-66cd29dd75e2
@@ -356,7 +356,7 @@ The results are returned as a JSON array, with each element containing informati
    * - HTTP Response
      - ``[{``
        ``   "timestamp": 1411266478717,``
-       ``   "statement": "SELECT * FROM cdap_user_mydataset",``
+       ``   "statement": "SELECT * FROM dataset_mydataset",``
        ``   "status": "FINISHED",``
        ``   "query_handle": "57cf1b01-8dba-423a-a8b4-66cd29dd75e2",
        ``   "has_results": true,

--- a/cdap-docs/reference-manual/source/java-client-api.rst
+++ b/cdap-docs/reference-manual/source/java-client-api.rst
@@ -340,7 +340,7 @@ QueryClient
   //
   // Perform an ad-hoc query using the Purchase example
   //
-  String query = "SELECT * FROM cdap_user_history WHERE customer IN ('Alice','Bob')"
+  String query = "SELECT * FROM dataset_history WHERE customer IN ('Alice','Bob')"
   QueryHandle queryHandle = queryClient.execute(query);
   QueryStatus status = new QueryStatus(null, false);
 


### PR DESCRIPTION
This isn't quite finished, but there are some things that can be checked already...

This PR covers:

- the upgrade docs (and the metrics migration tool)
- the "Update table names in explore docs" (https://issues.cask.co/browse/CDAP-1671)

The last item involves updating the table name references: 
- "cdap_user_[ds-name] -> dataset_[ds-name]" and 
- "cdap_stream_[stream-name] -> stream_[stream-name]"

...everywhere...so please look and see if that looks correct.

Staged at: http://stg-web101.sw.joyent.continuuity.net/cdap/2.8.0-SNAPSHOT-r2.8_upgrade_docs/