### PR TITLE
CDAP-1965: Provide AbstractCubeHttpHandler out of the box to query a Cube dataset

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/cube/AbstractCubeHttpHandler.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/cube/AbstractCubeHttpHandler.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.api.dataset.lib.cube;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.service.http.AbstractHttpServiceHandler;
+import co.cask.cdap.api.service.http.HttpServiceRequest;
+import co.cask.cdap.api.service.http.HttpServiceResponder;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Type;
+import java.util.Collection;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+
+/**
+ * A basic implementation of {@link co.cask.cdap.api.service.http.HttpServiceHandler} that provides endpoints to
+ * explore and execute queries in {@link Cube} dataset.
+ * <p/>
+ * Subclasses must implement {@link co.cask.cdap.api.dataset.lib.cube.AbstractCubeHttpHandler#getCube()} that returns
+ * {@link Cube} dataset.
+ */
+public abstract class AbstractCubeHttpHandler extends AbstractHttpServiceHandler {
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractCubeHttpHandler.class);
+
+  private static final Type CUBE_FACT_COLLECTION = new TypeToken<Collection<CubeFact>>() { }.getType();
+  private static final Gson GSON = new Gson();
+
+  /**
+   * @return {@link Cube} dataset.
+   */
+  protected abstract Cube getCube();
+
+  /**
+   * Adds facts to a {@link Cube} as defined by {@link Cube#add(java.util.Collection)}.
+   */
+  @Path("add")
+  @POST
+  public void addFact(HttpServiceRequest request, HttpServiceResponder responder) {
+    try {
+      String body = Bytes.toString(request.getContent());
+      Collection<CubeFact> facts = new Gson().fromJson(body, CUBE_FACT_COLLECTION);
+      getCube().add(facts);
+      responder.sendStatus(200);
+    } catch (Throwable th) {
+      LOG.error("Error while executing request", th);
+      responder.sendError(500, th.getMessage());
+    }
+  }
+
+  /**
+   * Searches tags in a {@link Cube} as defined by {@link Cube#findNextAvailableTags(CubeExploreQuery)}.
+   */
+  @Path("searchTag")
+  @POST
+  public void searchTag(HttpServiceRequest request, HttpServiceResponder responder) {
+    try {
+      String body = Bytes.toString(request.getContent());
+      CubeExploreQuery query = new Gson().fromJson(body, CubeExploreQuery.class);
+      Collection<TagValue> result = getCube().findNextAvailableTags(query);
+      responder.sendJson(result);
+    } catch (Throwable th) {
+      LOG.error("Error while executing request", th);
+      responder.sendError(500, th.getMessage());
+    }
+  }
+
+  /**
+   * Searches measurements in a {@link Cube} as defined by {@link Cube#findMeasureNames(CubeExploreQuery)}.
+   */
+  @Path("searchMeasure")
+  @POST
+  public void searchMeasure(HttpServiceRequest request, HttpServiceResponder responder) {
+    try {
+      String body = Bytes.toString(request.getContent());
+      CubeExploreQuery query = GSON.fromJson(body, CubeExploreQuery.class);
+      Collection<String> result = getCube().findMeasureNames(query);
+      responder.sendJson(result);
+    } catch (Throwable th) {
+      LOG.error("Error while executing request", th);
+      responder.sendError(500, th.getMessage());
+    }
+  }
+
+  /**
+   * Searches tags in a {@link Cube} as defined by {@link Cube#findNextAvailableTags(CubeExploreQuery)}.
+   */
+  @Path("query")
+  @POST
+  public void query(HttpServiceRequest request, HttpServiceResponder responder) {
+    try {
+      String body = Bytes.toString(request.getContent());
+      CubeQuery query = new Gson().fromJson(body, CubeQuery.class);
+      Collection<TimeSeries> result = getCube().query(query);
+      responder.sendJson(result);
+    } catch (Throwable th) {
+      LOG.error("Error while executing request", th);
+      responder.sendError(500, th.getMessage());
+    }
+  }
+}

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/cube/CubeQuery.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/cube/CubeQuery.java
@@ -51,10 +51,10 @@ public final class CubeQuery {
   private final List<String> groupByTags;
   private final Interpolator interpolator;
 
-  public CubeQuery(long startTs, long endTs, int resolution,
+  public CubeQuery(long startTs, long endTs, int resolution, int limit,
                    String measureName, MeasureType measureType,
                    Map<String, String> sliceByTagValues, List<String> groupByTags) {
-    this(startTs, endTs, resolution, -1,
+    this(startTs, endTs, resolution, limit,
          measureName, measureType,
          sliceByTagValues, groupByTags, null);
   }

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/AppWithCube.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/AppWithCube.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.test.app;
+
+import co.cask.cdap.api.annotation.UseDataSet;
+import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.lib.cube.AbstractCubeHttpHandler;
+import co.cask.cdap.api.dataset.lib.cube.Cube;
+
+/**
+ *
+ */
+public class AppWithCube extends AbstractApplication {
+  static final String CUBE_NAME = "cube";
+  static final String SERVICE_NAME = "service";
+
+  @Override
+  public void configure() {
+    DatasetProperties props = DatasetProperties.builder()
+      .add("dataset.cube.resolutions", "1,60")
+      .add("dataset.cube.aggregation.agg1.tags", "user,action")
+      .add("dataset.cube.aggregation.agg1.requiredTags", "user,action").build();
+    createDataset(CUBE_NAME, Cube.class, props);
+
+    addService(SERVICE_NAME, new CubeHandler());
+  }
+
+  /**
+   *
+   */
+  public static final class CubeHandler extends AbstractCubeHttpHandler {
+    @UseDataSet(CUBE_NAME)
+    private Cube cube;
+
+    @Override
+    protected Cube getCube() {
+      return cube;
+    }
+  }
+}

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestAppWithCube.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestAppWithCube.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestAppWithCube.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestAppWithCube.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.test.app;
+
+import co.cask.cdap.api.dataset.lib.cube.CubeExploreQuery;
+import co.cask.cdap.api.dataset.lib.cube.CubeFact;
+import co.cask.cdap.api.dataset.lib.cube.CubeQuery;
+import co.cask.cdap.api.dataset.lib.cube.MeasureType;
+import co.cask.cdap.api.dataset.lib.cube.TagValue;
+import co.cask.cdap.api.dataset.lib.cube.TimeSeries;
+import co.cask.cdap.api.dataset.lib.cube.TimeValue;
+import co.cask.cdap.test.ApplicationManager;
+import co.cask.cdap.test.ServiceManager;
+import co.cask.cdap.test.SlowTests;
+import co.cask.cdap.test.TestBase;
+import co.cask.common.http.HttpRequest;
+import co.cask.common.http.HttpRequests;
+import co.cask.common.http.HttpResponse;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ *
+ */
+public class TestAppWithCube extends TestBase {
+  private static final Gson GSON = new Gson();
+
+  @Category(SlowTests.class)
+  @Test
+  public void testApp() throws Exception {
+    // Deploy the application
+    ApplicationManager appManager = deployApplication(AppWithCube.class);
+
+    ServiceManager serviceManager = appManager.startService(AppWithCube.SERVICE_NAME);
+    try {
+      serviceManager.waitForStatus(true);
+      URL url = serviceManager.getServiceURL();
+
+      long tsInSec = System.currentTimeMillis() / 1000;
+
+      // round to a minute for testing minute resolution
+      tsInSec = (tsInSec / 60) * 60;
+
+      // add couple facts
+      add(url, ImmutableList.of(new CubeFact(ImmutableMap.of("user", "alex", "action", "click"),
+                                             MeasureType.COUNTER, "count",
+                                             new TimeValue(tsInSec, 1))));
+      add(url, ImmutableList.of(new CubeFact(ImmutableMap.of("user", "alex", "action", "click"),
+                                             MeasureType.COUNTER, "count",
+                                             new TimeValue(tsInSec, 1)),
+                                new CubeFact(ImmutableMap.of("user", "alex", "action", "back"),
+                                             MeasureType.COUNTER, "count",
+                                             new TimeValue(tsInSec + 1, 1)),
+                                new CubeFact(ImmutableMap.of("user", "alex", "action", "click"),
+                                             MeasureType.COUNTER, "count",
+                                             new TimeValue(tsInSec + 2, 1))));
+
+      // search for tags
+      Collection<TagValue> tags =
+        searchTag(url, new CubeExploreQuery(tsInSec - 60, tsInSec + 60, 1, 100, new ArrayList<TagValue>()));
+      Assert.assertEquals(1, tags.size());
+      TagValue tv = tags.iterator().next();
+      Assert.assertEquals("user", tv.getTagName());
+      Assert.assertEquals("alex", tv.getValue());
+
+      tags = searchTag(url, new CubeExploreQuery(tsInSec - 60, tsInSec + 60, 1, 100,
+                                                 ImmutableList.of(new TagValue("user", "alex"))));
+      Assert.assertEquals(2, tags.size());
+      Iterator<TagValue> iterator = tags.iterator();
+      tv = iterator.next();
+      Assert.assertEquals("action", tv.getTagName());
+      Assert.assertEquals("back", tv.getValue());
+      tv = iterator.next();
+      Assert.assertEquals("action", tv.getTagName());
+      Assert.assertEquals("click", tv.getValue());
+
+      // search for measures
+      Collection<String> measures =
+        searchMeasure(url, new CubeExploreQuery(tsInSec - 60, tsInSec + 60, 1, 100,
+                                                ImmutableList.of(new TagValue("user", "alex"))));
+      Assert.assertEquals(1, measures.size());
+      String measure = measures.iterator().next();
+      Assert.assertEquals("count", measure);
+
+      // query for data
+
+      // 1-sec resolution
+      Collection<TimeSeries> data =
+        query(url, new CubeQuery(tsInSec - 60, tsInSec + 60, 1, 100, "count", MeasureType.COUNTER,
+                                 ImmutableMap.of("action", "click"), new ArrayList<String>()));
+      Assert.assertEquals(1, data.size());
+      TimeSeries series = data.iterator().next();
+      List<TimeValue> timeValues = series.getTimeValues();
+      Assert.assertEquals(2, timeValues.size());
+      TimeValue timeValue = timeValues.get(0);
+      Assert.assertEquals(tsInSec, timeValue.getTimestamp());
+      Assert.assertEquals(2, timeValue.getValue());
+      timeValue = timeValues.get(1);
+      Assert.assertEquals(tsInSec + 2, timeValue.getTimestamp());
+      Assert.assertEquals(1, timeValue.getValue());
+
+      // 60-sec resolution
+      data = query(url, new CubeQuery(tsInSec - 60, tsInSec + 60, 60, 100, "count", MeasureType.COUNTER,
+                                      ImmutableMap.of("action", "click"), new ArrayList<String>()));
+      Assert.assertEquals(1, data.size());
+      series = data.iterator().next();
+      timeValues = series.getTimeValues();
+      Assert.assertEquals(1, timeValues.size());
+      timeValue = timeValues.get(0);
+      Assert.assertEquals(tsInSec, timeValue.getTimestamp());
+      Assert.assertEquals(3, timeValue.getValue());
+
+    } finally {
+      serviceManager.stop();
+      serviceManager.waitForStatus(false);
+    }
+  }
+
+  private void add(URL serviceUrl, Collection<CubeFact> facts) throws IOException {
+    URL url = new URL(serviceUrl, "add");
+    HttpRequest request = HttpRequest.post(url).withBody(GSON.toJson(facts)).build();
+    HttpResponse response = HttpRequests.execute(request);
+    Assert.assertEquals(200, response.getResponseCode());
+  }
+
+  private Collection<TagValue> searchTag(URL serviceUrl, CubeExploreQuery query) throws IOException {
+    URL url = new URL(serviceUrl, "searchTag");
+    HttpRequest request = HttpRequest.post(url).withBody(GSON.toJson(query)).build();
+    HttpResponse response = HttpRequests.execute(request);
+    Assert.assertEquals(200, response.getResponseCode());
+    return GSON.fromJson(response.getResponseBodyAsString(), new TypeToken<Collection<TagValue>>() { }.getType());
+  }
+
+  private Collection<String> searchMeasure(URL serviceUrl, CubeExploreQuery query) throws IOException {
+    URL url = new URL(serviceUrl, "searchMeasure");
+    HttpRequest request = HttpRequest.post(url).withBody(GSON.toJson(query)).build();
+    HttpResponse response = HttpRequests.execute(request);
+    Assert.assertEquals(200, response.getResponseCode());
+    return GSON.fromJson(response.getResponseBodyAsString(), new TypeToken<Collection<String>>() { }.getType());
+  }
+
+  private Collection<TimeSeries> query(URL serviceUrl, CubeQuery query) throws IOException {
+    URL url = new URL(serviceUrl, "query");
+    HttpRequest request = HttpRequest.post(url).withBody(GSON.toJson(query)).build();
+    HttpResponse response = HttpRequests.execute(request);
+    Assert.assertEquals(200, response.getResponseCode());
+    return GSON.fromJson(response.getResponseBodyAsString(), new TypeToken<Collection<TimeSeries>>() { }.getType());
+  }
+}


### PR DESCRIPTION
NOTE: Currently, we can only provide an abstract http handler which subclass has to implement method that returns Cube dataset. Because there's no support of instantiating dataset dynamically based on name in a program.