### PR TITLE
Bugfix/queue config upgrader idempotency

### DIFF
--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/AbstractQueueUpgrader.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/AbstractQueueUpgrader.java
@@ -18,6 +18,8 @@ package co.cask.cdap.data.tools;
 
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
+import co.cask.cdap.common.utils.ProjectInfo;
+import co.cask.cdap.data2.dataset2.lib.hbase.AbstractHBaseDataSetAdmin;
 import co.cask.cdap.data2.transaction.queue.QueueEntryRow;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
@@ -76,6 +78,13 @@ public abstract class AbstractQueueUpgrader extends AbstractUpgrader {
       return;
     }
     HTable hTable = tableUtil.createHTable(conf, tableId);
+    ProjectInfo.Version tableVersion = AbstractHBaseDataSetAdmin.getVersion(hTable.getTableDescriptor());
+    // Only upgrade if Upgrader's version is greater than table's version.
+    if (ProjectInfo.getVersion().compareTo(tableVersion) <= 0) {
+      LOG.info("Table {} has already been upgraded. Its version is: {}", tableId, tableVersion);
+      return;
+    }
+
     LOG.info("Starting upgrade for table {}", Bytes.toString(hTable.getTableName()));
     try {
       Scan scan = new Scan();

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/DatasetUpgrader.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/DatasetUpgrader.java
@@ -28,7 +28,6 @@ import co.cask.cdap.data2.datafabric.dataset.service.mds.DatasetTypeMDSUpgrader;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.lib.hbase.AbstractHBaseDataSetAdmin;
 import co.cask.cdap.data2.dataset2.lib.table.hbase.HBaseTableAdmin;
-import co.cask.cdap.data2.transaction.queue.QueueAdmin;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.HTableNameConverter;
@@ -57,7 +56,6 @@ public class DatasetUpgrader extends AbstractUpgrader {
   private final CConfiguration cConf;
   private final Configuration hConf;
   private final LocationFactory locationFactory;
-  private final QueueAdmin queueAdmin;
   private final HBaseTableUtil hBaseTableUtil;
   private final DatasetFramework dsFramework;
   private final Pattern userTablePrefix;
@@ -66,7 +64,7 @@ public class DatasetUpgrader extends AbstractUpgrader {
 
   @Inject
   private DatasetUpgrader(CConfiguration cConf, Configuration hConf, LocationFactory locationFactory,
-                          NamespacedLocationFactory namespacedLocationFactory, QueueAdmin queueAdmin,
+                          NamespacedLocationFactory namespacedLocationFactory,
                           HBaseTableUtil hBaseTableUtil, DatasetFramework dsFramework,
                           DatasetInstanceMDSUpgrader datasetInstanceMDSUpgrader,
                           DatasetTypeMDSUpgrader datasetTypeMDSUpgrader) {
@@ -75,7 +73,6 @@ public class DatasetUpgrader extends AbstractUpgrader {
     this.cConf = cConf;
     this.hConf = hConf;
     this.locationFactory = locationFactory;
-    this.queueAdmin = queueAdmin;
     this.hBaseTableUtil = hBaseTableUtil;
     this.dsFramework = dsFramework;
     this.datasetInstanceMDSUpgrader = datasetInstanceMDSUpgrader;
@@ -90,9 +87,6 @@ public class DatasetUpgrader extends AbstractUpgrader {
 
     // Upgrade all user hbase tables
     upgradeUserTables();
-
-    // Upgrade all queue and stream tables.
-    queueAdmin.upgrade();
 
     // Upgrade the datasets meta meta table
     datasetTypeMDSUpgrader.upgrade();

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/QueueConfigUpgrader.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/QueueConfigUpgrader.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.common.queue.QueueName;
+import co.cask.cdap.data2.transaction.queue.QueueAdmin;
 import co.cask.cdap.data2.transaction.queue.QueueConstants;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
@@ -37,11 +38,19 @@ import javax.annotation.Nullable;
  */
 public class QueueConfigUpgrader extends AbstractQueueUpgrader {
   private static final Logger LOG = LoggerFactory.getLogger(QueueConfigUpgrader.class);
+  private final QueueAdmin queueAdmin;
 
   @Inject
   public QueueConfigUpgrader(LocationFactory locationFactory, NamespacedLocationFactory namespacedLocationFactory,
-                             HBaseTableUtil tableUtil, Configuration conf) {
+                             HBaseTableUtil tableUtil, Configuration conf, QueueAdmin queueAdmin) {
     super(locationFactory, namespacedLocationFactory, tableUtil, conf);
+    this.queueAdmin = queueAdmin;
+  }
+
+  @Override
+  void upgrade() throws Exception {
+    super.upgrade();
+    queueAdmin.upgrade();
   }
 
   @Override

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/StreamStateStoreUpgrader.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/StreamStateStoreUpgrader.java
@@ -21,6 +21,7 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.common.queue.QueueName;
 import co.cask.cdap.data.stream.StreamUtils;
+import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.proto.Id;
@@ -37,11 +38,19 @@ import javax.annotation.Nullable;
  */
 public class StreamStateStoreUpgrader extends AbstractQueueUpgrader {
   private static final Logger LOG = LoggerFactory.getLogger(StreamStateStoreUpgrader.class);
+  private final StreamAdmin streamAdmin;
 
   @Inject
   public StreamStateStoreUpgrader(LocationFactory locationFactory, NamespacedLocationFactory namespacedLocationFactory,
-                                  HBaseTableUtil tableUtil, Configuration conf) {
+                                  HBaseTableUtil tableUtil, Configuration conf, StreamAdmin streamAdmin) {
     super(locationFactory, namespacedLocationFactory, tableUtil, conf);
+    this.streamAdmin = streamAdmin;
+  }
+
+  @Override
+  void upgrade() throws Exception {
+    super.upgrade();
+    streamAdmin.upgrade();
   }
 
   @Override


### PR DESCRIPTION
The Queue config table's rowkey format is different in 2.8.
Running the same logic to parse 2.6 rowkeys on the new rowkey caused it to fail.
Now ignoring those rows (that are already potentially upgraded).

http://builds.cask.co/browse/CDAP-RBT210-4