### PR TITLE
[CDAP-2150] convert all usages of v2/ APIs in test to v3/ - unless they test a v2 API

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/webapp/ServePathGenerator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/webapp/ServePathGenerator.java
@@ -29,7 +29,8 @@ import java.net.URI;
 public class ServePathGenerator {
   public static final String SRC_PATH = "/src/";
   public static final String DEFAULT_DIR_NAME = "default";
-  private static final String GATEWAY_PATH = Constants.Gateway.API_VERSION_2.substring(1) + "/";
+  private static final String GATEWAY_PATH_V2 = Constants.Gateway.API_VERSION_2.substring(1) + "/";
+  private static final String GATEWAY_PATH_V3 = Constants.Gateway.API_VERSION_3.substring(1) + "/";
 
   private static final String DEFAULT_PORT_STR = ":80";
 
@@ -97,9 +98,9 @@ public class ServePathGenerator {
     Iterable<String> pathParts = Splitter.on('/').limit(2).split(path);
     String servePath;
     if (Iterables.size(pathParts) > 1) {
-      String pathPart1 = Iterables.get(pathParts, 1);
-      if (pathPart1.startsWith(GATEWAY_PATH) || pathPart1.equals("status")) {
-        return constructPath(pathPart1, query);
+      String part1 = Iterables.get(pathParts, 1);
+      if (part1.startsWith(GATEWAY_PATH_V2) || part1.startsWith(GATEWAY_PATH_V3) || part1.equals("status")) {
+        return constructPath(part1, query);
       }
 
       servePath = String.format("%s/%s/%s%s%s", baseDir, hostHeader,
@@ -117,7 +118,7 @@ public class ServePathGenerator {
     }
 
     // Next try src/path
-    if (path.startsWith(GATEWAY_PATH) || path.equals("status")) {
+    if (path.startsWith(GATEWAY_PATH_V2) || path.startsWith(GATEWAY_PATH_V3) || path.equals("status")) {
       return constructPath(path, query);
     }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/test/internal/AppFabricClient.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/test/internal/AppFabricClient.java
@@ -278,7 +278,8 @@ public class AppFabricClient {
     LOG.info("Created deployedJar at {}", deployedJar.toURI().toASCIIString());
 
     String archiveName = appName + ".jar";
-    DefaultHttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/v2/apps");
+    DefaultHttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST,
+                                                        String.format("/v3/namespaces/%s/apps", namespace.getId()));
     request.setHeader(Constants.Gateway.API_KEY, "api-key-example");
     request.setHeader("X-Archive-Name", archiveName);
     MockResponder mockResponder = new MockResponder();

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/gateway/handlers/AppFabricDataHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/gateway/handlers/AppFabricDataHttpHandlerTest.java
@@ -35,8 +35,7 @@ public class AppFabricDataHttpHandlerTest extends AppFabricTestBase {
 
   @After
   public void cleanup() throws Exception {
-    HttpResponse response = doPost("/v2/unrecoverable/reset");
-    Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+    resetNamespaces();
   }
 
   @Test

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/service/http/HttpHandlerGeneratorTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/service/http/HttpHandlerGeneratorTest.java
@@ -53,7 +53,7 @@ import javax.ws.rs.PathParam;
  */
 public class HttpHandlerGeneratorTest {
 
-  @Path("/v1")
+  @Path("/p1")
   public abstract static class BaseHttpHandler extends AbstractHttpServiceHandler {
 
     @GET
@@ -63,7 +63,7 @@ public class HttpHandlerGeneratorTest {
     }
   }
 
-  @Path("/v2")
+  @Path("/p2")
   public static final class MyHttpHandler extends BaseHttpHandler {
 
     @Override
@@ -120,14 +120,14 @@ public class HttpHandlerGeneratorTest {
       InetSocketAddress bindAddress = service.getBindAddress();
 
       // Make a GET call
-      URLConnection urlConn = new URL(String.format("http://%s:%d/prefix/v2/handle",
+      URLConnection urlConn = new URL(String.format("http://%s:%d/prefix/p2/handle",
                                                     bindAddress.getHostName(), bindAddress.getPort())).openConnection();
       urlConn.setReadTimeout(2000);
 
       Assert.assertEquals("Hello World", new String(ByteStreams.toByteArray(urlConn.getInputStream()), Charsets.UTF_8));
 
       // Make a POST call
-      urlConn = new URL(String.format("http://%s:%d/prefix/v2/echo/test",
+      urlConn = new URL(String.format("http://%s:%d/prefix/p2/echo/test",
                                       bindAddress.getHostName(), bindAddress.getPort())).openConnection();
       urlConn.setReadTimeout(2000);
       urlConn.setDoOutput(true);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/webapp/ServePathGeneratorTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/webapp/ServePathGeneratorTest.java
@@ -78,6 +78,12 @@ public class ServePathGeneratorTest {
     Assert.assertEquals("/v2/apps?count=10",
                         servePathGenerator.getServePath("127.0.0.1:30000", "/v2/apps?count=10"));
 
+    Assert.assertEquals("/v3/apps?count=10",
+                        servePathGenerator.getServePath("127.0.0.1:30000", "/netlens/v3/apps?count=10"));
+
+    Assert.assertEquals("/v3/apps?count=10",
+                        servePathGenerator.getServePath("127.0.0.1:30000", "/v3/apps?count=10"));
+
     Assert.assertEquals("/status",
                         servePathGenerator.getServePath("127.0.0.1:30000", "/netlens/status"));
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AppFabricTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AppFabricTestBase.java
@@ -609,7 +609,13 @@ public abstract class AppFabricTestBase {
     }, 60, TimeUnit.SECONDS, 50, TimeUnit.MILLISECONDS);
   }
 
+  protected static void resetNamespaces() throws Exception {
+    deleteNamespaces();
+    createNamespaces();
+  }
+
   private static void createNamespaces() throws Exception {
+
     HttpResponse response = doPut(String.format("%s/namespaces/%s", Constants.Gateway.API_VERSION_3, TEST_NAMESPACE1),
                                   GSON.toJson(TEST_NAMESPACE_META1));
     Assert.assertEquals(200, response.getStatusLine().getStatusCode());

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/service/DFSStreamHeartbeatsTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/service/DFSStreamHeartbeatsTest.java
@@ -190,7 +190,8 @@ public class DFSStreamHeartbeatsTest {
     // Enqueue 10 entries
     for (int i = 0; i < entries; ++i) {
       HttpURLConnection urlConn =
-        openURL(String.format("http://%s:%d/v2/streams/%s", hostname, port, streamName), HttpMethod.POST);
+        openURL(String.format("http://%s:%d/v3/namespaces/default/streams/%s", hostname, port, streamName),
+                HttpMethod.POST);
       urlConn.setDoOutput(true);
       urlConn.addRequestProperty("test_stream1.header1", Integer.toString(i));
       urlConn.getOutputStream().write(TWO_BYTES);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/TransactionManagerDebuggerMain.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/TransactionManagerDebuggerMain.java
@@ -282,7 +282,7 @@ public class TransactionManagerDebuggerMain {
     URL url;
     HttpURLConnection connection = null;
     try {
-      url = new URL("http://" + hostname + ":" + portNumber + "/v2/transactions/" + txId + "/invalidate");
+      url = new URL("http://" + hostname + ":" + portNumber + "/v3/transactions/" + txId + "/invalidate");
       connection = (HttpURLConnection) url.openConnection();
       connection.setRequestMethod("POST");
       if (accessToken != null) {
@@ -316,7 +316,7 @@ public class TransactionManagerDebuggerMain {
     URL url;
     HttpURLConnection connection = null;
     try {
-      url = new URL("http://" + hostname + ":" + portNumber + "/v2/transactions/state");
+      url = new URL("http://" + hostname + ":" + portNumber + "/v3/transactions/state");
       connection = (HttpURLConnection) url.openConnection();
       connection.setRequestMethod("POST");
       if (accessToken != null) {
@@ -411,7 +411,7 @@ public class TransactionManagerDebuggerMain {
     URL url;
     HttpURLConnection connection = null;
     try {
-      url = new URL("http://" + hostname + ":" + portNumber + "/v2/transactions/state");
+      url = new URL("http://" + hostname + ":" + portNumber + "/v3/transactions/state");
       connection = (HttpURLConnection) url.openConnection();
       if (accessToken != null) {
         connection.setRequestProperty("Authorization", "Bearer " + accessToken);

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterPathLookup.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterPathLookup.java
@@ -55,8 +55,9 @@ public final class RouterPathLookup extends AuthenticatedHttpHandler {
       //If service contains "$HOST" and if first split element is NOT the gateway version, then send it to WebApp
       //WebApp serves only static files (HTML, CSS, JS) and so /<appname> calls should go to WebApp
       //But stream calls issued by the UI should be routed to the appropriate CDAP service
-      if (fallbackService.contains("$HOST") && (uriParts.length >= 1)
-        && (!(("/" + uriParts[0]).equals(Constants.Gateway.API_VERSION_2)))) {
+      if (fallbackService.contains("$HOST") && (uriParts.length >= 1) &&
+        (!(("/" + uriParts[0]).equals(Constants.Gateway.API_VERSION_2)
+          || ("/" + uriParts[0]).equals(Constants.Gateway.API_VERSION_3)))) {
         return fallbackService;
       }
 
@@ -93,7 +94,7 @@ public final class RouterPathLookup extends AuthenticatedHttpHandler {
     } else if ((uriParts.length >= 2) && uriParts[1].equals("streams")) {
       // /v2/streams should go to AppFabricHttp
       // /v2/streams/<stream-id> GET should go to AppFabricHttp, PUT, POST should go to Stream Handler
-      // GET /v2/streams/flows should go to AppFabricHttp, rest should go Stream Handler
+      // GET /v2/streams/<stream-id>/flows should go to AppFabricHttp, rest should go Stream Handler
       if (uriParts.length == 2) {
         return Constants.Service.APP_FABRIC_HTTP;
       } else if (uriParts.length == 3) {
@@ -137,13 +138,13 @@ public final class RouterPathLookup extends AuthenticatedHttpHandler {
     } else if ((uriParts.length >= 4) && uriParts[3].equals("streams")) {
       //     /v3/namespaces/<namespace>/streams goes to AppFabricHttp
       //     /v3/namespaces/<namespace>/streams/<stream-id> PUT, POST should go to Stream Handler
-      // GET /v3/namespaces/<namespace>/streams/flows should go to AppFabricHttp
+      // GET /v3/namespaces/<namespace>/streams/<stream-id>/flows should go to AppFabricHttp
       // All else go to Stream Handler
       if (uriParts.length == 4) {
         return Constants.Service.APP_FABRIC_HTTP;
       } else if (uriParts.length == 5) {
         return Constants.Service.STREAMS;
-      } else if ((uriParts.length == 6) && uriParts[3].equals("flows") && requestMethod.equals(AllowedMethod.GET)) {
+      } else if ((uriParts.length == 6) && uriParts[5].equals("flows") && requestMethod.equals(AllowedMethod.GET)) {
         return Constants.Service.APP_FABRIC_HTTP;
       } else {
         return Constants.Service.STREAMS;

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/GatewayFastTestsSuite.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/GatewayFastTestsSuite.java
@@ -195,9 +195,9 @@ public class GatewayFastTestsSuite {
 
     HttpEntityEnclosingRequestBase request;
     if (appName == null) {
-      request = getPost("/v2/apps");
+      request = getPost("/v3/namespaces/default/apps");
     } else {
-      request = getPut("/v2/apps/" + appName);
+      request = getPut("/v3/namespaces/default/apps/" + appName);
     }
     request.setHeader(Constants.Gateway.API_KEY, "api-key-example");
     request.setHeader("X-Archive-Name", application.getSimpleName() + ".jar");

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/GatewayTestBase.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/GatewayTestBase.java
@@ -247,7 +247,7 @@ public abstract class GatewayTestBase {
     int trials = 0;
     // it may take a while for workflow/mr to start...
     while (trials++ < 20) {
-      HttpResponse response = GatewayFastTestsSuite.doGet(String.format("/v2/apps/%s/%s/%s/status",
+      HttpResponse response = GatewayFastTestsSuite.doGet(String.format("/v3/namespaces/default/apps/%s/%s/%s/status",
                                                                         appId, runnableType, runnableId));
       JsonObject status = GSON.fromJson(EntityUtils.toString(response.getEntity()), JsonObject.class);
       if (status != null && status.has("status") && state.equals(status.get("status").getAsString())) {

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/RuntimeArgumentTestRun.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/RuntimeArgumentTestRun.java
@@ -40,17 +40,20 @@ public class RuntimeArgumentTestRun extends GatewayTestBase {
     //Set flow runtime arg threshold to 30
     JsonObject json = new JsonObject();
     json.addProperty("threshold", "30");
-    response = GatewayFastTestsSuite.doPut("/v2/apps/HighPassFilterApp/flows/FilterFlow/runtimeargs", json.toString());
+    response = GatewayFastTestsSuite.doPut(
+      "/v3/namespaces/default/apps/HighPassFilterApp/flows/FilterFlow/runtimeargs", json.toString());
     Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpResponseStatus.OK.getCode());
-    response = GatewayFastTestsSuite.doPost("/v2/apps/HighPassFilterApp/flows/FilterFlow/start", null);
+    response = GatewayFastTestsSuite.doPost(
+      "/v3/namespaces/default/apps/HighPassFilterApp/flows/FilterFlow/start", null);
     Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpResponseStatus.OK.getCode());
-    response = GatewayFastTestsSuite.doPost("/v2/apps/HighPassFilterApp/services/Count/start", null);
+    response = GatewayFastTestsSuite.doPost(
+      "/v3/namespaces/default/apps/HighPassFilterApp/services/Count/start", null);
     Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpResponseStatus.OK.getCode());
 
     //Send two values - 25 and 35; Since threshold is 30, expected count is 1
-    response = GatewayFastTestsSuite.doPost("/v2/streams/inputvalue", "25");
+    response = GatewayFastTestsSuite.doPost("/v3/namespaces/default/streams/inputvalue", "25");
     Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpResponseStatus.OK.getCode());
-    response = GatewayFastTestsSuite.doPost("/v2/streams/inputvalue", "35");
+    response = GatewayFastTestsSuite.doPost("/v3/namespaces/default/streams/inputvalue", "35");
     Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpResponseStatus.OK.getCode());
 
     // Check the service status. Make sure it is running before querying it
@@ -61,22 +64,25 @@ public class RuntimeArgumentTestRun extends GatewayTestBase {
 
     //Now modify the threshold to 50
     json.addProperty("threshold", "50");
-    response = GatewayFastTestsSuite.doPut("/v2/apps/HighPassFilterApp/flows/FilterFlow/runtimeargs", json.toString());
+    response = GatewayFastTestsSuite.doPut(
+      "/v3/namespaces/default/apps/HighPassFilterApp/flows/FilterFlow/runtimeargs", json.toString());
     Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpResponseStatus.OK.getCode());
 
     //Stop and start the flow and it should pick up the new threshold value; Verify that by sending 45 and 55
     //Then count should be 2
-    response = GatewayFastTestsSuite.doPost("/v2/apps/HighPassFilterApp/flows/FilterFlow/stop", null);
+    response = GatewayFastTestsSuite.doPost(
+      "/v3/namespaces/default/apps/HighPassFilterApp/flows/FilterFlow/stop", null);
     Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpResponseStatus.OK.getCode());
 
     waitState("flows", "HighPassFilterApp", "FilterFlow", "STOPPED");
 
-    response = GatewayFastTestsSuite.doPost("/v2/apps/HighPassFilterApp/flows/FilterFlow/start", null);
+    response = GatewayFastTestsSuite.doPost(
+      "/v3/namespaces/default/apps/HighPassFilterApp/flows/FilterFlow/start", null);
     Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpResponseStatus.OK.getCode());
 
-    response = GatewayFastTestsSuite.doPost("/v2/streams/inputvalue", "45");
+    response = GatewayFastTestsSuite.doPost("/v3/namespaces/default/streams/inputvalue", "45");
     Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpResponseStatus.OK.getCode());
-    response = GatewayFastTestsSuite.doPost("/v2/streams/inputvalue", "55");
+    response = GatewayFastTestsSuite.doPost("/v3/namespaces/default/streams/inputvalue", "55");
     Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpResponseStatus.OK.getCode());
 
     // Check the count. Gives it couple trials as it takes time for flow to process and write to the table
@@ -84,34 +90,38 @@ public class RuntimeArgumentTestRun extends GatewayTestBase {
 
     //Now stop the flow and update the threshold value during the start POST call to 100
     //Test it by sending 95 and 105 and the count should be 3
-    response = GatewayFastTestsSuite.doPost("/v2/apps/HighPassFilterApp/flows/FilterFlow/stop", null);
+    response = GatewayFastTestsSuite.doPost(
+      "/v3/namespaces/default/apps/HighPassFilterApp/flows/FilterFlow/stop", null);
     Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpResponseStatus.OK.getCode());
 
     waitState("flows", "HighPassFilterApp", "FilterFlow", "STOPPED");
 
     json.addProperty("threshold", "100");
-    response = GatewayFastTestsSuite.doPost("/v2/apps/HighPassFilterApp/flows/FilterFlow/start", json.toString());
+    response = GatewayFastTestsSuite.doPost(
+      "/v3/namespaces/default/apps/HighPassFilterApp/flows/FilterFlow/start", json.toString());
     Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpResponseStatus.OK.getCode());
 
-    response = GatewayFastTestsSuite.doPost("/v2/streams/inputvalue", "95");
+    response = GatewayFastTestsSuite.doPost("/v3/namespaces/default/streams/inputvalue", "95");
     Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpResponseStatus.OK.getCode());
-    response = GatewayFastTestsSuite.doPost("/v2/streams/inputvalue", "105");
+    response = GatewayFastTestsSuite.doPost("/v3/namespaces/default/streams/inputvalue", "105");
     Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpResponseStatus.OK.getCode());
 
     // Check the count. Gives it couple trials as it takes time for flow to process and write to the table
     checkCount("3");
 
     //Stop all flows and services and reset the state of the cdap
-    response = GatewayFastTestsSuite.doPost("/v2/apps/HighPassFilterApp/flows/FilterFlow/stop", null);
+    response = GatewayFastTestsSuite.doPost(
+      "/v3/namespaces/default/apps/HighPassFilterApp/flows/FilterFlow/stop", null);
     Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpResponseStatus.OK.getCode());
-    response = GatewayFastTestsSuite.doPost("/v2/apps/HighPassFilterApp/services/Count/stop", null);
+    response = GatewayFastTestsSuite.doPost(
+      "/v3/namespaces/default/apps/HighPassFilterApp/services/Count/stop", null);
     Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpResponseStatus.OK.getCode());
 
     // Wait for program states. Make sure they are stopped before deletion
     waitState("flows", "HighPassFilterApp", "FilterFlow", "STOPPED");
     waitState("services", "HighPassFilterApp", "Count", "STOPPED");
 
-    response = GatewayFastTestsSuite.doDelete("/v2/apps/HighPassFilterApp");
+    response = GatewayFastTestsSuite.doDelete("/v3/namespaces/default/apps/HighPassFilterApp");
     Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpResponseStatus.OK.getCode());
   }
 
@@ -119,7 +129,7 @@ public class RuntimeArgumentTestRun extends GatewayTestBase {
     int trials = 0;
     while (trials++ < 5) {
       HttpResponse response = GatewayFastTestsSuite.doGet(
-        "/v2/apps/HighPassFilterApp/services/Count/methods/result", null);
+        "/v3/namespaces/default/apps/HighPassFilterApp/services/Count/methods/result", null);
       if (response.getStatusLine().getStatusCode() == HttpResponseStatus.OK.getCode()) {
         String count = EntityUtils.toString(response.getEntity());
         if (expected.equals(count)) {

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/StreamHandlerTest.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/StreamHandlerTest.java
@@ -24,7 +24,6 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.stream.StreamEventTypeAdapter;
 import co.cask.cdap.data.format.TextRecordFormat;
 import co.cask.cdap.data2.transaction.stream.StreamConfig;
-import co.cask.cdap.gateway.GatewayFastTestsSuite;
 import co.cask.cdap.gateway.GatewayTestBase;
 import co.cask.cdap.internal.io.SchemaTypeAdapter;
 import co.cask.cdap.proto.StreamProperties;
@@ -34,10 +33,8 @@ import com.google.common.io.ByteStreams;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import org.apache.http.HttpResponse;
 import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -71,12 +68,6 @@ public abstract class StreamHandlerTest extends GatewayTestBase {
     urlConn.setRequestProperty(Constants.Gateway.API_KEY, API_KEY);
 
     return urlConn;
-  }
-
-  @After
-  public void reset() throws Exception {
-    HttpResponse httpResponse = GatewayFastTestsSuite.doPost("/v2/unrecoverable/reset", null);
-    Assert.assertEquals(200, httpResponse.getStatusLine().getStatusCode());
   }
 
   @Test

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/StreamHandlerTestV2.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/StreamHandlerTestV2.java
@@ -16,6 +16,11 @@
 
 package co.cask.cdap.gateway.handlers;
 
+import co.cask.cdap.gateway.GatewayFastTestsSuite;
+import org.apache.http.HttpResponse;
+import org.junit.After;
+import org.junit.Assert;
+
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -24,6 +29,13 @@ import java.net.URL;
  * Tests v2 stream endpoints
  */
 public class StreamHandlerTestV2 extends StreamHandlerTest {
+
+  @After
+  public void reset() throws Exception {
+    HttpResponse httpResponse = GatewayFastTestsSuite.doPost("/v2/unrecoverable/reset", null);
+    Assert.assertEquals(200, httpResponse.getStatusLine().getStatusCode());
+  }
+
   @Override
   protected URL createURL(String path) throws URISyntaxException, MalformedURLException {
     return getEndPoint(String.format("/v2/%s", path)).toURL();

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/StreamHandlerTestV3.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/StreamHandlerTestV3.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.gateway.handlers;
 
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.gateway.GatewayFastTestsSuite;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.MetricQueryResult;
 import co.cask.cdap.proto.NamespaceMeta;
@@ -30,6 +31,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import org.apache.commons.lang3.ArrayUtils;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -43,6 +45,13 @@ import java.util.concurrent.TimeUnit;
  * Tests v3 stream endpoints with default namespace
  */
 public class StreamHandlerTestV3 extends StreamHandlerTest {
+
+  @After
+  public void reset() throws Exception {
+    org.apache.http.HttpResponse httpResponse = GatewayFastTestsSuite.doDelete("/v3/unrecoverable/namespaces/default");
+    Assert.assertEquals(200, httpResponse.getStatusLine().getStatusCode());
+  }
+
   @Override
   protected URL createURL(String path) throws URISyntaxException, MalformedURLException {
     return createURL(Constants.DEFAULT_NAMESPACE, path);

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/RouterPathTest.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/RouterPathTest.java
@@ -198,54 +198,106 @@ public class RouterPathTest {
   @Test
   public void testStreamPath() throws Exception {
     //Following URIs might not give actual results but we want to test resilience of Router Path Lookup
-    String flowPath = "/v2/streams";
-    HttpRequest httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("GET"), flowPath);
-    String result = pathLookup.getRoutingService(FALLBACKSERVICE, flowPath, httpRequest);
+    String streamPath = "/v2/streams";
+    HttpRequest httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("GET"), streamPath);
+    String result = pathLookup.getRoutingService(FALLBACKSERVICE, streamPath, httpRequest);
     Assert.assertEquals(Constants.Service.APP_FABRIC_HTTP, result);
 
-    flowPath = "///v2/streams///";
-    httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("POST"), flowPath);
-    result = pathLookup.getRoutingService(FALLBACKSERVICE, flowPath, httpRequest);
+    streamPath = "///v2/streams///";
+    httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("POST"), streamPath);
+    result = pathLookup.getRoutingService(FALLBACKSERVICE, streamPath, httpRequest);
     Assert.assertEquals(Constants.Service.APP_FABRIC_HTTP, result);
 
-    flowPath = "v2///streams///";
-    httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("PUT"), flowPath);
-    result = pathLookup.getRoutingService(FALLBACKSERVICE, flowPath, httpRequest);
+    streamPath = "v2///streams///";
+    httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("PUT"), streamPath);
+    result = pathLookup.getRoutingService(FALLBACKSERVICE, streamPath, httpRequest);
     Assert.assertEquals(Constants.Service.APP_FABRIC_HTTP, result);
 
-    flowPath = "//v2///streams/HelloStream//flows///";
-    httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("GET"), flowPath);
-    result = pathLookup.getRoutingService(FALLBACKSERVICE, flowPath, httpRequest);
+    streamPath = "//v2///streams/HelloStream//flows///";
+    httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("GET"), streamPath);
+    result = pathLookup.getRoutingService(FALLBACKSERVICE, streamPath, httpRequest);
     Assert.assertEquals(Constants.Service.APP_FABRIC_HTTP, result);
 
-    flowPath = "//v2///streams/HelloStream//flows///";
-    httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("DELETE"), flowPath);
-    result = pathLookup.getRoutingService(FALLBACKSERVICE, flowPath, httpRequest);
+    streamPath = "//v2///streams/HelloStream//flows///";
+    httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("DELETE"), streamPath);
+    result = pathLookup.getRoutingService(FALLBACKSERVICE, streamPath, httpRequest);
     Assert.assertEquals(Constants.Service.STREAMS, result);
 
-    flowPath = "//v2///streams/HelloStream//flows///";
-    httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("POST"), flowPath);
-    result = pathLookup.getRoutingService(FALLBACKSERVICE, flowPath, httpRequest);
+    streamPath = "//v2///streams/HelloStream//flows///";
+    httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("POST"), streamPath);
+    result = pathLookup.getRoutingService(FALLBACKSERVICE, streamPath, httpRequest);
     Assert.assertEquals(Constants.Service.STREAMS, result);
 
-    flowPath = "v2//streams//flows///";
-    httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("DELETE"), flowPath);
-    result = pathLookup.getRoutingService(FALLBACKSERVICE, flowPath, httpRequest);
+    streamPath = "v2//streams//flows///";
+    httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("DELETE"), streamPath);
+    result = pathLookup.getRoutingService(FALLBACKSERVICE, streamPath, httpRequest);
     Assert.assertEquals(Constants.Service.STREAMS, result);
 
-    flowPath = "v2//streams/InvalidStreamName/flows/";
-    httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("GET"), flowPath);
-    result = pathLookup.getRoutingService(FALLBACKSERVICE, flowPath, httpRequest);
+    streamPath = "v2//streams/InvalidStreamName/flows/";
+    httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("GET"), streamPath);
+    result = pathLookup.getRoutingService(FALLBACKSERVICE, streamPath, httpRequest);
     Assert.assertEquals(Constants.Service.APP_FABRIC_HTTP, result);
 
-    flowPath = "v2//streams/InvalidStreamName/flows/";
-    httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("DELETE"), flowPath);
-    result = pathLookup.getRoutingService(FALLBACKSERVICE, flowPath, httpRequest);
+    streamPath = "v2//streams/InvalidStreamName/flows/";
+    httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("DELETE"), streamPath);
+    result = pathLookup.getRoutingService(FALLBACKSERVICE, streamPath, httpRequest);
     Assert.assertEquals(Constants.Service.STREAMS, result);
 
-    flowPath = "v2//streams/InvalidStreamName/info/";
-    httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("GET"), flowPath);
-    result = pathLookup.getRoutingService(FALLBACKSERVICE, flowPath, httpRequest);
+    streamPath = "v2//streams/InvalidStreamName/info/";
+    httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("GET"), streamPath);
+    result = pathLookup.getRoutingService(FALLBACKSERVICE, streamPath, httpRequest);
+    Assert.assertEquals(Constants.Service.STREAMS, result);
+
+    // v3 routes
+    //Following URIs might not give actual results but we want to test resilience of Router Path Lookup
+    streamPath = "/v3/namespaces/default/streams";
+    httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("GET"), streamPath);
+    result = pathLookup.getRoutingService(FALLBACKSERVICE, streamPath, httpRequest);
+    Assert.assertEquals(Constants.Service.APP_FABRIC_HTTP, result);
+
+    streamPath = "///v3/namespaces/default/streams///";
+    httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("POST"), streamPath);
+    result = pathLookup.getRoutingService(FALLBACKSERVICE, streamPath, httpRequest);
+    Assert.assertEquals(Constants.Service.APP_FABRIC_HTTP, result);
+
+    streamPath = "v3/namespaces/default///streams///";
+    httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("PUT"), streamPath);
+    result = pathLookup.getRoutingService(FALLBACKSERVICE, streamPath, httpRequest);
+    Assert.assertEquals(Constants.Service.APP_FABRIC_HTTP, result);
+
+    streamPath = "//v3/namespaces/default///streams/HelloStream//flows///";
+    httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("GET"), streamPath);
+    result = pathLookup.getRoutingService(FALLBACKSERVICE, streamPath, httpRequest);
+    Assert.assertEquals(Constants.Service.APP_FABRIC_HTTP, result);
+
+    streamPath = "//v3/namespaces/default///streams/HelloStream//flows///";
+    httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("DELETE"), streamPath);
+    result = pathLookup.getRoutingService(FALLBACKSERVICE, streamPath, httpRequest);
+    Assert.assertEquals(Constants.Service.STREAMS, result);
+
+    streamPath = "//v3/namespaces/default///streams/HelloStream//flows///";
+    httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("POST"), streamPath);
+    result = pathLookup.getRoutingService(FALLBACKSERVICE, streamPath, httpRequest);
+    Assert.assertEquals(Constants.Service.STREAMS, result);
+
+    streamPath = "v3/namespaces/default//streams//flows///";
+    httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("DELETE"), streamPath);
+    result = pathLookup.getRoutingService(FALLBACKSERVICE, streamPath, httpRequest);
+    Assert.assertEquals(Constants.Service.STREAMS, result);
+
+    streamPath = "v3/namespaces/default//streams/InvalidStreamName/flows/";
+    httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("GET"), streamPath);
+    result = pathLookup.getRoutingService(FALLBACKSERVICE, streamPath, httpRequest);
+    Assert.assertEquals(Constants.Service.APP_FABRIC_HTTP, result);
+
+    streamPath = "v3/namespaces/default//streams/InvalidStreamName/flows/";
+    httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("DELETE"), streamPath);
+    result = pathLookup.getRoutingService(FALLBACKSERVICE, streamPath, httpRequest);
+    Assert.assertEquals(Constants.Service.STREAMS, result);
+
+    streamPath = "v3/namespaces/default//streams/InvalidStreamName/info/";
+    httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("GET"), streamPath);
+    result = pathLookup.getRoutingService(FALLBACKSERVICE, streamPath, httpRequest);
     Assert.assertEquals(Constants.Service.STREAMS, result);
   }
 
@@ -255,29 +307,49 @@ public class RouterPathTest {
     HttpRequest httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("GET"), flowPath);
     String result = pathLookup.getRoutingService(FALLBACKSERVICE, flowPath, httpRequest);
     Assert.assertEquals(Constants.Service.APP_FABRIC_HTTP, result);
+
+    flowPath = "/v3/namespaces/default//apps/ResponseCodeAnalytics/flows/LogAnalyticsFlow/status";
+    httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("GET"), flowPath);
+    result = pathLookup.getRoutingService(FALLBACKSERVICE, flowPath, httpRequest);
+    Assert.assertEquals(Constants.Service.APP_FABRIC_HTTP, result);
   }
 
   @Test
   public void testRouterWorkFlowPathLookUp() throws Exception {
-    String procPath = "/v2/apps///PurchaseHistory///workflows/PurchaseHistoryWorkflow/status";
-    HttpRequest httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("GET"), procPath);
-    String result = pathLookup.getRoutingService(FALLBACKSERVICE, procPath, httpRequest);
+    String path = "/v2/apps///PurchaseHistory///workflows/PurchaseHistoryWorkflow/status";
+    HttpRequest httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("GET"), path);
+    String result = pathLookup.getRoutingService(FALLBACKSERVICE, path, httpRequest);
+    Assert.assertEquals(Constants.Service.APP_FABRIC_HTTP,  result);
+
+    path = "/v3/namespaces/default/apps///PurchaseHistory///workflows/PurchaseHistoryWorkflow/status";
+    httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("GET"), path);
+    result = pathLookup.getRoutingService(FALLBACKSERVICE, path, httpRequest);
     Assert.assertEquals(Constants.Service.APP_FABRIC_HTTP,  result);
   }
 
   @Test
   public void testRouterDeployPathLookUp() throws Exception {
-    String procPath = "/v2//apps/";
-    HttpRequest httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("PUT"), procPath);
-    String result = pathLookup.getRoutingService(FALLBACKSERVICE, procPath, httpRequest);
+    String path = "/v2//apps/";
+    HttpRequest httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("PUT"), path);
+    String result = pathLookup.getRoutingService(FALLBACKSERVICE, path, httpRequest);
+    Assert.assertEquals(Constants.Service.APP_FABRIC_HTTP,  result);
+
+    path = "/v3/namespaces/default//apps/";
+    httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("PUT"), path);
+    result = pathLookup.getRoutingService(FALLBACKSERVICE, path, httpRequest);
     Assert.assertEquals(Constants.Service.APP_FABRIC_HTTP,  result);
   }
 
   @Test
   public void testRouterFlowletInstancesLookUp() throws Exception {
-    String procPath = "/v2//apps/WordCount/flows/WordCountFlow/flowlets/StreamSource/instances";
-    HttpRequest httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("PUT"), procPath);
-    String result = pathLookup.getRoutingService(FALLBACKSERVICE, procPath, httpRequest);
+    String path = "/v2//apps/WordCount/flows/WordCountFlow/flowlets/StreamSource/instances";
+    HttpRequest httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("PUT"), path);
+    String result = pathLookup.getRoutingService(FALLBACKSERVICE, path, httpRequest);
+    Assert.assertEquals(Constants.Service.APP_FABRIC_HTTP,  result);
+
+    path = "/v3/namespaces/default//apps/WordCount/flows/WordCountFlow/flowlets/StreamSource/instances";
+    httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("PUT"), path);
+    result = pathLookup.getRoutingService(FALLBACKSERVICE, path, httpRequest);
     Assert.assertEquals(Constants.Service.APP_FABRIC_HTTP,  result);
   }
 
@@ -286,6 +358,11 @@ public class RouterPathTest {
     String explorePath = "/v2//data///explore//datasets////mydataset//enable";
     HttpRequest httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("POST"), explorePath);
     String result = pathLookup.getRoutingService(FALLBACKSERVICE, explorePath, httpRequest);
+    Assert.assertEquals(Constants.Service.EXPLORE_HTTP_USER_SERVICE, result);
+
+    explorePath = "/v3/namespaces/default//data///explore//datasets////mydataset//enable";
+    httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("POST"), explorePath);
+    result = pathLookup.getRoutingService(FALLBACKSERVICE, explorePath, httpRequest);
     Assert.assertEquals(Constants.Service.EXPLORE_HTTP_USER_SERVICE, result);
   }
 
@@ -300,6 +377,11 @@ public class RouterPathTest {
     Assert.assertEquals(webAppService, result);
 
     procPath = "/v2//metrics///";
+    httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("GET"), procPath);
+    result = pathLookup.getRoutingService(webAppService, procPath, httpRequest);
+    Assert.assertEquals(Constants.Service.METRICS, result);
+
+    procPath = "/v3//metrics///";
     httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("GET"), procPath);
     result = pathLookup.getRoutingService(webAppService, procPath, httpRequest);
     Assert.assertEquals(Constants.Service.METRICS, result);

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/run/StreamWriterTestRun.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/run/StreamWriterTestRun.java
@@ -38,15 +38,18 @@ public class StreamWriterTestRun extends GatewayTestBase {
     HttpResponse response = GatewayFastTestsSuite.deploy(AppWritingtoStream.class, AppWritingtoStream.APPNAME);
     Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpResponseStatus.OK.getCode());
     //Start Flow
-    response = GatewayFastTestsSuite.doPost(String.format("/v2/apps/%s/flows/%s/start", AppWritingtoStream.APPNAME,
+    response = GatewayFastTestsSuite.doPost(String.format("/v3/namespaces/default/apps/%s/flows/%s/start",
+                                                          AppWritingtoStream.APPNAME,
                                                           AppWritingtoStream.FLOW), null);
     Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpResponseStatus.OK.getCode());
     //Start Worker
-    response = GatewayFastTestsSuite.doPost(String.format("/v2/apps/%s/workers/%s/start", AppWritingtoStream.APPNAME,
+    response = GatewayFastTestsSuite.doPost(String.format("/v3/namespaces/default/apps/%s/workers/%s/start",
+                                                          AppWritingtoStream.APPNAME,
                                                           AppWritingtoStream.WORKER), null);
     Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpResponseStatus.OK.getCode());
     //Start Service
-    response = GatewayFastTestsSuite.doPost(String.format("/v2/apps/%s/services/%s/start", AppWritingtoStream.APPNAME,
+    response = GatewayFastTestsSuite.doPost(String.format("/v3/namespaces/default/apps/%s/services/%s/start",
+                                                          AppWritingtoStream.APPNAME,
                                                           AppWritingtoStream.SERVICE), null);
     Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpResponseStatus.OK.getCode());
 
@@ -57,15 +60,18 @@ public class StreamWriterTestRun extends GatewayTestBase {
     checkCount(AppWritingtoStream.VALUE);
 
     //Stop Flow
-    response = GatewayFastTestsSuite.doPost(String.format("/v2/apps/%s/flows/%s/stop", AppWritingtoStream.APPNAME,
+    response = GatewayFastTestsSuite.doPost(String.format("/v3/namespaces/default/apps/%s/flows/%s/stop",
+                                                          AppWritingtoStream.APPNAME,
                                                           AppWritingtoStream.FLOW), null);
     Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpResponseStatus.OK.getCode());
     //Stop Worker
-    response = GatewayFastTestsSuite.doPost(String.format("/v2/apps/%s/workers/%s/stop", AppWritingtoStream.APPNAME,
+    response = GatewayFastTestsSuite.doPost(String.format("/v3/namespaces/default/apps/%s/workers/%s/stop",
+                                                          AppWritingtoStream.APPNAME,
                                                           AppWritingtoStream.WORKER), null);
     Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpResponseStatus.OK.getCode());
     //Stop Service
-    response = GatewayFastTestsSuite.doPost(String.format("/v2/apps/%s/services/%s/stop", AppWritingtoStream.APPNAME,
+    response = GatewayFastTestsSuite.doPost(String.format("/v3/namespaces/default/apps/%s/services/%s/stop",
+                                                          AppWritingtoStream.APPNAME,
                                                           AppWritingtoStream.SERVICE), null);
     Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpResponseStatus.OK.getCode());
 
@@ -73,17 +79,19 @@ public class StreamWriterTestRun extends GatewayTestBase {
     waitState("workers", AppWritingtoStream.APPNAME, AppWritingtoStream.WORKER, "STOPPED");
     waitState("services", AppWritingtoStream.APPNAME, AppWritingtoStream.SERVICE, "STOPPED");
 
-    response = GatewayFastTestsSuite.doDelete(String.format("/v2/apps/%s", AppWritingtoStream.APPNAME));
+    response = GatewayFastTestsSuite.doDelete(String.format("/v3/namespaces/default/apps/%s",
+                                                            AppWritingtoStream.APPNAME));
     Assert.assertEquals(response.getStatusLine().getStatusCode(), HttpResponseStatus.OK.getCode());
   }
 
   private void checkCount(int expected) throws Exception {
     int trials = 0;
     while (trials++ < 5) {
-      HttpResponse response = GatewayFastTestsSuite.doGet(String.format("/v2/apps/%s/services/%s/methods/%s",
-                                                                        AppWritingtoStream.APPNAME,
-                                                                        AppWritingtoStream.SERVICE,
-                                                                        AppWritingtoStream.ENDPOINT));
+      HttpResponse response = GatewayFastTestsSuite.doGet(
+        String.format("/v3/namespaces/default/apps/%s/services/%s/methods/%s",
+                      AppWritingtoStream.APPNAME,
+                      AppWritingtoStream.SERVICE,
+                      AppWritingtoStream.ENDPOINT));
       if (response.getStatusLine().getStatusCode() == HttpResponseStatus.OK.getCode()) {
         String count = EntityUtils.toString(response.getEntity());
         if (expected == Integer.valueOf(count)) {


### PR DESCRIPTION
- also adds a few tests for v3/ routing that were not there previously. 
- also fixes a handful of bugs found while doing this