### PR TITLE
CDAP-2034: Removed unnecessary actions in AdapterClientTest, as StandaloneTestBase takes care of cleanup already

### DIFF
--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/AdapterClientTest.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/AdapterClientTest.java
@@ -113,9 +113,6 @@ public class AdapterClientTest extends ClientTestBase {
 
     List<AdapterDetail> finalList = adapterClient.list();
     Assert.assertEquals(0, finalList.size());
-
-    applicationClient.deleteAll();
-    applicationClient.waitForDeleted(TemplateApp.NAME, 30, TimeUnit.SECONDS);
   }
 
   private static void setupAdapters(File adapterDir) throws IOException {


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-2034
http://builds.cask.co/browse/CDAP-DUT1365