### PR TITLE
CDAP-1958 Job-level and Task-level information (historical and current) ...

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/mapreduce/MRJobClient.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/mapreduce/MRJobClient.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package co.cask.cdap.gateway.handlers;
+package co.cask.cdap.app.mapreduce;
 
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
@@ -22,6 +22,8 @@ import co.cask.cdap.common.exception.NotFoundException;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.MRJobInfo;
 import co.cask.cdap.proto.MRTaskInfo;
+import co.cask.cdap.proto.ProgramType;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.inject.Inject;
@@ -53,7 +55,7 @@ public class MRJobClient {
     int numRetries = cConf.getInt(Constants.AppFabric.MAPREDUCE_JOB_CLIENT_CONNECT_MAX_RETRIES);
     this.hConf = new Configuration(hConf);
     // Override a cloned hConf's configuration of IPC Client max retries based upon value in CConf to avoid longer
-    // amounts of retrying (especially when the Job History Server is not installed)
+    // amounts of retrying (this is helpful especially when the Job History Server is not installed)
     this.hConf.setInt(CommonConfigurationKeysPublic.IPC_CLIENT_CONNECT_MAX_RETRIES_KEY, numRetries);
   }
 
@@ -64,6 +66,8 @@ public class MRJobClient {
    * @throws NotFoundException if a Job with the given runId is not found.
    */
   public MRJobInfo getMRJobInfo(Id.Run runId) throws IOException, NotFoundException {
+    Preconditions.checkArgument(ProgramType.MAPREDUCE.equals(runId.getProgram().getType()));
+
     JobClient jobClient;
     JobStatus[] jobs;
     try {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/mapreduce/MapReduceMetricsInfo.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/mapreduce/MapReduceMetricsInfo.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.mapreduce;
+
+import co.cask.cdap.api.dataset.lib.cube.TimeValue;
+import co.cask.cdap.api.metrics.MetricDataQuery;
+import co.cask.cdap.api.metrics.MetricStore;
+import co.cask.cdap.api.metrics.MetricTimeSeries;
+import co.cask.cdap.api.metrics.MetricType;
+import co.cask.cdap.app.metrics.MapReduceMetrics;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.MRJobInfo;
+import co.cask.cdap.proto.MRTaskInfo;
+import co.cask.cdap.proto.ProgramType;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Table;
+import com.google.inject.Inject;
+import org.apache.hadoop.mapreduce.TaskCounter;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Retrieves information/reports for a MapReduce run via the Metrics system.
+ */
+public class MapReduceMetricsInfo {
+
+  private final MetricStore metricStore;
+
+  @Inject
+  public MapReduceMetricsInfo(MetricStore metricStore) {
+    this.metricStore = metricStore;
+  }
+
+  /**
+   * @param runId for which information will be returned.
+   * @return a {@link MRJobInfo} containing information about a particular MapReduce program run.
+   */
+  public MRJobInfo getMRJobInfo(Id.Run runId) throws Exception {
+    Preconditions.checkArgument(ProgramType.MAPREDUCE.equals(runId.getProgram().getType()));
+
+    // baseTags has tag keys: ns.app.mr.runid
+    Map<String, String> baseTags = Maps.newHashMap();
+    baseTags.put(Constants.Metrics.Tag.NAMESPACE, runId.getNamespace().getId());
+    baseTags.put(Constants.Metrics.Tag.APP, runId.getProgram().getApplicationId());
+    baseTags.put(Constants.Metrics.Tag.MAPREDUCE, runId.getProgram().getId());
+    baseTags.put(Constants.Metrics.Tag.RUN_ID, runId.getId());
+
+    Map<String, String> mapTags = Maps.newHashMap(baseTags);
+    mapTags.put(Constants.Metrics.Tag.MR_TASK_TYPE, MapReduceMetrics.TaskType.Mapper.getId());
+
+    Map<String, String> reduceTags = Maps.newHashMap(baseTags);
+    reduceTags.put(Constants.Metrics.Tag.MR_TASK_TYPE, MapReduceMetrics.TaskType.Reducer.getId());
+
+    // map from RunId -> (CounterName -> CounterValue)
+    Table<String, String, Long> mapTaskMetrics = HashBasedTable.create();
+    Table<String, String, Long> reduceTaskMetrics = HashBasedTable.create();
+
+
+    // Populate mapTaskMetrics and reduce Task Metrics via MetricStore. Used to construct MRTaskInfo below.
+    // Use batch-querying when it is available on the MetricStore. https://issues.cask.co/browse/CDAP-2045
+    putMetrics(queryGroupedAggregates(mapTags, MapReduceMetrics.METRIC_INPUT_RECORDS),
+               mapTaskMetrics, TaskCounter.MAP_INPUT_RECORDS.name());
+    putMetrics(queryGroupedAggregates(mapTags, MapReduceMetrics.METRIC_OUTPUT_RECORDS),
+               mapTaskMetrics, TaskCounter.MAP_OUTPUT_RECORDS.name());
+    putMetrics(queryGroupedAggregates(mapTags, MapReduceMetrics.METRIC_BYTES),
+               mapTaskMetrics, TaskCounter.MAP_OUTPUT_BYTES.name());
+
+    Map<String, Long> mapProgress = queryGroupedAggregates(mapTags, MapReduceMetrics.METRIC_TASK_COMPLETION);
+
+    putMetrics(queryGroupedAggregates(reduceTags, MapReduceMetrics.METRIC_INPUT_RECORDS),
+               reduceTaskMetrics, TaskCounter.REDUCE_INPUT_RECORDS.name());
+    putMetrics(queryGroupedAggregates(reduceTags, MapReduceMetrics.METRIC_OUTPUT_RECORDS),
+               reduceTaskMetrics, TaskCounter.REDUCE_OUTPUT_RECORDS.name());
+
+    Map<String, Long> reduceProgress = queryGroupedAggregates(reduceTags, MapReduceMetrics.METRIC_TASK_COMPLETION);
+
+    // Construct MRTaskInfos from the information we can get from Metric system.
+    List<MRTaskInfo> mapTaskInfos = Lists.newArrayList();
+    for (Map.Entry<String, Map<String, Long>> taskEntry : mapTaskMetrics.rowMap().entrySet()) {
+      String mapTaskId = taskEntry.getKey();
+      mapTaskInfos.add(new MRTaskInfo(mapTaskId, null, null, null,
+                                      mapProgress.get(mapTaskId) / 100.0F, taskEntry.getValue()));
+    }
+
+    List<MRTaskInfo> reduceTaskInfos = Lists.newArrayList();
+    for (Map.Entry<String, Map<String, Long>> taskEntry : reduceTaskMetrics.rowMap().entrySet()) {
+      String reduceTaskId = taskEntry.getKey();
+      reduceTaskInfos.add(new MRTaskInfo(reduceTaskId, null, null, null,
+                                         reduceProgress.get(reduceTaskId) / 100.0F, taskEntry.getValue()));
+    }
+
+    return getJobCounters(mapTags, reduceTags, mapTaskInfos, reduceTaskInfos);
+  }
+
+
+  /**
+   * Copies metric values from {@param taskMetrics} to {@param allTaskMetrics}.
+   * This is necessary because we read metrics from MetricStore in batch (one query for all map or reduce tasks
+   * via the MetricStore GroupBy functionality).
+   * @param taskMetrics mapping: TaskId -> metricValue
+   * @param allTaskMetrics mapping: TaskId -> (CounterName -> CounterValue)
+   * @param counterName the name of the key to copy over
+   */
+  private void putMetrics(Map<String, Long> taskMetrics, Table<String, String, Long> allTaskMetrics,
+                          String counterName) {
+    for (Map.Entry<String, Long> entry : taskMetrics.entrySet()) {
+      allTaskMetrics.put(entry.getKey(), counterName, entry.getValue());
+    }
+  }
+
+  private MRJobInfo getJobCounters(Map<String, String> mapTags, Map<String, String> reduceTags,
+                                   List<MRTaskInfo> mapTaskInfos, List<MRTaskInfo> reduceTaskInfos) throws Exception {
+    HashMap<String, Long> metrics = Maps.newHashMap();
+    // Use batch-querying when it is available on the MetricStore. https://issues.cask.co/browse/CDAP-2045
+    metrics.put(TaskCounter.MAP_INPUT_RECORDS.name(),
+                getAggregates(mapTags, MapReduceMetrics.METRIC_INPUT_RECORDS));
+    metrics.put(TaskCounter.MAP_OUTPUT_RECORDS.name(),
+                getAggregates(mapTags, MapReduceMetrics.METRIC_OUTPUT_RECORDS));
+    metrics.put(TaskCounter.MAP_OUTPUT_BYTES.name(),
+                getAggregates(mapTags, MapReduceMetrics.METRIC_BYTES));
+
+    metrics.put(TaskCounter.REDUCE_INPUT_RECORDS.name(),
+                getAggregates(reduceTags, MapReduceMetrics.METRIC_INPUT_RECORDS));
+    metrics.put(TaskCounter.REDUCE_OUTPUT_RECORDS.name(),
+                getAggregates(reduceTags, MapReduceMetrics.METRIC_OUTPUT_RECORDS));
+
+    float mapProgress = getAggregates(mapTags, MapReduceMetrics.METRIC_COMPLETION) / 100.0F;
+    float reduceProgress = getAggregates(reduceTags, MapReduceMetrics.METRIC_COMPLETION) / 100.0F;
+
+    return new MRJobInfo(null, null, null, mapProgress, reduceProgress, metrics, mapTaskInfos, reduceTaskInfos);
+  }
+
+  private String prependSystem(String metric) {
+    return "system." + metric;
+  }
+
+  private long getAggregates(Map<String, String> tags, String metric) throws Exception {
+    MetricDataQuery metricDataQuery =
+      new MetricDataQuery(0, Integer.MAX_VALUE, Integer.MAX_VALUE, prependSystem(metric), MetricType.COUNTER, tags,
+                          ImmutableList.<String>of());
+    Collection<MetricTimeSeries> query = metricStore.query(metricDataQuery);
+    if (query.isEmpty()) {
+      return 0;
+    }
+    MetricTimeSeries timeSeries = Iterables.getOnlyElement(query);
+    List<TimeValue> timeValues = timeSeries.getTimeValues();
+    TimeValue timeValue = Iterables.getOnlyElement(timeValues);
+    return timeValue.getValue();
+  }
+
+  // queries MetricStore for one metric across all tasks of a certain TaskType, using GroupBy InstanceId
+  private Map<String, Long> queryGroupedAggregates(Map<String, String> tags, String metric) throws Exception {
+    MetricDataQuery metricDataQuery =
+      new MetricDataQuery(0, Integer.MAX_VALUE, Integer.MAX_VALUE, prependSystem(metric), MetricType.GAUGE, tags,
+                          ImmutableList.of(Constants.Metrics.Tag.INSTANCE_ID));
+    Collection<MetricTimeSeries> query = metricStore.query(metricDataQuery);
+
+    // runId -> metricValue
+    Map<String, Long> taskMetrics = Maps.newHashMap();
+    for (MetricTimeSeries metricTimeSeries : query) {
+      List<TimeValue> timeValues = metricTimeSeries.getTimeValues();
+      TimeValue timeValue = Iterables.getOnlyElement(timeValues);
+      String taskId = metricTimeSeries.getTagValues().get(Constants.Metrics.Tag.INSTANCE_ID);
+      taskMetrics.put(taskId, timeValue.getValue());
+    }
+    return taskMetrics;
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/metrics/MapReduceMetrics.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/metrics/MapReduceMetrics.java
@@ -21,6 +21,14 @@ package co.cask.cdap.app.metrics;
  * todo: extract TaskType enum in its own class
  */
 public final class MapReduceMetrics {
+  public static final String METRIC_INPUT_RECORDS = "process.entries.in";
+  public static final String METRIC_OUTPUT_RECORDS = "process.entries.out";
+  public static final String METRIC_BYTES = "process.bytes";
+  public static final String METRIC_COMPLETION = "process.completion";
+  public static final String METRIC_TASK_COMPLETION = "process.completion.task";
+  public static final String METRIC_USED_CONTAINERS = "resources.used.containers";
+  public static final String METRIC_USED_MEMORY = "resources.used.memory";
+
   /**
    * Type of map reduce task.
    */

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
@@ -24,6 +24,8 @@ import co.cask.cdap.api.schedule.ScheduleSpecification;
 import co.cask.cdap.api.service.ServiceSpecification;
 import co.cask.cdap.api.service.ServiceWorkerSpecification;
 import co.cask.cdap.app.ApplicationSpecification;
+import co.cask.cdap.app.mapreduce.MRJobClient;
+import co.cask.cdap.app.mapreduce.MapReduceMetricsInfo;
 import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.program.Programs;
 import co.cask.cdap.app.runtime.ProgramController;
@@ -125,6 +127,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   private final SchedulerQueueResolver schedulerQueueResolver;
   private final NamespacedLocationFactory namespacedLocationFactory;
   private MRJobClient mrJobClient;
+  private MapReduceMetricsInfo mapReduceMetricsInfo;
 
   /**
    * Convenience class for representing the necessary components for retrieving status
@@ -194,7 +197,8 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
                                      CConfiguration cConf, ProgramRuntimeService runtimeService,
                                      DiscoveryServiceClient discoveryServiceClient, QueueAdmin queueAdmin,
                                      Scheduler scheduler, PreferencesStore preferencesStore,
-                                     NamespacedLocationFactory namespacedLocationFactory, MRJobClient mrJobClient) {
+                                     NamespacedLocationFactory namespacedLocationFactory, MRJobClient mrJobClient,
+                                     MapReduceMetricsInfo mapReduceMetricsInfo) {
     super(authenticator);
     this.namespacedLocationFactory = namespacedLocationFactory;
     this.store = store;
@@ -206,6 +210,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
     this.preferencesStore = preferencesStore;
     this.schedulerQueueResolver = new SchedulerQueueResolver(cConf, store);
     this.mrJobClient = mrJobClient;
+    this.mapReduceMetricsInfo = mapReduceMetricsInfo;
   }
 
   /**
@@ -223,23 +228,29 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
       Id.Run run = new Id.Run(programId, runId);
       ApplicationSpecification appSpec = store.getApplication(programId.getApplication());
       if (appSpec == null) {
-        responder.sendString(HttpResponseStatus.NOT_FOUND, String.format("Application not found: %s",
-                                                                         programId.getApplication()));
-        return;
+        throw new NotFoundException(programId.getApplication());
       }
       if (!appSpec.getMapReduce().containsKey(mapreduceId)) {
-        responder.sendString(HttpResponseStatus.NOT_FOUND, String.format("Program not found: %s", programId));
-        return;
+        throw new NotFoundException(programId);
+      }
+      if (store.getRun(programId, runId) == null) {
+        throw new NotFoundException(run);
       }
 
-      MRJobInfo mrJobInfo = mrJobClient.getMRJobInfo(run);
+
+      MRJobInfo mrJobInfo;
+      try {
+        mrJobInfo = mrJobClient.getMRJobInfo(run);
+      } catch (IOException ioe) {
+        LOG.warn("Failed to get run history from JobClient for runId: {}. Falling back to Metrics system.", run, ioe);
+        mrJobInfo = mapReduceMetricsInfo.getMRJobInfo(run);
+      }
+
+
       responder.sendJson(HttpResponseStatus.OK, mrJobInfo);
     } catch (NotFoundException e) {
-      LOG.debug("RunId not found: {}", runId, e);
+      LOG.warn("NotFoundException while getting MapReduce Run info.", e);
       responder.sendString(HttpResponseStatus.NOT_FOUND, e.getMessage());
-    } catch (IOException ioe) {
-      LOG.warn("Failed to get run history for runId: {}", runId, ioe);
-      responder.sendStatus(HttpResponseStatus.SERVICE_UNAVAILABLE);
     } catch (Exception e) {
       LOG.error("Failed to get run history for runId: {}", runId, e);
       responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, e.getMessage());

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/WorkflowHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/WorkflowHttpHandler.java
@@ -19,6 +19,8 @@ package co.cask.cdap.gateway.handlers;
 import co.cask.cdap.api.schedule.SchedulableProgramType;
 import co.cask.cdap.api.schedule.ScheduleSpecification;
 import co.cask.cdap.app.ApplicationSpecification;
+import co.cask.cdap.app.mapreduce.MRJobClient;
+import co.cask.cdap.app.mapreduce.MapReduceMetricsInfo;
 import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.app.runtime.ProgramRuntimeService;
 import co.cask.cdap.app.runtime.RunIds;
@@ -40,7 +42,6 @@ import com.google.common.collect.Lists;
 import com.google.gson.reflect.TypeToken;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.jboss.netty.handler.codec.http.HttpHeaders;
 import org.jboss.netty.handler.codec.http.HttpRequest;
@@ -67,12 +68,12 @@ public class WorkflowHttpHandler extends ProgramLifecycleHttpHandler {
 
   @Inject
   public WorkflowHttpHandler(Authenticator authenticator, Store store, WorkflowClient workflowClient,
-                             Configuration hConf, CConfiguration configuration, ProgramRuntimeService runtimeService,
+                             CConfiguration configuration, ProgramRuntimeService runtimeService,
                              DiscoveryServiceClient discoveryServiceClient, QueueAdmin queueAdmin, Scheduler scheduler,
                              PreferencesStore preferencesStore, NamespacedLocationFactory namespacedLocationFactory,
-                             MRJobClient mrJobClient) {
+                             MRJobClient mrJobClient, MapReduceMetricsInfo mapReduceMetricsInfo) {
     super(authenticator, store, configuration, runtimeService, discoveryServiceClient,
-          queueAdmin, scheduler, preferencesStore, namespacedLocationFactory, mrJobClient);
+          queueAdmin, scheduler, preferencesStore, namespacedLocationFactory, mrJobClient, mapReduceMetricsInfo);
     this.workflowClient = workflowClient;
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceMetricsWriter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceMetricsWriter.java
@@ -41,13 +41,6 @@ import java.util.Map;
  */
 public class MapReduceMetricsWriter {
   private static final Logger LOG = LoggerFactory.getLogger(MapReduceMetricsWriter.class);
-  private static final String METRIC_INPUT_RECORDS = "process.entries.in";
-  private static final String METRIC_OUTPUT_RECORDS = "process.entries.out";
-  private static final String METRIC_BYTES = "process.bytes";
-  private static final String METRIC_COMPLETION = "process.completion";
-  private static final String METRIC_TASK_COMPLETION = "process.completion.task";
-  private static final String METRIC_USED_CONTAINERS = "resources.used.containers";
-  private static final String METRIC_USED_MEMORY = "resources.used.memory";
 
   private final Job jobConf;
   private final BasicMapReduceContext context;
@@ -102,9 +95,9 @@ public class MapReduceMetricsWriter {
     int memoryPerMapper = jobConf.getConfiguration().getInt(Job.MAP_MEMORY_MB, Job.DEFAULT_MAP_MEMORY_MB);
     int memoryPerReducer = jobConf.getConfiguration().getInt(Job.REDUCE_MEMORY_MB, Job.DEFAULT_REDUCE_MEMORY_MB);
 
-    mapperMetrics.gauge(METRIC_COMPLETION, (long) (mapProgress * 100));
-    mapperMetrics.gauge(METRIC_USED_CONTAINERS, runningMappers);
-    mapperMetrics.gauge(METRIC_USED_MEMORY, runningMappers * memoryPerMapper);
+    mapperMetrics.gauge(MapReduceMetrics.METRIC_COMPLETION, (long) (mapProgress * 100));
+    mapperMetrics.gauge(MapReduceMetrics.METRIC_USED_CONTAINERS, runningMappers);
+    mapperMetrics.gauge(MapReduceMetrics.METRIC_USED_MEMORY, runningMappers * memoryPerMapper);
 
     LOG.trace("Reporting mapper stats: (completion, containers, memory) = ({}, {}, {})",
               (int) (mapProgress * 100), runningMappers, runningMappers * memoryPerMapper);
@@ -112,9 +105,9 @@ public class MapReduceMetricsWriter {
     // reduce stats
     float reduceProgress = jobStatus.getReduceProgress();
 
-    reducerMetrics.gauge(METRIC_COMPLETION, (long) (reduceProgress * 100));
-    reducerMetrics.gauge(METRIC_USED_CONTAINERS, runningReducers);
-    reducerMetrics.gauge(METRIC_USED_MEMORY, runningReducers * memoryPerReducer);
+    reducerMetrics.gauge(MapReduceMetrics.METRIC_COMPLETION, (long) (reduceProgress * 100));
+    reducerMetrics.gauge(MapReduceMetrics.METRIC_USED_CONTAINERS, runningReducers);
+    reducerMetrics.gauge(MapReduceMetrics.METRIC_USED_MEMORY, runningReducers * memoryPerReducer);
 
     LOG.trace("Reporting reducer stats: (completion, containers, memory) = ({}, {}, {})",
               (int) (reduceProgress * 100), runningReducers, runningReducers * memoryPerReducer);
@@ -123,18 +116,22 @@ public class MapReduceMetricsWriter {
   private void reportMapTaskMetrics(TaskReport taskReport) {
     Counters counters = taskReport.getTaskCounters();
     MetricsCollector metricsCollector = mapTaskMetricsCollectors.getUnchecked(taskReport.getTaskId());
-    metricsCollector.gauge(METRIC_INPUT_RECORDS, getTaskCounter(counters, TaskCounter.MAP_INPUT_RECORDS));
-    metricsCollector.gauge(METRIC_OUTPUT_RECORDS, getTaskCounter(counters, TaskCounter.MAP_OUTPUT_RECORDS));
-    metricsCollector.gauge(METRIC_BYTES, getTaskCounter(counters, TaskCounter.MAP_OUTPUT_BYTES));
-    metricsCollector.gauge(METRIC_TASK_COMPLETION, (long) (taskReport.getProgress() * 100));
+    metricsCollector.gauge(MapReduceMetrics.METRIC_INPUT_RECORDS,
+                           getTaskCounter(counters, TaskCounter.MAP_INPUT_RECORDS));
+    metricsCollector.gauge(MapReduceMetrics.METRIC_OUTPUT_RECORDS,
+                           getTaskCounter(counters, TaskCounter.MAP_OUTPUT_RECORDS));
+    metricsCollector.gauge(MapReduceMetrics.METRIC_BYTES, getTaskCounter(counters, TaskCounter.MAP_OUTPUT_BYTES));
+    metricsCollector.gauge(MapReduceMetrics.METRIC_TASK_COMPLETION, (long) (taskReport.getProgress() * 100));
   }
 
   private void reportReduceTaskMetrics(TaskReport taskReport) {
     Counters counters = taskReport.getTaskCounters();
     MetricsCollector metricsCollector = reduceTaskMetricsCollectors.getUnchecked(taskReport.getTaskId());
-    metricsCollector.gauge(METRIC_INPUT_RECORDS, getTaskCounter(counters, TaskCounter.REDUCE_INPUT_RECORDS));
-    metricsCollector.gauge(METRIC_OUTPUT_RECORDS, getTaskCounter(counters, TaskCounter.REDUCE_OUTPUT_RECORDS));
-    metricsCollector.gauge(METRIC_TASK_COMPLETION, (long) (taskReport.getProgress() * 100));
+    metricsCollector.gauge(MapReduceMetrics.METRIC_INPUT_RECORDS,
+                           getTaskCounter(counters, TaskCounter.REDUCE_INPUT_RECORDS));
+    metricsCollector.gauge(MapReduceMetrics.METRIC_OUTPUT_RECORDS,
+                           getTaskCounter(counters, TaskCounter.REDUCE_OUTPUT_RECORDS));
+    metricsCollector.gauge(MapReduceMetrics.METRIC_TASK_COMPLETION, (long) (taskReport.getProgress() * 100));
   }
 
   // report system stats coming from user metrics or dataset operations

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/app/mapreduce/MapReduceMetricsInfoTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/app/mapreduce/MapReduceMetricsInfoTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.mapreduce;
+
+import co.cask.cdap.api.metrics.MetricStore;
+import co.cask.cdap.api.metrics.MetricType;
+import co.cask.cdap.api.metrics.MetricValue;
+import co.cask.cdap.app.metrics.MapReduceMetrics;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.data2.datafabric.dataset.service.DatasetService;
+import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetOpExecutor;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.MRJobInfo;
+import co.cask.cdap.proto.MRTaskInfo;
+import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.test.internal.guice.AppFabricTestModule;
+import co.cask.tephra.TransactionManager;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.apache.hadoop.mapreduce.TaskCounter;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+public class MapReduceMetricsInfoTest {
+  private static Injector injector;
+  private static MetricStore metricStore;
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    CConfiguration conf = CConfiguration.create();
+    conf.set(Constants.AppFabric.OUTPUT_DIR, System.getProperty("java.io.tmpdir"));
+    conf.set(Constants.AppFabric.TEMP_DIR, System.getProperty("java.io.tmpdir"));
+    injector = startMetricsService(conf);
+    metricStore = injector.getInstance(MetricStore.class);
+  }
+
+  public static Injector startMetricsService(CConfiguration conf) {
+    Injector injector = Guice.createInjector(new AppFabricTestModule(conf));
+    injector.getInstance(TransactionManager.class).startAndWait();
+    injector.getInstance(DatasetOpExecutor.class).startAndWait();
+    injector.getInstance(DatasetService.class).startAndWait();
+    return injector;
+  }
+
+  @Test
+  public void testGetMRJobInfo() throws Exception {
+    Id.Program programId = Id.Program.from("fooNamespace", "testApp", ProgramType.MAPREDUCE, "fooMapReduce");
+    Id.Run runId = new Id.Run(programId, "run10878");
+
+    Map<String, String> runContext = ImmutableMap.of(Constants.Metrics.Tag.NAMESPACE, programId.getNamespaceId(),
+                                                     Constants.Metrics.Tag.APP, programId.getApplicationId(),
+                                                     Constants.Metrics.Tag.MAPREDUCE, programId.getId(),
+                                                     Constants.Metrics.Tag.RUN_ID, runId.getId());
+
+    Map<String, String> mapTypeContext =
+      addToContext(runContext, Constants.Metrics.Tag.MR_TASK_TYPE, MapReduceMetrics.TaskType.Mapper.getId());
+
+    Map<String, String> reduceTypeContext =
+      addToContext(runContext, Constants.Metrics.Tag.MR_TASK_TYPE, MapReduceMetrics.TaskType.Reducer.getId());
+
+    String mapTask1Name = "task_m_01";
+    Map<String, String> mapTask1Context = addToContext(mapTypeContext, Constants.Metrics.Tag.INSTANCE_ID, mapTask1Name);
+
+    String mapTask2Name = "task_m_02";
+    Map<String, String> mapTask2Context = addToContext(mapTypeContext, Constants.Metrics.Tag.INSTANCE_ID, mapTask2Name);
+
+    String reduceTaskName = "task_r_01";
+    Map<String, String> reduceTaskContext =
+      addToContext(reduceTypeContext, Constants.Metrics.Tag.INSTANCE_ID, reduceTaskName);
+
+
+    // Imitate a MapReduce Job running (gauge mapper and reducer metrics)
+    long measureTime = System.currentTimeMillis() / 1000;
+    gauge(mapTypeContext, MapReduceMetrics.METRIC_COMPLETION, measureTime, 76L);
+    gauge(reduceTypeContext, MapReduceMetrics.METRIC_COMPLETION, measureTime, 52L);
+
+    gauge(mapTask1Context, MapReduceMetrics.METRIC_TASK_COMPLETION, measureTime, 100L);
+    gauge(mapTask1Context, MapReduceMetrics.METRIC_INPUT_RECORDS, measureTime, 32L);
+    gauge(mapTask1Context, MapReduceMetrics.METRIC_OUTPUT_RECORDS, measureTime, 320L);
+
+    gauge(mapTask2Context, MapReduceMetrics.METRIC_TASK_COMPLETION, measureTime, 12L);
+    gauge(mapTask2Context, MapReduceMetrics.METRIC_INPUT_RECORDS, measureTime, 6L);
+    gauge(mapTask2Context, MapReduceMetrics.METRIC_OUTPUT_RECORDS, measureTime, 60L);
+
+
+    gauge(reduceTaskContext, MapReduceMetrics.METRIC_TASK_COMPLETION, measureTime, 76L);
+    gauge(reduceTaskContext, MapReduceMetrics.METRIC_INPUT_RECORDS, measureTime, 320L);
+    gauge(reduceTaskContext, MapReduceMetrics.METRIC_OUTPUT_RECORDS, measureTime, 1L);
+
+
+    MapReduceMetricsInfo mapReduceMetricsInfo = injector.getInstance(MapReduceMetricsInfo.class);
+    MRJobInfo mrJobInfo = mapReduceMetricsInfo.getMRJobInfo(runId);
+
+
+    // Check job-level counters
+    Map<String, Long> jobCounters = mrJobInfo.getCounters();
+    Assert.assertEquals((Long) 38L, jobCounters.get(TaskCounter.MAP_INPUT_RECORDS.name()));
+    Assert.assertEquals((Long) 380L, jobCounters.get(TaskCounter.MAP_OUTPUT_RECORDS.name()));
+    Assert.assertEquals((Long) 320L, jobCounters.get(TaskCounter.REDUCE_INPUT_RECORDS.name()));
+    Assert.assertEquals((Long) 1L, jobCounters.get(TaskCounter.REDUCE_OUTPUT_RECORDS.name()));
+
+
+    // Ensure all tasks show up
+    List<MRTaskInfo> mapTasks = mrJobInfo.getMapTasks();
+    List<MRTaskInfo> reduceTasks = mrJobInfo.getReduceTasks();
+    Assert.assertEquals(2, mapTasks.size());
+    Assert.assertEquals(1, reduceTasks.size());
+
+    MRTaskInfo mapTask1 = findByTaskId(mapTasks, mapTask1Name);
+    MRTaskInfo mapTask2 = findByTaskId(mapTasks, mapTask2Name);
+    MRTaskInfo reduceTask = findByTaskId(reduceTasks, reduceTaskName);
+
+    // Check task-level counters
+    Map<String, Long> mapTask1Counters = mapTask1.getCounters();
+    Assert.assertEquals((Long) 32L, mapTask1Counters.get(TaskCounter.MAP_INPUT_RECORDS.name()));
+    Assert.assertEquals((Long) 320L, mapTask1Counters.get(TaskCounter.MAP_OUTPUT_RECORDS.name()));
+
+    Map<String, Long> mapTask2Counters = mapTask2.getCounters();
+    Assert.assertEquals((Long) 6L, mapTask2Counters.get(TaskCounter.MAP_INPUT_RECORDS.name()));
+    Assert.assertEquals((Long) 60L, mapTask2Counters.get(TaskCounter.MAP_OUTPUT_RECORDS.name()));
+
+    Map<String, Long> reduceTaskCounters = reduceTask.getCounters();
+    Assert.assertEquals((Long) 320L, reduceTaskCounters.get(TaskCounter.REDUCE_INPUT_RECORDS.name()));
+    Assert.assertEquals((Long) 1L, reduceTaskCounters.get(TaskCounter.REDUCE_OUTPUT_RECORDS.name()));
+
+    // Checking progress
+    float permittedProgressDelta = 0.01F;
+    Assert.assertEquals(0.76F, mrJobInfo.getMapProgress(), permittedProgressDelta);
+    Assert.assertEquals(0.52F, mrJobInfo.getReduceProgress(), permittedProgressDelta);
+
+    Assert.assertEquals(1.0F, mapTask1.getProgress(), permittedProgressDelta);
+    Assert.assertEquals(0.12F, mapTask2.getProgress(), permittedProgressDelta);
+    Assert.assertEquals(0.76F, reduceTask.getProgress(), permittedProgressDelta);
+
+  }
+
+  private void gauge(Map<String, String> context, String metric, long timestamp, Long value) throws Exception {
+    metricStore.add(new MetricValue(context, metric, timestamp, value, MetricType.GAUGE));
+  }
+
+  // Returned copied map, with new key-value pair.
+  private Map<String, String> addToContext(Map<String, String> context, String key, String value) {
+    return ImmutableMap.<String, String>builder()
+      .putAll(context)
+      .put(key, value)
+      .build();
+  }
+
+  private MRTaskInfo findByTaskId(List<MRTaskInfo> taskInfos, String taskId) {
+    for (MRTaskInfo taskInfo : taskInfos) {
+      if (taskInfo.getTaskId().equals(taskId)) {
+        return taskInfo;
+      }
+    }
+    throw new IllegalArgumentException(
+      String.format("TaskId: %s not found in list of TaskInfos: %s", taskId, taskInfos));
+  }
+}

--- a/cdap-common/src/test/java/co/cask/cdap/io/DatumCodecTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/io/DatumCodecTest.java
@@ -38,7 +38,6 @@ import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
@@ -259,6 +258,12 @@ public class DatumCodecTest {
 
     String k;
     Inner inner;
+  }
+
+  @Test
+  public void test2() {
+    float f = 56L / 100F;
+    System.out.println(f);
   }
 
   @Test

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/MRJobInfo.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/MRJobInfo.java
@@ -18,22 +18,23 @@ package co.cask.cdap.proto;
 
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Simplified (filtered) representation of a MapReduce Job.
  */
 public class MRJobInfo {
   private final String state;
-  private final long startTime;
-  private final long finishTime;
-  private final float mapProgress;
-  private final float reduceProgress;
+  private final Long startTime;
+  private final Long finishTime;
+  private final Float mapProgress;
+  private final Float reduceProgress;
   private final Map<String, Long> counters;
   private final List<MRTaskInfo> mapTasks;
   private final List<MRTaskInfo> reduceTasks;
 
-  public MRJobInfo(String state, long startTime, long finishTime,
-                   float mapProcess, float reduceProgress,
+  public MRJobInfo(@Nullable String state, @Nullable Long startTime, @Nullable Long finishTime,
+                   Float mapProcess, Float reduceProgress,
                    Map<String, Long> counters,
                    List<MRTaskInfo> mapTasks, List<MRTaskInfo> reduceTasks) {
     this.state = state;
@@ -46,23 +47,26 @@ public class MRJobInfo {
     this.reduceTasks = reduceTasks;
   }
 
+  @Nullable
   public String getState() {
     return state;
   }
 
-  public long getStartTime() {
+  @Nullable
+  public Long getStartTime() {
     return startTime;
   }
 
-  public long getFinishTime() {
+  @Nullable
+  public Long getFinishTime() {
     return finishTime;
   }
 
-  public float getMapProgress() {
+  public Float getMapProgress() {
     return mapProgress;
   }
 
-  public float getReduceProgress() {
+  public Float getReduceProgress() {
     return reduceProgress;
   }
 

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/MRTaskInfo.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/MRTaskInfo.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.proto;
 
 import java.util.Map;
+import javax.annotation.Nullable;
 
 
 /**
@@ -25,13 +26,13 @@ import java.util.Map;
 public class MRTaskInfo {
   private final String taskId;
   private final String state;
-  private final long startTime;
-  private final long finishTime;
+  private final Long startTime;
+  private final Long finishTime;
   private final float progress;
   private final Map<String, Long> counters;
 
-  public MRTaskInfo(String taskId, String state, long startTime, long finishTime, float progress,
-                    Map<String, Long> counters) {
+  public MRTaskInfo(String taskId, @Nullable String state, @Nullable Long startTime, @Nullable Long finishTime,
+                    float progress, Map<String, Long> counters) {
     this.taskId = taskId;
     this.state = state;
     this.startTime = startTime;
@@ -44,15 +45,18 @@ public class MRTaskInfo {
     return taskId;
   }
 
+  @Nullable
   public String getState() {
     return state;
   }
 
-  public long getStartTime() {
+  @Nullable
+  public Long getStartTime() {
     return startTime;
   }
 
-  public long getFinishTime() {
+  @Nullable
+  public Long getFinishTime() {
     return finishTime;
   }
 


### PR DESCRIPTION
...via Metrics system (in case retrieving from jobHistoryServer fails).

The implementation in this PR uses JobHistoryServer: https://github.com/caskdata/cdap/pull/1878

This PR is the fallback (via Metrics system) if the JHS is not available. It doesn't return all the same data (it is missing fields such as status/startime/endtime as well as majority of the counters).

https://issues.cask.co/browse/CDAP-1958
http://builds.cask.co/browse/CDAP-DUT1324-16