### PR TITLE
Feature/log saver metrics plugin

### DIFF
--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/appender/kafka/KafkaTopic.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/appender/kafka/KafkaTopic.java
@@ -16,8 +16,6 @@
 
 package co.cask.cdap.logging.appender.kafka;
 
-import java.io.IOException;
-
 /**
  * Generates Kafka topic containing schema for logging.
  */
@@ -28,9 +26,8 @@ public final class KafkaTopic {
 
   /**
    * @return Kafka topic with schema.
-   * @throws IOException
    */
-  public static String getTopic() throws IOException {
+  public static String getTopic() {
     return KAFKA_TOPIC;
   }
 }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/appender/kafka/SimpleKafkaProducer.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/appender/kafka/SimpleKafkaProducer.java
@@ -18,14 +18,12 @@ package co.cask.cdap.logging.appender.kafka;
 
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.logging.LoggingConfiguration;
-import com.google.common.base.Throwables;
 import kafka.javaapi.producer.Producer;
 import kafka.producer.KeyedMessage;
 import kafka.producer.ProducerConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.Properties;
 
 /**
@@ -56,11 +54,7 @@ public final class SimpleKafkaProducer {
 
     ProducerConfig config = new ProducerConfig(props);
 
-    try {
-      kafkaTopic = KafkaTopic.getTopic();
-    } catch (IOException e) {
-      throw Throwables.propagate(e);
-    }
+    kafkaTopic = KafkaTopic.getTopic();
     producer = new Producer<String, byte[]>(config);
   }
 

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/LoggingContextHelper.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/context/LoggingContextHelper.java
@@ -248,7 +248,7 @@ public final class LoggingContextHelper {
 
   public static Map<String, String> getMetricsTags(LoggingContext context) throws IllegalArgumentException {
     if (context instanceof ServiceLoggingContext) {
-     return getTagsFromSystemContext((ServiceLoggingContext) context);
+     return getMetricsTagsFromSystemContext((ServiceLoggingContext) context);
     } else {
       return getMetricsTagsFromLoggingContext(context);
     }
@@ -289,15 +289,10 @@ public final class LoggingContextHelper {
   }
 
   private static String getValueFromTag(LoggingContext.SystemTag tag) {
-    if (tag == null) {
-      return null;
-    } else {
-      return tag.getValue();
-    }
+    return tag == null ? null : tag.getValue();
   }
 
-
-  public static Map<String, String> getTagsFromSystemContext(ServiceLoggingContext context) {
+  private static Map<String, String> getMetricsTagsFromSystemContext(ServiceLoggingContext context) {
     ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
     builder.put(Constants.Metrics.Tag.NAMESPACE, Constants.SYSTEM_NAMESPACE);
     builder.put(Constants.Metrics.Tag.COMPONENT,

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/guice/LoggingModules.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/guice/LoggingModules.java
@@ -28,6 +28,7 @@ import co.cask.cdap.logging.read.LogReader;
 import co.cask.cdap.logging.read.StandaloneLogReader;
 import co.cask.cdap.logging.save.KafkaLogProcessor;
 import co.cask.cdap.logging.save.KafkaLogWriterPlugin;
+import co.cask.cdap.logging.save.LogMetricsPlugin;
 import com.google.inject.AbstractModule;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
@@ -75,6 +76,7 @@ public class LoggingModules extends RuntimeModule {
         Multibinder<KafkaLogProcessor> handlerBinder = Multibinder.newSetBinder
           (binder(), KafkaLogProcessor.class, Names.named(Constants.LogSaver.MESSAGE_PROCESSORS));
         handlerBinder.addBinding().to(KafkaLogWriterPlugin.class);
+        handlerBinder.addBinding().to(LogMetricsPlugin.class);
       }
     };
   }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/AbstractKafkaLogProcessor.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/AbstractKafkaLogProcessor.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.logging.save;
+
+import co.cask.cdap.logging.kafka.KafkaLogEvent;
+import com.google.common.base.Throwables;
+import com.google.common.collect.Maps;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Abstract Log Processor that stores offsets for paritions and checks if a given event is already processed.
+ */
+public abstract class AbstractKafkaLogProcessor implements KafkaLogProcessor {
+
+  private final Map<Integer, Long> partitionOffsets;
+  public AbstractKafkaLogProcessor() {
+    this.partitionOffsets = Maps.newHashMap();
+  }
+
+  public void init(Set<Integer> partitions, CheckpointManager checkpointManager) {
+    partitionOffsets.clear();
+    try {
+     for (Integer partition : partitions) {
+        partitionOffsets.put(partition, checkpointManager.getCheckpoint(partition));
+      }
+    } catch (Exception e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  public boolean alreadyProcessed(KafkaLogEvent event) {
+    // if the event offset is less than what is already checkpointed then the event is already processed
+    return event.getNextOffset() < partitionOffsets.get(event.getPartition()) ? true : false;
+  }
+}

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/AbstractKafkaLogProcessor.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/AbstractKafkaLogProcessor.java
@@ -44,6 +44,19 @@ public abstract class AbstractKafkaLogProcessor implements KafkaLogProcessor {
     }
   }
 
+  public void process(KafkaLogEvent event) {
+    if (!alreadyProcessed(event)) {
+      doProcess(event);
+    }
+  }
+
+  /**
+   * doProcess method will be called if the event is not already processed.
+   *
+   * @param event KafkaLogEvent
+   */
+  protected abstract void doProcess(KafkaLogEvent event);
+
   public boolean alreadyProcessed(KafkaLogEvent event) {
     // if the event offset is less than what is already checkpointed then the event is already processed
     return event.getNextOffset() < partitionOffsets.get(event.getPartition()) ? true : false;

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/CheckPointWriter.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/CheckPointWriter.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+
+package co.cask.cdap.logging.save;
+
+import com.google.common.base.Throwables;
+
+import java.io.Flushable;
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Writes checkpoints of kafka partitions and offsets.
+ */
+public class CheckPointWriter implements Flushable, Runnable {
+
+  private final Map<Integer, Long> partitionOffsets;
+  private final CheckpointManager checkpointManager;
+
+  public CheckPointWriter(CheckpointManager checkpointManager, Map<Integer, Long> partitionOffsets) {
+    this.partitionOffsets = partitionOffsets;
+    this.checkpointManager = checkpointManager;
+  }
+
+  public void updateCheckPoint(Integer partition, long offset) {
+    partitionOffsets.put(partition, offset);
+  }
+
+  @Override
+  public void run() {
+    checkpoint();
+  }
+
+  @Override
+  public void flush() throws IOException {
+    checkpoint();
+  }
+
+  private void checkpoint() {
+    try {
+      for (Map.Entry<Integer, Long> entry : partitionOffsets.entrySet()) {
+        checkpointManager.saveCheckpoint(entry.getKey(), entry.getValue());
+      }
+    } catch (Exception e) {
+      throw Throwables.propagate(e);
+    }
+  }
+}

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/CheckpointManager.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/CheckpointManager.java
@@ -31,7 +31,6 @@ import com.google.inject.Inject;
  */
 public final class CheckpointManager {
 
-  private static final byte [] ROW_KEY_PREFIX = Bytes.toBytes(100);
   private static final byte [] OFFSET_COLNAME = Bytes.toBytes("nextOffset");
 
   private final Transactional<DatasetContext<Table>, Table> mds;
@@ -39,8 +38,8 @@ public final class CheckpointManager {
 
   @Inject
   public CheckpointManager(final LogSaverTableUtil tableUtil,
-                           TransactionExecutorFactory txExecutorFactory, String topic) {
-    this.rowKeyPrefix = Bytes.add(ROW_KEY_PREFIX, Bytes.toBytes(topic));
+                           TransactionExecutorFactory txExecutorFactory, String topic, int prefix) {
+    this.rowKeyPrefix = Bytes.add(Bytes.toBytes(prefix), Bytes.toBytes(topic));
     this.mds = Transactional.of(txExecutorFactory, new Supplier<DatasetContext<Table>>() {
       @Override
       public DatasetContext<Table> get() {

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/KafkaLogProcessor.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/KafkaLogProcessor.java
@@ -44,4 +44,14 @@ public interface KafkaLogProcessor {
    */
   public void stop();
 
+
+  /**
+   * Get the checkpoint offset for a given partition. This will be used to figure out the lowest offset to read
+   * from for any given partition across multiple plugins. If the plugin doesn't care about check pointing offset
+   * the implementations can just return -1;
+   *
+   * @param partition partition number in kafka
+   * @return checkpoint offset
+   */
+ public long getCheckPoint(int partition);
 }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/KafkaLogWriterPlugin.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/KafkaLogWriterPlugin.java
@@ -21,13 +21,17 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.logging.LoggingContext;
 import co.cask.cdap.logging.LoggingConfiguration;
+import co.cask.cdap.logging.appender.kafka.KafkaTopic;
 import co.cask.cdap.logging.appender.kafka.LoggingEventSerializer;
 import co.cask.cdap.logging.kafka.KafkaLogEvent;
 import co.cask.cdap.logging.write.AvroFileWriter;
 import co.cask.cdap.logging.write.FileMetaDataManager;
 import co.cask.cdap.logging.write.LogCleanup;
 import co.cask.cdap.logging.write.LogFileWriter;
+import co.cask.tephra.TransactionExecutorFactory;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.RowSortedTable;
 import com.google.common.collect.TreeBasedTable;
@@ -52,10 +56,11 @@ import java.util.concurrent.TimeUnit;
 /**
  * Plugin that writes the log data.
  */
-public class KafkaLogWriterPlugin implements KafkaLogProcessor {
+public class KafkaLogWriterPlugin extends AbstractKafkaLogProcessor {
 
   private static final long SLEEP_TIME_MS = 100;
   private static final Logger LOG = LoggerFactory.getLogger(KafkaLogWriterPlugin.class);
+  private static final int CHECKPOINT_ROW_KEY_PREFIX = 100;
 
   private ListeningScheduledExecutorService scheduledExecutor;
   private final String logBaseDir;
@@ -66,6 +71,7 @@ public class KafkaLogWriterPlugin implements KafkaLogProcessor {
   private final long maxNumberOfBucketsInTable;
   private final LoggingEventSerializer serializer;
   private final LogCleanup logCleanup;
+  private final CheckpointManager checkpointManager;
 
   private ScheduledFuture<?> logWriterFuture;
   private ScheduledFuture<?> cleanupFuture;
@@ -74,7 +80,8 @@ public class KafkaLogWriterPlugin implements KafkaLogProcessor {
 
   @Inject
   public KafkaLogWriterPlugin(CConfiguration cConfig, FileMetaDataManager fileMetaDataManager,
-                              CheckpointManager checkpointManager, LocationFactory locationFactory)
+                              LocationFactory locationFactory, LogSaverTableUtil tableUtil,
+                              TransactionExecutorFactory txExecutorFactory)
                               throws Exception {
 
     this.serializer = new LoggingEventSerializer();
@@ -133,6 +140,9 @@ public class KafkaLogWriterPlugin implements KafkaLogProcessor {
                                                        logBaseDir, serializer.getAvroSchema(), maxLogFileSizeBytes,
                                                        syncIntervalBytes, inactiveIntervalMs);
 
+     checkpointManager = new CheckpointManager(tableUtil, txExecutorFactory,
+                                              KafkaTopic.getTopic(), CHECKPOINT_ROW_KEY_PREFIX);
+
     this.logFileWriter = new CheckpointingLogFileWriter(avroFileWriter, checkpointManager, checkpointIntervalMs);
 
     String namespacesDir = cConfig.get(Constants.Namespace.NAMESPACES_DIR);
@@ -143,6 +153,7 @@ public class KafkaLogWriterPlugin implements KafkaLogProcessor {
 
   @Override
   public void init(Set<Integer> partitions) {
+    super.init(partitions, checkpointManager);
 
     scheduledExecutor = MoreExecutors.listeningDecorator(Executors.newSingleThreadScheduledExecutor(
       Threads.createDaemonThreadFactory("log-saver-log-processor")));;
@@ -161,6 +172,11 @@ public class KafkaLogWriterPlugin implements KafkaLogProcessor {
 
   @Override
   public void process(KafkaLogEvent event) {
+
+    if (alreadyProcessed(event)) {
+      return;
+    }
+
     LoggingContext loggingContext = event.getLoggingContext();
     ILoggingEvent logEvent = event.getLogEvent();
     try {
@@ -226,9 +242,8 @@ public class KafkaLogWriterPlugin implements KafkaLogProcessor {
 
       if (scheduledExecutor != null) {
         scheduledExecutor.shutdown();
+        scheduledExecutor.awaitTermination(5, TimeUnit.MINUTES);
       }
-
-      scheduledExecutor.awaitTermination(5, TimeUnit.MINUTES);
 
       logFileWriter.flush();
       logFileWriter.close();
@@ -237,5 +252,19 @@ public class KafkaLogWriterPlugin implements KafkaLogProcessor {
       LOG.error("Caught exception while closing logWriter {}", e.getMessage(), e);
     }
     messageTable.clear();
+  }
+
+  @Override
+  public long getCheckPoint(int partition) {
+    try {
+      return checkpointManager.getCheckpoint(partition);
+    } catch (Exception e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  @VisibleForTesting
+  CheckpointManager getCheckPointManager() {
+    return this.checkpointManager;
   }
 }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/KafkaLogWriterPlugin.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/KafkaLogWriterPlugin.java
@@ -140,7 +140,7 @@ public class KafkaLogWriterPlugin extends AbstractKafkaLogProcessor {
                                                        logBaseDir, serializer.getAvroSchema(), maxLogFileSizeBytes,
                                                        syncIntervalBytes, inactiveIntervalMs);
 
-     checkpointManager = new CheckpointManager(tableUtil, txExecutorFactory,
+    checkpointManager = new CheckpointManager(tableUtil, txExecutorFactory,
                                               KafkaTopic.getTopic(), CHECKPOINT_ROW_KEY_PREFIX);
 
     this.logFileWriter = new CheckpointingLogFileWriter(avroFileWriter, checkpointManager, checkpointIntervalMs);

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/KafkaLogWriterPlugin.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/KafkaLogWriterPlugin.java
@@ -171,11 +171,7 @@ public class KafkaLogWriterPlugin extends AbstractKafkaLogProcessor {
   }
 
   @Override
-  public void process(KafkaLogEvent event) {
-
-    if (alreadyProcessed(event)) {
-      return;
-    }
+  public void doProcess(KafkaLogEvent event) {
 
     LoggingContext loggingContext = event.getLoggingContext();
     ILoggingEvent logEvent = event.getLogEvent();

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/LogMetricsPlugin.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/LogMetricsPlugin.java
@@ -26,7 +26,6 @@ import co.cask.cdap.logging.kafka.KafkaLogEvent;
 import co.cask.tephra.TransactionExecutorFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
-import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.inject.Inject;
@@ -34,9 +33,9 @@ import org.apache.twill.common.Threads;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.lang.Integer;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/LogMetricsPlugin.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/LogMetricsPlugin.java
@@ -86,12 +86,7 @@ public class LogMetricsPlugin extends AbstractKafkaLogProcessor {
   }
 
   @Override
-  public void process(KafkaLogEvent event) {
-
-    if (alreadyProcessed(event)) {
-      // already processed.
-      return;
-    }
+  public void doProcess(KafkaLogEvent event) {
 
     LoggingContext context = event.getLoggingContext();
     Map<String, String> tags = LoggingContextHelper.getMetricsTags(context);

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/LogMetricsPlugin.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/LogMetricsPlugin.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.logging.save;
+
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.logging.LoggingContext;
+import co.cask.cdap.common.metrics.MetricsCollectionService;
+import co.cask.cdap.common.metrics.MetricsCollector;
+import co.cask.cdap.logging.appender.kafka.KafkaTopic;
+import co.cask.cdap.logging.context.LoggingContextHelper;
+import co.cask.cdap.logging.kafka.KafkaLogEvent;
+import co.cask.tephra.TransactionExecutorFactory;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Throwables;
+import com.google.common.collect.Maps;
+import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.inject.Inject;
+import org.apache.twill.common.Threads;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Plugin to process Log and generate metrics on Log level.
+ */
+public class LogMetricsPlugin extends AbstractKafkaLogProcessor {
+
+  private final MetricsCollectionService metricsCollectionService;
+
+  public static final String SYSTEM_METRIC_PREFIX = "services.log";
+  public static final String APP_METRIC_PREFIX = "app.log";
+  private final CheckpointManager checkpointManager;
+  private static final int ROW_KEY_PREFIX = 101;
+  private Map<Integer, Long> partitionOffsets = Maps.newHashMap();
+  private static final Logger LOG = LoggerFactory.getLogger(LogMetricsPlugin.class);
+  private ListeningScheduledExecutorService scheduledExecutor;
+  private ScheduledFuture<?> checkPointerFuture;
+  private CheckPointWriter checkPointWriter;
+
+  @Inject
+  public LogMetricsPlugin (MetricsCollectionService metricsCollectionService, LogSaverTableUtil tableUtil,
+                           TransactionExecutorFactory txExecutorFactory) {
+    this.metricsCollectionService = metricsCollectionService;
+    this.checkpointManager = new CheckpointManager(tableUtil, txExecutorFactory, KafkaTopic.getTopic(), ROW_KEY_PREFIX);
+  }
+
+  @Override
+  public void init(Set<Integer> partitions) {
+    super.init(partitions, checkpointManager);
+
+    scheduledExecutor = MoreExecutors.listeningDecorator(Executors.newSingleThreadScheduledExecutor(
+      Threads.createDaemonThreadFactory("log-saver-metrics-plugin")));;
+
+    partitionOffsets.clear();
+    try {
+      for (Integer partition : partitions) {
+        partitionOffsets.put(partition, checkpointManager.getCheckpoint(partition));
+      }
+    } catch (Exception e) {
+      LOG.error("Caught exception while reading checkpoint", e);
+      throw Throwables.propagate(e);
+    }
+
+    checkPointWriter = new CheckPointWriter(checkpointManager, partitionOffsets);
+    checkPointerFuture = scheduledExecutor.scheduleWithFixedDelay(checkPointWriter, 100, 200, TimeUnit.MILLISECONDS);
+  }
+
+  @Override
+  public void process(KafkaLogEvent event) {
+
+    if (alreadyProcessed(event)) {
+      // already processed.
+      return;
+    }
+
+    LoggingContext context = event.getLoggingContext();
+    Map<String, String> tags = LoggingContextHelper.getMetricsTags(context);
+    MetricsCollector collector = metricsCollectionService.getCollector(tags);
+
+    String metricName = getMetricName(tags.get(Constants.Metrics.Tag.NAMESPACE),
+                                      event.getLogEvent().getLevel().toString().toLowerCase());
+
+    if  (!(tags.containsKey(Constants.Metrics.Tag.COMPONENT) &&
+           tags.get(Constants.Metrics.Tag.COMPONENT).equals(Constants.Service.METRICS_PROCESSOR))) {
+      collector.increment(metricName, 1);
+    }
+
+    partitionOffsets.put(event.getPartition(), event.getNextOffset());
+
+  }
+
+  private String getMetricName(String namespace, String logLevel) {
+    if (namespace.equals(Constants.SYSTEM_NAMESPACE)) {
+      return String.format("%s.%s", SYSTEM_METRIC_PREFIX, logLevel);
+    } else {
+      return String.format("%s.%s", APP_METRIC_PREFIX, logLevel);
+    }
+  }
+
+  @Override
+  public void stop() {
+    try {
+      if (scheduledExecutor != null) {
+        scheduledExecutor.shutdown();
+        scheduledExecutor.awaitTermination(5, TimeUnit.MINUTES);
+      }
+      if (checkPointWriter != null) {
+        checkPointWriter.flush();
+      }
+    } catch (Throwable th) {
+      LOG.error("Caught exception while closing Log metrics plugin {}", th.getMessage(), th);
+    }
+  }
+
+  @Override
+  public long getCheckPoint(int partition) {
+    try {
+      return checkpointManager.getCheckpoint(partition);
+    } catch (Exception e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  @VisibleForTesting
+  CheckpointManager getCheckPointManager() {
+    return this.checkpointManager;
+  }
+}

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/LogMetricsPlugin.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/LogMetricsPlugin.java
@@ -45,14 +45,15 @@ import java.util.concurrent.TimeUnit;
  */
 public class LogMetricsPlugin extends AbstractKafkaLogProcessor {
 
+  private static final Logger LOG = LoggerFactory.getLogger(LogMetricsPlugin.class);
+  private static final int ROW_KEY_PREFIX = 101;
+  private static final String SYSTEM_METRIC_PREFIX = "services.log";
+  private static final String APP_METRIC_PREFIX = "app.log";
+
+  private final CheckpointManager checkpointManager;
   private final MetricsCollectionService metricsCollectionService;
 
-  public static final String SYSTEM_METRIC_PREFIX = "services.log";
-  public static final String APP_METRIC_PREFIX = "app.log";
-  private final CheckpointManager checkpointManager;
-  private static final int ROW_KEY_PREFIX = 101;
   private Map<Integer, Long> partitionOffsets = Maps.newHashMap();
-  private static final Logger LOG = LoggerFactory.getLogger(LogMetricsPlugin.class);
   private ListeningScheduledExecutorService scheduledExecutor;
   private ScheduledFuture<?> checkPointerFuture;
   private CheckPointWriter checkPointWriter;
@@ -105,11 +106,9 @@ public class LogMetricsPlugin extends AbstractKafkaLogProcessor {
   }
 
   private String getMetricName(String namespace, String logLevel) {
-    if (namespace.equals(Constants.SYSTEM_NAMESPACE)) {
-      return String.format("%s.%s", SYSTEM_METRIC_PREFIX, logLevel);
-    } else {
-      return String.format("%s.%s", APP_METRIC_PREFIX, logLevel);
-    }
+    return namespace.equals(Constants.SYSTEM_NAMESPACE) ?
+           String.format("%s.%s", SYSTEM_METRIC_PREFIX, logLevel) :
+           String.format("%s.%s", APP_METRIC_PREFIX, logLevel);
   }
 
   @Override

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/LogMetricsPlugin.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/LogMetricsPlugin.java
@@ -34,6 +34,7 @@ import org.apache.twill.common.Threads;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.Integer;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executors;
@@ -53,7 +54,7 @@ public class LogMetricsPlugin extends AbstractKafkaLogProcessor {
   private final CheckpointManager checkpointManager;
   private final MetricsCollectionService metricsCollectionService;
 
-  private Map<Integer, Long> partitionOffsets = Maps.newHashMap();
+  private Map<Integer, Long> partitionOffsets = new ConcurrentHashMap<Integer, Long>();
   private ListeningScheduledExecutorService scheduledExecutor;
   private ScheduledFuture<?> checkPointerFuture;
   private CheckPointWriter checkPointWriter;

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/LogSaver.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/LogSaver.java
@@ -47,15 +47,13 @@ public final class LogSaver extends AbstractIdleService implements PartitionChan
   private final String topic;
   private final KafkaClientService kafkaClient;
 
-  private final CheckpointManager checkpointManager;
-
   private Map<Integer, Cancellable> kafkaCancelMap;
   private Map<Integer, CountDownLatch> kafkaCancelCallbackLatchMap;
   private Set<KafkaLogProcessor> messageProcessors;
 
 
   @Inject
-  public LogSaver(CheckpointManager checkpointManager, KafkaClientService kafkaClient,
+  public LogSaver(KafkaClientService kafkaClient,
                   @Named(Constants.LogSaver.MESSAGE_PROCESSORS) Set<KafkaLogProcessor> messageProcessors)
                   throws Exception {
     LOG.info("Initializing LogSaver...");
@@ -63,7 +61,6 @@ public final class LogSaver extends AbstractIdleService implements PartitionChan
     this.topic = KafkaTopic.getTopic();
     LOG.info(String.format("Kafka topic is %s", this.topic));
 
-    this.checkpointManager = checkpointManager;
     this.kafkaClient = kafkaClient;
     this.kafkaCancelMap = new HashMap<Integer, Cancellable>();
     this.kafkaCancelCallbackLatchMap = new HashMap<Integer, CountDownLatch>();
@@ -138,7 +135,7 @@ public final class LogSaver extends AbstractIdleService implements PartitionChan
     Map<Integer, Long> partitionOffset = Maps.newHashMap();
     for (int part : partitions) {
       KafkaConsumer.Preparer preparer = kafkaClient.getConsumer().prepare();
-      long offset = checkpointManager.getCheckpoint(part);
+      long offset = getLowestCheckPoint(part);
       partitionOffset.put(part, offset);
 
       if (offset >= 0) {
@@ -155,11 +152,29 @@ public final class LogSaver extends AbstractIdleService implements PartitionChan
     LOG.info("Consumer created for topic {}, partitions {}", topic, partitionOffset);
   }
 
+  private long getLowestCheckPoint(int partition) {
+    long lowestCheckpoint = -1L;
+
+    for (KafkaLogProcessor processor : messageProcessors) {
+      long checkpoint = processor.getCheckPoint(partition);
+      // If checkpoint is -1; then ignore the checkpoint
+      if (checkpoint != -1) {
+        lowestCheckpoint =  (lowestCheckpoint == -1 || checkpoint < lowestCheckpoint) ?
+                             checkpoint :
+                             lowestCheckpoint;
+      }
+    }
+    return lowestCheckpoint;
+  }
+
+
   private void waitForDatasetAvailability() throws InterruptedException {
     boolean isDatasetAvailable = false;
     while (!isDatasetAvailable) {
       try {
-        checkpointManager.getCheckpoint(0);
+         for (KafkaLogProcessor processor : messageProcessors) {
+           processor.getCheckPoint(0);
+         }
         isDatasetAvailable = true;
       } catch (Exception e) {
         LOG.warn(String.format("Cannot discover dataset service. Retry after %d seconds timeout.", TIMEOUT_SECONDS));

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/LogSaver.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/LogSaver.java
@@ -19,6 +19,7 @@ package co.cask.cdap.logging.save;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.logging.appender.kafka.KafkaTopic;
 import co.cask.cdap.watchdog.election.PartitionChangeHandler;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.AbstractIdleService;
@@ -90,7 +91,8 @@ public final class LogSaver extends AbstractIdleService implements PartitionChan
     cancelLogCollectorCallbacks();
   }
 
-  private void scheduleTasks(Set<Integer> partitions) throws Exception {
+  @VisibleForTesting
+  void scheduleTasks(Set<Integer> partitions) throws Exception {
     // Don't schedule any tasks when not running
     if (!isRunning()) {
       LOG.info("Not scheduling when stopping!");
@@ -99,7 +101,8 @@ public final class LogSaver extends AbstractIdleService implements PartitionChan
     subscribe(partitions);
  }
 
-  private void unscheduleTasks() throws Exception {
+  @VisibleForTesting
+  void unscheduleTasks() throws Exception {
     for (KafkaLogProcessor processor : messageProcessors) {
       try {
         // Catching the exception to let all the plugins a chance to stop cleanly.

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/save/LogSaverPluginTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/save/LogSaverPluginTest.java
@@ -1,0 +1,476 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.logging.save;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.core.util.StatusPrinter;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.conf.KafkaConstants;
+import co.cask.cdap.common.guice.ConfigModule;
+import co.cask.cdap.common.guice.KafkaClientModule;
+import co.cask.cdap.common.guice.LocationRuntimeModule;
+import co.cask.cdap.common.guice.ZKClientModule;
+import co.cask.cdap.common.logging.ApplicationLoggingContext;
+import co.cask.cdap.common.logging.ComponentLoggingContext;
+import co.cask.cdap.common.logging.LoggingContext;
+import co.cask.cdap.common.logging.LoggingContextAccessor;
+import co.cask.cdap.common.logging.NamespaceLoggingContext;
+import co.cask.cdap.common.logging.ServiceLoggingContext;
+import co.cask.cdap.common.logging.SystemLoggingContext;
+import co.cask.cdap.data.runtime.DataSetsModules;
+import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;
+import co.cask.cdap.logging.KafkaTestBase;
+import co.cask.cdap.logging.LoggingConfiguration;
+import co.cask.cdap.logging.appender.LogAppenderInitializer;
+import co.cask.cdap.logging.appender.kafka.KafkaLogAppender;
+import co.cask.cdap.logging.context.FlowletLoggingContext;
+import co.cask.cdap.logging.filter.Filter;
+import co.cask.cdap.logging.guice.LoggingModules;
+import co.cask.cdap.logging.read.AvroFileReader;
+import co.cask.cdap.logging.read.DistributedLogReader;
+import co.cask.cdap.logging.read.LogEvent;
+import co.cask.cdap.logging.serialize.LogSchema;
+import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
+import co.cask.cdap.test.SlowTests;
+import co.cask.cdap.watchdog.election.MultiLeaderElection;
+import co.cask.tephra.TransactionManager;
+import co.cask.tephra.runtime.TransactionModules;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.google.common.reflect.TypeToken;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.name.Names;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.twill.filesystem.Location;
+import org.apache.twill.filesystem.LocationFactory;
+import org.apache.twill.kafka.client.KafkaClientService;
+import org.apache.twill.zookeeper.ZKClientService;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static co.cask.cdap.logging.appender.LoggingTester.LogCallback;
+
+/**
+ * Test LogSaver plugin.
+ */
+@Category(SlowTests.class)
+public class LogSaverPluginTest extends KafkaTestBase {
+  private static final Logger LOG = LoggerFactory.getLogger(LogSaverTest.class);
+
+  @ClassRule
+  public static TemporaryFolder temporaryFolder = new TemporaryFolder();
+  private static Injector injector;
+  private static TransactionManager txManager;
+  private static String logBaseDir;
+  private static ZKClientService zkClientService;
+  private static KafkaClientService kafkaClientService;
+  private static LogSaver logSaver;
+  private static MultiLeaderElection multiElection;
+  private static String namespaceDir;
+
+  @BeforeClass
+  public static void getInjector() throws IOException {
+    final CConfiguration cConf = CConfiguration.create();
+    cConf.set(Constants.CFG_LOCAL_DATA_DIR, temporaryFolder.newFolder().getAbsolutePath());
+    cConf.set(Constants.Zookeeper.QUORUM, getZkConnectString());
+    cConf.unset(KafkaConstants.ConfigKeys.ZOOKEEPER_NAMESPACE_CONFIG);
+    cConf.set(LoggingConfiguration.KAFKA_SEED_BROKERS, "localhost:" + getKafkaPort());
+    cConf.set(LoggingConfiguration.NUM_PARTITIONS, "2");
+    cConf.set(LoggingConfiguration.KAFKA_PRODUCER_TYPE, "sync");
+    cConf.set(LoggingConfiguration.KAFKA_PROCUDER_BUFFER_MS, "100");
+    cConf.set(LoggingConfiguration.LOG_RETENTION_DURATION_DAYS, "10");
+    cConf.set(LoggingConfiguration.LOG_MAX_FILE_SIZE_BYTES, "10240");
+    cConf.set(LoggingConfiguration.LOG_FILE_SYNC_INTERVAL_BYTES, "5120");
+    cConf.set(LoggingConfiguration.LOG_SAVER_EVENT_BUCKET_INTERVAL_MS, "100");
+    cConf.set(LoggingConfiguration.LOG_SAVER_MAXIMUM_INMEMORY_EVENT_BUCKETS, "2");
+    cConf.set(LoggingConfiguration.LOG_SAVER_TOPIC_WAIT_SLEEP_MS, "10");
+
+    logBaseDir = cConf.get(LoggingConfiguration.LOG_BASE_DIR);
+
+    Configuration hConf = HBaseConfiguration.create();
+
+    injector = Guice.createInjector(
+                          new ConfigModule(cConf, hConf),
+                          new ZKClientModule(),
+                          new KafkaClientModule(),
+                          new LocationRuntimeModule().getInMemoryModules(),
+                          new TransactionModules().getInMemoryModules(),
+                          new DataSetsModules().getInMemoryModules(),
+                          new SystemDatasetRuntimeModule().getInMemoryModules(),
+                          new MetricsClientRuntimeModule().getNoopModules(),
+                          new LoggingModules().getDistributedModules()
+                        );
+    namespaceDir = cConf.get(Constants.Namespace.NAMESPACES_DIR);
+  }
+
+  public void startLogSaver() throws Exception {
+    txManager = injector.getInstance(TransactionManager.class);
+    txManager.startAndWait();
+
+    zkClientService = injector.getInstance(ZKClientService.class);
+    zkClientService.startAndWait();
+
+    kafkaClientService = injector.getInstance(KafkaClientService.class);
+    kafkaClientService.startAndWait();
+
+    logSaver = injector.getInstance(LogSaver.class);
+    logSaver.startAndWait();
+
+    multiElection = new MultiLeaderElection(zkClientService, "log-saver", 2, logSaver);
+    multiElection.setLeaderElectionSleepMs(1);
+    multiElection.startAndWait();
+
+    // Sleep a while to let Kafka server fully initialized.
+    TimeUnit.SECONDS.sleep(5);
+  }
+
+  private void stopLogSaver() {
+    logSaver.stopAndWait();
+    multiElection.stopAndWait();
+    kafkaClientService.stopAndWait();
+    zkClientService.stopAndWait();
+  }
+
+  @Test
+  public void testPlugin() throws Exception {
+
+    // Start the log saver
+    // Publish logs
+    // Reset checkpoint for one of the plugins
+    // Re-process from the reset offset
+    // Verify checkpoints
+
+    startLogSaver();
+    publishLogs();
+
+    LocationFactory locationFactory = injector.getInstance(LocationFactory.class);
+    Location ns1LogBaseDir = locationFactory.create(namespaceDir).append("NS_1").append(logBaseDir);
+    waitTillLogSaverDone(ns1LogBaseDir, "APP_1/flow-FLOW_1/%s", "Test log message 59 arg1 arg2");
+
+    testLogRead(new FlowletLoggingContext("NS_1", "APP_1", "FLOW_1", "", "RUN1", "INSTANCE"));
+
+    LogCallback logCallback = new LogCallback();
+    DistributedLogReader distributedLogReader = injector.getInstance(DistributedLogReader.class);
+    distributedLogReader.getLog(new FlowletLoggingContext("NS_1", "APP_1", "FLOW_1", "", null, "INSTANCE"),
+                                0, Long.MAX_VALUE, Filter.EMPTY_FILTER, logCallback);
+    Assert.assertEquals(60, logCallback.getEvents().size());
+
+    // Reset checkpoint for metrics plugin
+    resetMetricsPluginCheckPoint();
+
+    // reset the logsaver to start reading from reset offset
+    Set<Integer> partitions = Sets.newHashSet(0, 1);
+    logSaver.unscheduleTasks();
+    logSaver.scheduleTasks(partitions);
+
+    waitTillLogSaverDone(ns1LogBaseDir, "APP_1/flow-FLOW_1/%s", "Test log message 59 arg1 arg2");
+    stopLogSaver();
+
+    //Verify that no more records are processed by LogWriter plugin
+    distributedLogReader.getLog(new FlowletLoggingContext("NS_1", "APP_1", "FLOW_1", "", null, "INSTANCE"),
+                                0, Long.MAX_VALUE, Filter.EMPTY_FILTER, logCallback);
+    Assert.assertEquals(60, logCallback.getEvents().size());
+    // Checkpoint should read 60 for both processor
+    verifyCheckpoint();
+  }
+
+  private void resetMetricsPluginCheckPoint() throws Exception {
+    TypeToken token = new TypeToken<Set<KafkaLogProcessor>> () { };
+    Set<KafkaLogProcessor> processors = (Set<KafkaLogProcessor>) injector.getInstance(Key.get(token.getType(),
+                                                                Names.named(Constants.LogSaver.MESSAGE_PROCESSORS)));
+    for (KafkaLogProcessor processor : processors) {
+      if (processor instanceof  LogMetricsPlugin) {
+        LogMetricsPlugin plugin = (LogMetricsPlugin) processor;
+        CheckpointManager manager = plugin.getCheckPointManager();
+        manager.saveCheckpoint(0, 10);
+        Set<Integer> partitions = Sets.newHashSet(0, 1);
+        plugin.init(partitions);
+      }
+    }
+  }
+
+  @AfterClass
+  public static void shutdown() {
+    txManager.stopAndWait();
+  }
+
+  public void verifyCheckpoint() throws Exception {
+    TypeToken token = new TypeToken<Set<KafkaLogProcessor>> () { };
+    Set<KafkaLogProcessor> processors = (Set<KafkaLogProcessor>) injector.getInstance(Key.get(token.getType(),
+                                                               Names.named (Constants.LogSaver.MESSAGE_PROCESSORS)));
+    for (KafkaLogProcessor processor : processors) {
+      CheckpointManager checkpointManager = getCheckPointManager(processor);
+      Assert.assertEquals(60, checkpointManager.getCheckpoint(0));
+    }
+  }
+
+  private static CheckpointManager getCheckPointManager(KafkaLogProcessor processor) {
+    if (processor instanceof KafkaLogWriterPlugin) {
+      KafkaLogWriterPlugin plugin = (KafkaLogWriterPlugin) processor;
+      return plugin.getCheckPointManager();
+    } else if (processor instanceof LogMetricsPlugin) {
+      LogMetricsPlugin plugin = (LogMetricsPlugin) processor;
+      return plugin.getCheckPointManager();
+    }
+    throw new IllegalArgumentException("Invalid processor");
+  }
+
+  private void testLogRead(LoggingContext loggingContext) throws Exception {
+    LOG.info("Verifying logging context {}", loggingContext.getLogPathFragment(logBaseDir));
+    DistributedLogReader distributedLogReader = injector.getInstance(DistributedLogReader.class);
+
+    LogCallback logCallback1 = new LogCallback();
+    distributedLogReader.getLog(loggingContext, 0, Long.MAX_VALUE, Filter.EMPTY_FILTER, logCallback1);
+    List<LogEvent> allEvents = logCallback1.getEvents();
+
+    for (int i = 0; i < 60; ++i) {
+      Assert.assertEquals(String.format("Test log message %d arg1 arg2", i),
+                          allEvents.get(i).getLoggingEvent().getFormattedMessage());
+      if (loggingContext instanceof ServiceLoggingContext) {
+        Assert.assertEquals(
+          loggingContext.getSystemTagsMap().get(SystemLoggingContext.TAG_SYSTEM_ID).getValue(),
+          allEvents.get(i).getLoggingEvent().getMDCPropertyMap().get(SystemLoggingContext.TAG_SYSTEM_ID));
+        Assert.assertEquals(
+          loggingContext.getSystemTagsMap().get(ComponentLoggingContext.TAG_COMPONENT_ID).getValue(),
+          allEvents.get(i).getLoggingEvent().getMDCPropertyMap().get(ComponentLoggingContext.TAG_COMPONENT_ID));
+        Assert.assertEquals(
+          loggingContext.getSystemTagsMap().get(ServiceLoggingContext.TAG_SERVICE_ID).getValue(),
+          allEvents.get(i).getLoggingEvent().getMDCPropertyMap().get(ServiceLoggingContext.TAG_SERVICE_ID));
+      } else {
+        Assert.assertEquals(
+          loggingContext.getSystemTagsMap().get(NamespaceLoggingContext.TAG_NAMESPACE_ID).getValue(),
+          allEvents.get(i).getLoggingEvent().getMDCPropertyMap().get(NamespaceLoggingContext.TAG_NAMESPACE_ID));
+        Assert.assertEquals(
+          loggingContext.getSystemTagsMap().get(ApplicationLoggingContext.TAG_APPLICATION_ID).getValue(),
+          allEvents.get(i).getLoggingEvent().getMDCPropertyMap().get(ApplicationLoggingContext.TAG_APPLICATION_ID));
+        Assert.assertEquals(
+          loggingContext.getSystemTagsMap().get(FlowletLoggingContext.TAG_FLOW_ID).getValue(),
+          allEvents.get(i).getLoggingEvent().getMDCPropertyMap().get(FlowletLoggingContext.TAG_FLOW_ID));
+      }
+    }
+
+    LogCallback logCallback2 = new LogCallback();
+    distributedLogReader.getLog(loggingContext, allEvents.get(10).getLoggingEvent().getTimeStamp(),
+                                allEvents.get(20).getLoggingEvent().getTimeStamp(), Filter.EMPTY_FILTER, logCallback2);
+    List<LogEvent> events = logCallback2.getEvents();
+    Assert.assertEquals(10, events.size());
+    Assert.assertEquals("Test log message 10 arg1 arg2", events.get(0).getLoggingEvent().getFormattedMessage());
+    Assert.assertEquals("Test log message 19 arg1 arg2", events.get(9).getLoggingEvent().getFormattedMessage());
+
+    LogCallback logCallback3 = new LogCallback();
+    distributedLogReader.getLog(loggingContext, allEvents.get(5).getLoggingEvent().getTimeStamp(),
+                                allEvents.get(55).getLoggingEvent().getTimeStamp(), Filter.EMPTY_FILTER, logCallback3);
+    events = logCallback3.getEvents();
+    Assert.assertEquals(50, events.size());
+    Assert.assertEquals("Test log message 5 arg1 arg2", events.get(0).getLoggingEvent().getFormattedMessage());
+    Assert.assertEquals("Test log message 54 arg1 arg2", events.get(49).getLoggingEvent().getFormattedMessage());
+
+    LogCallback logCallback4 = new LogCallback();
+    distributedLogReader.getLog(loggingContext, allEvents.get(30).getLoggingEvent().getTimeStamp(),
+                                allEvents.get(53).getLoggingEvent().getTimeStamp(), Filter.EMPTY_FILTER, logCallback4);
+    events = logCallback4.getEvents();
+    Assert.assertEquals(23, events.size());
+    Assert.assertEquals("Test log message 30 arg1 arg2", events.get(0).getLoggingEvent().getFormattedMessage());
+    Assert.assertEquals("Test log message 52 arg1 arg2", events.get(22).getLoggingEvent().getFormattedMessage());
+
+    LogCallback logCallback5 = new LogCallback();
+    distributedLogReader.getLog(loggingContext, allEvents.get(35).getLoggingEvent().getTimeStamp(),
+                                allEvents.get(38).getLoggingEvent().getTimeStamp(), Filter.EMPTY_FILTER, logCallback5);
+    events = logCallback5.getEvents();
+    Assert.assertEquals(3, events.size());
+    Assert.assertEquals("Test log message 35 arg1 arg2", events.get(0).getLoggingEvent().getFormattedMessage());
+    Assert.assertEquals("Test log message 37 arg1 arg2", events.get(2).getLoggingEvent().getFormattedMessage());
+
+    LogCallback logCallback6 = new LogCallback();
+    distributedLogReader.getLog(loggingContext, allEvents.get(53).getLoggingEvent().getTimeStamp(),
+                                allEvents.get(59).getLoggingEvent().getTimeStamp(), Filter.EMPTY_FILTER, logCallback6);
+    events = logCallback6.getEvents();
+    Assert.assertEquals(6, events.size());
+    Assert.assertEquals("Test log message 53 arg1 arg2", events.get(0).getLoggingEvent().getFormattedMessage());
+    Assert.assertEquals("Test log message 58 arg1 arg2", events.get(5).getLoggingEvent().getFormattedMessage());
+
+    LogCallback logCallback7 = new LogCallback();
+    distributedLogReader.getLog(loggingContext, allEvents.get(59).getLoggingEvent().getTimeStamp(),
+                                allEvents.get(59).getLoggingEvent().getTimeStamp(), Filter.EMPTY_FILTER, logCallback7);
+    events = logCallback7.getEvents();
+    Assert.assertEquals(0, events.size());
+
+    LogCallback logCallback8 = new LogCallback();
+    distributedLogReader.getLog(loggingContext, allEvents.get(0).getLoggingEvent().getTimeStamp(),
+                                allEvents.get(0).getLoggingEvent().getTimeStamp(), Filter.EMPTY_FILTER, logCallback8);
+    events = logCallback8.getEvents();
+    Assert.assertEquals(0, events.size());
+
+    LogCallback logCallback9 = new LogCallback();
+    distributedLogReader.getLog(loggingContext, allEvents.get(20).getLoggingEvent().getTimeStamp(),
+                                allEvents.get(20).getLoggingEvent().getTimeStamp(), Filter.EMPTY_FILTER, logCallback9);
+    events = logCallback9.getEvents();
+    Assert.assertEquals(0, events.size());
+
+    LogCallback logCallback10 = new LogCallback();
+    distributedLogReader.getLog(loggingContext, allEvents.get(32).getLoggingEvent().getTimeStamp() - 999999,
+                                allEvents.get(45).getLoggingEvent().getTimeStamp(), Filter.EMPTY_FILTER, logCallback10);
+    events = logCallback10.getEvents();
+    Assert.assertTrue(events.size() > 13);
+    Assert.assertEquals("Test log message 32 arg1 arg2",
+                        events.get(events.size() - 13).getLoggingEvent().getFormattedMessage());
+    Assert.assertEquals("Test log message 44 arg1 arg2",
+                        events.get(events.size() - 1).getLoggingEvent().getFormattedMessage());
+
+    LogCallback logCallback11 = new LogCallback();
+    distributedLogReader.getLog(loggingContext, allEvents.get(18).getLoggingEvent().getTimeStamp(),
+                                allEvents.get(34).getLoggingEvent().getTimeStamp() + 999999,
+                                Filter.EMPTY_FILTER, logCallback11);
+    events = logCallback11.getEvents();
+    Assert.assertTrue(events.size() > 16);
+    Assert.assertEquals("Test log message 18 arg1 arg2", events.get(0).getLoggingEvent().getFormattedMessage());
+    Assert.assertEquals("Test log message 33 arg1 arg2",
+                        events.get(events.size() - 1 - (events.size() - 16)).getLoggingEvent().getFormattedMessage());
+  }
+
+  private void publishLogs() throws Exception {
+    KafkaLogAppender appender = injector.getInstance(KafkaLogAppender.class);
+    new LogAppenderInitializer(appender).initialize("LogSaverTest");
+
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    StatusPrinter.setPrintStream(new PrintStream(bos));
+    StatusPrinter.print((LoggerContext) LoggerFactory.getILoggerFactory());
+
+    ListeningExecutorService executor = MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(3));
+    List<ListenableFuture<?>> futures = Lists.newArrayList();
+    futures.add(executor.submit(new LogPublisher(0, new FlowletLoggingContext("NS_1", "APP_1", "FLOW_1", "FLOWLET_1",
+                                                                              "RUN1", "INSTANCE1"))));
+    Futures.allAsList(futures).get();
+    appender.stop();
+  }
+
+  private static class LogPublisher implements Runnable {
+    private final int startIndex;
+    private final LoggingContext loggingContext;
+
+    private LogPublisher(int startIndex, LoggingContext loggingContext) {
+      this.startIndex = startIndex;
+      this.loggingContext = loggingContext;
+    }
+
+    @Override
+    public void run() {
+      LoggingContextAccessor.setLoggingContext(loggingContext);
+
+      Logger logger = LoggerFactory.getLogger("LogSaverTest");
+      Exception e1 = new Exception("Test Exception1");
+      Exception e2 = new Exception("Test Exception2", e1);
+
+      int startBatch = startIndex / 10;
+      try {
+        for (int j = startBatch; j < startBatch + 6; ++j) {
+          for (int i = 0; i < 10; ++i) {
+            logger.warn("Test log message " + (10 * j + i) + " {} {}", "arg1", "arg2", e2);
+            if (j == startIndex && (i <= 3)) {
+              // For some events introduce the sleep of more than 8 seconds for windowing to take effect
+              TimeUnit.MILLISECONDS.sleep(300);
+            } else {
+              TimeUnit.MILLISECONDS.sleep(1);
+            }
+          }
+          TimeUnit.MILLISECONDS.sleep(1200);
+        }
+      } catch (InterruptedException e) {
+        e.printStackTrace();
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+
+  private static void waitTillLogSaverDone(Location logBaseDir, String filePattern, String logLine) throws Exception {
+    long start = System.currentTimeMillis();
+
+    while (true) {
+      Location latestFile = getLatestFile(logBaseDir, filePattern);
+      if (latestFile != null) {
+        AvroFileReader logReader = new AvroFileReader(new LogSchema().getAvroSchema());
+        LogCallback logCallback = new LogCallback();
+        logCallback.init();
+        logReader.readLog(latestFile, Filter.EMPTY_FILTER, 0, Long.MAX_VALUE, Integer.MAX_VALUE, logCallback);
+        logCallback.close();
+        List<LogEvent> events = logCallback.getEvents();
+        if (events.size() > 0) {
+          LogEvent event = events.get(events.size() - 1);
+          System.out.println(event.getLoggingEvent().getFormattedMessage());
+          if (event.getLoggingEvent().getFormattedMessage().equals(logLine)) {
+            break;
+          }
+        }
+      }
+
+      Assert.assertTrue("Time exceeded", System.currentTimeMillis() - start < 30 * 1000);
+      TimeUnit.MILLISECONDS.sleep(30);
+    }
+
+    LOG.info("Done waiting!");
+    TimeUnit.SECONDS.sleep(1);
+  }
+
+  private static Location getLatestFile(Location logBaseDir, String filePattern) throws Exception {
+    String date = new SimpleDateFormat("yyyy-MM-dd").format(new Date());
+    Location dir = logBaseDir.append(String.format(filePattern, date));
+
+    if (!dir.exists()) {
+      return null;
+    }
+
+    List<Location> files = dir.list();
+    if (files.isEmpty()) {
+      return null;
+    }
+
+    SortedMap<Long, Location> map = Maps.newTreeMap();
+    for (Location file : files) {
+      String filename = FilenameUtils.getBaseName(file.getName());
+      map.put(Long.parseLong(filename), file);
+    }
+    return map.get(map.lastKey());
+  }
+}

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/save/LogSaverTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/save/LogSaverTest.java
@@ -45,18 +45,22 @@ import co.cask.cdap.logging.read.AvroFileReader;
 import co.cask.cdap.logging.read.DistributedLogReader;
 import co.cask.cdap.logging.read.LogEvent;
 import co.cask.cdap.logging.serialize.LogSchema;
+import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
 import co.cask.cdap.test.SlowTests;
 import co.cask.cdap.watchdog.election.MultiLeaderElection;
 import co.cask.tephra.TransactionManager;
 import co.cask.tephra.runtime.TransactionModules;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.reflect.TypeToken;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.name.Names;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseConfiguration;
@@ -79,6 +83,7 @@ import java.io.PrintStream;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
+import java.util.Set;
 import java.util.SortedMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -126,6 +131,7 @@ public class LogSaverTest extends KafkaTestBase {
       new TransactionModules().getInMemoryModules(),
       new DataSetsModules().getInMemoryModules(),
       new SystemDatasetRuntimeModule().getInMemoryModules(),
+      new MetricsClientRuntimeModule().getNoopModules(),
       new LoggingModules().getDistributedModules()
     );
 
@@ -170,12 +176,29 @@ public class LogSaverTest extends KafkaTestBase {
 
   @AfterClass
   public static void testCheckpoint() throws Exception {
-    CheckpointManager checkpointManager = injector.getInstance(CheckpointManager.class);
-    Assert.assertEquals(180, checkpointManager.getCheckpoint(0));
-    Assert.assertEquals(120, checkpointManager.getCheckpoint(1));
 
+    TypeToken token = new TypeToken<Set<KafkaLogProcessor>> () { };
+    Set<KafkaLogProcessor> processors = (Set<KafkaLogProcessor>) injector.getInstance(Key.get(token.getType(),
+                                         Names.named (Constants.LogSaver.MESSAGE_PROCESSORS)));
+    for (KafkaLogProcessor processor : processors) {
+      CheckpointManager checkpointManager = getCheckPointManager(processor);
+      Assert.assertEquals(180, checkpointManager.getCheckpoint(0));
+      Assert.assertEquals(120, checkpointManager.getCheckpoint(1));
+    }
     txManager.stopAndWait();
   }
+
+  private static CheckpointManager getCheckPointManager(KafkaLogProcessor processor) {
+    if (processor instanceof KafkaLogWriterPlugin) {
+      KafkaLogWriterPlugin plugin = (KafkaLogWriterPlugin) processor;
+      return plugin.getCheckPointManager();
+    } else if (processor instanceof LogMetricsPlugin) {
+      LogMetricsPlugin plugin = (LogMetricsPlugin) processor;
+      return plugin.getCheckPointManager();
+    }
+    throw new IllegalArgumentException("Invalid processor");
+  }
+
 
   @Test
   public void testLogRead1() throws Exception {
@@ -187,6 +210,8 @@ public class LogSaverTest extends KafkaTestBase {
     distributedLogReader.getLog(new FlowletLoggingContext("NS_1", "APP_1", "FLOW_1", "", null, "INSTANCE"),
       0, Long.MAX_VALUE, Filter.EMPTY_FILTER, logCallback);
     Assert.assertEquals(120, logCallback.getEvents().size());
+
+
   }
 
   @Test


### PR DESCRIPTION
CDAP Dashboard needs to surface System and application error rates (https://issues.cask.co/browse/CDAP-2079). The approach for getting the metrics involves extracting the log level from the logging context in the log-saver system component and emitting the metrics for various log levels. 

- [x] Add the metrics plugin to emit metrics

Related and previously completed PR: https://github.com/caskdata/cdap/pull/2002