### PR TITLE
Feature/adapter logs

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/AbstractMapReduceContextBuilder.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/AbstractMapReduceContextBuilder.java
@@ -68,7 +68,8 @@ public abstract class AbstractMapReduceContextBuilder {
                                      Program mrProgram,
                                      @Nullable String inputDataSetName,
                                      @Nullable List<Split> inputSplits,
-                                     @Nullable String outputDataSetName) {
+                                     @Nullable String outputDataSetName,
+                                     @Nullable String adapterName) {
     Injector injector = prepare();
 
     // Initializing Program
@@ -104,10 +105,9 @@ public abstract class AbstractMapReduceContextBuilder {
     // Creating mapreduce job context
     MapReduceSpecification spec = program.getApplicationSpecification().getMapReduce().get(program.getName());
     BasicMapReduceContext context =
-      new BasicMapReduceContext(program, type, RunIds.fromString(runId), taskId,
-                                runtimeArguments, datasets, spec, logicalStartTime,
-                                workflowBatch, discoveryServiceClient, metricsCollectionService,
-                                datasetFramework);
+      new BasicMapReduceContext(program, type, RunIds.fromString(runId), taskId, runtimeArguments, datasets, spec,
+                                logicalStartTime, workflowBatch, discoveryServiceClient, metricsCollectionService,
+                                datasetFramework, adapterName);
 
     // propagating tx to all txAware guys
     // NOTE: tx will be committed by client code

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
@@ -53,15 +53,15 @@ import javax.annotation.Nullable;
 public class BasicMapReduceContext extends AbstractContext implements MapReduceContext {
 
   private final MapReduceSpecification spec;
-  private final MapReduceLoggingContext loggingContext;
+  private final LoggingContext loggingContext;
   private final long logicalStartTime;
   private final String workflowBatch;
   private final Metrics userMetrics;
   private final MetricsCollectionService metricsCollectionService;
+  private final String adapterName;
 
   private String inputDatasetName;
   private List<Split> inputDataSelection;
-
   private String outputDatasetName;
   private Job job;
   private Dataset outputDataset;
@@ -79,12 +79,14 @@ public class BasicMapReduceContext extends AbstractContext implements MapReduceC
                                String workflowBatch,
                                DiscoveryServiceClient discoveryServiceClient,
                                MetricsCollectionService metricsCollectionService,
-                               DatasetFramework dsFramework) {
+                               DatasetFramework dsFramework,
+                               @Nullable String adapterName) {
     super(program, runId, runtimeArguments, datasets,
           getMetricCollector(metricsCollectionService, program, type, runId.getId(), taskId),
           dsFramework, discoveryServiceClient);
     this.logicalStartTime = logicalStartTime;
     this.workflowBatch = workflowBatch;
+    this.adapterName = adapterName;
     this.metricsCollectionService = metricsCollectionService;
 
     if (metricsCollectionService != null) {
@@ -92,7 +94,8 @@ public class BasicMapReduceContext extends AbstractContext implements MapReduceC
     } else {
       this.userMetrics = null;
     }
-    this.loggingContext = new MapReduceLoggingContext(getNamespaceId(), getApplicationId(), getProgramName());
+    this.loggingContext = new MapReduceLoggingContext(getNamespaceId(), getApplicationId(), getProgramName(),
+                                                      getAdapterName());
     this.spec = spec;
     this.mapperResources = spec.getMapperResources();
     this.reducerResources = spec.getReducerResources();
@@ -122,6 +125,14 @@ public class BasicMapReduceContext extends AbstractContext implements MapReduceC
    */
   public String getWorkflowBatch() {
     return workflowBatch;
+  }
+
+  /**
+   * @return the adapter name if run from within adapter, otherwise null
+   */
+  @Nullable
+  public String getAdapterName() {
+    return adapterName;
   }
 
   public void setJob(Job job) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/DynamicMapReduceContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/DynamicMapReduceContext.java
@@ -72,13 +72,13 @@ public class DynamicMapReduceContext extends BasicMapReduceContext implements Da
                                  RunId runId, String taskId,
                                  Arguments runtimeArguments,
                                  MapReduceSpecification spec,
-                                 long logicalStartTime, String workflowBatch,
+                                 long logicalStartTime, String workflowBatch, String adapterName,
                                  DiscoveryServiceClient discoveryServiceClient,
                                  MetricsCollectionService metricsCollectionService,
                                  TransactionSystemClient txClient,
                                  DatasetFramework dsFramework) {
     super(program, type, runId, taskId, runtimeArguments, Collections.<String>emptySet(), spec,
-          logicalStartTime, workflowBatch, discoveryServiceClient, metricsCollectionService, dsFramework);
+          logicalStartTime, workflowBatch, discoveryServiceClient, metricsCollectionService, dsFramework, adapterName);
     this.datasetsCache = CacheBuilder.newBuilder()
       .removalListener(new RemovalListener<Long, Map<DatasetCacheKey, Dataset>>() {
         @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextConfig.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextConfig.java
@@ -53,6 +53,7 @@ public final class MapReduceContextConfig {
   private static final String HCONF_ATTR_RUN_ID = "hconf.program.run.id";
   private static final String HCONF_ATTR_LOGICAL_START_TIME = "hconf.program.logical.start.time";
   private static final String HCONF_ATTR_WORKFLOW_BATCH = "hconf.program.workflow.batch";
+  private static final String HCONF_ATTR_ADAPTER_NAME = "hconf.program.adapter.name";
   private static final String HCONF_ATTR_ARGS = "hconf.program.args";
   private static final String HCONF_ATTR_PROGRAM_JAR_NAME = "hconf.program.jar.name";
   private static final String HCONF_ATTR_CCONF = "hconf.cconf";
@@ -70,7 +71,12 @@ public final class MapReduceContextConfig {
                   Transaction tx, String programJarName) {
     setRunId(context.getRunId().getId());
     setLogicalStartTime(context.getLogicalStartTime());
-    setWorkflowBatch(context.getWorkflowBatch());
+    if (context.getWorkflowBatch() != null) {
+      setWorkflowBatch(context.getWorkflowBatch());
+    }
+    if (context.getAdapterName() != null) {
+      setAdapterName(context.getAdapterName());
+    }
     setArguments(context.getRuntimeArguments());
     setProgramJarName(programJarName);
     setConf(conf);
@@ -117,15 +123,20 @@ public final class MapReduceContextConfig {
   }
 
   private void setWorkflowBatch(String workflowBatch) {
-    if (workflowBatch != null) {
-      jobContext.getConfiguration().set(HCONF_ATTR_WORKFLOW_BATCH, workflowBatch);
-    }
+    jobContext.getConfiguration().set(HCONF_ATTR_WORKFLOW_BATCH, workflowBatch);
   }
 
   public String getWorkflowBatch() {
     return jobContext.getConfiguration().get(HCONF_ATTR_WORKFLOW_BATCH);
   }
 
+  private void setAdapterName(String adapterName) {
+    jobContext.getConfiguration().set(HCONF_ATTR_ADAPTER_NAME, adapterName);
+  }
+
+  public String getAdapterName() {
+    return jobContext.getConfiguration().get(HCONF_ATTR_ADAPTER_NAME);
+  }
 
   private void setProgramJarName(String programJarName) {
     jobContext.getConfiguration().set(HCONF_ATTR_PROGRAM_JAR_NAME, programJarName);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextProvider.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextProvider.java
@@ -75,7 +75,9 @@ public final class MapReduceContextProvider {
                createProgram(),
                contextConfig.getInputDataSet(),
                contextConfig.getInputSelection(),
-               contextConfig.getOutputDataSet());
+               contextConfig.getOutputDataSet(),
+               contextConfig.getAdapterName()
+        );
     }
     return context;
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/DefaultSchedulerService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/DefaultSchedulerService.java
@@ -50,16 +50,12 @@ public class DefaultSchedulerService {
 
     private static final Logger LOG = LoggerFactory.getLogger(ScheduledJob.class);
     private final ScheduleTaskRunner taskRunner;
-    private final CConfiguration cConf;
-    private final Store store;
     private final SchedulerQueueResolver schedulerQueueResolver;
 
     ScheduledJob(Store store, ProgramRuntimeService programRuntimeService, PreferencesStore preferencesStore,
                  CConfiguration cConf, ListeningExecutorService taskExecutor) {
-      this.store = store;
-      this.cConf = cConf;
       this.schedulerQueueResolver = new SchedulerQueueResolver(cConf, store);
-      taskRunner = new ScheduleTaskRunner(store, programRuntimeService, preferencesStore, taskExecutor);
+      this.taskRunner = new ScheduleTaskRunner(store, programRuntimeService, preferencesStore, taskExecutor);
     }
 
     @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/ScheduleTaskRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/ScheduleTaskRunner.java
@@ -92,8 +92,9 @@ public final class ScheduleTaskRunner {
       userArgs.putAll(spec.getProperties());
 
       Map<String, String> runtimeArgs = preferencesStore.getResolvedProperties(programId.getNamespaceId(),
-                                                        programId.getApplicationId(), programType.getCategoryName(),
-                                                        programId.getId());
+                                                                               programId.getApplicationId(),
+                                                                               programType.getCategoryName(),
+                                                                               programId.getId());
 
       userArgs.putAll(runtimeArgs);
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/MapReduceProgramWorkflowRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/MapReduceProgramWorkflowRunner.java
@@ -20,7 +20,6 @@ import co.cask.cdap.api.mapreduce.MapReduceSpecification;
 import co.cask.cdap.api.workflow.WorkflowSpecification;
 import co.cask.cdap.app.ApplicationSpecification;
 import co.cask.cdap.app.program.Program;
-import co.cask.cdap.app.runtime.Arguments;
 import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.internal.app.runtime.ProgramRunnerFactory;
@@ -36,9 +35,8 @@ import java.util.concurrent.Callable;
 final class MapReduceProgramWorkflowRunner extends AbstractProgramWorkflowRunner {
 
   MapReduceProgramWorkflowRunner(WorkflowSpecification workflowSpec, ProgramRunnerFactory programRunnerFactory,
-                                 Program workflowProgram, RunId runId,
-                                 Arguments runtimeArguments, long logicalStartTime) {
-    super(runtimeArguments, runId, workflowProgram, logicalStartTime, programRunnerFactory, workflowSpec);
+                                 Program workflowProgram, RunId runId, ProgramOptions workflowProgramOptions) {
+    super(runId, workflowProgram, programRunnerFactory, workflowSpec, workflowProgramOptions);
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/ProgramWorkflowRunnerFactory.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/ProgramWorkflowRunnerFactory.java
@@ -23,11 +23,14 @@ import co.cask.cdap.api.workflow.WorkflowActionSpecification;
 import co.cask.cdap.api.workflow.WorkflowSpecification;
 import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.runtime.Arguments;
+import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.internal.app.runtime.ProgramRunnerFactory;
 import co.cask.cdap.internal.workflow.ProgramWorkflowAction;
 import org.apache.twill.api.RunId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
 
 /**
  * A Factory for {@link ProgramWorkflowRunner} which returns the appropriate {@link ProgramWorkflowRunner}
@@ -43,18 +46,15 @@ public class ProgramWorkflowRunnerFactory {
   private final ProgramRunnerFactory programRunnerFactory;
   private final Program workflowProgram;
   private final RunId runId;
-  private final Arguments userArguments;
-  private final long logicalStartTime;
+  private final ProgramOptions workflowProgramOptions;
 
   public ProgramWorkflowRunnerFactory(WorkflowSpecification workflowSpec, ProgramRunnerFactory programRunnerFactory,
-                                      Program workflowProgram, RunId runId, Arguments runtimeArguments,
-                                      long logicalStartTime) {
+                                      Program workflowProgram, RunId runId, ProgramOptions workflowProgramOptions) {
     this.workflowSpec = workflowSpec;
     this.programRunnerFactory = programRunnerFactory;
     this.workflowProgram = workflowProgram;
     this.runId = runId;
-    this.userArguments = runtimeArguments;
-    this.logicalStartTime = logicalStartTime;
+    this.workflowProgramOptions = workflowProgramOptions;
   }
 
   /**
@@ -71,10 +71,10 @@ public class ProgramWorkflowRunnerFactory {
       switch (SchedulableProgramType.valueOf(actionSpec.getProperties().get(ProgramWorkflowAction.PROGRAM_TYPE))) {
         case MAPREDUCE:
           return new MapReduceProgramWorkflowRunner(workflowSpec, programRunnerFactory, workflowProgram, runId,
-                                                    userArguments, logicalStartTime);
+                                                    workflowProgramOptions);
         case SPARK:
           return new SparkProgramWorkflowRunner(workflowSpec, programRunnerFactory, workflowProgram, runId,
-                                                userArguments, logicalStartTime);
+                                                workflowProgramOptions);
         default:
           LOG.debug("No workflow program runner found for this program");
       }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/SparkProgramWorkflowRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/SparkProgramWorkflowRunner.java
@@ -22,7 +22,6 @@ import co.cask.cdap.api.workflow.Workflow;
 import co.cask.cdap.api.workflow.WorkflowSpecification;
 import co.cask.cdap.app.ApplicationSpecification;
 import co.cask.cdap.app.program.Program;
-import co.cask.cdap.app.runtime.Arguments;
 import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.internal.app.runtime.ProgramRunnerFactory;
@@ -38,9 +37,8 @@ import java.util.concurrent.Callable;
 final class SparkProgramWorkflowRunner extends AbstractProgramWorkflowRunner {
 
   SparkProgramWorkflowRunner(WorkflowSpecification workflowSpec, ProgramRunnerFactory programRunnerFactory,
-                             Program workflowProgram, RunId runId,
-                             Arguments userArguments, long logicalStartTime) {
-    super(userArguments, runId, workflowProgram, logicalStartTime, programRunnerFactory, workflowSpec);
+                             Program workflowProgram, RunId runId, ProgramOptions workflowProgramOptions) {
+    super(runId, workflowProgram, programRunnerFactory, workflowSpec, workflowProgramOptions);
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowDriver.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowDriver.java
@@ -75,7 +75,6 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
   private static final Logger LOG = LoggerFactory.getLogger(WorkflowDriver.class);
 
   private final Program program;
-  private final RunId runId;
   private final InetAddress hostname;
   private final Map<String, String> runtimeArgs;
   private final WorkflowSpecification workflowSpec;
@@ -91,17 +90,15 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
   WorkflowDriver(Program program, RunId runId, ProgramOptions options, InetAddress hostname,
                  WorkflowSpecification workflowSpec, ProgramRunnerFactory programRunnerFactory) {
     this.program = program;
-    this.runId = runId;
     this.hostname = hostname;
     this.runtimeArgs = createRuntimeArgs(options.getUserArguments());
     this.workflowSpec = workflowSpec;
-    this.logicalStartTime = options.getArguments().hasOption(ProgramOptionConstants.LOGICAL_START_TIME)
-      ? Long.parseLong(options.getArguments()
-                         .getOption(ProgramOptionConstants.LOGICAL_START_TIME))
+    Arguments arguments = options.getArguments();
+    this.logicalStartTime = arguments.hasOption(ProgramOptionConstants.LOGICAL_START_TIME)
+      ? Long.parseLong(arguments.getOption(ProgramOptionConstants.LOGICAL_START_TIME))
       : System.currentTimeMillis();
     this.workflowProgramRunnerFactory = new ProgramWorkflowRunnerFactory(workflowSpec, programRunnerFactory, program,
-                                                                         runId, options.getUserArguments(),
-                                                                         logicalStartTime);
+                                                                         runId, options);
     lock = new ReentrantLock();
     condition = lock.newCondition();
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/worker/BasicWorkerContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/worker/BasicWorkerContext.java
@@ -144,7 +144,9 @@ public class BasicWorkerContext extends AbstractContext implements WorkerContext
   }
 
   public LoggingContext getLoggingContext() {
-    return new WorkerLoggingContext(program.getNamespaceId(), program.getApplicationId(), program.getId().getId());
+    //TODO: Add adapter name if present later
+    return new WorkerLoggingContext(program.getNamespaceId(), program.getApplicationId(), program.getId().getId(),
+                                    null);
   }
 
   private static MetricsCollector getMetricCollector(MetricsCollectionService service, Program program,

--- a/cdap-common/src/main/java/co/cask/cdap/common/logging/ApplicationLoggingContext.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/logging/ApplicationLoggingContext.java
@@ -16,20 +16,26 @@
 
 package co.cask.cdap.common.logging;
 
+import javax.annotation.Nullable;
+
 /**
  * Application logging context.
  */
 public abstract class ApplicationLoggingContext extends NamespaceLoggingContext {
   public static final String TAG_APPLICATION_ID = ".applicationId";
+  public static final String TAG_ADAPTER_ID = ".adapterId";
 
   /**
    * Constructs ApplicationLoggingContext.
    * @param namespaceId namespace id
    * @param applicationId application id
    */
-  public ApplicationLoggingContext(final String namespaceId, final String applicationId) {
+  public ApplicationLoggingContext(final String namespaceId, final String applicationId, @Nullable String adapterId) {
     super(namespaceId);
     setSystemTag(TAG_APPLICATION_ID, applicationId);
+    if (adapterId != null) {
+      setSystemTag(TAG_ADAPTER_ID, adapterId);
+    }
   }
 
   @Override

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterPathLookup.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterPathLookup.java
@@ -154,8 +154,11 @@ public final class RouterPathLookup extends AuthenticatedHttpHandler {
       } else {
         return Constants.Service.STREAMS;
       }
-    } else if (uriParts.length >= 8 && uriParts[7].equals("logs")) {
-      //Log Handler Path /v3/namespaces/<namespaceid>apps/<appid>/<programid-type>/<programid>/logs
+    } else if ((uriParts.length >= 8 && uriParts[7].equals("logs")) ||
+      (uriParts.length >= 6 && uriParts[5].equals("logs"))) {
+      //Log Handler Paths:
+      // /v3/namespaces/<namespaceid>/apps/<appid>/<programid-type>/<programid>/logs
+      // /v3/namespaces/<namespaceid>/adapters/<adapterid>/logs
       return Constants.Service.METRICS;
     } else if (uriParts.length >= 2 && uriParts[1].equals("metrics")) {
       //Metrics Search Handler Path /v3/metrics

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/log/MockLogReader.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/log/MockLogReader.java
@@ -55,21 +55,27 @@ public class MockLogReader implements LogReader {
       logMap.put(defaultNamespacedLogBaseDir + "/testApp1/flow-testFlow1", new LogLine(i, "testFlow1<img>-" + i));
     }
 
-    // Add log lines for app testApp1, flow testService1
+    // Add log lines for app testApp1, service testService1
     for (int i = 0; i < MAX; ++i) {
       logMap.put(defaultNamespacedLogBaseDir + "/testApp4/userservice-testService1",
                  new LogLine(i, "testService1<img>-" + i));
     }
 
-    // Add log lines for app testApp2, flow testProcedure1
+    // Add log lines for app testApp2, procedure testProcedure1
     for (int i = 0; i < MAX; ++i) {
       logMap.put(defaultNamespacedLogBaseDir + "/testApp2/procedure-testProcedure1",
                  new LogLine(i, "testProcedure1<img>-" + i));
     }
 
-    // Add log lines for app testApp3, flow testMapReduce1
+    // Add log lines for app testApp3, mapreduce testMapReduce1
     for (int i = 0; i < MAX; ++i) {
       logMap.put(defaultNamespacedLogBaseDir + "/testApp3/mapred-testMapReduce1",
+                 new LogLine(i, "testMapReduce1<img>-" + i));
+    }
+
+    // Add log lines for app testApp1, mapreduce testMapReduce1 run as part of batch adapter adapter1 in testNamespace
+    for (int i = 0; i < MAX; ++i) {
+      logMap.put(testNamespacedLogBaseDir + "/testTemplate1/mapred-testMapReduce1",
                  new LogLine(i, "testMapReduce1<img>-" + i));
     }
 
@@ -78,7 +84,7 @@ public class MockLogReader implements LogReader {
       logMap.put(testNamespacedLogBaseDir + "/testApp1/flow-testFlow1", new LogLine(i, "testFlow1<img>-" + i));
     }
 
-    // Add log lines for app testApp1, flow testService1 in testNamespace
+    // Add log lines for app testApp1, service testService1 in testNamespace
     for (int i = 0; i < MAX; ++i) {
       logMap.put(testNamespacedLogBaseDir + "/testApp4/userservice-testService1",
                  new LogLine(i, "testService1<img>-" + i));

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/FlowletLoggingContext.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/FlowletLoggingContext.java
@@ -37,7 +37,7 @@ public class FlowletLoggingContext extends ApplicationLoggingContext {
                                final String applicationId,
                                final String flowId,
                                final String flowletId) {
-    super(namespaceId, applicationId);
+    super(namespaceId, applicationId, null);
     setSystemTag(TAG_FLOW_ID, flowId);
     setSystemTag(TAG_FLOWLET_ID, flowletId);
   }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/GenericLoggingContext.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/GenericLoggingContext.java
@@ -33,7 +33,7 @@ public class GenericLoggingContext extends ApplicationLoggingContext {
   public GenericLoggingContext(final String namespaceId,
                                final String applicationId,
                                final String entityId) {
-    super(namespaceId, applicationId);
+    super(namespaceId, applicationId, null);
     setSystemTag(TAG_ENTITY_ID, entityId);
   }
 

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/LoggingContextHelper.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/LoggingContextHelper.java
@@ -32,6 +32,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Helper class for LoggingContext objects.
@@ -80,7 +81,8 @@ public final class LoggingContextHelper {
                                        tags.get(FlowletLoggingContext.TAG_FLOWLET_ID));
     } else if (tags.containsKey(MapReduceLoggingContext.TAG_MAP_REDUCE_JOB_ID)) {
       return new MapReduceLoggingContext(namespaceId, applicationId,
-                                         tags.get(MapReduceLoggingContext.TAG_MAP_REDUCE_JOB_ID));
+                                         tags.get(MapReduceLoggingContext.TAG_MAP_REDUCE_JOB_ID),
+                                         tags.get(ApplicationLoggingContext.TAG_ADAPTER_ID));
     } else if (tags.containsKey(SparkLoggingContext.TAG_SPARK_JOB_ID)) {
         return new SparkLoggingContext(namespaceId, applicationId, tags.get(SparkLoggingContext.TAG_SPARK_JOB_ID));
     } else if (tags.containsKey(ProcedureLoggingContext.TAG_PROCEDURE_ID)) {
@@ -97,7 +99,8 @@ public final class LoggingContextHelper {
       return new ServiceLoggingContext(systemId, componentId,
                                        tags.get(ServiceLoggingContext.TAG_SERVICE_ID));
     } else if (tags.containsKey(WorkerLoggingContext.TAG_WORKER_ID)) {
-      return new WorkerLoggingContext(namespaceId, applicationId, tags.get(WorkerLoggingContext.TAG_WORKER_ID));
+      return new WorkerLoggingContext(namespaceId, applicationId, tags.get(WorkerLoggingContext.TAG_WORKER_ID),
+                                      tags.get(ApplicationLoggingContext.TAG_ADAPTER_ID));
     }
 
     throw new IllegalArgumentException("Unsupported logging context");
@@ -109,19 +112,24 @@ public final class LoggingContextHelper {
 
   public static LoggingContext getLoggingContext(String namespaceId, String applicationId, String entityId,
                                                  ProgramType programType) {
+    return getLoggingContext(namespaceId, applicationId, entityId, programType, null);
+  }
+
+  public static LoggingContext getLoggingContext(String namespaceId, String applicationId, String entityId,
+                                                 ProgramType programType, @Nullable String adapterName) {
     switch (programType) {
       case FLOW:
         return new FlowletLoggingContext(namespaceId, applicationId, entityId, "");
       case PROCEDURE:
         return new ProcedureLoggingContext(namespaceId, applicationId, entityId);
       case MAPREDUCE:
-        return new MapReduceLoggingContext(namespaceId, applicationId, entityId);
+        return new MapReduceLoggingContext(namespaceId, applicationId, entityId, adapterName);
       case SPARK:
         return new SparkLoggingContext(namespaceId, applicationId, entityId);
       case SERVICE:
         return new UserServiceLoggingContext(namespaceId, applicationId, entityId, "");
       case WORKER:
-        return new WorkerLoggingContext(namespaceId, applicationId, entityId);
+        return new WorkerLoggingContext(namespaceId, applicationId, entityId, adapterName);
       default:
         throw new IllegalArgumentException(String.format("Illegal entity type for logging context: %s", programType));
     }
@@ -171,25 +179,39 @@ public final class LoggingContextHelper {
       // For backward compatibility: The old logs before namespace have .accountId and developer as value so we don't
       // want them to get filtered out if they belong to this application and entity
       OrFilter namespaceFilter = new OrFilter(ImmutableList.of(new MdcExpression(
-                                                                 FlowletLoggingContext.TAG_NAMESPACE_ID, namespaceId),
+                                                                 NamespaceLoggingContext.TAG_NAMESPACE_ID, namespaceId),
                                                                new MdcExpression(ACCOUNT_ID,
                                                                                  Constants.DEVELOPER_ACCOUNT)));
+      if (loggingContext.getSystemTagsMap().containsKey(ApplicationLoggingContext.TAG_ADAPTER_ID)) {
+        String adapterName = loggingContext.getSystemTagsMap().get(ApplicationLoggingContext.TAG_ADAPTER_ID).getValue();
+        return new AndFilter(ImmutableList.of(namespaceFilter,
+                                              new MdcExpression(ApplicationLoggingContext.TAG_APPLICATION_ID, applId),
+                                              new MdcExpression(tagName, entityId),
+                                              new MdcExpression(ApplicationLoggingContext.TAG_ADAPTER_ID, adapterName))
+        );
+      }
       return new AndFilter(
-        ImmutableList.of(namespaceFilter, new MdcExpression(FlowletLoggingContext.TAG_APPLICATION_ID, applId),
+        ImmutableList.of(namespaceFilter,
+                         new MdcExpression(ApplicationLoggingContext.TAG_APPLICATION_ID, applId),
                          new MdcExpression(tagName, entityId)
         )
       );
+
     }
   }
 
   private static Filter createGenericFilter(String namespaceId, String applicationId, String entityId) {
     FlowletLoggingContext flowletLoggingContext = new FlowletLoggingContext(namespaceId, applicationId, entityId, "");
     ProcedureLoggingContext procedureLoggingContext = new ProcedureLoggingContext(namespaceId, applicationId, entityId);
-    MapReduceLoggingContext mapReduceLoggingContext = new MapReduceLoggingContext(namespaceId, applicationId, entityId);
+    // we don't care about adapters in GenericLoggingContext
+    MapReduceLoggingContext mapReduceLoggingContext = new MapReduceLoggingContext(namespaceId, applicationId, entityId,
+                                                                                  null);
     SparkLoggingContext sparkLoggingContext = new SparkLoggingContext(namespaceId, applicationId, entityId);
     UserServiceLoggingContext userServiceLoggingContext = new UserServiceLoggingContext(namespaceId, applicationId,
                                                                                         entityId, "");
-    WorkerLoggingContext workerLoggingContext = new WorkerLoggingContext(namespaceId, applicationId, entityId);
+    // we don't care about adapters in GenericLoggingContext
+    WorkerLoggingContext workerLoggingContext = new WorkerLoggingContext(namespaceId, applicationId, entityId,
+                                                                         null);
 
 
     return new OrFilter(

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/MapReduceLoggingContext.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/MapReduceLoggingContext.java
@@ -18,6 +18,8 @@ package co.cask.cdap.logging.context;
 
 import co.cask.cdap.common.logging.ApplicationLoggingContext;
 
+import javax.annotation.Nullable;
+
 /**
  *
  */
@@ -31,8 +33,9 @@ public class MapReduceLoggingContext extends ApplicationLoggingContext {
    * @param applicationId application id
    * @param mapReduceId mapreduce job id
    */
-  public MapReduceLoggingContext(final String namespaceId, final String applicationId, final String mapReduceId) {
-    super(namespaceId, applicationId);
+  public MapReduceLoggingContext(final String namespaceId, final String applicationId, final String mapReduceId,
+                                 @Nullable String adapterId) {
+    super(namespaceId, applicationId, adapterId);
     setSystemTag(TAG_MAP_REDUCE_JOB_ID, mapReduceId);
   }
 

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/ProcedureLoggingContext.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/ProcedureLoggingContext.java
@@ -34,7 +34,7 @@ public class ProcedureLoggingContext extends ApplicationLoggingContext {
   public ProcedureLoggingContext(final String namespaceId,
                                  final String applicationId,
                                  final String procedureId) {
-    super(namespaceId, applicationId);
+    super(namespaceId, applicationId, null);
     setSystemTag(TAG_PROCEDURE_ID, procedureId);
   }
 

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/SparkLoggingContext.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/SparkLoggingContext.java
@@ -33,7 +33,7 @@ public class SparkLoggingContext extends ApplicationLoggingContext {
    * @param sparkId spark job id
    */
   public SparkLoggingContext(final String namespaceId, final String applicationId, final String sparkId) {
-    super(namespaceId, applicationId);
+    super(namespaceId, applicationId, null);
     setSystemTag(TAG_SPARK_JOB_ID, sparkId);
   }
 

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/UserServiceLoggingContext.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/UserServiceLoggingContext.java
@@ -30,7 +30,7 @@ public class UserServiceLoggingContext extends ApplicationLoggingContext {
                                    final String applicationId,
                                    final String serviceId,
                                    final String runnableId) {
-    super(namespaceId, applicationId);
+    super(namespaceId, applicationId, null);
     setSystemTag(TAG_USERSERVICE_ID, serviceId);
     setSystemTag(TAG_RUNNABLE_ID, runnableId);
   }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/WorkerLoggingContext.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/WorkerLoggingContext.java
@@ -19,6 +19,8 @@ package co.cask.cdap.logging.context;
 import co.cask.cdap.api.worker.Worker;
 import co.cask.cdap.common.logging.ApplicationLoggingContext;
 
+import javax.annotation.Nullable;
+
 /**
  * Logging Context for {@link Worker}
  */
@@ -26,8 +28,9 @@ public class WorkerLoggingContext extends ApplicationLoggingContext {
 
   public static final String TAG_WORKER_ID = ".workerid";
 
-  public WorkerLoggingContext(final String namespaceId, final String appId, final String workerId) {
-    super(namespaceId, appId);
+  public WorkerLoggingContext(final String namespaceId, final String appId, final String workerId,
+                              @Nullable String adapterId) {
+    super(namespaceId, appId, adapterId);
     setSystemTag(TAG_WORKER_ID, workerId);
   }
 

--- a/cdap-watchdog/src/test/java/co/cask/cdap/common/logging/logback/TestLoggingContext.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/common/logging/logback/TestLoggingContext.java
@@ -23,7 +23,7 @@ import co.cask.cdap.common.logging.ApplicationLoggingContext;
  */
 public class TestLoggingContext extends ApplicationLoggingContext {
   public TestLoggingContext(String namespaceId, String applicationId) {
-    super(namespaceId, applicationId);
+    super(namespaceId, applicationId, null);
   }
 
   @Override


### PR DESCRIPTION
Not ready for merging yet, this is just an approach of how logging for adapters could potentially work. 

- [x] Creates a ``BatchAdapterLoggingContext`` that is used if a mapreduce program was run via a schedule that started through an adapter.
- [x] Adds the ``/namespaces/[namespace-id]/adapters/[adapter-id]/logs`` API
- [x] End-to-end testing - Deployed an adapter, used the above API to get logs for the adapter.

Some stuff that is not nice in this PR, still exploring ways to fix, but some of this may require larger refactoring
- [ ] Uses ``adapterName`` encoded in ``scheduleName``
- [ ] Separation of concerns - ``ApplicationLoggingContext`` accepts an ``adapterId``, ``BasicMapreduceContext`` knows about ``adapterId`` as well.

Things that we need in future, but are not part of this PR:
* Currently gets ``templateId``, ``programType`` and ``programId`` as parameters in the ``/namespaces/[namespace-id]/adapters/[adapter-id]/logs`` API. Have to live with this until we have an ``AdapterClient`` that can be used from the log service to get this info by making a remote call?

Build: https://builds.cask.co/browse/CDAP-DUT1346-1
Issue: [CDAP-1786](https://issues.cask.co/browse/CDAP-1786)