### PR TITLE
[CDAP-1919] cdap-ui fails to build in some environments.

### DIFF
--- a/cdap-ui/pom.xml
+++ b/cdap-ui/pom.xml
@@ -62,7 +62,7 @@
           <plugin>
             <groupId>com.github.eirslett</groupId>
             <artifactId>frontend-maven-plugin</artifactId>
-            <version>0.0.20</version>
+            <version>0.0.23</version>
             <executions>
               <execution>
                 <id>dist</id>


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-1919

Update the frontend-maven-plugin version to pass build using maven 3.3.1.

This is due to conflict with slf4j and the plugin using particular maven [1].

See JIRA ticket for details of error stack.

[1] https://github.com/eirslett/frontend-maven-plugin/issues/183