### PR TITLE
Add a single-page version of HTTP RESTful API

### DIFF
--- a/cdap-docs/reference-manual/source/http-restful-api/dataset.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/dataset.rst
@@ -3,13 +3,14 @@
     :description: HTTP RESTful Interface to the Cask Data Application Platform
     :copyright: Copyright © 2014 Cask Data, Inc.
 
+
+.. highlight:: console
+
 .. _http-restful-api-dataset:
 
 ===========================================================
 Dataset HTTP RESTful API
 ===========================================================
-
-.. highlight:: console
 
 The Dataset API allows you to interact with Datasets through HTTP. You can list, create,
 delete, and truncate Datasets. For details, see the 

--- a/cdap-docs/reference-manual/source/http-restful-api/index.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/index.rst
@@ -28,6 +28,7 @@ CDAP HTTP RESTful API v3
     Metrics <metrics>
     Monitor <monitor>
     Transactions <transactions>
+    Single Page <single-page>
     
 
 .. highlight:: console
@@ -54,3 +55,5 @@ data isolation. This is an inital step towards introducing `multi-tenancy
 - :doc:`Metrics: <metrics>` retrieving metrics for system and user Applications (user-defined metrics)
 - :doc:`Monitor: <monitor>` checking the status of various System and Custom CDAP services
 - :doc:`Transactions: <transactions>` interacting with the Transaction Service
+
+The :doc:`Single Page <single-page>` is a listing of all the APIs together on a single page.

--- a/cdap-docs/reference-manual/source/http-restful-api/introduction.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/introduction.rst
@@ -3,13 +3,14 @@
     :description: HTTP RESTful Interface to the Cask Data Application Platform
     :copyright: Copyright © 2014 Cask Data, Inc.
 
+.. highlight:: console
+
+
 .. _http-restful-api-introduction:
 
 ===========================================================
 Introduction
 ===========================================================
-
-.. highlight:: console
 
 .. _http-restful-api-conventions:
 

--- a/cdap-docs/reference-manual/source/http-restful-api/lifecycle.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/lifecycle.rst
@@ -3,6 +3,9 @@
     :description: HTTP RESTful Interface to the Cask Data Application Platform
     :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
+.. highlight:: console
+
+
 .. _http-restful-api-lifecycle:
 
 ===========================================================
@@ -11,8 +14,6 @@ Lifecycle HTTP RESTful API
 
 Use the CDAP Lifecycle HTTP API to deploy or delete Applications and manage the lifecycle of 
 Flows, MapReduce programs, Workflows, Workers, and Custom Services.
-
-.. highlight:: console
 
 Deploy an Application
 ---------------------

--- a/cdap-docs/reference-manual/source/http-restful-api/logging.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/logging.rst
@@ -3,13 +3,14 @@
     :description: HTTP RESTful Interface to the Cask Data Application Platform
     :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
+.. highlight:: console
+
+
 .. _http-restful-api-logging:
 
 ===========================================================
 Logging HTTP RESTful API
 ===========================================================
-
-.. highlight:: console
 
 Downloading Application Logs
 ----------------------------

--- a/cdap-docs/reference-manual/source/http-restful-api/metrics.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/metrics.rst
@@ -3,13 +3,14 @@
     :description: HTTP RESTful Interface to the Cask Data Application Platform
     :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
+.. highlight:: console
+
+
 .. _http-restful-api-metrics:
 
 ===========================================================
 Metrics HTTP RESTful API
 ===========================================================
-
-.. highlight:: console
 
 As Applications process data, CDAP collects metrics about the Application’s behavior and
 performance. Some of these metrics are the same for every Application—how many events are

--- a/cdap-docs/reference-manual/source/http-restful-api/monitor.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/monitor.rst
@@ -3,13 +3,14 @@
     :description: HTTP RESTful Interface to the Cask Data Application Platform
     :copyright: Copyright © 2014 Cask Data, Inc.
 
+.. highlight:: console
+
+
 .. _http-restful-api-monitor:
 
 ===========================================================
 Monitor HTTP RESTful API
 ===========================================================
-
-.. highlight:: console
 
 CDAP internally uses a variety of System Services that are critical to its functionality.
 This section describes the RESTful APIs that can be used to see into System Services.

--- a/cdap-docs/reference-manual/source/http-restful-api/namespace.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/namespace.rst
@@ -3,14 +3,14 @@
     :description: HTTP RESTful Interface to the Cask Data Application Platform
     :copyright: Copyright © 2015 Cask Data, Inc.
 
+.. highlight:: console
+
 .. _http-restful-api-namespace:
 .. _http-restful-api-v3-namespace:
 
 ===========================================================
 Namespace HTTP RESTful API
 ===========================================================
-
-.. highlight:: console
 
 Use the CDAP Namespace HTTP API to create, list or delete namespaces in the CDAP instance.
 

--- a/cdap-docs/reference-manual/source/http-restful-api/preferences.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/preferences.rst
@@ -3,14 +3,14 @@
     :description: HTTP RESTful Interface to the Cask Data Application Platform
     :copyright: Copyright © 2015 Cask Data, Inc.
 
+.. highlight:: console
+
 .. _http-restful-api-preferences:
 .. _http-restful-api-v3-preferences:
 
 ============================
 Preferences HTTP RESTful API
 ============================
-
-.. highlight:: console
 
 Use the CDAP Preferences HTTP RESTful API to save, retrieve, and delete preferences in CDAP.
 

--- a/cdap-docs/reference-manual/source/http-restful-api/query.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/query.rst
@@ -3,13 +3,14 @@
     :description: HTTP RESTful Interface to the Cask Data Application Platform
     :copyright: Copyright © 2014 Cask Data, Inc.
 
+.. highlight:: console
+
+
 .. _http-restful-api-query:
 
 ===========================================================
 Query HTTP RESTful API
 ===========================================================
-
-.. highlight:: console
 
 This interface supports submitting SQL queries over Datasets. Queries are
 processed asynchronously; to obtain query results, perform these steps:

--- a/cdap-docs/reference-manual/source/http-restful-api/service.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/service.rst
@@ -3,13 +3,14 @@
     :description: HTTP RESTful Interface to the Cask Data Application Platform
     :copyright: Copyright © 2014 Cask Data, Inc.
 
+.. highlight:: console
+
+
 .. _http-restful-api-service:
 
 ========================
 Service HTTP RESTful API
 ========================
-
-.. highlight:: console
 
 This interface supports listing all Services and making requests to the methods of an Application’s Services.
 See the :ref:`http-restful-api-lifecycle` for how to control the lifecycle of Services.

--- a/cdap-docs/reference-manual/source/http-restful-api/single-page.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/single-page.rst
@@ -1,0 +1,49 @@
+.. meta::
+    :author: Cask Data, Inc.
+    :description: HTTP RESTful Interface to the Cask Data Application Platform
+    :copyright: Copyright © 2015 Cask Data, Inc.
+
+
+.. highlight:: console
+
+.. _http-restful-api-single-page:
+
+=====================
+CDAP HTTP RESTful API
+=====================
+
+.. include:: namespace.rst
+   :start-line: 11
+
+.. include:: lifecycle.rst
+   :start-line: 11
+
+.. include:: configuration.rst
+   :start-line: 11
+
+.. include:: preferences.rst
+   :start-line: 11
+   
+.. include:: stream.rst
+   :start-line: 11
+   
+.. include:: dataset.rst
+   :start-line: 11
+   
+.. include:: query.rst
+   :start-line: 11
+   
+.. include:: service.rst
+   :start-line: 11
+   
+.. include:: logging.rst
+   :start-line: 11
+   
+.. include:: metrics.rst
+   :start-line: 11
+   
+.. include:: monitor.rst
+   :start-line: 11
+   
+.. include:: transactions.rst
+   :start-line: 11

--- a/cdap-docs/reference-manual/source/http-restful-api/stream.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/stream.rst
@@ -3,13 +3,14 @@
     :description: HTTP RESTful Interface to the Cask Data Application Platform
     :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
+.. highlight:: console
+
+
 .. _http-restful-api-stream:
 
 ===========================================================
 Stream HTTP RESTful API
 ===========================================================
-
-.. highlight:: console
 
 This interface supports creation of a :ref:`Stream; <developers:streams>` sending, reading, and truncating events to
 and from a Stream; and setting the TTL property of a Stream.


### PR DESCRIPTION
These changes modify the documentation for the RESTful API such that a single-page version with all the APIs on one page can be created. There have been a number of requests for a page like this. It is generated by "including" together all the other pages, and so it is automatically updating with any changes in the other files.

The advantage with it is that you can search on this single page across all APIs.

It is staged as [Single Page](http://stg-web101.sw.joyent.continuuity.net/cdap/3.0.0-SNAPSHOT-3.0_Single_Page_RESTful_API/en/reference-manual/http-restful-api/single-page.html).

Please take a look and comment on if you think this is useful addition—or not.

Caveats:
- The metrics section of the single page is not formatted correctly, because the underlying document has a different structure than the other RESTful APIs. As that file is currently being worked on in another PR, I will fix it there so that problem will disappear.
- Numerous warnings are created in the build because duplicate references are created. However, the links all seem to work fine, so we have to just put up with these warnings, unless I figure out how to get around them.