### PR TITLE
[CDAP-1787] Added 'adapter' tag to mapreduce metrics when run through adapters

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
@@ -82,7 +82,7 @@ public class BasicMapReduceContext extends AbstractContext implements MapReduceC
                                DatasetFramework dsFramework,
                                @Nullable String adapterName) {
     super(program, runId, runtimeArguments, datasets,
-          getMetricCollector(metricsCollectionService, program, type, runId.getId(), taskId),
+          getMetricCollector(program, runId.getId(), taskId, metricsCollectionService, type, adapterName),
           dsFramework, discoveryServiceClient);
     this.logicalStartTime = logicalStartTime;
     this.workflowBatch = workflowBatch;
@@ -241,8 +241,11 @@ public class BasicMapReduceContext extends AbstractContext implements MapReduceC
     this.reducerResources = resources;
   }
 
-  private static MetricsCollector getMetricCollector(MetricsCollectionService service, Program program,
-                                                     MapReduceMetrics.TaskType type, String runId, String taskId) {
+  @Nullable
+  private static MetricsCollector getMetricCollector(Program program, String runId, String taskId,
+                                                     @Nullable MetricsCollectionService service,
+                                                     @Nullable MapReduceMetrics.TaskType type,
+                                                     @Nullable String adapterName) {
     if (service == null) {
       return null;
     }
@@ -257,6 +260,10 @@ public class BasicMapReduceContext extends AbstractContext implements MapReduceC
     } else {
       // in a runner (container that submits the job): put program info
       tags.putAll(getMetricsContext(program, runId));
+    }
+
+    if (adapterName != null) {
+      tags.put(Constants.Metrics.Tag.ADAPTER, adapterName);
     }
 
     return service.getCollector(tags);

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -434,6 +434,8 @@ public final class Constants {
 
       // who emitted: user vs system (scope is historical name)
       public static final String SCOPE = "scp";
+
+      public static final String ADAPTER = "adp";
     }
   }
 

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/metrics/MetricsHandlerTestRun.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/metrics/MetricsHandlerTestRun.java
@@ -115,6 +115,12 @@ public class MetricsHandlerTestRun extends MetricsSuiteTestBase {
     collector.increment("zz", 1);
     collector.increment("ab", 1);
 
+    collector = collectionService.getCollector(getAdapterContext("yourspace", "WCount1", "ClassicWordCount",
+                                                                 MapReduceMetrics.TaskType.Mapper,
+                                                                 "run1", "task1", "adapter1"));
+    collector.increment("areads", 3);
+    collector.increment("awrites", 4);
+
     // also: user metrics
     Metrics userMetrics = new ProgramUserMetrics(
       collectionService.getCollector(getFlowletContext("myspace", "WordCount1", "WordCounter",
@@ -151,14 +157,15 @@ public class MetricsHandlerTestRun extends MetricsSuiteTestBase {
   public void testSearchWithTags() throws Exception {
     // empty context
     verifySearchResultWithTags("/v3/metrics/search?target=tag", getSearchResultExpected("namespace", DOT_NAMESPACE,
-                                                                                "namespace", "myspace",
-                                                                                "namespace", "yourspace"));
+                                                                                        "namespace", "myspace",
+                                                                                        "namespace", "yourspace",
+                                                                                        "namespace", "system"));
 
     // WordCount is in myspace, WCount in yourspace
     verifySearchResultWithTags("/v3/metrics/search?target=tag&tag=namespace:myspace",
                        getSearchResultExpected("app", "WordCount1"));
     verifySearchResultWithTags("/v3/metrics/search?target=tag&tag=namespace:yourspace",
-                       getSearchResultExpected("app", "WCount1"));
+                       getSearchResultExpected("adapter", "adapter1", "app", "WCount1"));
 
     // WordCount should be found in myspace, not in yourspace
     verifySearchResultWithTags("/v3/metrics/search?target=tag&tag=namespace:myspace&tag=app:WordCount1",
@@ -170,10 +177,14 @@ public class MetricsHandlerTestRun extends MetricsSuiteTestBase {
     // WCount should be found in yourspace, not in myspace
     verifySearchResultWithTags("/v3/metrics/search?target=tag&tag=namespace:yourspace&tag=app:WCount1",
                        getSearchResultExpected("flow", "WCounter",
-                                                "flow", "WordCounter",
-                                                "mapreduce", "ClassicWordCount",
-                                                "procedure", "RCounts"
+                                               "flow", "WordCounter",
+                                               "mapreduce", "ClassicWordCount",
+                                               "procedure", "RCounts"
                        ));
+
+    // No more tags when you specify namespace and adapter
+    verifySearchResultWithTags("/v3/metrics/search?target=tag&tag=namespace:yourspace&tag=adapter:adapter1",
+                               getSearchResultExpected());
 
     verifySearchResultWithTags("/v3/metrics/search?target=tag&tag=namespace:myspace&tag=app:WCount1",
                                getSearchResultExpected());
@@ -198,7 +209,11 @@ public class MetricsHandlerTestRun extends MetricsSuiteTestBase {
     // verify "*"
 
     verifySearchResultWithTags("/v3/metrics/search?target=tag&tag=namespace:*",
-                               getSearchResultExpected("app", "WordCount1", "app", "WCount1"));
+                               getSearchResultExpected("adapter", "adapter1",
+                                                       "app", "WordCount1",
+                                                       "app", "WCount1",
+                                                       "app", DOT_APP,
+                                                       "component", "metrics.processor"));
 
     verifySearchResultWithTags("/v3/metrics/search?target=tag&tag=namespace:*&tag=app:*",
                                getSearchResultExpected("flow", "WCounter",
@@ -208,7 +223,8 @@ public class MetricsHandlerTestRun extends MetricsSuiteTestBase {
                                                        "procedure", "RCounts"));
 
     verifySearchResultWithTags("/v3/metrics/search?target=tag&tag=namespace:*&tag=app:*&tag=flow:*",
-                               getSearchResultExpected("run", "run1"));
+                               getSearchResultExpected("run", "run1",
+                                                       "run", DOT_RUN));
 
     // verify dots more
     String parts[] = new String[] {
@@ -243,7 +259,8 @@ public class MetricsHandlerTestRun extends MetricsSuiteTestBase {
     verifySearchResult("/v3/metrics/search?target=childContext&context=namespace.myspace",
                        ImmutableList.<String>of("namespace.myspace.app.WordCount1"));
     verifySearchResult("/v3/metrics/search?target=childContext&context=namespace.yourspace",
-                       ImmutableList.<String>of("namespace.yourspace.app.WCount1"));
+                       ImmutableList.<String>of("namespace.yourspace.adapter.adapter1",
+                                                "namespace.yourspace.app.WCount1"));
 
     // WordCount should be found in myspace, not in yourspace
     verifySearchResult("/v3/metrics/search?target=childContext&context=namespace.myspace.app.WordCount1",
@@ -259,6 +276,10 @@ public class MetricsHandlerTestRun extends MetricsSuiteTestBase {
                                                 "namespace.yourspace.app.WCount1.procedure.RCounts"));
 
     verifySearchResult("/v3/metrics/search?target=childContext&context=namespace.myspace.app.WCount1",
+                       ImmutableList.<String>of());
+
+    // child context for adapters should be empty
+    verifySearchResult("/v3/metrics/search?target=childContext&context=namespace.yourspace.adapter.adapter1",
                        ImmutableList.<String>of());
 
     // verify other metrics for WCount app
@@ -333,6 +354,21 @@ public class MetricsHandlerTestRun extends MetricsSuiteTestBase {
     verifyAggregateQueryResult(
       "/v3/metrics/query?context=" + getContext("yourspace", "WCount1", "WCounter", "*") +
         "&metric=system.reads&aggregate=true", 4);
+
+    // for adapters, the same metrics should be available at both, just adapter level as well as mapreduce level
+    // adapter level
+    verifyAggregateQueryResult(
+      "/v3/metrics/query?context=namespace.yourspace.adapter.adapter1&metric=system.areads&aggregate=true", 3);
+    verifyAggregateQueryResult(
+      "/v3/metrics/query?context=namespace.yourspace.adapter.adapter1&metric=system.awrites&aggregate=true", 4);
+    // mapreduce level
+    verifyAggregateQueryResult(
+      "/v3/metrics/query?context=namespace.yourspace.app.WCount1.mapreduce.ClassicWordCount" +
+        "&metric=system.areads&aggregate=true", 3);
+    verifyAggregateQueryResult(
+      "/v3/metrics/query?context=namespace.yourspace.app.WCount1.mapreduce.ClassicWordCount" +
+        "&metric=system.awrites&aggregate=true", 4);
+
 
     // aggregate result, in the wrong namespace
     verifyEmptyQueryResult(
@@ -528,6 +564,20 @@ public class MetricsHandlerTestRun extends MetricsSuiteTestBase {
     verifyAggregateQueryResult(
       "/v3/metrics/query?" + getTags("yourspace", "WCount1", "WCounter", "*") +
         "&metric=system.reads&aggregate=true", 4);
+
+    // for adapters, the same metrics should be available at both, just adapter level as well as mapreduce level
+    // adapter level
+    verifyAggregateQueryResult(
+      "/v3/metrics/query?tag=namespace:yourspace&tag=adapter:adapter1&metric=system.areads&aggregate=true", 3);
+    verifyAggregateQueryResult(
+      "/v3/metrics/query?tag=namespace:yourspace&tag=adapter:adapter1&metric=system.awrites&aggregate=true", 4);
+    // mapreduce level
+    verifyAggregateQueryResult(
+      "/v3/metrics/query?tag=namespace:yourspace&tag=app:WCount1&mapreduce:ClassicWordCount" +
+        "&metric=system.areads&aggregate=true", 3);
+    verifyAggregateQueryResult(
+      "/v3/metrics/query?tag=namespace:yourspace&tag=app:WCount1&mapreduce:ClassicWordCount" +
+        "&metric=system.awrites&aggregate=true", 4);
 
     // aggregate result, in the wrong namespace
     verifyEmptyQueryResult(
@@ -734,6 +784,9 @@ public class MetricsHandlerTestRun extends MetricsSuiteTestBase {
                                "&tag=flow:WCounter&tag=dataset:*&tag=run:run1&tag=flowlet:splitter",
                              ImmutableList.<String>of("system.reads"));
 
+    verifySearchMetricResult("/v3/metrics/search?target=metric&tag=namespace:yourspace&tag=adapter:adapter1",
+                             ImmutableList.<String>of("system.areads", "system.awrites"));
+
     // wrong namespace
     verifySearchMetricResult("/v3/metrics/search?target=metric&tag=namespace:myspace&tag=app:WCount1" +
                                "&tag=flow:WCounter&tag=dataset:*&tag=run:run1&tag=flowlet:splitter",
@@ -787,6 +840,9 @@ public class MetricsHandlerTestRun extends MetricsSuiteTestBase {
     verifySearchMetricResult("/v3/metrics/search?target=metric&context=namespace.yourspace.app.WCount1" +
                                ".flow.WCounter.dataset.*.run.run1.flowlet.splitter",
                              ImmutableList.<String>of("system.reads"));
+
+    verifySearchMetricResult("/v3/metrics/search?target=metric&context=namespace.yourspace.adapter.adapter1",
+                             ImmutableList.<String>of("system.areads", "system.awrites"));
 
     // wrong namespace
     verifySearchMetricResult("/v3/metrics/search?target=metric&context=namespace.myspace.app.WCount1" +
@@ -970,8 +1026,7 @@ public class MetricsHandlerTestRun extends MetricsSuiteTestBase {
     HttpResponse response = doPost(url, null);
     Assert.assertEquals(200, response.getStatusLine().getStatusCode());
     String result = EntityUtils.toString(response.getEntity());
-    List<String> reply = GSON.fromJson(result, new TypeToken<List<String>>() {
-    }.getType());
+    List<String> reply = GSON.fromJson(result, new TypeToken<List<String>>() { }.getType());
     // We want to make sure expectedValues are in the response. Response may also have other things that denote
     // null values for tags - we'll ignore them.
     Assert.assertTrue(reply.containsAll(expectedValues));
@@ -984,8 +1039,7 @@ public class MetricsHandlerTestRun extends MetricsSuiteTestBase {
     HttpResponse response = doPost(url, null);
     Assert.assertEquals(200, response.getStatusLine().getStatusCode());
     String result = EntityUtils.toString(response.getEntity());
-    List<String> reply = GSON.fromJson(result, new TypeToken<List<String>>() {
-    }.getType());
+    List<String> reply = GSON.fromJson(result, new TypeToken<List<String>>() { }.getType());
     Assert.assertEquals(expectedValues.size(), reply.size());
     for (int i = 0; i < expectedValues.size(); i++) {
       Assert.assertEquals(expectedValues.get(i), reply.get(i));
@@ -997,7 +1051,7 @@ public class MetricsHandlerTestRun extends MetricsSuiteTestBase {
     Assert.assertEquals(200, response.getStatusLine().getStatusCode());
     String result = EntityUtils.toString(response.getEntity(), Charsets.UTF_8);
     List<Map<String, String>> reply = GSON.fromJson(result, new TypeToken<List<Map<String, String>>>() { }.getType());
-    Assert.assertTrue(reply.containsAll(expectedValues));
+    Assert.assertTrue(reply.containsAll(expectedValues) && expectedValues.containsAll(reply));
   }
 
   private void verifySearchResultContains(String url, List<String> expectedValues) throws Exception {

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/metrics/MetricsSuiteTestBase.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/metrics/MetricsSuiteTestBase.java
@@ -467,4 +467,18 @@ public abstract class MetricsSuiteTestBase {
       .put(Constants.Metrics.Tag.INSTANCE_ID, instanceId)
       .build();
   }
+
+  protected static Map<String, String> getAdapterContext(String namespaceId, String appName, String jobName,
+                                                         MapReduceMetrics.TaskType type, String runId,
+                                                         String instanceId, String adapterName) {
+    return ImmutableMap.<String, String>builder()
+      .put(Constants.Metrics.Tag.NAMESPACE, namespaceId)
+      .put(Constants.Metrics.Tag.APP, appName)
+      .put(Constants.Metrics.Tag.MAPREDUCE, jobName)
+      .put(Constants.Metrics.Tag.MR_TASK_TYPE, type.getId())
+      .put(Constants.Metrics.Tag.RUN_ID, runId)
+      .put(Constants.Metrics.Tag.INSTANCE_ID, instanceId)
+      .put(Constants.Metrics.Tag.ADAPTER, adapterName)
+      .build();
+  }
 }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/MetricsHandler.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/MetricsHandler.java
@@ -107,6 +107,7 @@ public class MetricsHandler extends AuthenticatedHttpHandler {
       .put(Constants.Metrics.Tag.DATASET, "dataset")
 
       .put(Constants.Metrics.Tag.APP, "app")
+      .put(Constants.Metrics.Tag.ADAPTER, "adapter")
 
       .put(Constants.Metrics.Tag.SERVICE, "service")
       .put(Constants.Metrics.Tag.SERVICE_RUNNABLE, "runnable")

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/store/DefaultMetricStore.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/store/DefaultMetricStore.java
@@ -166,6 +166,12 @@ public class DefaultMetricStore implements MetricStore {
       ImmutableList.of(Constants.Metrics.Tag.NAMESPACE, Constants.Metrics.Tag.APP,
                        Constants.Metrics.Tag.SPARK)));
 
+    // batch adapters - can only contain mapreduce for now
+    aggs.add(new DefaultAggregation(
+      ImmutableList.of(Constants.Metrics.Tag.NAMESPACE, Constants.Metrics.Tag.ADAPTER),
+      // i.e. for adapter only
+      ImmutableList.of(Constants.Metrics.Tag.NAMESPACE, Constants.Metrics.Tag.ADAPTER)));
+
     // Streams:
     aggs.add(new DefaultAggregation(ImmutableList.of(Constants.Metrics.Tag.NAMESPACE, Constants.Metrics.Tag.STREAM),
                                     // i.e. for streams only


### PR DESCRIPTION
When a mapreduce is run through an adapter, you should be able to query its metrics using tags: *namespace* and *adapter* as well as *namespace*, *app*, *mapreduce*

Jira: https://issues.cask.co/browse/CDAP-1787
Build: https://builds.cask.co/browse/CDAP-DUT1389