### PR TITLE
check table exists before upgrade/delete kafka metrics table

### DIFF
--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
@@ -122,6 +122,7 @@ public class UpgradeTool {
               "  6. Logs Metadata\n" +
               "  7. Stream state store table\n" +
               "  8. Queue config table\n" +
+              "  9. Metrics Kafka table\n" +
               "  Note: Once you run the upgrade tool you cannot rollback to the previous version."),
     HELP("Show this help.");
 
@@ -401,8 +402,10 @@ public class UpgradeTool {
 
     LOG.info("Upgrading metrics.kafka.meta table ...");
     MetricsKafkaUpgrader metricsKafkaUpgrader = injector.getInstance(MetricsKafkaUpgrader.class);
-    metricsKafkaUpgrader.upgrade();
-    hBaseTableUtil.dropTable(hBaseAdmin, metricsKafkaUpgrader.getOldKafkaMetricsTableId());
+    if (metricsKafkaUpgrader.tableExists()) {
+      metricsKafkaUpgrader.upgrade();
+      hBaseTableUtil.dropTable(hBaseAdmin, metricsKafkaUpgrader.getOldKafkaMetricsTableId());
+    }
   }
 
   public static void main(String[] args) throws Exception {

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/store/upgrade/MetricsDataMigrator.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/store/upgrade/MetricsDataMigrator.java
@@ -234,11 +234,6 @@ public class MetricsDataMigrator {
 
   public void cleanUpOldTables(Version version) throws DataMigrationException {
     Set<String> tablesToDelete = Sets.newHashSet();
-    DefaultDatasetNamespace defaultDatasetNamespace = new DefaultDatasetNamespace(cConf);
-
-    // add kafka meta table to deleteList
-    tablesToDelete.add(addNamespace(defaultDatasetNamespace, cConf.get(MetricsConstants.ConfigKeys.KAFKA_META_TABLE,
-                                                                       MetricsConstants.DEFAULT_KAFKA_META_TABLE)));
 
     if (version == Version.VERSION_2_6_OR_LOWER) {
       List<String> scopes = ImmutableList.of("system", "user");


### PR DESCRIPTION
if table does not exist, we just return, previously we would throw exception which is not in contract with UpgradeTool. 
