### PR TITLE
Port the 2.8.0 fix for mouseover bolding

### DIFF
--- a/cdap-docs/_common/_themes/cdap/static/cdap.css_t
+++ b/cdap-docs/_common/_themes/cdap/static/cdap.css_t
@@ -129,7 +129,10 @@ div.sphinxsidebar p.topless {
 }
 
 div.sphinxsidebar ul {
-    margin: 10px 20px;
+    margin-top:    10px;
+    margin-bottom: 10px;
+    margin-right:  10px;
+    margin-left:   20px;
     padding: 0;
     color: #000;
 }
@@ -138,17 +141,17 @@ div.sphinxsidebar a {
     color: #444;
 }
 
+div.sphinxsidebar a:hover {
+    color: #ff6600;
+    text-decoration: underline;
+}
+
 div.sphinxsidebar a tt.docutils.literal {
     font-family: 'Source Sans Pro', "Helvetica", "Arial", sans-serif;
     font-style: italic;
     font-weight: normal;
     font-size: 1.0em;
 }
-
-div.sphinxsidebar a:hover tt.docutils.literal {
-	  font-weight: bold;
-}
-
 
 div.sphinxsidebar input {
     border: 1px solid #ccc;
@@ -167,16 +170,13 @@ a.current {
 /* -- body styles ----------------------------------------------------------- */
 
 a {
-    color: #005B81;
     color: #ff6600;
     text-decoration: none;
 }
 
 a:hover {
-    color: #E32E00;
     color: #005B81;
     text-decoration: underline;
-    font-weight: bold;
 }
 
 div.body h1,
@@ -189,8 +189,8 @@ div.body h6 {
     font-weight: normal;
     color: #111;
     margin: 30px 0px 10px -15px;
-    padding: 5px 0 5px 15px;
-    text-shadow: 0px 1px 0 white
+    padding: 5px 0px  5px  15px;
+    text-shadow: 0px 1px 0px white;
 }
 
 div.body h1 { border-top: 20px solid white; margin-top: 0; font-size: 180%; font-weight:bold;}
@@ -311,6 +311,10 @@ p.rubric {
 
 em {
     font-style: italic;
+}
+
+a em {
+	font-style: normal;
 }
 
 pre {

--- a/cdap-docs/_common/common_conf.py
+++ b/cdap-docs/_common/common_conf.py
@@ -131,7 +131,11 @@ rst_epilog = """
 .. role:: gp
 .. |$| replace:: :gp:`$`
 
+.. |copyright| replace:: %(copyright)s
+
 .. |http:| replace:: http:
+
+.. |https:| replace:: https:
 
 .. |(TM)| unicode:: U+2122 .. trademark sign
    :ltrim:
@@ -139,9 +143,8 @@ rst_epilog = """
 .. |(R)| unicode:: U+00AE .. registered trademark sign
    :ltrim:
 
-.. |copyright| replace:: %(copyright)s
-
 .. |--| unicode:: U+2013   .. en dash
+
 .. |---| unicode:: U+2014  .. em dash, trimming surrounding whitespace
    :trim:
 


### PR DESCRIPTION
and add a "https" replacement; re-order replacements in the conf.py

-[current style](http://docs.cask.co/cdap/2.6.2/en/admin-manual/installation/security.html)
-[new version](http://stg-web101.sw.joyent.continuuity.net/cdap/2.6.2-r2.6.0_fix_mouseovers/en/admin-manual/installation/security.html)

Merged in 2.8.0 already.
Fix for https://issues.cask.co/browse/CDAP-1944