### PR TITLE
(CDAP-1917) Added plugin repository and plugin instantiate support.

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/annotation/Description.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/annotation/Description.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.api.annotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Annotates the description for the element.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Description {
+
+  /**
+   * Returns the description.
+   */
+  String value() default "";
+}

--- a/cdap-api/src/main/java/co/cask/cdap/api/annotation/Name.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/annotation/Name.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.api.annotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Annotates the name of the element.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Name {
+
+  /**
+   * Returns the name.
+   */
+  String value();
+}

--- a/cdap-api/src/main/java/co/cask/cdap/api/annotation/Plugin.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/annotation/Plugin.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.api.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotate a class that it is a plugin.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Plugin {
+
+  /**
+   * Default plugin type name.
+   */
+  String DEFAULT_TYPE = "plugin";
+
+  /**
+   * Returns the name of the plugin type. Default is 'plugin'.
+   */
+  String type() default DEFAULT_TYPE;
+}

--- a/cdap-api/src/main/java/co/cask/cdap/api/templates/plugins/PluginClass.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/templates/plugins/PluginClass.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.api.templates.plugins;
+
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Contains information about a plugin class.
+ */
+public class PluginClass {
+
+  private final String type;
+  private final String name;
+  private final String description;
+  private final String className;
+  private final String configFieldName;
+  private final Map<String, PluginPropertyField> properties;
+
+  public PluginClass(String type, String name, String description, String className,
+                     @Nullable String configfieldName, Map<String, PluginPropertyField> properties) {
+    if (type == null) {
+      throw new IllegalArgumentException("Plugin class type cannot be null");
+    }
+    if (name == null) {
+      throw new IllegalArgumentException("Plugin class name cannot be null");
+    }
+    if (description == null) {
+      throw new IllegalArgumentException("Plugin class description cannot be null");
+    }
+    if (className == null) {
+      throw new IllegalArgumentException("Plugin class className cannot be null");
+    }
+    if (properties == null) {
+      throw new IllegalArgumentException("Plugin class properties cannot be null");
+    }
+
+    this.type = type;
+    this.name = name;
+    this.description = description;
+    this.className = className;
+    this.configFieldName = configfieldName;
+    this.properties = properties;
+  }
+
+  /**
+   * Returns the type name of the plugin.
+   */
+  public String getType() {
+    return type;
+  }
+
+  /**
+   * Returns name of the plugin.
+   */
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * Returns description of the plugin.
+   */
+  public String getDescription() {
+    return description;
+  }
+
+  /**
+   * Returns the fully qualified class name of the plugin.
+   */
+  public String getClassName() {
+    return className;
+  }
+
+  /**
+   * Returns the name of the field that extends from {@link PluginConfig} in the plugin class.
+   * If no such field, {@code null} will be returned.
+   */
+  @Nullable
+  public String getConfigFieldName() {
+    return configFieldName;
+  }
+
+  /**
+   * Returns a map from config property name to {@link PluginPropertyField} that are supported by the plugin class.
+   */
+  public Map<String, PluginPropertyField> getProperties() {
+    return properties;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    PluginClass that = (PluginClass) o;
+
+    return type.equals(that.type)
+      && name.equals(that.name)
+      && description.equals(that.description)
+      && className.equals(that.className)
+      && !(configFieldName != null ? !configFieldName.equals(that.configFieldName) : that.configFieldName != null)
+      && properties.equals(that.properties);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = type.hashCode();
+    result = 31 * result + name.hashCode();
+    result = 31 * result + description.hashCode();
+    result = 31 * result + className.hashCode();
+    result = 31 * result + (configFieldName != null ? configFieldName.hashCode() : 0);
+    result = 31 * result + properties.hashCode();
+    return result;
+  }
+}

--- a/cdap-api/src/main/java/co/cask/cdap/api/templates/plugins/PluginConfig.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/templates/plugins/PluginConfig.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.api.templates.plugins;
+
+/**
+ * Base class for writing configuration class for template plugin.
+ */
+public abstract class PluginConfig {
+
+  private PluginProperties properties;
+
+  /**
+   * Returns the {@link PluginProperties}.
+   */
+  public final PluginProperties getProperties() {
+    return properties;
+  }
+}

--- a/cdap-api/src/main/java/co/cask/cdap/api/templates/plugins/PluginInfo.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/templates/plugins/PluginInfo.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.api.templates.plugins;
+
+/**
+ * Contains plugin information.
+ */
+public final class PluginInfo implements Comparable<PluginInfo> {
+
+  private final String fileName;
+  private final String name;
+  private final PluginVersion version;
+
+  public PluginInfo(String fileName, String name, PluginVersion version) {
+    if (fileName == null) {
+      throw new IllegalArgumentException("Plugin fileName cannot be null");
+    }
+    if (name == null) {
+      throw new IllegalArgumentException("Plugin name cannot be null");
+    }
+    if (version == null) {
+      throw new IllegalArgumentException("Plugin version cannot be null");
+    }
+
+    this.fileName = fileName;
+    this.name = name;
+    this.version = version;
+  }
+
+  /**
+   * Returns file name of the plugin.
+   */
+  public String getFileName() {
+    return fileName;
+  }
+
+  /**
+   * Returns name of the plugin.
+   */
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * Returns version of the plugin.
+   */
+  public PluginVersion getVersion() {
+    return version;
+  }
+
+  @Override
+  public String toString() {
+    return "PluginInfo{" +
+      "name='" + name + '\'' +
+      ", version='" + version + '\'' +
+      '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    PluginInfo that = (PluginInfo) o;
+    return compareTo(that) == 0;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = name.hashCode();
+    result = 31 * result + version.hashCode();
+    return result;
+  }
+
+  @Override
+  public int compareTo(PluginInfo other) {
+    int cmp = name.compareTo(other.name);
+    if (cmp != 0) {
+      return cmp;
+    }
+    return version.compareTo(other.version);
+  }
+}

--- a/cdap-api/src/main/java/co/cask/cdap/api/templates/plugins/PluginProperties.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/templates/plugins/PluginProperties.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.api.templates.plugins;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Plugin instance properties.
+ */
+public class PluginProperties {
+
+  // Currently only support String->String map.
+  private final Map<String, String> properties;
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  private PluginProperties(Map<String, String> properties) {
+    this.properties = properties;
+  }
+
+  public Map<String, String> getProperties() {
+    return properties;
+  }
+
+  /**
+   * A builder to create {@link PluginProperties} instance.
+   */
+  public static final class Builder {
+
+    private final Map<String, String> properties;
+
+    private Builder() {
+      this.properties = new HashMap<String, String>();
+    }
+
+    /**
+     * Adds multiple properties.
+     *
+     * @param properties map of properties to add.
+     * @return this builder
+     */
+    public Builder addAll(Map<String, String> properties) {
+      this.properties.putAll(properties);
+      return this;
+    }
+
+    /**
+     * Adds a property
+     * @param key the name of the property
+     * @param value the value of the property
+     * @return this builder
+     */
+    public Builder add(String key, String value) {
+      this.properties.put(key, value);
+      return this;
+    }
+
+    /**
+     * Creates a new instance of {@link PluginProperties} with the properties added to this builder prior to this call.
+     */
+    public PluginProperties build() {
+      return new PluginProperties(Collections.unmodifiableMap(new HashMap<String, String>(properties)));
+    }
+  }
+}

--- a/cdap-api/src/main/java/co/cask/cdap/api/templates/plugins/PluginPropertyField.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/templates/plugins/PluginPropertyField.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.api.templates.plugins;
+
+/**
+ * Contains information about a property used by a plugin.
+ */
+public class PluginPropertyField {
+
+  private final String name;
+  private final String description;
+  private final String type;
+  private final boolean required;
+
+  public PluginPropertyField(String name, String description, String type, boolean required) {
+    if (name == null) {
+      throw new IllegalArgumentException("Plugin property name cannot be null");
+    }
+    if (description == null) {
+      throw new IllegalArgumentException("Plugin property description cannot be null");
+    }
+    if (type == null) {
+      throw new IllegalArgumentException("Plugin property type cannot be null");
+    }
+
+    this.name = name;
+    this.description = description;
+    this.type = type;
+    this.required = required;
+  }
+
+  /**
+   * Returns name of the property.
+   */
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * Returns description for the property.
+   */
+  public String getDescription() {
+    return description;
+  }
+
+  /**
+   * Returns {@code true} if the property is required by the plugin, {@code false} otherwise.
+   */
+  public boolean isRequired() {
+    return required;
+  }
+
+  /**
+   * Returns the type of the property.
+   */
+  public String getType() {
+    return type;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    PluginPropertyField that = (PluginPropertyField) o;
+
+    return required == that.required
+      && name.equals(that.name)
+      && description.equals(that.description)
+      && type.equals(that.type);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = name.hashCode();
+    result = 31 * result + description.hashCode();
+    result = 31 * result + type.hashCode();
+    result = 31 * result + (required ? 1 : 0);
+    return result;
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/program/ManifestFields.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/program/ManifestFields.java
@@ -16,16 +16,23 @@
 
 package co.cask.cdap.app.program;
 
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Set;
 import java.util.jar.Attributes;
+import java.util.jar.Manifest;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.annotation.Nullable;
 
 /**
  * Defines the attributes as constants that are being used in
  * manifest file.
  */
 public final class ManifestFields {
+
   public static final Attributes.Name MAIN_CLASS = Attributes.Name.MAIN_CLASS;
   public static final Attributes.Name MANIFEST_VERSION = Attributes.Name.MANIFEST_VERSION;
-  public static final Attributes.Name BUNDLE_VERSION = new Attributes.Name("Bundle-Version");
   public static final Attributes.Name PROGRAM_TYPE = new Attributes.Name("Processor-Type");
   public static final Attributes.Name SPEC_FILE = new Attributes.Name("Spec-File");
 
@@ -33,6 +40,55 @@ public final class ManifestFields {
   public static final Attributes.Name APPLICATION_ID = new Attributes.Name("Application-Id");
   public static final Attributes.Name PROGRAM_NAME = new Attributes.Name("Program-Name");
 
+  // This following are attributes for OSGI bundle
+  public static final Attributes.Name BUNDLE_VERSION = new Attributes.Name("Bundle-Version");
+  public static final Attributes.Name EXPORT_PACKAGE = new Attributes.Name("Export-Package");
+
   public static final String VERSION = "1.0";   // Defines manifest version value.
   public static final String MANIFEST_SPEC_FILE = "META-INF/specification/application.json";
+
+  /**
+   * Regex for extracting one package name from the Export-Package manifest entry.
+   * Refer to OSGI spec r4v43, section 3.6.5 for details. For example:
+   *
+   * co.cask.plugin;use:="\"test,test2\"";version="1.0",co.cask.plugin2
+   *
+   * It basically is a comma separated list of package information.
+   * Each package information is started with the package name, followed by number of directives or attributes.
+   *
+   * * A "directive" is a key value pair separate by ":="
+   * A "attribute" is a key value pair separated by "=".
+   *
+   * The following regex is for just extracting the package name (e.g. "co.cask.plugin" and "co.cask.plugin2") while
+   * matching the complete package information pattern.
+   */
+  private static final Pattern EXPORT_PACKAGE_PATTERN =
+    Pattern.compile("([\\w.]+)(?:;[\\w\\-.]+:?=(?:(?:\"(?:\\\\.|[^\\\"])+\")|[\\w\\-.]+))*,?");
+
+  /**
+   * Parses the manifest {@link #EXPORT_PACKAGE} attribute and returns a set of export packages.
+   */
+  public static Set<String> getExportPackages(@Nullable Manifest manifest) {
+    if (manifest == null) {
+      return ImmutableSet.of();
+    }
+
+    ImmutableSet.Builder<String> result = ImmutableSet.builder();
+    String exportPackages = manifest.getMainAttributes().getValue(ManifestFields.EXPORT_PACKAGE);
+    if (exportPackages == null) {
+      return result.build();
+    }
+
+    // The matcher matches the package name one by one.
+    Matcher matcher = EXPORT_PACKAGE_PATTERN.matcher(exportPackages);
+    int start = 0;
+    while (matcher.find(start)) {
+      result.add(matcher.group(1));
+      start = matcher.end();
+    }
+    return result.build();
+  }
+
+  private ManifestFields() {
+  }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/PluginClassLoader.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/PluginClassLoader.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.adapter;
+
+import co.cask.cdap.app.program.ManifestFields;
+import co.cask.cdap.common.lang.CombineClassLoader;
+import co.cask.cdap.common.lang.DirectoryClassLoader;
+import co.cask.cdap.common.lang.PackageFilterClassLoader;
+import co.cask.cdap.common.lang.ProgramClassLoader;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableList;
+
+import java.io.File;
+import java.util.Set;
+import java.util.jar.Manifest;
+
+/**
+ * ClassLoader for template plugin. The ClassLoader hierarchy is pretty complicated.
+ * <p/>
+ * First, we have the "Plugin Lib ClassLoader".
+ *
+ * <pre>{@code
+ *            CDAP System CL
+ *                  ^
+ *                  |
+ *          Program Filter CL (cdap-api and hadoop classes only)
+ *                  ^
+ *                  |
+ *             Template CL (expanded app bundle jar)
+ *                  ^
+ *                  |
+ *          Template Filter CL (Export-Package classes only)
+ *                  ^
+ *                  |
+ *           Plugin Lib CL (Common library for plugin)
+ * }</pre>
+ *
+ * <p/>
+ * Then, the parent of the PluginClassLoader is formed by a {@link CombineClassLoader} of
+ * {@code (Program Filter CL, Plugin Lib ClassLoader) }. It is a combine class loader because we
+ * want the cdap-api classes not affected by the "Template Filter ClassLoader" (which usually would have cdap-api
+ * classes filtered out).
+ *
+ * <p/>
+ * The Plugin ClassLoader is then a URLClassLoader created by expanding the plugin bundle jar, with the parent
+ * ClassLoader as the one described above.
+ */
+public class PluginClassLoader extends DirectoryClassLoader {
+
+  public static PluginClassLoader create(File unpackedDir, File pluginLibDir, ClassLoader templateClassLoader) {
+    return new PluginClassLoader(unpackedDir, createParent(pluginLibDir, templateClassLoader));
+  }
+
+  private static ClassLoader createParent(File pluginLibDir, ClassLoader templateClassLoader) {
+
+    // Find the ProgramClassLoader from the template ClassLoader
+    ClassLoader programClassLoader = templateClassLoader;
+    while (programClassLoader != null && !(programClassLoader instanceof ProgramClassLoader)) {
+      programClassLoader = templateClassLoader.getParent();
+    }
+    // This shouldn't happen
+    Preconditions.checkArgument(programClassLoader != null, "Cannot find ProgramClassLoader");
+
+    // Package filtered classloader of the template classloader, which only classes in "Export-Packages" are loadable.
+    Manifest manifest = ((ProgramClassLoader) programClassLoader).getManifest();
+    Set<String> exportPackages = ManifestFields.getExportPackages(manifest);
+    ClassLoader filteredTemplateClassLoader = new PackageFilterClassLoader(templateClassLoader,
+                                                                           Predicates.in(exportPackages));
+
+    // Includes all jars in the plugins/template/lib directory
+    ClassLoader pluginLibClassLoader = new DirectoryClassLoader(pluginLibDir, filteredTemplateClassLoader);
+
+    // The parent ClassLoader of the plugin ClassLoader will load class from the parent of the
+    // template program class loader (which is a filtered CDAP classloader), followed by a the
+    // plugin lib ClassLoader.
+    return new CombineClassLoader(null, ImmutableList.of(programClassLoader.getParent(), pluginLibClassLoader));
+  }
+
+  private PluginClassLoader(File directory, ClassLoader parent) {
+    super(directory, parent, "lib");
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/PluginFile.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/PluginFile.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.adapter;
+
+import co.cask.cdap.api.templates.plugins.PluginInfo;
+
+import java.io.File;
+
+/**
+ * An internal container for holding plugin {@link File} and the {@link PluginInfo} together.
+ * Comparison of instances of this class is purely based on the {@link PluginInfo}.
+ */
+final class PluginFile implements Comparable<PluginFile> {
+  private final File file;
+  private final PluginInfo pluginInfo;
+
+  PluginFile(File file, PluginInfo pluginInfo) {
+    this.file = file;
+    this.pluginInfo = pluginInfo;
+  }
+
+  File getFile() {
+    return file;
+  }
+
+  PluginInfo getPluginInfo() {
+    return pluginInfo;
+  }
+
+  @Override
+  public int compareTo(PluginFile o) {
+    return pluginInfo.compareTo(o.pluginInfo);
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/PluginInstantiator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/PluginInstantiator.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.adapter;
+
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.data.schema.UnsupportedTypeException;
+import co.cask.cdap.api.templates.plugins.PluginClass;
+import co.cask.cdap.api.templates.plugins.PluginConfig;
+import co.cask.cdap.api.templates.plugins.PluginInfo;
+import co.cask.cdap.api.templates.plugins.PluginProperties;
+import co.cask.cdap.api.templates.plugins.PluginPropertyField;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.io.Locations;
+import co.cask.cdap.common.lang.InstantiatorFactory;
+import co.cask.cdap.common.lang.jar.BundleJarUtil;
+import co.cask.cdap.common.utils.DirUtils;
+import co.cask.cdap.internal.lang.FieldVisitor;
+import co.cask.cdap.internal.lang.Fields;
+import co.cask.cdap.internal.lang.Reflections;
+import com.google.common.base.Throwables;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.primitives.Primitives;
+import com.google.common.reflect.TypeToken;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * This class helps creating new instances of plugins. It also contains a ClassLoader cache to
+ * save ClassLaoder creation.
+ *
+ * This class implements {@link Closeable} as well for cleanup of temporary directories created for the ClassLoaders.
+ */
+public class PluginInstantiator implements Closeable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(PluginInstantiator.class);
+
+  private final LoadingCache<PluginInfo, ClassLoader> classLoaders;
+  private final ClassLoader templateClassLoader;
+  private final File pluginDir;
+  private final InstantiatorFactory instantiatorFactory;
+  private final File tmpDir;
+
+  public PluginInstantiator(CConfiguration cConf, String template, ClassLoader templateClassLoader) {
+    this.pluginDir = new File(cConf.get(Constants.AppFabric.APP_TEMPLATE_DIR), template);
+    this.templateClassLoader = templateClassLoader;
+    this.instantiatorFactory = new InstantiatorFactory(false);
+
+    File tmpDir = new File(cConf.get(Constants.CFG_LOCAL_DATA_DIR),
+                           cConf.get(Constants.AppFabric.TEMP_DIR)).getAbsoluteFile();
+    this.tmpDir = DirUtils.createTempDir(tmpDir);
+    this.classLoaders = CacheBuilder.newBuilder().build(new ClassLoaderCacheLoader());
+  }
+
+  /**
+   * Returns a {@link ClassLoader} for the given plugin.
+   *
+   * @param pluginInfo information about the plugin
+   * @throws IOException if failed to expand the plugin jar to create the plugin ClassLoader
+   *
+   * @see PluginClassLoader
+   */
+  public ClassLoader getPluginClassLoader(PluginInfo pluginInfo) throws IOException {
+    try {
+      return classLoaders.get(pluginInfo);
+    } catch (ExecutionException e) {
+      Throwables.propagateIfInstanceOf(e.getCause(), IOException.class);
+      throw Throwables.propagate(e.getCause());
+    }
+  }
+
+  /**
+   * Creates a new instance of the given plugin class.
+   *
+   * @param pluginInfo information about the plugin. It is used for creating the ClassLoader for the plugin.
+   * @param pluginClass information about the plugin class. The plugin instance will be instantiated based on this.
+   * @param properties properties to populate into the {@link PluginConfig} of the plugin instance
+   * @param <T> Type of the plugin
+   * @return a new plugin instance
+   * @throws IOException if failed to expand the plugin jar to create the plugin ClassLoader
+   * @throws ClassNotFoundException if failed to load the given plugin class
+   */
+  @SuppressWarnings("unchecked")
+  public <T> T newInstance(PluginInfo pluginInfo, PluginClass pluginClass,
+                           PluginProperties properties) throws IOException, ClassNotFoundException {
+    ClassLoader classLoader = getPluginClassLoader(pluginInfo);
+    TypeToken<?> pluginType = TypeToken.of(classLoader.loadClass(pluginClass.getClassName()));
+
+    try {
+      String configFieldName = pluginClass.getConfigFieldName();
+      // Plugin doesn't have config. Simply return a new instance.
+      if (configFieldName == null) {
+        return (T) instantiatorFactory.get(pluginType).create();
+      }
+
+      // Create the config instance
+      Field field = Fields.findField(pluginType, configFieldName);
+      TypeToken<?> configFieldType = pluginType.resolveType(field.getGenericType());
+      Object config = instantiatorFactory.get(configFieldType).create();
+      Reflections.visit(config, configFieldType, new ConfigFieldSetter(pluginClass, pluginInfo, properties));
+
+      // Create the plugin instance
+      return newInstance(pluginType, field, configFieldType, config);
+    } catch (NoSuchFieldException e) {
+      throw new IllegalArgumentException("Config field not found in plugin class: " + pluginClass);
+    } catch (IllegalAccessException e) {
+      throw new IllegalArgumentException("Failed to set plugin config field: " + pluginClass);
+    }
+  }
+
+  /**
+   * Creates a new plugin instance and optionally setup the {@link PluginConfig} field.
+   */
+  @SuppressWarnings("unchecked")
+  private <T> T newInstance(TypeToken<?> pluginType, Field configField,
+                            TypeToken<?> configFieldType, Object config) throws IllegalAccessException {
+    // See if the plugin has a constructor that takes the config type.
+    // Need to loop because we need to resolve the constructor parameter type from generic.
+    for (Constructor<?> constructor : pluginType.getRawType().getConstructors()) {
+      Type[] parameterTypes = constructor.getGenericParameterTypes();
+      if (parameterTypes.length != 1) {
+        continue;
+      }
+      if (configFieldType.equals(pluginType.resolveType(parameterTypes[0]))) {
+        constructor.setAccessible(true);
+        try {
+          // Call the plugin constructor to construct the instance
+          return (T) constructor.newInstance(config);
+        } catch (Exception e) {
+          // Failed to instantiate. Resort to field injection
+          LOG.warn("Failed to invoke plugin constructor {}. Resort to config field injection.", constructor);
+          break;
+        }
+      }
+    }
+
+    // No matching constructor found, do field injection.
+    T plugin = (T) instantiatorFactory.get(pluginType).create();
+    configField.setAccessible(true);
+    configField.set(plugin, config);
+    return plugin;
+  }
+
+  @Override
+  public void close() throws IOException {
+    // Cleanup the ClassLoader cache and the temporary directoy for the expanded plugin jar.
+    classLoaders.invalidateAll();
+    DirUtils.deleteDirectoryContents(tmpDir);
+  }
+
+  /**
+   * A CacheLoader for creating plugin ClassLoader.
+   */
+  private final class ClassLoaderCacheLoader extends CacheLoader<PluginInfo, ClassLoader> {
+
+    @Override
+    public ClassLoader load(PluginInfo key) throws Exception {
+      File pluginJar = new File(pluginDir, key.getFileName());
+      File unpackedDir = DirUtils.createTempDir(tmpDir);
+      BundleJarUtil.unpackProgramJar(Locations.toLocation(pluginJar), unpackedDir);
+
+      return PluginClassLoader.create(unpackedDir, new File(pluginJar.getParentFile(), "lib"), templateClassLoader);
+    }
+  }
+
+  /**
+   * A {@link FieldVisitor} for setting values into {@link PluginConfig} object based on {@link PluginProperties}.
+   */
+  private static final class ConfigFieldSetter extends FieldVisitor {
+    private final PluginClass pluginClass;
+    private final PluginProperties properties;
+    private final PluginInfo pluginInfo;
+
+    public ConfigFieldSetter(PluginClass pluginClass, PluginInfo pluginInfo, PluginProperties properties) {
+      this.pluginClass = pluginClass;
+      this.pluginInfo = pluginInfo;
+      this.properties = properties;
+    }
+
+    @Override
+    public void visit(Object instance, TypeToken<?> inspectType,
+                      TypeToken<?> declareType, Field field) throws Exception {
+      if (PluginConfig.class.equals(declareType.getRawType())) {
+        if (field.getName().equals("properties")) {
+          field.set(instance, properties);
+        }
+        return;
+      }
+
+      Name nameAnnotation = field.getAnnotation(Name.class);
+      String name = nameAnnotation == null ? field.getName() : nameAnnotation.value();
+      PluginPropertyField pluginPropertyField = pluginClass.getProperties().get(name);
+      if (pluginPropertyField.isRequired() && !properties.getProperties().containsKey(name)) {
+        throw new IllegalArgumentException("Missing required plugin property " + name
+                                             + " for " + pluginClass.getName() + " in plugin " + pluginInfo);
+      }
+      String value = properties.getProperties().get(name);
+      if (pluginPropertyField.isRequired() || value != null) {
+        field.set(instance, convertValue(declareType.resolveType(field.getGenericType()), value));
+      }
+    }
+
+    /**
+     * Converts string value into value of the fieldType.
+     */
+    private Object convertValue(TypeToken<?> fieldType, String value) throws Exception {
+      // Currently we only support primitive, wrapped primitive and String types.
+      Class<?> rawType = fieldType.getRawType();
+
+      if (String.class.equals(rawType)) {
+        return value;
+      }
+
+      if (rawType.isPrimitive()) {
+        rawType = Primitives.wrap(rawType);
+      }
+
+      if (Primitives.isWrapperType(rawType)) {
+        Method valueOf = rawType.getMethod("valueOf", String.class);
+        return valueOf.invoke(null, value);
+      }
+
+      throw new UnsupportedTypeException("Only primitive and String types are supported");
+    }
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/PluginRepository.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/PluginRepository.java
@@ -1,0 +1,481 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.adapter;
+
+import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.data.schema.UnsupportedTypeException;
+import co.cask.cdap.api.templates.plugins.PluginClass;
+import co.cask.cdap.api.templates.plugins.PluginConfig;
+import co.cask.cdap.api.templates.plugins.PluginInfo;
+import co.cask.cdap.api.templates.plugins.PluginPropertyField;
+import co.cask.cdap.api.templates.plugins.PluginVersion;
+import co.cask.cdap.app.program.ManifestFields;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.lang.ProgramClassLoader;
+import co.cask.cdap.common.lang.jar.BundleJarUtil;
+import co.cask.cdap.common.utils.DirUtils;
+import com.google.common.base.Charsets;
+import com.google.common.base.Function;
+import com.google.common.base.Supplier;
+import com.google.common.base.Throwables;
+import com.google.common.collect.AbstractIterator;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import com.google.common.io.Closeables;
+import com.google.common.io.Files;
+import com.google.common.primitives.Primitives;
+import com.google.common.reflect.TypeToken;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.io.Reader;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.Type;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.jar.JarFile;
+import javax.annotation.Nullable;
+
+/**
+ * This class manage plugin information that are available for application templates.
+ */
+public class PluginRepository {
+
+  private static final Logger LOG = LoggerFactory.getLogger(PluginRepository.class);
+  private static final Gson GSON = new GsonBuilder()
+    .registerTypeAdapter(PluginClass.class, new PluginClassDeserializer())
+    .create();
+
+  // Object type for data in the config json file.
+  private static final Type CONFIG_OBJECT_TYPE = new TypeToken<List<PluginClass>>() { }.getType();
+
+  // Transform File into PluginInfo, assuming the plugin file name is in form [name][separator][version].jar
+  private static final Function<File, PluginFile> FILE_TO_PLUGIN_FILE = new Function<File, PluginFile>() {
+    @Override
+    public PluginFile apply(File file) {
+      String plugin = file.getName().substring(0, file.getName().length() - ".jar".length());
+      PluginVersion version = new PluginVersion(plugin, true);
+      String rawVersion = version.getVersion();
+
+      String pluginName = rawVersion == null ? plugin : plugin.substring(0, plugin.length() - rawVersion.length() - 1);
+      return new PluginFile(file, new PluginInfo(file.getName(), pluginName, version));
+    }
+  };
+
+  private final CConfiguration cConf;
+  private final File templateDir;
+  private final File tmpDir;
+  private final AtomicReference<Map<String, Multimap<PluginInfo, PluginClass>>> plugins;
+
+  @Inject
+  PluginRepository(CConfiguration cConf) {
+    this.cConf = cConf;
+    this.templateDir = new File(cConf.get(Constants.AppFabric.APP_TEMPLATE_DIR));
+    this.plugins = new AtomicReference<Map<String, Multimap<PluginInfo, PluginClass>>>(
+      new HashMap<String, Multimap<PluginInfo, PluginClass>>());
+    this.tmpDir = new File(cConf.get(Constants.CFG_LOCAL_DATA_DIR),
+                           cConf.get(Constants.AppFabric.TEMP_DIR)).getAbsoluteFile();
+  }
+
+  /**
+   * Returns a {@link Multimap} of all plugins available for the given application template.
+   */
+  public Multimap<PluginInfo, PluginClass> getPlugins(String template) {
+    Multimap<PluginInfo, PluginClass> result = plugins.get().get(template);
+    return result == null ? ImmutableMultimap.<PluginInfo, PluginClass>of() : result;
+  }
+
+  /**
+   * Inspects plugins for all the templates.
+   *
+   * @param templates map from template name to template jar file
+   */
+  void inspectPlugins(Map<String, File> templates) throws IOException {
+    Map<String, Multimap<PluginInfo, PluginClass>> result = Maps.newHashMap();
+    for (Map.Entry<String, File> entry : templates.entrySet()) {
+      result.put(entry.getKey(), inspectPlugins(entry.getKey(), entry.getValue()));
+    }
+
+    plugins.set(result);
+  }
+
+  /**
+   * Inspects and builds plugin information for the given application template.
+   *
+   * @param template name of the template
+   * @param templateJar application jar for the application template
+   */
+  private Multimap<PluginInfo, PluginClass> inspectPlugins(String template, File templateJar) throws IOException {
+    // We want the plugins sorted by the PluginInfo, which in turn is sorted by name and version.
+    Multimap<PluginInfo, PluginClass> templatePlugins = Multimaps.newMultimap(
+      Maps.<PluginInfo, Collection<PluginClass>>newTreeMap(), new Supplier<Collection<PluginClass>>() {
+        @Override
+        public Collection<PluginClass> get() {
+          return Lists.newArrayList();
+        }
+      });
+
+    File pluginDir = new File(templateDir, template);
+    List<File> pluginJars = DirUtils.listFiles(pluginDir, "jar");
+    if (pluginJars.isEmpty()) {
+      return templatePlugins;
+    }
+
+    Iterable<PluginFile> pluginFiles = Iterables.transform(pluginJars, FILE_TO_PLUGIN_FILE);
+    CloseableClassLoader templateClassLoader = createTemplateClassLoader(templateJar);
+    try {
+      PluginInstantiator pluginInstantiator = new PluginInstantiator(cConf, template, templateClassLoader);
+      try {
+        for (PluginFile pluginFile : pluginFiles) {
+          if (!configureByFile(pluginFile, templatePlugins)) {
+            configureByInspection(pluginFile, pluginInstantiator, templatePlugins);
+          }
+        }
+      } finally {
+        pluginInstantiator.close();
+      }
+    } finally {
+      templateClassLoader.close();
+    }
+
+    return templatePlugins;
+  }
+
+  /**
+   * Gathers plugin class information by parsing an external configuration file.
+   *
+   * @return {@code true} if there is an external configuration file, {@code false} otherwise.
+   */
+  private boolean configureByFile(PluginFile pluginFile,
+                                  Multimap<PluginInfo, PluginClass> templatePlugins) throws IOException {
+    String pluginFileName = pluginFile.getFile().getName();
+    String configFileName = pluginFileName.substring(0, pluginFileName.length() - ".jar".length()) + ".json";
+
+    File configFile = new File(pluginFile.getFile().getParentFile(), configFileName);
+    if (!configFile.isFile()) {
+      return false;
+    }
+
+    // The config file is a json array of PluginClass object (except the PluginClass.configFieldName)
+    Reader reader = Files.newReader(configFile, Charsets.UTF_8);
+    try {
+      List<PluginClass> pluginClasses = GSON.fromJson(reader, CONFIG_OBJECT_TYPE);
+      templatePlugins.putAll(pluginFile.getPluginInfo(), pluginClasses);
+    } finally {
+      Closeables.closeQuietly(reader);
+    }
+
+    return true;
+  }
+
+  /**
+   * Inspects the plugin file and extracts plugin classes information.
+   */
+  private void configureByInspection(PluginFile pluginFile, PluginInstantiator pluginInstantiator,
+                                     Multimap<PluginInfo, PluginClass> templatePlugins) throws IOException {
+
+    // See if there are export packages. Plugins should be in those packages
+    Set<String> exportPackages = getExportPackages(pluginFile.getFile());
+    if (exportPackages.isEmpty()) {
+      return;
+    }
+
+    // Load the plugin class and inspect the config field.
+    ClassLoader pluginClassLoader = pluginInstantiator.getPluginClassLoader(pluginFile.getPluginInfo());
+    for (Class<?> pluginClass : getPluginClasses(exportPackages, pluginClassLoader)) {
+      Plugin pluginAnnotation = pluginClass.getAnnotation(Plugin.class);
+      if (pluginAnnotation == null) {
+        continue;
+      }
+      Map<String, PluginPropertyField> pluginProperties = Maps.newHashMap();
+      try {
+        String configField = getProperties(TypeToken.of(pluginClass), pluginProperties);
+        templatePlugins.put(pluginFile.getPluginInfo(), new PluginClass(pluginAnnotation.type(),
+                                                                        getPluginName(pluginClass),
+                                                                        getPluginDescription(pluginClass),
+                                                                        pluginClass.getName(),
+                                                                        configField, pluginProperties));
+      } catch (UnsupportedTypeException e) {
+        LOG.warn("Plugin configuration type not supported. Plugin ignored. {}", pluginClass, e);
+      }
+    }
+  }
+
+  /**
+   * Returns the set of package names that are declared in "Export-Package" in the jar file Manifest.
+   */
+  private Set<String> getExportPackages(File file) throws IOException {
+    JarFile jarFile = new JarFile(file);
+    try {
+      return ManifestFields.getExportPackages(jarFile.getManifest());
+    } finally {
+      jarFile.close();
+    }
+  }
+
+  /**
+   * Returns an {@link Iterable} of class name that are under the given list of package names that are loadable
+   * through the plugin ClassLoader.
+   */
+  private Iterable<Class<?>> getPluginClasses(final Iterable<String> packages, final ClassLoader pluginClassLoader) {
+    return new Iterable<Class<?>>() {
+      @Override
+      public Iterator<Class<?>> iterator() {
+        final Iterator<String> packageIterator = packages.iterator();
+
+        return new AbstractIterator<Class<?>>() {
+          Iterator<String> classIterator = ImmutableList.<String>of().iterator();
+          String currentPackage;
+
+          @Override
+          protected Class<?> computeNext() {
+            while (!classIterator.hasNext()) {
+              if (!packageIterator.hasNext()) {
+                return endOfData();
+              }
+              currentPackage = packageIterator.next();
+
+              URL packageResource = pluginClassLoader.getResource(currentPackage.replace('.', File.separatorChar));
+              if (packageResource == null) {
+                // Cannot happen since we know the class loader expand the jar into directory, the class loader
+                // should have the package URL pointing to the package directory.
+                continue;
+              }
+
+              try {
+                classIterator = DirUtils.list(new File(packageResource.toURI()), "class").iterator();
+              } catch (URISyntaxException e) {
+                // Cannot happen
+                throw Throwables.propagate(e);
+              }
+            }
+
+            try {
+              return pluginClassLoader.loadClass(getClassName(currentPackage, classIterator.next()));
+            } catch (ClassNotFoundException e) {
+              // Cannot happen, since the class name is from the list of the class files under the classloader.
+              throw Throwables.propagate(e);
+            }
+          }
+        };
+      }
+    };
+  }
+
+  /**
+   * Creates a ClassLoader for the given template application.
+   *
+   * @param templateJar the template jar file.
+   * @return a {@link CloseableClassLoader} for the template application.
+   * @throws IOException if failed to expand the jar
+   */
+  private CloseableClassLoader createTemplateClassLoader(File templateJar) throws IOException {
+    final File unpackDir = DirUtils.createTempDir(tmpDir);
+    BundleJarUtil.unpackProgramJar(Files.newInputStreamSupplier(templateJar), unpackDir);
+    ProgramClassLoader programClassLoader = ProgramClassLoader.create(unpackDir, getClass().getClassLoader());
+    return new CloseableClassLoader(programClassLoader, new Closeable() {
+      @Override
+      public void close() throws IOException {
+        DirUtils.deleteDirectoryContents(unpackDir);
+      }
+    });
+  }
+
+  /**
+   * Extracts and returns name of the plugin.
+   */
+  private String getPluginName(Class<?> cls) {
+    Name annotation = cls.getAnnotation(Name.class);
+    return annotation == null || annotation.value().isEmpty() ? cls.getName() : annotation.value();
+  }
+
+  /**
+   * Returns description for the plugin.
+   */
+  private String getPluginDescription(Class<?> cls) {
+    Description annotation = cls.getAnnotation(Description.class);
+    return annotation == null ? "" : annotation.value();
+  }
+
+  /**
+   * Constructs the fully qualified class name based on the package name and the class file name.
+   */
+  private String getClassName(String packageName, String classFileName) {
+    return packageName + "." + classFileName.substring(0, classFileName.length() - ".class".length());
+  }
+
+  /**
+   * Gets all config properties for the given plugin.
+   *
+   * @return the name of the config field in the plugin class or {@code null} if the plugin doesn't have a config field
+   */
+  @Nullable
+  private String getProperties(TypeToken<?> pluginType,
+                               Map<String, PluginPropertyField> result) throws UnsupportedTypeException {
+    // Get the config field
+    for (TypeToken<?> type : pluginType.getTypes().classes()) {
+      for (Field field : type.getRawType().getDeclaredFields()) {
+        TypeToken<?> fieldType = TypeToken.of(field.getGenericType());
+        if (PluginConfig.class.isAssignableFrom(fieldType.getRawType())) {
+          // Pick up all config properties
+          inspectConfigField(fieldType, result);
+          return field.getName();
+        }
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Inspects the plugin config class and build up a map for {@link PluginPropertyField}.
+   *
+   * @param configType type of the config class
+   * @param result map for storing the result
+   * @throws UnsupportedTypeException if a field type in the config class is not supported
+   */
+  private void inspectConfigField(TypeToken<?> configType,
+                                  Map<String, PluginPropertyField> result) throws UnsupportedTypeException {
+    for (TypeToken<?> type : configType.getTypes().classes()) {
+      if (PluginConfig.class.equals(type.getRawType())) {
+        break;
+      }
+
+      for (Field field : type.getRawType().getDeclaredFields()) {
+        PluginPropertyField property = createPluginProperty(field, type);
+        if (result.containsKey(property.getName())) {
+          throw new IllegalArgumentException("Plugin config with name " + property.getName()
+                                               + " already defined in " + configType.getRawType());
+        }
+        result.put(property.getName(), property);
+      }
+    }
+  }
+
+  /**
+   * Creates a {@link PluginPropertyField} based on the given field.
+   */
+  private PluginPropertyField createPluginProperty(Field field,
+                                                   TypeToken<?> resolvingType) throws UnsupportedTypeException {
+    TypeToken<?> fieldType = resolvingType.resolveType(field.getGenericType());
+    Class<?> rawType = fieldType.getRawType();
+
+    Name nameAnnotation = field.getAnnotation(Name.class);
+    Description descAnnotation = field.getAnnotation(Description.class);
+    String name = nameAnnotation == null ? field.getName() : nameAnnotation.value();
+    String description = descAnnotation == null ? "" : descAnnotation.value();
+
+    if (rawType.isPrimitive()) {
+      return new PluginPropertyField(name, description, rawType.getName(), true);
+    }
+
+    rawType = Primitives.unwrap(rawType);
+    if (!rawType.isPrimitive() && !String.class.equals(rawType)) {
+      throw new UnsupportedTypeException("Only primitive and String types are supported");
+    }
+
+    boolean required = true;
+    for (Annotation annotation : field.getAnnotations()) {
+      if (annotation.annotationType().getName().endsWith(".Nullable")) {
+        required = false;
+        break;
+      }
+    }
+
+    return new PluginPropertyField(name, description, rawType.getSimpleName().toLowerCase(), required);
+  }
+
+  /**
+   * A {@link ClassLoader} that implements {@link Closeable} for resource cleanup. All classloading is done
+   * by the delegate {@link ClassLoader}.
+   */
+  private static final class CloseableClassLoader extends ClassLoader implements Closeable {
+
+    private final Closeable closeable;
+
+    public CloseableClassLoader(ClassLoader delegate, Closeable closeable) {
+      super(delegate);
+      this.closeable = closeable;
+    }
+
+    @Override
+    public void close() throws IOException {
+      closeable.close();
+    }
+  }
+
+  /**
+   * A Gson deserialization for creating {@link PluginClass} object from external plugin config file.
+   */
+  private static final class PluginClassDeserializer implements JsonDeserializer<PluginClass> {
+
+    // Type for the PluginClass.properties map.
+    private static final Type PROPERTIES_TYPE = new TypeToken<Map<String, PluginPropertyField>>() { }.getType();
+
+    @Override
+    public PluginClass deserialize(JsonElement json, Type typeOfT,
+                                   JsonDeserializationContext context) throws JsonParseException {
+      if (!json.isJsonObject()) {
+        throw new JsonParseException("Expects json object");
+      }
+
+      JsonObject jsonObj = json.getAsJsonObject();
+
+      String type = jsonObj.has("type") ? jsonObj.get("type").getAsString() : Plugin.DEFAULT_TYPE;
+      String name = getRequired(jsonObj, "name").getAsString();
+      String description = getRequired(jsonObj, "description").getAsString();
+      String className = getRequired(jsonObj, "className").getAsString();
+      Map<String, PluginPropertyField> properties = context.deserialize(getRequired(jsonObj, "properties"),
+                                                                        PROPERTIES_TYPE);
+
+      return new PluginClass(type, name, description, className, null, properties);
+    }
+
+    private JsonElement getRequired(JsonObject jsonObj, String name) {
+      if (!jsonObj.has(name)) {
+        throw new JsonParseException("Property '" + name + "' is missing");
+      }
+      return jsonObj.get(name);
+    }
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/PluginTestAppTemplate.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/PluginTestAppTemplate.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap;
+
+import co.cask.cdap.api.app.ApplicationConfigurer;
+import co.cask.cdap.api.app.ApplicationContext;
+import co.cask.cdap.api.templates.ApplicationTemplate;
+import co.cask.cdap.api.worker.AbstractWorker;
+
+/**
+ * An {@link ApplicationTemplate} for testing plugin supports.
+ */
+public class PluginTestAppTemplate extends ApplicationTemplate<PluginTestAppTemplate.TemplateConfig> {
+
+  public static final class TemplateConfig {
+
+  }
+
+  @Override
+  public void configure(ApplicationConfigurer configurer, ApplicationContext context) {
+    configurer.addWorker(new PluginTestWorker());
+  }
+
+  public static final class PluginTestWorker extends AbstractWorker {
+
+    @Override
+    public void run() {
+      // No-op
+    }
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/plugins/test/TestPlugin.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/plugins/test/TestPlugin.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.plugins.test;
+
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.templates.plugins.PluginConfig;
+
+import java.util.concurrent.Callable;
+import javax.annotation.Nullable;
+
+/**
+ * Plugin class for testing instantiation with field injection.
+ */
+@Plugin
+@Name("TestPlugin")
+public class TestPlugin implements Callable<String> {
+
+  protected Config config;
+
+  @Override
+  public String call() throws Exception {
+    if (config.timeout % 2 == 0) {
+      return Class.forName(config.className).getName();
+    }
+    return null;
+  }
+
+  public static final class Config extends PluginConfig {
+
+    @Name("class.name")
+    private String className;
+
+    @Nullable
+    private Long timeout;
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/plugins/test/TestPlugin2.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/plugins/test/TestPlugin2.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.plugins.test;
+
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+
+/**
+ * Plugin class for testing instantiation with constructor.
+ */
+@Plugin
+@Name("TestPlugin2")
+public class TestPlugin2 extends TestPlugin {
+
+  private boolean constructed;
+
+  public TestPlugin2(Config config) {
+    this.config = config;
+    this.constructed = true;
+  }
+
+  @Override
+  public String call() throws Exception {
+    if (!constructed) {
+      throw new IllegalStateException("Constructor not called");
+    }
+    return super.call();
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/plugins/test/package-info.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/plugins/test/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * This package is for plugin under testing. No regular test class should goes in this package.
+ */
+package co.cask.cdap.internal.app.plugins.test;

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/adapter/EmptyClass.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/adapter/EmptyClass.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.adapter;
+
+/**
+ * A empty class for the purpose of {@link PluginTest} only.
+ */
+public final class EmptyClass {
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/adapter/PluginTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/adapter/PluginTest.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.adapter;
+
+import co.cask.cdap.PluginTestAppTemplate;
+import co.cask.cdap.api.templates.plugins.PluginClass;
+import co.cask.cdap.api.templates.plugins.PluginInfo;
+import co.cask.cdap.api.templates.plugins.PluginProperties;
+import co.cask.cdap.api.templates.plugins.PluginPropertyField;
+import co.cask.cdap.app.program.ManifestFields;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.io.Locations;
+import co.cask.cdap.common.lang.DirectoryClassLoader;
+import co.cask.cdap.common.lang.ProgramClassLoader;
+import co.cask.cdap.common.lang.jar.BundleJarUtil;
+import co.cask.cdap.common.utils.DirUtils;
+import co.cask.cdap.internal.app.plugins.test.TestPlugin;
+import co.cask.cdap.internal.test.AppJarHelper;
+import com.google.common.base.Charsets;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Multimap;
+import com.google.common.io.Files;
+import com.google.gson.Gson;
+import org.apache.twill.filesystem.LocalLocationFactory;
+import org.apache.twill.filesystem.Location;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Writer;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
+
+/**
+ * Unit-tests for app template plugin support.
+ */
+public class PluginTest {
+
+  @ClassRule
+  public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
+
+  private static final String TEMPLATE_NAME = "PluginTest";
+
+  private static CConfiguration cConf;
+  private static File appTemplateJar;
+  private static File templatePluginDir;
+  private static ClassLoader templateClassLoader;
+
+  @BeforeClass
+  public static void setup() throws IOException, ClassNotFoundException {
+    cConf = CConfiguration.create();
+    cConf.set(Constants.CFG_LOCAL_DATA_DIR, TMP_FOLDER.newFolder().getAbsolutePath());
+
+    DirUtils.mkdirs(new File(cConf.get(Constants.AppFabric.APP_TEMPLATE_DIR)));
+
+    // Create the template jar
+    File appTemplateDir = new File(cConf.get(Constants.AppFabric.APP_TEMPLATE_DIR));
+    appTemplateJar = createJar(PluginTestAppTemplate.class, new File(appTemplateDir, "PluginTest-1.0.jar"));
+
+    templateClassLoader = createAppClassLoader(appTemplateJar);
+
+    // Create the plugin directory for the PluginTest template
+    templatePluginDir = new File(appTemplateDir, TEMPLATE_NAME);
+    DirUtils.mkdirs(templatePluginDir);
+
+    // Create a lib jar that is shared among all plugins for the template.
+    File libDir = TMP_FOLDER.newFolder();
+    generateClass(EmptyClass.class, "test.EmptyClass", libDir);
+    createJar(new DirectoryClassLoader(libDir, null).loadClass("test.EmptyClass"),
+              new File(new File(templatePluginDir, "lib"), "common.jar"));
+  }
+
+  @Test
+  public void testExportPackage() {
+    Manifest manifest = new Manifest();
+    manifest.getMainAttributes().put(ManifestFields.EXPORT_PACKAGE,
+                                     "co.cask.plugin;use:=\"\\\"test,test2\\\"\";version=\"1.0\",co.cask.plugin2");
+
+    Set<String> packages = ManifestFields.getExportPackages(manifest);
+    Assert.assertEquals(ImmutableSet.of("co.cask.plugin", "co.cask.plugin2"), packages);
+  }
+
+  @Test
+  public void testPlugin() throws Exception {
+    // Create the plugin jar. There should be two plugins there (TestPlugin and TestPlugin2).
+    Manifest manifest = createManifest(ManifestFields.EXPORT_PACKAGE, TestPlugin.class.getPackage().getName());
+    createJar(TestPlugin.class, new File(templatePluginDir, "myPlugin-1.0.jar"), manifest);
+
+    // Build up the plugin repository.
+    PluginRepository repository = new PluginRepository(cConf);
+    repository.inspectPlugins(ImmutableMap.of(TEMPLATE_NAME, appTemplateJar));
+
+    // Retrieve plugin info
+    Multimap<PluginInfo, PluginClass> pluginInfos = repository.getPlugins(TEMPLATE_NAME);
+    Assert.assertEquals(2, pluginInfos.size());
+
+    // Instantiate the plugins and execute them
+    PluginInstantiator instantiator = new PluginInstantiator(cConf, TEMPLATE_NAME, templateClassLoader);
+    for (Map.Entry<PluginInfo, PluginClass> entry : pluginInfos.entries()) {
+      Callable<String> plugin = instantiator.newInstance(entry.getKey(), entry.getValue(),
+                                                         PluginProperties.builder()
+                                                          .add("class.name", "test.EmptyClass")
+                                                          .add("timeout", "10")
+                                                          .build()
+      );
+
+      Assert.assertEquals("test.EmptyClass", plugin.call());
+    }
+  }
+
+  @Test
+  public void testExternalConfig() throws IOException {
+    // For testing plugins that are configure externally through a json file.
+    // Create a jar, without any export package information
+    createJar(TestPlugin.class, new File(templatePluginDir, "external-plugin-1.0.jar"));
+
+    // Create a config json file.
+    PluginClass pluginClass = new PluginClass("plugin", "External", "External Plugin", TestPlugin.class.getName(), null,
+      ImmutableMap.of(
+        "class.name", new PluginPropertyField("class.name", "Name of the class", "string", true),
+        "timeout", new PluginPropertyField("timeout", "Timeout value", "long", false)
+      ));
+    File configFile = new File(templatePluginDir, "external-plugin-1.0.json");
+    Writer writer = Files.newWriter(configFile, Charsets.UTF_8);
+    try {
+      new Gson().toJson(ImmutableList.of(pluginClass), writer);
+    } finally {
+      writer.close();
+    }
+
+    // Build up the plugin repository.
+    PluginRepository repository = new PluginRepository(cConf);
+    repository.inspectPlugins(ImmutableMap.of(TEMPLATE_NAME, appTemplateJar));
+
+    // There should be one for the external-plugin
+    Multimap<PluginInfo, PluginClass> plugins = repository.getPlugins(TEMPLATE_NAME);
+    Map.Entry<PluginInfo, PluginClass> pluginEntry = null;
+    for (Map.Entry<PluginInfo, PluginClass> entry : plugins.entries()) {
+      if (entry.getKey().getName().equals("external-plugin")) {
+        pluginEntry = entry;
+        break;
+      }
+    }
+
+    Assert.assertNotNull(pluginEntry);
+    // There should be exactly one plugin class for the external plugin.
+    Assert.assertEquals(1, plugins.get(pluginEntry.getKey()).size());
+    Assert.assertEquals(pluginClass, pluginEntry.getValue());
+  }
+
+  private static ClassLoader createAppClassLoader(File jarFile) throws IOException {
+    final File unpackDir = DirUtils.createTempDir(TMP_FOLDER.newFolder());
+    BundleJarUtil.unpackProgramJar(Files.newInputStreamSupplier(jarFile), unpackDir);
+    return ProgramClassLoader.create(unpackDir, PluginTest.class.getClassLoader());
+  }
+
+  private static File createJar(Class<?> cls, File destFile) throws IOException {
+    return createJar(cls, destFile, new Manifest());
+  }
+
+  private static File createJar(Class<?> cls, File destFile, Manifest manifest) throws IOException {
+    Location deploymentJar = AppJarHelper.createDeploymentJar(new LocalLocationFactory(TMP_FOLDER.newFolder()),
+                                                              cls, manifest);
+    DirUtils.mkdirs(destFile.getParentFile());
+    Files.copy(Locations.newInputSupplier(deploymentJar), destFile);
+    return destFile;
+  }
+
+  private Manifest createManifest(Object...entries) {
+    Preconditions.checkArgument(entries.length % 2 == 0);
+    Attributes attributes = new Attributes();
+    for (int i = 0; i < entries.length; i += 2) {
+      attributes.put(entries[i], entries[i + 1]);
+    }
+    Manifest manifest = new Manifest();
+    manifest.getMainAttributes().putAll(attributes);
+    return manifest;
+  }
+
+  private static File generateClass(Class<?> fromClass, final String className, File directory) throws IOException {
+    // Generate a class dynamically using ASM from another class, but use a different class name,
+    // so that it won't be in the test class path.
+    InputStream byteCode = fromClass.getClassLoader().getResourceAsStream(Type.getInternalName(fromClass) + ".class");
+    try {
+      ClassReader reader = new ClassReader(byteCode);
+      ClassWriter writer = new ClassWriter(0);
+      reader.accept(new ClassVisitor(Opcodes.ASM4, writer) {
+        @Override
+        public void visit(int version, int access, String name, String signature,
+                          String superName, String[] interfaces) {
+          super.visit(version, access, className.replace('.', '/'), signature, superName, interfaces);
+        }
+      }, 0);
+
+      File target = new File(directory, className.replace('.', File.separatorChar) + ".class");
+      DirUtils.mkdirs(target.getParentFile());
+      Files.write(writer.toByteArray(), target);
+      return target;
+    } finally {
+      byteCode.close();
+    }
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/utils/DirUtils.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/utils/DirUtils.java
@@ -17,15 +17,22 @@
 package co.cask.cdap.common.utils;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Queues;
+import com.google.common.io.Files;
 
 import java.io.File;
+import java.io.FileFilter;
+import java.io.FilenameFilter;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Deque;
+import java.util.List;
+import javax.annotation.Nullable;
 
 /**
- * Copied from Google Guava as these methods are now deprecated.
+ * Provides utility methods for operating on directories.
  */
 public final class DirUtils {
 
@@ -89,5 +96,103 @@ public final class DirUtils {
     // The last clause is needed so that if there are multiple threads trying to create the same directory
     // this method will still return true.
     return dir.isDirectory() || dir.mkdirs() || dir.isDirectory();
+  }
+
+  /**
+   * Returns list of file names under the given directory. An empty list will be returned if the given file is
+   * not a directory.
+   */
+  public static List<String> list(File directory) {
+    return listOf(directory.list());
+  }
+
+  /**
+   * Returns list of file names under the given directory that are accepted by the given filter.
+   * An empty list will be returned if the given file is not a directory.
+   */
+  public static List<String> list(File directory, FilenameFilter filenameFilter) {
+    return listOf(directory.list(filenameFilter));
+  }
+
+  /**
+   * Returns list of file names under the given directory that matches the give set of file name extension.
+   * An empty list will be returned if the given file is not a directory.
+   */
+  public static List<String> list(File directory, String...extensions) {
+    return list(directory, ImmutableSet.copyOf(extensions));
+  }
+
+  /**
+   * Returns list of file names under the given directory that matches the give set of file name extension.
+   * An empty list will be returned if the given file is not a directory.
+   */
+  public static List<String> list(File directory, Iterable<String> extensions) {
+    final ImmutableSet<String> allowedExtensions = ImmutableSet.copyOf(extensions);
+
+    return list(directory, new FilenameFilter() {
+      @Override
+      public boolean accept(File dir, String name) {
+        return allowedExtensions.contains(Files.getFileExtension(name));
+      }
+    });
+  }
+
+  /**
+   * Returns list of files under the given directory. An empty list will be returned if the
+   * given file is not a directory.
+   */
+  public static List<File> listFiles(File directory) {
+    return listOf(directory.listFiles());
+  }
+
+  /**
+   * Returns list of files under the given directory that are accepted by the given filter.
+   * An empty list will be returned if the given file is not a directory.
+   */
+  public static List<File> listFiles(File directory, FileFilter fileFilter) {
+    return listOf(directory.listFiles(fileFilter));
+  }
+
+  /**
+   * Returns list of files under the given directory that are accepted by the given filter.
+   * An empty list will be returned if the given file is not a directory.
+   */
+  public static List<File> listFiles(File directory, FilenameFilter filenameFilter) {
+    return listOf(directory.listFiles(filenameFilter));
+  }
+
+  /**
+   * Returns list of files under the given directory that matches the give set of file name extension.
+   * An empty list will be returned if the given file is not a directory.
+   */
+  public static List<File> listFiles(File directory, String...extensions) {
+    return listFiles(directory, ImmutableSet.copyOf(extensions));
+  }
+
+  /**
+   * Returns list of files under the given directory that matches the give set of file name extension.
+   * An empty list will be returned if the given file is not a directory.
+   */
+  public static List<File> listFiles(File directory, Iterable<String> extensions) {
+    final ImmutableSet<String> allowedExtensions = ImmutableSet.copyOf(extensions);
+
+    return listFiles(directory, new FilenameFilter() {
+      @Override
+      public boolean accept(File dir, String name) {
+        return allowedExtensions.contains(Files.getFileExtension(name));
+      }
+    });
+  }
+
+  /**
+   * Converts the given array into a list. An empty list will be returned if the given array is {@code null}.
+   * (Note: This method might worth to be in some other common class, which we don't have now).
+   *
+   * @param elements array to convert
+   * @param <T> type of elements in the array
+   * @return a new immutable list.
+   */
+  private static <T> List<T> listOf(@Nullable T[] elements) {
+    return elements == null ? ImmutableList.<T>of() : ImmutableList.copyOf(elements);
   }
 }


### PR DESCRIPTION
It is the ground work for the whole plugin system for application template.

This PR includes works on the following pieces:
- New annotations defined for annotating plugin class and plugin config properties
- New data structure classes for recording plugin information and plugin class information.
- A `PluginClassLoader` for defining the class loading behavior of plugin classes
- A `PluginRepository` for inspecting and caching plugin information
- A `PluginInstantiator` for creating new instances of plugin classes

Template plugins are deployed as JAR files under the template plugin directory (i.e. under "data/plugins/[template_name]").

There are two ways of defining plugin classes in a plugin jar.

  1. Annotate class with the `@Plugin` annotation, and make the package name of the class available under the "Export-Package" jar manifest field.
    - The syntax for the "Export-Package" is the same as defined in OSGI, but only the package name part is being used. All other attributes are currently ignored
    - Plugin class can have a field with type extended from `PluginConfig` class. If such field exists, it will be inspected and information will be extracted to form the set of plugin properties being supported by that plugin class
    - At runtime, the config field of the plugin class will be injected with an instance with fields populated with plugin configurations provided by the user.
  2. Use an external json file to declare what classes are available as plugin class. In this mode, no class inspecting and config field field will happen.