### PR TITLE
The cdap-ui module uses bower to get angular via git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,11 +24,9 @@ RUN apt-get update && \
     apt-get install -y software-properties-common python-software-properties && \
     add-apt-repository ppa:chris-lea/node.js && \
     apt-get update && \
-    apt-get install -y curl && \
+    apt-get install -y curl nodejs unzip git \
     apt-get install -y --no-install-recommends openjdk-7-jdk && \
-    apt-get install -y nodejs && \
-    apt-get install -y maven && \
-    apt-get install -y unzip
+    apt-get install -y maven
 
 # create Software directory
 RUN mkdir /Build /Software


### PR DESCRIPTION
Also, moved apt packages to a single line, except openjdk and maven, which depends on it.

Fixes this:
```
[INFO] bower angular#1.3.14                      ENOGIT git is not installed or not in the PATH
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO]
[INFO] Cask Data Application Platform (CDAP) ............. SUCCESS [25.042s]
[INFO] CDAP Build Common ................................. SUCCESS [4.643s]
[INFO] CDAP API .......................................... SUCCESS [12.859s]
[INFO] CDAP Protocol ..................................... SUCCESS [5.155s]
[INFO] CDAP Common ....................................... SUCCESS [11.788s]
[INFO] CDAP Watchdog API ................................. SUCCESS [4.000s]
[INFO] CDAP Notifications APIs ........................... SUCCESS [3.531s]
[INFO] CDAP Explore Client ............................... SUCCESS [3.798s]
[INFO] CDAP Data-Fabric .................................. SUCCESS [18.214s]
[INFO] CDAP Watchdog ..................................... SUCCESS [8.512s]
[INFO] CDAP Notifications ................................ SUCCESS [4.661s]
[INFO] CDAP App-Fabric ................................... SUCCESS [18.859s]
[INFO] CDAP Security ..................................... SUCCESS [19.244s]
[INFO] CDAP Gateway ...................................... SUCCESS [4.497s]
[INFO] CDAP Explore JDBC Driver .......................... SUCCESS [5.898s]
[INFO] CDAP Explore ...................................... SUCCESS [6.417s]
[INFO] CDAP Test Framework ............................... SUCCESS [3.094s]
[INFO] CDAP Unit Test Framework .......................... SUCCESS [4.377s]
[INFO] CDAP Java Client .................................. SUCCESS [4.921s]
[INFO] CDAP CLI .......................................... SUCCESS [14.721s]
[INFO] CDAP UI ........................................... FAILURE [1:31.963s]
[INFO] CDAP Web-App ...................................... SKIPPED
[INFO] CDAP Adapters ..................................... SKIPPED
[INFO] CDAP Standalone ................................... SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 4:38.600s
[INFO] Finished at: Tue Mar 24 01:47:33 UTC 2015
[INFO] Final Memory: 136M/692M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal com.github.eirslett:frontend-maven-plugin:0.0.20:bower (bower-install) on project cdap-ui: Failed to run task: 'bower install --allow-root' failed. (error code 1) -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
[ERROR]
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <goals> -rf :cdap-ui
INFO[0661] The command [/bin/sh -c cd Build &&     MAVEN_OPTS="-Xmx512m" mvn clean package -DskipTests -P examples -pl cdap-examples -am -amd &&     mvn package -pl cdap-standalone -am -DskipTests -P dist,release &&     unzip cdap-standalone/target/cdap-sdk-[0-9]*.[0-9]*.[0-9]*.zip -d /Software &&     cd /Software &&     rm -rf /Build /root/.m2 /var/cache/debconf/*-old /usr/share/{doc,man}     /usr/share/locale/{a,b,c,d,e{l,o,s,t,u},f,g,h,i,j,k,lt,lv,m,n,o,p,r,s,t,u,v,w,x,z}*] returned a non-zero code: 1
```