### PR TITLE
(CDAP-2148) Make adapter service thread-safe

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/AdapterService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/AdapterService.java
@@ -82,11 +82,13 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.Reader;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
 
 /**
@@ -104,9 +106,9 @@ public class AdapterService extends AbstractIdleService {
   private final PropertiesResolver resolver;
   private final NamespacedLocationFactory namespacedLocationFactory;
   // template name to template info mapping
-  private Map<String, ApplicationTemplateInfo> appTemplateInfos;
+  private final AtomicReference<Map<String, ApplicationTemplateInfo>> appTemplateInfos;
   // jar file name to template info mapping
-  private Map<String, ApplicationTemplateInfo> fileToTemplateMap;
+  private final AtomicReference<Map<File, ApplicationTemplateInfo>> fileToTemplateMap;
 
   @Inject
   public AdapterService(CConfiguration configuration, Scheduler scheduler, Store store,
@@ -123,8 +125,10 @@ public class AdapterService extends AbstractIdleService {
     this.store = store;
     this.templateManagerFactory = templateManagerFactory;
     this.adapterManagerFactory = adapterManagerFactory;
-    this.appTemplateInfos = Maps.newHashMap();
-    this.fileToTemplateMap = Maps.newHashMap();
+    this.appTemplateInfos = new AtomicReference<Map<String, ApplicationTemplateInfo>>(
+      new HashMap<String, ApplicationTemplateInfo>());
+    this.fileToTemplateMap = new AtomicReference<Map<File, ApplicationTemplateInfo>>(
+      new HashMap<File, ApplicationTemplateInfo>());
     this.resolver = resolver;
   }
 
@@ -151,7 +155,7 @@ public class AdapterService extends AbstractIdleService {
    */
   public void deployTemplate(Id.Namespace namespace, String templateName)
     throws NotFoundException, InterruptedException, ExecutionException, TimeoutException, IOException {
-    ApplicationTemplateInfo templateInfo = appTemplateInfos.get(templateName);
+    ApplicationTemplateInfo templateInfo = appTemplateInfos.get().get(templateName);
     if (templateInfo == null) {
       throw new NotFoundException(Id.ApplicationTemplate.from(templateName));
     }
@@ -168,7 +172,7 @@ public class AdapterService extends AbstractIdleService {
    */
   @Nullable
   public ApplicationTemplateInfo getApplicationTemplateInfo(String templateName) {
-    return appTemplateInfos.get(templateName);
+    return appTemplateInfos.get().get(templateName);
   }
 
   /**
@@ -267,7 +271,7 @@ public class AdapterService extends AbstractIdleService {
   public void createAdapter(Id.Namespace namespace, String adapterName, AdapterConfig adapterConfig)
     throws IllegalArgumentException, AdapterAlreadyExistsException {
 
-    ApplicationTemplateInfo applicationTemplateInfo = appTemplateInfos.get(adapterConfig.getTemplate());
+    ApplicationTemplateInfo applicationTemplateInfo = appTemplateInfos.get().get(adapterConfig.getTemplate());
     Preconditions.checkArgument(applicationTemplateInfo != null,
                                 "Application template %s not found", adapterConfig.getTemplate());
 
@@ -326,7 +330,7 @@ public class AdapterService extends AbstractIdleService {
 
     AdapterSpecification adapterSpec = getAdapter(namespace, adapterName);
 
-    ProgramType programType = appTemplateInfos.get(adapterSpec.getTemplate()).getProgramType();
+    ProgramType programType = appTemplateInfos.get().get(adapterSpec.getTemplate()).getProgramType();
     if (programType == ProgramType.WORKFLOW) {
       stopWorkflowAdapter(namespace, adapterSpec);
     } else if (programType == ProgramType.WORKER) {
@@ -359,7 +363,7 @@ public class AdapterService extends AbstractIdleService {
 
     AdapterSpecification adapterSpec = getAdapter(namespace, adapterName);
 
-    ProgramType programType = appTemplateInfos.get(adapterSpec.getTemplate()).getProgramType();
+    ProgramType programType = appTemplateInfos.get().get(adapterSpec.getTemplate()).getProgramType();
     if (programType == ProgramType.WORKFLOW) {
       startWorkflowAdapter(namespace, adapterSpec);
     } else if (programType == ProgramType.WORKER) {
@@ -411,7 +415,7 @@ public class AdapterService extends AbstractIdleService {
 
   private Id.Program getProgramId(Id.Namespace namespace, String adapterName) throws NotFoundException {
     AdapterSpecification adapterSpec = getAdapter(namespace, adapterName);
-    ProgramType programType = appTemplateInfos.get(adapterSpec.getTemplate()).getProgramType();
+    ProgramType programType = appTemplateInfos.get().get(adapterSpec.getTemplate()).getProgramType();
     Id.Program program;
     if (programType == ProgramType.WORKFLOW) {
       program = getWorkflowId(namespace, adapterSpec);
@@ -589,9 +593,8 @@ public class AdapterService extends AbstractIdleService {
       throw new FileNotFoundException(msg);
     }
     String appFabricDir = configuration.get(Constants.AppFabric.OUTPUT_DIR);
-    Location destination = namespaceHomeLocation.append(appFabricDir)
+    return namespaceHomeLocation.append(appFabricDir)
       .append(Constants.ARCHIVE_DIR).append(templateInfo.getFile().getName());
-    return destination;
   }
 
   // Reads all the jars from the adapter directory and sets up required internal structures.
@@ -600,7 +603,7 @@ public class AdapterService extends AbstractIdleService {
     try {
       // generate a completely new map in case some templates were removed
       Map<String, ApplicationTemplateInfo> newInfoMap = Maps.newHashMap();
-      Map<String, ApplicationTemplateInfo> newFileTemplateMap = Maps.newHashMap();
+      Map<File, ApplicationTemplateInfo> newFileTemplateMap = Maps.newHashMap();
 
       File baseDir = new File(configuration.get(Constants.AppFabric.APP_TEMPLATE_DIR));
       Collection<File> files = FileUtils.listFiles(baseDir, new String[]{"jar"}, true);
@@ -608,13 +611,13 @@ public class AdapterService extends AbstractIdleService {
         try {
           ApplicationTemplateInfo info = getTemplateInfo(file);
           newInfoMap.put(info.getName(), info);
-          newFileTemplateMap.put(info.getFile().getName(), info);
+          newFileTemplateMap.put(info.getFile().getAbsoluteFile(), info);
         } catch (IllegalArgumentException e) {
           LOG.error("Application template from file {} in invalid. Skipping it.", file.getName(), e);
         }
       }
-      appTemplateInfos = newInfoMap;
-      fileToTemplateMap = newFileTemplateMap;
+      appTemplateInfos.set(newInfoMap);
+      fileToTemplateMap.set(newFileTemplateMap);
     } catch (Exception e) {
       LOG.warn("Unable to read the plugins directory");
     }
@@ -622,7 +625,7 @@ public class AdapterService extends AbstractIdleService {
 
   private ApplicationTemplateInfo getTemplateInfo(File jarFile)
     throws InterruptedException, ExecutionException, TimeoutException, IOException {
-    ApplicationTemplateInfo existing = fileToTemplateMap.get(jarFile.getAbsolutePath());
+    ApplicationTemplateInfo existing = fileToTemplateMap.get().get(jarFile.getAbsoluteFile());
     HashCode fileHash = Files.hash(jarFile, Hashing.md5());
     // if the file is the same, just return
     if (existing != null && fileHash.equals(existing.getFileHash())) {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/adapter/AdapterServiceTests.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/adapter/AdapterServiceTests.java
@@ -214,6 +214,8 @@ public class AdapterServiceTests extends AppFabricTestBase {
   @Test
   public void testRedeploy() throws Exception {
     ApplicationTemplateInfo info1 = adapterService.getApplicationTemplateInfo(DummyTemplate1.NAME);
+    // Update the jar and force redeploy
+    setupAdapter(DummyTemplate1.class);
     adapterService.deployTemplate(NAMESPACE, DummyTemplate1.NAME);
     ApplicationTemplateInfo info2 = adapterService.getApplicationTemplateInfo(DummyTemplate1.NAME);
     Assert.assertNotEquals(info1.getDescription(), info2.getDescription());
@@ -247,9 +249,12 @@ public class AdapterServiceTests extends AppFabricTestBase {
     setupAdapter(DummyWorkerTemplate.class);
   }
 
-  private static void setupAdapter(Class<?> clz) throws IOException {
-    Location adapterJar = AppJarHelper.createDeploymentJar(locationFactory, clz);
-    File destination =  new File(String.format("%s/%s", adapterDir.getAbsolutePath(), adapterJar.getName()));
+  private static void setupAdapter(Class<? extends ApplicationTemplate> clz) throws IOException {
+    // Create a temp file to be included in the jar so that the jar is different every time even the same
+    // template class is given.
+    File randomFile = tmpFolder.newFile();
+    Location adapterJar = AppJarHelper.createDeploymentJar(locationFactory, clz, randomFile);
+    File destination =  new File(String.format("%s/%s.jar", adapterDir.getAbsolutePath(), clz.getSimpleName()));
     Files.copy(Locations.newInputSupplier(adapterJar), destination);
   }
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AppFabricTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AppFabricTestBase.java
@@ -24,6 +24,7 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.discovery.EndpointStrategy;
 import co.cask.cdap.common.discovery.RandomEndpointStrategy;
 import co.cask.cdap.common.metrics.MetricsCollectionService;
+import co.cask.cdap.common.utils.DirUtils;
 import co.cask.cdap.common.utils.Tasks;
 import co.cask.cdap.data.stream.service.StreamService;
 import co.cask.cdap.data2.datafabric.dataset.service.DatasetService;
@@ -135,15 +136,11 @@ public abstract class AppFabricTestBase {
   private static StreamAdmin streamAdmin;
   private static ServiceStore serviceStore;
 
-  private static final String adapterFolder = "adapter";
-
   @ClassRule
   public static TemporaryFolder tmpFolder = new TemporaryFolder();
 
   @BeforeClass
   public static void beforeClass() throws Throwable {
-    File adapterDir = tmpFolder.newFolder(adapterFolder);
-
     CConfiguration conf = CConfiguration.create();
 
     conf.set(Constants.AppFabric.SERVER_ADDRESS, hostname);
@@ -153,7 +150,8 @@ public abstract class AppFabricTestBase {
     conf.setBoolean(Constants.Scheduler.SCHEDULERS_LAZY_START, true);
 
     conf.setBoolean(Constants.Dangerous.UNRECOVERABLE_RESET, true);
-    conf.set(Constants.AppFabric.APP_TEMPLATE_DIR, adapterDir.getAbsolutePath());
+
+    DirUtils.mkdirs(new File(conf.get(Constants.AppFabric.APP_TEMPLATE_DIR)));
 
     injector = Guice.createInjector(new AppFabricTestModule(conf));
 

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -605,9 +605,9 @@
     </property>
 
     <property>
-      <name>app.template.dir</name>
-      <value>/opt/cdap/master/plugins</value>
-      <description>Directory where all archives for app templates are stored</description>
+        <name>app.template.dir</name>
+        <value>${local.data.dir}/plugins</value>
+        <description>Directory where all archives for app templates are stored</description>
     </property>
 
     <property>

--- a/cdap-standalone/src/main/resources/cdap-site.xml
+++ b/cdap-standalone/src/main/resources/cdap-site.xml
@@ -110,13 +110,4 @@
         <description>Number of stream writer instance. In local mode, it's always one</description>
     </property>
 
-    <!--
-        Application Template Jar directory
-    -->
-    <property>
-      <name>app.template.dir</name>
-      <value>plugins</value>
-      <description>Directory where all archives for application templates are stored</description>
-    </property>
-
 </configuration>


### PR DESCRIPTION
- Also fixed a bug in the template upgrade logic
  - It uses file name when update the internal file->template info map, but uses full file path when looking up
- Fix a unit test that relies on the bug mentioned above.