### PR TITLE
Use RunRecords for job-level state, start/end time.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/mapreduce/MRJobClient.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/mapreduce/MRJobClient.java
@@ -23,7 +23,6 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.MRJobInfo;
 import co.cask.cdap.proto.MRTaskInfo;
 import co.cask.cdap.proto.ProgramType;
-import co.cask.cdap.proto.RunRecord;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -62,12 +61,11 @@ public class MRJobClient {
 
   /**
    * @param runId for which information will be returned.
-   * @param runRecord for the run (we already keep track of information such as job-level state, start/end time).
    * @return a {@link MRJobInfo} containing information about a particular MapReduce program run.
    * @throws IOException if there is failure to communicate through the JobClient.
    * @throws NotFoundException if a Job with the given runId is not found.
    */
-  public MRJobInfo getMRJobInfo(Id.Run runId, RunRecord runRecord) throws IOException, NotFoundException {
+  public MRJobInfo getMRJobInfo(Id.Run runId) throws IOException, NotFoundException {
     Preconditions.checkArgument(ProgramType.MAPREDUCE.equals(runId.getProgram().getType()));
 
     JobClient jobClient;
@@ -86,9 +84,7 @@ public class MRJobClient {
     TaskReport[] mapTaskReports = jobClient.getMapTaskReports(thisJob.getJobID());
     TaskReport[] reduceTaskReports = jobClient.getReduceTaskReports(thisJob.getJobID());
 
-    return new MRJobInfo(runRecord.getStatus().name(),
-                         runRecord.getStartTs(), runRecord.getStopTs(),
-                         thisJob.getMapProgress(), thisJob.getReduceProgress(),
+    return new MRJobInfo(thisJob.getMapProgress(), thisJob.getReduceProgress(),
                          groupToMap(counters.getGroup(TaskCounter.class.getName())),
                          toMRTaskInfos(mapTaskReports), toMRTaskInfos(reduceTaskReports), true);
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/mapreduce/MRJobClient.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/mapreduce/MRJobClient.java
@@ -23,6 +23,7 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.MRJobInfo;
 import co.cask.cdap.proto.MRTaskInfo;
 import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.RunRecord;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -61,11 +62,12 @@ public class MRJobClient {
 
   /**
    * @param runId for which information will be returned.
+   * @param runRecord for the run (we already keep track of information such as job-level state, start/end time).
    * @return a {@link MRJobInfo} containing information about a particular MapReduce program run.
    * @throws IOException if there is failure to communicate through the JobClient.
    * @throws NotFoundException if a Job with the given runId is not found.
    */
-  public MRJobInfo getMRJobInfo(Id.Run runId) throws IOException, NotFoundException {
+  public MRJobInfo getMRJobInfo(Id.Run runId, RunRecord runRecord) throws IOException, NotFoundException {
     Preconditions.checkArgument(ProgramType.MAPREDUCE.equals(runId.getProgram().getType()));
 
     JobClient jobClient;
@@ -84,11 +86,11 @@ public class MRJobClient {
     TaskReport[] mapTaskReports = jobClient.getMapTaskReports(thisJob.getJobID());
     TaskReport[] reduceTaskReports = jobClient.getReduceTaskReports(thisJob.getJobID());
 
-    return new MRJobInfo(thisJob.getState().name(),
-                         thisJob.getStartTime(), thisJob.getFinishTime(),
+    return new MRJobInfo(runRecord.getStatus().name(),
+                         runRecord.getStartTs(), runRecord.getStopTs(),
                          thisJob.getMapProgress(), thisJob.getReduceProgress(),
                          groupToMap(counters.getGroup(TaskCounter.class.getName())),
-                         toMRTaskInfos(mapTaskReports), toMRTaskInfos(reduceTaskReports));
+                         toMRTaskInfos(mapTaskReports), toMRTaskInfos(reduceTaskReports), true);
   }
 
   private JobStatus findJobForRunId(JobStatus[] jobs, Id.Run runId) throws NotFoundException {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/mapreduce/MapReduceMetricsInfo.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/mapreduce/MapReduceMetricsInfo.java
@@ -27,7 +27,6 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.MRJobInfo;
 import co.cask.cdap.proto.MRTaskInfo;
 import co.cask.cdap.proto.ProgramType;
-import co.cask.cdap.proto.RunRecord;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.ImmutableList;
@@ -59,7 +58,7 @@ public class MapReduceMetricsInfo {
    * @param runId for which information will be returned.
    * @return a {@link MRJobInfo} containing information about a particular MapReduce program run.
    */
-  public MRJobInfo getMRJobInfo(Id.Run runId, RunRecord runRecord) throws Exception {
+  public MRJobInfo getMRJobInfo(Id.Run runId) throws Exception {
     Preconditions.checkArgument(ProgramType.MAPREDUCE.equals(runId.getProgram().getType()));
 
     // baseTags has tag keys: ns.app.mr.runid
@@ -113,7 +112,7 @@ public class MapReduceMetricsInfo {
                                          reduceProgress.get(reduceTaskId) / 100.0F, taskEntry.getValue()));
     }
 
-    return getJobCounters(runRecord, mapTags, reduceTags, mapTaskInfos, reduceTaskInfos);
+    return getJobCounters(mapTags, reduceTags, mapTaskInfos, reduceTaskInfos);
   }
 
 
@@ -132,7 +131,7 @@ public class MapReduceMetricsInfo {
     }
   }
 
-  private MRJobInfo getJobCounters(RunRecord runRecord, Map<String, String> mapTags, Map<String, String> reduceTags,
+  private MRJobInfo getJobCounters(Map<String, String> mapTags, Map<String, String> reduceTags,
                                    List<MRTaskInfo> mapTaskInfos, List<MRTaskInfo> reduceTaskInfos) throws Exception {
     HashMap<String, Long> metrics = Maps.newHashMap();
     // Use batch-querying when it is available on the MetricStore. https://issues.cask.co/browse/CDAP-2045
@@ -152,9 +151,7 @@ public class MapReduceMetricsInfo {
     float reduceProgress = getAggregates(reduceTags, MapReduceMetrics.METRIC_COMPLETION) / 100.0F;
 
 
-    return new MRJobInfo(runRecord.getStatus().name(), runRecord.getStartTs(), runRecord.getStopTs(),
-                         mapProgress, reduceProgress, metrics, mapTaskInfos, reduceTaskInfos,
-                         false);
+    return new MRJobInfo(mapProgress, reduceProgress, metrics, mapTaskInfos, reduceTaskInfos, false);
   }
 
   private String prependSystem(String metric) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/mapreduce/MapReduceMetricsInfo.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/mapreduce/MapReduceMetricsInfo.java
@@ -27,6 +27,7 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.MRJobInfo;
 import co.cask.cdap.proto.MRTaskInfo;
 import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.RunRecord;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.ImmutableList;
@@ -58,7 +59,7 @@ public class MapReduceMetricsInfo {
    * @param runId for which information will be returned.
    * @return a {@link MRJobInfo} containing information about a particular MapReduce program run.
    */
-  public MRJobInfo getMRJobInfo(Id.Run runId) throws Exception {
+  public MRJobInfo getMRJobInfo(Id.Run runId, RunRecord runRecord) throws Exception {
     Preconditions.checkArgument(ProgramType.MAPREDUCE.equals(runId.getProgram().getType()));
 
     // baseTags has tag keys: ns.app.mr.runid
@@ -112,7 +113,7 @@ public class MapReduceMetricsInfo {
                                          reduceProgress.get(reduceTaskId) / 100.0F, taskEntry.getValue()));
     }
 
-    return getJobCounters(mapTags, reduceTags, mapTaskInfos, reduceTaskInfos);
+    return getJobCounters(runRecord, mapTags, reduceTags, mapTaskInfos, reduceTaskInfos);
   }
 
 
@@ -131,7 +132,7 @@ public class MapReduceMetricsInfo {
     }
   }
 
-  private MRJobInfo getJobCounters(Map<String, String> mapTags, Map<String, String> reduceTags,
+  private MRJobInfo getJobCounters(RunRecord runRecord, Map<String, String> mapTags, Map<String, String> reduceTags,
                                    List<MRTaskInfo> mapTaskInfos, List<MRTaskInfo> reduceTaskInfos) throws Exception {
     HashMap<String, Long> metrics = Maps.newHashMap();
     // Use batch-querying when it is available on the MetricStore. https://issues.cask.co/browse/CDAP-2045
@@ -150,7 +151,10 @@ public class MapReduceMetricsInfo {
     float mapProgress = getAggregates(mapTags, MapReduceMetrics.METRIC_COMPLETION) / 100.0F;
     float reduceProgress = getAggregates(reduceTags, MapReduceMetrics.METRIC_COMPLETION) / 100.0F;
 
-    return new MRJobInfo(null, null, null, mapProgress, reduceProgress, metrics, mapTaskInfos, reduceTaskInfos);
+
+    return new MRJobInfo(runRecord.getStatus().name(), runRecord.getStartTs(), runRecord.getStopTs(),
+                         mapProgress, reduceProgress, metrics, mapTaskInfos, reduceTaskInfos,
+                         false);
   }
 
   private String prependSystem(String metric) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
@@ -216,11 +216,11 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
    */
   @GET
   @Path("/apps/{app-id}/mapreduce/{mapreduce-id}/runs/{run-id}/info")
-  public void mapReduceInfo(HttpRequest request, HttpResponder responder,
-                            @PathParam("namespace-id") String namespaceId,
-                            @PathParam("app-id") String appId,
-                            @PathParam("mapreduce-id") String mapreduceId,
-                            @PathParam("run-id") String runId) {
+  public void getMapReduceInfo(HttpRequest request, HttpResponder responder,
+                               @PathParam("namespace-id") String namespaceId,
+                               @PathParam("app-id") String appId,
+                               @PathParam("mapreduce-id") String mapreduceId,
+                               @PathParam("run-id") String runId) {
     try {
       Id.Program programId = Id.Program.from(namespaceId, appId, ProgramType.MAPREDUCE, mapreduceId);
       Id.Run run = new Id.Run(programId, runId);
@@ -231,17 +231,18 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
       if (!appSpec.getMapReduce().containsKey(mapreduceId)) {
         throw new NotFoundException(programId);
       }
-      if (store.getRun(programId, runId) == null) {
+      RunRecord runRecord = store.getRun(programId, runId);
+      if (runRecord == null) {
         throw new NotFoundException(run);
       }
 
 
       MRJobInfo mrJobInfo;
       try {
-        mrJobInfo = mrJobClient.getMRJobInfo(run);
+        mrJobInfo = mrJobClient.getMRJobInfo(run, runRecord);
       } catch (IOException ioe) {
         LOG.warn("Failed to get run history from JobClient for runId: {}. Falling back to Metrics system.", run, ioe);
-        mrJobInfo = mapReduceMetricsInfo.getMRJobInfo(run);
+        mrJobInfo = mapReduceMetricsInfo.getMRJobInfo(run, runRecord);
       }
 
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/app/mapreduce/MapReduceMetricsInfoTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/app/mapreduce/MapReduceMetricsInfoTest.java
@@ -27,9 +27,7 @@ import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetOpExecutor;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.MRJobInfo;
 import co.cask.cdap.proto.MRTaskInfo;
-import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.ProgramType;
-import co.cask.cdap.proto.RunRecord;
 import co.cask.cdap.test.internal.guice.AppFabricTestModule;
 import co.cask.tephra.TransactionManager;
 import com.google.common.collect.ImmutableMap;
@@ -67,11 +65,7 @@ public class MapReduceMetricsInfoTest {
   @Test
   public void testGetMRJobInfo() throws Exception {
     Id.Program programId = Id.Program.from("fooNamespace", "testApp", ProgramType.MAPREDUCE, "fooMapReduce");
-    String run = "run10878";
-    Id.Run runId = new Id.Run(programId, run);
-    Long stopTime = System.currentTimeMillis();
-    Long startTime = stopTime - 10000;
-    RunRecord runRecord = new RunRecord(run, startTime, stopTime, ProgramRunStatus.COMPLETED);
+    Id.Run runId = new Id.Run(programId, "run10878");
 
     Map<String, String> runContext = ImmutableMap.of(Constants.Metrics.Tag.NAMESPACE, programId.getNamespaceId(),
                                                      Constants.Metrics.Tag.APP, programId.getApplicationId(),
@@ -115,14 +109,11 @@ public class MapReduceMetricsInfoTest {
 
 
     MapReduceMetricsInfo mapReduceMetricsInfo = injector.getInstance(MapReduceMetricsInfo.class);
-    MRJobInfo mrJobInfo = mapReduceMetricsInfo.getMRJobInfo(runId, runRecord);
+    MRJobInfo mrJobInfo = mapReduceMetricsInfo.getMRJobInfo(runId);
 
 
     // Incomplete because MapReduceMetricsInfo does not provide task-level state and start/end times.
     Assert.assertFalse(mrJobInfo.isComplete());
-    Assert.assertEquals(startTime, mrJobInfo.getStartTime());
-    Assert.assertEquals(stopTime, mrJobInfo.getStopTime());
-    Assert.assertEquals(ProgramRunStatus.COMPLETED.name(), mrJobInfo.getState());
 
     // Check job-level counters
     Map<String, Long> jobCounters = mrJobInfo.getCounters();

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/MRJobInfo.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/MRJobInfo.java
@@ -18,7 +18,6 @@ package co.cask.cdap.proto;
 
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nullable;
 
 /**
  * Simplified (filtered) representation of a MapReduce Job.
@@ -26,40 +25,41 @@ import javax.annotation.Nullable;
 public class MRJobInfo {
   private final String state;
   private final Long startTime;
-  private final Long finishTime;
+  private final Long stopTime;
   private final Float mapProgress;
   private final Float reduceProgress;
   private final Map<String, Long> counters;
   private final List<MRTaskInfo> mapTasks;
   private final List<MRTaskInfo> reduceTasks;
+  // If false, the nullable fields in the MRTaskInfo in the mapTasks and reduceTasks will be null.
+  private final boolean complete;
 
-  public MRJobInfo(@Nullable String state, @Nullable Long startTime, @Nullable Long finishTime,
+  public MRJobInfo(String state, Long startTime, Long stopTime,
                    Float mapProcess, Float reduceProgress,
                    Map<String, Long> counters,
-                   List<MRTaskInfo> mapTasks, List<MRTaskInfo> reduceTasks) {
+                   List<MRTaskInfo> mapTasks, List<MRTaskInfo> reduceTasks,
+                   boolean complete) {
     this.state = state;
     this.startTime = startTime;
-    this.finishTime = finishTime;
+    this.stopTime = stopTime;
     this.mapProgress = mapProcess;
     this.reduceProgress = reduceProgress;
     this.counters = counters;
     this.mapTasks = mapTasks;
     this.reduceTasks = reduceTasks;
+    this.complete = complete;
   }
 
-  @Nullable
   public String getState() {
     return state;
   }
 
-  @Nullable
   public Long getStartTime() {
     return startTime;
   }
 
-  @Nullable
-  public Long getFinishTime() {
-    return finishTime;
+  public Long getStopTime() {
+    return stopTime;
   }
 
   public Float getMapProgress() {
@@ -80,5 +80,9 @@ public class MRJobInfo {
 
   public List<MRTaskInfo> getReduceTasks() {
     return reduceTasks;
+  }
+
+  public boolean isComplete() {
+    return complete;
   }
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/MRJobInfo.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/MRJobInfo.java
@@ -18,14 +18,19 @@ package co.cask.cdap.proto;
 
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Simplified (filtered) representation of a MapReduce Job.
  */
 public class MRJobInfo {
-  private final String state;
-  private final Long startTime;
-  private final Long stopTime;
+  @Nullable
+  private String state;
+  @Nullable
+  private Long startTime;
+  @Nullable
+  private Long stopTime;
+
   private final Float mapProgress;
   private final Float reduceProgress;
   private final Map<String, Long> counters;
@@ -34,14 +39,8 @@ public class MRJobInfo {
   // If false, the nullable fields in the MRTaskInfo in the mapTasks and reduceTasks will be null.
   private final boolean complete;
 
-  public MRJobInfo(String state, Long startTime, Long stopTime,
-                   Float mapProcess, Float reduceProgress,
-                   Map<String, Long> counters,
-                   List<MRTaskInfo> mapTasks, List<MRTaskInfo> reduceTasks,
-                   boolean complete) {
-    this.state = state;
-    this.startTime = startTime;
-    this.stopTime = stopTime;
+  public MRJobInfo(Float mapProcess, Float reduceProgress, Map<String, Long> counters,
+                   List<MRTaskInfo> mapTasks, List<MRTaskInfo> reduceTasks, boolean complete) {
     this.mapProgress = mapProcess;
     this.reduceProgress = reduceProgress;
     this.counters = counters;
@@ -50,14 +49,29 @@ public class MRJobInfo {
     this.complete = complete;
   }
 
+  public void setState(@Nullable String state) {
+    this.state = state;
+  }
+
+  public void setStartTime(@Nullable Long startTime) {
+    this.startTime = startTime;
+  }
+
+  public void setStopTime(@Nullable Long stopTime) {
+    this.stopTime = stopTime;
+  }
+
+  @Nullable
   public String getState() {
     return state;
   }
 
+  @Nullable
   public Long getStartTime() {
     return startTime;
   }
 
+  @Nullable
   public Long getStopTime() {
     return stopTime;
   }

--- a/cdap-ui/app/features/mapreduce/templates/tabs/runs/run-detail.html
+++ b/cdap-ui/app/features/mapreduce/templates/tabs/runs/run-detail.html
@@ -20,8 +20,8 @@
         <tbody>
           <td> {{info.state || 'Not Available'}} </td>
           <td> {{info.startTime || 'Not Available' | date: 'medium' }} </td>
-          <td ng-show="info.finishTime !== 0"> {{ (info.finishTime - info.startTime) | amDurationFormat}} </td>
-          <td ng-hide="info.finishTime !== 0"> N/A </td>
+          <td ng-show="info.stopTime !== 0"> {{ (info.stopTime - info.startTime) | amDurationFormat}} </td>
+          <td ng-hide="info.stopTime !== 0"> N/A </td>
         </tbody>
       </table>
     </div>


### PR DESCRIPTION
1) Use RunRecords for job-level state, start/end time.
2) Add a field to the return object which returns if the return object is complete or not.

Change no. 1 helps to provide that information in standalone as well as when the JobHistory server is missing.

Build: http://builds.cask.co/browse/CDAP-DUT1324-20