### PR TITLE
Fix/ui programs view consistency

### DIFF
--- a/cdap-ui/app/features/apps/templates/detail.html
+++ b/cdap-ui/app/features/apps/templates/detail.html
@@ -1,14 +1,10 @@
 <div ncy-breadcrumb></div>
-  <h1><span ng-bind="$state.params.appId | caskCapitalizeFilter"></span></h1>
-  <p> Type: App </p>
+  <h1>
+    <span ng-bind="$state.params.appId | caskCapitalizeFilter"></span>
+    <small> Type: App </small>
+  </h1>
   <div class="cdap-subnav-end"></div>
   <my-tabs
     data-tabs-list="['Status']"
     data-tabs-partial-path="/assets/features/apps/templates/tabs/">
   </my-tabs>
-
-<!--
-<my-tabs ng-if="false"
-  data-tabs-list="['Status','Data','Metadata','Schedules','History','Resource','Manage']"
-  data-tabs-partial-path="/assets/features/apps/templates/tabs/"></my-tabs>
- -->

--- a/cdap-ui/app/features/flows/controllers/detail-ctrl.js
+++ b/cdap-ui/app/features/flows/controllers/detail-ctrl.js
@@ -1,5 +1,6 @@
 angular.module(PKG.name + '.feature.flows')
   .controller('FlowsDetailController', function($scope, MyDataSource, $state, FlowDiagramData, myHelpers, $timeout) {
+    $scope.status = null;
     var dataSrc = new MyDataSource($scope),
         basePath = '/apps/' + $state.params.appId + '/flows/' + $state.params.programId;
 
@@ -13,11 +14,13 @@ angular.module(PKG.name + '.feature.flows')
 
 
     $scope.do = function(action) {
+      $scope.status = action;
       dataSrc.request({
         _cdapNsPath: basePath + '/' + action,
         method: 'POST'
       }).then(function() {
         $timeout(function() {
+          $scope.status = null;
           $state.go($state.current, $state.params, { reload: true });
         });
       });

--- a/cdap-ui/app/features/flows/templates/detail.html
+++ b/cdap-ui/app/features/flows/templates/detail.html
@@ -1,38 +1,41 @@
 <div ncy-breadcrumb></div>
-<h1><span ng-bind="$state.params.programId | caskCapitalizeFilter"></span></h1>
-<p> Type: Tigon </p>
 
-
-<div class="row">
-  <div class="col-sm-6 h4">
-
-      <ng-pluralize data-count="activeRuns"
-          data-when="{'one': '1 Active Run', 'other': '{{activeRuns}} Active Runs'}"></ng-pluralize>
-
+<div class="row" program-heading>
+  <div class="col-sm-6">
+    <h2 class="programTitle">
+      <span ng-bind="$state.params.programId | caskCapitalizeFilter"></span>
+      <small> <em>Type: Tigon </em></small>
+    </h2>
   </div>
   <div class="col-sm-6 text-right">
-
-    <a ng-show = "activeRuns === 0"
-         class="btn btn-success"
+    <span class="programTitle h4">
+      <ng-pluralize data-count="activeRuns"
+          data-when="{'one': '1 Active Run', 'other': '{{activeRuns}} Active Runs'}"></ng-pluralize>
+    </span>
+    <div ng-show="activeRuns === 0 && status === null"
+         class="btn btn-success btn-md"
          ng-click="do('start')">
-      Start a new run
-    </a>
+      <span class="fa fa-play"></span>
+      <span>Start</span>
+    </div>
 
-    <a ng-show="activeRuns > 0"
-        class="btn btn-default"
-        ng-click="do('stop')">
-      <i class="fa fa-stop"></i>
-    </a>
+    <div ng-show="activeRuns > 0 && status === null"
+         class="btn btn-primary btn-md"
+         ng-click="do('stop')">
+      <span class="fa fa-stop"></span>
+      <span>Stop</span>
+    </div>
 
-    <a ng-show="status == 'start' || status == 'stop'"
-         class="btn btn-default">
+    <div ng-show="status == 'start' || status == 'stop'"
+          ng-class="{'btn-success': status === 'start', 'btn-primary': status === 'stop'}"
+          class="btn btn-md">
       <span class="fa fa-refresh fa-spin"></span>
-    </a>
-
+      <span>{{status | caskCapitalizeFilter}}</span>
+    </div>
   </div>
 </div>
 
-<br />
+<div class="cdap-subnav-end"></div>
 
 <ul class="nav nav-tabs" role="tablist">
 

--- a/cdap-ui/app/features/flows/templates/detail.html
+++ b/cdap-ui/app/features/flows/templates/detail.html
@@ -8,7 +8,7 @@
     </h2>
   </div>
   <div class="col-sm-6 text-right">
-    <span class="programTitle h4">
+    <span class="programTitle">
       <ng-pluralize data-count="activeRuns"
           data-when="{'one': '1 Active Run', 'other': '{{activeRuns}} Active Runs'}"></ng-pluralize>
     </span>

--- a/cdap-ui/app/features/mapreduce/routes.js
+++ b/cdap-ui/app/features/mapreduce/routes.js
@@ -62,7 +62,7 @@ angular.module(PKG.name + '.feature.mapreduce')
           templateUrl: '/assets/features/mapreduce/templates/tabs/history.html',
           ncyBreadcrumb: {
             parent: 'apps.detail.overview',
-            label: '{{$state.params.programId}} < History'
+            label: '{{$state.params.programId}}'
           }
         });
   });

--- a/cdap-ui/app/features/mapreduce/templates/detail.html
+++ b/cdap-ui/app/features/mapreduce/templates/detail.html
@@ -12,18 +12,11 @@
       <ng-pluralize data-count="activeRuns"
           data-when="{'one': '1 Active Run', 'other': '{{activeRuns}} Active Runs'}"></ng-pluralize>
     </span>
-    <div ng-show="status === 'STOPPED'"
+    <div ng-hide="status === 'STARTING'"
          class="btn btn-success btn-md"
          ng-click="toggleFlow('start')">
       <span class="fa fa-play"></span>
       <span>Start</span>
-    </div>
-
-    <div ng-show="status === 'RUNNING'"
-         class="btn btn-primary btn-md"
-         ng-click="toggleFlow('stop')">
-      <span class="fa fa-stop"></span>
-      <span>Stop</span>
     </div>
 
     <div ng-show="status === 'STARTING' || status === 'STOPPING'"

--- a/cdap-ui/app/features/mapreduce/templates/detail.html
+++ b/cdap-ui/app/features/mapreduce/templates/detail.html
@@ -8,7 +8,7 @@
     </h2>
   </div>
   <div class="col-sm-6 text-right">
-    <span class="programTitle h4">
+    <span class="programTitle">
       <ng-pluralize data-count="activeRuns"
           data-when="{'one': '1 Active Run', 'other': '{{activeRuns}} Active Runs'}"></ng-pluralize>
     </span>

--- a/cdap-ui/app/features/mapreduce/templates/detail.html
+++ b/cdap-ui/app/features/mapreduce/templates/detail.html
@@ -1,34 +1,36 @@
 <div ncy-breadcrumb></div>
 
-<h2>
-  <span ng-bind="$state.params.programId | caskCapitalizeFilter"></span>
-  <br />
-  <small> <em>Type: Mapreduce </em></small>
-</h2>
-
-<div class="row">
+<div class="row" program-heading>
   <div class="col-sm-6">
-    <h4>
+    <h2 class="programTitle">
+      <span ng-bind="$state.params.programId | caskCapitalizeFilter"></span>
+      <small> <em>Type: Mapreduce </em></small>
+    </h2>
+  </div>
+  <div class="col-sm-6 text-right">
+    <span class="programTitle h4">
       <ng-pluralize data-count="activeRuns"
           data-when="{'one': '1 Active Run', 'other': '{{activeRuns}} Active Runs'}"></ng-pluralize>
-    </h4>
-  </div>
-  <div class="col-sm-6 text-right h4">
-    <div ng-show="status == 'RUNNING'"
-         class="btn btn-default btn-md"
-         ng-click="toggleFlow('stop')">
-      <span class="fa fa-stop"> </span>
+    </span>
+    <div ng-show="status === 'STOPPED'"
+         class="btn btn-success btn-md"
+         ng-click="toggleFlow('start')">
+      <span class="fa fa-play"></span>
+      <span>Start</span>
     </div>
 
-    <div ng-show="status == 'STOPPED'"
-         class="btn btn-default btn-md"
-         ng-click="toggleFlow('start')">
-      <span class="fa fa-play"> </span>
+    <div ng-show="status === 'RUNNING'"
+         class="btn btn-primary btn-md"
+         ng-click="toggleFlow('stop')">
+      <span class="fa fa-stop"></span>
+      <span>Stop</span>
     </div>
-    <div ng-show="status == 'start' || status == 'stop' || status == 'STARTING' || status == 'STOPPING'"
+
+    <div ng-show="status === 'STARTING' || status === 'STOPPING'"
+         ng-class="{'btn-success': status === 'STARTING', 'btn-primary': status === 'STOPPING'}"
          class="btn btn-default btn-md">
-      <span> {{status}} </span>
       <span class="fa fa-refresh fa-spin"></span>
+      <span>{{status | caskCapitalizeFilter}}</span>
     </div>
   </div>
 </div>

--- a/cdap-ui/app/features/services/controllers/detail-ctrl.js
+++ b/cdap-ui/app/features/services/controllers/detail-ctrl.js
@@ -21,7 +21,7 @@ angular.module(PKG.name + '.feature.services')
       });
     };
 
-    dataSrc.request({
+    dataSrc.poll({
       _cdapNsPath: path + '/status'
     }, function(res) {
       $scope.status = res.status || 'Unknown';

--- a/cdap-ui/app/features/services/controllers/detail-ctrl.js
+++ b/cdap-ui/app/features/services/controllers/detail-ctrl.js
@@ -1,0 +1,29 @@
+angular.module(PKG.name + '.feature.services')
+  .controller('ServicesDetailController', function($scope, MyDataSource, $state) {
+    var dataSrc = new MyDataSource($scope),
+        path = '/apps/' +
+          $state.params.appId + '/services/' +
+          $state.params.programId;
+
+    $scope.start = function() {
+      $scope.status = 'STARTING';
+      dataSrc.request({
+        _cdapNsPath: path + '/start',
+        method: 'POST'
+      });
+    };
+
+    $scope.stop = function() {
+      $scope.status = 'STOPPING';
+      dataSrc.request({
+        _cdapNsPath: path + '/stop',
+        method: 'POST'
+      });
+    };
+
+    dataSrc.request({
+      _cdapNsPath: path + '/status'
+    }, function(res) {
+      $scope.status = res.status || 'Unknown';
+    });
+  });

--- a/cdap-ui/app/features/services/controllers/tabs/status-ctrl.js
+++ b/cdap-ui/app/features/services/controllers/tabs/status-ctrl.js
@@ -26,27 +26,10 @@ angular.module(PKG.name + '.feature.services')
         $scope.instances = res;
       });
 
-    dataSrc.poll({
+    dataSrc.request({
       _cdapNsPath: path + '/status'
     }, function(res) {
       $scope.status = res.status || 'Unknown';
     });
-
-
-    $scope.start = function() {
-      $scope.status = 'STARTING';
-      dataSrc.request({
-        _cdapNsPath: path + '/start',
-        method: 'POST'
-      });
-    };
-
-    $scope.stop = function() {
-      $scope.status = 'STOPPING';
-      dataSrc.request({
-        _cdapNsPath: path + '/stop',
-        method: 'POST'
-      });
-    };
 
   });

--- a/cdap-ui/app/features/services/controllers/tabs/status-ctrl.js
+++ b/cdap-ui/app/features/services/controllers/tabs/status-ctrl.js
@@ -26,7 +26,7 @@ angular.module(PKG.name + '.feature.services')
         $scope.instances = res;
       });
 
-    dataSrc.request({
+    dataSrc.poll({
       _cdapNsPath: path + '/status'
     }, function(res) {
       $scope.status = res.status || 'Unknown';

--- a/cdap-ui/app/features/services/routes.js
+++ b/cdap-ui/app/features/services/routes.js
@@ -22,6 +22,7 @@ angular.module(PKG.name + '.feature.services')
       })
       .state('services.detail', {
         url: '/:programId',
+        controller: 'ServicesDetailController',
         templateUrl: '/assets/features/services/templates/detail.html',
         onEnter: function($state, $timeout) {
 
@@ -42,7 +43,7 @@ angular.module(PKG.name + '.feature.services')
           templateUrl: '/assets/features/services/templates/tabs/status.html',
           ncyBreadcrumb: {
             parent: 'apps.detail.overview',
-            label: '{{$state.params.programId}} / Status'
+            label: '{{$state.params.programId}}'
           }
         })
           .state('services.detail.status.makerequest', {

--- a/cdap-ui/app/features/services/templates/detail.html
+++ b/cdap-ui/app/features/services/templates/detail.html
@@ -1,30 +1,45 @@
 <div ncy-breadcrumb></div>
 
-<h2>
-  <span ng-bind="$state.params.programId | caskCapitalizeFilter"> </span>
-  <small> Type: Service </small>
-</h2>
+<div class="row" program-heading>
+  <div class="col-sm-6">
+    <h2 class="programTitle">
+      <span ng-bind="$state.params.programId | caskCapitalizeFilter"> </span>
+      <small> Type: Service </small>
+    </h2>
+  </div>
+  <div class="col-sm-6 text-right">
+    <div ng-show="status == 'RUNNING'"
+         class="btn btn-primary btn-md"
+         ng-click="stop()">
+      <span class="fa fa-stop"> </span>
+    </div>
+
+    <div ng-show="status == 'STOPPED'"
+         class="btn btn-success btn-md"
+         ng-click="start()">
+      <span class="fa fa-play"> </span>
+      <span>Start</span>
+    </div>
+    <div ng-show="status == 'STARTING' || status == 'STOPPING'"
+         class="btn btn-md"
+         ng-class="{'btn-success': status === 'STARTING', 'btn-primary': status === 'STOPPING'}">
+      <span class="fa fa-refresh fa-spin"></span>
+      <span>{{status | caskCapitalizeFilter}}</span>
+    </div>
+  </div>
+</div>
 
 <div class="cdap-subnav-end"></div>
 <ul class="nav nav-tabs" role="tablist">
   <li role="presentation" ui-sref-active="active">
     <a ui-sref="services.detail.status" ui-sref-opts="{reload: true}" role="tab">Status</a>
   </li>
-<!--   <li role="presentation" ui-sref-active="active">
-    <a ui-sref="services.detail.data" role="tab">Data</a>
-  </li>
-  <li role="presentation" ui-sref-active="active">
-    <a ui-sref="services.detail.metadata" role="tab">Metadata</a>
-  </li> -->
   <li role="presentation" ui-sref-active="active">
     <a ui-sref="services.detail.history" role="tab">History</a>
   </li>
   <li role="presentation" ui-sref-active="active">
     <a ui-sref="services.detail.logs" ui-sref-opts="{reload: true}" role="tab">Logs</a>
   </li>
-<!--   <li role="presentation" ui-sref-active="active">
-    <a ui-sref="services.detail.resources" role="tab">Resources</a>
-  </li> -->
 </ul>
 
 <br/>

--- a/cdap-ui/app/features/services/templates/detail.html
+++ b/cdap-ui/app/features/services/templates/detail.html
@@ -4,7 +4,7 @@
   <div class="col-sm-6">
     <h2 class="programTitle">
       <span ng-bind="$state.params.programId | caskCapitalizeFilter"> </span>
-      <small> Type: Service </small>
+      <small> <em> Type: Service  </em></small>
     </h2>
   </div>
   <div class="col-sm-6 text-right">

--- a/cdap-ui/app/features/services/templates/tabs/status.html
+++ b/cdap-ui/app/features/services/templates/tabs/status.html
@@ -6,12 +6,6 @@
           <h4> Status </h4>
           <em ng-bind="status"> </em>
         </div>
-        <!-- <div class="col-sm-3">
-          <h4> Started </h4>
-        </div>
-        <div class="col-sm-3">
-          <h4> Last Run </h4>
-        </div> -->
         <div class="col-sm-3">
           <h4> Instances </h4>
           <div> <em  ng-bind="instances.provisioned + ' provisioned'"></em> </div>
@@ -19,22 +13,8 @@
         </div>
       </div>
     </div>
-    <div class="col-sm-6 text-right h4">
-      <div ng-show="status == 'RUNNING'"
-           class="btn btn-default btn-md"
-           ng-click="stop()">
-        <span class="fa fa-stop"> </span>
-      </div>
+    <div class="col-sm-6">
 
-      <div ng-show="status == 'STOPPED'"
-           class="btn btn-default btn-md"
-           ng-click="start()">
-        <span class="fa fa-play"> </span>
-      </div>
-      <div ng-show="status == 'STARTING' || status == 'STOPPING'"
-           class="btn btn-default btn-md">
-        <span class="fa fa-refresh fa-spin"></span>
-      </div>
     </div>
   </div>
 

--- a/cdap-ui/app/features/workflows/controllers/detail-ctrl.js
+++ b/cdap-ui/app/features/workflows/controllers/detail-ctrl.js
@@ -27,15 +27,22 @@ angular.module(PKG.name + '.feature.workflows')
       $scope.status = res.status;
     });
 
-    $scope.toggleFlow = function(action) {
-      $scope.status = action;
+    $scope.start = function() {
+      $scope.status = 'STARTING';
       dataSrc.request({
-        method: 'POST',
-        _cdapNsPath: basePath + '/' + action
+        _cdapNsPath: basePath + '/start',
+        method: 'POST'
       })
         .then(function() {
           $state.go('workflows.detail.runs', {}, {reload: true});
         });
+    };
+    $scope.stop = function() {
+      $scope.status = 'STOPPING';
+      dataSrc.request({
+        _cdapNsPath: basePath + '/stop',
+        method: 'POST'
+      });
     };
 
 });

--- a/cdap-ui/app/features/workflows/controllers/tabs/runs/tabs/status-ctrl.js
+++ b/cdap-ui/app/features/workflows/controllers/tabs/runs/tabs/status-ctrl.js
@@ -1,5 +1,5 @@
 angular.module(PKG.name + '.feature.workflows')
-  .controller('WorkflowsRunsStatusController', function($state, $scope, MyDataSource, $filter, $state) {
+  .controller('WorkflowsRunsStatusController', function($state, $scope, MyDataSource, $filter, $alert) {
     var dataSrc = new MyDataSource($scope),
         filterFilter = $filter('filter'),
         basePath = '/apps/' + $state.params.appId + '/workflows/' + $state.params.programId;
@@ -46,6 +46,18 @@ angular.module(PKG.name + '.feature.workflows')
         $scope.actions = programs;
       });
 
+    $scope.stop = function() {
+      $alert({
+        type: 'info',
+        content: 'Stopping a workflow at run level is not possible yet. Will be fixed soon.'
+      });
+      return;
+      $scope.status = 'STOPPING';
+      dataSrc.request({
+        _cdapNsPath: basePath + '/stop',
+        method: 'POST'
+      });
+    };
 
     $scope.goToDetailActionView = function(programId, programType) {
       // As of 2.7 only a mapreduce job is scheduled in a workflow.

--- a/cdap-ui/app/features/workflows/templates/detail.html
+++ b/cdap-ui/app/features/workflows/templates/detail.html
@@ -7,7 +7,7 @@
     </h2>
   </div>
   <div class="col-sm-6 text-right">
-    <span class="programTitle h4">
+    <span class="programTitle">
       <ng-pluralize data-count="activeRuns"
           data-when="{'one': '1 Active Run', 'other': '{{activeRuns}} Active Runs'}"></ng-pluralize>
     </span>

--- a/cdap-ui/app/features/workflows/templates/detail.html
+++ b/cdap-ui/app/features/workflows/templates/detail.html
@@ -1,29 +1,38 @@
 <div ncy-breadcrumb></div>
-<h2>
-  <span ng-bind="$state.params.programId | caskCapitalizeFilter"></span>
-  <small> <em>Type: WorkFlow </em></small>
-</h2>
-
-<div class="row">
+<div class="row" program-heading>
   <div class="col-sm-6">
-    <h4>
+    <h2 class="programTitle">
+      <span ng-bind="$state.params.programId | caskCapitalizeFilter"></span>
+      <small> <em>Type: WorkFlow </em></small>
+    </h2>
+  </div>
+  <div class="col-sm-6 text-right">
+    <span class="programTitle h4">
       <ng-pluralize data-count="activeRuns"
           data-when="{'one': '1 Active Run', 'other': '{{activeRuns}} Active Runs'}"></ng-pluralize>
-    </h4>
-  </div>
-  <div class="col-sm-6 text-right h4">
-
-    <div ng-show="status != 'start' && status != 'stop'"
-         ng-disabled = "status == 'RUNNING'"
-         class="btn btn-default btn-md"
-         ng-click="toggleFlow('start')">
+    </span>
+    <div ng-show="status === 'STOPPED'"
+         class="btn btn-success btn-md"
+         ng-click="start()">
       <span class="fa fa-play"></span>
-      <span>Start a new run</span>
+      <span>Start</span>
     </div>
-    <div ng-show="status == 'start' || status == 'stop'"
+
+    <div ng-show="status === 'RUNNING'"
+         class="btn btn-primary btn-md"
+         ng-click="stop()">
+      <span class="fa fa-stop"></span>
+      <span>Stop</span>
+    </div>
+
+    <div ng-show="status === 'STARTING' || status === 'STOPPING'"
+         ng-class="{'btn-success': status === 'STARTING', 'btn-primary': status === 'STOPPING'}"
          class="btn btn-default btn-md">
       <span class="fa fa-refresh fa-spin"></span>
+      <span>{{status | caskCapitalizeFilter}}</span>
     </div>
+
+
   </div>
 </div>
 

--- a/cdap-ui/app/features/workflows/templates/detail.html
+++ b/cdap-ui/app/features/workflows/templates/detail.html
@@ -11,18 +11,11 @@
       <ng-pluralize data-count="activeRuns"
           data-when="{'one': '1 Active Run', 'other': '{{activeRuns}} Active Runs'}"></ng-pluralize>
     </span>
-    <div ng-show="status === 'STOPPED'"
+    <div ng-hide="status === 'STARTING'"
          class="btn btn-success btn-md"
          ng-click="start()">
       <span class="fa fa-play"></span>
       <span>Start</span>
-    </div>
-
-    <div ng-show="status === 'RUNNING'"
-         class="btn btn-primary btn-md"
-         ng-click="stop()">
-      <span class="fa fa-stop"></span>
-      <span>Stop</span>
     </div>
 
     <div ng-show="status === 'STARTING' || status === 'STOPPING'"

--- a/cdap-ui/app/features/workflows/templates/tabs/runs/tabs/status.html
+++ b/cdap-ui/app/features/workflows/templates/tabs/runs/tabs/status.html
@@ -16,16 +16,10 @@
     <div class="col-sm-3 text-right">
       <div ng-show="status == 'RUNNING'"
            class="btn btn-default btn-md"
-           ng-click="toggleFlow('stop')">
+           ng-click="stop('stop')">
         <span class="fa fa-stop"> </span>
       </div>
 
-      <div ng-show="status == 'STOPPED' || status == 'COMPLETED'"
-           disabled="true"
-           class="btn btn-default btn-md"
-           ng-click="toggleFlow('start')">
-        <span class="fa fa-play"> </span>
-      </div>
       <div ng-show="status == 'start' || status == 'stop'"
            class="btn btn-default btn-md">
         <span class="fa fa-refresh fa-spin"></span>

--- a/cdap-ui/app/styles/common.less
+++ b/cdap-ui/app/styles/common.less
@@ -153,3 +153,15 @@ footer {
 
 }
 
+.breadcrumb {
+  margin: 0;
+  padding: 0;
+}
+
+[program-heading] {
+  margin-top: 10px;
+  margin-bottom: 5px;
+  .programTitle {
+    margin: 0;
+  }
+}

--- a/cdap-ui/app/styles/common.less
+++ b/cdap-ui/app/styles/common.less
@@ -162,6 +162,7 @@ footer {
   margin-top: 10px;
   margin-bottom: 5px;
   .programTitle {
+    vertical-align: middle;
     margin: 0;
   }
 }

--- a/cdap-ui/app/styles/themes/cdap/theme.less
+++ b/cdap-ui/app/styles/themes/cdap/theme.less
@@ -206,7 +206,7 @@ body.theme-cdap {
       a { color: @cdap-header; }
       + li:before {
         content: ">";
-        padding: 0 10px;
+        padding: 0 5px;
         color: @cdap-gray;
         // font-weight: bold;
       }

--- a/cdap-ui/app/styles/themes/cdap/theme.less
+++ b/cdap-ui/app/styles/themes/cdap/theme.less
@@ -206,7 +206,7 @@ body.theme-cdap {
       a { color: @cdap-header; }
       + li:before {
         content: ">";
-        padding: 0 5px;
+        padding: 0 3px;
         color: @cdap-gray;
         // font-weight: bold;
       }


### PR DESCRIPTION
#### Long Pending simple changes


- Unifies the look (layout) of a program detail view's heading & start/stop button + active runs (if applicable)
- Unifies the behavior of start & stop buttons in all program views 
- Minor style modifications to breadcrumbs

![screen shot 2015-04-15 at 2 03 23 am](https://cloud.githubusercontent.com/assets/1452845/7155456/b6b1903e-e313-11e4-8716-16cb3205c1ed.png)
![screen shot 2015-04-15 at 1 58 09 am](https://cloud.githubusercontent.com/assets/1452845/7155364/083a2412-e313-11e4-8ed9-044da1dc4c94.png)
![screen shot 2015-04-15 at 1 57 56 am](https://cloud.githubusercontent.com/assets/1452845/7155365/083cc640-e313-11e4-9571-6203022485db.png)
![screen shot 2015-04-15 at 1 57 31 am](https://cloud.githubusercontent.com/assets/1452845/7155366/083f43ca-e313-11e4-9689-8644c896256e.png)

TODO:
  Make this as a directive (if it makes sense) and simplify the start/stop function handlers in the scope.
 EDIT: 
   Starting/Stopping a concurrent run of a mapreduce/workflow is not possible yet. Will be fixed within this week.