### PR TITLE
CDAP-1966: first part: transformation from StructuredRecord to CubeFact

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/cube/CubeFact.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/cube/CubeFact.java
@@ -83,6 +83,16 @@ public class CubeFact {
   }
 
   /**
+   * Adds a {@link Measurement} to this {@link CubeFact}.
+   * @param measurement a {@link Measurement} to add
+   * @return this {@link CubeFact}
+   */
+  public CubeFact addMeasurement(Measurement measurement) {
+    measurements.add(measurement);
+    return this;
+  }
+
+  /**
    * Adds multiple {@link Measurement}s to this {@link CubeFact}
    * @param measurements {@link Measurement}s to add
    * @return this {@link CubeFact}

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/transforms/StructuredRecordToCubeFactTransform.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/transforms/StructuredRecordToCubeFactTransform.java
@@ -1,0 +1,391 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.templates.etl.transforms;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.dataset.lib.cube.CubeFact;
+import co.cask.cdap.api.dataset.lib.cube.MeasureType;
+import co.cask.cdap.api.dataset.lib.cube.Measurement;
+import co.cask.cdap.templates.etl.api.Emitter;
+import co.cask.cdap.templates.etl.api.Property;
+import co.cask.cdap.templates.etl.api.StageConfigurer;
+import co.cask.cdap.templates.etl.api.Transform;
+import co.cask.cdap.templates.etl.api.TransformContext;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.gson.Gson;
+
+import java.nio.ByteBuffer;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Collection;
+import javax.annotation.Nullable;
+
+/**
+ * Transforms a {@link StructuredRecord} into a {@link CubeFact} object that can be written to a
+ * {@link co.cask.cdap.api.dataset.lib.cube.Cube} dataset.
+ * <p/>
+ * This transformation requires a configuration for mapping {@link StructuredRecord} into a {@link CubeFact} that is
+ * provided in JSON form in {@link #MAPPING_CONFIG_PROPERTY} property. Example of the configuration:
+<pre>
+  {
+    timestamp: {
+      sourceField: "timeField",
+      sourceFieldFormat: "HH:mm:ss"
+    }
+
+    tags: [
+      {
+        name: "tag1",
+        sourceField: "field1"
+      },
+      {
+        name: "tag2",
+        value: "staticValue"
+      }
+    ],
+
+    measurements: [
+      {
+        name: "metric1",
+        type: "COUNTER",
+        sourceField: "field7"
+      },
+      {
+        name: "metric2",
+        type: "GAUGE",
+        sourceField: "field7"
+      },
+      {
+        name: "metric3",
+        type: "COUNTER",
+        value: "1"
+      },
+    ],
+  }
+</pre>
+ *
+ * In general, the value for a timestamp, tag or measurement fields can be retrieved from {@link StructuredRecord}
+ * field using 'srcField' property or set to a fixed value using 'value' property. If both are specified, then the one
+ * in 'value' is used as the default when 'srcField' is not present in {@link StructuredRecord}.
+ *
+ * <h3>Special cases</h3>
+ * <p/>
+ * Timestamp is either retrieved from the record field or is set to a current ts (at processing) is used.
+ * If record field is used, either dateFormat is used to parse the value, or it is assumed as epoch in ms.
+ * To use current ts, configure it the following way:
+ *
+<pre>
+  {
+    timestamp: {
+      value: "now"
+    },
+    ...
+  }
+ </pre>
+ *
+ * <p/>
+ * Measurement type (specified in 'type' property) can be one of {@link MeasureType} values.
+ *
+ */
+public class StructuredRecordToCubeFactTransform extends Transform<StructuredRecord, CubeFact> {
+  public static final String MAPPING_CONFIG_PROPERTY = "mapping.config";
+
+  private CubeFactBuilder factBuilder;
+
+  @Override
+  public void configure(StageConfigurer configurer) {
+    configurer.setName(StructuredRecordToCubeFactTransform.class.getSimpleName());
+    configurer.setDescription("Transforms a StructuredRecord to a CubeFact object used to write to a Cube.");
+    configurer.addProperty(new Property(MAPPING_CONFIG_PROPERTY,
+                                        "the StructuredRecord to CubeFact mapping configuration " +
+                                          "(see StructuredRecordToCubeFactTransform javadoc for detailed description).",
+                                        true));
+  }
+
+  @Override
+  public void initialize(TransformContext context) {
+    String configAsString = context.getRuntimeArguments().get(MAPPING_CONFIG_PROPERTY);
+    Preconditions.checkArgument(configAsString != null && !configAsString.isEmpty(),
+                                "the mapping config must be given");
+    MappingConfig config = new Gson().fromJson(configAsString, MappingConfig.class);
+    factBuilder = new CubeFactBuilder(config);
+  }
+
+  @Override
+  public void transform(StructuredRecord record,
+                        Emitter<CubeFact> emitter) throws Exception {
+    Schema recordSchema = record.getSchema();
+    Preconditions.checkArgument(recordSchema.getType() == Schema.Type.RECORD, "input must be a record.");
+    emitter.emit(factBuilder.build(record));
+  }
+
+  private static final class CubeFactBuilder {
+    private final TimestampResolver timestampResolver;
+    private final Collection<TagValueResolver> tagResolvers;
+    private final Collection<MeasurementResolver> measurementResolvers;
+
+    public CubeFactBuilder(MappingConfig config) {
+      this.timestampResolver = new TimestampResolver(config.timestamp);
+      if (config.tags == null) {
+        throw new IllegalArgumentException("Missing required 'tags' configuration: " + config);
+      }
+      this.tagResolvers = Lists.newArrayList();
+      for (ValueMapping mapping : config.tags) {
+        tagResolvers.add(new TagValueResolver(mapping));
+      }
+      if (config.measurements == null) {
+        throw new IllegalArgumentException("Missing required 'measurements' configuration: " + config);
+      }
+      this.measurementResolvers = Lists.newArrayList();
+      for (ValueMapping mapping : config.measurements) {
+        measurementResolvers.add(new MeasurementResolver(mapping));
+      }
+    }
+
+    public CubeFact build(StructuredRecord record) {
+      CubeFact fact = new CubeFact(timestampResolver.getTimestamp(record));
+      for (TagValueResolver resolver : tagResolvers) {
+        String value = resolver.getValue(record);
+        if (value != null) {
+          fact.addTag(resolver.getName(), value);
+        }
+      }
+      for (MeasurementResolver resolver : measurementResolvers) {
+        Measurement measurement = resolver.getMeasurement(record);
+        if (measurement != null) {
+          fact.addMeasurement(measurement);
+        }
+      }
+      return fact;
+    }
+  }
+
+  private static final class TimestampResolver {
+    private String srcField;
+    private DateFormat dateFormat;
+
+    public TimestampResolver(ValueMapping valueMapping) {
+      if (valueMapping == null) {
+        throw new IllegalArgumentException("Missing required configuration for CubeFact timestamp.");
+      }
+      // Timestamp is either retrieved from the record field or current ts (at processing) is used.
+      // If record field is used, either dateFormat is used to parse the value, or it is assumed as epoch in ms
+      if (valueMapping.sourceField != null) {
+        this.srcField = valueMapping.sourceField;
+        if (valueMapping.sourceFieldFormat != null) {
+          this.dateFormat = new SimpleDateFormat(valueMapping.sourceFieldFormat);
+        }
+      } else if (!"now".equals(valueMapping.value)) {
+        throw new IllegalArgumentException("Invalid configuration for CubeFact timestamp: " + valueMapping);
+      }
+    }
+
+    public long getTimestamp(StructuredRecord record) {
+      if (srcField == null) {
+        return System.currentTimeMillis();
+      }
+      Object val = record.get(srcField);
+      if (val == null) {
+        throw new IllegalArgumentException("Required field to determine timestamp is missing: " + srcField);
+      }
+      String valAsString = val.toString();
+      if (dateFormat != null) {
+        try {
+          return dateFormat.parse(valAsString).getTime();
+        } catch (ParseException e) {
+          throw new IllegalArgumentException("Cannot parse field value to determine timestamp: " + valAsString, e);
+        }
+      }
+      return Long.valueOf(valAsString);
+    }
+  }
+
+  private static class TagValueResolver {
+    protected String name;
+    protected String srcField;
+    protected String value;
+
+    public TagValueResolver(ValueMapping valueMapping) {
+      if (valueMapping.name == null) {
+        throw new IllegalArgumentException("Required 'name' of a tag is missing in CubeFact mapping config: " +
+                                             valueMapping);
+      }
+      this.name = valueMapping.name;
+      // The value is either retrieved from record field or set as static value.
+      if (valueMapping.sourceField != null) {
+        this.srcField = valueMapping.sourceField;
+      } else if (valueMapping.value == null) {
+        throw new IllegalArgumentException("Either 'value' or 'sourceField' must be specified for tag: " +
+                                             valueMapping);
+      }
+      this.value = valueMapping.value;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    @Nullable
+    public String getValue(StructuredRecord record) {
+      if (srcField == null) {
+        return value;
+      }
+      Object val = record.get(srcField);
+      if (val != null) {
+        Schema recordSchema = record.getSchema();
+        Schema.Field field = recordSchema.getField(srcField);
+        Schema.Type type = validateAndGetType(field);
+        String tagValue;
+        switch (type) {
+          case BYTES:
+            if (val instanceof ByteBuffer) {
+              tagValue = Bytes.toString((ByteBuffer) val);
+            } else {
+              tagValue = Bytes.toStringBinary((byte[]) val);
+            }
+            break;
+          default:
+            tagValue = val.toString();
+        }
+
+        return tagValue;
+      }
+      // value is default if srcField is missing
+      if (value != null) {
+        return value;
+      }
+
+      return null;
+    }
+  }
+
+  private static Schema.Type validateAndGetType(Schema.Field field) {
+    Schema.Type type;
+    if (field.getSchema().isNullable()) {
+      type = field.getSchema().getNonNullable().getType();
+    } else {
+      type = field.getSchema().getType();
+    }
+    Preconditions.checkArgument(type.isSimpleType(),
+                                "only simple types are supported (boolean, int, long, float, double, bytes).");
+    return type;
+  }
+
+  private static final class MeasurementResolver {
+    private String name;
+    private MeasureType type;
+    private String srcField;
+    private Long value;
+
+    public MeasurementResolver(ValueMapping valueMapping) {
+      if (valueMapping.name == null) {
+        throw new IllegalArgumentException("Required 'name' of a measurement is missing in CubeFact mapping config: " +
+                                             valueMapping);
+      }
+      this.name = valueMapping.name;
+      // The value is either retrieved from record field or set as static value.
+      if (valueMapping.sourceField != null) {
+        this.srcField = valueMapping.sourceField;
+      } else if (valueMapping.value == null) {
+        throw new IllegalArgumentException("Either 'value' or 'sourceField' must be specified for measurement" +
+                                             valueMapping);
+      }
+      if (valueMapping.type == null) {
+        throw new IllegalArgumentException("Required 'type' value is missing in CubeFact measurement mapping config: " +
+                                             valueMapping);
+      }
+      this.type = MeasureType.valueOf(valueMapping.type);
+      try {
+        this.value = valueMapping.value == null ? null : Long.valueOf(valueMapping.value);
+      } catch (NumberFormatException e) {
+        throw new IllegalArgumentException("Cannot parse 'value' of a measurement as long: " + valueMapping.value);
+      }
+    }
+
+    @Nullable
+    public Measurement getMeasurement(StructuredRecord record) {
+      Long value = getValue(record);
+      if (value == null) {
+        return null;
+      }
+      return new Measurement(name, type, value);
+    }
+
+    private Long getValue(StructuredRecord record) {
+      if (srcField == null) {
+        return value;
+      }
+      Object val = record.get(srcField);
+      if (val != null) {
+        return Double.valueOf(val.toString()).longValue();
+      }
+      // value is default if srcField is missing
+      if (value != null) {
+        return value;
+      }
+
+      return null;
+    }
+  }
+
+  // This class is needed to help with JSON serde
+  @SuppressWarnings("unused")
+  static final class MappingConfig {
+    ValueMapping timestamp;
+    ValueMapping[] tags;
+    ValueMapping[] measurements;
+
+    @Override
+    public String toString() {
+      final StringBuilder sb = new StringBuilder();
+      sb.append("MappingConfig");
+      sb.append("{timestamp=").append(timestamp);
+      sb.append(", tags=").append(tags == null ? "null" : Arrays.asList(tags).toString());
+      sb.append(", measurements=").append(measurements == null ? "null" : Arrays.asList(measurements).toString());
+      sb.append('}');
+      return sb.toString();
+    }
+  }
+
+  // This class is needed to help with JSON serde
+  @SuppressWarnings("unused")
+  static final class ValueMapping {
+    String name;
+    String type;
+    String value;
+    String sourceField;
+    String sourceFieldFormat;
+
+    @Override
+    public String toString() {
+      final StringBuilder sb = new StringBuilder();
+      sb.append("ValueMapping");
+      sb.append("{name='").append(name).append('\'');
+      sb.append(", type='").append(type).append('\'');
+      sb.append(", value='").append(value).append('\'');
+      sb.append(", sourceField='").append(sourceField).append('\'');
+      sb.append(", sourceFieldFormat='").append(sourceFieldFormat).append('\'');
+      sb.append('}');
+      return sb.toString();
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/templates/etl/transforms/StructuredRecordToCubeFactTransformTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/templates/etl/transforms/StructuredRecordToCubeFactTransformTest.java
@@ -1,0 +1,323 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.templates.etl.transforms;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.dataset.lib.cube.CubeFact;
+import co.cask.cdap.api.dataset.lib.cube.MeasureType;
+import co.cask.cdap.api.dataset.lib.cube.Measurement;
+import co.cask.cdap.templates.etl.api.Transform;
+import co.cask.cdap.templates.etl.api.TransformContext;
+import co.cask.cdap.templates.etl.common.MockEmitter;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.text.SimpleDateFormat;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 
+ */
+@SuppressWarnings("unchecked")
+public class StructuredRecordToCubeFactTransformTest {
+
+  private static final String DATE_FORMAT = "yyyy:MM:dd-HH:mm:ss Z";
+
+  @Test
+  public void testInvalidConfiguration() throws Exception {
+    // no config
+    verifyInvalidConfigDetected(null);
+    // empty
+    verifyInvalidConfigDetected(new StructuredRecordToCubeFactTransform.MappingConfig());
+
+    // bad timestamp
+    StructuredRecordToCubeFactTransform.MappingConfig config = createValidConfig();
+    config.timestamp = null;
+    verifyInvalidConfigDetected(config);
+
+    config = createValidConfig();
+    config.timestamp.sourceField = null;
+    verifyInvalidConfigDetected(config);
+
+    config = createValidConfig();
+    config.timestamp.sourceField = null;
+    config.timestamp.value = "not_now";
+    verifyInvalidConfigDetected(config);
+
+    // bad tags
+    config = createValidConfig();
+    config.tags = null;
+    verifyInvalidConfigDetected(config);
+
+    config = createValidConfig();
+    config.tags[0].name = null;
+    verifyInvalidConfigDetected(config);
+
+    config = createValidConfig();
+    config.tags[0].sourceField = null;
+    verifyInvalidConfigDetected(config);
+
+    // bad measurements
+    config = createValidConfig();
+    config.measurements = null;
+    verifyInvalidConfigDetected(config);
+
+    config = createValidConfig();
+    config.measurements[0].name = null;
+    verifyInvalidConfigDetected(config);
+
+    config = createValidConfig();
+    config.measurements[0].type = null;
+    verifyInvalidConfigDetected(config);
+
+    config = createValidConfig();
+    config.measurements[0].sourceField = null;
+    verifyInvalidConfigDetected(config);
+
+    config = createValidConfig();
+    config.measurements[0].sourceField = null;
+    config.measurements[0].value = "not_long";
+    verifyInvalidConfigDetected(config);
+
+    config = createValidConfig();
+    config.measurements[0].value = "not_long";
+    verifyInvalidConfigDetected(config);
+  }
+
+  @Test
+  public void testTransform() throws Exception {
+    // initialize the transform
+    Transform transform = new StructuredRecordToCubeFactTransform();
+    TransformContext context = new MockTransformContext(
+      ImmutableMap.of(StructuredRecordToCubeFactTransform.MAPPING_CONFIG_PROPERTY,
+                      new Gson().toJson(createValidConfig())));
+    transform.initialize(context);
+
+    Schema schema = Schema.recordOf(
+      "record",
+      Schema.Field.of("tsField", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
+      Schema.Field.of("tagField1", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
+      Schema.Field.of("tagField3", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
+      Schema.Field.of("boolField", Schema.nullableOf(Schema.of(Schema.Type.BOOLEAN))),
+      Schema.Field.of("intField", Schema.nullableOf(Schema.of(Schema.Type.INT))),
+      Schema.Field.of("longField", Schema.nullableOf(Schema.of(Schema.Type.LONG))),
+      Schema.Field.of("floatField", Schema.nullableOf(Schema.of(Schema.Type.FLOAT))),
+      Schema.Field.of("bytesField", Schema.nullableOf(Schema.of(Schema.Type.BYTES))),
+      Schema.Field.of("metricField1", Schema.nullableOf(Schema.of(Schema.Type.STRING))));
+
+    // 1. All values are there in fields
+
+    long ts = System.currentTimeMillis();
+    StructuredRecord record = StructuredRecord.builder(schema)
+        .set("tsField", new SimpleDateFormat(DATE_FORMAT).format(new Date(ts)))
+        .set("tagField1", "tagVal1")
+        .set("tagField3", "tagVal3")
+        .set("boolField", true)
+        .set("intField", 5)
+        .set("longField", 10L)
+        .set("floatField", 3.14f)
+        .set("bytesField", Bytes.toBytes("foo"))
+        .set("metricField1", "15")
+        .build();
+
+    MockEmitter<CubeFact> emitter = new MockEmitter<CubeFact>();
+    transform.transform(record, emitter);
+
+    CubeFact transformed = emitter.getEmitted().get(0);
+    // note: our date format doesn't include millis
+    Assert.assertEquals(ts / 1000 * 1000, transformed.getTimestamp());
+
+    Map<String, String> tags = transformed.getTags();
+    Assert.assertEquals(7, tags.size());
+    Assert.assertEquals("tagVal1", tags.get("tag1"));
+    Assert.assertEquals("value2", tags.get("tag2"));
+    Assert.assertEquals("tagVal3", tags.get("tag3"));
+    Assert.assertEquals("true", tags.get("boolTag"));
+    Assert.assertEquals("5", tags.get("intTag"));
+    Assert.assertTrue(Math.abs(3.14f - Float.valueOf(tags.get("floatTag"))) < 0.000001);
+    Assert.assertEquals(Bytes.toStringBinary(Bytes.toBytes("foo")), tags.get("bytesTag"));
+
+    Collection<Measurement> expectedMeasurements = ImmutableList.of(
+      new Measurement("metric1", MeasureType.COUNTER, 15),
+      new Measurement("metric2", MeasureType.COUNTER, 55),
+      new Measurement("intMetric", MeasureType.GAUGE, 5),
+      new Measurement("longMetric", MeasureType.COUNTER, 10),
+      new Measurement("floatMetric", MeasureType.GAUGE, 3)
+    );
+
+    verifyMeasurements(expectedMeasurements, transformed.getMeasurements());
+
+    // 2. Not all values are there, validate fallback to defaults and alternative timestamp retrieval
+
+    transform = new StructuredRecordToCubeFactTransform();
+    StructuredRecordToCubeFactTransform.MappingConfig config = createValidConfig();
+    config.timestamp.sourceField = null;
+    config.timestamp.sourceFieldFormat = null;
+    config.timestamp.value = "now";
+    context = new MockTransformContext(ImmutableMap.of(StructuredRecordToCubeFactTransform.MAPPING_CONFIG_PROPERTY,
+                                                       new Gson().toJson(config)));
+    transform.initialize(context);
+
+    long tsStart = System.currentTimeMillis();
+    record = StructuredRecord.builder(schema)
+      .set("tsField", new SimpleDateFormat(DATE_FORMAT).format(new Date(ts)))
+      .set("tagField1", "tagVal1")
+      .set("boolField", true)
+      .set("longField", 10L)
+      .set("floatField", 3.14f)
+      .set("bytesField", Bytes.toBytes("foo"))
+      .set("metricField1", "15")
+      .build();
+
+    emitter = new MockEmitter<CubeFact>();
+    transform.transform(record, emitter);
+
+    long tsEnd = System.currentTimeMillis();
+
+    transformed = emitter.getEmitted().get(0);
+    // note: our date format doesn't include millis
+    // verify that assigned ts was current ts
+    Assert.assertTrue(tsStart / 1000 * 1000 <= transformed.getTimestamp());
+    Assert.assertTrue(1000 + tsEnd / 1000 * 1000 >= transformed.getTimestamp());
+
+    tags = transformed.getTags();
+    Assert.assertEquals(6, tags.size());
+    Assert.assertEquals("tagVal1", tags.get("tag1"));
+    Assert.assertEquals("value2", tags.get("tag2"));
+    Assert.assertEquals("defaultTagVal3", tags.get("tag3"));
+    Assert.assertEquals("true", tags.get("boolTag"));
+    Assert.assertTrue(Math.abs(3.14f - Float.valueOf(tags.get("floatTag"))) < 0.000001);
+    Assert.assertEquals(Bytes.toStringBinary(Bytes.toBytes("foo")), tags.get("bytesTag"));
+
+    expectedMeasurements = ImmutableList.of(
+      new Measurement("metric1", MeasureType.COUNTER, 15),
+      new Measurement("metric2", MeasureType.COUNTER, 55),
+      new Measurement("intMetric", MeasureType.GAUGE, 66),
+      new Measurement("longMetric", MeasureType.COUNTER, 10),
+      new Measurement("floatMetric", MeasureType.GAUGE, 3)
+    );
+
+    verifyMeasurements(expectedMeasurements, transformed.getMeasurements());
+
+  }
+
+  private StructuredRecordToCubeFactTransform.MappingConfig createValidConfig() {
+    StructuredRecordToCubeFactTransform.MappingConfig config = new StructuredRecordToCubeFactTransform.MappingConfig();
+    config.timestamp = new StructuredRecordToCubeFactTransform.ValueMapping();
+    config.timestamp.sourceField = "tsField";
+    config.timestamp.sourceFieldFormat = DATE_FORMAT;
+
+    config.tags = new StructuredRecordToCubeFactTransform.ValueMapping[7];
+    config.tags[0] = new StructuredRecordToCubeFactTransform.ValueMapping();
+    config.tags[0].name = "tag1";
+    config.tags[0].sourceField = "tagField1";
+
+    config.tags[1] = new StructuredRecordToCubeFactTransform.ValueMapping();
+    config.tags[1].name = "tag2";
+    config.tags[1].value = "value2";
+
+    config.tags[2] = new StructuredRecordToCubeFactTransform.ValueMapping();
+    config.tags[2].name = "tag3";
+    config.tags[2].sourceField = "tagField3";
+    config.tags[2].value = "defaultTagVal3";
+
+    config.tags[3] = new StructuredRecordToCubeFactTransform.ValueMapping();
+    config.tags[3].name = "boolTag";
+    config.tags[3].sourceField = "boolField";
+
+    config.tags[4] = new StructuredRecordToCubeFactTransform.ValueMapping();
+    config.tags[4].name = "intTag";
+    config.tags[4].sourceField = "intField";
+
+    config.tags[5] = new StructuredRecordToCubeFactTransform.ValueMapping();
+    config.tags[5].name = "floatTag";
+    config.tags[5].sourceField = "floatField";
+
+    config.tags[6] = new StructuredRecordToCubeFactTransform.ValueMapping();
+    config.tags[6].name = "bytesTag";
+    config.tags[6].sourceField = "bytesField";
+
+    config.measurements = new StructuredRecordToCubeFactTransform.ValueMapping[5];
+    config.measurements[0] = new StructuredRecordToCubeFactTransform.ValueMapping();
+    config.measurements[0].name = "metric1";
+    config.measurements[0].type = "COUNTER";
+    config.measurements[0].sourceField = "metricField1";
+
+    config.measurements[1] = new StructuredRecordToCubeFactTransform.ValueMapping();
+    config.measurements[1].name = "metric2";
+    config.measurements[1].type = "COUNTER";
+    config.measurements[1].value = "55";
+
+    config.measurements[2] = new StructuredRecordToCubeFactTransform.ValueMapping();
+    config.measurements[2].name = "intMetric";
+    config.measurements[2].type = "GAUGE";
+    config.measurements[2].sourceField = "intField";
+    config.measurements[2].value = "66";
+
+    config.measurements[3] = new StructuredRecordToCubeFactTransform.ValueMapping();
+    config.measurements[3].name = "longMetric";
+    config.measurements[3].type = "COUNTER";
+    config.measurements[3].sourceField = "longField";
+
+    config.measurements[4] = new StructuredRecordToCubeFactTransform.ValueMapping();
+    config.measurements[4].name = "floatMetric";
+    config.measurements[4].type = "GAUGE";
+    config.measurements[4].sourceField = "floatField";
+
+    return config;
+  }
+
+  private void verifyInvalidConfigDetected(StructuredRecordToCubeFactTransform.MappingConfig config) {
+    Transform transform = new StructuredRecordToCubeFactTransform();
+    TransformContext context =
+      new MockTransformContext(config == null ? new HashMap<String, String>() :
+                                 ImmutableMap.of(StructuredRecordToCubeFactTransform.MAPPING_CONFIG_PROPERTY,
+                                                 new Gson().toJson(config)));
+    try {
+      transform.initialize(context);
+      Assert.fail("IllegalArgumentException is expected to be thrown on invalid config");
+    } catch (IllegalArgumentException e) {
+      // Expected
+    }
+  }
+
+  private void verifyMeasurements(Collection<Measurement> expected, Collection<Measurement> toCompare) {
+    Assert.assertEquals(expected.size(), toCompare.size());
+    for (Measurement measurement : expected) {
+      verifyContainsMeasurement(measurement, toCompare);
+    }
+  }
+
+  private void verifyContainsMeasurement(Measurement expected, Collection<Measurement> toCompare) {
+    for (Measurement measurement : toCompare) {
+      if (expected.getName().equals(measurement.getName())) {
+        Assert.assertEquals(expected.getType(), measurement.getType());
+        Assert.assertEquals(expected.getValue(), measurement.getValue());
+        return;
+      }
+    }
+    Assert.fail("Expected measurement not found: " + expected.getName());
+  }
+}


### PR DESCRIPTION
Second part will be the Cube dataset sink.

In the end, these two will likely to merge into one, as the new idea is for sink to accept StructuredRecord to ease its usage. For now, it is separate transform to be consistent with other similar sink cases.