### PR TITLE
Adding endpoint to fetch logs by runid

### DIFF
--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterPathLookup.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterPathLookup.java
@@ -155,10 +155,13 @@ public final class RouterPathLookup extends AuthenticatedHttpHandler {
         return Constants.Service.STREAMS;
       }
     } else if ((uriParts.length >= 8 && uriParts[7].equals("logs")) ||
+      (uriParts.length >= 10 && uriParts[9].equals("logs")) ||
       (uriParts.length >= 6 && uriParts[5].equals("logs"))) {
       //Log Handler Paths:
       // /v3/namespaces/<namespaceid>/apps/<appid>/<programid-type>/<programid>/logs
+      // /v3/namespaces/{namespace-id}/apps/{app-id}/{program-type}/{program-id}/runs/{run-id}/logs
       // /v3/namespaces/<namespaceid>/adapters/<adapterid>/logs
+      // /v3/namespaces/{namespace-id}/adapters/{adapter-id}/runs/{run-id}/logs (same as case 1)
       return Constants.Service.METRICS;
     } else if (uriParts.length >= 2 && uriParts[1].equals("metrics")) {
       //Metrics Search Handler Path /v3/metrics

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/log/LogLine.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/log/LogLine.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.gateway.handlers.log;
 
 import co.cask.cdap.logging.read.LogOffset;
+import com.google.common.base.Objects;
 
 /**
 * Test Log object.
@@ -40,9 +41,9 @@ class LogLine {
 
   @Override
   public String toString() {
-    return "LogLine{" +
-      "offset=" + offset +
-      ", log='" + log + '\'' +
-      '}';
+    return Objects.toStringHelper(this)
+      .add("offset", offset)
+      .add("log", log)
+      .toString();
   }
 }

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/log/MockLogReader.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/log/MockLogReader.java
@@ -18,20 +18,27 @@ package co.cask.cdap.gateway.handlers.log;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.LoggingEvent;
-import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.logging.ApplicationLoggingContext;
 import co.cask.cdap.common.logging.LoggingContext;
-import co.cask.cdap.logging.LoggingConfiguration;
+import co.cask.cdap.logging.context.FlowletLoggingContext;
+import co.cask.cdap.logging.context.LoggingContextHelper;
+import co.cask.cdap.logging.context.MapReduceLoggingContext;
+import co.cask.cdap.logging.context.ProcedureLoggingContext;
+import co.cask.cdap.logging.context.UserServiceLoggingContext;
 import co.cask.cdap.logging.filter.Filter;
 import co.cask.cdap.logging.read.Callback;
 import co.cask.cdap.logging.read.LogEvent;
 import co.cask.cdap.logging.read.LogOffset;
 import co.cask.cdap.logging.read.LogReader;
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Multimap;
-import com.google.inject.Inject;
+import com.google.common.base.Function;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
 
 /**
 * Mock LogReader for testing.
@@ -39,59 +46,38 @@ import org.slf4j.LoggerFactory;
 public class MockLogReader implements LogReader {
   private static final Logger LOG = LoggerFactory.getLogger(MockLogReader.class);
 
-  private final Multimap<String, LogLine> logMap;
+  private final List<LogEvent> logEvents = Lists.newArrayList();
   private static final int MAX = 80;
   public static final String TEST_NAMESPACE = "testNamespace";
-  private final String logBaseDir;
 
-  @Inject
-  MockLogReader(CConfiguration cConf) {
-    this.logBaseDir = cConf.get(LoggingConfiguration.LOG_BASE_DIR);
-    String defaultNamespacedLogBaseDir = String.format("%s/%s", Constants.DEFAULT_NAMESPACE, this.logBaseDir);
-    String testNamespacedLogBaseDir = String.format("%s/%s", TEST_NAMESPACE, this.logBaseDir);
-    logMap = ArrayListMultimap.create();
+  MockLogReader() {
+    // Add logs for app testApp1, flow testFlow1
+    generateLogs(new FlowletLoggingContext(Constants.DEFAULT_NAMESPACE,
+                                           "testApp1", "testFlow1", "testFlowlet1", "", ""));
 
-    // Add log lines for app testApp1, flow testFlow1
-    for (int i = 0; i < MAX; ++i) {
-      logMap.put(defaultNamespacedLogBaseDir + "/testApp1/flow-testFlow1",
-                 new LogLine(new LogOffset(i, i), "testFlow1<img>-" + i));
-    }
+    // Add logs for app testApp2, procedure testProcedure1
+    generateLogs(new ProcedureLoggingContext(Constants.DEFAULT_NAMESPACE,
+                                             "testApp2", "testProcedure1", "", ""));
 
-    // Add log lines for app testApp1, service testService1
-    for (int i = 0; i < MAX; ++i) {
-      logMap.put(defaultNamespacedLogBaseDir + "/testApp4/userservice-testService1",
-                 new LogLine(new LogOffset(i, i), "testService1<img>-" + i));
-    }
+    // Add logs for app testApp3, mapreduce testMapReduce1
+    generateLogs(new MapReduceLoggingContext(Constants.DEFAULT_NAMESPACE,
+                                             "testApp3", "testMapReduce1", "", null));
 
-    // Add log lines for app testApp2, procedure testProcedure1
-    for (int i = 0; i < MAX; ++i) {
-      logMap.put(defaultNamespacedLogBaseDir + "/testApp2/procedure-testProcedure1",
-                 new LogLine(new LogOffset(i, i), "testProcedure1<img>-" + i));
-    }
+    // Add logs for app testApp1, service testService1
+    generateLogs(new UserServiceLoggingContext(Constants.DEFAULT_NAMESPACE,
+                                               "testApp4", "testService1", "test1", "", ""));
 
-    // Add log lines for app testApp3, mapreduce testMapReduce1
-    for (int i = 0; i < MAX; ++i) {
-      logMap.put(defaultNamespacedLogBaseDir + "/testApp3/mapred-testMapReduce1",
-                 new LogLine(new LogOffset(i, i), "testMapReduce1<img>-" + i));
-    }
+    // Add logs for app testApp1, mapreduce testMapReduce1 run as part of batch adapter adapter1 in testNamespace
+    generateLogs(new MapReduceLoggingContext(TEST_NAMESPACE,
+                                             "testTemplate1", "testMapReduce1", "", "testAdapter1"));
 
-    // Add log lines for app testApp1, mapreduce testMapReduce1 run as part of batch adapter adapter1 in testNamespace
-    for (int i = 0; i < MAX; ++i) {
-      logMap.put(testNamespacedLogBaseDir + "/testTemplate1/mapred-testMapReduce1",
-                 new LogLine(new LogOffset(i, i), "testMapReduce1<img>-" + i));
-    }
+    // Add logs for app testApp1, flow testFlow1 in testNamespace
+    generateLogs(new FlowletLoggingContext(TEST_NAMESPACE,
+                                           "testApp1", "testFlow1", "testFlowlet1", "", ""));
 
-    // Add log lines for app testApp1, flow testFlow1 in testNamespace
-    for (int i = 0; i < MAX; ++i) {
-      logMap.put(testNamespacedLogBaseDir + "/testApp1/flow-testFlow1",
-                 new LogLine(new LogOffset(i, i), "testFlow1<img>-" + i));
-    }
-
-    // Add log lines for app testApp1, service testService1 in testNamespace
-    for (int i = 0; i < MAX; ++i) {
-      logMap.put(testNamespacedLogBaseDir + "/testApp4/userservice-testService1",
-                 new LogLine(new LogOffset(i, i), "testService1<img>-" + i));
-    }
+    // Add logs for app testApp1, service testService1 in testNamespace
+    generateLogs(new UserServiceLoggingContext(TEST_NAMESPACE,
+                                               "testApp4", "testService1", "test1", "", ""));
   }
 
   @Override
@@ -102,11 +88,17 @@ public class MockLogReader implements LogReader {
       return;
     }
 
+    Filter contextFilter = LoggingContextHelper.createFilter(loggingContext);
+
     callback.init();
     try {
       int count = 0;
-      for (LogLine logLine : logMap.get(loggingContext.getLogPathFragment(logBaseDir))) {
+      for (LogEvent logLine : logEvents) {
         if (logLine.getOffset().getKafkaOffset() >= fromOffset.getKafkaOffset()) {
+          if (!contextFilter.match(logLine.getLoggingEvent())) {
+            continue;
+          }
+
           if (++count > maxEvents) {
             break;
           }
@@ -115,13 +107,7 @@ public class MockLogReader implements LogReader {
             continue;
           }
 
-          callback.handle(
-            new LogEvent(
-              new LoggingEvent("com.continuiity.Test",
-                               (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME),
-                               Level.WARN, logLine.getLog(), null, null),
-                                       logLine.getOffset())
-          );
+          callback.handle(logLine);
         }
       }
     } catch (Throwable e) {
@@ -138,11 +124,17 @@ public class MockLogReader implements LogReader {
       fromOffset = new LogOffset(MAX, MAX);
     }
 
+    Filter contextFilter = LoggingContextHelper.createFilter(loggingContext);
+
     callback.init();
     try {
       int count = 0;
       long startOffset = fromOffset.getKafkaOffset() - maxEvents;
-      for (LogLine logLine : logMap.get(loggingContext.getLogPathFragment(logBaseDir))) {
+      for (LogEvent logLine : logEvents) {
+        if (!contextFilter.match(logLine.getLoggingEvent())) {
+          continue;
+        }
+
         if (logLine.getOffset().getKafkaOffset() >= startOffset &&
           logLine.getOffset().getKafkaOffset() < fromOffset.getKafkaOffset()) {
           if (++count > maxEvents) {
@@ -153,13 +145,7 @@ public class MockLogReader implements LogReader {
             continue;
           }
 
-          callback.handle(
-            new LogEvent(
-              new LoggingEvent("com.continuiity.Test",
-                               (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME),
-                               Level.WARN, logLine.getLog(), null, null),
-              logLine.getOffset())
-          );
+          callback.handle(logLine);
         }
       }
     } catch (Throwable e) {
@@ -179,5 +165,30 @@ public class MockLogReader implements LogReader {
 
   @Override
   public void close() {
+  }
+
+  private static final Function<LoggingContext.SystemTag, String> TAG_TO_STRING_FUNCTION =
+    new Function<LoggingContext.SystemTag, String>() {
+      @Override
+      public String apply(LoggingContext.SystemTag input) {
+        return input.getValue();
+      }
+    };
+
+  private void generateLogs(LoggingContext loggingContext) {
+    String entityId = LoggingContextHelper.getEntityId(loggingContext).getValue();
+    for (int i = 0; i < MAX; ++i) {
+      LoggingEvent event =
+        new LoggingEvent("com.continuiity.Test",
+                         (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME),
+                         i % 2 == 0 ? Level.ERROR : Level.WARN, entityId + "<img>-" + i, null, null);
+
+      // Add runid to logging context
+      Map<String, String> tagMap = Maps.newHashMap(Maps.transformValues(loggingContext.getSystemTagsMap(),
+                                                                         TAG_TO_STRING_FUNCTION));
+      tagMap.put(ApplicationLoggingContext.TAG_RUNID_ID, String.valueOf(i % 2));
+      event.setMDCPropertyMap(tagMap);
+      logEvents.add(new LogEvent(event, new LogOffset(i, i)));
+    }
   }
 }

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/RouterPathTest.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/RouterPathTest.java
@@ -92,18 +92,28 @@ public class RouterPathTest {
   @Test
   public void testLogPath() throws Exception {
     //Following URIs might not give actual results but we want to test resilience of Router Path Lookup
-    String flowPath = "/v2/apps//InvalidApp///procedures/ProcName/logs/";
+    String flowPath = "/v3/namespaces/default/apps//InvalidApp///flows/FlowName/logs/";
     HttpRequest httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("GET"), flowPath);
     String result = pathLookup.getRoutingService(FALLBACKSERVICE, flowPath, httpRequest);
     Assert.assertEquals(Constants.Service.METRICS, result);
 
-    flowPath = "///v2///apps/InvalidApp/flows/FlowName/////logs";
+    flowPath = "///v3/namespaces/default///apps/InvalidApp/flows/FlowName/////logs";
     httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("POST"), flowPath);
     result = pathLookup.getRoutingService(FALLBACKSERVICE, flowPath, httpRequest);
     Assert.assertEquals(Constants.Service.METRICS, result);
 
-    flowPath = "v2/apps/InvalidApp/procedures/ProName/logs/abcd";
+    flowPath = "v3/namespaces/default/apps/InvalidApp/procedures/ProName/logs/abcd";
     httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("DELETE"), flowPath);
+    result = pathLookup.getRoutingService(FALLBACKSERVICE, flowPath, httpRequest);
+    Assert.assertEquals(Constants.Service.METRICS, result);
+
+    flowPath = "/v3/namespaces/default/apps/InvalidApp/service/ServiceName/runs/7e6adc79-0f5d-4252-70817ea47698/logs/";
+    httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("GET"), flowPath);
+    result = pathLookup.getRoutingService(FALLBACKSERVICE, flowPath, httpRequest);
+    Assert.assertEquals(Constants.Service.METRICS, result);
+
+    flowPath = "/v3/namespaces/default/apps/InvalidApp/adapters/Adapter1/runs/7e6adc79-0f5d-b559-70817ea47698/logs/";
+    httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("GET"), flowPath);
     result = pathLookup.getRoutingService(FALLBACKSERVICE, flowPath, httpRequest);
     Assert.assertEquals(Constants.Service.METRICS, result);
   }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/LogHandlerV2.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/LogHandlerV2.java
@@ -82,8 +82,8 @@ public class LogHandlerV2 extends AuthenticatedHttpHandler {
                    @PathParam("entity-id") String entityId, @QueryParam("start") long fromTimeMs,
                    @QueryParam("stop") long toTimeMs, @QueryParam("escape") @DefaultValue("true") boolean escape,
                    @QueryParam("filter") @DefaultValue("") String filterStr) {
-    logHandler.list(RESTMigrationUtils.rewriteV2RequestToV3(request), responder, Constants.DEFAULT_NAMESPACE, appId,
-                    entityType, entityId, fromTimeMs, toTimeMs, escape, filterStr);
+    logHandler.getLogs(RESTMigrationUtils.rewriteV2RequestToV3(request), responder, Constants.DEFAULT_NAMESPACE, appId,
+                       entityType, entityId, fromTimeMs, toTimeMs, escape, filterStr);
   }
 
   @GET

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/LoggingTester.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/LoggingTester.java
@@ -16,23 +16,98 @@
 
 package co.cask.cdap.logging.appender;
 
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.core.util.StatusPrinter;
+import co.cask.cdap.common.logging.ApplicationLoggingContext;
 import co.cask.cdap.common.logging.LoggingContext;
+import co.cask.cdap.common.logging.LoggingContextAccessor;
+import co.cask.cdap.common.logging.NamespaceLoggingContext;
+import co.cask.cdap.logging.context.LoggingContextHelper;
 import co.cask.cdap.logging.filter.Filter;
 import co.cask.cdap.logging.read.Callback;
 import co.cask.cdap.logging.read.LogEvent;
 import co.cask.cdap.logging.read.LogOffset;
 import co.cask.cdap.logging.read.LogReader;
+import com.google.common.base.Function;
+import com.google.common.collect.Maps;
 import org.junit.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 
 /**
  *
  */
 public class LoggingTester {
+  public void generateLogs(Logger logger, LoggingContext loggingContextNs1) {
+    Exception e1 = new Exception("Test Exception1");
+    Exception e2 = new Exception("Test Exception2", e1);
+
+    LoggingContext loggingContextNs2 =
+      replaceTag(loggingContextNs1,
+                 new Entry(NamespaceLoggingContext.TAG_NAMESPACE_ID, getNamespace2(loggingContextNs1)));
+
+    LoggingContextAccessor.setLoggingContext(loggingContextNs2);
+    for (int i = 0; i < 40; ++i) {
+      logger.warn("NS_2 Test log message {} {} {}", i, "arg1", "arg2", e2);
+    }
+
+    LoggingContextAccessor.setLoggingContext(loggingContextNs1);
+    for (int i = 0; i < 20; ++i) {
+      logger.warn("Test log message {} {} {}", i, "arg1", "arg2", e2);
+    }
+
+    LoggingContextAccessor.setLoggingContext(loggingContextNs2);
+    for (int i = 40; i < 80; ++i) {
+      logger.warn("NS_2 Test log message {} {} {}", i, "arg1", "arg2", e2);
+    }
+
+    LoggingContextAccessor.setLoggingContext(loggingContextNs1);
+    for (int i = 20; i < 40; ++i) {
+      logger.warn("Test log message {} {} {}", i, "arg1", "arg2", e2);
+    }
+
+    LoggingContextAccessor.setLoggingContext(loggingContextNs1);
+    for (int i = 40; i < 60; ++i) {
+      logger.warn("Test log message {} {} {}", i, "arg1", "arg2", e2);
+    }
+
+    // Add logs with a different runid
+    LoggingContextAccessor.setLoggingContext(
+      replaceTag(loggingContextNs1, new Entry(ApplicationLoggingContext.TAG_RUNID_ID, "RUN2")));
+    for (int i = 40; i < 60; ++i) {
+      logger.warn("RUN2 Test log message {} {} {}", i, "arg1", "arg2", e2);
+    }
+
+    // Add logs with null runid and null instanceid
+    LoggingContextAccessor.setLoggingContext(
+      replaceTag(loggingContextNs1, new Entry(ApplicationLoggingContext.TAG_RUNID_ID, null),
+                 new Entry(ApplicationLoggingContext.TAG_INSTANCE_ID, null)));
+    for (int i = 40; i < 60; ++i) {
+      logger.warn("NULL Test log message {} {} {}", i, "arg1", "arg2", e2);
+    }
+
+    // Check with null runId and null instanceId
+    LoggingContextAccessor.setLoggingContext(
+      replaceTag(loggingContextNs2, new Entry(ApplicationLoggingContext.TAG_RUNID_ID, null),
+                 new Entry(ApplicationLoggingContext.TAG_INSTANCE_ID, null)));
+    for (int i = 80; i < 120; ++i) {
+      logger.warn("NS_2 Test log message {} {} {}", i, "arg1", "arg2", e2);
+    }
+
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    StatusPrinter.setPrintStream(new PrintStream(bos));
+    StatusPrinter.print((LoggerContext) LoggerFactory.getILoggerFactory());
+    System.out.println(bos.toString());
+  }
+
   public void testGetNext(LogReader logReader, LoggingContext loggingContext) throws Exception {
     LogCallback logCallback1 = new LogCallback();
     logReader.getLogNext(loggingContext, LogOffset.LATEST_OFFSET, 10, Filter.EMPTY_FILTER, logCallback1);
@@ -85,6 +160,24 @@ public class LoggingTester {
     events = logCallback7.getEvents();
     Assert.assertEquals(1, events.size());
     Assert.assertEquals("Test log message 59 arg1 arg2", events.get(0).getLoggingEvent().getFormattedMessage());
+
+    // Try with a different run
+    LogCallback logCallback10 = new LogCallback();
+    logReader.getLogPrev(replaceTag(loggingContext, new Entry(ApplicationLoggingContext.TAG_RUNID_ID, "RUN2")),
+                         LogOffset.LATEST_OFFSET, 20, Filter.EMPTY_FILTER, logCallback10);
+    events = logCallback10.getEvents();
+    Assert.assertEquals(20, events.size());
+    Assert.assertEquals("RUN2 Test log message 40 arg1 arg2", events.get(0).getLoggingEvent().getFormattedMessage());
+    Assert.assertEquals("RUN2 Test log message 59 arg1 arg2", events.get(19).getLoggingEvent().getFormattedMessage());
+
+    // Try with a null runid, should return all events with or without runid
+    LogCallback logCallback11 = new LogCallback();
+    logReader.getLogPrev(replaceTag(loggingContext, new Entry(ApplicationLoggingContext.TAG_RUNID_ID, null)),
+                         LogOffset.LATEST_OFFSET, 35, Filter.EMPTY_FILTER, logCallback11);
+    events = logCallback11.getEvents();
+    Assert.assertEquals(35, events.size());
+    Assert.assertEquals("RUN2 Test log message 45 arg1 arg2", events.get(0).getLoggingEvent().getFormattedMessage());
+    Assert.assertEquals("NULL Test log message 59 arg1 arg2", events.get(34).getLoggingEvent().getFormattedMessage());
   }
 
   public void testGetPrev(LogReader logReader, LoggingContext loggingContext) throws Exception {
@@ -156,6 +249,24 @@ public class LoggingTester {
     Assert.assertEquals(15, events.size());
     Assert.assertEquals("Test log message 45 arg1 arg2", events.get(0).getLoggingEvent().getFormattedMessage());
     Assert.assertEquals("Test log message 59 arg1 arg2", events.get(14).getLoggingEvent().getFormattedMessage());
+
+    // Try with a different run
+    LogCallback logCallback10 = new LogCallback();
+    logReader.getLogPrev(replaceTag(loggingContext, new Entry(ApplicationLoggingContext.TAG_RUNID_ID, "RUN2")),
+                         LogOffset.LATEST_OFFSET, 20, Filter.EMPTY_FILTER, logCallback10);
+    events = logCallback10.getEvents();
+    Assert.assertEquals(20, events.size());
+    Assert.assertEquals("RUN2 Test log message 40 arg1 arg2", events.get(0).getLoggingEvent().getFormattedMessage());
+    Assert.assertEquals("RUN2 Test log message 59 arg1 arg2", events.get(19).getLoggingEvent().getFormattedMessage());
+
+    // Try with a null runid, should return all events with or without runid
+    LogCallback logCallback11 = new LogCallback();
+    logReader.getLogPrev(replaceTag(loggingContext, new Entry(ApplicationLoggingContext.TAG_RUNID_ID, null)),
+                         LogOffset.LATEST_OFFSET, 40, Filter.EMPTY_FILTER, logCallback11);
+    events = logCallback11.getEvents();
+    Assert.assertEquals(40, events.size());
+    Assert.assertEquals("RUN2 Test log message 40 arg1 arg2", events.get(0).getLoggingEvent().getFormattedMessage());
+    Assert.assertEquals("NULL Test log message 59 arg1 arg2", events.get(39).getLoggingEvent().getFormattedMessage());
   }
 
   /**
@@ -203,4 +314,44 @@ public class LoggingTester {
   private LogOffset getNextOffset(LogOffset offset) {
     return new LogOffset(offset.getKafkaOffset() + 1, offset.getTime() + 1);
   }
+
+  private LoggingContext replaceTag(LoggingContext loggingContext, Entry... entries) {
+    Map<String, String> tagMap =
+      Maps.newHashMap(Maps.transformValues(loggingContext.getSystemTagsMap(), TAG_TO_STRING_FUNCTION));
+    for (Entry entry : entries) {
+      tagMap.put(entry.getKey(), entry.getValue());
+    }
+    return LoggingContextHelper.getLoggingContext(tagMap);
+  }
+
+  private String getNamespace2(LoggingContext loggingContext) {
+    String ns = loggingContext.getSystemTagsMap().get(NamespaceLoggingContext.TAG_NAMESPACE_ID).getValue();
+    return ns.substring(0, ns.length() - 1) + "2";
+  }
+
+  private static final class Entry {
+    private final String key;
+    private final String value;
+
+    public Entry(String key, String value) {
+      this.key = key;
+      this.value = value;
+    }
+
+    public String getKey() {
+      return key;
+    }
+
+    public String getValue() {
+      return value;
+    }
+  }
+
+  private static final Function<LoggingContext.SystemTag, String> TAG_TO_STRING_FUNCTION =
+    new Function<LoggingContext.SystemTag, String>() {
+      @Override
+      public String apply(LoggingContext.SystemTag input) {
+        return input.getValue();
+      }
+    };
 }

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/kafka/TestKafkaLogging.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/kafka/TestKafkaLogging.java
@@ -16,14 +16,11 @@
 
 package co.cask.cdap.logging.appender.kafka;
 
-import ch.qos.logback.classic.LoggerContext;
-import ch.qos.logback.core.util.StatusPrinter;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.LocationRuntimeModule;
 import co.cask.cdap.common.logging.LoggingContext;
-import co.cask.cdap.common.logging.LoggingContextAccessor;
 import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;
 import co.cask.cdap.logging.KafkaTestBase;
@@ -48,9 +45,6 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
 
 /**
  * Kafka Test for logging.
@@ -87,52 +81,9 @@ public class TestKafkaLogging extends KafkaTestBase {
     new LogAppenderInitializer(appender).initialize("TestKafkaLogging");
 
     Logger logger = LoggerFactory.getLogger("TestKafkaLogging");
-    Exception e1 = new Exception("Test Exception1");
-    Exception e2 = new Exception("Test Exception2", e1);
-
-    LoggingContextAccessor.setLoggingContext(new FlowletLoggingContext("TFL_ACCT_2", "APP_1", "FLOW_1", "FLOWLET_1",
-                                                                       "RUN1", "INSTANCE1"));
-    for (int i = 0; i < 40; ++i) {
-      logger.warn("ACCT_2 Test log message " + i + " {} {}", "arg1", "arg2", e2);
-    }
-
-    LoggingContextAccessor.setLoggingContext(new FlowletLoggingContext("TFL_ACCT_1", "APP_1", "FLOW_1", "FLOWLET_1",
-                                                                       "RUN1", "INSTANCE1"));
-    for (int i = 0; i < 20; ++i) {
-      logger.warn("Test log message " + i + " {} {}", "arg1", "arg2", e2);
-    }
-
-    LoggingContextAccessor.setLoggingContext(new FlowletLoggingContext("TFL_ACCT_2", "APP_1", "FLOW_1", "FLOWLET_1",
-                                                                       "RUN1", "INSTANCE1"));
-    for (int i = 40; i < 80; ++i) {
-      logger.warn("ACCT_2 Test log message " + i + " {} {}", "arg1", "arg2", e2);
-    }
-
-    LoggingContextAccessor.setLoggingContext(new FlowletLoggingContext("TFL_ACCT_1", "APP_1", "FLOW_1", "FLOWLET_1",
-                                                                       "RUN1", "INSTANCE1"));
-    for (int i = 20; i < 40; ++i) {
-      logger.warn("Test log message " + i + " {} {}", "arg1", "arg2", e2);
-    }
-
-    // Check with null runId and null instanceId
-    LoggingContextAccessor.setLoggingContext(new FlowletLoggingContext("TFL_ACCT_1", "APP_1", "FLOW_1", "FLOWLET_1",
-                                                                       null, null));
-    for (int i = 40; i < 60; ++i) {
-      logger.warn("Test log message " + i + " {} {}", "arg1", "arg2", e2);
-    }
-
-    // Check with null runId and null instanceId
-    LoggingContextAccessor.setLoggingContext(new FlowletLoggingContext("TFL_ACCT_2", "APP_1", "FLOW_1", "FLOWLET_1",
-                                                                       null, null));
-    for (int i = 80; i < 120; ++i) {
-      logger.warn("ACCT_2 Test log message " + i + " {} {}", "arg1", "arg2", e2);
-    }
-
-    ByteArrayOutputStream bos = new ByteArrayOutputStream();
-    StatusPrinter.setPrintStream(new PrintStream(bos));
-    StatusPrinter.print((LoggerContext) LoggerFactory.getILoggerFactory());
-    System.out.println(bos.toString());
-
+    LoggingTester loggingTester = new LoggingTester();
+    loggingTester.generateLogs(logger, new FlowletLoggingContext("TKL_NS_1", "APP_1", "FLOW_1", "FLOWLET_1",
+                                                                 "RUN1", "INSTANCE1"));
     appender.stop();
   }
 
@@ -144,8 +95,8 @@ public class TestKafkaLogging extends KafkaTestBase {
   @Test
   public void testGetNext() throws Exception {
     // Check with null runId and null instanceId
-    LoggingContext loggingContext = new FlowletLoggingContext("TFL_ACCT_1", "APP_1", "FLOW_1", "",
-                                                              null, null);
+    LoggingContext loggingContext = new FlowletLoggingContext("TKL_NS_1", "APP_1", "FLOW_1", "",
+                                                              "RUN1", "INSTANCE1");
     DistributedLogReader logReader = injector.getInstance(DistributedLogReader.class);
     LoggingTester tester = new LoggingTester();
     tester.testGetNext(logReader, loggingContext);
@@ -154,10 +105,12 @@ public class TestKafkaLogging extends KafkaTestBase {
 
   @Test
   public void testGetPrev() throws Exception {
-    LoggingContext loggingContext = new FlowletLoggingContext("TFL_ACCT_1", "APP_1", "FLOW_1", "", "RUN1", "INSTANCE1");
+    LoggingContext loggingContext = new FlowletLoggingContext("TKL_NS_1", "APP_1", "FLOW_1", "", "RUN1", "INSTANCE1");
     DistributedLogReader logReader = injector.getInstance(DistributedLogReader.class);
     LoggingTester tester = new LoggingTester();
     tester.testGetPrev(logReader, loggingContext);
     logReader.close();
   }
+
+  // Note: LogReader.getLog is tested in LogSaverTest for distributed mode
 }

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/save/LogSaverTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/save/LogSaverTest.java
@@ -156,8 +156,8 @@ public class LogSaverTest extends KafkaTestBase {
     Location ns2LogBaseDir = locationFactory.create(namespacesDir).append("NS_2").append(logBaseDir);
     Location systemLogBaseDir = locationFactory.create(namespacesDir).append("system").append(logBaseDir);
 
-    waitTillLogSaverDone(ns1LogBaseDir, "APP_1/flow-FLOW_1/%s", "Test log message 59 arg1 arg2");
-    waitTillLogSaverDone(ns2LogBaseDir, "APP_2/flow-FLOW_2/%s", "Test log message 59 arg1 arg2");
+    waitTillLogSaverDone(ns1LogBaseDir, "APP_1/flow-FLOW_1/%s", "Test log message 119 arg1 arg2");
+    waitTillLogSaverDone(ns2LogBaseDir, "APP_2/flow-FLOW_2/%s", "Test log message 119 arg1 arg2");
     waitTillLogSaverDone(systemLogBaseDir, "services/service-metrics/%s", "Test log message 59 arg1 arg2");
 
     logSaver.stopAndWait();
@@ -169,20 +169,34 @@ public class LogSaverTest extends KafkaTestBase {
   @AfterClass
   public static void testCheckpoint() throws Exception {
     CheckpointManager checkpointManager = injector.getInstance(CheckpointManager.class);
-    Assert.assertEquals(120, checkpointManager.getCheckpoint(0));
-    Assert.assertEquals(60, checkpointManager.getCheckpoint(1));
+    Assert.assertEquals(180, checkpointManager.getCheckpoint(0));
+    Assert.assertEquals(120, checkpointManager.getCheckpoint(1));
 
     txManager.stopAndWait();
   }
 
   @Test
-  public void testLogRead2() throws Exception {
-    testLogRead(new FlowletLoggingContext("NS_1", "APP_1", "FLOW_1", "", "RUN", "INSTANCE"));
+  public void testLogRead1() throws Exception {
+    testLogRead(new FlowletLoggingContext("NS_1", "APP_1", "FLOW_1", "", "RUN1", "INSTANCE"));
+
+    // Read with null runid should give 120 results back
+    LogCallback logCallback = new LogCallback();
+    DistributedLogReader distributedLogReader = injector.getInstance(DistributedLogReader.class);
+    distributedLogReader.getLog(new FlowletLoggingContext("NS_1", "APP_1", "FLOW_1", "", null, "INSTANCE"),
+      0, Long.MAX_VALUE, Filter.EMPTY_FILTER, logCallback);
+    Assert.assertEquals(120, logCallback.getEvents().size());
   }
 
   @Test
-  public void testLogRead1() throws Exception {
-    testLogRead(new FlowletLoggingContext("NS_2", "APP_2", "FLOW_2", "", "RUN", "INSTANCE"));
+  public void testLogRead2() throws Exception {
+    testLogRead(new FlowletLoggingContext("NS_2", "APP_2", "FLOW_2", "", "RUN1", "INSTANCE"));
+
+    // Read with null runid should give 120 results back
+    LogCallback logCallback = new LogCallback();
+    DistributedLogReader distributedLogReader = injector.getInstance(DistributedLogReader.class);
+    distributedLogReader.getLog(new FlowletLoggingContext("NS_2", "APP_2", "FLOW_2", "", null, "INSTANCE"),
+                                0, Long.MAX_VALUE, Filter.EMPTY_FILTER, logCallback);
+    Assert.assertEquals(120, logCallback.getEvents().size());
   }
 
   @Test
@@ -312,13 +326,19 @@ public class LogSaverTest extends KafkaTestBase {
     StatusPrinter.setPrintStream(new PrintStream(bos));
     StatusPrinter.print((LoggerContext) LoggerFactory.getILoggerFactory());
 
-    ListeningExecutorService executor = MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(2));
+    ListeningExecutorService executor = MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(3));
     List<ListenableFuture<?>> futures = Lists.newArrayList();
-    futures.add(executor.submit(new LogPublisher(new FlowletLoggingContext("NS_1", "APP_1", "FLOW_1", "FLOWLET_1",
-                                                                           "RUN", "INSTANCE"))));
-    futures.add(executor.submit(new LogPublisher(new FlowletLoggingContext("NS_2", "APP_2", "FLOW_2", "FLOWLET_2",
-                                                                           "RUN", "INSTANCE"))));
-    futures.add(executor.submit(new LogPublisher(new ServiceLoggingContext("system", "services", "metrics"))));
+    futures.add(executor.submit(new LogPublisher(0, new FlowletLoggingContext("NS_1", "APP_1", "FLOW_1", "FLOWLET_1",
+                                                                           "RUN1", "INSTANCE1"))));
+    futures.add(executor.submit(new LogPublisher(0, new FlowletLoggingContext("NS_2", "APP_2", "FLOW_2", "FLOWLET_2",
+                                                                           "RUN1", "INSTANCE1"))));
+    futures.add(executor.submit(new LogPublisher(0, new ServiceLoggingContext("system", "services", "metrics"))));
+
+    // Make sure the final segments of logs are added at end to simplify checking for done in waitTillLogSaverDone
+    futures.add(executor.submit(new LogPublisher(60, new FlowletLoggingContext("NS_1", "APP_1", "FLOW_1", "FLOWLET_1",
+                                                                               "RUN2", "INSTANCE2"))));
+    futures.add(executor.submit(new LogPublisher(60, new FlowletLoggingContext("NS_2", "APP_2", "FLOW_2", "FLOWLET_2",
+                                                                           "RUN2", "INSTANCE2"))));
 
     Futures.allAsList(futures).get();
 
@@ -328,9 +348,11 @@ public class LogSaverTest extends KafkaTestBase {
   }
 
   private static class LogPublisher implements Runnable {
+    private final int startIndex;
     private final LoggingContext loggingContext;
 
-    private LogPublisher(LoggingContext loggingContext) {
+    private LogPublisher(int startIndex, LoggingContext loggingContext) {
+      this.startIndex = startIndex;
       this.loggingContext = loggingContext;
     }
 
@@ -342,11 +364,12 @@ public class LogSaverTest extends KafkaTestBase {
       Exception e1 = new Exception("Test Exception1");
       Exception e2 = new Exception("Test Exception2", e1);
 
+      int startBatch = startIndex / 10;
       try {
-        for (int j = 0; j < 6; ++j) {
+        for (int j = startBatch; j < startBatch + 6; ++j) {
           for (int i = 0; i < 10; ++i) {
             logger.warn("Test log message " + (10 * j + i) + " {} {}", "arg1", "arg2", e2);
-            if (j == 0 && (i <= 3)) {
+            if (j == startIndex && (i <= 3)) {
               // For some events introduce the sleep of more than 8 seconds for windowing to take effect
               TimeUnit.MILLISECONDS.sleep(300);
             } else {


### PR DESCRIPTION
JIRA https://issues.cask.co/browse/CDAP-2051

Adding log endpoints to fetch logs by run-id -
* `/namespaces/{namespace-id}/apps/{app-id}/{program-type}/{program-id}/runs/{run-id}/logs`
* `/namespaces/{namespace-id}/apps/{app-id}/{program-type}/{program-id}/runs/{run-id}/logs/next`
* `/namespaces/{namespace-id}/apps/{app-id}/{program-type}/{program-id}/runs/{run-id}/logs/prev`
* `/namespaces/{namespace-id}/adapters/{adapter-id}/runs/{run-id}/logs`

Also refactored test cases.

