### PR TITLE
Add notes about limitations on upgrade tools.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ For more information, see our collection of
 To install and use CDAP and its included examples, there are a few simple prerequisites:
 
   1. JDK 6 or JDK 7 (required to run CDAP; note that $JAVA_HOME should be set)
-  2. Node.js (from v0.8.16 through v0.10.32; required to run the CDAP Console)
+  2. Node.js (from v0.8.16 through v0.10.37; required to run the CDAP Console)
   3. Apache Maven 3.0+ (required to build the example applications)
   
 ### Build

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ For more information, see our collection of
 To install and use CDAP and its included examples, there are a few simple prerequisites:
 
   1. JDK 6 or JDK 7 (required to run CDAP; note that $JAVA_HOME should be set)
-  2. Node.js 0.8.16+ (required to run the CDAP Console)
+  2. Node.js (from v0.8.16 through v0.10.32; required to run the CDAP Console)
   3. Apache Maven 3.0+ (required to build the example applications)
   
 ### Build

--- a/cdap-docs/admin-manual/source/installation/installation.rst
+++ b/cdap-docs/admin-manual/source/installation/installation.rst
@@ -127,9 +127,9 @@ Once you have installed the JDK, you'll need to set the JAVA_HOME environment va
 
 Node.js Runtime
 +++++++++++++++
-You can download the appropriate version of Node.js (from v0.8.16 through v0.10.32) from `nodejs.org <http://nodejs.org>`__:
+You can download the appropriate version of Node.js (from v0.8.16 through v0.10.37) from `nodejs.org <http://nodejs.org>`__:
 
-#. The version of Node.js must be from v0.8.16 through v0.10.36.
+#. The version of Node.js must be from v0.8.16 through v0.10.37.
 #. Download the appropriate Linux or Solaris binary ``.tar.gz`` from
    `nodejs.org/download/ <http://nodejs.org/dist/>`__.
  #. Extract somewhere such as ``/opt/node-[version]/``

--- a/cdap-docs/admin-manual/source/installation/installation.rst
+++ b/cdap-docs/admin-manual/source/installation/installation.rst
@@ -584,6 +584,11 @@ to make sure the CDAP table definitions in HBase are up-to-date.
 These steps will stop CDAP, update the installation, run an upgrade tool for the table definitions,
 and then restart CDAP.
 
+These steps will upgrade from CDAP 2.6.x to 2.8.0. (**Note:** Apps need to be both
+recompiled and re-deployed.) An upgrade from 2.7.x to 2.8.0 is not currently supported. If
+you have a use case for it, please reach out to us at `cdap-user@googlegroups.com
+<https://groups.google.com/d/forum/cdap-user>`__.
+
 .. highlight:: console
 
 1. Stop all Flows, Services, and other Programs in all your applications.

--- a/cdap-docs/admin-manual/source/operations/cdap-console.rst
+++ b/cdap-docs/admin-manual/source/operations/cdap-console.rst
@@ -37,6 +37,10 @@ As part of release 2.8.0, a new alpha User Interface (UI) for the CDAP Console w
 
 To try out the new UI, changes are required before CDAP is started.
 
+- The version of Node.js used must be in the range of v0.10.25 through v0.10.37 in order to
+  use the New UI. (These versions will also work with the current CDAP Console, so you can
+  use either console version.)
+
 - For CDAP Standalone SDK, pass an additional argument :ref:`when starting CDAP <start-stop-cdap>`::
 
     $ ./bin/cdap.sh start --enable-alpha-ui

--- a/cdap-docs/admin-manual/source/operations/resource-guarantees.rst
+++ b/cdap-docs/admin-manual/source/operations/resource-guarantees.rst
@@ -34,13 +34,13 @@ Configurations for submitting to non-default YARN queues can be specified in two
     <property>
       <name>app.scheduler.queue</name>
       <value>app</value>
-      <description>Scheduler queue for CDAP Programs and Explore Queries </description>
+      <description>Scheduler queue for CDAP Programs and Explore Queries</description>
     </property>
 
 2. Using a Namespace-level property: 
 
    The queue name to submit programs and Hive queries in YARN can be specified at a
-   Namespace-level by using the :ref:`RESTful API <http-restful-api-lifecycle>` to
+   Namespace-level by using the v3 :ref:`RESTful API <http-restful-api-namespace-editing>` to
    configure the property ``scheduler.queue.name``.
    
    The configuration specified at the Namespace-level will override the configuration
@@ -49,7 +49,7 @@ Configurations for submitting to non-default YARN queues can be specified in two
    For example, to set ``A`` as the queue name to be used for the namespace
    *<namespace-id>*, you use this HTTP PUT method::
    
-      PUT <base-url>/v3/namespaces/<namespace-id>/properties
+      PUT <base-url>/namespaces/<namespace-id>/properties
    
    with the property as a JSON string in the body::
    

--- a/cdap-docs/developers-manual/source/building-blocks/namespaces.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/namespaces.rst
@@ -32,7 +32,7 @@ is part of the :ref:`HTTP RESTful API v3 <http-restful-api-v3>`.
 Namespace Components
 ====================
 
-A Namespace has a namespace identifier (the namespace ID), a display name, and a description.
+A Namespace has a namespace identifier (the namespace 'name') and a description.
 
 Namespace IDs are composed from a limited set of characters; they are restricted to
 letters (a-z, A-Z), digits (0-9), hyphens (-), and underscores (_). There is no size limit
@@ -43,8 +43,8 @@ namespace, however, can be used by anyone, though like all reserved namespaces, 
 be deleted.
 
 
-Independent and Non-hierarchal
-==============================
+Independent and Non-hierarchical
+================================
 
 Namespaces are flat, with no hierarchy inside them. (Namespaces are not allowed inside
 another namespace.)

--- a/cdap-docs/developers-manual/source/getting-started/standalone/index.rst
+++ b/cdap-docs/developers-manual/source/getting-started/standalone/index.rst
@@ -27,7 +27,7 @@ The CDAP SDK runs on Linux, MacOS and Windows, and has three requirements:
 
 - `JDK 6 or JDK 7 <http://www.oracle.com/technetwork/java/javase/downloads/index.html>`__ 
   (required to run CDAP; note that $JAVA_HOME should be set)
-- `Node.js 0.8.16 through 0.10.36 <http://nodejs.org/dist/>`__ (required to run the CDAP Console UI)
+- `Node.js 0.8.16 through 0.10.37 <http://nodejs.org/dist/>`__ (required to run the CDAP Console UI)
 - `Apache Maven 3.0+ <http://maven.apache.org>`__ (required to build CDAP applications)
 
 We recommend using an IDE when building CDAP applications, such as either `IntelliJ

--- a/cdap-docs/integrations/source/partners/cloudera/configuring.rst
+++ b/cdap-docs/integrations/source/partners/cloudera/configuring.rst
@@ -41,7 +41,7 @@ the 'cdap' user installed by the parcel.
 Prerequisites
 =======================================
 
-#. Node.js (version from 0.8.16 through 0.10.36) must be installed on the node(s) where the Web-App
+#. Node.js (version from 0.8.16 through 0.10.37) must be installed on the node(s) where the Web-App
    role instance will run. You can download the appropriate version of Node.js from `nodejs.org
    <http://nodejs.org/dist/>`__.
 

--- a/cdap-docs/integrations/source/partners/cloudera/configuring.rst
+++ b/cdap-docs/integrations/source/partners/cloudera/configuring.rst
@@ -41,7 +41,7 @@ the 'cdap' user installed by the parcel.
 Prerequisites
 =======================================
 
-#. Node.js (version from 0.8.16 through 0.10.37) must be installed on the node(s) where the Web-App
+#. Node.js (version 0.8.16 through 0.10.37) must be installed on the node(s) where the Web-App
    role instance will run. You can download the appropriate version of Node.js from `nodejs.org
    <http://nodejs.org/dist/>`__.
 

--- a/cdap-docs/reference-manual/source/faq.rst
+++ b/cdap-docs/reference-manual/source/faq.rst
@@ -84,7 +84,7 @@ in your environment; we recommend the Oracle JDK.
 
 .. rubric:: What Version of Node.JS is Required by CDAP?
 
-The version of Node.js must be from v0.8.16 through v0.10.36.
+The version of Node.js must be from v0.8.16 through v0.10.37.
 
 
 Hadoop

--- a/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v3/metrics.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v3/metrics.rst
@@ -509,7 +509,7 @@ or as a ``start`` and ``end`` to define a specific range and return a series of 
 By default, queries without a time range retrieve a value based on ``aggregate=true``.
 
 .. list-table::
-   :widths: 20 80
+   :widths: 30 70
    :header-rows: 1
 
    * - Parameter

--- a/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v3/metrics.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v3/metrics.rst
@@ -522,7 +522,6 @@ By default, queries without a time range retrieve a value based on ``aggregate=t
      - Time range defined by start and end times, where the times are either in seconds
        since the start of the Epoch, or a relative time, using ``now`` and times added to it.
    * - ``count=<count>``
-     - Number of seconds since the *start time*.
      - Number of time intervals since start with length of time interval defined by *resolution*. 
        If ``count=60`` and ``resolution=1s``, the time range would be 60 seconds in length.
    * - ``resolution=[1s|1m|1h|auto]``

--- a/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v3/metrics.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v3/metrics.rst
@@ -534,8 +534,8 @@ points for a metric. By default, 1 second resolution is used. Acceptable values 
 above. If ``resolution=auto``, the resolution will be determined based on a time
 difference calculated between the start and end times:
 
-- ``(endTime - startTime) >= 3610``, resolution will be 3600 seconds (effectively in hours); 
-- ``(endTime - startTime) >= 610``, resolution will be 60 seconds (effectively in minutes); 
+- ``(endTime - startTime) >= 3610 seconds``, resolution will be 3600 seconds (effectively in hours); 
+- ``(endTime - startTime) >= 610 seconds``, resolution will be 60 seconds (effectively in minutes); 
 - otherwise, resolution will be in seconds.
 
 

--- a/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v3/metrics.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v3/metrics.rst
@@ -523,6 +523,8 @@ By default, queries without a time range retrieve a value based on ``aggregate=t
        since the start of the Epoch, or a relative time, using ``now`` and times added to it.
    * - ``count=<count>``
      - Number of seconds since the *start time*.
+     - Number of time intervals since start with length of time interval defined by *resolution*. 
+       If ``count=60`` and ``resolution=1s``, the time range would be 60 seconds in length.
    * - ``resolution=[1s|1m|1h|auto]``
      - Time resolution in seconds, minutes or hours; or if "auto", one of ``{1s, 1m, 1h}``
        is used based on the time difference.
@@ -550,9 +552,9 @@ difference calculated between the start and end times:
        For example: ``now-5d-12h`` is 5 days and 12 hours ago.
    * - ``start=1385625600&`` ``end=1385629200``
      - From ``Thu, 28 Nov 2013 08:00:00 GMT`` to ``Thu, 28 Nov 2013 09:00:00 GMT``,
-       both given as since the start of the Epoch
+       both given as since the start of the Epoch.
    * - ``start=1385625600&`` ``count=3600&`` ``resolution=1s``
-     - The same as before, the count given as a number of seconds
+     - The same as before, the count given as a number of time intervals, each 1 second.
    * - ``start=1385625600&`` ``end=1385629200&`` ``resolution=1m``
      - From ``Thu, 28 Nov 2013 08:00:00 GMT`` to ``Thu, 28 Nov 2013 09:00:00 GMT``,
        with 1 minute resolution, will return 61 data points with metrics aggregated for each minute.

--- a/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v3/metrics.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v3/metrics.rst
@@ -523,9 +523,9 @@ By default, queries without a time range retrieve a value based on ``aggregate=t
        since the start of the Epoch, or a relative time, using ``now`` and times added to it.
    * - ``count=<count>``
      - Number of seconds since the *start time*.
-   * - ``resolution=[1|60|3600|auto]``
-     - Time resolution in seconds; or if "auto", one of ``{1, 60, 3600}`` is used based on
-       the time difference.
+   * - ``resolution=[1s|1m|1h|auto]``
+     - Time resolution in seconds, minutes or hours; or if "auto", one of ``{1s, 1m, 1h}``
+       is used based on the time difference.
 
 With a specific time range, a ``resolution`` can be included to retrieve a series of data
 points for a metric. By default, 1 second resolution is used. Acceptable values are noted
@@ -551,12 +551,12 @@ difference calculated between the start and end times:
    * - ``start=1385625600&`` ``end=1385629200``
      - From ``Thu, 28 Nov 2013 08:00:00 GMT`` to ``Thu, 28 Nov 2013 09:00:00 GMT``,
        both given as since the start of the Epoch
-   * - ``start=1385625600&`` ``count=3600&`` ``resolution=1``
+   * - ``start=1385625600&`` ``count=3600&`` ``resolution=1s``
      - The same as before, the count given as a number of seconds
-   * - ``start=1385625600&`` ``end=1385629200&`` ``resolution=60``
+   * - ``start=1385625600&`` ``end=1385629200&`` ``resolution=1m``
      - From ``Thu, 28 Nov 2013 08:00:00 GMT`` to ``Thu, 28 Nov 2013 09:00:00 GMT``,
        with 1 minute resolution, will return 61 data points with metrics aggregated for each minute.
-   * - ``start=1385625600&`` ``end=1385632800&`` ``resolution=3600``
+   * - ``start=1385625600&`` ``end=1385632800&`` ``resolution=1h``
      - From ``Thu, 28 Nov 2013 08:00:00 GMT`` to ``Thu, 28 Nov 2013 10:00:00 GMT``,
        with 1 hour resolution, will return 3 data points with metrics aggregated for each hour.
 

--- a/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v3/metrics.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v3/metrics.rst
@@ -521,6 +521,8 @@ By default, queries without a time range retrieve a value based on ``aggregate=t
    * - ``start=<time>&end=<time>``
      - Time range defined by start and end times, where the times are either in seconds
        since the start of the Epoch, or a relative time, using ``now`` and times added to it.
+   * - ``count=<count>``
+     - Number of seconds since the *start time*.
    * - ``resolution=[1 | 60 | 3600 | auto]``
      - Time resolution in seconds; or if "auto", one of ``{1, 60, 3600}`` is used based on
        the time difference.
@@ -549,12 +551,12 @@ difference calculated between the start and end times:
    * - ``start=1385625600&`` ``end=1385629200``
      - From ``Thu, 28 Nov 2013 08:00:00 GMT`` to ``Thu, 28 Nov 2013 09:00:00 GMT``,
        both given as since the start of the Epoch
-   * - ``start=1385625600&`` ``count=3600&`` ``resolution=1s``
+   * - ``start=1385625600&`` ``count=3600&`` ``resolution=1``
      - The same as before, the count given as a number of seconds
-   * - ``start=1385625600&`` ``end=1385629200&`` ``resolution=1m``
+   * - ``start=1385625600&`` ``end=1385629200&`` ``resolution=60``
      - From ``Thu, 28 Nov 2013 08:00:00 GMT`` to ``Thu, 28 Nov 2013 09:00:00 GMT``,
        with 1 minute resolution, will return 61 data points with metrics aggregated for each minute.
-   * - ``start=1385625600&`` ``end=1385632800&`` ``resolution=1h``
+   * - ``start=1385625600&`` ``end=1385632800&`` ``resolution=3600``
      - From ``Thu, 28 Nov 2013 08:00:00 GMT`` to ``Thu, 28 Nov 2013 10:00:00 GMT``,
        with 1 hour resolution, will return 3 data points with metrics aggregated for each hour.
 
@@ -599,7 +601,7 @@ Examples of using a run-ID (reformatted to fit)::
   POST <base-url>/metrics/query?context=namespace.default.app.CountRandom.flow.CountRandom.run.
     bca50436-9650-448e-9ab1-f1d186eb2285.flowlet.splitter&metric=system.process.events.processed&aggregate=true
 
-The last example will return something similar to::
+The last example will return something similar to (where ``time=0`` means aggregated total number)::
 
   {"startTime":0,"endTime":0,"series":[{"metricName":"system.process.events.processed",
    "grouping":{},"data":[{"time":0,"value":11188}]}]}

--- a/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v3/metrics.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v3/metrics.rst
@@ -523,7 +523,7 @@ By default, queries without a time range retrieve a value based on ``aggregate=t
        since the start of the Epoch, or a relative time, using ``now`` and times added to it.
    * - ``count=<count>``
      - Number of seconds since the *start time*.
-   * - ``resolution=[1 | 60 | 3600 | auto]``
+   * - ``resolution=[1|60|3600|auto]``
      - Time resolution in seconds; or if "auto", one of ``{1, 60, 3600}`` is used based on
        the time difference.
 

--- a/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v3/metrics.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v3/metrics.rst
@@ -493,7 +493,6 @@ multiple tags for grouping by providing a comma-separated list.
      - Description
    * - ``groupBy=app``
      - Retrieves the time series for each application. 
-       For example: ``now-5d-12h`` is 5 days and 12 hours ago.
    * - ``groupBy=app,flow``
      - Retrieves a time series for each app and flow combination
 
@@ -533,9 +532,9 @@ points for a metric. By default, 1 second resolution is used. Acceptable values 
 above. If ``resolution=auto``, the resolution will be determined based on a time
 difference calculated between the start and end times:
 
-- ``(endTime - startTime) >= 3610 seconds``, resolution will be 3600 seconds (effectively in hours); 
-- ``(endTime - startTime) >= 610 seconds``, resolution will be 60 seconds (effectively in minutes); 
-- otherwise, resolution will be in seconds.
+- ``(endTime - startTime) >= 3610``, resolution will be 1 hour; 
+- ``(endTime - startTime) >= 610``, resolution will be 1 minute; 
+- otherwise, resolution will be 1 second.
 
 
 .. list-table::

--- a/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v3/metrics.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v3/metrics.rst
@@ -532,8 +532,8 @@ points for a metric. By default, 1 second resolution is used. Acceptable values 
 above. If ``resolution=auto``, the resolution will be determined based on a time
 difference calculated between the start and end times:
 
-- ``(endTime - startTime) >= 3610``, resolution will be 1 hour; 
-- ``(endTime - startTime) >= 610``, resolution will be 1 minute; 
+- ``(endTime - startTime) >= 3610 seconds``, resolution will be 1 hour; 
+- ``(endTime - startTime) >= 610 seconds``, resolution will be 1 minute; 
 - otherwise, resolution will be 1 second.
 
 

--- a/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v3/namespace.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v3/namespace.rst
@@ -141,8 +141,10 @@ for when you `Create a Namespace`_.
      - Description
    * - ``description``
      - Display description of the namespace
-   * - ``scheduler.queue.name``
-     - :ref:`Scheduler queue <resource-guarantees>` for CDAP Programs and Explore Queries in the namespace
+   * - ``config``
+     - Configuration properties, with a JSON map of name-value pairs. Currently, the only
+       supported configuration property is ``scheduler.queue.name``: 
+       :ref:`Scheduler queue <resource-guarantees>` for CDAP Programs and Explore Queries in the namespace.
     
 .. rubric:: HTTP Responses
 .. list-table::

--- a/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v3/namespace.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v3/namespace.rst
@@ -112,6 +112,8 @@ response, such as::
    * - ``200 OK``
      - The event successfully called the method, and the body contains the results
 
+.. _http-restful-api-namespace-editing:
+
 Editing a Namespace
 -------------------
 To edit an existing namespace, submit an HTTP PUT request to::
@@ -130,3 +132,48 @@ To edit an existing namespace, submit an HTTP PUT request to::
 The ``<namespace>`` must be the name of an existing namespace.
 Properties for the namespace are passed in the JSON request body, as described
 for when you `Create a Namespace`_.
+
+.. list-table::
+   :widths: 20 80
+   :header-rows: 1
+
+   * - Property
+     - Description
+   * - ``description``
+     - Display description of the namespace
+   * - ``scheduler.queue.name``
+     - :ref:`Scheduler queue <resource-guarantees>` for CDAP Programs and Explore Queries in the namespace
+    
+.. rubric:: HTTP Responses
+.. list-table::
+   :widths: 20 80
+   :header-rows: 1
+
+   * - Status Codes
+     - Description
+   * - ``200 OK``
+     - Namespace properties were changed successfully
+   * - ``400 Bad Request``
+     - The request was not created correctly
+   * - ``404 Not Found``
+     - The Namespace does not exist
+
+.. rubric:: Example
+.. list-table::
+   :widths: 20 80
+   :stub-columns: 1
+
+   * - HTTP Method
+     - ``PUT <base-url>/namespaces/dev/properties``::
+
+         { 
+           "description" : "Namespace for development of applications",
+           "config": {
+             "scheduler.queue.name": "A",
+           },
+         }
+     
+   * - Description
+     - Set the *description* property of the Namespace named *dev*,
+       and set the *scheduler.queue.name* to *A*. 
+    

--- a/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v3/stream.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v3/stream.rst
@@ -309,7 +309,7 @@ publishing a notification.
 
 Stream properties can be changed with an HTTP PUT method to the URL::
 
-  PUT <base-url>/namespaces/<namespace>/streams/<stream-id>/config
+  PUT <base-url>/namespaces/<namespace>/streams/<stream-id>/properties
 
 .. list-table::
    :widths: 20 80
@@ -364,7 +364,7 @@ the Stream and re-create it with the new schema.
    :stub-columns: 1
 
    * - HTTP Method
-     - ``PUT <base-url>/namespaces/default/streams/mystream/config``::
+     - ``PUT <base-url>/namespaces/default/streams/mystream/properties``::
 
          { 
            "ttl" : 86400,

--- a/cdap-docs/reference-manual/source/release-notes.rst
+++ b/cdap-docs/reference-manual/source/release-notes.rst
@@ -46,7 +46,7 @@ General
 
 - Added the ability to specify 
   :ref:`custom logback file for CDAP programs <application-logback>`
-  (`CDAP-1741 <https://issues.cask.co/browse/CDAP-1741>`__).
+  (`CDAP-1100 <https://issues.cask.co/browse/CDAP-1100>`__).
 
 - System HTTP services now bind to all interfaces (0.0.0.0), rather than 127.0.0.1.
 

--- a/cdap-docs/reference-manual/source/release-notes.rst
+++ b/cdap-docs/reference-manual/source/release-notes.rst
@@ -117,6 +117,8 @@ New Features
 
   - Added an :ref:`automated upgrade tool <install-upgrade>` which supports upgrading from
     2.6.x to 2.8.0. (**Note:** Apps need to be both recompiled and re-deployed.)
+    Upgrade from 2.7.x to 2.8.0 is not currently supported. If you have a use case for it, 
+    please reach out to us at `cdap-user@googlegroups.com <https://groups.google.com/d/forum/cdap-user>`__.
   - Added a metric migration tool which migrates old metrics to the new 2.8 format.
 
 


### PR DESCRIPTION
Staged at:

- [Installation: Upgrade](http://stg-web101.sw.joyent.continuuity.net/cdap/2.8.0-SNAPSHOT-r2.8_doc_upgrade_limitation/en/admin-manual/installation/installation.html#upgrading-an-existing-version)
- [Release Notes](http://stg-web101.sw.joyent.continuuity.net/cdap/2.8.0-SNAPSHOT-r2.8_doc_upgrade_limitation/en/reference-manual/release-notes.html#new-features)
- [Stream Properties](http://stg-web101.sw.joyent.continuuity.net/cdap/2.8.0-SNAPSHOT-r2.8_doc_upgrade_limitation/en/reference-manual/http-restful-api/http-restful-api-v3/stream.html#setting-stream-properties)
- [Namespace Components](http://stg-web101.sw.joyent.continuuity.net/cdap/2.8.0-SNAPSHOT-r2.8_doc_upgrade_limitation/en/developers-manual/building-blocks/namespaces.html#namespace-components)
- [Namespace Editing](http://stg-web101.sw.joyent.continuuity.net/cdap/2.8.0-SNAPSHOT-r2.8_doc_upgrade_limitation/en/reference-manual/http-restful-api/http-restful-api-v3/namespace.html#http-restful-api-namespace-editing)
- [Resource Guarantees](http://stg-web101.sw.joyent.continuuity.net/cdap/2.8.0-SNAPSHOT-r2.8_doc_upgrade_limitation/en/admin-manual/operations/resource-guarantees.html)
- [Metrics Queries by Time Range](http://stg-web101.sw.joyent.continuuity.net/cdap/2.8.0-SNAPSHOT-r2.8_doc_upgrade_limitation/en/reference-manual/http-restful-api/http-restful-api-v3/metrics.html#querying-by-a-time-range)