### PR TITLE
CDAP-2052 Restructuring adapter id in logging context

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/logging/ApplicationLoggingContext.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/logging/ApplicationLoggingContext.java
@@ -16,8 +16,6 @@
 
 package co.cask.cdap.common.logging;
 
-import javax.annotation.Nullable;
-
 /**
  * Application logging context.
  */
@@ -30,12 +28,13 @@ public abstract class ApplicationLoggingContext extends NamespaceLoggingContext 
    * @param namespaceId namespace id
    * @param applicationId application id
    */
-  public ApplicationLoggingContext(final String namespaceId, final String applicationId, @Nullable String adapterId) {
+  public ApplicationLoggingContext(final String namespaceId, final String applicationId) {
     super(namespaceId);
     setSystemTag(TAG_APPLICATION_ID, applicationId);
-    if (adapterId != null) {
-      setSystemTag(TAG_ADAPTER_ID, adapterId);
-    }
+  }
+
+  protected void setAdapterId(String adapterId) {
+    setSystemTag(TAG_ADAPTER_ID, adapterId);
   }
 
   @Override

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/FlowletLoggingContext.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/FlowletLoggingContext.java
@@ -37,7 +37,7 @@ public class FlowletLoggingContext extends ApplicationLoggingContext {
                                final String applicationId,
                                final String flowId,
                                final String flowletId) {
-    super(namespaceId, applicationId, null);
+    super(namespaceId, applicationId);
     setSystemTag(TAG_FLOW_ID, flowId);
     setSystemTag(TAG_FLOWLET_ID, flowletId);
   }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/GenericLoggingContext.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/GenericLoggingContext.java
@@ -33,7 +33,7 @@ public class GenericLoggingContext extends ApplicationLoggingContext {
   public GenericLoggingContext(final String namespaceId,
                                final String applicationId,
                                final String entityId) {
-    super(namespaceId, applicationId, null);
+    super(namespaceId, applicationId);
     setSystemTag(TAG_ENTITY_ID, entityId);
   }
 

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/MapReduceLoggingContext.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/MapReduceLoggingContext.java
@@ -32,11 +32,15 @@ public class MapReduceLoggingContext extends ApplicationLoggingContext {
    * @param namespaceId namespace id
    * @param applicationId application id
    * @param mapReduceId mapreduce job id
+   * @param adapterId adapter id
    */
   public MapReduceLoggingContext(final String namespaceId, final String applicationId, final String mapReduceId,
                                  @Nullable String adapterId) {
-    super(namespaceId, applicationId, adapterId);
+    super(namespaceId, applicationId);
     setSystemTag(TAG_MAP_REDUCE_JOB_ID, mapReduceId);
+    if (adapterId != null) {
+      setAdapterId(adapterId);
+    }
   }
 
   @Override

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/ProcedureLoggingContext.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/ProcedureLoggingContext.java
@@ -34,7 +34,7 @@ public class ProcedureLoggingContext extends ApplicationLoggingContext {
   public ProcedureLoggingContext(final String namespaceId,
                                  final String applicationId,
                                  final String procedureId) {
-    super(namespaceId, applicationId, null);
+    super(namespaceId, applicationId);
     setSystemTag(TAG_PROCEDURE_ID, procedureId);
   }
 

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/SparkLoggingContext.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/SparkLoggingContext.java
@@ -33,7 +33,7 @@ public class SparkLoggingContext extends ApplicationLoggingContext {
    * @param sparkId spark job id
    */
   public SparkLoggingContext(final String namespaceId, final String applicationId, final String sparkId) {
-    super(namespaceId, applicationId, null);
+    super(namespaceId, applicationId);
     setSystemTag(TAG_SPARK_JOB_ID, sparkId);
   }
 

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/UserServiceLoggingContext.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/UserServiceLoggingContext.java
@@ -30,7 +30,7 @@ public class UserServiceLoggingContext extends ApplicationLoggingContext {
                                    final String applicationId,
                                    final String serviceId,
                                    final String runnableId) {
-    super(namespaceId, applicationId, null);
+    super(namespaceId, applicationId);
     setSystemTag(TAG_USERSERVICE_ID, serviceId);
     setSystemTag(TAG_RUNNABLE_ID, runnableId);
   }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/WorkerLoggingContext.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/WorkerLoggingContext.java
@@ -30,8 +30,11 @@ public class WorkerLoggingContext extends ApplicationLoggingContext {
 
   public WorkerLoggingContext(final String namespaceId, final String appId, final String workerId,
                               @Nullable String adapterId) {
-    super(namespaceId, appId, adapterId);
+    super(namespaceId, appId);
     setSystemTag(TAG_WORKER_ID, workerId);
+    if (adapterId != null) {
+      setAdapterId(adapterId);
+    }
   }
 
   @Override

--- a/cdap-watchdog/src/test/java/co/cask/cdap/common/logging/logback/TestLoggingContext.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/common/logging/logback/TestLoggingContext.java
@@ -23,7 +23,7 @@ import co.cask.cdap.common.logging.ApplicationLoggingContext;
  */
 public class TestLoggingContext extends ApplicationLoggingContext {
   public TestLoggingContext(String namespaceId, String applicationId) {
-    super(namespaceId, applicationId, null);
+    super(namespaceId, applicationId);
   }
 
   @Override


### PR DESCRIPTION
Using setter for adapter id eliminates the need to have Nullable constructor parameters.

JIRA - https://issues.cask.co/browse/CDAP-2052