### PR TITLE
Correct the grammar of Command Line Interface messages and its test.

### DIFF
--- a/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
+++ b/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
@@ -225,7 +225,7 @@ public class CLIMainTest extends StandaloneTestBase {
       writer.close();
     }
     testCommandOutputContains(cli, "load stream " + streamId + " " + file.getAbsolutePath(),
-                              "Successfully send stream event to stream");
+                              "Successfully sent stream event to stream");
     testCommandOutputContains(cli, "get stream " + streamId, "9, Event 9");
     testCommandOutputContains(cli, "get stream-stats " + streamId,
                               String.format("No schema found for Stream '%s'", streamId));

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/LoadStreamCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/LoadStreamCommand.java
@@ -77,7 +77,7 @@ public class LoadStreamCommand extends AbstractAuthCommand implements Categorize
     }
 
     streamClient.sendFile(streamId, contentType, file);
-    output.printf("Successfully send stream event to stream '%s'\n", streamId);
+    output.printf("Successfully sent stream event to stream '%s'\n", streamId);
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/SendStreamEventCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/SendStreamEventCommand.java
@@ -48,7 +48,7 @@ public class SendStreamEventCommand extends AbstractAuthCommand implements Categ
     String streamId = arguments.get(ArgumentName.STREAM.toString());
     String streamEvent = arguments.get(ArgumentName.STREAM_EVENT.toString());
     streamClient.sendEvent(streamId, streamEvent);
-    output.printf("Successfully send stream event to stream '%s'\n", streamId);
+    output.printf("Successfully sent stream event to stream '%s'\n", streamId);
   }
 
   @Override


### PR DESCRIPTION
Corrects the tense: "send" -> "sent". Adjusted in both output and in the test that depends on the output.