### PR TITLE
Adding Dataset example links and glossary entries

### DIFF
--- a/cdap-docs/developers-manual/source/building-blocks/datasets/fileset.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/datasets/fileset.rst
@@ -364,7 +364,7 @@ Additionally:
 Using TimePartitionedFileSets in MapReduce
 ==========================================
 
-Using time partitioned file sets in MapReduce is similar to partitioned file sets; however, instead of
+Using time-partitioned file sets in MapReduce is similar to partitioned file sets; however, instead of
 setting an input partition filter and an output partition key, you configure an input time range and an
 output partition time in the ``beforeSubmit()`` of the MapReduce::
 

--- a/cdap-docs/developers-manual/source/building-blocks/datasets/index.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/datasets/index.rst
@@ -164,6 +164,9 @@ While these Tables have rows and columns similar to relational database tables, 
 A |fileset|_ represents a collections of files in the file system that share some common attributes
 such as the format and schema, while abstracting from the actual underlying file system interfaces.
 
+.. |fileset| replace:: **FileSet**
+.. _fileset: fileset.html
+
 - Every file in a FileSet is in a location relative to the FileSet's base directory.
 
 - Knowing a file's relative path, any program can obtain a ``Location`` for that file through a method
@@ -174,17 +177,23 @@ such as the format and schema, while abstracting from the actual underlying file
   the input and output format to use, or configuration for these |---| the FileSet dataset provides this
   information to the MapReduce runtime system.
 
-- An extension of FileSets, ``PartitionedFileSets`` allow the associating of meta data (partitioning keys)
+- An abstraction of FileSets, ``PartitionedFileSets`` allow the associating of meta data (partitioning keys)
   with each file. The file can then be addressed through its meta data, removing the need for programs to
   be aware of actual file paths.
   
 - A ``TimePartitionedFileSet`` is a further variation that uses a timestamp as the partitioning key.
-  Unlike a :ref:`Timeseries Table <cdap-timeseries-guide>` dataset, where the same schema is
-  used for all batches, a ``TimePartitionedFileSet`` can be used to batch together data
-  whose schema varies from batch to batch.
+  Though it is not required that data in each partition be organized by time,
+  each partition is assigned a logical time. 
 
-.. |fileset| replace:: **FileSet**
-.. _fileset: fileset.html
+  This is in contrast to a :ref:`Timeseries Table <cdap-timeseries-guide>` dataset, where
+  time is the primary means of how data is organized, and both the data model and the
+  schema that represents the data are optimized for querying and aggregating over time
+  ranges.
+
+  Time partition filesets are typically written in batch: into large files, every *N* minutes or
+  hours...while a timeseries table is typically written in realtime, one data point at a
+  time.
+ 
 
 .. rubric::  Examples of Using Datasets
 

--- a/cdap-docs/developers-manual/source/building-blocks/datasets/index.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/datasets/index.rst
@@ -190,7 +190,7 @@ such as the format and schema, while abstracting from the actual underlying file
   schema that represents the data are optimized for querying and aggregating over time
   ranges.
 
-  Time partition filesets are typically written in batch: into large files, every *N* minutes or
+  Time-partitioned FileSets are typically written in batch: into large files, every *N* minutes or
   hours...while a timeseries table is typically written in realtime, one data point at a
   time.
  

--- a/cdap-docs/developers-manual/source/building-blocks/datasets/index.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/datasets/index.rst
@@ -161,7 +161,6 @@ While these Tables have rows and columns similar to relational database tables, 
   and written independently of other columns, and columns are ordered
   in byte-lexicographic order. They are also known as *Ordered Columnar Tables*.
 
-
 A |fileset|_ represents a collections of files in the file system that share some common attributes
 such as the format and schema, while abstracting from the actual underlying file system interfaces.
 
@@ -178,6 +177,11 @@ such as the format and schema, while abstracting from the actual underlying file
 - An extension of FileSets, ``PartitionedFileSets`` allow the associating of meta data (partitioning keys)
   with each file. The file can then be addressed through its meta data, removing the need for programs to
   be aware of actual file paths.
+  
+- A ``TimePartitionedFileSet`` is a further variation that uses a timestamp as the partitioning key.
+  Unlike a :ref:`Timeseries Table <cdap-timeseries-guide>` dataset, where the same schema is
+  used for all batches, a ``TimePartitionedFileSet`` can be used to batch together data
+  whose schema varies from batch to batch.
 
 .. |fileset| replace:: **FileSet**
 .. _fileset: fileset.html
@@ -213,3 +217,8 @@ Datasets are included in just about every CDAP :ref:`application <apps-and-packs
 
 - For an example of a **Timeseries Table dataset,** see the how-to guide :ref:`cdap-timeseries-guide`.
 
+- For an example of a FileSet dataset, see the :ref:`FileSet example <examples-fileset>`.
+  The :ref:`Sport Results example <examples-sport-results>` demonstrates the use of a
+  ``PartitionedFileSet``, while the :ref:`Stream Conversion example 
+  <examples-stream-conversion>` shows use of a ``TimePartitionedFileSet``.
+  

--- a/cdap-docs/developers-manual/source/building-blocks/datasets/index.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/datasets/index.rst
@@ -204,10 +204,11 @@ Datasets are included in just about every CDAP :ref:`application <apps-and-packs
 
 - For an example of a **FileSet dataset,** see the :ref:`FileSet <examples-fileset>` example.
 
-- For an example of a **PartitionedFileSet,** see the :ref:`Sport Results example <examples-sport-results>`.
+- For an example of a **PartitionedFileSet,** see the :ref:`Sport Results <examples-sport-results>`
+  example.
 
-- For an example of a **TimePartitionedFileSet,** see the :ref:`Stream Conversion example 
-  <examples-stream-conversion>`.
+- For an example of a **TimePartitionedFileSet,** see the :ref:`Stream Conversion 
+  <examples-stream-conversion>` example.
 
 - For examples of **key-value Table datasets,** see the
   :ref:`Hello World <examples-hello-world>`,
@@ -221,4 +222,5 @@ Datasets are included in just about every CDAP :ref:`application <apps-and-packs
   :ref:`Spark K-Means <examples-spark-k-means>`, and :ref:`Spark Page Rank <examples-spark-page-rank>` examples.
 
 - For an example of a **Timeseries Table dataset,** see the how-to guide :ref:`cdap-timeseries-guide`.
+
   

--- a/cdap-docs/developers-manual/source/building-blocks/datasets/index.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/datasets/index.rst
@@ -204,6 +204,11 @@ Datasets are included in just about every CDAP :ref:`application <apps-and-packs
 
 - For an example of a **FileSet dataset,** see the :ref:`FileSet <examples-fileset>` example.
 
+- For an example of a **PartitionedFileSet,** see the :ref:`Sport Results example <examples-sport-results>`.
+
+- For an example of a **TimePartitionedFileSet,** see the :ref:`Stream Conversion example 
+  <examples-stream-conversion>`.
+
 - For examples of **key-value Table datasets,** see the
   :ref:`Hello World <examples-hello-world>`,
   :ref:`Count Random <examples-count-random>`,
@@ -216,9 +221,4 @@ Datasets are included in just about every CDAP :ref:`application <apps-and-packs
   :ref:`Spark K-Means <examples-spark-k-means>`, and :ref:`Spark Page Rank <examples-spark-page-rank>` examples.
 
 - For an example of a **Timeseries Table dataset,** see the how-to guide :ref:`cdap-timeseries-guide`.
-
-- For an example of a FileSet dataset, see the :ref:`FileSet example <examples-fileset>`.
-  The :ref:`Sport Results example <examples-sport-results>` demonstrates the use of a
-  ``PartitionedFileSet``, while the :ref:`Stream Conversion example 
-  <examples-stream-conversion>` shows use of a ``TimePartitionedFileSet``.
   

--- a/cdap-docs/reference-manual/source/glossary.rst
+++ b/cdap-docs/reference-manual/source/glossary.rst
@@ -135,13 +135,19 @@ Glossary
       CDAP system services that are run in YARN containers like Transaction Service,
       Dataset Executor, Log Saver, Metrics Processor, etc.
 
-   TimePartitioned Dataset
-      A :term:`Dataset` that consists of batches of data, differentiated by a timestamp.
-      Unlike a :term:`TimeSeries Dataset`, the schema of batches may vary from batch to
-      batch.
+   Fileset Dataset
+      A :term:`Dataset` composed of collections of files in the file system that share
+      some common attributes such as the format and schema, which abstracts from the
+      actual underlying file system interfaces.
+
+   TimePartitioned Fileset
+      A :term:`Fileset` :term:`Dataset` that uses a timestamp as the partitioning key to
+      split the data into indivividual files. Though it is not required that data in each
+      partition be organized by time, each partition is assigned a logical time. Typically
+      written to in batch mode, at a set time interval.
 
    TimeSeries Dataset
-      A :term:`Dataset` that consists of batches of data with identical schema,
-      differentiated by a timestamp. Unlike a :term:`TimePartitioned Dataset`, the schema
-      of the batches must be identical.
+      A :term:`Dataset` where time is the primary means of how data is organized, and both
+      the data model and the schema that represents the data are optimized for querying
+      and aggregating over time ranges.
 

--- a/cdap-docs/reference-manual/source/glossary.rst
+++ b/cdap-docs/reference-manual/source/glossary.rst
@@ -135,7 +135,7 @@ Glossary
       CDAP system services that are run in YARN containers like Transaction Service,
       Dataset Executor, Log Saver, Metrics Processor, etc.
 
-   Fileset Dataset
+   Fileset
       A :term:`Dataset` composed of collections of files in the file system that share
       some common attributes such as the format and schema, which abstracts from the
       actual underlying file system interfaces.

--- a/cdap-docs/reference-manual/source/glossary.rst
+++ b/cdap-docs/reference-manual/source/glossary.rst
@@ -134,13 +134,14 @@ Glossary
    Master Services
       CDAP system services that are run in YARN containers like Transaction Service,
       Dataset Executor, Log Saver, Metrics Processor, etc.
-  
-  TimePartitioned Dataset
+
+   TimePartitioned Dataset
       A :term:`Dataset` that consists of batches of data, differentiated by a timestamp.
       Unlike a :term:`TimeSeries Dataset`, the schema of batches may vary from batch to
       batch.
-  
-  TimeSeries Dataset
+
+   TimeSeries Dataset
       A :term:`Dataset` that consists of batches of data with identical schema,
       differentiated by a timestamp. Unlike a :term:`TimePartitioned Dataset`, the schema
       of the batches must be identical.
+

--- a/cdap-docs/reference-manual/source/glossary.rst
+++ b/cdap-docs/reference-manual/source/glossary.rst
@@ -135,4 +135,12 @@ Glossary
       CDAP system services that are run in YARN containers like Transaction Service,
       Dataset Executor, Log Saver, Metrics Processor, etc.
   
-
+  TimePartitioned Dataset
+      A :term:`Dataset` that consists of batches of data, differentiated by a timestamp.
+      Unlike a :term:`TimeSeries Dataset`, the schema of batches may vary from batch to
+      batch.
+  
+  TimeSeries Dataset
+      A :term:`Dataset` that consists of batches of data with identical schema,
+      differentiated by a timestamp. Unlike a :term:`TimePartitioned Dataset`, the schema
+      of the batches must be identical.

--- a/cdap-docs/reference-manual/source/glossary.rst
+++ b/cdap-docs/reference-manual/source/glossary.rst
@@ -135,18 +135,18 @@ Glossary
       CDAP system services that are run in YARN containers like Transaction Service,
       Dataset Executor, Log Saver, Metrics Processor, etc.
 
-   Fileset
+   FileSet
       A :term:`Dataset` composed of collections of files in the file system that share
       some common attributes such as the format and schema, which abstracts from the
       actual underlying file system interfaces.
 
-   TimePartitioned Fileset
-      A :term:`Fileset` :term:`Dataset` that uses a timestamp as the partitioning key to
+   Time-partitioned FileSet
+      A :term:`FileSet` :term:`Dataset` that uses a timestamp as the partitioning key to
       split the data into indivividual files. Though it is not required that data in each
       partition be organized by time, each partition is assigned a logical time. Typically
       written to in batch mode, at a set time interval.
 
-   TimeSeries Dataset
+   Timeseries Dataset
       A :term:`Dataset` where time is the primary means of how data is organized, and both
       the data model and the schema that represents the data are optimized for querying
       and aggregating over time ranges.


### PR DESCRIPTION
Add entries to glossary for TimePartitioned and TimeSeries Datasets, added links to examples to Building Blocks Datasets, added description to Filesets commentary.

Staged at: http://stg-web101.sw.joyent.continuuity.net/cdap/3.0.0-SNAPSHOT-3.0_1827_Dataset_Building_Block/en/index.html

Pages of note:
- [Datasets, page bottom](http://stg-web101.sw.joyent.continuuity.net/cdap/3.0.0-SNAPSHOT-3.0_1827_Dataset_Building_Block/en/developers-manual/building-blocks/datasets/index.html)
- [Glossary](http://stg-web101.sw.joyent.continuuity.net/cdap/3.0.0-SNAPSHOT-3.0_1827_Dataset_Building_Block/en/reference-manual/glossary.html#term-timepartitioned-dataset)

Fix for https://issues.cask.co/browse/CDAP-1827 and https://issues.cask.co/browse/CDAP-1972