### PR TITLE
Fixes documentation for "Sport Results" and "Stream Conversion"

### DIFF
--- a/cdap-docs/_common/common_conf.py
+++ b/cdap-docs/_common/common_conf.py
@@ -63,7 +63,7 @@ def print_sdk_version():
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-#needs_sphinx = '1.0'
+#needs_sphinx = '1.3.1'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/cdap-docs/examples-manual/source/examples/sport-results.rst
+++ b/cdap-docs/examples-manual/source/examples/sport-results.rst
@@ -16,14 +16,14 @@ Overview
 
 This Application demonstrates the use of the PartitionedFileSet dataset:
 
-   - Game results are stored in the PartitionedFileSet ``results``. It is partitioned by league and season,
-     and each partition is a CSV (comma-separated values) file containing the results in one league for a season;
-     for example, the 2014 season of the NFL (National Football League).
-   - Results are uploaded into the file set using the ``UploadService``.
-   - The ``ScoreCounter`` MapReduce program reads game results for a given league and
-     aggregates total counts such as games won and lost, or points scored and conceded, across all
-     seasons, and writes these totals to the partitioned file set ``totals`` that is partitioned by league.
-   - Both the original game results and the aggregated totals can be explored using ad-hoc SQL queries.
+- Game results are stored in the PartitionedFileSet ``results``. It is partitioned by league and season,
+  and each partition is a CSV (comma-separated values) file containing the results in one league for a season;
+  for example, the 2014 season of the NFL (National Football League).
+- Results are uploaded into the file set using the ``UploadService``.
+- The ``ScoreCounter`` MapReduce program reads game results for a given league and
+  aggregates total counts such as games won and lost, or points scored and conceded, across all
+  seasons, and writes these totals to the partitioned file set ``totals`` that is partitioned by league.
+- Both the original game results and the aggregated totals can be explored using ad-hoc SQL queries.
 
 Let's look at some of these components, and then run the Application and see the results.
 
@@ -65,6 +65,7 @@ dataset as a file. It declares its use of the dataset using a ``@UseDataSet`` an
 .. literalinclude:: /../../../cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/UploadService.java
     :language: java
     :lines: 58-61
+    :dedent: 2
 
 Let's take a closer look at the upload method:
 
@@ -81,6 +82,7 @@ Let's take a closer look at the upload method:
 .. literalinclude:: /../../../cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/UploadService.java
     :language: java
     :lines: 88-118
+    :dedent: 4
 
 MapReduce over File Partitions
 ==============================
@@ -97,6 +99,7 @@ the ``totals`` PartitionedFileSet. The ``beforeSubmit()`` method prepares the Ma
 .. literalinclude:: /../../../cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/ScoreCounter.java
     :language: java
     :lines: 58-84
+    :dedent: 2
 
 It is worth mentioning that nothing else in ``ScoreCounter`` is specifically programmed to use file partitions.
 Instead of ``results`` and ``totals``, it could use any other dataset as long as the key and value types match.

--- a/cdap-docs/examples-manual/source/examples/stream-conversion.rst
+++ b/cdap-docs/examples-manual/source/examples/stream-conversion.rst
@@ -35,7 +35,7 @@ of the Application are tied together by the class ``StreamConversionApp``:
 
 .. literalinclude:: /../../../cdap-examples/StreamConversion/src/main/java/co/cask/cdap/examples/streamconversion/StreamConversionApp.java
      :language: java
-     :lines: 34-
+     :lines: 32-
 
 The interesting part is the creation of the dataset ``converted``:
 
@@ -61,30 +61,35 @@ and it configures the ``events`` stream as its input and the ``converted`` datas
   .. literalinclude:: /../../../cdap-examples/StreamConversion/src/main/java/co/cask/cdap/examples/streamconversion/StreamConversionMapReduce.java
      :language: java
      :lines: 63-68
-
+     :dedent: 4
+     
 - Based on the logical start time, the MapReduce determines the range of events to read from the stream:
 
   .. literalinclude:: /../../../cdap-examples/StreamConversion/src/main/java/co/cask/cdap/examples/streamconversion/StreamConversionMapReduce.java
      :language: java
      :lines: 70-72
+     :dedent: 4
 
 - Each MapReduce run writes its output to a partition with the logical start time:
 
   .. literalinclude:: /../../../cdap-examples/StreamConversion/src/main/java/co/cask/cdap/examples/streamconversion/StreamConversionMapReduce.java
      :language: java
      :lines: 75-77
+     :dedent: 4
 
 - Note that the output file path is derived from the output partition time by the dataset itself:
 
   .. literalinclude:: /../../../cdap-examples/StreamConversion/src/main/java/co/cask/cdap/examples/streamconversion/StreamConversionMapReduce.java
      :language: java
      :lines: 79-80
+     :dedent: 4
 
 - The Mapper itself is straight-forward: for each event, it emits an Avro record:
 
   .. literalinclude:: /../../../cdap-examples/StreamConversion/src/main/java/co/cask/cdap/examples/streamconversion/StreamConversionMapReduce.java
      :language: java
-     :lines: 90-97
+     :lines: 86-98
+     :dedent: 2
 
 Building and Starting
 =====================


### PR DESCRIPTION
Sets the minimum required version of Sphinx needed to 1.3.1.
Corrected text in "Sport Results" that was overly-indented, and added dedents to code samples.
Added dedents and corrected an include sample in "Stream Conversion".

Staged at:
- [Sport Results](http://stg-web101.sw.joyent.continuuity.net/cdap/3.0.0-SNAPSHOT-3.0_fix_pfs_output_commiter/en/examples-manual/examples/sport-results.html)
- [Stream Conversion](http://stg-web101.sw.joyent.continuuity.net/cdap/3.0.0-SNAPSHOT-3.0_fix_pfs_output_commiter/en/examples-manual/examples/stream-conversion.html)