### PR TITLE
Fix doc build on bamboo by removing an extra space character.

### DIFF
--- a/cdap-docs/_common/highlevel_conf.py
+++ b/cdap-docs/_common/highlevel_conf.py
@@ -158,5 +158,3 @@ def merger(dict1, dict2, offset):
         
         dict1[term]=new_files
     return dict1
-
- 


### PR DESCRIPTION
Apparently, under CentOS, having even a single extra space at the end of a python file causes grief.
This change deletes that last line with that single character in it.