### PR TITLE
Fix datasets collection used during the creation of MapReduce Context

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/AbstractMapReduceContextBuilder.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/AbstractMapReduceContextBuilder.java
@@ -28,11 +28,13 @@ import co.cask.cdap.internal.app.runtime.workflow.WorkflowMapReduceProgram;
 import co.cask.tephra.Transaction;
 import co.cask.tephra.TransactionAware;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Sets;
 import com.google.inject.Injector;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.apache.twill.internal.RunIds;
 
 import java.util.List;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
@@ -90,12 +92,20 @@ public abstract class AbstractMapReduceContextBuilder {
       (type == null) ? null : injector.getInstance(MetricsCollectionService.class);
 
     DiscoveryServiceClient discoveryServiceClient = injector.getInstance(DiscoveryServiceClient.class);
+    Set<String> datasets = Sets.newHashSet(programSpec.getDatasets().keySet());
+    if (inputDataSetName != null) {
+      datasets.add(inputDataSetName);
+    }
+
+    if (outputDataSetName != null) {
+      datasets.add(outputDataSetName);
+    }
 
     // Creating mapreduce job context
     MapReduceSpecification spec = program.getApplicationSpecification().getMapReduce().get(program.getName());
     BasicMapReduceContext context =
       new BasicMapReduceContext(program, type, RunIds.fromString(runId), taskId,
-                                runtimeArguments, programSpec.getDatasets().keySet(), spec, logicalStartTime,
+                                runtimeArguments, datasets, spec, logicalStartTime,
                                 workflowBatch, discoveryServiceClient, metricsCollectionService,
                                 datasetFramework);
 

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/DatasetWithMRApp.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/DatasetWithMRApp.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.test.app;
+
+import co.cask.cdap.api.ProgramLifecycle;
+import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.api.mapreduce.AbstractMapReduce;
+import co.cask.cdap.api.mapreduce.MapReduceContext;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.Mapper;
+
+import java.io.IOException;
+
+/**
+ * App which copies data from one KVTable to another using a MapReduce program.
+ */
+public class DatasetWithMRApp extends AbstractApplication {
+
+  public static final String INPUT_KEY = "input";
+  public static final String OUTPUT_KEY = "output";
+  public static final String MAPREDUCE_PROGRAM = "copymr";
+
+  @Override
+  public void configure() {
+    setName("DatasetWithMRApp");
+    setDescription("Copy Data from one KVTable Dataset to another");
+    addMapReduce(new CopyMapReduce());
+  }
+
+  public static class CopyMapReduce extends AbstractMapReduce {
+
+    @Override
+    public void configure() {
+      setName(MAPREDUCE_PROGRAM);
+    }
+
+    @Override
+    public void beforeSubmit(MapReduceContext context) {
+      context.setInput(context.getRuntimeArguments().get(INPUT_KEY));
+      context.setOutput(context.getRuntimeArguments().get(OUTPUT_KEY));
+      Job hadoopJob = context.getHadoopJob();
+      hadoopJob.setMapperClass(IdentityMapper.class);
+      hadoopJob.setNumReduceTasks(0);
+    }
+
+    public static class IdentityMapper extends Mapper<byte[], byte[], byte[], byte[]>
+      implements ProgramLifecycle<MapReduceContext> {
+
+      @Override
+      public void initialize(MapReduceContext context) throws Exception {
+        // no-op
+      }
+
+      public void map(byte[] key, byte[] value, Context context) throws IOException, InterruptedException {
+        context.write(key, value);
+      }
+
+      @Override
+      public void destroy() {
+        // no-op
+      }
+    }
+  }
+}

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/DatasetWithMRApp.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/DatasetWithMRApp.java
@@ -57,6 +57,7 @@ public class DatasetWithMRApp extends AbstractApplication {
     }
 
     public static class IdentityMapper extends Mapper<byte[], byte[], byte[], byte[]> {
+
       public void map(byte[] key, byte[] value, Context context) throws IOException, InterruptedException {
         context.write(key, value);
       }

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/DatasetWithMRApp.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/DatasetWithMRApp.java
@@ -16,7 +16,6 @@
 
 package co.cask.cdap.test.app;
 
-import co.cask.cdap.api.ProgramLifecycle;
 import co.cask.cdap.api.app.AbstractApplication;
 import co.cask.cdap.api.mapreduce.AbstractMapReduce;
 import co.cask.cdap.api.mapreduce.MapReduceContext;
@@ -57,21 +56,9 @@ public class DatasetWithMRApp extends AbstractApplication {
       hadoopJob.setNumReduceTasks(0);
     }
 
-    public static class IdentityMapper extends Mapper<byte[], byte[], byte[], byte[]>
-      implements ProgramLifecycle<MapReduceContext> {
-
-      @Override
-      public void initialize(MapReduceContext context) throws Exception {
-        // no-op
-      }
-
+    public static class IdentityMapper extends Mapper<byte[], byte[], byte[], byte[]> {
       public void map(byte[] key, byte[] value, Context context) throws IOException, InterruptedException {
         context.write(key, value);
-      }
-
-      @Override
-      public void destroy() {
-        // no-op
       }
     }
   }


### PR DESCRIPTION
Bamboo : http://builds.cask.co/browse/CDAP-DUT1305

This fix includes input/output dataset names in the dataset collection used in the creation of the MapReduceContext. For example, this will enable the use case illustrated in the test added in this PR - accessing datasets without adding the names during compile time.