### PR TITLE
surface worker metrics

### DIFF
--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/MetricsHandler.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/MetricsHandler.java
@@ -94,6 +94,8 @@ public class MetricsHandler extends AuthenticatedHttpHandler {
       .put(Constants.Metrics.Tag.SERVICE, "service")
       .put(Constants.Metrics.Tag.SERVICE_RUNNABLE, "runnable")
 
+      .put(Constants.Metrics.Tag.WORKER, "worker")
+
       .put(Constants.Metrics.Tag.FLOW, "flow")
       .put(Constants.Metrics.Tag.FLOWLET, "flowlet")
       .put(Constants.Metrics.Tag.FLOWLET_QUEUE, "queue")

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/store/DefaultMetricStore.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/store/DefaultMetricStore.java
@@ -130,6 +130,14 @@ public class DefaultMetricStore implements MetricStore {
       // i.e. for service only
       ImmutableList.of(Constants.Metrics.Tag.NAMESPACE, Constants.Metrics.Tag.APP,
                        Constants.Metrics.Tag.SERVICE)));
+    // worker
+    aggs.add(new DefaultAggregation(
+      ImmutableList.of(Constants.Metrics.Tag.NAMESPACE, Constants.Metrics.Tag.APP,
+                       Constants.Metrics.Tag.WORKER, Constants.Metrics.Tag.DATASET,
+                       Constants.Metrics.Tag.RUN_ID, Constants.Metrics.Tag.INSTANCE_ID),
+      // i.e. for worker only
+      ImmutableList.of(Constants.Metrics.Tag.NAMESPACE, Constants.Metrics.Tag.APP,
+                       Constants.Metrics.Tag.WORKER)));
 
     // procedure
     aggs.add(new DefaultAggregation(


### PR DESCRIPTION
worker metrics didn't have aggregation group defined, so we weren't collecting metrics emitted from worker. this is the fix.