### PR TITLE
CDAP-1943 Added policy to do nothing on the trigger misfire.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/TimeScheduler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/TimeScheduler.java
@@ -152,7 +152,9 @@ final class TimeScheduler implements Scheduler {
       Trigger trigger = TriggerBuilder.newTrigger()
         .withIdentity(triggerKey)
         .forJob(job)
-        .withSchedule(CronScheduleBuilder.cronSchedule(getQuartzCronExpression(cronEntry)))
+        .withSchedule(CronScheduleBuilder
+                        .cronSchedule(getQuartzCronExpression(cronEntry))
+                        .withMisfireHandlingInstructionDoNothing())
         .build();
       try {
         scheduler.scheduleJob(trigger);


### PR DESCRIPTION
Jira: https://issues.cask.co/browse/CDAP-1943

Updated the misfire instruction for the time scheduler to the `MISFIRE_INSTRUCTION_DO_NOTHING `. This will discard the misfired execution and the scheduler will simply waits for next scheduled time.