### PR TITLE
(CDAP-2043) Make AvroRecordFormat decodes Avro binary data into StructuredRecord

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/data/format/StructuredRecord.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/data/format/StructuredRecord.java
@@ -19,8 +19,8 @@ package co.cask.cdap.api.data.format;
 import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.data.schema.Schema;
-import com.google.common.collect.Maps;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -80,7 +80,7 @@ public class StructuredRecord {
 
     private Builder(Schema schema) {
       this.schema = schema;
-      this.fields = Maps.newHashMap();
+      this.fields = new HashMap<String, Object>();
     }
 
     /**

--- a/cdap-api/src/main/java/co/cask/cdap/api/data/schema/Schema.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/data/schema/Schema.java
@@ -44,7 +44,7 @@ import java.util.Set;
  */
 @Beta
 public final class Schema {
-  private static final SchemaTypeAdapter schemaTypeAdapter = new SchemaTypeAdapter();
+  private static final SchemaTypeAdapter SCHEMA_TYPE_ADAPTER = new SchemaTypeAdapter();
 
   /**
    * Types known to Schema.
@@ -126,7 +126,7 @@ public final class Schema {
    * @throws IOException if there was an exception parsing the schema
    */
   public static Schema parseJson(String schemaJson) throws IOException {
-    return schemaTypeAdapter.fromJson(schemaJson);
+    return SCHEMA_TYPE_ADAPTER.fromJson(schemaJson);
   }
 
   /**
@@ -137,7 +137,7 @@ public final class Schema {
    * @throws IOException if there was an exception parsing the schema
    */
   public static Schema parseJson(Reader reader) throws IOException {
-    return schemaTypeAdapter.fromJson(reader);
+    return SCHEMA_TYPE_ADAPTER.fromJson(reader);
   }
 
   /**
@@ -760,7 +760,7 @@ public final class Schema {
     StringBuilder builder = new StringBuilder();
     JsonWriter writer = new JsonWriter(CharStreams.asWriter(builder));
     try {
-      schemaTypeAdapter.write(writer, this);
+      SCHEMA_TYPE_ADAPTER.write(writer, this);
       writer.close();
       return builder.toString();
     } catch (IOException e) {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/format/StructuredRecordDatumReader.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/format/StructuredRecordDatumReader.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data.format;
+
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import com.google.common.collect.Lists;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.io.ResolvingDecoder;
+
+import java.io.IOException;
+import java.util.Collection;
+
+/**
+ * An Avro {@link DatumReader} that reads data into {@link StructuredRecord}.
+ */
+public class StructuredRecordDatumReader extends GenericDatumReader<StructuredRecord> {
+
+  private Schema currentSchema;
+
+  /**
+   * Constructs a new instance.
+   *
+   * @param schema The schema for the {@link StructuredRecord} created through this class
+   * @param avroSchema The Avro Schema equivalent of the schema
+   */
+  public StructuredRecordDatumReader(Schema schema, org.apache.avro.Schema avroSchema) {
+    this.currentSchema = schema;
+    setExpected(avroSchema);
+  }
+
+  @Override
+  protected Object read(Object old, org.apache.avro.Schema expected, ResolvingDecoder in) throws IOException {
+    if (expected.getType() != org.apache.avro.Schema.Type.UNION) {
+      return super.read(old, expected, in);
+    }
+
+    // For Union type
+    Schema tmpSchema = currentSchema;
+    try {
+      int idx = in.readIndex();
+      currentSchema = currentSchema.getUnionSchema(idx);
+      return read(old, expected.getTypes().get(idx), in);
+    } finally {
+      currentSchema = tmpSchema;
+    }
+  }
+
+  @Override
+  protected Object newArray(Object old, int size, org.apache.avro.Schema schema) {
+    if (old instanceof Collection) {
+      ((Collection) old).clear();
+      return old;
+    } else {
+      return Lists.newArrayListWithExpectedSize(size);
+    }
+  }
+
+  @Override
+  protected Object createEnum(String symbol, org.apache.avro.Schema schema) {
+    return symbol;
+  }
+
+  @Override
+  protected Object readString(Object old, Decoder in) throws IOException {
+    // super.readString returns an Utf8 object. Calling toString() to turn it into a String.
+    return super.readString(old, in).toString();
+  }
+
+  @Override
+  protected Object readArray(Object old, org.apache.avro.Schema expected, ResolvingDecoder in) throws IOException {
+    Schema tmpSchema = currentSchema;
+    try {
+      currentSchema = currentSchema.getComponentSchema();
+      return super.readArray(old, expected, in);
+    } finally {
+      currentSchema = tmpSchema;
+    }
+  }
+
+  @Override
+  protected Object readMap(Object old, org.apache.avro.Schema expected, ResolvingDecoder in) throws IOException {
+    Schema tmpSchema = currentSchema;
+    try {
+      currentSchema = tmpSchema.getMapSchema().getValue();
+      return super.readMap(old, expected, in);
+    } finally {
+      currentSchema = tmpSchema;
+    }
+  }
+
+  @Override
+  protected Object readRecord(Object old, org.apache.avro.Schema expected, ResolvingDecoder in) throws IOException {
+    StructuredRecord.Builder builder = StructuredRecord.builder(currentSchema);
+
+    for (org.apache.avro.Schema.Field f : in.readFieldOrder()) {
+      String name = f.name();
+      Schema tmpSchema = currentSchema;
+      try {
+        currentSchema = getFieldSchema(name, currentSchema);
+        builder.set(name, read(null, f.schema(), in));
+      } finally {
+        currentSchema = tmpSchema;
+      }
+    }
+    return builder.build();
+  }
+
+  /**
+   * Returns the {@link Schema} of the given field in the record.
+   *
+   * @throws IllegalArgumentException if the field does not exist in the record schema.
+   */
+  private Schema getFieldSchema(String fieldName, Schema recordSchema) {
+    Schema.Field field = recordSchema.getField(fieldName);
+    if (field == null) {
+      throw new IllegalArgumentException("Field '" + fieldName + "' not exists in record '" + recordSchema + "'");
+    }
+    return field.getSchema();
+  }
+}

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/serde/ObjectDeserializer.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/serde/ObjectDeserializer.java
@@ -24,7 +24,6 @@ import co.cask.cdap.hive.objectinspector.ObjectInspectorFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import org.apache.avro.generic.GenericRecord;
 import org.apache.hadoop.hive.serde.serdeConstants;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
@@ -33,7 +32,6 @@ import org.apache.hadoop.hive.serde2.typeinfo.MapTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.StructTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
-import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
 
 import java.lang.reflect.Array;
@@ -321,9 +319,6 @@ public class ObjectDeserializer {
     throws NoSuchFieldException, IllegalAccessException {
     if (record instanceof StructuredRecord) {
       return ((StructuredRecord) record).get(fieldName);
-    }
-    if (record instanceof GenericRecord) {
-      return ((GenericRecord) record).get(fieldName);
     }
     Class recordClass = record.getClass();
     Field field = recordClass.getDeclaredField(fieldName);

--- a/cdap-unit-test/src/test/java/co/cask/cdap/mapreduce/AppWithMapReduceUsingStream.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/mapreduce/AppWithMapReduceUsingStream.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.app.AbstractApplication;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.data.format.FormatSpecification;
 import co.cask.cdap.api.data.format.Formats;
+import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.data.stream.Stream;
 import co.cask.cdap.api.data.stream.StreamBatchReadable;
@@ -27,7 +28,6 @@ import co.cask.cdap.api.dataset.lib.KeyValueTable;
 import co.cask.cdap.api.mapreduce.AbstractMapReduce;
 import co.cask.cdap.api.mapreduce.MapReduceContext;
 import co.cask.cdap.api.stream.GenericStreamEventData;
-import org.apache.avro.generic.GenericRecord;
 import org.apache.hadoop.io.FloatWritable;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Text;
@@ -81,15 +81,15 @@ public class AppWithMapReduceUsingStream extends AbstractApplication {
 
   // reads input from the stream as avro and calculates the total prices of all stocks traded
   public static class TickerMapper extends
-    Mapper<LongWritable, GenericStreamEventData<GenericRecord>, Text, FloatWritable> {
+    Mapper<LongWritable, GenericStreamEventData<StructuredRecord>, Text, FloatWritable> {
 
     @Override
-    public void map(LongWritable key, GenericStreamEventData<GenericRecord> eventData, Context context)
+    public void map(LongWritable key, GenericStreamEventData<StructuredRecord> eventData, Context context)
       throws IOException, InterruptedException {
-      GenericRecord body = eventData.getBody();
+      StructuredRecord body = eventData.getBody();
       String ticker = body.get("ticker").toString();
-      Integer numTraded = (Integer) body.get("num_traded");
-      Float price = (Float) body.get("price");
+      Integer numTraded = body.get("num_traded");
+      Float price = body.get("price");
       context.write(new Text(ticker), new FloatWritable(numTraded * price));
     }
   }


### PR DESCRIPTION
We never expose `GenericRecord` class through Program ClassLoader, hence having the record format emit `GenericRecord` would make it unusable from the user program (there will be class cast exception if avro jar is bundled with user program jar).