### PR TITLE
Make chart color a hash of metric name. Fix a bug which occurred if metr...

### DIFF
--- a/cdap-ui/app/features/dashboard/controllers/addwdgt-ctrl.js
+++ b/cdap-ui/app/features/dashboard/controllers/addwdgt-ctrl.js
@@ -58,7 +58,7 @@ function ($scope, $modalInstance, caskFocusManager, Widget) {
           new Widget({
             type: $scope.model.type,
             title: $scope.model.metric.title,
-            color: classes[(generateHash($scope.model.metric.context) * 13) % classes.length],
+            color: classes[(generateHash(value) * 13) % classes.length],
             metric: {
               context: $scope.model.metric.context,
               names: [value],
@@ -69,7 +69,7 @@ function ($scope, $modalInstance, caskFocusManager, Widget) {
       });
       $scope.currentDashboard.addWidget(widgets);
     } else {
-      $scope.model.color = classes[(generateHash($scope.model.metric.context) * 13) % classes.length];
+      $scope.model.color = classes[(generateHash($scope.model.metric.name) * 13) % classes.length];
       $scope.currentDashboard.addWidget($scope.model);
     }
     $scope.$close();

--- a/cdap-ui/app/features/dashboard/controllers/widget.js
+++ b/cdap-ui/app/features/dashboard/controllers/widget.js
@@ -163,7 +163,13 @@ angular.module(PKG.name+'.feature.dashboard')
 
         hist = [];
         for (var i = 0; i < vs.length; i++) {
-          hist.push({label: $scope.wdgt.metric.names[i], values: vs[i]});
+          // http://stackoverflow.com/questions/20306204/using-queryselector-with-ids-that-are-numbers
+          // http://www.w3.org/TR/CSS21/syndata.html#value-def-identifier
+          var metricName = $scope.wdgt.metric.names[i];
+          // Replace all invalid characters with '_'. This is ok for now, since we do not display the chart labels
+          // to the user. Source: http://stackoverflow.com/questions/13979323/how-to-test-if-selector-is-valid-in-jquery
+          var replacedMetricName = metricName.replace(/([;&,\.\+\*\~':"\!\^#$%@\[\]\(\)=><\|])/g, '_');
+          hist.push({label: replacedMetricName, values: vs[i]});
         }
         $scope.chartHistory = hist;
       }


### PR DESCRIPTION
Make chart color a hash of metric name.
Fix a bug which occurred if metric name had '>', '.\d', or other illegal jquery selector characters.