### PR TITLE
Errors Chart on overview page

### DIFF
--- a/cdap-ui/app/directives/c3/charts.js
+++ b/cdap-ui/app/directives/c3/charts.js
@@ -28,12 +28,18 @@ ngC3.controller('c3Controller', function ($scope, caskWindowManager, c3, myHelpe
       return;
     }
 
-    // TODO: Implement support for chart-* options to customize chart, by using attrs of directive.
     // Default options:
     var options = {stack: false, formatAsTimestamp: true};
     angular.extend(options, forcedOpts || {}, {
       el: elem[0]
     });
+
+    angular.forEach(attr, function (v, k) {
+      if ( v && k.indexOf('chart')===0 ) {
+        var key = k.substring(5);
+        this[key.charAt(0).toLowerCase() + key.slice(1)] = $scope.$eval(v);
+      }
+    }, options);
 
     options.data = { x: 'x', columns: [] };
 
@@ -82,7 +88,7 @@ ngC3.controller('c3Controller', function ($scope, caskWindowManager, c3, myHelpe
 
           render()
           // WARN: using load() API has funny animation (when inserting new data points to the right)
-          //  $scope.me.load(myData);  // Alternative to render()
+//            $scope.me.load(myData);  // Alternative to render()
         }
       });
     }
@@ -103,14 +109,21 @@ ngC3.controller('c3Controller', function ($scope, caskWindowManager, c3, myHelpe
     }
 
     var chartConfig = {bindto: $scope.options.el, data: data, tooltip: myTooltip};
-    chartConfig.size = { height: 200 };
+    chartConfig.size = $scope.options.size;
 
+    var xTick = {};
     if ($scope.options.formatAsTimestamp) {
       var timestampFormat = function(timestamp) {
         return $filter('amDateFormat')(timestamp, 'h:mm:ss a');
       };
-      chartConfig.axis = { x: { tick : { format: timestampFormat } } };
+      xTick.format = timestampFormat;
     }
+    chartConfig.axis = { x: { show: $scope.options.showx,
+                              tick : xTick },
+                         y: { show: $scope.options.showy } };
+    chartConfig.color = $scope.options.color;
+    chartConfig.legend = $scope.options.legend;
+    chartConfig.point = { show: false };
     $scope.me = c3.generate(chartConfig);
   }
 

--- a/cdap-ui/app/features/dashboard/controllers/widget.js
+++ b/cdap-ui/app/features/dashboard/controllers/widget.js
@@ -3,16 +3,20 @@
  */
 
 angular.module(PKG.name+'.feature.dashboard')
-  .factory('Widget', function (MyDataSource) {
+  .factory('Widget', function (MyDataSource, myHelpers) {
 
     function Widget (opts) {
       opts = opts || {};
       this.title = opts.title || 'Widget';
       this.type = opts.type;
       this.metric = opts.metric || false;
+      // TODO: reconsider this field once Epoch is removed.
       this.color = opts.color;
       this.dataSrc = null;
-      this.isLive = false;
+      this.isLive = opts.isLive || false;
+      this.interval = opts.interval;
+      this.aggregate = opts.aggregate;
+      this.metricAlias =  opts.metricAlias || {};
     }
 
     // 'ns.default.app.foo' -> {'ns': 'default', 'app': 'foo'}
@@ -29,11 +33,15 @@ angular.module(PKG.name+'.feature.dashboard')
       return tags;
     }
 
-    function constructQuery(queryId, tags, metrics) {
+    function constructQuery(queryId, tags, metric) {
       var timeRange, retObj;
-      timeRange = {'start': 'now-60s', 'end': 'now'};
+      timeRange = {'start': metric.startTime || 'now-60s',
+                  'end': metric.endTime || 'now'};
+      if (metric.resolution) {
+        timeRange['resolution'] = metric.resolution;
+      }
       retObj = {};
-      retObj[queryId] = {tags: tags, metrics: metrics, groupBy: [], timeRange: timeRange};
+      retObj[queryId] = {tags: tags, metrics: metric.names, groupBy: [], timeRange: timeRange};
       return retObj;
     }
 
@@ -47,7 +55,7 @@ angular.module(PKG.name+'.feature.dashboard')
       this.dataSrc.request({
         _cdapPath: '/metrics/query',
         method: 'POST',
-        body: constructQuery(queryId, contextToTags(this.metric.context), this.metric.names)
+        body: constructQuery(queryId, contextToTags(this.metric.context), this.metric)
       })
         .then(this.processData.bind(this))
     }
@@ -62,7 +70,8 @@ angular.module(PKG.name+'.feature.dashboard')
         {
           _cdapPath: '/metrics/query',
           method: 'POST',
-          body: constructQuery(queryId, contextToTags(this.metric.context), this.metric.names)
+          body: constructQuery(queryId, contextToTags(this.metric.context), this.metric),
+          interval: this.interval
         },
         this.processData.bind(this)
       );
@@ -71,6 +80,26 @@ angular.module(PKG.name+'.feature.dashboard')
     Widget.prototype.stopPolling = function(id) {
       if (!this.dataSrc) return;
       this.dataSrc.stopPoll(id);
+    };
+
+    var zeroFill = function(resolution, result) {
+        // interpolating (filling with zeros) the data since backend returns only metrics at specific time periods
+        // instead of for the whole range. We have to interpolate the rest with 0s to draw the graph.
+        if (resolution == '1h') {
+          skipAmt = 60 * 60;
+        } else if (resolution == '1m') {
+          skipAmt = 60;
+        } else {
+          skipAmt = 1;
+        }
+
+        var startTime = myHelpers.roundUpToNearest(result.startTime, skipAmt);
+        var endTime = myHelpers.roundDownToNearest(result.endTime, skipAmt);
+        var tempMap = {};
+        for (j = startTime; j <= endTime; j += skipAmt) {
+          tempMap[j] = 0;
+        }
+        return tempMap;
     };
 
     Widget.prototype.processData = function (queryResults) {
@@ -82,12 +111,7 @@ angular.module(PKG.name+'.feature.dashboard')
       metrics = this.metric.names;
       for (i = 0; i < metrics.length; i++) {
         metric = metrics[i];
-        tempMap[metric] = {};
-        // interpolating the data since backend returns only metrics at specific time periods instead of
-        // for the whole range. We have to interpolate the rest with 0s to draw the graph.
-        for (j = result.startTime; j <= result.endTime; j++) {
-          tempMap[metric][j] = 0;
-        }
+        tempMap[metric] = zeroFill(this.metric.resolution, result);
       }
       for (i = 0; i < result.series.length; i++) {
         data = result.series[i].data;
@@ -98,7 +122,11 @@ angular.module(PKG.name+'.feature.dashboard')
         }
       }
       for (i = 0; i < metrics.length; i++) {
-        tmpData.push(tempMap[metrics[i]]);
+        var thisMetricData = tempMap[metrics[i]];
+        if (this.aggregate) {
+          thisMetricData = myHelpers.aggregate(thisMetricData, this.aggregate);
+        }
+        tmpData.push(thisMetricData);
       }
       this.data = tmpData;
     };
@@ -166,12 +194,17 @@ angular.module(PKG.name+'.feature.dashboard')
           // http://stackoverflow.com/questions/20306204/using-queryselector-with-ids-that-are-numbers
           // http://www.w3.org/TR/CSS21/syndata.html#value-def-identifier
           var metricName = $scope.wdgt.metric.names[i];
+
+          var metricAlias = $scope.wdgt.metricAlias[metricName];
+          if (metricAlias !== undefined) {
+            metricName = metricAlias;
+          }
           // Replace all invalid characters with '_'. This is ok for now, since we do not display the chart labels
           // to the user. Source: http://stackoverflow.com/questions/13979323/how-to-test-if-selector-is-valid-in-jquery
           var replacedMetricName = metricName.replace(/([;&,\.\+\*\~':"\!\^#$%@\[\]\(\)=><\|])/g, '_');
-          // TODO: This replacement is not required for c3 (only for Epoch).
-          //       Need to take advantage of that.
-          hist.push({label: replacedMetricName, values: vs[i]});
+          // TODO: This replacement is not required for c3 (only for Epoch). c3 does it internally, where needed.
+          //       Need to take advantage of that, once we remove Epoch
+          hist.push({label: metricName, values: vs[i]});
         }
         $scope.chartHistory = hist;
       }

--- a/cdap-ui/app/features/dashboard/templates/widgets/c3-bar.html
+++ b/cdap-ui/app/features/dashboard/templates/widgets/c3-bar.html
@@ -2,7 +2,7 @@
 
   <c3-bar
     data-history="chartHistory"
-    chart-height="200"
+    chart-size="{ height: 200 }"
     chart-ticks="{ bottom: 3 }"
     chart-axes="['left', 'bottom']"
   ></c3-bar>

--- a/cdap-ui/app/features/dashboard/templates/widgets/c3-donut.html
+++ b/cdap-ui/app/features/dashboard/templates/widgets/c3-donut.html
@@ -2,9 +2,7 @@
 
   <c3-donut
     data-history="chartHistory"
-    chart-height="200"
-    chart-ticks="{ bottom: 3 }"
-    chart-axes="['left', 'bottom']"
+    chart-size="{ height: 200 }"
   ></c3-donut>
 
 </div>

--- a/cdap-ui/app/features/dashboard/templates/widgets/c3-line.html
+++ b/cdap-ui/app/features/dashboard/templates/widgets/c3-line.html
@@ -2,9 +2,7 @@
 
   <c3-line
     data-history="chartHistory"
-    chart-height="200"
-    chart-ticks="{ bottom: 3 }"
-    chart-axes="['left', 'bottom']"
+    chart-size="{ height: 200 }"
   ></c3-line>
 
 </div>

--- a/cdap-ui/app/features/dashboard/templates/widgets/c3-pie.html
+++ b/cdap-ui/app/features/dashboard/templates/widgets/c3-pie.html
@@ -2,9 +2,7 @@
 
   <c3-pie
     data-history="chartHistory"
-    chart-height="200"
-    chart-ticks="{ bottom: 3 }"
-    chart-axes="['left', 'bottom']"
+    chart-size="{ height: 200 }"
   ></c3-pie>
 
 </div>

--- a/cdap-ui/app/features/overview/controllers/overview-ctrl.js
+++ b/cdap-ui/app/features/overview/controllers/overview-ctrl.js
@@ -3,7 +3,7 @@
  */
 
 angular.module(PKG.name+'.feature.overview').controller('OverviewCtrl',
-function ($scope, MyDataSource, $state, myLocalStorage, MY_CONFIG) {
+function ($scope, MyDataSource, $state, myLocalStorage, MY_CONFIG, Widget) {
 
   if(!$state.params.namespace) {
     // the controller for "ns" state should handle the case of
@@ -35,7 +35,8 @@ function ($scope, MyDataSource, $state, myLocalStorage, MY_CONFIG) {
   $scope.isEnterprise = MY_CONFIG.isEnterprise;
   $scope.systemStatus = '';
   dataSrc.poll({
-    _cdapPath: '/system/services/status'
+    _cdapPath: '/system/services/status',
+    interval: 10000
   }, function(res) {
     var serviceStatuses = Object.keys(res).map(function(value, i) {
       return res[value];
@@ -73,4 +74,32 @@ function ($scope, MyDataSource, $state, myLocalStorage, MY_CONFIG) {
     }
   });
 
+  $scope.wdgts = [];
+  // type field is overridden by what is rendered in view because we do not use widget.getPartial()
+  $scope.wdgts.push(new Widget({title: 'System', type: 'c3-line', isLive: true,
+                  metric: {
+                    context: 'namespace.*',
+                    names: ['system.log.error', 'system.log.warn'],
+                    startTime: 'now-3600s',
+                    endTime: 'now',
+                    resolution: '1m'
+                  },
+                  metricAlias: {'system.log.error': 'System Errors',
+                                'system.log.warn' : 'System Warnings'},
+                  interval: 60*1000,
+                  aggregate: 5
+  }));
+  $scope.wdgts.push(new Widget({title: 'App', type: 'c3-line', isLive: true,
+                  metric: {
+                    context: 'namespace.' + $state.params.namespace,
+                    names: ['system.app.log.error', 'system.app.log.warn'],
+                    startTime: 'now-3600s',
+                    endTime: 'now',
+                    resolution: '1m'
+                  },
+                  metricAlias: {'system.app.log.error': 'Application Errors',
+                                'system.app.log.warn' : 'Application Warnings'},
+                  interval: 60*1000,
+                  aggregate: 5
+  }));
 });

--- a/cdap-ui/app/features/overview/overview.html
+++ b/cdap-ui/app/features/overview/overview.html
@@ -98,16 +98,24 @@
       </div>
     </div>
 
+
     <div class="col-xs-12 col-lg-8">
-      <div>
-        <p class="text-left"> <strong>Errors last hour</strong> </p>
-        <img src="assets/img/health_graph.png" alt="" />
-        <p class="text-center"> System </p>
-      </div>
-      <div>
-        <br />
-        <img src="assets/img/health_graph.png" alt="" />
-        <p class="text-center"> App </p>
+      <div ng-controller="WidgetTimeseriesCtrl" ng-repeat="wdgt in wdgts" class="col-xs-5">
+        <p class="text-left" ng-show="$first">
+          <strong class="text-left"> Errors last hour </strong>
+        </p>
+        <br ng-hide="$first">
+        <c3-spline
+          data-history="chartHistory"
+          chart-size="{ height: 100 }"
+          chart-showx="false"
+          chart-showy="false"
+          chart-color="{ pattern: ['red', '#FFBF00'] }"
+          chart-legend="{ show: false, position: 'inset' }"
+          ></c3-spline>
+
+        <p class="text-center">{{wdgt.title}} - {{chartHistory[0].values.slice(-1)[0].y}} - {{chartHistory[1].values.slice(-1)[0].y}}</p>
+
       </div>
     </div>
   </div>

--- a/cdap-ui/app/features/overview/overview.less
+++ b/cdap-ui/app/features/overview/overview.less
@@ -82,7 +82,16 @@ body.state-overview {
             .box-shadow(inset 0 0 5px lightgray);
           }
           path { stroke: lightgray; }
-          > g > g { display: none; }
+          .c3-line {
+            stroke-width: 2px;
+          }
+        }
+        .c3 {
+          svg {
+            border-radius: 5px;
+            border: 2px solid #E2E3E9;
+            background-color: #E2E3E9;
+          }
         }
       }
       &.data-apps {

--- a/cdap-ui/app/services/helpers.js
+++ b/cdap-ui/app/services/helpers.js
@@ -96,11 +96,46 @@ angular.module(PKG.name+'.services')
     return obj;
   }
 
+    var roundUpToNearest = function(val, nearest) {
+      return Math.ceil(val / nearest) * nearest;
+    };
+    var roundDownToNearest = function(val, nearest) {
+      return Math.floor(val / nearest) * nearest;
+    };
+
+    function aggregate(inputMetrics, by) {
+      // Given an object in the format: { ts1: value, ts2: value, ts3: value, ts4: value },
+      // This will return an object in the same format, where each sequence of {by} timestamps will be summed up.
+      // Not currently considering resolution of the metric values (It groups simply starting from the first timestamp),
+      // as opposed to grouping into 5-minute interval.
+      var aggregated = {};
+      var timeValues = Object.keys(inputMetrics);
+      var roundedDown = roundDownToNearest(timeValues.length, by);
+      for (var i = 0; i < roundedDown; i += by) {
+        var sum = 0;
+        for (var j = 0; j < by; j++) {
+          sum += inputMetrics[timeValues[i + j]];
+        }
+        aggregated[timeValues[i]] = sum;
+      }
+      // Add up remainder elements (in case number of elements in obj is not evenly divisible by {by}
+      if (roundedDown < timeValues.length) {
+        var finalKey = timeValues[roundedDown];
+        aggregated[finalKey] = 0;
+        for (var i = roundedDown; i < timeValues.length; i++) {
+          aggregated[finalKey] += inputMetrics[timeValues[j]]
+        }
+      }
+      return aggregated;
+    }
   /* ----------------------------------------------------------------------- */
 
   return {
     deepSet: deepSet,
     deepGet: deepGet,
-    objectQuery: objectQuery
+    objectQuery: objectQuery,
+    roundUpToNearest: roundUpToNearest,
+    roundDownToNearest: roundDownToNearest,
+    aggregate: aggregate
   };
 });


### PR DESCRIPTION
System and app errors on overview page, using c3.

Perhaps a single number should also be visible (either aggregated for past 5 minutes or past hour).

Note: Because it is based off of c3 charts, it depends on: https://github.com/caskdata/cdap/pull/2184

![](http://g.recordit.co/BZYXeTs1l5.gif)