### PR TITLE
Use less whitespace in AltStyleTableRenderer

### DIFF
--- a/cdap-cli/src/main/java/co/cask/cdap/cli/util/table/AltStyleTableRenderer.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/util/table/AltStyleTableRenderer.java
@@ -23,6 +23,7 @@ import com.google.inject.Inject;
 
 import java.io.PrintStream;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -145,7 +146,10 @@ public class AltStyleTableRenderer implements TableRenderer {
       done = true;
       for (int i = 0; i < row.size(); i++) {
         Cell cell = row.get(i);
-        cell.output(output, "| %-" + columnWidths[i] + "s ", line);
+        output.printf("|");
+        if (columnWidths[i] != 0) {
+          cell.output(output, " %-" + columnWidths[i] + "s ", line);
+        }
         done = done && (line + 1 >= cell.size());
       }
       output.printf("|").println();
@@ -164,7 +168,9 @@ public class AltStyleTableRenderer implements TableRenderer {
   private void outputDivider(PrintStream output, int[] columnWidths, char lineChar, char edgeChar) {
     output.print(edgeChar);
     for (int columnWidth : columnWidths) {
-      output.print(Strings.repeat(Character.toString(lineChar), columnWidth + 2));
+      if (columnWidth != 0) {
+        output.print(Strings.repeat(Character.toString(lineChar), columnWidth + 2));
+      }
     }
 
     // one for each divider
@@ -188,6 +194,10 @@ public class AltStyleTableRenderer implements TableRenderer {
     for (int column = 0; column < row.size(); column++) {
       Object field = row.get(column);
       int width = columnWidths[column];
+      if (width == 0) {
+        builder.add(new Cell());
+        continue;
+      }
 
       String fieldString = field == null ? "" : field.toString();
       Iterable<String> splitField = newlineSplitter.split(fieldString);
@@ -239,22 +249,57 @@ public class AltStyleTableRenderer implements TableRenderer {
       return new int[0];
     }
 
-    int maxInnerTableWidth = maxOuterTableWidth
-      - (widths.length + 1) // for the '|' borders
-      - (2 * widths.length); // for the spaces within each column
-
-    // distribute maxInnerTableWidth equally to each column
-    int remainingWidth = maxInnerTableWidth;
-    for (int i = 0; i < widths.length; i++) {
-      widths[i] = (int) (maxInnerTableWidth * 1.0 / widths.length);
-      remainingWidth -= widths[i];
+    // max(header or content length of cells in row) for every column
+    int[] maxColumnWidths = new int[widths.length];
+    if (!header.isEmpty()) {
+      for (int i = 0; i < maxColumnWidths.length; i++) {
+        maxColumnWidths[i] = Math.max(maxColumnWidths[i], header.get(i).length());
+      }
     }
-    // fix any rounding issues by resizing the last column width
-    widths[widths.length - 1] += remainingWidth;
+    for (List<String> row : rows) {
+      for (int i = 0; i < maxColumnWidths.length; i++) {
+        maxColumnWidths[i] = Math.max(maxColumnWidths[i], row.get(i).length());
+      }
+    }
 
-    // apply minColumnWidth constraint
+    int numBorderAndSpaceChars = (widths.length + 1) // for the '|' borders
+      + (2 * widths.length); // for the spaces within each column
+
+    // outer width of the table if every row was in a single line
+    int flatOuterTableWidth = numBorderAndSpaceChars;
+    for (int maxColumnWidth : maxColumnWidths) {
+      flatOuterTableWidth += maxColumnWidth;
+    }
+
+    // may not need the entire maxOuterTableWidth, so downsize if necessary
+    int actualOuterTableWidth = Math.min(maxOuterTableWidth, flatOuterTableWidth);
+    int remainingInnerTableWidth = actualOuterTableWidth - numBorderAndSpaceChars;
+
+    int maxInnerTableWidth = maxOuterTableWidth - numBorderAndSpaceChars;
+    int defaultWidthPerColumn = (int) (maxInnerTableWidth * 1.0 / widths.length);
+
+    // downsize any column widths if they're < defaultWidthPerColumn
+    for (int i = 0; i < maxColumnWidths.length; i++) {
+      int maxColumnWidth = maxColumnWidths[i];
+      if (maxColumnWidth < defaultWidthPerColumn) {
+        widths[i] = maxColumnWidth;
+        remainingInnerTableWidth -= maxColumnWidth;
+      }
+    }
+
+    // distribute remainingInnerTableWidth equally to the remaining columns
+    int widthPerRemainingColumn = (int) (remainingInnerTableWidth * 1.0 / widths.length);
     for (int i = 0; i < widths.length; i++) {
-      widths[i] = Math.max(widths[i], minColumnWidth);
+      // 0 means width is not yet set
+      if (widths[i] == 0) {
+        widths[i] = widthPerRemainingColumn;
+        remainingInnerTableWidth -= widths[i];
+        // fix any rounding issues by resizing the last column width
+        if (i == widths.length - 1) {
+          widths[i] += remainingInnerTableWidth;
+          remainingInnerTableWidth = 0;
+        }
+      }
     }
 
     return widths;
@@ -277,6 +322,10 @@ public class AltStyleTableRenderer implements TableRenderer {
         }
       }
       this.width = maxWidth;
+    }
+
+    Cell() {
+      this(Collections.<String>emptyList());
     }
 
     /**

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/util/table/AltStyleTableRenderer.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/util/table/AltStyleTableRenderer.java
@@ -245,8 +245,8 @@ public class AltStyleTableRenderer implements TableRenderer {
 
     // distribute maxInnerTableWidth equally to each column
     int remainingWidth = maxInnerTableWidth;
-    for (int i = 0; i < header.size(); i++) {
-      widths[i] = (int) (maxInnerTableWidth * 1.0 / header.size());
+    for (int i = 0; i < widths.length; i++) {
+      widths[i] = (int) (maxInnerTableWidth * 1.0 / widths.length);
       remainingWidth -= widths[i];
     }
     // fix any rounding issues by resizing the last column width

--- a/cdap-cli/src/test/java/co/cask/cdap/cli/util/table/TableRendererTest.java
+++ b/cdap-cli/src/test/java/co/cask/cdap/cli/util/table/TableRendererTest.java
@@ -48,6 +48,18 @@ public abstract class TableRendererTest {
   }
 
   @Test
+  public void testNoHeader() {
+    Table table = Table.builder()
+      .setRows(Table.rows()
+                 .add("r1\n456", "r11", "r1")
+                 .add("r2", "r2222\n123", "r")
+                 .add("r3333", "r3", "r3\n1")
+                 .build())
+      .build();
+    getRenderer().render(TEST_CONFIG, OUTPUT, table);
+  }
+
+  @Test
   public void testFormat() {
     Table table = Table.builder()
       .setHeader("c1", "c2", "c3333")

--- a/cdap-cli/src/test/java/co/cask/cdap/cli/util/table/TableRendererTest.java
+++ b/cdap-cli/src/test/java/co/cask/cdap/cli/util/table/TableRendererTest.java
@@ -48,6 +48,32 @@ public abstract class TableRendererTest {
   }
 
   @Test
+  public void testEmptyColumns() {
+    Table table = Table.builder()
+      .setHeader("c1", "c2", "c3333", "", "foo")
+      .setRows(Table.rows()
+                 .add("r1\n456", "", "r1", "", "foo")
+                 .add("r2", "", "r", "", "foo")
+                 .add("r3333", "", "r3\n1", "", "foo")
+                 .build())
+      .build();
+    getRenderer().render(TEST_CONFIG, OUTPUT, table);
+  }
+
+  @Test
+  public void testLastColumnEmpty() {
+    Table table = Table.builder()
+      .setHeader("c1", "c2", "c3333", "")
+      .setRows(Table.rows()
+                 .add("r1\n456", "", "r1", "")
+                 .add("r2", "", "r", "")
+                 .add("r3333", "", "r3\n1", "")
+                 .build())
+      .build();
+    getRenderer().render(TEST_CONFIG, OUTPUT, table);
+  }
+
+  @Test
   public void testNoHeader() {
     Table table = Table.builder()
       .setRows(Table.rows()


### PR DESCRIPTION
http://builds.cask.co/browse/CDAP-DUT1301

Now CLI table rendering will no longer use up the entire terminal when it doesn't need to.

```
cdap (http://Alvins-MacBook-Pro-2.local:10000/default)> list apps
+==================+
| id | description |
+==================+
+==================+
 
cdap (http://Alvins-MacBook-Pro-2.local:10000/default)> deploy app /opt/cdap/sdk/cdap-sdk-2.8.0-SNAPSHOT/examples/Purchase/target/Purchase-2.8.0-SNAPSHOT.jar
Successfully deployed application

cdap (http://Alvins-MacBook-Pro-2.local:10000/default)> list apps
+=================================================+
| id              | description                   |
+=================================================+
| PurchaseHistory | Purchase history application. |
+=================================================+
```