### PR TITLE
CDAP-1902 enabling explore on a dataset that is not explorable

### DIFF
--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/ExploreTableManager.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/ExploreTableManager.java
@@ -196,7 +196,12 @@ public class ExploreTableManager {
       }
     }
 
-    return exploreService.execute(datasetID.getNamespace(), createStatement);
+    if (createStatement != null) {
+      return exploreService.execute(datasetID.getNamespace(), createStatement);
+    } else {
+      // if the dataset is not explorable, this is a no op.
+      return QueryHandle.NO_OP;
+    }
   }
 
   /**


### PR DESCRIPTION
should be a no-op.