### PR TITLE
CDAP-2144 getStopTs returns Long instead of long.

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/DefaultStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/DefaultStoreTest.java
@@ -208,6 +208,10 @@ public class DefaultStoreTest {
     RunId run3 = RunIds.generate(now);
     store.setStart(programId, run3.getId(), runIdToSecs(run3));
 
+    // For a RunRecord that has not yet been completed, getStopTs should return null
+    RunRecord runRecord = store.getRun(programId, run3.getId());
+    Assert.assertNull(runRecord.getStopTs());
+
     // record run of different program
     Id.Program programId2 = Id.Program.from("account1", "application1", ProgramType.FLOW, "flow2");
     RunId run4 = RunIds.generate(now - 5000);
@@ -234,12 +238,12 @@ public class DefaultStoreTest {
     // records should be sorted by start time latest to earliest
     RunRecord run = successHistory.get(0);
     Assert.assertEquals(nowSecs - 10, run.getStartTs());
-    Assert.assertEquals(nowSecs - 5, run.getStopTs());
+    Assert.assertEquals(Long.valueOf(nowSecs - 5), run.getStopTs());
     Assert.assertEquals(ProgramController.State.COMPLETED.getRunStatus(), run.getStatus());
 
     run = failureHistory.get(0);
     Assert.assertEquals(nowSecs - 20, run.getStartTs());
-    Assert.assertEquals(nowSecs - 10, run.getStopTs());
+    Assert.assertEquals(Long.valueOf(nowSecs - 10), run.getStopTs());
     Assert.assertEquals(ProgramController.State.ERROR.getRunStatus(), run.getStatus());
 
     // Assert all history

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/RunRecord.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/RunRecord.java
@@ -31,6 +31,7 @@ public final class RunRecord {
   @SerializedName("start")
   private final long startTs;
 
+  @Nullable
   @SerializedName("end")
   private final Long stopTs;
 
@@ -40,7 +41,8 @@ public final class RunRecord {
   @SerializedName("adapter")
   private final String adapterName;
 
-  public RunRecord(String pid, long startTs, Long stopTs, ProgramRunStatus status, @Nullable String adapterName) {
+  public RunRecord(String pid, long startTs, @Nullable Long stopTs,
+                   ProgramRunStatus status, @Nullable String adapterName) {
     this.pid = pid;
     this.startTs = startTs;
     this.stopTs = stopTs;
@@ -48,11 +50,12 @@ public final class RunRecord {
     this.adapterName = adapterName;
   }
 
-  public RunRecord(String pid, long startTs, Long stopTs, ProgramRunStatus status) {
+  public RunRecord(String pid, long startTs, @Nullable Long stopTs,
+                   ProgramRunStatus status) {
     this(pid, startTs, stopTs, status, null);
   }
 
-  public RunRecord(RunRecord started, long stopTs, ProgramRunStatus status) {
+  public RunRecord(RunRecord started, @Nullable Long stopTs, ProgramRunStatus status) {
     this(started.pid, started.startTs, stopTs, status, started.getAdapterName());
   }
 
@@ -64,7 +67,8 @@ public final class RunRecord {
     return startTs;
   }
 
-  public long getStopTs() {
+  @Nullable
+  public Long getStopTs() {
     return stopTs;
   }
 


### PR DESCRIPTION
Resolves: https://issues.cask.co/browse/CDAP-2144
                RunRecord of a RUNNING program throws NPE upon getStopTime().
                This was happening because the return type of `getStopTs` is `long`, even though its possible for `stopTs` to be null.
Build: http://builds.cask.co/browse/CDAP-DUT1472-2