### PR TITLE
Treat options and command as two separate sections of args from main()

### DIFF
--- a/cdap-cli/src/main/java/co/cask/cdap/cli/CLIMainArgs.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/CLIMainArgs.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2014-2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.cli;
+
+import com.google.common.base.Objects;
+import com.google.common.collect.Lists;
+import org.apache.commons.cli.Options;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Represents the command line arguments for {@link CLIMain}.
+ */
+public class CLIMainArgs {
+
+  private final String[] optionTokens;
+  private final String[] commandTokens;
+
+  public CLIMainArgs(String[] optionTokens, String[] commandTokens) {
+    this.optionTokens = optionTokens;
+    this.commandTokens = commandTokens;
+  }
+
+  public String[] getOptionTokens() {
+    return optionTokens;
+  }
+
+  public String[] getCommandTokens() {
+    return commandTokens;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(Arrays.hashCode(optionTokens), Arrays.hashCode(commandTokens));
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null || getClass() != obj.getClass()) {
+      return false;
+    }
+    final CLIMainArgs other = (CLIMainArgs) obj;
+    return Arrays.equals(this.optionTokens, other.optionTokens) &&
+      Arrays.equals(this.commandTokens, other.commandTokens);
+  }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(this).add("optionTokens", Arrays.toString(optionTokens))
+      .add("commandTokens", Arrays.toString(commandTokens)).toString();
+  }
+
+  public static CLIMainArgs parse(String[] args, Options options) {
+    List<String> optionsPart = Lists.newArrayList();
+    List<String> commandPart = Lists.newArrayList();
+
+    boolean inOptionsPart = true;
+    for (int i = 0; i < args.length; i++) {
+      String token = args[i];
+      if (inOptionsPart) {
+        if (!token.startsWith("-")) {
+          inOptionsPart = false;
+        } else {
+          if (!options.getOption(token).hasArg()) {
+            inOptionsPart = true;
+          } else if (options.getOption(token).hasArg() && i + 1 < args.length) {
+            inOptionsPart = true;
+            // add the option and option value
+            optionsPart.add(token);
+            optionsPart.add(args[++i]);
+            continue;
+          } else {
+            inOptionsPart = false;
+          }
+        }
+      }
+
+      if (inOptionsPart) {
+        optionsPart.add(token);
+      } else {
+        commandPart.add(token);
+      }
+    }
+    return new CLIMainArgs(optionsPart.toArray(new String[optionsPart.size()]),
+                           commandPart.toArray(new String[commandPart.size()]));
+  }
+}

--- a/cdap-cli/src/test/java/co/cask/cdap/cli/CLIMainArgsTest.java
+++ b/cdap-cli/src/test/java/co/cask/cdap/cli/CLIMainArgsTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2014-2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.cli;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ *
+ */
+public class CLIMainArgsTest {
+
+  @Test
+  public void testParse() {
+    String noArgFlag = "-" + CLIMain.HELP_OPTION.getOpt();
+    String withArgFlag = "-" + CLIMain.AUTOCONNECT_OPTION.getOpt();
+    Assert.assertEquals(true, CLIMain.AUTOCONNECT_OPTION.hasArg());
+
+    Assert.assertEquals(
+      new CLIMainArgs(new String[] {}, new String[] {"hello", "world"}),
+      CLIMainArgs.parse(new String[]{"hello", "world"}, CLIMain.getOptions()));
+
+    Assert.assertEquals(
+      new CLIMainArgs(new String[] {noArgFlag}, new String[] {"hello", "world"}),
+      CLIMainArgs.parse(new String[]{noArgFlag, "hello", "world"}, CLIMain.getOptions()));
+
+    Assert.assertEquals(
+      new CLIMainArgs(new String[] {}, new String[] {"hello", noArgFlag, "world"}),
+      CLIMainArgs.parse(new String[]{"hello", noArgFlag, "world"}, CLIMain.getOptions()));
+
+    Assert.assertEquals(
+      new CLIMainArgs(new String[] {}, new String[] {"hello", "world", noArgFlag}),
+      CLIMainArgs.parse(new String[]{"hello", "world", noArgFlag}, CLIMain.getOptions()));
+
+    Assert.assertEquals(
+      new CLIMainArgs(new String[] {withArgFlag, "somevalue"}, new String[] {"hello", "world"}),
+      CLIMainArgs.parse(new String[]{withArgFlag, "somevalue", "hello", "world"}, CLIMain.getOptions()));
+
+    Assert.assertEquals(
+      new CLIMainArgs(new String[] {}, new String[] {"hello", withArgFlag, "world"}),
+      CLIMainArgs.parse(new String[]{"hello", withArgFlag, "world"}, CLIMain.getOptions()));
+
+    Assert.assertEquals(
+      new CLIMainArgs(new String[] {}, new String[] {"hello", "world", withArgFlag}),
+      CLIMainArgs.parse(new String[]{"hello", "world", withArgFlag}, CLIMain.getOptions()));
+  }
+
+}


### PR DESCRIPTION
http://builds.cask.co/browse/CDAP-DUT1330

The command below wasn't working because Apache commons-cli was parsing the `-0400` as a command line option. `CLIMain` needs to use the convention of having command line options first in the main() args, then the command to execute after.

```
cdap-cli.sh send stream logEventStream '255.255.255.185 - - [23/Sep/2014:11:45:38 -0400] "GET /cdap.html HTTP/1.0" 401 2969 " " "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1)"'
```