### PR TITLE
[CDAP-1879]  Add JMS realtime source for ETL Template

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/pom.xml
@@ -124,6 +124,27 @@
       <artifactId>avro-mapred</artifactId>
       <version>1.7.6</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.geronimo.specs</groupId>
+      <artifactId>geronimo-jms_2.0_spec</artifactId>
+      <version>1.0-alpha-2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.activemq</groupId>
+      <artifactId>activemq-core</artifactId>
+      <version>5.5.1</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
 </project>

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/pom.xml
@@ -126,8 +126,8 @@
     </dependency>
     <dependency>
       <groupId>org.apache.geronimo.specs</groupId>
-      <artifactId>geronimo-jms_2.0_spec</artifactId>
-      <version>1.0-alpha-2</version>
+      <artifactId>geronimo-jms_1.1_spec</artifactId>
+      <version>1.1.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.activemq</groupId>

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/jms/JmsProvider.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/jms/JmsProvider.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.templates.etl.realtime.jms;
+
+import co.cask.cdap.templates.etl.api.realtime.RealtimeSource;
+import javax.jms.ConnectionFactory;
+import javax.jms.Destination;
+
+/**
+ * Define an interface to get <code>Destination</code> JMS objects and <code>ConnectionFactory</code> to manage
+ * a topic/queue connection over the course of a source lifecycle.
+ */
+public interface JmsProvider {
+
+  /**
+   * Provides the JMS <code>ConnectionFactory</code>
+   * @return the instance of JMS {@link ConnectionFactory}
+   */
+  ConnectionFactory getConnectionFactory();
+
+  /**
+   * Provides the <code>Destination</code> (topic or queue) from which the {@link RealtimeSource} will get
+   * data from.
+   * @return instance of JMS {@link Destination}
+   */
+  Destination getDestination();
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/sources/JmsSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/sources/JmsSource.java
@@ -98,14 +98,14 @@ public class JmsSource extends RealtimeSource<String> implements MessageListener
         try {
           session.close();
         } catch (JMSException ex1) {
-          LOG.debug("Exception when closing session", ex1);
+          LOG.warn("Exception when closing session", ex1);
         }
       }
       if (connection != null) {
         try {
           connection.close();
         } catch (JMSException ex2) {
-          LOG.debug("Exception when closing connection", ex2);
+          LOG.warn("Exception when closing connection", ex2);
         }
       }
       throw new RuntimeException("JMSException thrown when trying to initialize connection: " + ex.getMessage(),
@@ -141,7 +141,7 @@ public class JmsSource extends RealtimeSource<String> implements MessageListener
         // Different kind of messages, just get String for now
         // TODO Process different kind of JMS messages
         String text = message.toString();
-        LOG.debug("Process JMS message : " + text);
+        LOG.trace("Processing JMS message : " + text);
         writer.emit(text);
       }
     }  catch (JMSException e) {
@@ -212,13 +212,13 @@ public class JmsSource extends RealtimeSource<String> implements MessageListener
     try {
       messageID = message.getJMSMessageID();
     } catch (JMSException e) {
-      LOG.debug("Error when trying to get message ID for JMS message.");
+      LOG.warn("Encountered exception when trying to get message ID for JMS message.");
     }
 
-    LOG.debug("Attempt to add message: {}", messageID);
+    LOG.trace("Attempt to add message: {}", messageID);
 
     messageQueue.add(message);
 
-    LOG.debug("Success adding message: {}", messageID);
+    LOG.trace("Success adding message: {}", messageID);
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/sources/JmsSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/sources/JmsSource.java
@@ -203,7 +203,7 @@ public class JmsSource extends RealtimeSource<String> implements MessageListener
 
   /**
    * <p>
-   * The {@link javax.jms.MessageListener} implementation that will store the messsages to be processed by next poll
+   * The {@link javax.jms.MessageListener} implementation that will store the messages to be processed by next poll
    * to this {@link JmsSource}
    * </p>
    */

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/sources/JmsSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/sources/JmsSource.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.templates.etl.realtime.sources;
+
+import co.cask.cdap.templates.etl.api.ValueEmitter;
+import co.cask.cdap.templates.etl.api.realtime.RealtimeConfigurer;
+import co.cask.cdap.templates.etl.api.realtime.RealtimeSource;
+import co.cask.cdap.templates.etl.api.realtime.SourceContext;
+import co.cask.cdap.templates.etl.api.realtime.SourceState;
+import co.cask.cdap.templates.etl.realtime.jms.JmsProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import javax.jms.Connection;
+import javax.jms.Session;
+
+/**
+ * <p>
+ * Implementation of CDAP {@link RealtimeSource} that listen to external JMS producer and send the message
+ * as String to the CDAP ETL Template.
+ * </p>
+ */
+public class JmsSource extends RealtimeSource<String> {
+  private static final Logger LOG = LoggerFactory.getLogger(JmsSource.class);
+
+  private int jmsAcknowledgeMode = Session.AUTO_ACKNOWLEDGE;
+  private JmsProvider jmsProvider;
+
+  private transient Connection connection;
+  private transient Session session;
+
+  /**
+   * Configure the JMS Source.
+   *
+   * @param configurer {@link RealtimeConfigurer}
+   */
+  @Override
+  public void configure(RealtimeConfigurer configurer) {
+    configurer.setName("JMS Realtime Source");
+    configurer.setDescription("CDAP JMS Realtime Source");
+  }
+
+  /**
+   * Initialize the Source.
+   *
+   * @param context {@link SourceContext}
+   */
+  public void initialize(SourceContext context) {
+    super.initialize(context);
+
+    // TODO Bootstrap the JMS consumer
+
+  }
+
+  @Nullable
+  @Override
+  public SourceState poll(ValueEmitter<String> writer, SourceState currentState) {
+    // TODO code this shit
+
+    return null;
+  }
+
+  @Override
+  public void destroy() {
+    try {
+      if(session != null) {
+        session.close();
+      }
+      if(connection != null) {
+        connection.close();
+      }
+    } catch (Exception ex) {
+      throw new RuntimeException("Exception on closing JMS connection: " + ex.getMessage(), ex);
+    }
+  }
+
+  /**
+   * Sets the JMS Session acknowledgement mode for this source.
+   * <p/>
+   * Possible values:
+   * <ul>
+   * <li>javax.jms.Session.AUTO_ACKNOWLEDGE</li>
+   * <li>javax.jms.Session.CLIENT_ACKNOWLEDGE</li>
+   * <li>javax.jms.Session.DUPS_OK_ACKNOWLEDGE</li>
+   * </ul>
+   * @param mode JMS Session Acknowledgement mode
+   * @throws IllegalArgumentException if the mode is not recognized.
+   */
+  public void setSessionAcknowledgeMode(int mode) {
+    switch (mode) {
+      case Session.AUTO_ACKNOWLEDGE:
+      case Session.CLIENT_ACKNOWLEDGE:
+      case Session.DUPS_OK_ACKNOWLEDGE:
+      case Session.SESSION_TRANSACTED:
+        break;
+      default:
+        throw new IllegalArgumentException("Unknown JMS Session acknowledge mode: " + mode);
+    }
+    this.jmsAcknowledgeMode = mode;
+  }
+
+  /**
+   * Set the {@link JmsProvider} to be used by the source.
+   * implementation that this Spout will use to connect to
+   * a JMS <code>javax.jms.Desination</code>
+   *
+   * @param provider the instance of {@link JmsProvider}
+   */
+  public void setJmsProvider(JmsProvider provider){
+    jmsProvider = provider;
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/sources/JmsSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/sources/JmsSource.java
@@ -80,7 +80,7 @@ public class JmsSource extends RealtimeSource<String> implements MessageListener
    * Helper method to initialize the JMS Connection to start listening messages.
    */
   private void initializeJMSConnection() {
-    if(jmsProvider == null) {
+    if (jmsProvider == null) {
       throw new IllegalStateException("Could not have null JMSProvider for JMS Source. " +
                                          "Please set the right JMSProvider");
     }
@@ -94,7 +94,7 @@ public class JmsSource extends RealtimeSource<String> implements MessageListener
       consumer.setMessageListener(this);
       connection.start();
     } catch (JMSException ex) {
-      if(session != null) {
+      if (session != null) {
         try {
           session.close();
         } catch (JMSException ex1) {
@@ -133,7 +133,7 @@ public class JmsSource extends RealtimeSource<String> implements MessageListener
         int bodyLength = (int) bytesMessage.getBodyLength();
         byte[] data = new byte[bodyLength];
         int bytesRead = bytesMessage.readBytes(data);
-        if(bytesRead != bodyLength) {
+        if (bytesRead != bodyLength) {
           LOG.warn("Number of bytes read {} not same as expected {}", bytesRead, bodyLength);
         }
         writer.emit(new String(data));
@@ -155,10 +155,10 @@ public class JmsSource extends RealtimeSource<String> implements MessageListener
   @Override
   public void destroy() {
     try {
-      if(session != null) {
+      if (session != null) {
         session.close();
       }
-      if(connection != null) {
+      if (connection != null) {
         connection.close();
       }
     } catch (Exception ex) {
@@ -196,7 +196,7 @@ public class JmsSource extends RealtimeSource<String> implements MessageListener
    *
    * @param provider the instance of {@link JmsProvider}
    */
-  public void setJmsProvider(JmsProvider provider){
+  public void setJmsProvider(JmsProvider provider) {
     jmsProvider = provider;
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/sources/JmsSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/sources/JmsSource.java
@@ -24,6 +24,7 @@ import co.cask.cdap.templates.etl.realtime.jms.JmsProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import javax.annotation.Nullable;
 import javax.jms.BytesMessage;
@@ -46,9 +47,11 @@ import javax.jms.TextMessage;
 public class JmsSource extends RealtimeSource<String> implements MessageListener {
   private static final Logger LOG = LoggerFactory.getLogger(JmsSource.class);
 
+  // TODO Need option to add Max size of the internal queue
+  private final BlockingQueue<Message> messageQueue = new LinkedBlockingQueue<Message>();
+
   private int jmsAcknowledgeMode = Session.AUTO_ACKNOWLEDGE;
   private JmsProvider jmsProvider;
-  private final LinkedBlockingQueue<Message> messageQueue = new LinkedBlockingQueue<Message>();
 
   private transient Connection connection;
   private transient Session session;

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/sources/JmsSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/sources/JmsSource.java
@@ -171,9 +171,10 @@ public class JmsSource extends RealtimeSource<String> implements MessageListener
    * <p/>
    * Possible values:
    * <ul>
-   * <li>javax.jms.Session.AUTO_ACKNOWLEDGE</li>
-   * <li>javax.jms.Session.CLIENT_ACKNOWLEDGE</li>
-   * <li>javax.jms.Session.DUPS_OK_ACKNOWLEDGE</li>
+   *  <li>javax.jms.Session.AUTO_ACKNOWLEDGE</li>
+   *  <li>javax.jms.Session.CLIENT_ACKNOWLEDGE</li>
+   *  <li>javax.jms.Session.DUPS_OK_ACKNOWLEDGE</li>
+   *  <li>javax.jms.Session.SESSION_TRANSACTED</li>
    * </ul>
    * @param mode JMS Session Acknowledgement mode
    * @throws IllegalArgumentException if the mode is not recognized.
@@ -188,7 +189,7 @@ public class JmsSource extends RealtimeSource<String> implements MessageListener
       default:
         throw new IllegalArgumentException("Unknown JMS Session acknowledge mode: " + mode);
     }
-    this.jmsAcknowledgeMode = mode;
+    jmsAcknowledgeMode = mode;
   }
 
   /**

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/sources/JmsSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/sources/JmsSource.java
@@ -87,7 +87,7 @@ public class JmsSource extends RealtimeSource<String> implements MessageListener
 
     try {
       connection = connectionFactory.createConnection();
-      session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+      session = connection.createSession(false, jmsAcknowledgeMode);
       Destination destination = jmsProvider.getDestination();
       MessageConsumer consumer = session.createConsumer(destination);
       consumer.setMessageListener(this);
@@ -110,7 +110,6 @@ public class JmsSource extends RealtimeSource<String> implements MessageListener
       throw new RuntimeException("JMSException thrown when trying to initialize connection: " + ex.getMessage(),
                                  ex);
     }
-
   }
 
   @Nullable

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/templates/etl/realtime/sources/JmsMessageToStringSourceTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/templates/etl/realtime/sources/JmsMessageToStringSourceTest.java
@@ -93,7 +93,7 @@ public class JmsMessageToStringSourceTest {
 
   @After
   public void afterTest() {
-    if(jmsSource != null) {
+    if (jmsSource != null) {
       jmsSource.destroy();
     }
     originalMessage = "NO_MATCH";

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/templates/etl/realtime/sources/JmsMessageToStringSourceTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/templates/etl/realtime/sources/JmsMessageToStringSourceTest.java
@@ -247,7 +247,7 @@ public class JmsMessageToStringSourceTest {
   /**
    * Helper class to emit JMS message to next stage
    */
-  public static class MockValueEmitter implements ValueEmitter<String> {
+  private static class MockValueEmitter implements ValueEmitter<String> {
     private String currentValue;
 
     /**

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/templates/etl/realtime/sources/JmsMessageToStringSourceTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/templates/etl/realtime/sources/JmsMessageToStringSourceTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.templates.etl.realtime.sources;
+
+import co.cask.cdap.api.Resources;
+import co.cask.cdap.templates.etl.api.Property;
+import co.cask.cdap.templates.etl.api.ValueEmitter;
+import co.cask.cdap.templates.etl.api.realtime.RealtimeConfigurer;
+import co.cask.cdap.templates.etl.api.realtime.RealtimeSpecification;
+import co.cask.cdap.templates.etl.api.realtime.SourceContext;
+import co.cask.cdap.templates.etl.realtime.jms.JmsProvider;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.Destination;
+import javax.jms.JMSException;
+import javax.jms.MessageProducer;
+import javax.jms.Queue;
+import javax.jms.QueueConnection;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+import javax.jms.Topic;
+import javax.jms.TopicConnection;
+import javax.naming.NamingException;
+
+/**
+ * Unit test for JMS ETL realtime source
+ */
+public class JmsMessageToStringSourceTest {
+  private static final Logger LOG = LoggerFactory.getLogger(JmsMessageToStringSourceTest.class);
+
+  private final int sessionAckMode = Session.DUPS_OK_ACKNOWLEDGE;
+
+  private JmsSource jmsSource;
+  private JmsProvider jmsProvider;
+
+  @Before
+  public void beforeTest() {
+    jmsSource = new JmsSource();
+
+    jmsSource.configure(new RealtimeConfigurer() {
+      @Override
+      public void setName(String name) {
+        // no-op
+      }
+
+      @Override
+      public void setDescription(String description) {
+        // no-op
+      }
+
+      @Override
+      public void addProperties(List<Property> properties) {
+        // no-op
+      }
+
+      @Override
+      public void addProperty(Property property) {
+        // no-op
+      }
+
+      @Override
+      public void setResources(Resources resources) {
+        // no-op
+      }
+    });
+
+    jmsSource.initialize(new SourceContext() {
+      @Override
+      public RealtimeSpecification getSpecification() {
+        return null;
+      }
+
+      @Override
+      public int getInstanceId() {
+        return 0;
+      }
+
+      @Override
+      public int getInstanceCount() {
+        return 0;
+      }
+
+      @Override
+      public Map<String, String> getRuntimeArguments() {
+        return null;
+      }
+    });
+  }
+
+  @After
+  public void afterTest() {
+    if(jmsSource != null) {
+      jmsSource.destroy();
+    }
+  }
+
+  @Test
+  public void testSimpleQueueMessages() throws JMSException, NamingException {
+    jmsProvider = new MockJmsProvider("dynamicQueues/CDAP.QUEUE");
+    jmsSource.setJmsProvider(jmsProvider);
+    jmsSource.setSessionAcknowledgeMode(sessionAckMode);
+
+    ConnectionFactory connectionFactory = jmsProvider.getConnectionFactory();
+    QueueConnection queueConn = (QueueConnection) connectionFactory.createConnection();
+    Queue queueDestination = (Queue) jmsProvider.getDestination();
+
+    // Let's start the Connection
+    queueConn.start();
+    sendMessage(queueConn, queueDestination, "Queue:" + queueDestination.getQueueName());
+
+    // TODO Lets verify from JMS source
+    //jmsSource.poll()
+
+  }
+
+  @Test
+  public void testSimpleTopicMessages() throws NamingException, JMSException {
+    jmsProvider = new MockJmsProvider("dynamicTopics/CDAP.TOPIC");
+    jmsSource.setJmsProvider(jmsProvider);
+
+    // TODO Add test for Topic
+    jmsSource.setSessionAcknowledgeMode(sessionAckMode);
+
+    ConnectionFactory connectionFactory = jmsProvider.getConnectionFactory();
+    TopicConnection topicConn = (TopicConnection) connectionFactory.createConnection();
+    Topic topicDestination = (Topic) jmsProvider.getDestination();
+
+    // Let's start the Connection
+    topicConn.start();
+    sendMessage(topicConn, topicDestination, "Topic:" + topicDestination.getTopicName());
+
+    // TODO Lets verify from JMS source
+    //jmsSource.poll()
+
+  }
+
+  // Helper method to start sending message to destination
+  public void sendMessage(Connection connection, Destination destination, String destType) throws JMSException {
+    Session session = connection.createSession(false, sessionAckMode);
+    MessageProducer producer = session.createProducer(destination);
+    TextMessage msg = session.createTextMessage();
+    msg.setText("Hello World to destination: " + destination.getClass().getName());
+    LOG.info("Sending Message: " + msg.getText());
+    producer.send(msg);
+
+    System.out.println("Sending Message to " + destType + " destination with text: " + msg.getText());
+  }
+
+
+  /**
+   * Helper class to emit JMS message to next stage
+   */
+  public static class MockValueEmitter implements ValueEmitter<String> {
+
+    /**
+     * Emit objects to the next stage.
+     *
+     * @param value data object.
+     */
+    @Override
+    public void emit(String value) {
+
+    }
+
+    /**
+     * Emit a key, value pair.
+     *
+     * @param key   key object
+     * @param value value object
+     */
+    @Override
+    public void emit(Void key, String value) {
+
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/templates/etl/realtime/sources/MockJmsProvider.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/templates/etl/realtime/sources/MockJmsProvider.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.templates.etl.realtime.sources;
+
+import co.cask.cdap.templates.etl.realtime.jms.JmsProvider;
+import org.apache.activemq.ActiveMQConnectionFactory;
+
+import javax.jms.ConnectionFactory;
+import javax.jms.Destination;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+/**
+ * This class is used to provide mock JMS ConnectionFactory for testing JMS realtime template source.
+ */
+public class MockJmsProvider implements JmsProvider {
+
+  private ConnectionFactory connectionFactory;
+  private Destination destination;
+
+  public MockJmsProvider(String destinationName) throws NamingException {
+    connectionFactory =  new ActiveMQConnectionFactory("vm://localhost?broker.persistent=false");
+
+    // Set JNDI Context
+    Context jndiContext = new InitialContext();
+    destination = (Destination) jndiContext.lookup(destinationName);
+  }
+
+  @Override
+  public ConnectionFactory getConnectionFactory() {
+    return connectionFactory;
+  }
+
+  @Override
+  public Destination getDestination() {
+    return destination;
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/resources/jndi.properties
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/resources/jndi.properties
@@ -1,0 +1,28 @@
+#
+# Copyright © 2015 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
+java.naming.factory.initial = org.apache.activemq.jndi.ActiveMQInitialContextFactory
+
+# use the following property to configure the default connector
+java.naming.provider.url = vm://localhost?broker.persistent=false
+
+# register some queues in JNDI using the form
+# queue.[jndiName] = [physicalName]
+#queue.MyQueue = example.MyQueue
+
+# register some topics in JNDI using the form
+# topic.[jndiName] = [physicalName]
+#topic.MyTopic = example.MyTopic


### PR DESCRIPTION
This is the first drop to support JMS realtime source for ETL Template.

The PR consists of:
-) Add new JmsSource class in the etl/realtime/sources package
-) Add new JmsProvider interface that Adapter need to implement or get from configuration to provide JMS ConnectionFactory in the etl/realtime/jms package
-) Added MockJmsProvider and unit test JmsMessageToStringSourceTest to test getting JMSMessage to String emitter.
-) Currently just use Session.AUTO_ACKNOWLEDGE for message acknowledgement [1]
-) To test just run the JmsMessageToStringSourceTest and if successful you should see this message in console:

Sending Message to Topic:CDAP.TOPIC destination with text: Hello World to destination: org.apache.activemq.command.ActiveMQTopic
Getting JMS Message in emitter with value: Hello World to destination: org.apache.activemq.command.ActiveMQTopic

Sending Message to Queue:CDAP.QUEUE destination with text: Hello World to destination: org.apache.activemq.command.ActiveMQQueue
Getting JMS Message in emitter with value: Hello World to destination: org.apache.activemq.command.ActiveMQQueue

Process finished with exit code 0

[1] http://docs.oracle.com/javaee/6/tutorial/doc/bncfu.html#bncfw