### PR TITLE
The cdap-ui child module was added

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,7 @@ COPY cdap-proto /Build/cdap-proto
 COPY cdap-security /Build/cdap-security
 COPY cdap-standalone /Build/cdap-standalone
 COPY cdap-test /Build/cdap-test
+COPY cdap-ui /Build/cdap-ui
 COPY cdap-unit-test /Build/cdap-unit-test
 COPY cdap-unit-test-standalone /Build/cdap-unit-test-standalone
 COPY cdap-watchdog /Build/cdap-watchdog


### PR DESCRIPTION
It needs to be added to the Dockerfile...

```
[ERROR] The build could not read 1 project -> [Help 1]
[ERROR]
[ERROR]   The project co.cask.cdap:cdap:2.8.0 (/Build/pom.xml) has 1 error
[ERROR]     Child module /Build/cdap-ui of /Build/pom.xml does not exist
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/ProjectBuildingException
INFO[0552] The command [/bin/sh -c cd Build &&     MAVEN_OPTS="-Xmx512m" mvn clean package -DskipTests -P examples -pl cdap-examples -am -amd &&     mvn package -pl cdap-standalone -am -DskipTests -P dist,release &&     unzip cdap-standalone/target/cdap-sdk-[0-9]*.[0-9]*.[0-9]*.zip -d /Software &&     cd /Software &&     rm -rf /Build /root/.m2 /var/cache/debconf/*-old /usr/share/{doc,man}     /usr/share/locale/{a,b,c,d,e{l,o,s,t,u},f,g,h,i,j,k,lt,lv,m,n,o,p,r,s,t,u,v,w,x,z}*] returned a non-zero code: 1
```