### PR TITLE
CDAP-2185 extend the get all rest api for adapters to support an

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AdapterHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AdapterHttpHandler.java
@@ -107,13 +107,18 @@ public class AdapterHttpHandler extends AbstractAppFabricHttpHandler {
   @GET
   @Path("/adapters")
   public void listAdapters(HttpRequest request, HttpResponder responder,
-                           @PathParam("namespace-id") String namespaceId) {
+                           @PathParam("namespace-id") String namespaceId,
+                           @QueryParam("template") String template) {
     if (!namespaceAdmin.hasNamespace(Id.Namespace.from(namespaceId))) {
       responder.sendString(HttpResponseStatus.NOT_FOUND,
                            String.format("Namespace '%s' does not exist.", namespaceId));
       return;
     }
-    responder.sendJson(HttpResponseStatus.OK, adapterService.getAdapters(Id.Namespace.from(namespaceId)));
+    if (template != null) {
+      responder.sendJson(HttpResponseStatus.OK, adapterService.getAdapters(Id.Namespace.from(namespaceId), template));
+    } else {
+      responder.sendJson(HttpResponseStatus.OK, adapterService.getAdapters(Id.Namespace.from(namespaceId)));
+    }
   }
 
   /**

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/adapter/AdapterLifecycleTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/adapter/AdapterLifecycleTest.java
@@ -228,6 +228,55 @@ public class AdapterLifecycleTest extends AppFabricTestBase {
     deleteApplication(60, deleteURL, 200);
   }
 
+  @Test
+  public void testGetAllAdapters() throws Exception {
+    // create first adapter
+    String namespaceId = Constants.DEFAULT_NAMESPACE;
+    String adapter1 = "adapter1";
+    DummyWorkerTemplate.Config config1 = new DummyWorkerTemplate.Config(2);
+    createAdapter(namespaceId, adapter1,
+                  new AdapterConfig("description", DummyWorkerTemplate.NAME, GSON.toJsonTree(config1)));
+
+    // create second adapter with a different template
+    String adapter2 = "adapter2";
+    DummyBatchTemplate.Config config2 = new DummyBatchTemplate.Config("somesource", "0 0 1 1 *");
+    createAdapter(namespaceId, adapter2,
+      new AdapterConfig("description", DummyBatchTemplate.NAME, GSON.toJsonTree(config2)));
+
+    // test get all endpoint
+    HttpResponse response = listAdapters(namespaceId);
+    Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+    List<AdapterSpecification> list = readResponse(response, ADAPTER_SPEC_LIST_TYPE);
+    Assert.assertEquals(2, list.size());
+
+    // test get all for a template
+    response = listAdaptersForTemplate(namespaceId, DummyWorkerTemplate.NAME);
+    Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+    list = readResponse(response, ADAPTER_SPEC_LIST_TYPE);
+    Assert.assertEquals(1, list.size());
+    Assert.assertEquals(adapter1, list.get(0).getName());
+
+    response = listAdaptersForTemplate(namespaceId, DummyBatchTemplate.NAME);
+    Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+    list = readResponse(response, ADAPTER_SPEC_LIST_TYPE);
+    Assert.assertEquals(1, list.size());
+    Assert.assertEquals(adapter2, list.get(0).getName());
+
+    // delete adapters
+    deleteAdapter(namespaceId, adapter1);
+    deleteAdapter(namespaceId, adapter2);
+    deleteApplication(60, getVersionedAPIPath("apps/" + DummyBatchTemplate.NAME,
+      Constants.Gateway.API_VERSION_3_TOKEN, Constants.DEFAULT_NAMESPACE), 200);
+    deleteApplication(60, getVersionedAPIPath("apps/" + DummyWorkerTemplate.NAME,
+      Constants.Gateway.API_VERSION_3_TOKEN, Constants.DEFAULT_NAMESPACE), 200);
+
+    // check there are none
+    response = listAdapters(namespaceId);
+    Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+    list = readResponse(response, ADAPTER_SPEC_LIST_TYPE);
+    Assert.assertTrue(list.isEmpty());
+  }
+
   private static void setupAdapter(Class<?> clz) throws IOException {
     Location adapterJar = AppJarHelper.createDeploymentJar(locationFactory, clz);
     File destination =  new File(String.format("%s/%s", adapterDir.getAbsolutePath(), adapterJar.getName()));
@@ -247,6 +296,11 @@ public class AdapterLifecycleTest extends AppFabricTestBase {
   private HttpResponse listAdapters(String namespaceId) throws Exception {
     return doGet(String.format("%s/namespaces/%s/adapters",
                                Constants.Gateway.API_VERSION_3, namespaceId));
+  }
+
+  private HttpResponse listAdaptersForTemplate(String namespaceId, String template) throws Exception {
+    return doGet(String.format("%s/namespaces/%s/adapters?template=%s",
+                               Constants.Gateway.API_VERSION_3, namespaceId, template));
   }
 
   private HttpResponse getAdapter(String namespaceId, String adapterId) throws Exception {


### PR DESCRIPTION
optional 'template' query param that will filter the adapters
returned by those that match the template given.