### PR TITLE
(CDAP-2177) Fix standalone log appender

### DIFF
--- a/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
+++ b/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
@@ -66,7 +66,6 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
@@ -325,8 +324,7 @@ public class CLIMainTest extends StandaloneTestBase {
     }
   }
 
-  @Test @Ignore
-  // JIRA to track the ignore: CDAP-2177
+  @Test
   public void testSpark() throws Exception {
     String sparkId = FakeApp.SPARK.get(0);
     String qualifiedSparkId = FakeApp.NAME + "." + sparkId;

--- a/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
+++ b/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
@@ -69,7 +69,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.PrintStream;
-import java.net.InetAddress;
 import java.util.List;
 
 /**

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/appender/standalone/StandaloneLogAppender.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/appender/standalone/StandaloneLogAppender.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.logging.appender.standalone;
 
+import ch.qos.logback.classic.spi.ILoggingEvent;
 import co.cask.cdap.logging.appender.LogAppender;
 import co.cask.cdap.logging.appender.LogMessage;
 import co.cask.cdap.logging.kafka.KafkaLogEvent;
@@ -43,6 +44,21 @@ public class StandaloneLogAppender extends LogAppender {
     for (KafkaLogProcessor plugin : plugins) {
       plugin.process(getKafkaLogEvent(logMessage));
     }
+  }
+
+  @Override
+  public void doAppend(ILoggingEvent eventObject) {
+    append(eventObject);
+  }
+
+  @Override
+  public void start() {
+    appender.start();
+  }
+
+  @Override
+  public void stop() {
+    appender.stop();
   }
 
   private KafkaLogEvent getKafkaLogEvent(LogMessage message) {


### PR DESCRIPTION
It needs to override the lifecycle methods and the append method to correctly delegate calls from logback into underlying log appender.