### PR TITLE
CDAP-2087 adding a table sink for the etl template. As part of

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/templates/etl/batch/ETLBatchTemplate.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/templates/etl/batch/ETLBatchTemplate.java
@@ -26,7 +26,9 @@ import co.cask.cdap.templates.etl.api.batch.BatchSink;
 import co.cask.cdap.templates.etl.api.batch.BatchSource;
 import co.cask.cdap.templates.etl.api.config.ETLStage;
 import co.cask.cdap.templates.etl.batch.config.ETLBatchConfig;
+import co.cask.cdap.templates.etl.batch.sinks.BatchWritableSink;
 import co.cask.cdap.templates.etl.batch.sinks.KVTableSink;
+import co.cask.cdap.templates.etl.batch.sinks.TableSink;
 import co.cask.cdap.templates.etl.batch.sources.BatchReadableSource;
 import co.cask.cdap.templates.etl.batch.sources.KVTableSource;
 import co.cask.cdap.templates.etl.batch.sources.TableSource;
@@ -36,6 +38,7 @@ import co.cask.cdap.templates.etl.common.DefaultStageConfigurer;
 import co.cask.cdap.templates.etl.transforms.IdentityTransform;
 import co.cask.cdap.templates.etl.transforms.RowToStructuredRecordTransform;
 import co.cask.cdap.templates.etl.transforms.StructuredRecordToGenericRecordTransform;
+import co.cask.cdap.templates.etl.transforms.StructuredRecordToPutTransform;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -69,8 +72,11 @@ public class ETLBatchTemplate extends ApplicationTemplate<ETLBatchConfig> {
     initTable(Lists.<Class>newArrayList(KVTableSource.class,
                                         KVTableSink.class,
                                         BatchReadableSource.class,
+                                        BatchWritableSink.class,
                                         TableSource.class,
+                                        TableSink.class,
                                         IdentityTransform.class,
+                                        StructuredRecordToPutTransform.class,
                                         RowToStructuredRecordTransform.class,
                                         StructuredRecordToGenericRecordTransform.class));
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/co/cask/cdap/templates/etl/batch/ETLMapReduceTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/co/cask/cdap/templates/etl/batch/ETLMapReduceTest.java
@@ -17,13 +17,21 @@
 package co.cask.cdap.templates.etl.batch;
 
 import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.lib.KeyValueTable;
+import co.cask.cdap.api.dataset.table.Put;
+import co.cask.cdap.api.dataset.table.Row;
+import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.api.templates.ApplicationTemplate;
 import co.cask.cdap.common.utils.ImmutablePair;
 import co.cask.cdap.templates.etl.api.config.ETLStage;
 import co.cask.cdap.templates.etl.batch.config.ETLBatchConfig;
+import co.cask.cdap.templates.etl.batch.sinks.TableSink;
 import co.cask.cdap.templates.etl.batch.sources.BatchReadableSource;
+import co.cask.cdap.templates.etl.batch.sources.TableSource;
+import co.cask.cdap.templates.etl.transforms.RowToStructuredRecordTransform;
+import co.cask.cdap.templates.etl.transforms.StructuredRecordToPutTransform;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.DataSetManager;
 import co.cask.cdap.test.MapReduceManager;
@@ -32,6 +40,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -43,16 +52,27 @@ import java.util.concurrent.TimeUnit;
  * Tests for {@link ETLBatchTemplate}.
  */
 public class ETLMapReduceTest extends TestBase {
+  private static ApplicationManager templateManager;
+
+  @BeforeClass
+  public static void setupTests() {
+    // simulate template deployment
+    templateManager = deployApplication(ETLBatchTemplate.class);
+  }
 
   @Test
   public void testConfig() throws Exception {
-
-    // simulate template deployment
-    ApplicationManager batchManager = deployApplication(ETLBatchTemplate.class);
-
     // simulate pipeline creation
     ApplicationTemplate<ETLBatchConfig> appTemplate = new ETLBatchTemplate();
-    ETLBatchConfig adapterConfig = constructETLBatchConfig();
+
+    // kv table to kv table pipeline
+    ETLStage source = new ETLStage(BatchReadableSource.class.getSimpleName(),
+                                   ImmutableMap.of("name", "table1", "type", KeyValueTable.class.getName()));
+    ETLStage sink = new ETLStage("KVTableSink", ImmutableMap.of("name", "table2"));
+    ETLStage transform = new ETLStage("IdentityTransform", ImmutableMap.<String, String>of());
+    List<ETLStage> transformList = Lists.newArrayList(transform);
+    ETLBatchConfig adapterConfig = new ETLBatchConfig("", source, sink, transformList);
+
     MockAdapterConfigurer adapterConfigurer = new MockAdapterConfigurer();
     appTemplate.configureAdapter("myAdapter", adapterConfig, adapterConfigurer);
 
@@ -71,23 +91,13 @@ public class ETLMapReduceTest extends TestBase {
     for (Map.Entry<String, String> entry : adapterConfigurer.getArguments().entrySet()) {
       mapReduceArgs.put(entry.getKey(), entry.getValue());
     }
-    MapReduceManager mrManager = batchManager.startMapReduce("ETLMapReduce", mapReduceArgs);
+    MapReduceManager mrManager = templateManager.startMapReduce("ETLMapReduce", mapReduceArgs);
     mrManager.waitForFinish(5, TimeUnit.MINUTES);
-    batchManager.stopAll();
+    templateManager.stopAll();
     DataSetManager<KeyValueTable> table2 = getDataset("table2");
     KeyValueTable outputTable = table2.get();
     for (int i = 0; i < 10000; i++) {
       Assert.assertEquals("world" + i, Bytes.toString(outputTable.read("hello" + i)));
-    }
-  }
-
-  private void addDatasetInstances(MockAdapterConfigurer configurer) throws Exception {
-    for (Map.Entry<String, ImmutablePair<String, DatasetProperties>> entry :
-      configurer.getDatasetInstances().entrySet()) {
-      String typeName = entry.getValue().getFirst();
-      DatasetProperties properties = entry.getValue().getSecond();
-      String instanceName = entry.getKey();
-      addDatasetInstance(typeName, instanceName, properties);
     }
   }
 
@@ -101,13 +111,91 @@ public class ETLMapReduceTest extends TestBase {
     appTemplate.configureAdapter("myAdapter", adapterConfig, mockAdapterConfigurer);
   }
 
-  private ETLBatchConfig constructETLBatchConfig() {
-    ETLStage source = new ETLStage(BatchReadableSource.class.getSimpleName(),
-                                   ImmutableMap.of("name", "table1", "type", KeyValueTable.class.getName()));
-    ETLStage sink = new ETLStage("KVTableSink", ImmutableMap.of("name", "table2"));
-    ETLStage transform = new ETLStage("IdentityTransform", ImmutableMap.<String, String>of());
-    List<ETLStage> transformList = Lists.newArrayList(transform);
-    return new ETLBatchConfig("", source, sink, transformList);
+  @SuppressWarnings("ConstantConditions")
+  @Test
+  public void testTableToTable() throws Exception {
+
+    // simulate pipeline creation
+    ApplicationTemplate<ETLBatchConfig> appTemplate = new ETLBatchTemplate();
+
+    ETLStage source = new ETLStage(TableSource.class.getSimpleName(), ImmutableMap.of("name", "inputTable"));
+    ETLStage sink = new ETLStage(TableSink.class.getSimpleName(), ImmutableMap.of("name", "outputTable"));
+    Schema schema = Schema.recordOf(
+      "purchase",
+      Schema.Field.of("rowkey", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("user", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("count", Schema.of(Schema.Type.INT)),
+      Schema.Field.of("price", Schema.of(Schema.Type.DOUBLE)),
+      Schema.Field.of("item", Schema.of(Schema.Type.STRING))
+    );
+    ETLStage transform1 = new ETLStage(RowToStructuredRecordTransform.class.getSimpleName(),
+                                       ImmutableMap.of(
+                                         "schema", schema.toString(),
+                                         "row.field", "rowkey"
+                                       ));
+    ETLStage transform2 = new ETLStage(StructuredRecordToPutTransform.class.getSimpleName(),
+                                       ImmutableMap.of(
+                                         "schema", schema.toString(),
+                                         "row.field", "rowkey"
+                                       ));
+    ETLBatchConfig adapterConfig = new ETLBatchConfig("", source, sink, Lists.newArrayList(transform1, transform2));
+
+    MockAdapterConfigurer adapterConfigurer = new MockAdapterConfigurer();
+    appTemplate.configureAdapter("myAdapter", adapterConfig, adapterConfigurer);
+
+    // add dataset instances that the source and sink added
+    addDatasetInstances(adapterConfigurer);
+    // add some data to the input table
+    DataSetManager<Table> inputManager = getDataset("inputTable");
+    Table inputTable = inputManager.get();
+    Put put = new Put(Bytes.toBytes("row1"));
+    put.add("user", "samuel");
+    put.add("count", 5);
+    put.add("price", 123.45);
+    put.add("item", "scotch");
+    inputTable.put(put);
+    inputManager.flush();
+    put = new Put(Bytes.toBytes("row2"));
+    put.add("user", "jackson");
+    put.add("count", 10);
+    put.add("price", 123456789d);
+    put.add("item", "island");
+    inputTable.put(put);
+    inputManager.flush();
+
+    // add the runtime args that CDAP would normally add to the mapreduce job
+    Map<String, String> mapReduceArgs = Maps.newHashMap();
+    for (Map.Entry<String, String> entry : adapterConfigurer.getArguments().entrySet()) {
+      mapReduceArgs.put(entry.getKey(), entry.getValue());
+    }
+    MapReduceManager mrManager = templateManager.startMapReduce("ETLMapReduce", mapReduceArgs);
+    mrManager.waitForFinish(5, TimeUnit.MINUTES);
+    templateManager.stopAll();
+
+    DataSetManager<Table> outputManager = getDataset("outputTable");
+    Table outputTable = outputManager.get();
+
+    Row row = outputTable.get(Bytes.toBytes("row1"));
+    Assert.assertEquals("samuel", row.getString("user"));
+    Assert.assertEquals(5, (int) row.getInt("count"));
+    Assert.assertTrue(Math.abs(123.45 - row.getDouble("price")) < 0.000001);
+    Assert.assertEquals("scotch", row.getString("item"));
+
+    row = outputTable.get(Bytes.toBytes("row2"));
+    Assert.assertEquals("jackson", row.getString("user"));
+    Assert.assertEquals(10, (int) row.getInt("count"));
+    Assert.assertTrue(Math.abs(123456789 - row.getDouble("price")) < 0.000001);
+    Assert.assertEquals("island", row.getString("item"));
+  }
+
+  private void addDatasetInstances(MockAdapterConfigurer configurer) throws Exception {
+    for (Map.Entry<String, ImmutablePair<String, DatasetProperties>> entry :
+      configurer.getDatasetInstances().entrySet()) {
+      String typeName = entry.getValue().getFirst();
+      DatasetProperties properties = entry.getValue().getSecond();
+      String instanceName = entry.getKey();
+      addDatasetInstance(typeName, instanceName, properties);
+    }
   }
 
   private ETLBatchConfig constructTypeMismatchConfig() {

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/batch/sinks/BatchWritableSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/batch/sinks/BatchWritableSink.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.templates.etl.batch.sinks;
+
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.table.Put;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.templates.etl.api.PipelineConfigurer;
+import co.cask.cdap.templates.etl.api.Property;
+import co.cask.cdap.templates.etl.api.StageConfigurer;
+import co.cask.cdap.templates.etl.api.batch.BatchSink;
+import co.cask.cdap.templates.etl.api.batch.BatchSinkContext;
+import co.cask.cdap.templates.etl.api.config.ETLStage;
+import com.google.common.base.Preconditions;
+
+/**
+ * Sink for CDAP Datasets that are batch writable, which means they can be used as output of a
+ * mapreduce job. User is responsible for providing any necessary dataset properties.
+ *
+ * @param <KEY> the type of key
+ * @param <VALUE> the type of value
+ */
+public class BatchWritableSink<KEY, VALUE> extends BatchSink<KEY, VALUE> {
+  protected static final String NAME = "name";
+  protected static final String TYPE = "type";
+
+  @Override
+  public void configure(StageConfigurer configurer) {
+    configurer.setName("BatchWritableSink");
+    configurer.setDescription("Sink for CDAP Datasets that are batch writable." +
+                                " The name and type of dataset are required properties." +
+                                " Any properties required by the desired dataset type must also be provided.");
+    configurer.addProperty(new Property(NAME, "Name of the dataset. If the dataset does not already exist," +
+      " one will be created.", true));
+    configurer.addProperty(new Property(TYPE, "The type of batch writable dataset to use.", true));
+  }
+
+  @Override
+  public void configurePipeline(ETLStage stageConfig, PipelineConfigurer pipelineConfigurer) {
+    String datasetName = stageConfig.getProperties().get(NAME);
+    Preconditions.checkArgument(datasetName != null && !datasetName.isEmpty(), "Dataset name must be given.");
+    String datasetType = getDatasetType(stageConfig);
+    Preconditions.checkArgument(datasetType != null && !datasetType.isEmpty(), "Dataset type must be given.");
+
+    pipelineConfigurer.createDataset(datasetName, datasetType, DatasetProperties.builder()
+      .addAll(stageConfig.getProperties())
+      .build());
+  }
+
+  // this is a separate method so that it can be overriden by classes that extend this one.
+  protected String getDatasetType(ETLStage stageConfig) {
+    return stageConfig.getProperties().get(TYPE);
+  }
+
+  @Override
+  public void prepareJob(BatchSinkContext context) {
+    context.setOutput(context.getRuntimeArguments().get(NAME));
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/batch/sinks/TableSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/batch/sinks/TableSink.java
@@ -16,7 +16,9 @@
 
 package co.cask.cdap.templates.etl.batch.sinks;
 
-import co.cask.cdap.api.dataset.lib.KeyValueTable;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.table.Put;
+import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.templates.etl.api.Property;
 import co.cask.cdap.templates.etl.api.StageConfigurer;
 import co.cask.cdap.templates.etl.api.config.ETLStage;
@@ -24,17 +26,24 @@ import co.cask.cdap.templates.etl.api.config.ETLStage;
 /**
  * CDAP Table Dataset Batch Sink.
  */
-public class KVTableSink extends BatchWritableSink<byte[], byte[]> {
+public class TableSink extends BatchWritableSink<byte[], Put> {
 
   @Override
   public void configure(StageConfigurer configurer) {
-    configurer.setName("KVTableSink");
-    configurer.setDescription("CDAP Key Value Table Dataset Batch Sink");
-    configurer.addProperty(new Property(NAME, "Dataset Name", true));
+    configurer.setName("TableSink");
+    configurer.setDescription("CDAP Table Dataset Batch Sink");
+    configurer.addProperty(new Property(NAME, "Name of the table. If the table does not already exist," +
+      " one will be created.", true));
+    configurer.addProperty(
+      new Property(DatasetProperties.SCHEMA,
+                   "Optional schema of the table as a JSON Object. If the table does not already exist," +
+                     " one will be created with this schema, which will allow the table to be explored through Hive.",
+                   false));
   }
 
   @Override
   protected String getDatasetType(ETLStage config) {
-    return KeyValueTable.class.getName();
+    return Table.class.getName();
   }
+
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/transforms/StructuredRecordToPutTransform.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/transforms/StructuredRecordToPutTransform.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.templates.etl.transforms;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.dataset.table.Put;
+import co.cask.cdap.templates.etl.api.Emitter;
+import co.cask.cdap.templates.etl.api.Property;
+import co.cask.cdap.templates.etl.api.StageConfigurer;
+import co.cask.cdap.templates.etl.api.Transform;
+import co.cask.cdap.templates.etl.api.TransformContext;
+import com.google.common.base.Preconditions;
+
+import java.nio.ByteBuffer;
+import javax.annotation.Nullable;
+
+/**
+ * Transforms a StructuredRecord into a Put object used to write to a Table. Each field in the record
+ * will be added as a column in the Put. Only simple types are supported. The transform does not assume that
+ * all input will have the same schema, but it does assume that there will always be a field present that
+ * will be the row key for the table Put.
+ */
+public class StructuredRecordToPutTransform extends Transform<Object, StructuredRecord, Object, Put> {
+  private static final String ROW_FIELD = "row.field";
+  private String rowField;
+
+  @Override
+  public void configure(StageConfigurer configurer) {
+    configurer.setName(StructuredRecordToPutTransform.class.getSimpleName());
+    configurer.setDescription("Transforms a StructuredRecord to a Put object used to write to a Table.");
+    configurer.addProperty(new Property(ROW_FIELD, "the name of the record field that should be used as the row key" +
+      " for the table put.", true));
+  }
+
+  @Override
+  public void initialize(TransformContext context) {
+    rowField = context.getRuntimeArguments().get(ROW_FIELD);
+    Preconditions.checkArgument(rowField != null && !rowField.isEmpty(), "the row key must be given");
+  }
+
+  @Override
+  public void transform(@Nullable Object key, StructuredRecord record,
+                        Emitter<Object, Put> emitter) throws Exception {
+    Schema recordSchema = record.getSchema();
+    Preconditions.checkArgument(recordSchema.getType() == Schema.Type.RECORD, "input must be a record.");
+    Put output = createPut(record, recordSchema);
+
+    for (Schema.Field field : recordSchema.getFields()) {
+      if (field.getName().equals(rowField)) {
+        continue;
+      }
+      setField(output, field, record.get(field.getName()));
+    }
+    emitter.emit(key, output);
+  }
+
+  @SuppressWarnings("ConstantConditions")
+  private void setField(Put put, Schema.Field field, Object val) {
+    // have to handle nulls differently. In a Put object, it's only valid to use the add(byte[], byte[])
+    // for null values, as the other add methods take boolean vs Boolean, int vs Integer, etc.
+    if (field.getSchema().isNullable() && val == null) {
+      put.add(field.getName(), (byte[]) null);
+      return;
+    }
+    Schema.Type type = validateAndGetType(field);
+
+    switch (type) {
+      case BOOLEAN:
+        put.add(field.getName(), (Boolean) val);
+        break;
+      case INT:
+        put.add(field.getName(), (Integer) val);
+        break;
+      case LONG:
+        put.add(field.getName(), (Long) val);
+        break;
+      case FLOAT:
+        put.add(field.getName(), (Float) val);
+        break;
+      case DOUBLE:
+        put.add(field.getName(), (Double) val);
+        break;
+      case BYTES:
+        if (val instanceof ByteBuffer) {
+          put.add(field.getName(), Bytes.toBytes((ByteBuffer) val));
+        } else {
+          put.add(field.getName(), (byte[]) val);
+        }
+        break;
+      case STRING:
+        put.add(field.getName(), (String) val);
+        break;
+      default:
+        throw new IllegalArgumentException("Field " + field.getName() + " is of unsupported type " + type);
+    }
+  }
+
+  // get the non-nullable type of the field and check that it's a simple type.
+  private Schema.Type validateAndGetType(Schema.Field field) {
+    Schema.Type type;
+    if (field.getSchema().isNullable()) {
+      type = field.getSchema().getNonNullable().getType();
+    } else {
+      type = field.getSchema().getType();
+    }
+    Preconditions.checkArgument(type.isSimpleType(),
+                                "only simple types are supported (boolean, int, long, float, double, bytes).");
+    return type;
+  }
+
+  private Put createPut(StructuredRecord record, Schema recordSchema) {
+    Schema.Field keyField = recordSchema.getField(rowField);
+    Object val = record.get(keyField.getName());
+    Preconditions.checkArgument(val != null, "Row key cannot be null.");
+
+    Schema.Type keyType = validateAndGetType(keyField);
+    switch (keyType) {
+      case BOOLEAN:
+        return new Put(Bytes.toBytes((Boolean) record.get(rowField)));
+      case INT:
+        return new Put(Bytes.toBytes((Integer) record.get(rowField)));
+      case LONG:
+        return new Put(Bytes.toBytes((Long) record.get(rowField)));
+      case FLOAT:
+        return new Put(Bytes.toBytes((Float) record.get(rowField)));
+      case DOUBLE:
+        return new Put(Bytes.toBytes((Double) record.get(rowField)));
+      case BYTES:
+        Object bytes = record.get(rowField);
+        if (bytes instanceof ByteBuffer) {
+          return new Put(Bytes.toBytes((ByteBuffer) bytes));
+        } else {
+          return new Put((byte[]) bytes);
+        }
+      case STRING:
+        return new Put(Bytes.toBytes((String) record.get(rowField)));
+      default:
+        throw new IllegalArgumentException("Row key is of unsupported type " + keyType);
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/templates/etl/transforms/StructuredRecordToPutTransformTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/templates/etl/transforms/StructuredRecordToPutTransformTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.templates.etl.transforms;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.dataset.table.Put;
+import co.cask.cdap.templates.etl.api.Transform;
+import co.cask.cdap.templates.etl.api.TransformContext;
+import co.cask.cdap.templates.etl.common.MockEmitter;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Map;
+
+/**
+ */
+@SuppressWarnings("unchecked")
+public class StructuredRecordToPutTransformTest {
+  
+  @Test(expected = IllegalArgumentException.class)
+  public void testNullRowkeyThrowsException() throws Exception {
+    // initialize transform
+    Transform transform = new StructuredRecordToPutTransform();
+    TransformContext context = new MockTransformContext(ImmutableMap.of("row.field", "key"));
+    transform.initialize(context);
+
+    Schema schema = Schema.recordOf("record", Schema.Field.of("key", Schema.nullableOf(Schema.of(Schema.Type.STRING))));
+
+    StructuredRecord record = StructuredRecord.builder(schema).build();
+
+    MockEmitter<Object, Put> emitter = new MockEmitter<Object, Put>();
+    transform.transform(0L, record, emitter);
+  }
+
+  @Test
+  public void testNullableFields() throws Exception {
+    // initialize the transform
+    Transform transform = new StructuredRecordToPutTransform();
+    TransformContext context = new MockTransformContext(ImmutableMap.of("row.field", "key"));
+    transform.initialize(context);
+
+    Schema schema = Schema.recordOf(
+      "record",
+      Schema.Field.of("key", Schema.of(Schema.Type.INT)),
+      Schema.Field.of("nullable", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
+      Schema.Field.of("non_nullable", Schema.of(Schema.Type.STRING))
+    );
+
+    // valid record
+    StructuredRecord record = StructuredRecord.builder(schema)
+      .set("key", 1)
+      .set("non_nullable", "foo")
+      .build();
+
+    MockEmitter<Object, Put> emitter = new MockEmitter<Object, Put>();
+    transform.transform(0L, record, emitter);
+    Put transformed = emitter.getEmitted().get(0).getVal();
+
+    Assert.assertEquals(1, Bytes.toInt(transformed.getRow()));
+    // expect a null value for the nullable field
+    Assert.assertEquals(2, transformed.getValues().size());
+    Assert.assertEquals("foo", Bytes.toString(transformed.getValues().get(Bytes.toBytes("non_nullable"))));
+    Assert.assertNull(transformed.getValues().get(Bytes.toBytes("nullable")));
+  }
+
+  @Test
+  public void testTransform() throws Exception {
+    // initialize the transform
+    Transform transform = new StructuredRecordToPutTransform();
+    TransformContext context = new MockTransformContext(ImmutableMap.of("row.field", "stringField"));
+    transform.initialize(context);
+
+    Schema schema = Schema.recordOf(
+      "record",
+      Schema.Field.of("boolField", Schema.nullableOf(Schema.of(Schema.Type.BOOLEAN))),
+      Schema.Field.of("intField", Schema.nullableOf(Schema.of(Schema.Type.INT))),
+      Schema.Field.of("longField", Schema.nullableOf(Schema.of(Schema.Type.LONG))),
+      Schema.Field.of("floatField", Schema.nullableOf(Schema.of(Schema.Type.FLOAT))),
+      Schema.Field.of("doubleField", Schema.nullableOf(Schema.of(Schema.Type.DOUBLE))),
+      Schema.Field.of("bytesField", Schema.nullableOf(Schema.of(Schema.Type.BYTES))),
+      Schema.Field.of("stringField", Schema.of(Schema.Type.STRING))
+    );
+
+    StructuredRecord record = StructuredRecord.builder(schema)
+      .set("boolField", true)
+      .set("intField", 5)
+      .set("longField", 10L)
+      .set("floatField", 3.14f)
+      .set("doubleField", 3.14)
+      .set("bytesField", Bytes.toBytes("foo"))
+      .set("stringField", "key")
+      .build();
+
+    MockEmitter<Object, Put> emitter = new MockEmitter<Object, Put>();
+    transform.transform(0L, record, emitter);
+    Put transformed = emitter.getEmitted().get(0).getVal();
+
+    Assert.assertEquals("key", Bytes.toString(transformed.getRow()));
+    Map<byte[], byte[]> values = transformed.getValues();
+    Assert.assertTrue(Bytes.toBoolean(values.get(Bytes.toBytes("boolField"))));
+    Assert.assertEquals(5, Bytes.toInt(values.get(Bytes.toBytes("intField"))));
+    Assert.assertEquals(10L, Bytes.toLong(values.get(Bytes.toBytes("longField"))));
+    Assert.assertTrue(Math.abs(3.14f - Bytes.toFloat(values.get(Bytes.toBytes("floatField")))) < 0.000001);
+    Assert.assertTrue(Math.abs(3.14 - Bytes.toDouble(values.get(Bytes.toBytes("doubleField")))) < 0.000001);
+    Assert.assertArrayEquals(Bytes.toBytes("foo"), values.get(Bytes.toBytes("bytesField")));
+  }
+}


### PR DESCRIPTION
this, also adding a BatchWritableSink that will work for any
CDAP BatchWritable, but which requires users to supply the dataset
type and any properties that type requires. TableSink and
KVTableSink then extend the BatchWritableSink.