### PR TITLE
CDAP-2184 document that throwing an IllegalArgumentException

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/templates/ApplicationTemplate.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/templates/ApplicationTemplate.java
@@ -37,7 +37,8 @@ public abstract class ApplicationTemplate<T> implements Application {
    * @param name name of the adapter
    * @param configuration adapter configuration
    * @param configurer {@link AdapterConfigurer}
-   * @throws Exception if the configuration is not valid
+   * @throws IllegalArgumentException if the configuration is not valid
+   * @throws Exception if there was some other error configuring the adapter
    */
   public void configureAdapter(String name, T configuration, AdapterConfigurer configurer) throws Exception {
     // no-op

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/LocalAdapterManager.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/LocalAdapterManager.java
@@ -81,7 +81,7 @@ public class LocalAdapterManager implements Manager<AdapterDeploymentInfo, Adapt
                                                           datasetFramework, inMemoryDatasetFramework));
     pipeline.addLast(new CreateAdapterDatasetInstancesStage(configuration, datasetFramework, namespace));
     pipeline.addLast(new CreateAdapterStreamsStage(namespace, streamAdmin, exploreFacade, exploreEnabled));
-    pipeline.setFinally(new AdapterRegistrationStage(namespace, store));
+    pipeline.addLast(new AdapterRegistrationStage(namespace, store));
     return pipeline.execute(input);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/LocalApplicationManager.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/LocalApplicationManager.java
@@ -111,7 +111,7 @@ public class LocalApplicationManager<I, O> implements Manager<I, O> {
                                                     queueAdmin, discoveryServiceClient));
     pipeline.addLast(new ProgramGenerationStage(configuration, namespacedLocationFactory));
     pipeline.addLast(new ApplicationRegistrationStage(store));
-    pipeline.setFinally(new CreateSchedulesStage(scheduler));
+    pipeline.addLast(new CreateSchedulesStage(scheduler));
     return pipeline.execute(input);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/LocalApplicationTemplateManager.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/LocalApplicationTemplateManager.java
@@ -112,7 +112,7 @@ public class LocalApplicationTemplateManager implements Manager<DeploymentInfo, 
                                                     queueAdmin, discoveryServiceClient));
     pipeline.addLast(new ProgramGenerationStage(configuration, namespacedLocationFactory));
     pipeline.addLast(new ApplicationRegistrationStage(store));
-    pipeline.setFinally(new EnableConcurrentRunsStage(preferencesStore));
+    pipeline.addLast(new EnableConcurrentRunsStage(preferencesStore));
     return pipeline.execute(input);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/pipeline/Pipeline.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/pipeline/Pipeline.java
@@ -46,5 +46,5 @@ public interface Pipeline<T> {
    *
    * @param o argument to run the pipeline.
    */
-  ListenableFuture<T> execute(Object o);
+  ListenableFuture<T> execute(Object o) throws Exception;
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/DummyBatchTemplate.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/DummyBatchTemplate.java
@@ -76,8 +76,8 @@ public class DummyBatchTemplate extends ApplicationTemplate<DummyBatchTemplate.C
   @Override
   public void configureAdapter(String adapterName, Config configuration,
                                AdapterConfigurer configurer) throws Exception {
-    Preconditions.checkNotNull(configuration.sourceName);
-    Preconditions.checkNotNull(configuration.crontab);
+    Preconditions.checkArgument(configuration.sourceName != null, "sourceName must be specified.");
+    Preconditions.checkArgument(configuration.crontab != null, "crontab must be specified.");
 
     Schedule schedule = Schedules.createTimeSchedule("dummy.schedule", "a dummy schedule", configuration.crontab);
     configurer.setSchedule(schedule);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/adapter/AdapterLifecycleTests.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/adapter/AdapterLifecycleTests.java
@@ -181,7 +181,8 @@ public class AdapterLifecycleTests extends AppFabricTestBase {
   @Test
   public void testRestrictUserApps() throws Exception {
     // Testing that users can not deploy an application
-    HttpResponse response = deploy(AppWithServices.class, DummyBatchTemplate.NAME);
+    HttpResponse response = deploy(AppWithServices.class, Constants.Gateway.API_VERSION_3_TOKEN,
+      Constants.DEFAULT_NAMESPACE, DummyBatchTemplate.NAME);
     Assert.assertEquals(400, response.getStatusLine().getStatusCode());
     String responseString = readResponse(response);
     Assert.assertTrue(String.format("Response String: %s", responseString),
@@ -214,7 +215,17 @@ public class AdapterLifecycleTests extends AppFabricTestBase {
 
   @Test
   public void testInvalidConfigReturns400() throws Exception {
-    // TODO: implement once adapter creation calls configureTemplate()
+    String adapterName = "badConfigAdapter";
+    DummyBatchTemplate.Config config = new DummyBatchTemplate.Config("somesource", null);
+    AdapterConfig adapterConfig = new AdapterConfig("description", DummyBatchTemplate.NAME, GSON.toJsonTree(config));
+    HttpResponse response = doPut(
+      String.format("%s/namespaces/%s/adapters/%s",
+        Constants.Gateway.API_VERSION_3, Constants.DEFAULT_NAMESPACE, adapterName), GSON.toJson(adapterConfig));
+    Assert.assertEquals(400, response.getStatusLine().getStatusCode());
+
+    String deleteURL = getVersionedAPIPath("apps/" + DummyBatchTemplate.NAME,
+      Constants.Gateway.API_VERSION_3_TOKEN, Constants.DEFAULT_NAMESPACE);
+    deleteApplication(60, deleteURL, 200);
   }
 
   private static void setupAdapter(Class<?> clz) throws IOException {

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/templates/etl/api/EndPointStage.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/templates/etl/api/EndPointStage.java
@@ -35,6 +35,8 @@ public interface EndPointStage {
    *
    * @param stageConfig the configuration for the source
    * @param pipelineConfigurer the configurer used to add required datasets and streams
+   * @throws IllegalArgumentException if the given config is invalid
    */
-  public void configurePipeline(ETLStage stageConfig, PipelineConfigurer pipelineConfigurer);
+  public void configurePipeline(ETLStage stageConfig,
+                                PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException;
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/templates/etl/batch/ETLBatchTemplate.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/templates/etl/batch/ETLBatchTemplate.java
@@ -37,6 +37,8 @@ import co.cask.cdap.templates.etl.transforms.IdentityTransform;
 import co.cask.cdap.templates.etl.transforms.ScriptFilterTransform;
 import co.cask.cdap.templates.etl.transforms.StreamToStructuredRecordTransform;
 import co.cask.cdap.templates.etl.transforms.StructuredRecordToGenericRecordTransform;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.gson.Gson;
 
@@ -68,9 +70,12 @@ public class ETLBatchTemplate extends ETLTemplate<ETLBatchConfig> {
   }
 
   @Override
-  public void configureAdapter(String adapterName, ETLBatchConfig etlBatchConfig, AdapterConfigurer configurer)
-    throws Exception {
+  public void configureAdapter(String adapterName, ETLBatchConfig etlBatchConfig,
+                               AdapterConfigurer configurer) throws Exception {
     super.configureAdapter(adapterName, etlBatchConfig, configurer);
+    String scheduleStr = etlBatchConfig.getSchedule();
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(scheduleStr), "Schedule must be specified in the config.");
+
     configurer.addRuntimeArgument(Constants.CONFIG_KEY, GSON.toJson(etlBatchConfig));
     configurer.setSchedule(new TimeSchedule(String.format("etl.batch.adapter.%s.schedule", adapterName),
                                             String.format("Schedule for %s Adapter", adapterName),

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/templates/etl/common/ETLTemplate.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/templates/etl/common/ETLTemplate.java
@@ -118,8 +118,7 @@ public abstract class ETLTemplate<T> extends ApplicationTemplate<T> {
   }
 
   @Override
-  public void configureAdapter(String adapterName, T config, AdapterConfigurer configurer)
-    throws Exception {
+  public void configureAdapter(String adapterName, T config, AdapterConfigurer configurer) throws Exception {
     ETLConfig etlConfig = (ETLConfig) config;
     ETLStage sourceConfig = etlConfig.getSource();
     ETLStage sinkConfig = etlConfig.getSink();


### PR DESCRIPTION
when configuring an adapter will tell the framework that the
config was invalid. This will make the rest api return a 400
instead of a 500. Also making sure the exception is not lost
wrapped in layers of ExecutionExceptions.