### PR TITLE
name tests correctly so they actually get run by maven,

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/adapter/AdapterLifecycleTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/adapter/AdapterLifecycleTest.java
@@ -48,7 +48,7 @@ import java.util.Map;
 /**
  * AdapterService life cycle tests.
  */
-public class AdapterLifecycleTests extends AppFabricTestBase {
+public class AdapterLifecycleTest extends AppFabricTestBase {
   private static final Gson GSON = new Gson();
   private static final Type ADAPTER_SPEC_LIST_TYPE =
     new TypeToken<List<AdapterSpecification>>() { }.getType();

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/adapter/AdapterServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/adapter/AdapterServiceTest.java
@@ -57,7 +57,7 @@ import java.util.Map;
 /**
  * AdapterService life cycle tests.
  */
-public class AdapterServiceTests extends AppFabricTestBase {
+public class AdapterServiceTest extends AppFabricTestBase {
   private static final Id.Namespace NAMESPACE = Id.Namespace.from(TEST_NAMESPACE1);
   private static LocationFactory locationFactory;
   private static File adapterDir;

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AppFabricTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AppFabricTestBase.java
@@ -336,6 +336,9 @@ public abstract class AppFabricTestBase {
    */
   protected HttpResponse deploy(Class<?> application, @Nullable String apiVersion, @Nullable String namespace,
                                        @Nullable String appName, @Nullable String appVersion) throws Exception {
+    namespace = namespace == null ? Constants.DEFAULT_NAMESPACE : namespace;
+    apiVersion = apiVersion == null ? Constants.Gateway.API_VERSION_3_TOKEN : apiVersion;
+
     Manifest manifest = new Manifest();
     manifest.getMainAttributes().put(ManifestFields.MANIFEST_VERSION, "1.0");
     manifest.getMainAttributes().put(ManifestFields.MAIN_CLASS, application.getName());

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/NettyRouterPipelineTest.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/NettyRouterPipelineTest.java
@@ -91,9 +91,9 @@ import javax.ws.rs.Path;
 /**
  * Verify the ordering of events in the RouterPipeline.
  */
-public class NettyRouterPipelineTests {
+public class NettyRouterPipelineTest {
 
-  private static final Logger LOG = LoggerFactory.getLogger(NettyRouterPipelineTests.class);
+  private static final Logger LOG = LoggerFactory.getLogger(NettyRouterPipelineTest.class);
   private static final String hostname = "127.0.0.1";
   private static final DiscoveryService discoveryService = new InMemoryDiscoveryService();
   private static final String gatewayService = Constants.Service.APP_FABRIC_HTTP;


### PR DESCRIPTION
and make sure api version and namespace are always specified in
AppFabricTestBase when deploying an app.