### PR TITLE
Fix/ui workflow status removal

### DIFF
--- a/cdap-ui/app/features/apps/templates/tabs/status.html
+++ b/cdap-ui/app/features/apps/templates/tabs/status.html
@@ -21,7 +21,7 @@
               <a ng-bind="program.name"
                   ng-if="program.type === 'Flow'" ui-sref="flows.detail.status({programId: program.name})"></a>
               <a ng-bind="program.name"
-                  ng-if="program.type === 'Workflow'" ui-sref="workflows.detail.status({programId: program.name})"></a>
+                  ng-if="program.type === 'Workflow'" ui-sref="workflows.detail.runs({programId: program.name})"></a>
               <a ng-bind="program.name"
                   ng-if="program.type === 'Service'" ui-sref="services.detail.status({programId: program.name})"></a>
               <a ng-bind="program.name"

--- a/cdap-ui/app/features/workflows/controllers/tabs/runs-ctrl.js
+++ b/cdap-ui/app/features/workflows/controllers/tabs/runs-ctrl.js
@@ -16,6 +16,14 @@ angular.module(PKG.name + '.feature.workflows')
       }
     }
 
+    $scope.$watch('runs.selected.runid', function(newVal) {
+     if ($state.params.runid) {
+       return;
+     } else {
+       $scope.runs.selected = rRuns[0];
+     }
+   });
+
     $scope.tabs = [{
       title: 'Status',
       template: '/assets/features/workflows/templates/tabs/runs/tabs/status.html'

--- a/cdap-ui/app/features/workflows/controllers/tabs/runs-ctrl.js
+++ b/cdap-ui/app/features/workflows/controllers/tabs/runs-ctrl.js
@@ -8,8 +8,12 @@ angular.module(PKG.name + '.feature.workflows')
       if (match.length) {
         $scope.runs.selected = match[0];
       }
-    } else {
+    } else if (rRuns.length) {
       $scope.runs.selected = rRuns[0];
+    } else {
+      $scope.runs.selected = {
+        runid: 'No Runs!'
+      }
     }
 
     $scope.tabs = [{

--- a/cdap-ui/app/features/workflows/controllers/tabs/runs-ctrl.js
+++ b/cdap-ui/app/features/workflows/controllers/tabs/runs-ctrl.js
@@ -1,31 +1,19 @@
 angular.module(PKG.name + '.feature.workflows')
-  .controller('WorkflowsRunsController', function($scope, $state, MyDataSource, $timeout, $rootScope) {
-    var dataSrc = new MyDataSource($scope),
-        basePath = '/apps/' + $state.params.appId + '/workflows/' + $state.params.programId;;
+  .controller('WorkflowsRunsController', function($scope, $state, $filter, rRuns) {
+    var fFilter = $filter('filter');
+    $scope.runs = rRuns;
 
-    dataSrc.request({
-      _cdapNsPath: basePath + '/runs'
-    })
-      .then(function(res) {
-        $scope.runs = res;
-        angular.forEach($scope.runs, function(value) {
-          value.isOpen = $state.params.runid === value.runid;
-        });
-      });
-
-    // This is for toggling (opening/closing) accordions if state changes.
-    $rootScope.$on('$stateChangeSuccess', function(event, toState, toParams, fromState, fromParams) {
-      if (fromState.name !== 'workflows.detail.runs.run' && toState.name !== 'workflows.detail.runs.run') {
-        return;
+    if ($state.params.runid) {
+      var match = fFilter(rRuns, {runid: $state.params.runid});
+      if (match.length) {
+        $scope.runs.selected = match[0];
       }
-      angular.forEach($scope.runs, function(value) {
-        if (value.runid === toParams.runid) {
-          value.isOpen = true;
-        }
-        if (value.runid === fromParams.runid) {
-          value.isOpen = false;
-        }
-      });
-    });
+    } else {
+      $scope.runs.selected = rRuns[0];
+    }
 
+    $scope.tabs = [{
+      title: 'Status',
+      template: '/assets/features/workflows/templates/tabs/runs/tabs/status.html'
+    }];
   });

--- a/cdap-ui/app/features/workflows/controllers/tabs/runs/runs-detail-ctrl.js
+++ b/cdap-ui/app/features/workflows/controllers/tabs/runs/runs-detail-ctrl.js
@@ -4,4 +4,7 @@ angular.module(PKG.name + '.feature.flows')
       title: 'Status',
       template: '/assets/features/workflows/templates/tabs/runs/tabs/status.html'
     }];
+    $scope.$on('$destroy', function(event) {
+      event.targetScope.runs.selected = null;
+    });
   });

--- a/cdap-ui/app/features/workflows/controllers/tabs/runs/tabs/status-ctrl.js
+++ b/cdap-ui/app/features/workflows/controllers/tabs/runs/tabs/status-ctrl.js
@@ -1,8 +1,15 @@
 angular.module(PKG.name + '.feature.workflows')
-  .controller('WorkflowsRunsStatusController', function($state, $scope, MyDataSource, $filter) {
+  .controller('WorkflowsRunsStatusController', function($state, $scope, MyDataSource, $filter, $state) {
     var dataSrc = new MyDataSource($scope),
         filterFilter = $filter('filter'),
         basePath = '/apps/' + $state.params.appId + '/workflows/' + $state.params.programId;
+
+    if ($state.params.runid) {
+      var match = filterFilter($scope.runs, {runid: $state.params.runid});
+      if (match.length) {
+        $scope.runs.selected = match[0];
+      }
+    }
     $scope.status = null;
     $scope.duration = null;
     $scope.startTime = null;
@@ -49,22 +56,15 @@ angular.module(PKG.name + '.feature.workflows')
       }
     };
 
+
     dataSrc.poll({
-      _cdapNsPath: basePath + '/runs'
+      _cdapNsPath: basePath + '/runs/' + $scope.runs.selected.runid
     }, function(res) {
-        var run, startMs;
-        var runsThatWeCareAbout = filterFilter(res, { runid:$state.params.runid });
-        if(runsThatWeCareAbout.length) {
-          run = runsThatWeCareAbout[0];
-          startMs = run.start * 1000;
-          $scope.startTime = new Date(startMs);
-          $scope.status = run.status;
-          $scope.duration = (run.end ? (run.end * 1000) - startMs : 0);
-        }
-
-
-      });
-
+        startMs = res.start * 1000;
+        $scope.startTime = new Date(startMs);
+        $scope.status = res.status;
+        $scope.duration = (res.end ? (res.end * 1000) - startMs : 0);
+    });
   });
 
 /**

--- a/cdap-ui/app/features/workflows/routes.js
+++ b/cdap-ui/app/features/workflows/routes.js
@@ -23,22 +23,25 @@ angular.module(PKG.name + '.feature.workflows')
             label: 'Workflows',
             skip: true
           },
+          resolve : {
+            rRuns: function(MyDataSource, $stateParams, $q) {
+              var defer = $q.defer();
+              var dataSrc = new MyDataSource();
+              dataSrc.request({
+                _cdapPath: '/namespaces/' + $stateParams.namespace +
+                           '/apps/' + $stateParams.appId +
+                           '/workflows/' + $stateParams.programId +
+                           '/runs'
+              })
+                .then(function(res) {
+                  defer.resolve(res);
+                });
+              return defer.promise;
+            }
+          },
           templateUrl: '/assets/features/workflows/templates/detail.html',
           controller: 'WorkflowsDetailController'
         })
-
-          .state('workflows.detail.status', {
-            url: '/status',
-            data: {
-              authorizedRoles: MYAUTH_ROLE.all,
-              highlightTab: 'development'
-            },
-            ncyBreadcrumb: {
-              label: '{{$state.params.programId}}'
-            },
-            templateUrl: '/assets/features/workflows/templates/tabs/status.html',
-            controller: 'WorkflowsStatusController'
-          })
 
           .state('workflows.detail.runs', {
             url: '/runs',

--- a/cdap-ui/app/features/workflows/routes.js
+++ b/cdap-ui/app/features/workflows/routes.js
@@ -27,6 +27,9 @@ angular.module(PKG.name + '.feature.workflows')
             rRuns: function(MyDataSource, $stateParams, $q) {
               var defer = $q.defer();
               var dataSrc = new MyDataSource();
+              // Using _cdapPath here as $state.params is not updated with
+              // runid param when the request goes out
+              // (timing issue with re-direct from login state).
               dataSrc.request({
                 _cdapPath: '/namespaces/' + $stateParams.namespace +
                            '/apps/' + $stateParams.appId +

--- a/cdap-ui/app/features/workflows/templates/detail.html
+++ b/cdap-ui/app/features/workflows/templates/detail.html
@@ -29,9 +29,6 @@
 
 <div class="cdap-subnav-end"></div>
 <ul class="nav nav-tabs" role="tablist">
-  <li role="presentation" ui-sref-active="active">
-    <a ui-sref="workflows.detail.status" ui-sref-opts="{reload: true}" role="tab">Status</a>
-  </li>
 
   <li role="presentation" ui-sref-active="active">
     <a ui-sref="workflows.detail.runs" ui-sref-opts="{reload: true}" role="tab">Runs</a>

--- a/cdap-ui/app/features/workflows/templates/tabs/runs.html
+++ b/cdap-ui/app/features/workflows/templates/tabs/runs.html
@@ -18,6 +18,9 @@
   </div>
 </div>
 <br/>
+<div ng-if="runs.length">
+
+
 <div class="panel panel-default" ng-if="!$stateParams.runid">
   <div class="panel-heading">
     <div class="panel-title">
@@ -40,7 +43,12 @@
     <div ui-view> </div>
   </div>
 </div>
-
+</div>
+<div ng-if="!runs.length">
+  <div class="well well-lg text-center h3">
+    <div>No runs yet! Start one.</div>
+  </div>
+</div>
 
 
 </div>

--- a/cdap-ui/app/features/workflows/templates/tabs/runs.html
+++ b/cdap-ui/app/features/workflows/templates/tabs/runs.html
@@ -1,24 +1,46 @@
-<div class="panel-group" ng-if="runs.length > 0">
-  <div class="panel panel-default" id="c{{run.runid}}" ng-repeat="run in runs">
-    <div class="panel-heading">
-      <a ui-sref="workflows.detail.runs.run({runid: run.runid})" class="clearfix">
-        <div>
-          <span class="pull-left">{{run.runid}}</span>
-          <span class="pull-right">
-            {{run.status}}
-            <i class="fa fa-fw"
-              ng-class="{'fa-chevron-down': run.isOpen, 'fa-chevron-right': !run.isOpen}"></i>
-          </span>
-        </div>
-      </a>
+<div class="row">
+  <div class="col-lg-4 col-md-5 col-sm-6 col-xs-12">
+    <div class="btn-group"
+          dropdown is-open="dropdown.isopen">
+      <button type="button"
+              class="btn btn-default dropdown-toggle"
+              dropdown-toggle ng-disabled="current === 'No Run'">
+        {{ runs.selected.runid }}
+        <span class="caret"></span>
+      </button>
+      <ul class="dropdown-menu" role="menu">
+        <li ng-repeat="run in runs">
+          <a ui-sref="workflows.detail.runs.run({runid: run.runid})">{{ run.runid }}</a>
+        </li>
+      </ul>
     </div>
-    <div class="panel-body" ng-if="run.isOpen">
-      <div ui-view></div>
+
+  </div>
+</div>
+<br/>
+<div class="panel panel-default" ng-if="!$stateParams.runid">
+  <div class="panel-heading">
+    <div class="panel-title">
+      {{::runs.selected.runid}}
+    </div>
+  </div>
+  <div class="panel-body">
+
+    <div ng-include="'/assets/features/workflows/templates/tabs/runs/runs-detail.html'">
     </div>
   </div>
 </div>
-<div ng-if="runs.length === 0">
-  <div class="well well-lg text-center h2">
-    <div> The WorkFlow {{State.params.programId}} hasn't run so far. Start a new Run!</div>
+<div class="panel panel-default" ng-if="$stateParams.runid">
+  <div class="panel-heading">
+    <div class="panel-title">
+      {{$stateParams.runid}}
+    </div>
   </div>
+  <div class="panel-body">
+    <div ui-view> </div>
+  </div>
+</div>
+
+
+
 </div>


### PR DESCRIPTION
- Re-implements the mocks for workflows view
- Makes workflows runs available even before loading details view of workflows
    - This is to make sure we don't make workflows/workflowId/runs call at multiple places.
- Uses one template to render detailed view of a run (used both in runs & runs/runid)
   In the case of runs state, it will always show the detailed view of the latest run id
   In the case of runs/runid it will show the detailed view of the respective run id

