### PR TITLE
(CDAP-2160) Fix the stream coordination when deleting stream

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowletProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowletProgramRunner.java
@@ -670,20 +670,14 @@ public final class FlowletProgramRunner implements ProgramRunner {
         }
 
         @Override
-        public void ttlDeleted(Id.Stream streamId) {
-          LOG.debug("TTL for stream '{}' deleted for flowlet '{}'", streamId, flowletName);
-          suspendAndResume();
-        }
-
-        @Override
         public void generationChanged(Id.Stream streamId, int generation) {
           LOG.debug("Generation for stream '{}' changed to {} for flowlet '{}'", streamId, generation, flowletName);
           suspendAndResume();
         }
 
         @Override
-        public void generationDeleted(Id.Stream streamId) {
-          LOG.debug("Generation for stream '{}' deleted for flowlet '{}'", streamId, flowletName);
+        public void deleted(Id.Stream streamId) {
+          LOG.debug("Properties deleted for stream '{}'", streamId);
           suspendAndResume();
         }
       };

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamCoordinatorClient.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamCoordinatorClient.java
@@ -72,5 +72,5 @@ public interface StreamCoordinatorClient extends Service {
    * @param action action to perform.
    * @throws Exception if the action throws Exception
    */
-  void deleteStream(Id.Stream streamId, Callable<CoordinatorStreamProperties> action) throws Exception;
+  void deleteStream(Id.Stream streamId, Runnable action) throws Exception;
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamPropertyListener.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamPropertyListener.java
@@ -34,15 +34,6 @@ public abstract class StreamPropertyListener {
   }
 
   /**
-   * Invoked when the stream generation property is deleted.
-   *
-   * @param streamId Id of the stream
-   */
-  public void generationDeleted(Id.Stream streamId) {
-    // Default no-op
-  }
-
-  /**
    * Invoked when the stream TTL property is changed.
    *
    * @param streamId Id of the stream
@@ -53,21 +44,21 @@ public abstract class StreamPropertyListener {
   }
 
   /**
-   * Invoked when the stream TTL property is deleted.
-   *
-   * @param streamId Id of the stream
-   */
-  public void ttlDeleted(Id.Stream streamId) {
-    // Default no-op
-  }
-
-  /**
    * Invoked when the stream Notification threshold property is changed.
    *
    * @param streamId Id of the stream
    * @param threshold Notification threshold of the stream
    */
   public void thresholdChanged(Id.Stream streamId, int threshold) {
+    // Default no-op
+  }
+
+  /**
+   * Invoked when the stream property is deleted.
+   *
+   * @param streamId Id of the stream
+   */
+  public void deleted(Id.Stream streamId) {
     // Default no-op
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/ConcurrentStreamWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/ConcurrentStreamWriter.java
@@ -279,7 +279,16 @@ public final class ConcurrentStreamWriter implements Closeable {
     @Override
     public void generationChanged(Id.Stream streamId, int generation) {
       LOG.debug("Generation for stream '{}' changed to {} for stream writer", streamId, generation);
+      closeEventQueue(streamId);
+    }
 
+    @Override
+    public void deleted(Id.Stream streamId) {
+      LOG.debug("Properties deleted for stream '{}' for stream writer", streamId);
+      closeEventQueue(streamId);
+    }
+
+    private void closeEventQueue(Id.Stream streamId) {
       EventQueue eventQueue = eventQueues.remove(streamId);
       if (eventQueue != null) {
         try {
@@ -288,11 +297,6 @@ public final class ConcurrentStreamWriter implements Closeable {
           LOG.warn("Failed to close writer.", e);
         }
       }
-    }
-
-    @Override
-    public void generationDeleted(Id.Stream streamId) {
-      LOG.debug("Generation for stream '{}' deleted for stream writer", streamId);
     }
 
     /**


### PR DESCRIPTION
- Instead of incrementing the generation, a stream deleted event should be sent.