### PR TITLE
PartitionedFileset Source and Sink Implementation with tests

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/templates/etl/batch/ETLBatchTemplate.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/templates/etl/batch/ETLBatchTemplate.java
@@ -27,8 +27,10 @@ import co.cask.cdap.templates.etl.api.batch.BatchSource;
 import co.cask.cdap.templates.etl.api.config.ETLStage;
 import co.cask.cdap.templates.etl.batch.config.ETLBatchConfig;
 import co.cask.cdap.templates.etl.batch.sinks.KVTableSink;
+import co.cask.cdap.templates.etl.batch.sinks.PartitionedFileSetSink;
 import co.cask.cdap.templates.etl.batch.sinks.TimePartitionedFileSetDatasetAvroSink;
 import co.cask.cdap.templates.etl.batch.sources.KVTableSource;
+import co.cask.cdap.templates.etl.batch.sources.PartitionedFileSetSource;
 import co.cask.cdap.templates.etl.batch.sources.StreamBatchSource;
 import co.cask.cdap.templates.etl.common.Constants;
 import co.cask.cdap.templates.etl.common.DefaultPipelineConfigurer;
@@ -71,7 +73,8 @@ public class ETLBatchTemplate extends ApplicationTemplate<ETLBatchConfig> {
                                         StreamBatchSource.class, StreamToStructuredRecordTransform.class,
                                         StructuredRecordToGenericRecordTransform.class,
                                         GenericTypeToAvroKeyTransform.class,
-                                        TimePartitionedFileSetDatasetAvroSink.class));
+                                        TimePartitionedFileSetDatasetAvroSink.class, PartitionedFileSetSource.class,
+                                        PartitionedFileSetSink.class));
   }
 
   private void initTable(List<Class> classList) throws Exception {

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/co/cask/cdap/templates/etl/batch/ETLPartitionedFileSetSourceSinkTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/co/cask/cdap/templates/etl/batch/ETLPartitionedFileSetSourceSinkTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.templates.etl.batch;
+
+import co.cask.cdap.api.dataset.lib.Partition;
+import co.cask.cdap.api.dataset.lib.PartitionKey;
+import co.cask.cdap.api.dataset.lib.PartitionOutput;
+import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
+import co.cask.cdap.api.dataset.lib.PartitionedFileSetProperties;
+import co.cask.cdap.api.dataset.lib.Partitioning;
+import co.cask.cdap.api.templates.ApplicationTemplate;
+import co.cask.cdap.templates.etl.api.config.ETLStage;
+import co.cask.cdap.templates.etl.batch.config.ETLBatchConfig;
+import co.cask.cdap.templates.etl.batch.sinks.PartitionedFileSetSink;
+import co.cask.cdap.templates.etl.batch.sources.PartitionedFileSetSource;
+import co.cask.cdap.test.ApplicationManager;
+import co.cask.cdap.test.DataSetManager;
+import co.cask.cdap.test.MapReduceManager;
+import co.cask.cdap.test.TestBase;
+import com.google.common.base.Charsets;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.gson.Gson;
+import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
+import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
+import org.apache.twill.filesystem.Location;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Test for {@link PartitionedFileSetSource} and {@link PartitionedFileSetSink}
+ */
+public class ETLPartitionedFileSetSourceSinkTest extends TestBase {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ETLPartitionedFileSetSourceSinkTest.class);
+  private static final Gson GSON = new Gson();
+  private static final String sourceFileset = "inputFileset";
+  private static final String sinkFileset = "outputFileset";
+
+  private static final String DUMMY_RECORD = "2015/3/10,Red Falcons,Blue Bonnets,28,17\n";
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    addDatasetInstance("partitionedFileSet", sourceFileset, PartitionedFileSetProperties.builder()
+      .setPartitioning(Partitioning.builder().addStringField("league").addIntField("season").build())
+      .setInputFormat(TextInputFormat.class)
+      .build());
+
+    addDatasetInstance("partitionedFileSet", sinkFileset, PartitionedFileSetProperties.builder()
+      .setPartitioning(Partitioning.builder().addStringField("league").build())
+      .setOutputFormat(TextOutputFormat.class)
+      .setOutputProperty(TextOutputFormat.SEPERATOR, ",")
+      .build());
+  }
+
+  @AfterClass
+  public static void afterClass() throws Exception {
+    clear();
+  }
+
+  @Test
+  public void testConfig() throws Exception {
+
+    writeToSource();
+
+    ApplicationManager batchManager = deployApplication(ETLBatchTemplate.class);
+
+    ApplicationTemplate<ETLBatchConfig> appTemplate = new ETLBatchTemplate();
+    ETLBatchConfig adapterConfig = constructETLBatchConfig();
+    MockAdapterConfigurer adapterConfigurer = new MockAdapterConfigurer();
+    appTemplate.configureAdapter("myAdapter", adapterConfig, adapterConfigurer);
+
+    Map<String, String> mapReduceArgs = Maps.newHashMap();
+    for (Map.Entry<String, String> entry : adapterConfigurer.getArguments().entrySet()) {
+      mapReduceArgs.put(entry.getKey(), entry.getValue());
+    }
+
+    mapReduceArgs.put("config", GSON.toJson(adapterConfig));
+    MapReduceManager mrManager = batchManager.startMapReduce("ETLMapReduce", mapReduceArgs);
+    mrManager.waitForFinish(5, TimeUnit.MINUTES);
+    batchManager.stopAll();
+
+    verySinkData();
+  }
+
+  private void verySinkData() throws Exception {
+    DataSetManager<PartitionedFileSet> sink = getDataset(sinkFileset);
+    PartitionedFileSet sinkPFS = sink.get();
+    Partition sinkPartition = sinkPFS.getPartition(PartitionKey.builder()
+                                                     .addStringField("league", "nfl")
+                                                     .build());
+
+    Assert.assertNotNull("Partition not found", sinkPartition);
+    try {
+      Location location = sinkPartition.getLocation();
+      for (Location file : location.list()) {
+        if (file.getName().startsWith("part")) {
+          BufferedReader reader = new BufferedReader(new InputStreamReader(location.getInputStream()));
+          Assert.assertEquals("The data in source and sink is not same", reader.readLine(), DUMMY_RECORD);
+        }
+      }
+    } catch (IOException e) {
+      LOG.info("Unable to read path {}", sinkPartition.getRelativePath());
+    }
+  }
+
+  private void writeToSource() throws Exception {
+    DataSetManager<PartitionedFileSet> table1 = getDataset(sourceFileset);
+    PartitionedFileSet inputFileset = table1.get();
+
+    PartitionKey key = PartitionKey.builder()
+      .addStringField("league", "nfl")
+      .addIntField("season", 1985)
+      .build();
+
+    if (inputFileset.getPartition(key) != null) {
+      LOG.info("Partition already exists");
+      throw new RuntimeException("Partition already exists");
+    }
+    PartitionOutput output = inputFileset.getPartitionOutput(key);
+
+    try {
+      Location location = output.getLocation();
+      OutputStream outputStream = location.getOutputStream();
+      try {
+        outputStream.write(DUMMY_RECORD.getBytes(Charsets.UTF_8));
+      } finally {
+        outputStream.close();
+      }
+    } catch (IOException e) {
+      LOG.warn(String.format("Unable to write path '%s'", output.getRelativePath()));
+      throw e;
+    }
+    output.addPartition();
+    table1.flush();
+  }
+
+  private ETLBatchConfig constructETLBatchConfig() {
+    ETLStage source = new ETLStage(PartitionedFileSetSource.class.getSimpleName(),
+                                   ImmutableMap.of("filesetName", sourceFileset, "filter",
+                                                   "{\"league.value\": \"nfl\",\"season.lower\": " +
+                                                     "\"1980\",\"season.upper\": \"1990\"}"));
+    ETLStage sink = new ETLStage(PartitionedFileSetSink.class.getSimpleName(),
+                                 ImmutableMap.of("filesetName", sinkFileset, "outputPath", sinkFileset,
+                                                 "partitionKey", "{\"league\" : \"nfl\"}"));
+    List<ETLStage> transformList = Lists.newArrayList();
+    return new ETLBatchConfig("", source, sink, transformList);
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/batch/sinks/PartitionedFileSetSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/batch/sinks/PartitionedFileSetSink.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.templates.etl.batch.sinks;
+
+import co.cask.cdap.api.dataset.lib.PartitionKey;
+import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
+import co.cask.cdap.api.dataset.lib.PartitionedFileSetArguments;
+import co.cask.cdap.api.dataset.lib.PartitionedFileSetProperties;
+import co.cask.cdap.templates.etl.api.PipelineConfigurer;
+import co.cask.cdap.templates.etl.api.Property;
+import co.cask.cdap.templates.etl.api.StageConfigurer;
+import co.cask.cdap.templates.etl.api.batch.BatchSink;
+import co.cask.cdap.templates.etl.api.batch.BatchSinkContext;
+import co.cask.cdap.templates.etl.api.config.ETLStage;
+import co.cask.cdap.templates.etl.common.ETLUtils;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.google.common.collect.Maps;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
+import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+
+/**
+ * CDAP {@link PartitionedFileSet} Batch Sink
+ */
+public class PartitionedFileSetSink extends BatchSink<LongWritable, Text> {
+
+  private static final String FILESET_NAME = "filesetName";
+  private static final String PARTITION_KEY = "partitionKey";
+  private static final String PARTITIONING = "partitioning";
+
+  @Override
+  public void configure(StageConfigurer configurer) {
+    configurer.setName(PartitionedFileSetSink.class.getSimpleName());
+    configurer.setDescription("CDAP Partitioned fileSet batch sink");
+    configurer.addProperty(new Property(FILESET_NAME, "Partitioned fileset name", true));
+    configurer.addProperty(new Property(PARTITION_KEY, "Partition key in JSON format to use while writing " +
+      "ex: {\"league\" : \"nfl\", \"season\" : \"1980\"}", true));
+    configurer.addProperty(new Property(PARTITIONING, "Partitioning to use for the Partitioned FileSet in JSON " +
+      "format. Should be provided if you want the pipeline to create the fileset. ex: " +
+      "{\"league\" : \"string\", \"season\" : \"int\"}", false));
+    configurer.addProperty(new Property(TextOutputFormat.SEPERATOR, "The output format separator. Must be provided " +
+      "if you want the pipeline to create the fileset", false));
+  }
+
+  @Override
+  public void configurePipeline(ETLStage stageConfig, PipelineConfigurer pipelineConfigurer) {
+    // if the partitioning is provided then we should try to create the fileset here
+    if (!Strings.isNullOrEmpty(stageConfig.getProperties().get(PARTITIONING))) {
+      String pfsName = stageConfig.getProperties().get(FILESET_NAME);
+      String separator = stageConfig.getProperties().get(TextOutputFormat.SEPERATOR);
+      Preconditions.checkArgument(!Strings.isNullOrEmpty(pfsName), "PartitionedFileSet name must be given.");
+      Preconditions.checkArgument(!Strings.isNullOrEmpty(pfsName), "A separator for " +
+        TextOutputFormat.SEPERATOR + "must be given");
+      pipelineConfigurer.createDataset(pfsName, PartitionedFileSet.class.getName(),
+                                       PartitionedFileSetProperties.builder()
+        .setPartitioning(ETLUtils.createPartitioning(stageConfig.getProperties().get(PARTITIONING)))
+        .setInputFormat(TextInputFormat.class)
+        .setOutputFormat(TextOutputFormat.class)
+        .setOutputProperty(TextOutputFormat.SEPERATOR, separator)
+        .build());
+    }
+  }
+
+  @Override
+  public void prepareJob(BatchSinkContext context) {
+    Map<String, String> inputArgs = Maps.newHashMap();
+    PartitionedFileSetArguments.setOutputPartitionKey(inputArgs,
+                                                      buildParitionKey(
+                                                        context.getRuntimeArguments().get(PARTITION_KEY)));
+    PartitionedFileSet input = context.getDataset(context.getRuntimeArguments().get(FILESET_NAME), inputArgs);
+    context.setOutput(context.getRuntimeArguments().get(FILESET_NAME), input);
+  }
+
+  /**
+   * Builds a {@link PartitionKey} from user supplied JSON string.
+   *
+   * @param paritionKeyString the partition key JSON string
+   * @return {@link PartitionKey}
+   */
+  private PartitionKey buildParitionKey(String paritionKeyString) {
+    PartitionKey.Builder builder = PartitionKey.builder();
+    Type stringStringMap = new TypeToken<Map<String, String>>() {
+    }.getType();
+    Map<String, String> paritionKeyMap = new Gson().fromJson(paritionKeyString, stringStringMap);
+    for (Map.Entry<String, String> entrySet : paritionKeyMap.entrySet()) {
+      builder.addField(entrySet.getKey(), entrySet.getValue());
+    }
+    return builder.build();
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/batch/sources/PartitionedFileSetSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/batch/sources/PartitionedFileSetSource.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.templates.etl.batch.sources;
+
+import co.cask.cdap.api.dataset.lib.PartitionFilter;
+import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
+import co.cask.cdap.api.dataset.lib.PartitionedFileSetArguments;
+import co.cask.cdap.api.dataset.lib.PartitionedFileSetProperties;
+import co.cask.cdap.templates.etl.api.PipelineConfigurer;
+import co.cask.cdap.templates.etl.api.Property;
+import co.cask.cdap.templates.etl.api.StageConfigurer;
+import co.cask.cdap.templates.etl.api.batch.BatchSource;
+import co.cask.cdap.templates.etl.api.batch.BatchSourceContext;
+import co.cask.cdap.templates.etl.api.config.ETLStage;
+import co.cask.cdap.templates.etl.common.ETLUtils;
+import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.google.common.collect.Maps;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
+import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+
+/**
+ * CDAP {@link PartitionedFileSet} Batch Source
+ */
+public class PartitionedFileSetSource extends BatchSource<LongWritable, Text> {
+
+  private static final String FILESET_NAME = "filesetName";
+  private static final String FILTER = "filter";
+  private static final String PARTITIONING = "partitioning";
+  private static final String VALUE = "value";
+  private static final String LOWER = "lower";
+  private static final String UPPER = "upper";
+
+
+  @Override
+  public void configure(StageConfigurer configurer) {
+    configurer.setName(PartitionedFileSetSource.class.getSimpleName());
+    configurer.setDescription("CDAP Partitioned fileSet batch source");
+    configurer.addProperty(new Property(FILESET_NAME, "Partitioned fileset name", true));
+    configurer.addProperty(new Property(FILTER, "Partition filter to use if any while reading in JSON format " +
+      "ex: {\"league.value\": \"nfl\",\"season.lower\": \"1980\",\"season.upper\": \"1990\"}", false));
+    configurer.addProperty(new Property(PARTITIONING, "Partitioning to use for the Partitioned FileSet. " +
+      "Must be provided if you want the pipeline to create the fileset. ex: " +
+      "{\"league\" : \"string\", \"season\" : \"int\"}", false));
+    configurer.addProperty(new Property(TextOutputFormat.SEPERATOR, "The output format separator must be provided " +
+      "if you want the pipeline to create the fileset", false));
+
+  }
+
+  @Override
+  public void configurePipeline(ETLStage stageConfig, PipelineConfigurer pipelineConfigurer) {
+    // if the partitioning is provided then we should try to create the fileset here
+    if (!Strings.isNullOrEmpty(stageConfig.getProperties().get(PARTITIONING))) {
+      String pfsName = stageConfig.getProperties().get(FILESET_NAME);
+      String separator = stageConfig.getProperties().get(TextOutputFormat.SEPERATOR);
+      Preconditions.checkArgument(!Strings.isNullOrEmpty(pfsName), "PartitionedFileSet name must be given.");
+      Preconditions.checkArgument(!Strings.isNullOrEmpty(pfsName), "A separator for " +
+        TextOutputFormat.SEPERATOR + "must be given");
+      pipelineConfigurer.createDataset(pfsName, PartitionedFileSet.class.getName(),
+                                       PartitionedFileSetProperties.builder()
+        .setPartitioning(ETLUtils.createPartitioning(stageConfig.getProperties().get(PARTITIONING)))
+        .setInputFormat(TextInputFormat.class)
+        .setOutputFormat(TextOutputFormat.class)
+        .setOutputProperty(TextOutputFormat.SEPERATOR, separator)
+        .build());
+    }
+  }
+
+  @Override
+  public void prepareJob(BatchSourceContext context) {
+    Map<String, String> inputArgs = Maps.newHashMap();
+    PartitionedFileSetArguments.setInputPartitionFilter(inputArgs,
+                                                        createPartitionFilter(
+                                                          context.getRuntimeArguments().get(FILTER)));
+    PartitionedFileSet input = context.getDataset(context.getRuntimeArguments().get(FILESET_NAME), inputArgs);
+    context.setInput(context.getRuntimeArguments().get(FILESET_NAME), input);
+  }
+
+  /**
+   * creates a {@link PartitionFilter} from a given string in JSON format
+   *
+   * @param filterString partition filter JSON string
+   * @return {@link PartitionFilter}
+   */
+  private PartitionFilter createPartitionFilter(String filterString) {
+    PartitionFilter.Builder builder = PartitionFilter.builder();
+    Type stringStringMap = new TypeToken<Map<String, String>>() {
+    }.getType();
+    Map<String, String> filters = new Gson().fromJson(filterString, stringStringMap);
+    for (Map.Entry<String, String> entrySet : filters.entrySet()) {
+      String key = entrySet.getKey();
+      if (key.endsWith(VALUE)) {
+        builder.addValueCondition(key.split("\\.")[0], entrySet.getValue());
+      } else if (key.endsWith(LOWER)) {
+        String fieldName = key.split("\\.")[0];
+        // if the upper range is found for  this lowe range add it to PartitionFilter else just ignore
+        String upperRange = Joiner.on(".").join(fieldName, UPPER);
+        if (filters.containsKey(upperRange)) {
+          builder.addRangeCondition(fieldName, entrySet.getValue(), filters.get(upperRange));
+        }
+      }
+    }
+    return builder.build();
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/common/ETLUtils.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/common/ETLUtils.java
@@ -16,10 +16,16 @@
 
 package co.cask.cdap.templates.etl.common;
 
+import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
+import co.cask.cdap.api.dataset.lib.Partitioning;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
 
+import java.lang.reflect.Type;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -61,5 +67,23 @@ public class ETLUtils {
         return TimeUnit.DAYS.toMillis(parsedValue);
     }
     throw new IllegalArgumentException(String.format("Time unit not supported: %s", lastChar));
+  }
+
+  /**
+   * Builds a {@link Partitioning} which is used to set the partitioning for
+   * {@link PartitionedFileSet}
+   *
+   * @param partitioningString a JSON format partitioning string
+   * @return {@link Partitioning}
+   */
+  public static Partitioning createPartitioning(String partitioningString) {
+    Partitioning.Builder builder = Partitioning.builder();
+    Type stringStringMap = new TypeToken<Map<String, String>>() {
+    }.getType();
+    Map<String, String> filters = new Gson().fromJson(partitioningString, stringStringMap);
+    for (Map.Entry<String, String> entrySet : filters.entrySet()) {
+      builder.addField(entrySet.getKey(), Partitioning.FieldType.valueOf(entrySet.getValue()));
+    }
+    return builder.build();
   }
 }

--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestManager.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestManager.java
@@ -41,6 +41,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.sql.Connection;
+import java.util.Map;
 
 /**
  *
@@ -119,6 +120,12 @@ public class IntegrationTestManager implements TestManager {
 
   @Override
   public <T> DataSetManager<T> getDataset(Id.Namespace namespace, String datasetInstanceName) throws Exception {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public <T> DataSetManager<T> getDataset(Id.Namespace namespace, String datasetInstanceName,
+                                          Map<String, String> arguments) throws Exception {
     throw new UnsupportedOperationException();
   }
 

--- a/cdap-test/src/main/java/co/cask/cdap/test/TestManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/TestManager.java
@@ -26,6 +26,7 @@ import co.cask.cdap.proto.NamespaceMeta;
 
 import java.io.File;
 import java.sql.Connection;
+import java.util.Map;
 
 /**
  *
@@ -98,6 +99,19 @@ public interface TestManager {
    */
   @Beta
   <T> DataSetManager<T> getDataset(Id.Namespace namespace, String datasetInstanceName) throws Exception;
+
+  /**
+   * Gets Dataset manager of Dataset instance of type <T>
+   *
+   * @param namespace namespace of the dataset
+   * @param datasetInstanceName instance name of dataset
+   * @param arguments the arguments for the dataset
+   * @return Dataset Manager of Dataset instance of type <T>
+   * @throws Exception
+   */
+  @Beta
+  <T> DataSetManager<T> getDataset(Id.Namespace namespace, String datasetInstanceName,
+                                   Map<String, String> arguments) throws Exception;
 
   /**
    * @param namespace namespace to interact within

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/ConfigurableTestBase.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/ConfigurableTestBase.java
@@ -485,6 +485,19 @@ public class ConfigurableTestBase {
    * Gets Dataset manager of Dataset instance of type <T>
    *
    * @param datasetInstanceName - instance name of dataset
+   * @param arguments the arguments for the dataset
+   * @return Dataset Manager of Dataset instance of type <T>
+   * @throws Exception
+   */
+  protected final <T> DataSetManager<T> getDataset(String datasetInstanceName,
+                                                   Map<String, String> arguments) throws Exception {
+    return getTestManager().getDataset(Constants.DEFAULT_NAMESPACE_ID, datasetInstanceName, arguments);
+  }
+
+  /**
+   * Gets Dataset manager of Dataset instance of type <T>
+   *
+   * @param datasetInstanceName - instance name of dataset
    * @return Dataset Manager of Dataset instance of type <T>
    * @throws Exception
    */

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/UnitTestManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/UnitTestManager.java
@@ -51,6 +51,7 @@ import java.net.InetSocketAddress;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.util.HashMap;
+import java.util.Map;
 
 /**
  *
@@ -147,16 +148,18 @@ public class UnitTestManager implements TestManager {
   /**
    * Gets Dataset manager of Dataset instance of type <T>
    * @param datasetInstanceName - instance name of dataset
+   * @param arguments the arguments for the dataset
    * @return Dataset Manager of Dataset instance of type <T>
    * @throws Exception
    */
   @Beta
   @Override
-  public final <T> DataSetManager<T> getDataset(Id.Namespace namespace, String datasetInstanceName) throws Exception {
+  public final <T> DataSetManager<T> getDataset(Id.Namespace namespace, String datasetInstanceName,
+                                                Map<String, String> arguments) throws Exception {
     //TODO: Expose namespaces later. Hardcoding to default right now.
     Id.DatasetInstance datasetInstanceId = Id.DatasetInstance.from(namespace, datasetInstanceName);
     @SuppressWarnings("unchecked")
-    final T dataSet = (T) datasetFramework.getDataset(datasetInstanceId, new HashMap<String, String>(), null);
+    final T dataSet = (T) datasetFramework.getDataset(datasetInstanceId, arguments, null);
     try {
       final TransactionContext txContext;
       // not every dataset is TransactionAware. FileSets for example, are not transactional.
@@ -188,6 +191,13 @@ public class UnitTestManager implements TestManager {
     } catch (Exception e) {
       throw Throwables.propagate(e);
     }
+  }
+
+
+  @Beta
+  @Override
+  public final <T> DataSetManager<T> getDataset(Id.Namespace namespace, String datasetInstanceName) throws Exception {
+    return getDataset(namespace, datasetInstanceName, new HashMap<String, String>());
   }
 
   /**


### PR DESCRIPTION
Implements: 
1. PartitionedFilesetSource: https://issues.cask.co/browse/CDAP-2063
2. PartitionedFilesetSink: https://issues.cask.co/browse/CDAP-2065
3. Unit test with PartitionedFilesetSource as source and PartitionedFilesetSink as a sink

This currently does not set explore enabled while creating the filesets. We need a small discussion on it and I will update this PR after the discussion. 