### PR TITLE
Adding Access to Documentation Timeline...and other Cask Data Sites

### DIFF
--- a/cdap-docs/_common/_themes/cdap/casksites.html
+++ b/cdap-docs/_common/_themes/cdap/casksites.html
@@ -5,23 +5,11 @@
     
 #}
 <div role="note" aria-label="other links">
-    <h3>Cask Data Sites</h3>
+    <h3><a href="http://docs.cask.co/" target="_blank">Documentation</a></h3>
     <ul class="this-page-menu">
-      <li><a href="http://docs.cask.co/">Cask Data Documentation <em>(docs.cask.co)</em></a></li>
-        <ul>
-        <li><a href="http://docs.cask.co/cdap/index.html">CDAP</a></li>
-        <li><a href="http://docs.cask.co/coopr/index.html">Coopr</a></li>
-        <li><a href="http://docs.cask.co/tephra/index.html">Tephra</em></a></li>
-        <li><a href="http://docs.cask.co/tigon/index.html">Tigon</a></li>
-        </ul>
-    </ul>
-    <ul class="this-page-menu">
-      <li><a href="http://cask.co/">Cask Data <em>(cask.co)</em></a></li>
-        <ul>
-        <li><a href="http://cdap.io/">CDAP <em>(cdap.io)</em></a></li>
-        <li><a href="http://coopr.io/">Coopr <em>(coopr.io)</em></a></li>
-        <li><a href="http://tephra.io/">Tephra <em>(tephra.io)</em></a></li>
-        <li><a href="http://tigon.io/">Tigon <em>(tigon.io)</em></a></li>
-        </ul>
+        <li><a href="http://docs.cask.co/cdap/index.html" target="_blank">CDAP</a></li>
+        <li><a href="http://docs.cask.co/coopr/index.html" target="_blank">Coopr</a></li>
+        <li><a href="http://docs.cask.co/tephra/index.html" target="_blank">Tephra</em></a></li>
+        <li><a href="http://docs.cask.co/tigon/index.html" target="_blank">Tigon</a></li>
     </ul>
 </div>

--- a/cdap-docs/_common/_themes/cdap/casksites.html
+++ b/cdap-docs/_common/_themes/cdap/casksites.html
@@ -14,6 +14,8 @@
         <li><a href="http://docs.cask.co/tephra/index.html">Tephra</em></a></li>
         <li><a href="http://docs.cask.co/tigon/index.html">Tigon</a></li>
         </ul>
+    </ul>
+    <ul class="this-page-menu">
       <li><a href="http://cask.co/">Cask Data <em>(cask.co)</em></a></li>
         <ul>
         <li><a href="http://cdap.io/">CDAP <em>(cdap.io)</em></a></li>

--- a/cdap-docs/_common/_themes/cdap/casksites.html
+++ b/cdap-docs/_common/_themes/cdap/casksites.html
@@ -1,0 +1,25 @@
+{#
+    casksites.html
+    ~~~~~~~~~~~~~~~~~~~~~
+    Sphinx sidebar template: "CDAP Data Sites" links.
+    
+#}
+<div role="note" aria-label="other links">
+    <h3>Cask Data Sites</h3>
+    <ul class="this-page-menu">
+      <li><a href="http://docs.cask.co/">Cask Data Documentation <em>(docs.cask.co)</em></a></li>
+        <ul>
+        <li><a href="http://docs.cask.co/cdap/index.html">CDAP</a></li>
+        <li><a href="http://docs.cask.co/coopr/index.html">Coopr</a></li>
+        <li><a href="http://docs.cask.co/tephra/index.html">Tephra</em></a></li>
+        <li><a href="http://docs.cask.co/tigon/index.html">Tigon</a></li>
+        </ul>
+      <li><a href="http://cask.co/">Cask Data <em>(cask.co)</em></a></li>
+        <ul>
+        <li><a href="http://cdap.io/">CDAP <em>(cdap.io)</em></a></li>
+        <li><a href="http://coopr.io/">Coopr <em>(coopr.io)</em></a></li>
+        <li><a href="http://tephra.io/">Tephra <em>(tephra.io)</em></a></li>
+        <li><a href="http://tigon.io/">Tigon <em>(tigon.io)</em></a></li>
+        </ul>
+    </ul>
+</div>

--- a/cdap-docs/_common/common_conf.py
+++ b/cdap-docs/_common/common_conf.py
@@ -232,7 +232,9 @@ html_theme = 'cdap'
 # versions points to the JSON file on the webservers
 # versions_data is used to generate the JSONP file at http://docs.cask.co/cdap/json-versions.js
 # format is a dictionary, with "development" and "older" lists of lists, and "current" a list, 
-# the inner-lists being the directory and a label
+# the inner-lists being the directory, a label, and the release date in YYYY-MM-DD format.
+# The label is currently not used in output, but is there for a future possibility of using 
+# a label instead of the directory to identify a release.
 #
 # manual_list is an ordered list of the manuals
 # Fields: directory, manual name, icon 
@@ -261,10 +263,17 @@ html_theme_options = {
   "versions":"http://docs.cask.co/cdap/json-versions.js",
   "versions_data":
     { "development": 
-        [ ["2.8.0-SNAPSHOT", "2.8.0"], ], 
-      "current": ["2.7.1", "2.7.1"], 
-      "older": 
-        [ ["2.6.1", "2.6.1"],["2.6.0", "2.6.0"],["2.5.2", "2.5.2"], ["2.5.1", "2.5.1"], ["2.5.0", "2.5.0"], ], 
+        [ ['3.0.0-SNAPSHOT', '3.0.0'], ], 
+      "current": ['2.8.0', '2.8.0', '2015-03-23'], 
+      "older": [ 
+        ['2.7.1', '2.7.1', '2015-02-05'], 
+        ['2.6.2', '2.6.2', '2015-03-23'], 
+        ['2.6.1', '2.6.1', '2015-01-29'], 
+        ['2.6.0', '2.6.0', '2015-01-10'], 
+        ['2.5.2', '2.5.2', '2014-11-14'], 
+        ['2.5.1', '2.5.1', '2014-10-15'], 
+        ['2.5.0', '2.5.0', '2014-09-26'],
+        ],
     },
 }
 

--- a/cdap-docs/_common/common_conf.py
+++ b/cdap-docs/_common/common_conf.py
@@ -335,7 +335,14 @@ html_static_path = ['../../_common/_static']
 #html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
-html_sidebars = {'**': ['manuals.html', 'globaltoc.html', 'relations.html', 'downloads.html', 'searchbox.html', ],}
+html_sidebars = {'**': [
+    'manuals.html', 
+    'globaltoc.html', 
+    'relations.html', 
+    'downloads.html', 
+    'searchbox.html',
+    'casksites.html',
+     ],}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.


### PR DESCRIPTION
This PR adds a short list of links to the bottom of the left sidebar of each page of the documentation, back to the other documentation pages. Up on the highest-level CDAP page is the new timeline (http://docs.cask.co/cdap/index.html).

It updates the version information used to generate the timeline in the common_conf.py.

This is staged at: http://stg-web101.sw.joyent.continuuity.net/cdap/3.0.0-SNAPSHOT-3.0_add_doc_timeline/en/index.html

See the lower-left portion of the left sidebar for the new "Documentation" section that lists all documentation directories.

Issue: https://issues.cask.co/browse/CDAP-1985