### PR TITLE
Making sure that we don't propogate connection errors into alerts

### DIFF
--- a/cdap-ui/app/main.js
+++ b/cdap-ui/app/main.js
@@ -111,17 +111,15 @@ angular
   })
 
   .run(function ($rootScope, MYSOCKET_EVENT, myAlert) {
-
-    $rootScope.$on(MYSOCKET_EVENT.closed, function (angEvent, sockEvent) {
+    $rootScope.$on(MYSOCKET_EVENT.closed, function (angEvent, data) {
       myAlert({
         title: 'Error',
-        content: sockEvent.reason || 'could not connect to the server',
+        content: data.reason || 'could not connect to the server',
         type: 'danger'
       });
     });
 
     $rootScope.$on(MYSOCKET_EVENT.message, function (angEvent, data) {
-
       if(data.statusCode>399) {
         myAlert({
           title: data.statusCode.toString(),
@@ -130,7 +128,12 @@ angular
         });
       }
 
-      if(data.warning) {
+      // The user doesn't need to know that the backend node 
+      // is unable to connect to CDAP. Error messages add no
+      // more value than the pop showing that the FE is waiting 
+      // for system to come back up. Most of the issues are with 
+      // connect, other that connect pass everything else to user. 
+      if(data.warning && data.error.syscall !== 'connect') {
         myAlert({
           content: data.warning,
           type: 'warning'


### PR DESCRIPTION
Currently, issues related to NodeJS not being able to communicate with CDAP are being propagated to user. This information is useless as if the NodeJS is not able to connect to CDAP, then we block the screen and show a pop-up. But, adding alerts for every time we try connecting with CDAP makes no sense. This PR includes the fix for the same.

It makes sure, that it will not push the response only if it's not a connect call failure. 