### PR TITLE
Adding support to show source for configuration in administrator section

### DIFF
--- a/cdap-ui/app/features/admin/controllers/ConfigurationController.js
+++ b/cdap-ui/app/features/admin/controllers/ConfigurationController.js
@@ -8,12 +8,7 @@ angular.module(PKG.name + '.feature.admin')
       _cdapPath: '/config/cdap'
     })
     .then(function (res) {
-      angular.forEach(res, function(v, k) {
-        $scope.config.push({
-          key: k,
-          value: v
-        });
-      });
+      $scope.config = res;
     });
 
   });

--- a/cdap-ui/app/features/admin/templates/system/configuration.html
+++ b/cdap-ui/app/features/admin/templates/system/configuration.html
@@ -14,14 +14,16 @@
     <table class="table table-responsive" cask-sortable>
       <thead>
         <tr ng-class="{'sort-enabled': config.length>0}">
-          <th data-predicate="key">Name</th>
+          <th data-predicate="source">Source</th>
+          <th data-predicate="name">Name</th>
           <th data-predicate="value">Value</th>
         </tr>
       </thead>
 
       <tbody>
         <tr ng-repeat="row in config | filter: searchText | orderBy:sortable.predicate:sortable.reverse">
-          <td>{{row.key}}</td>
+          <td>{{row.source}}</td>
+          <td>{{row.name}}</td>
           <td>{{row.value}}</td>
         </tr>
       </tbody>


### PR DESCRIPTION
Backend API changed for config/cdap to return the source of configuration. This caused the UI to break. This PR fixes that issue. Now, we display source, name and value of the configuration. 