### PR TITLE
[CDAP-2066] Added DB Batch Sink

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/templates/etl/batch/ETLBatchTemplate.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/templates/etl/batch/ETLBatchTemplate.java
@@ -22,6 +22,7 @@ import co.cask.cdap.api.templates.AdapterConfigurer;
 import co.cask.cdap.internal.schedule.TimeSchedule;
 import co.cask.cdap.templates.etl.batch.config.ETLBatchConfig;
 import co.cask.cdap.templates.etl.batch.sinks.BatchWritableSink;
+import co.cask.cdap.templates.etl.batch.sinks.DBSink;
 import co.cask.cdap.templates.etl.batch.sinks.KVTableSink;
 import co.cask.cdap.templates.etl.batch.sinks.TableSink;
 import co.cask.cdap.templates.etl.batch.sinks.TimePartitionedFileSetDatasetAvroSink;
@@ -62,7 +63,8 @@ public class ETLBatchTemplate extends ETLTemplate<ETLBatchConfig> {
                                         TimePartitionedFileSetDatasetAvroSink.class,
                                         StreamToStructuredRecordTransform.class,
                                         ScriptFilterTransform.class,
-                                        DBSource.class));
+                                        DBSource.class,
+                                        DBSink.class));
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/co/cask/cdap/templates/etl/batch/BatchETLDBAdapterTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/co/cask/cdap/templates/etl/batch/BatchETLDBAdapterTest.java
@@ -20,13 +20,17 @@ import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.lib.KeyValue;
+import co.cask.cdap.api.dataset.table.Put;
 import co.cask.cdap.api.dataset.table.Row;
 import co.cask.cdap.api.dataset.table.Scanner;
 import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.api.templates.ApplicationTemplate;
 import co.cask.cdap.templates.etl.api.config.ETLStage;
 import co.cask.cdap.templates.etl.batch.config.ETLBatchConfig;
+import co.cask.cdap.templates.etl.batch.sinks.DBSink;
+import co.cask.cdap.templates.etl.batch.sinks.TableSink;
 import co.cask.cdap.templates.etl.batch.sources.DBSource;
+import co.cask.cdap.templates.etl.batch.sources.TableSource;
 import co.cask.cdap.templates.etl.common.MockAdapterConfigurer;
 import co.cask.cdap.templates.etl.common.Properties;
 import co.cask.cdap.test.ApplicationManager;
@@ -41,12 +45,12 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.io.Resources;
 import org.hsqldb.Server;
-import org.hsqldb.persist.HsqlProperties;
 import org.hsqldb.server.ServerAcl;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
@@ -66,8 +70,10 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
 import java.text.SimpleDateFormat;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import javax.sql.rowset.serial.SerialBlob;
 
 /**
  * Test for ETL using databases
@@ -76,6 +82,8 @@ public class BatchETLDBAdapterTest extends TestBase {
   private static final long currentTs = System.currentTimeMillis();
   private static final String clobData = "this is a long string with line separators \n that can be used as \n a clob";
   private static HSQLDBServer hsqlDBServer;
+  private static ApplicationManager templateManager;
+  private static Schema schema;
 
   @ClassRule
   public static TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -87,38 +95,71 @@ public class BatchETLDBAdapterTest extends TestBase {
     hsqlDBServer.start();
     Connection conn = hsqlDBServer.getConnection();
     try {
-      createTestTable(conn);
+      createTestTables(conn);
       prepareTestData(conn);
     } finally {
       conn.close();
     }
+    // deploy etl batch template
+    String path = Resources.getResource("org/hsqldb/jdbcDriver.class").getPath();
+    File hsqldbJar = new File(URI.create(path.substring(0, path.indexOf('!'))));
+    templateManager = deployApplication(ETLBatchTemplate.class, hsqldbJar);
+
+    Schema nullableString = Schema.nullableOf(Schema.of(Schema.Type.STRING));
+    Schema nullableBoolean = Schema.nullableOf(Schema.of(Schema.Type.BOOLEAN));
+    Schema nullableInt = Schema.nullableOf(Schema.of(Schema.Type.INT));
+    Schema nullableLong = Schema.nullableOf(Schema.of(Schema.Type.LONG));
+    Schema nullableFloat = Schema.nullableOf(Schema.of(Schema.Type.FLOAT));
+    Schema nullableDouble = Schema.nullableOf(Schema.of(Schema.Type.DOUBLE));
+    Schema nullableBytes = Schema.nullableOf(Schema.of(Schema.Type.BYTES));
+    schema = Schema.recordOf("student",
+                             Schema.Field.of("ID", Schema.of(Schema.Type.INT)),
+                             Schema.Field.of("NAME", Schema.of(Schema.Type.STRING)),
+                             Schema.Field.of("SCORE", nullableDouble),
+                             Schema.Field.of("GRADUATED", nullableBoolean),
+                             Schema.Field.of("TINY", nullableInt),
+                             Schema.Field.of("SMALL", nullableInt),
+                             Schema.Field.of("BIG", nullableLong),
+                             Schema.Field.of("FLOAT", nullableFloat),
+                             Schema.Field.of("REAL", nullableFloat),
+                             Schema.Field.of("NUMERIC", nullableDouble),
+                             Schema.Field.of("DECIMAL", nullableDouble),
+                             Schema.Field.of("BIT", nullableBoolean),
+                             Schema.Field.of("DATE", nullableLong),
+                             Schema.Field.of("TIME", nullableLong),
+                             Schema.Field.of("TIMESTAMP", nullableLong),
+                             Schema.Field.of("BINARY", nullableBytes),
+                             Schema.Field.of("BLOB", nullableBytes),
+                             Schema.Field.of("CLOB", nullableString));
   }
 
-  private static void createTestTable(Connection conn) throws SQLException {
+  private static void createTestTables(Connection conn) throws SQLException {
     Statement stmt = conn.createStatement();
     try {
       stmt.execute("CREATE TABLE my_table" +
                      "(" +
-                     "id INT NOT NULL, " +
-                     "name VARCHAR(40) NOT NULL, " +
-                     "score DOUBLE, " +
-                     "graduated BOOLEAN, " +
-                     "not_imported VARCHAR(30), " +
-                     "tiny TINYINT, " +
-                     "small SMALLINT, " +
-                     "big BIGINT, " +
-                     "float FLOAT, " +
-                     "real REAL, " +
-                     "numeric NUMERIC(10, 2), " +
-                     "decimal DECIMAL(10, 2), " +
-                     "bit BIT, " +
-                     "date DATE, " +
-                     "time TIME, " +
-                     "timestamp TIMESTAMP, " +
-                     "binary BINARY(100)," +
-                     "blob BLOB(100), " +
-                     "clob CLOB" +
+                     "ID INT NOT NULL, " +
+                     "NAME VARCHAR(40) NOT NULL, " +
+                     "SCORE DOUBLE, " +
+                     "GRADUATED BOOLEAN, " +
+                     "NOT_IMPORTED VARCHAR(30), " +
+                     "TINY TINYINT, " +
+                     "SMALL SMALLINT, " +
+                     "BIG BIGINT, " +
+                     "FLOAT_COL FLOAT, " +
+                     "REAL_COL REAL, " +
+                     "NUMERIC_COL NUMERIC(10, 2), " +
+                     "DECIMAL_COL DECIMAL(10, 2), " +
+                     "BIT_COL BIT, " +
+                     "DATE_COL DATE, " +
+                     "TIME_COL TIME, " +
+                     "TIMESTAMP_COL TIMESTAMP, " +
+                     "BINARY_COL BINARY(100)," +
+                     "BLOB_COL BLOB(100), " +
+                     "CLOB_COL CLOB(100)" +
                      ")");
+      stmt.execute("CREATE TABLE my_dest_table AS (" +
+                     "SELECT * FROM my_table) WITH DATA");
     } finally {
       stmt.close();
     }
@@ -151,7 +192,7 @@ public class BatchETLDBAdapterTest extends TestBase {
         pStmt.setTime(15, new Time(currentTs));
         pStmt.setTimestamp(16, new Timestamp(currentTs));
         pStmt.setBytes(17, name.getBytes(Charsets.UTF_8));
-        pStmt.setBlob(18, new ByteArrayInputStream(name.getBytes(Charsets.UTF_8)));
+        pStmt.setBlob(18, new SerialBlob(name.getBytes(Charsets.UTF_8)));
         pStmt.setClob(19, new InputStreamReader(new ByteArrayInputStream(clobData.getBytes(Charsets.UTF_8))));
         pStmt.executeUpdate();
       }
@@ -163,16 +204,12 @@ public class BatchETLDBAdapterTest extends TestBase {
   @Test
   @Category(SlowTests.class)
   public void testDBSource() throws Exception {
-    String path = Resources.getResource("org/hsqldb/jdbcDriver.class").getPath();
-    File hsqldbJar = new File(URI.create(path.substring(0, path.indexOf('!'))));
-
-    ApplicationManager applicationManager = deployApplication(ETLBatchTemplate.class, hsqldbJar);
-
     ApplicationTemplate<ETLBatchConfig> appTemplate = new ETLBatchTemplate();
 
-    String importQuery = "SELECT id, name, score, graduated, tiny, small, big, float, real, numeric, decimal, bit, " +
-      "date, time, timestamp, binary, blob, clob FROM my_table WHERE id < 3";
-    String countQuery = "SELECT COUNT(id) from my_table WHERE id < 3";
+    String importQuery = "SELECT ID, NAME, SCORE, GRADUATED, TINY, SMALL, BIG, FLOAT_COL, REAL_COL, NUMERIC_COL, " +
+      "DECIMAL_COL, BIT_COL, DATE_COL, TIME_COL, TIMESTAMP_COL, BINARY_COL, BLOB_COL, CLOB_COL FROM my_table " +
+      "WHERE ID < 3";
+    String countQuery = "SELECT COUNT(ID) from my_table WHERE id < 3";
     ETLStage source = new ETLStage(DBSource.class.getSimpleName(),
                                    ImmutableMap.of(Properties.DB.DRIVER_CLASS, hsqlDBServer.getHsqlDBDriver(),
                                                    Properties.DB.CONNECTION_STRING, hsqlDBServer.getConnectionUrl(),
@@ -181,32 +218,7 @@ public class BatchETLDBAdapterTest extends TestBase {
                                                    Properties.DB.COUNT_QUERY, countQuery
                                    ));
 
-    Schema nullableBoolean = Schema.nullableOf(Schema.of(Schema.Type.BOOLEAN));
-    Schema nullableInt = Schema.nullableOf(Schema.of(Schema.Type.INT));
-    Schema nullableLong = Schema.nullableOf(Schema.of(Schema.Type.LONG));
-    Schema nullableFloat = Schema.nullableOf(Schema.of(Schema.Type.FLOAT));
-    Schema nullableDouble = Schema.nullableOf(Schema.of(Schema.Type.DOUBLE));
-    Schema nullableBytes = Schema.nullableOf(Schema.of(Schema.Type.BYTES));
-    Schema schema = Schema.recordOf("student",
-                                    Schema.Field.of("rowkey", Schema.of(Schema.Type.STRING)),
-                                    Schema.Field.of("ID", Schema.of(Schema.Type.INT)),
-                                    Schema.Field.of("NAME", Schema.of(Schema.Type.STRING)),
-                                    Schema.Field.of("SCORE", nullableDouble),
-                                    Schema.Field.of("GRADUATED", nullableBoolean),
-                                    Schema.Field.of("TINY", nullableInt),
-                                    Schema.Field.of("SMALL", nullableInt),
-                                    Schema.Field.of("BIG", nullableLong),
-                                    Schema.Field.of("FLOAT", nullableFloat),
-                                    Schema.Field.of("REAL", nullableFloat),
-                                    Schema.Field.of("NUMERIC", nullableDouble),
-                                    Schema.Field.of("BIT", nullableBoolean),
-                                    Schema.Field.of("DATE", nullableLong),
-                                    Schema.Field.of("TIME", nullableLong),
-                                    Schema.Field.of("TIMESTAMP", nullableLong),
-                                    Schema.Field.of("BINARY", nullableBytes),
-                                    Schema.Field.of("CLOB", nullableBytes));
-
-    ETLStage sink = new ETLStage("TableSink", ImmutableMap.of(
+    ETLStage sink = new ETLStage(TableSink.class.getSimpleName(), ImmutableMap.of(
       "name", "outputTable",
       Table.PROPERTY_SCHEMA, schema.toString(),
       Table.PROPERTY_SCHEMA_ROW_FIELD, "ID"));
@@ -218,9 +230,9 @@ public class BatchETLDBAdapterTest extends TestBase {
     addDatasetInstances(adapterConfigurer);
 
     Map<String, String> mapReduceArgs = Maps.newHashMap(adapterConfigurer.getArguments());
-    MapReduceManager mrManager = applicationManager.startMapReduce(ETLMapReduce.class.getSimpleName(), mapReduceArgs);
+    MapReduceManager mrManager = templateManager.startMapReduce(ETLMapReduce.class.getSimpleName(), mapReduceArgs);
     mrManager.waitForFinish(5, TimeUnit.MINUTES);
-    applicationManager.stopAll();
+    templateManager.stopAll();
 
     DataSetManager<Table> outputManager = getDataset("outputTable");
     Table outputTable = outputManager.get();
@@ -254,36 +266,96 @@ public class BatchETLDBAdapterTest extends TestBase {
     Assert.assertEquals(1, (long) row1.getLong("BIG"));
     Assert.assertEquals(2, (long) row2.getLong("BIG"));
     // TODO: Reading from table as FLOAT seems to be giving back the wrong value.
-    Assert.assertEquals(124.45, row1.getDouble("FLOAT"), 0.00001);
-    Assert.assertEquals(125.45, row2.getDouble("FLOAT"), 0.00001);
-    Assert.assertEquals(124.45, row1.getDouble("REAL"), 0.00001);
-    Assert.assertEquals(125.45, row2.getDouble("REAL"), 0.00001);
-    Assert.assertEquals(124.45, row1.getDouble("NUMERIC"), 0.000001);
-    Assert.assertEquals(125.45, row2.getDouble("NUMERIC"), 0.000001);
-    Assert.assertEquals(124.45, row1.getDouble("DECIMAL"), 0.000001);
-    Assert.assertEquals(null, row2.get("DECIMAL"));
-    Assert.assertEquals(true, row1.getBoolean("BIT"));
-    Assert.assertEquals(false, row2.getBoolean("BIT"));
+    Assert.assertEquals(124.45, row1.getDouble("FLOAT_COL"), 0.00001);
+    Assert.assertEquals(125.45, row2.getDouble("FLOAT_COL"), 0.00001);
+    Assert.assertEquals(124.45, row1.getDouble("REAL_COL"), 0.00001);
+    Assert.assertEquals(125.45, row2.getDouble("REAL_COL"), 0.00001);
+    Assert.assertEquals(124.45, row1.getDouble("NUMERIC_COL"), 0.000001);
+    Assert.assertEquals(125.45, row2.getDouble("NUMERIC_COL"), 0.000001);
+    Assert.assertEquals(124.45, row1.getDouble("DECIMAL_COL"), 0.000001);
+    Assert.assertEquals(null, row2.get("DECIMAL_COL"));
+    Assert.assertEquals(true, row1.getBoolean("BIT_COL"));
+    Assert.assertEquals(false, row2.getBoolean("BIT_COL"));
     // Verify time columns
     java.util.Date date = new java.util.Date(currentTs);
     SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
     long expectedDateTimestamp = Date.valueOf(sdf.format(date)).getTime();
     sdf = new SimpleDateFormat("H:mm:ss");
     long expectedTimeTimestamp = Time.valueOf(sdf.format(date)).getTime();
-    Assert.assertEquals(expectedDateTimestamp, (long) row1.getLong("DATE"));
-    Assert.assertEquals(expectedDateTimestamp, (long) row2.getLong("DATE"));
-    Assert.assertEquals(expectedTimeTimestamp, (long) row1.getLong("TIME"));
-    Assert.assertEquals(expectedTimeTimestamp, (long) row2.getLong("TIME"));
-    Assert.assertEquals(currentTs, (long) row1.getLong("TIMESTAMP"));
-    Assert.assertEquals(currentTs, (long) row2.getLong("TIMESTAMP"));
+    Assert.assertEquals(expectedDateTimestamp, (long) row1.getLong("DATE_COL"));
+    Assert.assertEquals(expectedDateTimestamp, (long) row2.getLong("DATE_COL"));
+    Assert.assertEquals(expectedTimeTimestamp, (long) row1.getLong("TIME_COL"));
+    Assert.assertEquals(expectedTimeTimestamp, (long) row2.getLong("TIME_COL"));
+    Assert.assertEquals(currentTs, (long) row1.getLong("TIMESTAMP_COL"));
+    Assert.assertEquals(currentTs, (long) row2.getLong("TIMESTAMP_COL"));
     // verify binary columns
-    Assert.assertEquals("user1", Bytes.toString(row1.get("BINARY"), 0, 5));
-    Assert.assertEquals("user2", Bytes.toString(row2.get("BINARY"), 0, 5));
-    Assert.assertEquals("user1", Bytes.toString(row1.get("BLOB"), 0, 5));
-    Assert.assertEquals("user2", Bytes.toString(row2.get("BLOB"), 0, 5));
-    Assert.assertEquals(clobData, Bytes.toString(row1.get("CLOB"), 0, clobData.length()));
-    Assert.assertEquals(clobData, Bytes.toString(row2.get("CLOB"), 0, clobData.length()));
+    Assert.assertEquals("user1", Bytes.toString(row1.get("BINARY_COL"), 0, 5));
+    Assert.assertEquals("user2", Bytes.toString(row2.get("BINARY_COL"), 0, 5));
+    Assert.assertEquals("user1", Bytes.toString(row1.get("BLOB_COL"), 0, 5));
+    Assert.assertEquals("user2", Bytes.toString(row2.get("BLOB_COL"), 0, 5));
+    Assert.assertEquals(clobData, Bytes.toString(row1.get("CLOB_COL"), 0, clobData.length()));
+    Assert.assertEquals(clobData, Bytes.toString(row2.get("CLOB_COL"), 0, clobData.length()));
+  }
 
+  @Test
+  @Ignore
+  @Category(SlowTests.class)
+  public void testDBSink() throws Exception {
+    ApplicationTemplate<ETLBatchConfig> appTemplate = new ETLBatchTemplate();
+    String cols = "ID, NAME, SCORE, GRADUATED, TINY, SMALL, BIG, FLOAT_COL, REAL_COL, NUMERIC_COL, DECIMAL_COL, " +
+      "BIT_COL, DATE_COL, TIME_COL, TIMESTAMP_COL, BINARY_COL, BLOB_COL, CLOB_COL";
+    ETLStage source = new ETLStage(TableSource.class.getSimpleName(),
+                                   ImmutableMap.of(
+                                     "name", "inputTable",
+                                     Table.PROPERTY_SCHEMA_ROW_FIELD, "ID",
+                                     Table.PROPERTY_SCHEMA, schema.toString()));
+    ETLStage sink = new ETLStage(DBSink.class.getSimpleName(),
+                                 ImmutableMap.of(Properties.DB.DRIVER_CLASS, hsqlDBServer.getHsqlDBDriver(),
+                                                 Properties.DB.CONNECTION_STRING, hsqlDBServer.getConnectionUrl(),
+                                                 Properties.DB.TABLE_NAME, "my_dest_table",
+                                                 Properties.DB.COLUMNS, cols
+                                 ));
+    List<ETLStage> transforms = Lists.newArrayList();
+    ETLBatchConfig adapterConfig = new ETLBatchConfig("", source, sink, transforms);
+    MockAdapterConfigurer adapterConfigurer = new MockAdapterConfigurer();
+    appTemplate.configureAdapter("myAdapter", adapterConfig, adapterConfigurer);
+    // add dataset instances that the source and sink added
+    addDatasetInstances(adapterConfigurer);
+    createInputData();
+    Map<String, String> mapReduceArgs = Maps.newHashMap(adapterConfigurer.getArguments());
+    MapReduceManager mrManager = templateManager.startMapReduce(ETLMapReduce.class.getSimpleName(), mapReduceArgs);
+    mrManager.waitForFinish(5, TimeUnit.MINUTES);
+    templateManager.stopAll();
+  }
+
+  private void createInputData() throws Exception {
+    // add some data to the input table
+    DataSetManager<Table> inputManager = getDataset("inputTable");
+    Table inputTable = inputManager.get();
+    for (int i = 1; i <= 2; i++) {
+      Put put = new Put(Bytes.toBytes("row" + i));
+      String name = "user" + i;
+      put.add("ID", i);
+      put.add("NAME", name);
+      put.add("SCORE", 3.451);
+      put.add("GRADUATED", (i % 2 == 0));
+      put.add("TINY", i + 1);
+      put.add("SMALL", i + 2);
+      put.add("BIG", 3456987L);
+      put.add("FLOAT", 3.456f);
+      put.add("REAL", 3.457f);
+      put.add("NUMERIC", 3.458);
+      put.add("DECIMAL", 3.459);
+      put.add("BIT", (i % 2 == 1));
+      put.add("DATE", currentTs);
+      put.add("TIME", currentTs);
+      put.add("TIMESTAMP", currentTs);
+      put.add("BINARY", name.getBytes(Charsets.UTF_8));
+      put.add("BLOB", name.getBytes(Charsets.UTF_8));
+      put.add("CLOB", clobData);
+      inputTable.put(put);
+      inputManager.flush();
+    }
   }
 
   private void addDatasetInstances(MockAdapterConfigurer configurer) throws Exception {
@@ -306,7 +378,6 @@ public class BatchETLDBAdapterTest extends TestBase {
       } finally {
         stmt.close();
       }
-      stmt.close();
     } finally {
       conn.close();
     }
@@ -330,10 +401,8 @@ public class BatchETLDBAdapterTest extends TestBase {
     }
 
     public int start() throws IOException, ServerAcl.AclFormatException {
-      HsqlProperties props = new HsqlProperties();
-      props.setProperty("server.database.0", locationUrl);
-      props.setProperty("server.dbname.0", database);
-      server.setProperties(props);
+      server.setDatabasePath(0, locationUrl);
+      server.setDatabaseName(0, database);
       return server.start();
     }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/batch/sinks/DBSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/batch/sinks/DBSink.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.templates.etl.batch.sinks;
+
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.dataset.lib.KeyValue;
+import co.cask.cdap.templates.etl.api.Emitter;
+import co.cask.cdap.templates.etl.api.PipelineConfigurer;
+import co.cask.cdap.templates.etl.api.Property;
+import co.cask.cdap.templates.etl.api.StageConfigurer;
+import co.cask.cdap.templates.etl.api.batch.BatchSink;
+import co.cask.cdap.templates.etl.api.batch.BatchSinkContext;
+import co.cask.cdap.templates.etl.api.config.ETLStage;
+import co.cask.cdap.templates.etl.common.DBRecord;
+import co.cask.cdap.templates.etl.common.ETLDBOutputFormat;
+import co.cask.cdap.templates.etl.common.Properties;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
+import com.google.common.base.Throwables;
+import com.google.common.collect.Lists;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapred.lib.db.DBConfiguration;
+import org.apache.hadoop.mapreduce.Job;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Sink that can be configured to export data to a database table
+ */
+public class DBSink extends BatchSink<StructuredRecord, DBRecord, NullWritable> {
+
+  private ResultSetMetaData resultSetMetadata;
+
+  @Override
+  public void configure(StageConfigurer configurer) {
+    configurer.setDescription("Batch sink for database");
+    configurer.addProperty(new Property(Properties.DB.DRIVER_CLASS, "Driver class to connect to the database", true));
+    configurer.addProperty(
+      new Property(Properties.DB.CONNECTION_STRING, "JDBC connection string including database name", true));
+    configurer.addProperty(
+      new Property(Properties.DB.USER,
+                   "User to use to connect to the specified database. " +
+                     "Required for databases that require authentication. " +
+                     "Optional for databases that do not require authentication.",
+                   false));
+    configurer.addProperty(
+      new Property(Properties.DB.PASSWORD,
+                   "Password to use to connect to the specified database. " +
+                     "Required for databases that require authentication. " +
+                     "Optional for databases that do not require authentication.",
+                   false));
+    configurer.addProperty(new Property(Properties.DB.TABLE_NAME, "Table name to import", true));
+    configurer.addProperty(new Property(Properties.DB.COLUMNS, "Comma-separated list of columns to sink to", true));
+  }
+
+  @Override
+  public void configurePipeline(ETLStage stageConfig, PipelineConfigurer pipelineConfigurer) {
+    Map<String, String> properties = stageConfig.getProperties();
+    String dbDriverClass = properties.get(Properties.DB.DRIVER_CLASS);
+    String dbConnectionString = properties.get(Properties.DB.CONNECTION_STRING);
+    String dbUser = properties.get(Properties.DB.USER);
+    String dbPassword = properties.get(Properties.DB.PASSWORD);
+    String dbTableName = properties.get(Properties.DB.TABLE_NAME);
+    String dbColumns = properties.get(Properties.DB.COLUMNS);
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(dbDriverClass), "dbDriverClass cannot be null");
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(dbConnectionString), "dbConnectionString cannot be null");
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(dbTableName), "dbTableName cannot be null");
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(dbColumns), "dbColumns cannot be null");
+    Preconditions.checkArgument(!(dbUser == null && dbPassword != null),
+                                "dbUser is null. Please provide both user name and password if database requires " +
+                                  "authentication. If not, please remove dbPassword and retry.");
+    Preconditions.checkArgument(!(dbUser != null && dbPassword == null),
+                                "dbPassword is null. Please provide both user name and password if database requires" +
+                                  "authentication. If not, please remove dbUser and retry.");
+  }
+
+  @Override
+  public void prepareJob(BatchSinkContext context) {
+    Map<String, String> runtimeArguments = context.getRuntimeArguments();
+    String dbDriverClass = runtimeArguments.get(Properties.DB.DRIVER_CLASS);
+    String dbConnectionString = runtimeArguments.get(Properties.DB.CONNECTION_STRING);
+    String dbUser = runtimeArguments.get(Properties.DB.USER);
+    String dbPassword = runtimeArguments.get(Properties.DB.PASSWORD);
+    String dbTableName = runtimeArguments.get(Properties.DB.TABLE_NAME);
+    String dbColumns = runtimeArguments.get(Properties.DB.COLUMNS);
+
+    Job job = context.getHadoopJob();
+    Configuration conf = job.getConfiguration();
+    if (dbUser == null && dbPassword == null) {
+      DBConfiguration.configureDB(conf, dbDriverClass, dbConnectionString);
+    } else {
+      DBConfiguration.configureDB(conf, dbDriverClass, dbConnectionString, dbUser, dbPassword);
+    }
+    List<String> fields = Lists.newArrayList(Splitter.on(",").omitEmptyStrings().split(dbColumns));
+    try {
+      ETLDBOutputFormat.setOutput(job, dbTableName, fields.toArray(new String[fields.size()]));
+    } catch (IOException e) {
+      throw Throwables.propagate(e);
+    }
+    job.setOutputFormatClass(ETLDBOutputFormat.class);
+  }
+
+  @Override
+  public void initialize(ETLStage stageConfig) throws Exception {
+    super.initialize(stageConfig);
+    setResultSetMetadata(stageConfig.getProperties());
+  }
+
+  @Override
+  public void transform(StructuredRecord input, Emitter<KeyValue<DBRecord, NullWritable>> emitter) throws Exception {
+    emitter.emit(new KeyValue<DBRecord, NullWritable>(new DBRecord(input, resultSetMetadata), null));
+  }
+
+  private void setResultSetMetadata(Map<String, String> runtimeArgs) throws SQLException {
+    String connectionString = runtimeArgs.get(Properties.DB.CONNECTION_STRING);
+    String tableName = runtimeArgs.get(Properties.DB.TABLE_NAME);
+    String columns = runtimeArgs.containsKey(Properties.DB.COLUMNS) ? runtimeArgs.get(Properties.DB.COLUMNS) : "*";
+    String userName = runtimeArgs.get(Properties.DB.USER);
+    String password = runtimeArgs.get(Properties.DB.PASSWORD);
+
+    Connection connection;
+    if (userName == null) {
+      connection = DriverManager.getConnection(connectionString);
+    } else {
+      connection = DriverManager.getConnection(connectionString, userName, password);
+    }
+    try {
+      Statement statement = connection.createStatement();
+      try {
+        // Using LIMIT in the following query even though its not SQL standard since DBInputFormat already depends on it
+        ResultSet rs = statement.executeQuery(String.format("SELECT %s from %s LIMIT 1", columns, tableName));
+        try {
+          resultSetMetadata = rs.getMetaData();
+        } finally {
+          rs.close();
+        }
+      } finally {
+        statement.close();
+      }
+    } finally {
+      connection.close();
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/common/ETLDBOutputFormat.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/common/ETLDBOutputFormat.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.templates.etl.common;
+
+import com.google.common.base.Throwables;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.RecordWriter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.lib.db.DBConfiguration;
+import org.apache.hadoop.mapreduce.lib.db.DBOutputFormat;
+import org.apache.hadoop.mapreduce.lib.db.DBWritable;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+
+/**
+ * Class that extends {@link DBOutputFormat} to load the database driver class correctly.
+ *
+ * @param <K> - Key passed to this class to be written
+ * @param <V> - Value passed to this class to be written. The value is ignored.
+ *
+ * {@inheritDoc}
+ */
+public class ETLDBOutputFormat<K extends DBWritable, V>  extends DBOutputFormat<K, V> {
+
+  @Override
+  public RecordWriter<K, V> getRecordWriter(TaskAttemptContext context) throws IOException {
+    Configuration conf = context.getConfiguration();
+    DBConfiguration dbConf = new DBConfiguration(conf);
+    String tableName = dbConf.getOutputTableName();
+    String[] fieldNames = dbConf.getOutputFieldNames();
+
+    if (fieldNames == null) {
+      fieldNames = new String[dbConf.getOutputFieldCount()];
+    }
+
+    try {
+      Connection connection = getConnection(conf);
+      PreparedStatement statement = connection.prepareStatement(constructQuery(tableName, fieldNames));
+      return new DBRecordWriter(connection, statement);
+    } catch (Exception ex) {
+      throw new IOException(ex.getMessage());
+    }
+  }
+
+  private Connection getConnection(Configuration conf) {
+    ClassLoader classLoader = conf.getClassLoader();
+    Connection connection;
+    try {
+      Class.forName(conf.get(DBConfiguration.DRIVER_CLASS_PROPERTY), true, classLoader);
+      String url = conf.get(DBConfiguration.URL_PROPERTY);
+      if (conf.get(DBConfiguration.USERNAME_PROPERTY) == null) {
+        connection = DriverManager.getConnection(url);
+      } else {
+        connection = DriverManager.getConnection(url,
+                                                 conf.get(DBConfiguration.USERNAME_PROPERTY),
+                                                 conf.get(DBConfiguration.PASSWORD_PROPERTY));
+      }
+      connection.setAutoCommit(false);
+      connection.setTransactionIsolation(Connection.TRANSACTION_SERIALIZABLE);
+    } catch (Exception e) {
+      throw Throwables.propagate(e);
+    }
+    return connection;
+  }
+}

--- a/cdap-app-templates/cdap-etl/pom.xml
+++ b/cdap-app-templates/cdap-etl/pom.xml
@@ -40,7 +40,7 @@
 
   <properties>
     <twitter4j.version>4.0.1</twitter4j.version>
-    <mysql.jdbc.version>5.1.6</mysql.jdbc.version>
+    <mysql.jdbc.version>5.1.35</mysql.jdbc.version>
     <etl.avro.version>1.7.7</etl.avro.version>
     <hsqldb.version>2.3.1</hsqldb.version>
   </properties>


### PR DESCRIPTION
Adds a ``DBSink`` that:
1. Reads a ``StructuredRecord``
2. Makes a JDBC call to the destination table to figure out the schema of the destination table as ``ResultSetMetadata``. This is needed because Database Drivers do not reliably return the schema from a ``PreparedStatement``.
3. Constructs a ``DBRecord`` using the ``StructuredRecord`` and ``ResultSetMetadata`` from 1 and 2 above.
4. Sends the ``DBRecord`` a custom ``ETLDBOutputFormat``, which is needed to load the driver class properly, just like we do in ``ETLDBInputFormat``.

- [x] Tested most SQL column types.
- [x] Tested on a local MySQL.
- [x] Tested a CDAP Table to MySQL table ETL pipeline on a cluster.
- [ ] The unit test for this fails, because when ``DBOutputFormat`` calls ``PreparedStatement.executeBatch()``, HSQLDB throws an exception saying *Statement is not in batch mode.* I'm trying to debug this a little more, but if it does not work, we may have to rely instead on an audi test that sets up a local mysql for this.

Jira: [CDAP-2066](https://issues.cask.co/browse/CDAP-2066)
Build: https://builds.cask.co/browse/CDAP-DT26