### PR TITLE
CDAP-2143 adding a method to MapReduceContext to set a

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/data/stream/StreamBatchReadable.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/data/stream/StreamBatchReadable.java
@@ -54,9 +54,8 @@ import java.util.Map;
  *
  * class MyMapReduce implements MapReduce {
  *    public void beforeSubmit(MapReduceContext context) {
- *      context.setInput(new StreamBatchReadable("mystream"), null);
+ *      context.setInput(new StreamBatchReadable("mystream"));
  *    }
- * }
  * }
  * </pre>
  *
@@ -102,7 +101,7 @@ public class StreamBatchReadable implements BatchReadable<Long, String> {
    * @param endTime End timestamp in milliseconds (exclusive) of stream events provided to the job
    */
   public static void useStreamInput(MapReduceContext context, String streamName, long startTime, long endTime) {
-    context.setInput(new StreamBatchReadable(streamName, startTime, endTime).toURI().toString());
+    context.setInput(new StreamBatchReadable(streamName, startTime, endTime));
   }
 
   /**
@@ -117,7 +116,7 @@ public class StreamBatchReadable implements BatchReadable<Long, String> {
    */
   public static void useStreamInput(MapReduceContext context, String streamName,
                                     long startTime, long endTime, Class<? extends StreamEventDecoder> decoderType) {
-    context.setInput(new StreamBatchReadable(streamName, startTime, endTime, decoderType).toURI().toString());
+    context.setInput(new StreamBatchReadable(streamName, startTime, endTime, decoderType));
   }
 
   /**
@@ -133,7 +132,7 @@ public class StreamBatchReadable implements BatchReadable<Long, String> {
    */
   public static void useStreamInput(MapReduceContext context, String streamName,
                                     long startTime, long endTime, FormatSpecification bodyFormatSpec) {
-    context.setInput(new StreamBatchReadable(streamName, startTime, endTime, bodyFormatSpec).toURI().toString());
+    context.setInput(new StreamBatchReadable(streamName, startTime, endTime, bodyFormatSpec));
   }
 
   /**

--- a/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceContext.java
@@ -24,6 +24,7 @@ import co.cask.cdap.api.data.batch.BatchReadable;
 import co.cask.cdap.api.data.batch.InputFormatProvider;
 import co.cask.cdap.api.data.batch.OutputFormatProvider;
 import co.cask.cdap.api.data.batch.Split;
+import co.cask.cdap.api.data.stream.StreamBatchReadable;
 import co.cask.cdap.api.dataset.Dataset;
 
 import java.util.List;
@@ -49,6 +50,13 @@ public interface MapReduceContext extends RuntimeContext, DatasetContext, Servic
   /**
    */
   <T> T getHadoopJob();
+
+  /**
+   * Overrides the input configuration of this MapReduce job to use the specific stream.
+   *
+   * @param stream the input stream.
+   */
+  void setInput(StreamBatchReadable stream);
 
   /**
    * Overrides the input configuration of this MapReduce job to use

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
@@ -21,6 +21,7 @@ import co.cask.cdap.api.data.batch.BatchReadable;
 import co.cask.cdap.api.data.batch.InputFormatProvider;
 import co.cask.cdap.api.data.batch.OutputFormatProvider;
 import co.cask.cdap.api.data.batch.Split;
+import co.cask.cdap.api.data.stream.StreamBatchReadable;
 import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.mapreduce.MapReduceContext;
 import co.cask.cdap.api.mapreduce.MapReduceSpecification;
@@ -143,6 +144,11 @@ public class BasicMapReduceContext extends AbstractContext implements MapReduceC
   @Override
   public <T> T getHadoopJob() {
     return (T) job;
+  }
+
+  @Override
+  public void setInput(StreamBatchReadable stream) {
+    setInput(stream.toURI().toString());
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/templates/etl/api/batch/BatchSourceContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/templates/etl/api/batch/BatchSourceContext.java
@@ -19,6 +19,7 @@ package co.cask.cdap.templates.etl.api.batch;
 import co.cask.cdap.api.data.batch.BatchReadable;
 import co.cask.cdap.api.data.batch.InputFormatProvider;
 import co.cask.cdap.api.data.batch.Split;
+import co.cask.cdap.api.data.stream.StreamBatchReadable;
 import co.cask.cdap.api.dataset.Dataset;
 
 import java.util.List;
@@ -27,6 +28,13 @@ import java.util.List;
  * Context of a Batch Source.
  */
 public interface BatchSourceContext extends BatchContext {
+
+  /**
+   * Overrides the input configuration of this Batch job to use the specific stream.
+   *
+   * @param stream the input stream.
+   */
+  void setInput(StreamBatchReadable stream);
 
   /**
    * Overrides the input configuration of this Batch job to use

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/templates/etl/batch/MapReduceSourceContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/templates/etl/batch/MapReduceSourceContext.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.templates.etl.batch;
 
 import co.cask.cdap.api.data.batch.Split;
+import co.cask.cdap.api.data.stream.StreamBatchReadable;
 import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.mapreduce.MapReduceContext;
 import co.cask.cdap.templates.etl.api.StageSpecification;
@@ -35,6 +36,11 @@ public class MapReduceSourceContext extends MapReduceBatchContext implements Bat
   public MapReduceSourceContext(MapReduceContext context, ETLStage sourceStage, StageSpecification specification) {
     super(context, specification);
     this.sourceStage = sourceStage;
+  }
+
+  @Override
+  public void setInput(StreamBatchReadable stream) {
+    mrContext.setInput(stream);
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/batch/sources/StreamBatchSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/batch/sources/StreamBatchSource.java
@@ -64,9 +64,8 @@ public class StreamBatchSource extends BatchSource<LongWritable, StreamEvent> {
 
     String streamName = context.getRuntimeArguments().get(STREAM_NAME);
     LOG.info("Setting input to Stream : {}", streamName);
-    Schema schema = Schema.recordOf("streamEvent", Schema.Field.of("body", Schema.of(Schema.Type.STRING)));
 
     // TODO: This is not clean.
-    context.setInput(new StreamBatchReadable(streamName, startTime, endTime).toURI().toString());
+    context.setInput(new StreamBatchReadable(streamName, startTime, endTime));
   }
 }


### PR DESCRIPTION
StreamBatchReadable as the input to match the static methods
available in StreamBatchReadable and to match what is in the
javadoc for the class. Also updating the ETL template to use the
new method instead of converting StreamBatchReadable to its uri.