### PR TITLE
Javadoc Cleanup

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -34,7 +34,7 @@ See [Surefire doc](http://maven.apache.org/surefire/maven-surefire-plugin/exampl
     mvn clean package javadoc:javadoc -pl cdap-api -am -DskipTests -P release
 
 ### Build the complete set of Javadocs, for all modules
-    MAVEN_OPTS="-Xmx512m" mvn clean site -Dmaxmemory=512m -DskipTests
+    MAVEN_OPTS="-Xmx512m" mvn clean site -Dmaxmemory=1024m -DskipTests
     
 ### Build distributions (rpm, deb, tgz)
     mvn package -DskipTests -P dist,rpm-prepare,rpm,deb-prepare,deb,tgz

--- a/BUILD.md
+++ b/BUILD.md
@@ -34,7 +34,7 @@ See [Surefire doc](http://maven.apache.org/surefire/maven-surefire-plugin/exampl
     mvn clean package javadoc:javadoc -pl cdap-api -am -DskipTests -P release
 
 ### Build the complete set of Javadocs, for all modules
-    mvn clean site -DskipTests
+    MAVEN_OPTS="-Xmx512m" mvn clean site -Dmaxmemory=512m -DskipTests
     
 ### Build distributions (rpm, deb, tgz)
     mvn package -DskipTests -P dist,rpm-prepare,rpm,deb-prepare,deb,tgz

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
@@ -474,26 +474,32 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   }
 
   /**
-   * Returns the status for all programs that are passed into the data. The data is an array of Json objects
+   * Returns the status for all programs that are passed into the data. The data is an array of JSON objects
    * where each object must contain the following three elements: appId, programType, and programId
    * (flow name, service name, etc.).
-   * <p/>
+   * <p>
    * Example input:
+   * <pre><code>
    * [{"appId": "App1", "programType": "Service", "programId": "Service1"},
-   * {"appId": "App1", "programType": "Procedure", "programId": "Proc2"},
+   * {"appId": "App1", "programType": "Mapreduce", "programId": "MapReduce2"},
    * {"appId": "App2", "programType": "Flow", "programId": "Flow1"}]
-   * <p/>
+   * </code></pre>
+   * </p><p>
    * The response will be an array of JsonObjects each of which will contain the three input parameters
    * as well as 2 fields, "status" which maps to the status of the program and "statusCode" which maps to the
-   * status code for the data in that JsonObjects. If an error occurs in the
-   * input (i.e. in the example above, App2 does not exist), then all JsonObjects for which the parameters
-   * have a valid status will have the status field but all JsonObjects for which the parameters do not have a valid
-   * status will have an error message and statusCode.
-   * <p/>
+   * status code for the data in that JsonObjects.
+   * </p><p>
+   * If an error occurs in the input (for the example above, App2 does not exist), then all JsonObjects for which the
+   * parameters have a valid status will have the status field but all JsonObjects for which the parameters do not have
+   * a valid status will have an error message and statusCode.
+   * </p><p>
    * For example, if there is no App2 in the data above, then the response would be 200 OK with following possible data:
+   * </p>
+   * <pre><code>
    * [{"appId": "App1", "programType": "Service", "programId": "Service1", "statusCode": 200, "status": "RUNNING"},
-   * {"appId": "App1", "programType": "Procedure", "programId": "Proc2"}, "statusCode": 200, "status": "STOPPED"},
+   * {"appId": "App1", "programType": "Mapreduce", "programId": "Mapreduce2", "statusCode": 200, "status": "STOPPED"},
    * {"appId":"App2", "programType":"Flow", "programId":"Flow1", "statusCode":404, "error": "App: App2 not found"}]
+   * </code></pre>
    */
   @POST
   @Path("/status")
@@ -536,28 +542,36 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
    * (flow name, service name, or procedure name). Retrieving instances only applies to flows, procedures, and user
    * services. For flows and procedures, another parameter, "runnableId", must be provided. This corresponds to the
    * flowlet/runnable for which to retrieve the instances. This does not apply to procedures.
-   *
+   * <p>
    * Example input:
+   * <pre><code>
    * [{"appId": "App1", "programType": "Service", "programId": "Service1", "runnableId": "Runnable1"},
-   *  {"appId": "App1", "programType": "Procedure", "programId": "Proc2"},
+   *  {"appId": "App1", "programType": "Mapreduce", "programId": "Mapreduce2"},
    *  {"appId": "App2", "programType": "Flow", "programId": "Flow1", "runnableId": "Flowlet1"}]
-   *
+   * </code></pre>
+   * </p><p>
    * The response will be an array of JsonObjects each of which will contain the three input parameters
    * as well as 3 fields:
-   * "provisioned" which maps to the number of instances actually provided for the input runnable,
-   * "requested" which maps to the number of instances the user has requested for the input runnable,
-   * "statusCode" which maps to the http status code for the data in that JsonObjects. (200, 400, 404)
-   * If an error occurs in the input (i.e. in the example above, Flowlet1 does not exist), then all JsonObjects for
+   * <ul>
+   * <li>"provisioned" which maps to the number of instances actually provided for the input runnable;</li>
+   * <li>"requested" which maps to the number of instances the user has requested for the input runnable; and</li>
+   * <li>"statusCode" which maps to the http status code for the data in that JsonObjects (200, 400, 404).</li>
+   * </ul>
+   * </p><p>
+   * If an error occurs in the input (for the example above, Flowlet1 does not exist), then all JsonObjects for
    * which the parameters have a valid instances will have the provisioned and requested fields status code fields
    * but all JsonObjects for which the parameters are not valid will have an error message and statusCode.
-   *
-   * E.g. given the above data, if there is no Flowlet1, then the response would be 200 OK with following possible data:
+   * </p><p>
+   * For example, if there is no Flowlet1 in the above data, then the response could be 200 OK with the following data:
+   * </p>
+   * <pre><code>
    * [{"appId": "App1", "programType": "Service", "programId": "Service1", "runnableId": "Runnable1",
    *   "statusCode": 200, "provisioned": 2, "requested": 2},
-   *  {"appId": "App1", "programType": "Procedure", "programId": "Proc2", "statusCode": 200, "provisioned": 1,
+   *  {"appId": "App1", "programType": "Mapreduce", "programId": "Mapreduce2", "statusCode": 200, "provisioned": 1,
    *   "requested": 3},
    *  {"appId": "App2", "programType": "Flow", "programId": "Flow1", "runnableId": "Flowlet1", "statusCode": 404,
    *   "error": "Program": Flowlet1 not found"}]
+   * </code></pre>
    */
   @POST
   @Path("/instances")

--- a/cdap-client/src/main/java/co/cask/cdap/client/config/ClientConfig.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/config/ClientConfig.java
@@ -107,7 +107,7 @@ public class ClientConfig {
    * Resolves a path against the target CDAP server with the provided namespace, using V3 APIs
    *
    * @param path Path to the HTTP endpoint. For example, "apps" would result
-   *             in a URL like "http://example.com:10000/v3/<namespace>/apps".
+   *             in a URL like "http://example.com:10000/v3/&lt;namespace&gt;/apps".
    * @return URL of the resolved path
    * @throws MalformedURLException
    */

--- a/cdap-common/src/main/java/co/cask/cdap/common/stream/StreamEventTypeAdapter.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/stream/StreamEventTypeAdapter.java
@@ -35,10 +35,11 @@ import java.util.Map;
  * A GSon {@link TypeAdapter} for serializing/deserializing {@link StreamEvent} to/from JSON. It serializes
  *
  * StreamEvent into
- * <p/>
+ * <p>
  * {@code {"timestamp": ... , "headers": { ... }, "body": ... }}
- * <p/>
- * where the the body is encoded as string binary using Bytes.toStringBinary
+ * </p><p>
+ * where the body is encoded as a string binary using Bytes.toStringBinary.
+ * </p>
  */
 public class StreamEventTypeAdapter extends TypeAdapter<StreamEvent> {
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/decoder/FormatStreamEventDecoder.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/decoder/FormatStreamEventDecoder.java
@@ -30,7 +30,7 @@ import java.util.Map;
 /**
  * A {@link StreamEventDecoder} that decodes {@link StreamEvent} into {@link LongWritable} as key
  * and {@link GenericStreamEventData} as value for Mapper input. The key carries the event timestamp, while
- * the value is a {@link GenericStreamEventData>}, which contains the event headers and the event body
+ * the value is a {@link GenericStreamEventData}, which contains the event headers and the event body
  * formatted by some {@link RecordFormat}.
  *
  * @param <T> Type of the stream body.

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamFetchHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamFetchHandler.java
@@ -88,17 +88,19 @@ public final class StreamFetchHandler extends AuthenticatedHttpHandler {
 
   /**
    * Handler for the HTTP API {@code /streams/[stream_name]/events?start=[start_ts]&end=[end_ts]&limit=[event_limit]}
-   * <p/>
+   * <p>
    * Responds with:
    * <ul>
    * <li>404 if stream does not exist</li>
    * <li>204 if no event in the given start/end time range exists</li>
    * <li>200 if there is are one or more events</li>
    * </ul>
-   * <p/>
+   * </p>
+   * <p>
    * Response body is a JSON array of the StreamEvent object.
+   * </p>
    *
-   * @see co.cask.cdap.common.stream.StreamEventTypeAdapter for the format of the StreamEvent object
+   * @see StreamEventTypeAdapter StreamEventTypeAdapter for the format of the StreamEvent object
    */
   @GET
   @Path("/{stream}/events")

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamFetchHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamFetchHandler.java
@@ -89,14 +89,16 @@ public final class StreamFetchHandler extends AuthenticatedHttpHandler {
   /**
    * Handler for the HTTP API {@code /streams/[stream_name]/events?start=[start_ts]&end=[end_ts]&limit=[event_limit]}
    * <p/>
-   * Response with
-   * 404 if stream not exists.
-   * 204 if no event in the given start/end time range
-   * 200 if there is event
+   * Responds with:
+   * <ul>
+   * <li>404 if stream does not exist</li>
+   * <li>204 if no event in the given start/end time range exists</li>
+   * <li>200 if there is are one or more events</li>
+   * </ul>
    * <p/>
-   * Response body is an Json array of StreamEvent object
+   * Response body is a JSON array of the StreamEvent object.
    *
-   * @see StreamEventTypeAdapter for the format of StreamEvent object.
+   * @see co.cask.cdap.common.stream.StreamEventTypeAdapter for the format of the StreamEvent object
    */
   @GET
   @Path("/{stream}/events")


### PR DESCRIPTION
This is a few minor Javadoc fixes. It was found by running Javadocs on the entire CDAP repo, using increased memory for Javadocs. This is what I found worked reliably:
```
MAVEN_OPTS="-Xmx512m" mvn clean site -Dmaxmemory=1024m -DskipTests
```
Running a grep over the source tree identifies a 162 potential errors that need correcting, in addition to the approximately 500 existing broken links (seen in the output the above command) that exist in the full set Javadocs:
```
grep -rnw --include=*.java . -e "^ *\*.*[<>]" | grep --ignore-case -v -e "</*[bip]/*>" -e "</*pre/*>" -e "</*[ou]l/*>" -e "</*li/*>" -e "</*h.*>" -e "</*br/*>" -e "</*code/*>" -e "</*strong/*>" -e "</*table/*.*>" -e "</*t[dhrt]/*>" -e "</*a/*.*>" -e "{@literal <}" -e "<[A-Z]>"
```