### PR TITLE
Feature/cdap 1227 pfs output committer

### DIFF
--- a/cdap-adapters/src/main/java/co/cask/cdap/conversion/app/StreamConversionMapReduce.java
+++ b/cdap-adapters/src/main/java/co/cask/cdap/conversion/app/StreamConversionMapReduce.java
@@ -96,7 +96,7 @@ public class StreamConversionMapReduce extends AbstractMapReduce {
     job.setJobName("adapter.stream-conversion." + adapterArguments.getSourceName()
                      + ".to." + sinkName + "." + partitionTime);
   }
-  
+
   /**
    * Mapper that reads events from a stream and writes them out as Avro.
    */

--- a/cdap-api/src/main/java/co/cask/cdap/api/data/batch/DatasetOutputCommitter.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/data/batch/DatasetOutputCommitter.java
@@ -20,7 +20,7 @@ import co.cask.cdap.api.dataset.DataSetException;
 
 /**
  * This interface is implemented by a dataset if at the end of a batch job (MapReduce, Spark, ...)
- * the output needs to be committed, or rolled back, depending one success of the job. This is
+ * the output needs to be committed, or rolled back, depending on success of the job. This is
  * similar to what Hadoop's OutputCommitter does, however, this is dataset-centric and does not
  * assume any dependencies on Hadoop.
  */

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
@@ -401,8 +401,8 @@ final class MapReduceRuntimeService extends AbstractExecutionThreadService {
                 ((DatasetOutputCommitter) outputDataset).onFailure();
               }
             } catch (Throwable t) {
-              LOG.error("Error from {} method of output dataset {}.",
-                        succeeded ? "onSuccess" : "onFailure", outputDataset);
+              LOG.error(String.format("Error from %s method of output dataset %s.",
+                        succeeded ? "onSuccess" : "onFailure", context.getOutputDatasetName()), t);
               success = false;
             }
           }

--- a/cdap-docs/examples-manual/source/examples/sport-results.rst
+++ b/cdap-docs/examples-manual/source/examples/sport-results.rst
@@ -64,7 +64,7 @@ dataset as a file. It declares its use of the dataset using a ``@UseDataSet`` an
 
 .. literalinclude:: /../../../cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/UploadService.java
     :language: java
-    :lines: 57-60
+    :lines: 58-61
 
 Let's take a closer look at the upload method:
 
@@ -96,7 +96,7 @@ the ``totals`` PartitionedFileSet. The ``beforeSubmit()`` method prepares the Ma
 
 .. literalinclude:: /../../../cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/ScoreCounter.java
     :language: java
-    :lines: 60-86
+    :lines: 58-84
 
 It is worth mentioning that nothing else in ``ScoreCounter`` is specifically programmed to use file partitions.
 Instead of ``results`` and ``totals``, it could use any other dataset as long as the key and value types match.

--- a/cdap-docs/examples-manual/source/examples/stream-conversion.rst
+++ b/cdap-docs/examples-manual/source/examples/stream-conversion.rst
@@ -86,7 +86,7 @@ The Mapper itself is straight-forward: for each event, it emits an Avro record:
 
 .. literalinclude:: /../../../cdap-examples/StreamConversion/src/main/java/co/cask/cdap/examples/streamconversion/StreamConversionMapReduce.java
      :language: java
-     :lines: 104-111
+     :lines: 90-97
 
 Building and Starting
 =====================


### PR DESCRIPTION
 - adds an interface for datasets to run code after completion of a batch job. This is like onFinish() for MapReduce without the dependency on Hadoop. This interface is called from the MapReduce runner before calling onFinish()
- partitioned file sets implement that interface to add the output partition to the meta data on success
- removed the addPartition from our existing MapReduces (adapter, examples, tests)
- changed addPartition() to succeed even if the same partition already exists - if it was added in the same transaction. This is to keep existing jobs from failing if they have the addPartition in their onFinish().
- added a unit test for backward compatibility with such existing apps.
- updated the docs to remove mentions of this limitation
