### PR TITLE
Ignore zero values only for COUNTER Metric Type.

### DIFF
--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/collect/AggregatedMetricsCollectionService.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/collect/AggregatedMetricsCollectionService.java
@@ -15,6 +15,7 @@
  */
 package co.cask.cdap.metrics.collect;
 
+import co.cask.cdap.api.metrics.MetricType;
 import co.cask.cdap.api.metrics.MetricValue;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.metrics.MetricsCollectionService;
@@ -154,10 +155,13 @@ public abstract class AggregatedMetricsCollectionService extends AbstractSchedul
         while (iterator.hasNext()) {
           Map.Entry<EmitterKey, AggregatedMetricsEmitter> entry = iterator.next();
           MetricValue metricValue = entry.getValue().emit(timestamp);
-          if (metricValue.getValue() != 0) {
-            LOG.trace("Emit metric {}", metricValue);
-            return metricValue;
+
+          if (metricValue.getValue() == 0 && MetricType.COUNTER == metricValue.getType()) {
+            // Ignore 0 values only for COUNTER Metric Type.
+            continue;
           }
+          LOG.trace("Emit metric {}", metricValue);
+          return metricValue;
         }
         return endOfData();
       }

--- a/cdap-watchdog/src/test/java/co/cask/cdap/metrics/collect/AggregatedMetricsCollectionServiceTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/metrics/collect/AggregatedMetricsCollectionServiceTest.java
@@ -138,6 +138,9 @@ public class AggregatedMetricsCollectionServiceTest {
       // gauge just updates the value, so polling should return the most recent value written
       verifyGaugeMetricsValue(published.poll(10, TimeUnit.SECONDS));
       verifyGaugeMetricsValue(published.poll(10, TimeUnit.SECONDS));
+
+      flowletInstanceCollector.gauge(METRIC, 0);
+      verifyMetricsValue(published.poll(10, TimeUnit.SECONDS), 0L);
     } finally {
       service.stopAndWait();
     }
@@ -169,5 +172,10 @@ public class AggregatedMetricsCollectionServiceTest {
     } else {
       Assert.fail("Unexpected number of tags while verifying gauge metrics value - " + tags.size());
     }
+  }
+
+  private void verifyMetricsValue(MetricValue metricValue, long expected) {
+    Assert.assertNotNull(metricValue);
+    Assert.assertEquals(expected, metricValue.getValue());
   }
 }


### PR DESCRIPTION
Ignore zero values only for COUNTER Metric Type. Gauge of a zero value should NOT be ignored.

https://issues.cask.co/browse/CDAP-2055
http://builds.cask.co/browse/CDAP-DUT1399-1