### PR TITLE
Convert documentation build to run under python 2.6

### DIFF
--- a/cdap-docs/_common/_themes/cdap/globaltoc.html
+++ b/cdap-docs/_common/_themes/cdap/globaltoc.html
@@ -21,8 +21,8 @@
 {%- set hideglobaltoc = '' %}
 {%- set hideglobaltoc_key = 'hide-global-toc' %}
 {%- if meta is defined %}
-    {%- if hideglobaltoc_key in meta.viewkeys() %}
-      {%- set hideglobaltoc = meta.get(hideglobaltoc_key) %}
+    {%- if hideglobaltoc_key in meta %}
+      {%- set hideglobaltoc = meta[hideglobaltoc_key] %}
     {%- endif %}
 {%- endif %}
 {%- if not hideglobaltoc %}

--- a/cdap-docs/_common/_themes/cdap/layout.html
+++ b/cdap-docs/_common/_themes/cdap/layout.html
@@ -120,8 +120,8 @@
     {%- set hidetoc = '' %}
     {%- set hidetoc_key = 'hide-toc' %}
     {%- if meta is defined %}
-        {%- if hidetoc_key in meta.viewkeys() %}
-            {%- set hidetoc = meta.get(hidetoc_key) %}
+        {%- if hidetoc_key in meta %}
+            {%- set hidetoc = meta[hidetoc_key] %}
         {%- endif %}
     {%- endif %}
     {%- if hidetoc %}
@@ -135,8 +135,8 @@
     {%- set hidenav = '' %}
     {%- set hidenav_key = 'hide-nav' %}
     {%- if meta is defined %}
-        {%- if hidenav_key in meta.viewkeys() %}
-            {%- set hidenav = meta.get(hidenav_key) %}
+        {%- if hidenav_key in meta %}
+            {%- set hidenav = meta[hidenav_key] %}
         {%- endif %}
     {%- endif %}
     {%- if hidenav %}

--- a/cdap-docs/_common/_themes/cdap/relations.html
+++ b/cdap-docs/_common/_themes/cdap/relations.html
@@ -14,8 +14,8 @@
 {%- set hiderel = '' %}
 {%- set hiderel_key = 'hide-relations' %}
 {%- if meta is defined %}
-    {%- if hiderel_key in meta.viewkeys() %}
-        {%- set hiderel = meta.get(hiderel_key) %}
+    {%- if hiderel_key in meta %}
+        {%- set hiderel = meta[hiderel_key] %}
     {%- endif %}
 {%- endif %}
 {%- if not hiderel %}

--- a/cdap-docs/_common/common_conf.py
+++ b/cdap-docs/_common/common_conf.py
@@ -49,7 +49,6 @@ def get_sdk_version():
         p2 = subprocess.Popen(["awk", "NR==1;START{print $1}"], stdin=p1.stdout, stdout=subprocess.PIPE)
         full_version_temp = p2.communicate()[0]
 # 
-        print "full_version_temp: %s" % full_version_temp
         full_version = full_version_temp.strip().replace("<version>", "").replace("</version>", "")
         version = full_version.replace("-SNAPSHOT", "")
         short_version = '%s.%s' % tuple(version.split('.')[0:2])

--- a/cdap-docs/_common/common_conf.py
+++ b/cdap-docs/_common/common_conf.py
@@ -36,15 +36,25 @@ from datetime import datetime
 
 def get_sdk_version():
     # Sets the Build Version
-    grep_version_cmd = "grep '<version>' ../../../pom.xml | awk 'NR==1;START{print $1}'"
     version = None
     short_version = None
     full_version = None
     try:
-        full_version = subprocess.check_output(grep_version_cmd, shell=True).strip().replace("<version>", "").replace("</version>", "")
+# Python 2.7 commands
+#         grep_version_cmd = "grep '<version>' ../../../pom.xml | awk 'NR==1;START{print $1}'"
+#         print "grep_version_cmd: %s" % grep_version_cmd
+#         full_version_temp = subprocess.check_output(grep_version_cmd, shell=True)
+# Python 2.6 commands
+        p1 = subprocess.Popen(["grep" , "<version>", "../../../pom.xml" ], stdout=subprocess.PIPE)
+        p2 = subprocess.Popen(["awk", "NR==1;START{print $1}"], stdin=p1.stdout, stdout=subprocess.PIPE)
+        full_version_temp = p2.communicate()[0]
+# 
+        print "full_version_temp: %s" % full_version_temp
+        full_version = full_version_temp.strip().replace("<version>", "").replace("</version>", "")
         version = full_version.replace("-SNAPSHOT", "")
         short_version = '%s.%s' % tuple(version.split('.')[0:2])
     except:
+        print "Unexpected error:", sys.exc_info()[0]
         pass
     return version, short_version, full_version
 

--- a/cdap-docs/admin-manual/source/conf.py
+++ b/cdap-docs/admin-manual/source/conf.py
@@ -10,6 +10,10 @@ import os
 sys.path.insert(0, os.path.abspath('../../_common'))
 from common_conf import * 
 
+print_sdk_version()
+
+print get_sdk_version()
+
 # Override the common config
 
 html_short_title_toc = manuals_dict["admin-manual"]

--- a/cdap-docs/admin-manual/source/conf.py
+++ b/cdap-docs/admin-manual/source/conf.py
@@ -10,10 +10,6 @@ import os
 sys.path.insert(0, os.path.abspath('../../_common'))
 from common_conf import * 
 
-print_sdk_version()
-
-print get_sdk_version()
-
 # Override the common config
 
 html_short_title_toc = manuals_dict["admin-manual"]

--- a/cdap-docs/examples-manual/build.sh
+++ b/cdap-docs/examples-manual/build.sh
@@ -58,7 +58,13 @@ function download_file() {
 
   echo "Downloading using curl $file_name from $source_dir"
   curl $source_dir/$file_name --output $target --silent
-  local new_md5_hash=`md5 -q $target`
+  
+  if [ "$OSTYPE" == "darwin"* ]; then
+    local new_md5_hash=`md5 -q $target`
+  else
+    local new_md5_hash=`md5sum $target | awk '{print $1}'`
+  fi
+  
   if [ "x$md5_hash" != "x$new_md5_hash" ]; then
     echo -e "$WARNING MD5 Hash for $file_name has changed! Compare files and update hash!"  
     echo "Old md5_hash: $md5_hash New md5_hash: $new_md5_hash"


### PR DESCRIPTION
These changes modify the build scripts so that they will successfully run under Python 2.6 on CentOS 6.

The script runs successfully; the documentation built is [staged](http://stg-web101.sw.joyent.continuuity.net/cdap/2.8.0-r2.8_convert_build_to_python_2.6/en/index.html).

These changes would need to be ported to 3.0 in order for it to build there.