### PR TITLE
Removing Procedures, Fixing Errors in downloading logs

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricHttpHandler.java
@@ -510,25 +510,31 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
    * (flow name, service name, or procedure name). Retrieving instances only applies to flows, procedures, and user
    * services. For flows and procedures, another parameter, "runnableId", must be provided. This corresponds to the
    * flowlet/runnable for which to retrieve the instances. This does not apply to procedures.
-   *
+   * <p>
    * Example input:
+   * <pre><code>
    * [{"appId": "App1", "programType": "Service", "programId": "Service1", "runnableId": "Runnable1"},
-   *  {"appId": "App1", "programType": "Procedure", "programId": "Proc2"},
+   *  {"appId": "App1", "programType": "Mapreduce", "programId": "Mapreduce2"},
    *  {"appId": "App2", "programType": "Flow", "programId": "Flow1", "runnableId": "Flowlet1"}]
-   *
+   * </code></pre>
+   * </p><p>
    * The response will be an array of JsonObjects each of which will contain the three input parameters
    * as well as 3 fields:
-   * "provisioned" which maps to the number of instances actually provided for the input runnable,
-   * "requested" which maps to the number of instances the user has requested for the input runnable,
-   * "statusCode" which maps to the http status code for the data in that JsonObjects. (200, 400, 404)
+   * </p><ul>
+   * <li>"provisioned" which maps to the number of instances actually provided for the input runnable,</li>
+   * <li>"requested" which maps to the number of instances the user has requested for the input runnable,</li>
+   * <li>"statusCode" which maps to the http status code for the data in that JsonObjects (200, 400, 404).</li>
+   * </p><p>
    * If an error occurs in the input (i.e. in the example above, Flowlet1 does not exist), then all JsonObjects for
    * which the parameters have a valid instances will have the provisioned and requested fields status code fields
    * but all JsonObjects for which the parameters are not valid will have an error message and statusCode.
-   *
-   * E.g. given the above data, if there is no Flowlet1, then the response would be 200 OK with following possible data:
+   * </p><p>
+   * For example, if there is no Flowlet1 in the above data, then the response could be 200 OK with the following data:
+   * </p>
+   * <pre><code>
    * [{"appId": "App1", "programType": "Service", "programId": "Service1", "runnableId": "Runnable1",
    *   "statusCode": 200, "provisioned": 2, "requested": 2},
-   *  {"appId": "App1", "programType": "Procedure", "programId": "Proc2", "statusCode": 200, "provisioned": 1,
+   *  {"appId": "App1", "programType": "Mapreduce", "programId": "Mapreduce2", "statusCode": 200, "provisioned": 1,
    *   "requested": 3},
    *  {"appId": "App2", "programType": "Flow", "programId": "Flow1", "runnableId": "Flowlet1", "statusCode": 404,
    *   "error": "Runnable": Flowlet1 not found"}]
@@ -544,23 +550,33 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
    * Returns the status for all programs that are passed into the data. The data is an array of Json objects
    * where each object must contain the following three elements: appId, programType, and programId
    * (flow name, service name, etc.).
-   * <p/>
+   * <p>
    * Example input:
+   * <pre><code>
    * [{"appId": "App1", "programType": "Service", "programId": "Service1"},
-   * {"appId": "App1", "programType": "Procedure", "programId": "Proc2"},
+   * {"appId": "App1", "programType": "Mapreduce", "programId": "Mapreduce2"},
    * {"appId": "App2", "programType": "Flow", "programId": "Flow1"}]
-   * <p/>
+   * </code></pre>
+   * </p><p>
    * The response will be an array of JsonObjects each of which will contain the three input parameters
-   * as well as 2 fields, "status" which maps to the status of the program and "statusCode" which maps to the
-   * status code for the data in that JsonObjects. If an error occurs in the
+   * as well as 2 fields:
+   * <ul>
+   * <li>"status" which maps to the status of the program and </li>
+   * <li>"statusCode" which maps to the status code for the data in that JsonObjects.</li>
+   * </ul>
+   * </p><p>
+   * If an error occurs in the
    * input (i.e. in the example above, App2 does not exist), then all JsonObjects for which the parameters
    * have a valid status will have the status field but all JsonObjects for which the parameters do not have a valid
    * status will have an error message and statusCode.
-   * <p/>
-   * For example, if there is no App2 in the data above, then the response would be 200 OK with following possible data:
+   * </p><p>
+   * For example, if there is no App2 in the data above, then the response could be 200 OK with the following data:
+   * </p>
+   * <pre><code>
    * [{"appId": "App1", "programType": "Service", "programId": "Service1", "statusCode": 200, "status": "RUNNING"},
-   * {"appId": "App1", "programType": "Procedure", "programId": "Proc2"}, "statusCode": 200, "status": "STOPPED"},
+   * {"appId": "App1", "programType": "Mapreduce", "programId": "Mapreduce2", "statusCode": 200, "status": "STOPPED"},
    * {"appId":"App2", "programType":"Flow", "programId":"Flow1", "statusCode":404, "error": "App: App2 not found"}]
+   * </code></pre>
    */
   @POST
   @Path("/status")

--- a/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v3/logging.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v3/logging.rst
@@ -50,6 +50,8 @@ downloaded with the Logging HTTP API. To do that, send an HTTP GET request::
        ending ``Thu, 24 Oct 2013 01:05:00 GMT`` (five minutes later)
 
 
+.. _http-restful-api-logging_downloading_system_logs:
+
 Downloading System Logs
 -----------------------
 Logs emitted by a system service running in CDAP can be downloaded with the Logging HTTP

--- a/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v3/logging.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v3/logging.rst
@@ -41,7 +41,7 @@ downloaded with the Logging HTTP API. To do that, send an HTTP GET request::
    :stub-columns: 1
 
    * - HTTP Method
-     - ``GET <base-url>/namespaces/default/apps/WordCount/flows/WordCountFlow/``
+     - ``GET <base-url>/namespaces/default/apps/WordCount/flows/WordCountFlow/``\
        ``logs?start=1382576400&stop=1382576700``
    * - Description
      - Return the logs for all the events from the Flow *WordCountFlow* of the *WordCount*
@@ -55,7 +55,9 @@ Downloading System Logs
 Logs emitted by a system service running in CDAP can be downloaded with the Logging HTTP
 API. To do that, send an HTTP GET request::
 
-  GET <base-url>/namespaces/<namespace>/system/<component-id>/<service-id>/logs?start=<ts>&stop=<ts>
+  GET <base-url>/system/services/<service-id>/logs?start=<ts>&stop=<ts>
+  
+where:
 
 .. list-table::
    :widths: 20 80
@@ -63,15 +65,24 @@ API. To do that, send an HTTP GET request::
 
    * - Parameter
      - Description
-   * - ``<namespace>``
-     - Namespace ID
-   * - ``<component-id>``
-     - ``appfabric``
    * - ``<service-id>``
-     - [to be completed]
+     - One of ``appfabric``, ``dataset.executor``, ``explore.service``, ``metrics``, ``streams``
    * - ``<ts>``
      - *Start* and *stop* times, given as seconds since the start of the Epoch.
-     
+
+Note that the start and stop times are **not** optional.
+
+.. rubric:: Example
+.. list-table::
+   :widths: 20 80
+   :stub-columns: 1
+
+   * - HTTP Method
+     - ``GET <base-url>/services/system/appfabric/logs?start=1428541200&stop=1428541500``
+   * - Description
+     - Return the logs for the *AppFabric* 
+       beginning ``Thu, 09 Apr 2015 01:00:00 GMT`` and
+       ending ``Thu, 09 Apr 2015 01:05:00 GMT`` (five minutes later)
 
 Formatting
 ----------

--- a/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v3/logging.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v3/logging.rst
@@ -82,7 +82,7 @@ Note that the start and stop times are **not** optional.
    * - HTTP Method
      - ``GET <base-url>/services/system/appfabric/logs?start=1428541200&stop=1428541500``
    * - Description
-     - Return the logs for the *AppFabric* 
+     - Return the logs for the *AppFabric* Service
        beginning ``Thu, 09 Apr 2015 01:00:00 GMT`` and
        ending ``Thu, 09 Apr 2015 01:05:00 GMT`` (five minutes later)
 

--- a/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v3/logging.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v3/logging.rst
@@ -68,7 +68,7 @@ where:
    * - Parameter
      - Description
    * - ``<service-id>``
-     - One of ``appfabric``, ``dataset.executor``, ``explore.service``, ``metrics``, ``streams``
+     - One of ``appfabric``, ``dataset.executor``, ``explore.service``, ``metrics``, ``metrics.processor``, ``streams``, ``transaction``
    * - ``<ts>``
      - *Start* and *stop* times, given as seconds since the start of the Epoch.
 

--- a/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v3/service.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v3/service.rst
@@ -17,7 +17,7 @@ See the :ref:`http-restful-api-lifecycle` for how to control the lifecycle of Se
 Listing all Services
 --------------------
 
-You can list all Services in CDAP by issuing an HTTP GET request to the URL::
+You can list all Services in a namespace in CDAP by issuing an HTTP GET request to the URL::
 
   GET <base-url>/namespaces/<namespace>/services
 
@@ -42,6 +42,39 @@ The response body will contain a JSON-formatted list of the existing Services::
       }
       ...
   ]
+
+Listing all System Services
+---------------------------
+
+You can list all System Services in CDAP by issuing an HTTP GET request to the URL::
+
+  GET <base-url>/system/services
+
+.. list-table::
+   :widths: 20 80
+   :header-rows: 1
+
+   * - Parameter
+     - Description
+   * - ``<namespace>``
+     - Namespace ID
+     
+The response body will contain a JSON-formatted list of the existing System Services::
+
+  [
+      {
+          "name": "appfabric",
+          "description": "Service for managing application lifecycle.",
+          "status": "OK",
+          "logs": "OK",
+          "min": 1,
+          "max": 1,
+          "requested": 1,
+          "provisioned": 1
+      }
+      ...
+  ]
+
 
 Requesting Service Methods
 --------------------------

--- a/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v3/service.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/http-restful-api-v3/service.rst
@@ -49,15 +49,6 @@ Listing all System Services
 You can list all System Services in CDAP by issuing an HTTP GET request to the URL::
 
   GET <base-url>/system/services
-
-.. list-table::
-   :widths: 20 80
-   :header-rows: 1
-
-   * - Parameter
-     - Description
-   * - ``<namespace>``
-     - Namespace ID
      
 The response body will contain a JSON-formatted list of the existing System Services::
 
@@ -74,6 +65,9 @@ The response body will contain a JSON-formatted list of the existing System Serv
       }
       ...
   ]
+  
+See :ref:`downloading System Logs <http-restful-api-logging_downloading_system_logs>` for
+information and an example of using these system services.
 
 
 Requesting Service Methods


### PR DESCRIPTION
Removes Procedures from Javadocs, fixes errors in downloading logging and obtaining list of of System Services.

Staged at: http://stg-web101.sw.joyent.continuuity.net/cdap/2.8.0-r2.8_fix_logging/en/index.html
Pages of interest:
-[v3 Service RESTful API](http://stg-web101.sw.joyent.continuuity.net/cdap/2.8.0-r2.8_fix_logging/en/reference-manual/http-restful-api/http-restful-api-v3/service.html)
-[v3 Logging RESTful API](http://stg-web101.sw.joyent.continuuity.net/cdap/2.8.0-r2.8_fix_logging/en/reference-manual/http-restful-api/http-restful-api-v3/logging.html#downloading-system-logs)
