### PR TITLE
Remove workerSpec from AdapterSpec

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/AdapterService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/AdapterService.java
@@ -348,10 +348,7 @@ public class AdapterService extends AbstractIdleService {
   private Id.Program getWorkflowId(Id.Namespace namespace, AdapterSpecification adapterSpec) throws NotFoundException {
     Id.Application appId = Id.Application.from(namespace, adapterSpec.getTemplate());
     ApplicationSpecification appSpec = store.getApplication(appId);
-    try {
-      Preconditions.checkArgument(appSpec != null);
-      Preconditions.checkArgument(appSpec.getWorkflows().size() == 1);
-    } catch (IllegalArgumentException e) {
+    if (appSpec == null || appSpec.getWorkflows().size() != 1) {
       throw new NotFoundException(appId);
     }
     String workflowName = Iterables.getFirst(appSpec.getWorkflows().keySet(), null);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/templates/AdapterSpecification.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/templates/AdapterSpecification.java
@@ -60,7 +60,7 @@ public final class AdapterSpecification {
     this.datasets = datasets == null ? ImmutableMap.<String, DatasetCreationSpec>of() : ImmutableMap.copyOf(datasets);
     this.datasetModules = datasetModules == null ?
       ImmutableMap.<String, String>of() : ImmutableMap.copyOf(datasetModules);
-    this.runtimeArgs = ImmutableMap.copyOf(runtimeArgs);
+    this.runtimeArgs = runtimeArgs == null ? ImmutableMap.<String, String>of() : ImmutableMap.copyOf(runtimeArgs);
     this.config = config;
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/templates/AdapterSpecification.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/templates/AdapterSpecification.java
@@ -18,7 +18,6 @@ package co.cask.cdap.templates;
 
 import co.cask.cdap.api.data.stream.StreamSpecification;
 import co.cask.cdap.api.schedule.ScheduleSpecification;
-import co.cask.cdap.api.worker.WorkerSpecification;
 import co.cask.cdap.data.dataset.DatasetCreationSpec;
 import com.clearspring.analytics.util.Preconditions;
 import com.google.common.base.Objects;
@@ -36,32 +35,32 @@ public final class AdapterSpecification {
   private final String description;
   private final String template;
   private final ScheduleSpecification scheduleSpec;
-  private final WorkerSpecification workerSpec;
+  private final int instances;
   private final Map<String, StreamSpecification> streams;
   private final Map<String, DatasetCreationSpec> datasets;
   private final Map<String, String> datasetModules;
-  private final int instances;
+  private final Map<String, String> runtimeArgs;
   // this is a json representation of some config that templates will use to configure
   // an adapter. At configuration time it will be translated into the correct object,
   // but the platform itself never interprets it but just passes it along.
   private final JsonElement config;
 
   private AdapterSpecification(String name, String description, String template,
-                               ScheduleSpecification scheduleSpec, WorkerSpecification workerSpec,
+                               ScheduleSpecification scheduleSpec, int instances,
                                Map<String, StreamSpecification> streams,
                                Map<String, DatasetCreationSpec> datasets,
                                Map<String, String> datasetModules,
-                               int instances, JsonElement config) {
+                               Map<String, String> runtimeArgs, JsonElement config) {
     this.name = name;
     this.description = description;
     this.template = template;
     this.scheduleSpec = scheduleSpec;
-    this.workerSpec = workerSpec;
+    this.instances = instances;
     this.streams = streams == null ? ImmutableMap.<String, StreamSpecification>of() : ImmutableMap.copyOf(streams);
     this.datasets = datasets == null ? ImmutableMap.<String, DatasetCreationSpec>of() : ImmutableMap.copyOf(datasets);
     this.datasetModules = datasetModules == null ?
       ImmutableMap.<String, String>of() : ImmutableMap.copyOf(datasetModules);
-    this.instances = instances;
+    this.runtimeArgs = ImmutableMap.copyOf(runtimeArgs);
     this.config = config;
   }
 
@@ -77,14 +76,13 @@ public final class AdapterSpecification {
     return template;
   }
 
-  @Nullable
-  public ScheduleSpecification getScheduleSpec() {
-    return scheduleSpec;
+  public Map<String, String> getRuntimeArgs() {
+    return runtimeArgs;
   }
 
   @Nullable
-  public WorkerSpecification getWorkerSpec() {
-    return workerSpec;
+  public ScheduleSpecification getScheduleSpec() {
+    return scheduleSpec;
   }
 
   public Map<String, StreamSpecification> getStreams() {
@@ -99,7 +97,8 @@ public final class AdapterSpecification {
     return datasetModules;
   }
 
-  public int getInstances() {
+  @Nullable
+  public Integer getInstances() {
     return instances;
   }
 
@@ -118,8 +117,8 @@ public final class AdapterSpecification {
     private final String name;
     private final String template;
     private String description;
-    private ScheduleSpecification scheduleSpec;
-    private WorkerSpecification workerSpec;
+    private ScheduleSpecification schedule;
+    private Map<String, String> runtimeArgs;
     private Map<String, StreamSpecification> streams;
     private Map<String, DatasetCreationSpec> datasets;
     private Map<String, String> datasetModules;
@@ -141,13 +140,13 @@ public final class AdapterSpecification {
       return this;
     }
 
-    public Builder setScheduleSpec(ScheduleSpecification scheduleSpec) {
-      this.scheduleSpec = scheduleSpec;
+    public Builder setScheduleSpec(ScheduleSpecification schedule) {
+      this.schedule = schedule;
       return this;
     }
 
-    public Builder setWorkerSpec(WorkerSpecification workerSpec) {
-      this.workerSpec = workerSpec;
+    public Builder setRuntimeArgs(Map<String, String> runtimeArgs) {
+      this.runtimeArgs = runtimeArgs;
       return this;
     }
 
@@ -177,8 +176,8 @@ public final class AdapterSpecification {
     }
 
     public AdapterSpecification build() {
-      return new AdapterSpecification(name, description, template, scheduleSpec, workerSpec,
-                                      streams, datasets, datasetModules, instances, config);
+      return new AdapterSpecification(name, description, template, schedule, instances,
+                                      streams, datasets, datasetModules, runtimeArgs, config);
     }
   }
 
@@ -198,7 +197,7 @@ public final class AdapterSpecification {
       Objects.equal(template, that.template) &&
       Objects.equal(config, that.config) &&
       Objects.equal(scheduleSpec, that.scheduleSpec) &&
-      Objects.equal(workerSpec, that.workerSpec) &&
+      Objects.equal(runtimeArgs, that.runtimeArgs) &&
       Objects.equal(streams, that.streams) &&
       Objects.equal(datasets, that.datasets) &&
       Objects.equal(datasetModules, that.datasetModules) &&
@@ -207,7 +206,7 @@ public final class AdapterSpecification {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(name, description, template, config, scheduleSpec, workerSpec,
+    return Objects.hashCode(name, description, template, config, scheduleSpec, runtimeArgs,
                             streams, datasets, datasetModules, instances);
   }
 
@@ -219,7 +218,7 @@ public final class AdapterSpecification {
       .add("template", template)
       .add("config", config)
       .add("scheduleSpec", scheduleSpec)
-      .add("workerSpec", workerSpec)
+      .add("runtimeargs", runtimeArgs)
       .add("streams", streams)
       .add("datasets", datasets)
       .add("datasetModules", datasetModules)

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/templates/DefaultAdapterConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/templates/DefaultAdapterConfigurer.java
@@ -35,6 +35,7 @@ import co.cask.cdap.internal.schedule.TimeSchedule;
 import co.cask.cdap.proto.AdapterConfig;
 import co.cask.cdap.proto.ProgramType;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 
 import java.util.Map;
@@ -165,7 +166,7 @@ public class DefaultAdapterConfigurer implements AdapterConfigurer {
   public AdapterSpecification createSpecification() {
     ScheduleSpecification scheduleSpec = null;
     if (programType == ProgramType.WORKFLOW) {
-      String workflowName = templateSpec.getWorkflows().values().iterator().next().getName();
+      String workflowName = Iterables.getFirst(templateSpec.getWorkflows().keySet(), null);
       scheduleSpec = new ScheduleSpecification(schedule, new ScheduleProgramInfo(
         SchedulableProgramType.WORKFLOW, workflowName), runtimeArgs);
     }


### PR DESCRIPTION
Removing WorkerSpec from AdapterSpec since it can be retrieved from the ApplicationSpec from Store. The only information that is required to be passed on from the Template's configureAdpater method is instances and runtime args (in case of Realtime Adapter) and ScheduleSpecification (in case of Batch Adapter) since we don't allow schedules to be part of Application Template.

More changes need to be done to AdapterSpec but they will be addressed in subsequent PRs so that PR #1962 can make use of these changes.

Bamboo : http://builds.cask.co/browse/CDAP-DUT1405-3