### PR TITLE
Fixes data interpolation with 0s for operations dashboard.

### DIFF
--- a/cdap-ui/app/features/dashboard/widget.js
+++ b/cdap-ui/app/features/dashboard/widget.js
@@ -28,11 +28,22 @@ angular.module(PKG.name+'.feature.dashboard')
           method: 'POST'
         },
         (function (result) {
+          var data, tempMap = {};
           if(result.series && result.series.length) {
-            var data = result.series[0].data;
-            data.splice(data.length-1, 1);
-            this.data = data;
+            data = result.series[0].data;
+            for (var k =0 ; k<data.length; k++) {
+              tempMap[data[k].time] = data[k].value;
+            }
           }
+          // interpolating the data since backend returns only
+          // metrics at specific timeperiods instead of for the
+          // whole range. We have to interpolate the rest with 0s to draw the graph.
+          for(var i = result.startTime; i<result.endTime; i++) {
+            if (!tempMap[i]) {
+              tempMap[i] = 0;
+            }
+          }
+          this.data = tempMap;
         }).bind(this)
       );
     };
@@ -53,19 +64,26 @@ angular.module(PKG.name+'.feature.dashboard')
   .controller('WidgetTimeseriesCtrl', function ($scope) {
 
     $scope.wdgt.fetchData();
-
+    $scope.chartHistory = null;
+    $scope.stream = null;
     $scope.$watch('wdgt.data', function (newVal) {
-      if(angular.isArray(newVal)) {
+      var v;
+      if(angular.isObject(newVal)) {
+        v = Object.keys(newVal).map(function(key) {
+          return {
+            time: key,
+            y: newVal[key]
+          };
+        });
+
+        if ($scope.chartHistory) {
+          $scope.stream = v.slice(-1);
+        }
 
         $scope.chartHistory = [
           {
             label: $scope.wdgt.metric.name,
-            values: newVal.map(function (o) {
-              return {
-                time: o.time,
-                y: o.value
-              };
-            })
+            values: v
           }
         ];
 

--- a/cdap-ui/app/features/dashboard/widgets/line.html
+++ b/cdap-ui/app/features/dashboard/widgets/line.html
@@ -2,6 +2,7 @@
 
   <epoch-line
     data-history="chartHistory"
+    data-stream ="stream"
     chart-height="200"
     chart-ticks="{ bottom: 3 }"
     chart-axes="['left', 'bottom']"


### PR DESCRIPTION
- Backend send metrics only when it is emitted.
  So even if I ask for a particular metric for the last 1 min it will give me a series with some data only if that particular metric was emitted by something in the backend. Otherwise the UI gets an empty array.

- We are interpolating the rest of the values with 0s if we don't get any.

Get ```events.in``` metric for a flow in an app for the last 1 min:
Scenario1:
  Three events happend in the last one min. So we get exactly three values with three timestamps. Even though we are requesting metrics for 60 timestamps since the metric was not emitted at other time periods we will have only 3 values for corresponding 3 time stamps.

Scenario2:
  No events are in the last one min. So we get no time series data from the backend.

In both the cases we have startTime and endTime. Even if we get sporadic data for random timestamps within that startTime and endTime we need to draw a graph which is smooth. Thats the reason we are interpolating the rest of the timestamps with 0s so that the graph moves from right to left.

![dashboardlive](https://cloud.githubusercontent.com/assets/1452845/6864216/82a645f2-d41b-11e4-87c4-04d98d47fbb8.gif)

  