### PR TITLE
Process quoted input passed as command line arguments to CLIMain

### DIFF
--- a/cdap-cli/src/main/java/co/cask/cdap/cli/CLIMain.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/CLIMain.java
@@ -32,6 +32,7 @@ import co.cask.common.cli.Command;
 import co.cask.common.cli.CommandSet;
 import co.cask.common.cli.exception.CLIExceptionHandler;
 import co.cask.common.cli.exception.InvalidCommandException;
+import co.cask.common.cli.util.Parser;
 import com.google.common.base.Joiner;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
@@ -53,6 +54,7 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.List;
 import java.util.Map;
 import javax.net.ssl.SSLHandshakeException;
 
@@ -216,7 +218,8 @@ public class CLIMain {
     Options options = getOptions();
     CommandLineParser parser = new BasicParser();
     try {
-      CommandLine command = parser.parse(options, args);
+      List<String> processedArgs = Parser.parseInput(Joiner.on(" ").join(args));
+      CommandLine command = parser.parse(options, processedArgs.toArray(new String[processedArgs.size()]));
       if (command.hasOption(HELP_OPTION.getOpt())) {
         usage();
         System.exit(0);


### PR DESCRIPTION
**Note:** This also needs to go into 2.8.1, because otherwise the quickstart guide for 2.8 will not work.

http://builds.cask.co/browse/CDAP-DUT1317

The command below wasn't working because Apache commons-cli was parsing the `-0400` as a command line option. `CLIMain` needs to parse the command line arguments first, and then pass the processed arguments to Apache commons-cli.

```
cdap-cli.sh send stream logEventStream '255.255.255.185 - - [23/Sep/2014:11:45:38 -0400] "GET /cdap.html HTTP/1.0" 401 2969 " " "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1)"'
```

Fix for https://issues.cask.co/browse/CDAP-1975.