### PR TITLE
Set Adpater Worker resources before starting the program

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/Resources.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/Resources.java
@@ -67,24 +67,4 @@ public final class Resources {
   public int getMemoryMB() {
     return memoryMB;
   }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-
-    Resources that = (Resources) o;
-    return (this.memoryMB == that.memoryMB) && (this.virtualCores == that.virtualCores);
-  }
-
-  @Override
-  public int hashCode() {
-    int result = memoryMB;
-    result = 31 * result + virtualCores;
-    return result;
-  }
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/Resources.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/Resources.java
@@ -67,4 +67,24 @@ public final class Resources {
   public int getMemoryMB() {
     return memoryMB;
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    Resources that = (Resources) o;
+    return (this.memoryMB == that.memoryMB) && (this.virtualCores == that.virtualCores);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = memoryMB;
+    result = 31 * result + virtualCores;
+    return result;
+  }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/Store.java
@@ -17,7 +17,6 @@
 package co.cask.cdap.app.store;
 
 import co.cask.cdap.api.ProgramSpecification;
-import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.data.stream.StreamSpecification;
 import co.cask.cdap.api.flow.FlowSpecification;
 import co.cask.cdap.api.schedule.SchedulableProgramType;
@@ -290,22 +289,6 @@ public interface Store {
    * @return number of instances
    */
   int getWorkerInstances(Id.Program id);
-
-  /**
-   * Sets the {@link Resources} for a {@link Worker}.
-   *
-   * @param id program id
-   * @param resources {@link Resources}
-   */
-  void setWorkerResources(Id.Program id, Resources resources);
-
-  /**
-   * Gets the {@link Resources} for a {@link Worker}.
-   *
-   * @param id program id
-   * @return {@link Resources}
-   */
-  Resources getWorkerResources(Id.Program id);
 
   /**
    * Removes all program under the given application and also the application itself.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/Store.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.app.store;
 
 import co.cask.cdap.api.ProgramSpecification;
+import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.data.stream.StreamSpecification;
 import co.cask.cdap.api.flow.FlowSpecification;
 import co.cask.cdap.api.schedule.SchedulableProgramType;
@@ -284,10 +285,27 @@ public interface Store {
 
   /**
    * Gets the number of instances of a {@link Worker}
+   *
    * @param id program id
    * @return number of instances
    */
   int getWorkerInstances(Id.Program id);
+
+  /**
+   * Sets the {@link Resources} for a {@link Worker}.
+   *
+   * @param id program id
+   * @param resources {@link Resources}
+   */
+  void setWorkerResources(Id.Program id, Resources resources);
+
+  /**
+   * Gets the {@link Resources} for a {@link Worker}.
+   *
+   * @param id program id
+   * @return {@link Resources}
+   */
+  Resources getWorkerResources(Id.Program id);
 
   /**
    * Removes all program under the given application and also the application itself.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/ProgramOptionConstants.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/ProgramOptionConstants.java
@@ -50,4 +50,6 @@ public final class ProgramOptionConstants {
   public static final String RUN_BASE_COUNT_TIME = "runBaseCountTime";
 
   public static final String ADAPTER_NAME = "adapterName";
+
+  public static final String RESOURCES = "resources";
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/AdapterService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/AdapterService.java
@@ -419,16 +419,14 @@ public class AdapterService extends AbstractIdleService {
     try {
       Map<String, String> sysArgs = resolver.getSystemProperties(workerId, ProgramType.WORKER);
       Map<String, String> userArgs = resolver.getUserProperties(workerId, ProgramType.WORKER);
+
       // Pass Adapter Name as a system property
       sysArgs.put(ProgramOptionConstants.ADAPTER_NAME, adapterSpec.getName());
+      sysArgs.put(ProgramOptionConstants.INSTANCES, String.valueOf(adapterSpec.getInstances()));
+      sysArgs.put(ProgramOptionConstants.RESOURCES, GSON.toJson(adapterSpec.getResources()));
+
       // Override resolved preferences with adapter worker spec properties.
       userArgs.putAll(adapterSpec.getRuntimeArgs());
-
-      // TODO: CDAP-2146 Instances, Resources should not be set through Store
-      store.setWorkerInstances(workerId, adapterSpec.getInstances());
-      if (adapterSpec.getResources() != null) {
-        store.setWorkerResources(workerId, adapterSpec.getResources());
-      }
 
       ProgramRuntimeService.RuntimeInfo runtimeInfo = lifecycleService.start(workerId, ProgramType.WORKER,
                                                                              sysArgs, userArgs, false);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/AdapterService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/AdapterService.java
@@ -423,7 +423,13 @@ public class AdapterService extends AbstractIdleService {
       sysArgs.put(ProgramOptionConstants.ADAPTER_NAME, adapterSpec.getName());
       // Override resolved preferences with adapter worker spec properties.
       userArgs.putAll(adapterSpec.getRuntimeArgs());
+
+      // TODO: CDAP-2146 Instances, Resources should not be set through Store
       store.setWorkerInstances(workerId, adapterSpec.getInstances());
+      if (adapterSpec.getResources() != null) {
+        store.setWorkerResources(workerId, adapterSpec.getResources());
+      }
+
       ProgramRuntimeService.RuntimeInfo runtimeInfo = lifecycleService.start(workerId, ProgramType.WORKER,
                                                                              sysArgs, userArgs, false);
       final ProgramController controller = runtimeInfo.getController();

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWorkerProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWorkerProgramRunner.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.internal.app.runtime.distributed;
 
+import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.worker.WorkerSpecification;
 import co.cask.cdap.app.ApplicationSpecification;
 import co.cask.cdap.app.program.Program;
@@ -24,8 +25,10 @@ import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.twill.AbortOnTimeoutEventHandler;
+import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
 import co.cask.cdap.proto.ProgramType;
 import com.google.common.base.Preconditions;
+import com.google.gson.Gson;
 import com.google.inject.Inject;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.twill.api.EventHandler;
@@ -42,6 +45,7 @@ import java.io.File;
 public class DistributedWorkerProgramRunner extends AbstractDistributedProgramRunner {
 
   private static final Logger LOG = LoggerFactory.getLogger(DistributedWorkerProgramRunner.class);
+  private static final Gson GSON = new Gson();
 
   @Inject
   DistributedWorkerProgramRunner(TwillRunner twillRunner, Configuration hConfig, CConfiguration cConfig) {
@@ -61,10 +65,21 @@ public class DistributedWorkerProgramRunner extends AbstractDistributedProgramRu
     WorkerSpecification workerSpec = appSpec.getWorkers().get(program.getName());
     Preconditions.checkNotNull(workerSpec, "Missing WorkerSpecification for %s", program.getName());
 
+    String instances = options.getArguments().getOption(ProgramOptionConstants.INSTANCES,
+                                                        String.valueOf(workerSpec.getInstances()));
+    String resourceString = options.getArguments().getOption(ProgramOptionConstants.RESOURCES, null);
+    Resources newResources = (resourceString != null) ? GSON.fromJson(resourceString, Resources.class) :
+      workerSpec.getResources();
+
+    WorkerSpecification newWorkerSpec = new WorkerSpecification(workerSpec.getClassName(), workerSpec.getName(),
+                                                                workerSpec.getDescription(), workerSpec.getProperties(),
+                                                                workerSpec.getDatasets(), newResources,
+                                                                Integer.valueOf(instances));
+
     LOG.info("Launching distributed worker {}", program.getName());
 
-    TwillController controller = launcher.launch(new WorkerTwillApplication(program, workerSpec, hConfFile, cConfFile,
-                                                                            eventHandler));
+    TwillController controller = launcher.launch(new WorkerTwillApplication(program, newWorkerSpec,
+                                                                            hConfFile, cConfFile, eventHandler));
     return new WorkerTwillProgramController(program.getName(), controller).startListen();
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/InMemoryWorkerRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/InMemoryWorkerRunner.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.internal.app.runtime.worker;
 
+import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.worker.Worker;
 import co.cask.cdap.api.worker.WorkerSpecification;
 import co.cask.cdap.app.ApplicationSpecification;
@@ -39,6 +40,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Table;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.gson.Gson;
 import com.google.inject.Inject;
 import org.apache.twill.api.RunId;
 import org.slf4j.Logger;
@@ -51,6 +53,7 @@ import java.util.Map;
  */
 public class InMemoryWorkerRunner extends AbstractInMemoryProgramRunner {
   private static final Logger LOG = LoggerFactory.getLogger(InMemoryWorkerRunner.class);
+  private static final Gson GSON = new Gson();
 
   @Inject
   InMemoryWorkerRunner(ProgramRunnerFactory programRunnerFactory) {
@@ -79,10 +82,21 @@ public class InMemoryWorkerRunner extends AbstractInMemoryProgramRunner {
     WorkerSpecification workerSpec = appSpec.getWorkers().get(program.getName());
     Preconditions.checkNotNull(workerSpec, "Missing WorkerSpecification for %s", program.getName());
 
+    String instances = options.getArguments().getOption(ProgramOptionConstants.INSTANCES,
+                                                        String.valueOf(workerSpec.getInstances()));
+    String resourceString = options.getArguments().getOption(ProgramOptionConstants.RESOURCES, null);
+    Resources newResources = (resourceString != null) ? GSON.fromJson(resourceString, Resources.class) :
+      workerSpec.getResources();
+
+    WorkerSpecification newWorkerSpec = new WorkerSpecification(workerSpec.getClassName(), workerSpec.getName(),
+                                                                workerSpec.getDescription(), workerSpec.getProperties(),
+                                                                workerSpec.getDatasets(), newResources,
+                                                                Integer.valueOf(instances));
+
     //RunId for worker
     RunId runId = RunIds.generate();
     Table<String, Integer, ProgramController> components = startWorkers(program, runId, options.getUserArguments(),
-                                                                        workerSpec);
+                                                                        newWorkerSpec);
     return new InMemoryProgramController(components, runId, program, workerSpec, options.getUserArguments(),
                                          ProgramRunnerFactory.Type.WORKER_COMPONENT);
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
@@ -538,39 +538,6 @@ public class DefaultStore implements Store {
   }
 
   @Override
-  public void setWorkerResources(final Id.Program id, final Resources resources) {
-    txnl.executeUnchecked(new TransactionExecutor.Function<AppMds, Void>() {
-      @Override
-      public Void apply(AppMds mds) throws Exception {
-        ApplicationSpecification appSpec = getAppSpecOrFail(mds, id);
-        WorkerSpecification workerSpec = getWorkerSpecOrFail(id, appSpec);
-        workerSpec = new WorkerSpecification(workerSpec.getClassName(), workerSpec.getName(),
-                                             workerSpec.getDescription(), workerSpec.getProperties(),
-                                             workerSpec.getDatasets(), resources, workerSpec.getInstances());
-        ApplicationSpecification newAppSpec = replaceWorkerInAppSpec(appSpec, id, workerSpec);
-        replaceAppSpecInProgramJar(id, newAppSpec, ProgramType.WORKER);
-        mds.apps.updateAppSpec(id.getNamespaceId(), id.getApplicationId(), newAppSpec);
-        return null;
-      }
-    });
-
-    LOG.trace("Setting program resources: namespace: {}, application: {}, worker: {}, new resources: {}",
-              id.getNamespaceId(), id.getApplicationId(), id.getId(), resources);
-  }
-
-  @Override
-  public Resources getWorkerResources(final Id.Program id) {
-    return txnl.executeUnchecked(new TransactionExecutor.Function<AppMds, Resources>() {
-      @Override
-      public Resources apply(AppMds mds) throws Exception {
-        ApplicationSpecification appSpec = getAppSpecOrFail(mds, id);
-        WorkerSpecification workerSpec = getWorkerSpecOrFail(id, appSpec);
-        return workerSpec.getResources();
-      }
-    });
-  }
-
-  @Override
   public int getServiceWorkerInstances(final Id.Program id, final String workerName) {
     return txnl.executeUnchecked(new TransactionExecutor.Function<AppMds, Integer>() {
       @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.internal.app.store;
 
 import co.cask.cdap.api.ProgramSpecification;
+import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.data.stream.StreamSpecification;
 import co.cask.cdap.api.dataset.DatasetAdmin;
 import co.cask.cdap.api.dataset.DatasetDefinition;
@@ -411,6 +412,9 @@ public class DefaultStore implements Store {
         return null;
       }
     });
+
+    LOG.trace("Setting program instances: namespace: {}, application: {}, worker: {}, new instances count: {}",
+              id.getNamespaceId(), id.getApplicationId(), id.getId(), instances);
   }
 
   @Override
@@ -529,6 +533,39 @@ public class DefaultStore implements Store {
         ApplicationSpecification appSpec = getAppSpecOrFail(mds, id);
         WorkerSpecification workerSpec = getWorkerSpecOrFail(id, appSpec);
         return workerSpec.getInstances();
+      }
+    });
+  }
+
+  @Override
+  public void setWorkerResources(final Id.Program id, final Resources resources) {
+    txnl.executeUnchecked(new TransactionExecutor.Function<AppMds, Void>() {
+      @Override
+      public Void apply(AppMds mds) throws Exception {
+        ApplicationSpecification appSpec = getAppSpecOrFail(mds, id);
+        WorkerSpecification workerSpec = getWorkerSpecOrFail(id, appSpec);
+        workerSpec = new WorkerSpecification(workerSpec.getClassName(), workerSpec.getName(),
+                                             workerSpec.getDescription(), workerSpec.getProperties(),
+                                             workerSpec.getDatasets(), resources, workerSpec.getInstances());
+        ApplicationSpecification newAppSpec = replaceWorkerInAppSpec(appSpec, id, workerSpec);
+        replaceAppSpecInProgramJar(id, newAppSpec, ProgramType.WORKER);
+        mds.apps.updateAppSpec(id.getNamespaceId(), id.getApplicationId(), newAppSpec);
+        return null;
+      }
+    });
+
+    LOG.trace("Setting program resources: namespace: {}, application: {}, worker: {}, new resources: {}",
+              id.getNamespaceId(), id.getApplicationId(), id.getId(), resources);
+  }
+
+  @Override
+  public Resources getWorkerResources(final Id.Program id) {
+    return txnl.executeUnchecked(new TransactionExecutor.Function<AppMds, Resources>() {
+      @Override
+      public Resources apply(AppMds mds) throws Exception {
+        ApplicationSpecification appSpec = getAppSpecOrFail(mds, id);
+        WorkerSpecification workerSpec = getWorkerSpecOrFail(id, appSpec);
+        return workerSpec.getResources();
       }
     });
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/templates/AdapterSpecification.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/templates/AdapterSpecification.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.templates;
 
+import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.data.stream.StreamSpecification;
 import co.cask.cdap.api.schedule.ScheduleSpecification;
 import co.cask.cdap.data.dataset.DatasetCreationSpec;
@@ -40,6 +41,7 @@ public final class AdapterSpecification {
   private final Map<String, DatasetCreationSpec> datasets;
   private final Map<String, String> datasetModules;
   private final Map<String, String> runtimeArgs;
+  private final Resources resources;
   // this is a json representation of some config that templates will use to configure
   // an adapter. At configuration time it will be translated into the correct object,
   // but the platform itself never interprets it but just passes it along.
@@ -50,7 +52,8 @@ public final class AdapterSpecification {
                                Map<String, StreamSpecification> streams,
                                Map<String, DatasetCreationSpec> datasets,
                                Map<String, String> datasetModules,
-                               Map<String, String> runtimeArgs, JsonElement config) {
+                               Map<String, String> runtimeArgs, Resources resources,
+                               JsonElement config) {
     this.name = name;
     this.description = description;
     this.template = template;
@@ -62,6 +65,7 @@ public final class AdapterSpecification {
       ImmutableMap.<String, String>of() : ImmutableMap.copyOf(datasetModules);
     this.runtimeArgs = runtimeArgs == null ? ImmutableMap.<String, String>of() : ImmutableMap.copyOf(runtimeArgs);
     this.config = config;
+    this.resources = resources;
   }
 
   public String getName() {
@@ -102,6 +106,13 @@ public final class AdapterSpecification {
     return instances;
   }
 
+  // Use the Resources set while creating Adapter. If it is not set, use the Resources set in the configuration
+  // of the Program in the Template Application.
+  @Nullable
+  public Resources getResources() {
+    return resources;
+  }
+
   public JsonElement getConfig() {
     return config;
   }
@@ -123,6 +134,7 @@ public final class AdapterSpecification {
     private Map<String, DatasetCreationSpec> datasets;
     private Map<String, String> datasetModules;
     private int instances;
+    private Resources resources;
     private JsonElement config;
 
     public Builder(String name, String template) {
@@ -175,9 +187,14 @@ public final class AdapterSpecification {
       return this;
     }
 
+    public Builder setResources(Resources resources) {
+      this.resources = resources;
+      return this;
+    }
+
     public AdapterSpecification build() {
       return new AdapterSpecification(name, description, template, schedule, instances,
-                                      streams, datasets, datasetModules, runtimeArgs, config);
+                                      streams, datasets, datasetModules, runtimeArgs, resources, config);
     }
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/templates/AdapterSpecification.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/templates/AdapterSpecification.java
@@ -106,9 +106,6 @@ public final class AdapterSpecification {
     return instances;
   }
 
-  // Use the Resources set while creating Adapter. If it is not set, use the Resources set in the configuration
-  // of the Program in the Template Application.
-  @Nullable
   public Resources getResources() {
     return resources;
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/templates/DefaultAdapterConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/templates/DefaultAdapterConfigurer.java
@@ -180,7 +180,8 @@ public class DefaultAdapterConfigurer implements AdapterConfigurer {
         .setStreams(streams)
         .setRuntimeArgs(runtimeArgs)
         .setScheduleSpec(scheduleSpec)
-        .setInstances(instances);
+        .setInstances(instances)
+        .setResources(resources);
     return builder.build();
   }
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/DefaultStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/DefaultStoreTest.java
@@ -572,24 +572,6 @@ public class DefaultStoreTest {
   }
 
   @Test
-  public void testWorkerResources() throws Exception {
-    AppFabricTestHelper.deployApplication(AppWithWorker.class);
-    ApplicationSpecification spec = Specifications.from(new AppWithWorker());
-
-    Id.Application appId = Id.Application.from(DefaultId.NAMESPACE.getId(), spec.getName());
-    Id.Program programId = Id.Program.from(appId, ProgramType.WORKER, AppWithWorker.WORKER);
-
-    Resources resourcesFromSpec = spec.getWorkers().get(AppWithWorker.WORKER).getResources();
-    Assert.assertEquals(new Resources(), resourcesFromSpec);
-    Resources resources = store.getWorkerResources(programId);
-    Assert.assertEquals(resourcesFromSpec, resources);
-
-    Resources newResources = new Resources(2048, 32);
-    store.setWorkerResources(programId, newResources);
-    Assert.assertEquals(newResources, store.getWorkerResources(programId));
-  }
-
-  @Test
   public void testRemoveAllApplications() throws Exception {
     ApplicationSpecification spec = Specifications.from(new WordCountApp());
     Id.Namespace namespaceId = new Id.Namespace("account1");


### PR DESCRIPTION
Use ProgramOptions (system arguments) to pass instances, resources. Unfortunately this has to be replicated thrice in different places. Need to fix this cleanly in the future.

Bamboo: http://builds.cask.co/browse/CDAP-DUT1476-2