### PR TITLE
prepend relative path (dot slash) to sourced file

### DIFF
--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -26,7 +26,7 @@
 # Builds each of these individually, and then packages them into a single zip file for distribution.
 # _common directory holds common files and scripts.
 
-source vars
+source ./vars
 source _common/common-build.sh
 
 ARG_1="$1"


### PR DESCRIPTION
The shell bamboo drops into during scripts needs a relative path for handling files in the current directory (based on our testing). It cannot find the file otherwise.

The script runs like this, essentially:
./build.sh <options>
The first line in build.sh (source vars) is failing, because it cannot find vars in the current directory (even though it is there).
This works: 
source ./vars