### PR TITLE
CDAP-2056 Change to MapReduceRuntimeService inferDecoderClass

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
@@ -588,20 +588,18 @@ final class MapReduceRuntimeService extends AbstractExecutionThreadService {
    * @param <V> type of the super class
    */
   private <V> void setStreamEventDecoder(Job job, TypeToken<V> type) throws IOException {
-    // The super type must be a parameterized type with <IN_KEY, IN_VALUE, OUT_KEY, OUT_VALUE>
-    if (!(type.getType() instanceof ParameterizedType)) {
-      // Assume to be StreamEvent
-      StreamInputFormat.inferDecoderClass(job.getConfiguration(), StreamEvent.class);
-    } else {
+    // The super type must be a parametrized type with <IN_KEY, IN_VALUE, OUT_KEY, OUT_VALUE>
+    Type valueType = StreamEvent.class;
+    if ((type.getType() instanceof ParameterizedType)) {
       try {
         // Try to determine the decoder to use from the first input types
         // The first argument must be LongWritable for it to consumer stream event, as it carries the event timestamp
-        Type[] typeArgs = ((ParameterizedType) type.getType()).getActualTypeArguments();
-        StreamInputFormat.inferDecoderClass(job.getConfiguration(), typeArgs[1]);
+        valueType = ((ParameterizedType) type.getType()).getActualTypeArguments()[1];
       } catch (IllegalArgumentException e) {
         throw new IOException("Type not support for consuming StreamEvent from " + type, e);
       }
     }
+    StreamInputFormat.inferDecoderClass(job.getConfiguration(), valueType);
   }
 
   private String getJobName(BasicMapReduceContext context) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
@@ -591,15 +591,15 @@ final class MapReduceRuntimeService extends AbstractExecutionThreadService {
     // The super type must be a parametrized type with <IN_KEY, IN_VALUE, OUT_KEY, OUT_VALUE>
     Type valueType = StreamEvent.class;
     if ((type.getType() instanceof ParameterizedType)) {
-      try {
-        // Try to determine the decoder to use from the first input types
-        // The first argument must be LongWritable for it to consumer stream event, as it carries the event timestamp
-        valueType = ((ParameterizedType) type.getType()).getActualTypeArguments()[1];
-      } catch (IllegalArgumentException e) {
-        throw new IOException("Type not support for consuming StreamEvent from " + type, e);
-      }
+      // Try to determine the decoder to use from the first input types
+      // The first argument must be LongWritable for it to consumer stream event, as it carries the event timestamp
+      valueType = ((ParameterizedType) type.getType()).getActualTypeArguments()[1];
     }
-    StreamInputFormat.inferDecoderClass(job.getConfiguration(), valueType);
+    try {
+      StreamInputFormat.inferDecoderClass(job.getConfiguration(), valueType);
+    } catch (IllegalArgumentException e) {
+      throw new IOException("Type not support for consuming StreamEvent from " + type, e);
+    }
   }
 
   private String getJobName(BasicMapReduceContext context) {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/StreamDecoderDetectionTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/StreamDecoderDetectionTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.batch;
+
+import co.cask.cdap.api.flow.flowlet.StreamEvent;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.data.stream.StreamInputFormat;
+import co.cask.cdap.data.stream.decoder.IdentityStreamEventDecoder;
+import co.cask.cdap.data.stream.decoder.TextStreamEventDecoder;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.Mapper;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+/**
+ * Unit test for stream decoder detection.
+ */
+public class StreamDecoderDetectionTest {
+
+  @Test
+  public void testDecoderDetection() throws IOException {
+    // For testing purpose, we don't need all those parameters
+    Configuration hConf = new Configuration();
+    MapReduceRuntimeService runtimeService = new MapReduceRuntimeService(
+      CConfiguration.create(), hConf, null, null, null, null, null, null, null);
+
+    hConf.setClass(Job.MAP_CLASS_ATTR, IdentityMapper.class, Mapper.class);
+    runtimeService.setStreamEventDecoder(hConf);
+    Assert.assertSame(IdentityStreamEventDecoder.class, StreamInputFormat.getDecoderClass(hConf));
+
+    hConf.setClass(Job.MAP_CLASS_ATTR, NoTypeMapper.class, Mapper.class);
+    runtimeService.setStreamEventDecoder(hConf);
+    Assert.assertSame(IdentityStreamEventDecoder.class, StreamInputFormat.getDecoderClass(hConf));
+
+    hConf.setClass(Job.MAP_CLASS_ATTR, TextMapper.class, Mapper.class);
+    runtimeService.setStreamEventDecoder(hConf);
+    Assert.assertSame(TextStreamEventDecoder.class, StreamInputFormat.getDecoderClass(hConf));
+
+    try {
+      hConf.setClass(Job.MAP_CLASS_ATTR, InvalidTypeMapper.class, Mapper.class);
+      runtimeService.setStreamEventDecoder(hConf);
+      Assert.fail("Expected Exception");
+    } catch (IllegalArgumentException e) {
+      // Expected
+    }
+  }
+
+  public static final class IdentityMapper extends Mapper<LongWritable, StreamEvent, String, String> {
+    // No-op
+  }
+
+  public static final class NoTypeMapper extends Mapper {
+    // No-op
+  }
+
+  public static final class TextMapper extends Mapper<LongWritable, Text, String, String> {
+    // No-op
+  }
+
+  public static final class InvalidTypeMapper<I, O> extends Mapper<I, O, String, String> {
+    // No-op
+  }
+}


### PR DESCRIPTION
This is needed as for BatchSources in ETL which does not have access to internal classes. 
Conversation here: https://github.com/caskdata/cdap/pull/1921/files#r28036460

Build running here: http://builds.cask.co/browse/CDAP-DUT1408-1