### PR TITLE
[CDAP-2062] Added real-time Stream Sink

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/DistributedProgramRunnerModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/DistributedProgramRunnerModule.java
@@ -15,8 +15,11 @@
  */
 package co.cask.cdap.app.guice;
 
+import co.cask.cdap.api.data.stream.StreamWriter;
 import co.cask.cdap.app.runtime.ProgramRunner;
 import co.cask.cdap.app.runtime.ProgramRuntimeService;
+import co.cask.cdap.app.stream.DefaultStreamWriter;
+import co.cask.cdap.app.stream.StreamWriterFactory;
 import co.cask.cdap.internal.app.runtime.ProgramRunnerFactory;
 import co.cask.cdap.internal.app.runtime.distributed.DistributedFlowProgramRunner;
 import co.cask.cdap.internal.app.runtime.distributed.DistributedMapReduceProgramRunner;
@@ -31,6 +34,7 @@ import com.google.inject.Provider;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.Singleton;
+import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.multibindings.MapBinder;
 
 import java.util.Map;
@@ -55,6 +59,10 @@ final class DistributedProgramRunnerModule extends PrivateModule {
     // Bind and expose ProgramRuntimeService
     bind(ProgramRuntimeService.class).to(DistributedProgramRuntimeService.class).in(Scopes.SINGLETON);
     expose(ProgramRuntimeService.class);
+
+    // Create StreamWriter factory.
+    install(new FactoryModuleBuilder().implement(StreamWriter.class, DefaultStreamWriter.class)
+              .build(StreamWriterFactory.class));
   }
 
   @Singleton

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/InMemoryProgramRunnerModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/InMemoryProgramRunnerModule.java
@@ -16,8 +16,11 @@
 
 package co.cask.cdap.app.guice;
 
+import co.cask.cdap.api.data.stream.StreamWriter;
 import co.cask.cdap.app.runtime.ProgramRunner;
 import co.cask.cdap.app.runtime.ProgramRuntimeService;
+import co.cask.cdap.app.stream.DefaultStreamWriter;
+import co.cask.cdap.app.stream.StreamWriterFactory;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.discovery.ResolvingDiscoverable;
@@ -57,11 +60,26 @@ import org.apache.twill.discovery.DiscoveryService;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  *
  */
-final class InMemoryProgramRunnerModule extends PrivateModule {
+public final class InMemoryProgramRunnerModule extends PrivateModule {
+
+  private final Class<? extends StreamWriter> streamWriterClass;
+
+  public InMemoryProgramRunnerModule() {
+    this(null);
+  }
+
+  public InMemoryProgramRunnerModule(@Nullable Class<? extends StreamWriter> streamWriterClass) {
+    if (streamWriterClass == null) {
+      this.streamWriterClass = DefaultStreamWriter.class;
+    } else {
+      this.streamWriterClass = streamWriterClass;
+    }
+  }
 
   /**
    * Configures a {@link com.google.inject.Binder} via the exposed methods.
@@ -109,6 +127,10 @@ final class InMemoryProgramRunnerModule extends PrivateModule {
     // Create webapp http handler factory.
     install(new FactoryModuleBuilder().implement(JarHttpHandler.class, IntactJarHttpHandler.class)
               .build(WebappHttpHandlerFactory.class));
+
+    // Create StreamWriter factory.
+    install(new FactoryModuleBuilder().implement(StreamWriter.class, streamWriterClass)
+              .build(StreamWriterFactory.class));
   }
 
   @Singleton

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/stream/DefaultStreamWriter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/stream/DefaultStreamWriter.java
@@ -30,6 +30,8 @@ import co.cask.common.http.HttpResponse;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.net.HttpHeaders;
+import com.google.inject.Inject;
+import com.google.inject.assistedinject.Assisted;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import org.apache.twill.discovery.Discoverable;
 import org.apache.twill.discovery.DiscoveryServiceClient;
@@ -49,12 +51,12 @@ import java.util.concurrent.TimeUnit;
 public class DefaultStreamWriter implements StreamWriter {
 
   private final String namespaceId;
-  private final DiscoveryServiceClient discoveryServiceClient;
   private final EndpointStrategy endpointStrategy;
 
-  public DefaultStreamWriter(String namespaceId, DiscoveryServiceClient discoveryServiceClient) {
+  @Inject
+  public DefaultStreamWriter(@Assisted("namespaceId") String namespaceId,
+                             DiscoveryServiceClient discoveryServiceClient) {
     this.namespaceId = namespaceId;
-    this.discoveryServiceClient = discoveryServiceClient;
     this.endpointStrategy = new RandomEndpointStrategy(discoveryServiceClient.discover(Constants.Service.STREAMS));
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/stream/StreamWriterFactory.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/stream/StreamWriterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,17 +14,19 @@
  * the License.
  */
 
-package co.cask.cdap.test.internal;
+package co.cask.cdap.app.stream;
 
-import co.cask.cdap.common.conf.Constants;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.api.data.stream.StreamWriter;
+import com.google.inject.assistedinject.Assisted;
 
 /**
- * Default Ids to use in test if you do not want to construct your own.
+ * Factory to create {@link StreamWriter} objects
  */
-public class DefaultId {
-  private static final String DEFAULT_APPLICATION_ID = "myapp";
-
-  public static final Id.Namespace NAMESPACE = Constants.DEFAULT_NAMESPACE_ID;
-  public static final Id.Application APPLICATION = Id.Application.from(NAMESPACE, DEFAULT_APPLICATION_ID);
+public interface StreamWriterFactory {
+  /**
+   * @param namespaceId the namespaceId for which to return a {@link StreamWriter}
+   * @return a {@link StreamWriter} for the specified namespaceId
+   */
+  StreamWriter create(@Assisted("namespaceId") String namespaceId);
 }
+

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/WorkerProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/WorkerProgramRunner.java
@@ -25,6 +25,7 @@ import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.app.runtime.ProgramRunner;
+import co.cask.cdap.app.stream.StreamWriterFactory;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.internal.app.runtime.ProgramControllerServiceAdapter;
@@ -49,16 +50,18 @@ public class WorkerProgramRunner implements ProgramRunner {
   private final DatasetFramework datasetFramework;
   private final DiscoveryServiceClient discoveryServiceClient;
   private final TransactionSystemClient txClient;
+  private final StreamWriterFactory streamWriterFactory;
 
   @Inject
   public WorkerProgramRunner(CConfiguration cConf, MetricsCollectionService metricsCollectionService,
                              DatasetFramework datasetFramework, DiscoveryServiceClient discoveryServiceClient,
-                             TransactionSystemClient txClient) {
+                             TransactionSystemClient txClient, StreamWriterFactory streamWriterFactory) {
     this.cConf = cConf;
     this.metricsCollectionService = metricsCollectionService;
     this.datasetFramework = datasetFramework;
     this.discoveryServiceClient = discoveryServiceClient;
     this.txClient = txClient;
+    this.streamWriterFactory = streamWriterFactory;
   }
 
   @Override
@@ -99,7 +102,7 @@ public class WorkerProgramRunner implements ProgramRunner {
     BasicWorkerContext context = new BasicWorkerContext(newWorkerSpec, program, runId, instanceId, instanceCount,
                                                         options.getUserArguments(), cConf,
                                                         metricsCollectionService, datasetFramework,
-                                                        txClient, discoveryServiceClient);
+                                                        txClient, discoveryServiceClient, streamWriterFactory);
     WorkerDriver worker = new WorkerDriver(program, newWorkerSpec, context);
 
     ProgramControllerServiceAdapter controller = new WorkerControllerServiceAdapter(worker, workerName, runId);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/test/internal/MockResponder.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/test/internal/MockResponder.java
@@ -25,6 +25,7 @@ import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import org.jboss.netty.buffer.ChannelBuffer;
 import org.jboss.netty.buffer.ChannelBufferInputStream;
+import org.jboss.netty.buffer.ChannelBuffers;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 
 import java.io.File;
@@ -39,7 +40,6 @@ public final class MockResponder extends AbstractHttpResponder {
   private HttpResponseStatus status = null;
   private ChannelBuffer content = null;
   private static final Gson GSON = new Gson();
-
 
   public HttpResponseStatus getStatus() {
     return status;
@@ -61,12 +61,15 @@ public final class MockResponder extends AbstractHttpResponder {
     return new ChunkResponder() {
       @Override
       public void sendChunk(ByteBuffer chunk) throws IOException {
-        // No-op
+        sendChunk(ChannelBuffers.wrappedBuffer(chunk));
       }
 
       @Override
       public void sendChunk(ChannelBuffer chunk) throws IOException {
-        // No-op
+        if (content == null) {
+          content = ChannelBuffers.dynamicBuffer();
+        }
+        content.writeBytes(chunk);
       }
 
       @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/common/Properties.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/common/Properties.java
@@ -36,7 +36,7 @@ public final class Properties {
   }
 
   /**
-   * Properties for the StreamBatchSource
+   * Properties for the StreamBatchSource as well as the real-time StreamSink
    */
   public static class Stream {
     public static final String NAME = "name";
@@ -44,6 +44,10 @@ public final class Properties {
     public static final String FORMAT = "format";
     public static final String DELAY = "delay";
     public static final String DURATION = "duration";
+    public static final String DATA_FIELD = "data.field";
+    public static final String DEFAULT_DATA_FIELD = "data";
+    public static final String HEADERS_FIELD = "headers.field";
+    public static final String DEFAULT_HEADERS_FIELD = "headers";
   }
 
   /**

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/sinks/StreamSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/sinks/StreamSink.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.templates.etl.realtime.sinks;
+
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.data.stream.Stream;
+import co.cask.cdap.api.stream.StreamEventData;
+import co.cask.cdap.templates.etl.api.PipelineConfigurer;
+import co.cask.cdap.templates.etl.api.Property;
+import co.cask.cdap.templates.etl.api.StageConfigurer;
+import co.cask.cdap.templates.etl.api.config.ETLStage;
+import co.cask.cdap.templates.etl.api.realtime.DataWriter;
+import co.cask.cdap.templates.etl.api.realtime.RealtimeContext;
+import co.cask.cdap.templates.etl.api.realtime.RealtimeSink;
+import co.cask.cdap.templates.etl.common.Properties;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Map;
+
+/**
+ * Real-time sink for Streams
+ */
+public class StreamSink extends RealtimeSink<StructuredRecord> {
+  private static final Logger LOG = LoggerFactory.getLogger(StreamSink.class);
+  private String streamName;
+  private String headersField;
+  private String dataField;
+
+  @Override
+  public void configure(StageConfigurer configurer) {
+    configurer.setDescription("Real-time sink that outputs to the specified stream.");
+    configurer.addProperty(new Property(Properties.Stream.NAME,
+                                        "The name of the stream to output to. Must be a valid stream name. " +
+                                          "The stream will be created if it does not exist.",
+                                        true));
+    configurer.addProperty(new Property(Properties.Stream.DATA_FIELD,
+                                        "Name of the field in the record that contains the data to be written to " +
+                                          "the specified stream. The data could be in binary format as " +
+                                          "a byte array or a ByteBuffer. It can also be a String." +
+                                          "If unspecified, the 'data' key is used.",
+                                        false));
+    configurer.addProperty(new Property(Properties.Stream.HEADERS_FIELD,
+                                        "Name of the field in the record that contains headers. Headers are presumed" +
+                                          " to be a map of string to string.",
+                                        false));
+  }
+
+  @Override
+  public void configurePipeline(ETLStage stageConfig, PipelineConfigurer pipelineConfigurer) {
+    Map<String, String> properties = stageConfig.getProperties();
+    String streamName = properties.get(Properties.Stream.NAME);
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(streamName), "Stream name should be non-null, non-empty.");
+    pipelineConfigurer.addStream(new Stream(streamName));
+  }
+
+  @Override
+  public void initialize(RealtimeContext context) throws Exception {
+    super.initialize(context);
+    Map<String, String> runtimeArguments = context.getRuntimeArguments();
+    streamName = runtimeArguments.get(Properties.Stream.NAME);
+    headersField = runtimeArguments.containsKey(Properties.Stream.HEADERS_FIELD) ?
+      runtimeArguments.get(Properties.Stream.HEADERS_FIELD) : Properties.Stream.DEFAULT_HEADERS_FIELD;
+    dataField = runtimeArguments.containsKey(Properties.Stream.DATA_FIELD) ?
+      runtimeArguments.get(Properties.Stream.DATA_FIELD) : Properties.Stream.DEFAULT_DATA_FIELD;
+  }
+
+  @Override
+  public int write(Iterable<StructuredRecord> structuredRecords, DataWriter dataWriter) throws Exception {
+    int numRecordsWritten = 0;
+    for (StructuredRecord structuredRecord : structuredRecords) {
+      Schema schema = structuredRecord.getSchema();
+      Object data = structuredRecord.get(dataField);
+      Object headers = structuredRecord.get(headersField);
+      if (data == null) {
+        LOG.debug("Found null data. Skipping record.");
+        continue;
+      }
+
+      if (headers != null && !isHeadersSchemaPresentAndSupported(schema)) {
+        LOG.debug("Headers found in input, however either the headers schema is not provided or the provided " +
+                    "schema is not supported. Only a map of string keys and string values is supported. " +
+                    "Skipping record.");
+        continue;
+      }
+
+      Schema.Field dataSchemaField = schema.getField(dataField);
+      switch (dataSchemaField.getSchema().getType()) {
+        case BYTES:
+          numRecordsWritten += writeBytes(dataWriter, data, headers);
+          break;
+        case STRING:
+          numRecordsWritten += writeString(dataWriter, data, headers);
+          break;
+        default:
+          LOG.debug("Type {} is not supported for writing to stream", data.getClass().getName());
+          break;
+      }
+    }
+    return numRecordsWritten;
+  }
+
+  private boolean isHeadersSchemaPresentAndSupported(Schema recordSchema) {
+    Schema.Field headersSchemaField = recordSchema.getField(headersField);
+    if (headersSchemaField != null) {
+      Map.Entry<Schema, Schema> mapSchema = headersSchemaField.getSchema().getMapSchema();
+      return mapSchema.getKey().getType().equals(Schema.Type.STRING) &&
+        mapSchema.getValue().getType().equals(Schema.Type.STRING);
+    }
+    return false;
+  }
+
+  private int writeBytes(DataWriter writer, Object data, Object headers) throws IOException {
+    ByteBuffer buffer;
+    if (data instanceof ByteBuffer) {
+      buffer = (ByteBuffer) data;
+    } else if (data instanceof byte []) {
+      buffer = ByteBuffer.wrap((byte []) data);
+    } else {
+      LOG.debug("Type {} is not supported for writing to stream", data.getClass().getName());
+      return 0;
+    }
+    if (headers != null && headers instanceof Map) {
+      StreamEventData streamEventData = new StreamEventData((Map<String, String>) headers, buffer);
+      writer.write(streamName, streamEventData);
+    } else {
+      writer.write(streamName, buffer);
+    }
+    return 1;
+  }
+
+  private int writeString(DataWriter writer, Object data, Object headers) throws IOException {
+    if (headers != null && headers instanceof Map) {
+      writer.write(streamName, (String) data, (Map<String, String>) headers);
+    } else {
+      writer.write(streamName, (String) data);
+    }
+    return 1;
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/sources/TestSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/sources/TestSource.java
@@ -81,7 +81,6 @@ public class TestSource extends RealtimeSource<StructuredRecord> {
     }
 
     LOG.info("Emitting data! {}", prevCount);
-
     if (type == null) {
       writeDefaultRecords(writer);
     } else if (STREAM_TYPE.equals(type)) {
@@ -103,7 +102,6 @@ public class TestSource extends RealtimeSource<StructuredRecord> {
     Schema.Field dataField = Schema.Field.of("data", Schema.of(Schema.Type.STRING));
     Schema.Field headersField = Schema.Field.of("headers", Schema.mapOf(Schema.of(Schema.Type.STRING),
                                                                         Schema.of(Schema.Type.STRING)));
-    Schema.Field tsField = Schema.Field.of("timestamp", Schema.of(Schema.Type.LONG));
     // emit only string
     StructuredRecord.Builder recordBuilder = StructuredRecord.builder(Schema.recordOf("StringRecord", dataField));
     recordBuilder.set("data", "Hello");
@@ -119,12 +117,10 @@ public class TestSource extends RealtimeSource<StructuredRecord> {
     recordBuilder.set("data", "Hello".getBytes(Charsets.UTF_8));
     recordBuilder.set("headers", ImmutableMap.of("h1", "v1"));
     writer.emit(recordBuilder.build());
-    // ByteBuffer + headers + timestamp
-    recordBuilder = StructuredRecord.builder(Schema.recordOf("ByteBufferHeadersTsRecord", dataField, headersField,
-                                                             tsField));
+    // ByteBuffer + headers
+    recordBuilder = StructuredRecord.builder(Schema.recordOf("ByteBufferHeadersRecord", dataField, headersField));
     recordBuilder.set("data", ByteBuffer.wrap("Hello".getBytes(Charsets.UTF_8)));
     recordBuilder.set("headers", ImmutableMap.of("h1", "v1"));
-    recordBuilder.set("timestamp", System.currentTimeMillis());
     writer.emit(recordBuilder.build());
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/main/java/co/cask/cdap/templates/etl/realtime/ETLRealtimeTemplate.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/main/java/co/cask/cdap/templates/etl/realtime/ETLRealtimeTemplate.java
@@ -24,7 +24,7 @@ import co.cask.cdap.api.templates.AdapterConfigurer;
 import co.cask.cdap.templates.etl.common.Constants;
 import co.cask.cdap.templates.etl.common.ETLTemplate;
 import co.cask.cdap.templates.etl.realtime.config.ETLRealtimeConfig;
-import co.cask.cdap.templates.etl.realtime.sinks.NoOpSink;
+import co.cask.cdap.templates.etl.realtime.sinks.StreamSink;
 import co.cask.cdap.templates.etl.realtime.sources.TestSource;
 import co.cask.cdap.templates.etl.transforms.IdentityTransform;
 import co.cask.cdap.templates.etl.transforms.ProjectionTransform;
@@ -46,11 +46,11 @@ public class ETLRealtimeTemplate extends ETLTemplate<ETLRealtimeConfig> {
     // Add class from lib here to be made available for use in the ETL Worker.
     // TODO : Remove this when plugins management is available.
     initTable(Lists.<Class>newArrayList(IdentityTransform.class,
-                                        NoOpSink.class,
                                         TestSource.class,
                                         StructuredRecordToGenericRecordTransform.class,
                                         ScriptFilterTransform.class,
-                                        ProjectionTransform.class));
+                                        ProjectionTransform.class,
+                                        StreamSink.class));
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/test/java/co/cask/cdap/templates/etl/realtime/ETLWorkerTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/test/java/co/cask/cdap/templates/etl/realtime/ETLWorkerTest.java
@@ -16,23 +16,34 @@
 
 package co.cask.cdap.templates.etl.realtime;
 
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.flow.flowlet.StreamEvent;
 import co.cask.cdap.api.templates.ApplicationTemplate;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.templates.etl.api.config.ETLStage;
 import co.cask.cdap.templates.etl.common.MockAdapterConfigurer;
+import co.cask.cdap.templates.etl.common.Properties;
 import co.cask.cdap.templates.etl.realtime.config.ETLRealtimeConfig;
-import co.cask.cdap.templates.etl.realtime.sinks.NoOpSink;
+import co.cask.cdap.templates.etl.realtime.sinks.StreamSink;
 import co.cask.cdap.templates.etl.realtime.sources.TestSource;
 import co.cask.cdap.test.ApplicationManager;
+import co.cask.cdap.test.SlowTests;
+import co.cask.cdap.test.StreamManager;
 import co.cask.cdap.test.TestBase;
 import co.cask.cdap.test.WorkerManager;
 import com.clearspring.analytics.util.Lists;
+import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -46,26 +57,40 @@ public class ETLWorkerTest extends TestBase {
     templateManager = deployApplication(ETLRealtimeTemplate.class);
   }
 
-  // TODO: Replace this test with meaningful sources and sinks once they are available.
   @Test
-  public void testSimpleConfig() throws Exception {
+  @Category(SlowTests.class)
+  public void testStreamSink() throws Exception {
+    StreamManager streamManager = getStreamManager(Constants.DEFAULT_NAMESPACE_ID, "testStream");
+    streamManager.createStream();
+
     ApplicationTemplate<ETLRealtimeConfig> appTemplate = new ETLRealtimeTemplate();
 
-    ETLStage source = new ETLStage(TestSource.class.getSimpleName(), ImmutableMap.<String, String>of());
-    ETLStage sink = new ETLStage(NoOpSink.class.getSimpleName(), ImmutableMap.<String, String>of());
-    List<ETLStage> transforms = Lists.newArrayList();
-    ETLRealtimeConfig adapterConfig = new ETLRealtimeConfig(source, sink, transforms);
+    long startTime = System.currentTimeMillis();
+    ETLStage source = new ETLStage(TestSource.class.getSimpleName(),
+                                   ImmutableMap.of(TestSource.PROPERTY_TYPE, TestSource.STREAM_TYPE));
+    ETLStage sink = new ETLStage(StreamSink.class.getSimpleName(),
+                                 ImmutableMap.of(Properties.Stream.NAME, "testStream"));
+    ETLRealtimeConfig adapterConfig = new ETLRealtimeConfig(source, sink, Lists.<ETLStage>newArrayList());
     MockAdapterConfigurer adapterConfigurer = new MockAdapterConfigurer();
     appTemplate.configureAdapter("myAdapter", adapterConfig, adapterConfigurer);
-
-    Map<String, String> workerArgs = Maps.newHashMap();
-    for (Map.Entry<String, String> entry : adapterConfigurer.getArguments().entrySet()) {
-      workerArgs.put(entry.getKey(), entry.getValue());
-    }
-
+    Map<String, String> workerArgs = Maps.newHashMap(adapterConfigurer.getArguments());
     WorkerManager workerManager = templateManager.startWorker(ETLWorker.class.getSimpleName(), workerArgs);
+    // Let the worker run for 5 seconds
     TimeUnit.SECONDS.sleep(5);
     workerManager.stop();
     templateManager.stopAll();
+
+    List<StreamEvent> streamEvents = streamManager.getEvents(startTime, System.currentTimeMillis(), Integer.MAX_VALUE);
+    // verify that some events were sent to the stream
+    Assert.assertTrue(streamEvents.size() > 0);
+    // since we sent all identical events, verify the contents of just one of them
+    Random random = new Random();
+    StreamEvent event = streamEvents.get(random.nextInt(streamEvents.size()));
+    ByteBuffer body = event.getBody();
+    Map<String, String> headers = event.getHeaders();
+    if (headers != null && !headers.isEmpty()) {
+      Assert.assertEquals("v1", headers.get("h1"));
+    }
+    Assert.assertEquals("Hello", Bytes.toString(body, Charsets.UTF_8));
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/test/resources/logback-test.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/test/resources/logback-test.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestManager.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestManager.java
@@ -136,4 +136,9 @@ public class IntegrationTestManager implements TestManager {
   public void deleteNamespace(Id.Namespace namespace) throws Exception {
     namespaceClient.delete(namespace.getId());
   }
+
+  @Override
+  public StreamManager getStreamManager(Id.Stream streamId) {
+    throw new UnsupportedOperationException();
+  }
 }

--- a/cdap-test/src/main/java/co/cask/cdap/test/StreamManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/StreamManager.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.test;
+
+import co.cask.cdap.api.annotation.Beta;
+import co.cask.cdap.api.flow.flowlet.StreamEvent;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * This interface allows you to interact with streams.
+ * Currently, it only exposes methods to read from a stream.
+ * Eventually, {@link StreamWriter} should be deprecated and all its functionality moved here
+ */
+@Beta
+public interface StreamManager {
+
+  /**
+   * Create the stream.
+   *
+   * @throws java.io.IOException If there is an error creating the stream.
+   */
+  void createStream() throws IOException;
+
+  /**
+   * Get events from the specified stream in the specified interval
+   *
+   * @param startTime the start time
+   * @param endTime the end time
+   * @param limit the maximum number of events to return
+   * @return a list of stream events in the given time range
+   */
+  List<StreamEvent> getEvents(long startTime, long endTime, int limit) throws IOException;
+}

--- a/cdap-test/src/main/java/co/cask/cdap/test/TestManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/TestManager.java
@@ -121,4 +121,7 @@ public interface TestManager {
    * @throws Exception
    */
   void deleteNamespace(Id.Namespace namespace) throws Exception;
+
+
+  StreamManager getStreamManager(Id.Stream streamId);
 }

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/ConfigurableTestBase.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/ConfigurableTestBase.java
@@ -23,6 +23,7 @@ import co.cask.cdap.api.dataset.module.DatasetModule;
 import co.cask.cdap.api.metrics.MetricStore;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.app.guice.AppFabricServiceRuntimeModule;
+import co.cask.cdap.app.guice.InMemoryProgramRunnerModule;
 import co.cask.cdap.app.guice.ProgramRunnerRuntimeModule;
 import co.cask.cdap.app.guice.ServiceStoreModules;
 import co.cask.cdap.common.conf.CConfiguration;
@@ -75,8 +76,11 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.test.internal.ApplicationManagerFactory;
 import co.cask.cdap.test.internal.DefaultApplicationManager;
+import co.cask.cdap.test.internal.DefaultStreamManager;
 import co.cask.cdap.test.internal.DefaultStreamWriter;
 import co.cask.cdap.test.internal.LocalNamespaceClient;
+import co.cask.cdap.test.internal.LocalStreamWriter;
+import co.cask.cdap.test.internal.StreamManagerFactory;
 import co.cask.cdap.test.internal.StreamWriterFactory;
 import co.cask.tephra.TransactionManager;
 import com.google.common.base.Preconditions;
@@ -218,7 +222,7 @@ public class ConfigurableTestBase {
       new DiscoveryRuntimeModule().getInMemoryModules(),
       new AppFabricServiceRuntimeModule().getInMemoryModules(),
       new ServiceStoreModules().getInMemoryModule(),
-      new ProgramRunnerRuntimeModule().getInMemoryModules(),
+      new InMemoryProgramRunnerModule(LocalStreamWriter.class),
       new AbstractModule() {
         @Override
         protected void configure() {
@@ -246,6 +250,8 @@ public class ConfigurableTestBase {
                     .build(ApplicationManagerFactory.class));
           install(new FactoryModuleBuilder().implement(StreamWriter.class, DefaultStreamWriter.class)
                     .build(StreamWriterFactory.class));
+          install(new FactoryModuleBuilder().implement(StreamManager.class, DefaultStreamManager.class)
+                    .build(StreamManagerFactory.class));
           bind(TemporaryFolder.class).toInstance(tmpFolder);
         }
       }
@@ -494,6 +500,10 @@ public class ConfigurableTestBase {
    */
   protected final Connection getQueryClient() throws Exception {
     return getQueryClient(Constants.DEFAULT_NAMESPACE_ID);
+  }
+
+  protected final StreamManager getStreamManager(Id.Namespace namespace, String streamName) throws Exception {
+    return getTestManager().getStreamManager(Id.Stream.from(namespace, streamName));
   }
 }
 

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/UnitTestManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/UnitTestManager.java
@@ -33,6 +33,7 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.test.internal.AppFabricClient;
 import co.cask.cdap.test.internal.ApplicationManagerFactory;
+import co.cask.cdap.test.internal.StreamManagerFactory;
 import co.cask.tephra.TransactionAware;
 import co.cask.tephra.TransactionContext;
 import co.cask.tephra.TransactionFailureException;
@@ -63,17 +64,20 @@ public class UnitTestManager implements TestManager {
   private final DiscoveryServiceClient discoveryClient;
   private final ApplicationManagerFactory appManagerFactory;
   private final NamespaceAdmin namespaceAdmin;
+  private final StreamManagerFactory streamManagerFactory;
 
   @Inject
   public UnitTestManager(AppFabricClient appFabricClient, DatasetFramework datasetFramework,
                          TransactionSystemClient txSystemClient, DiscoveryServiceClient discoveryClient,
-                         ApplicationManagerFactory appManagerFactory, NamespaceAdmin namespaceAdmin) {
+                         ApplicationManagerFactory appManagerFactory, NamespaceAdmin namespaceAdmin,
+                         StreamManagerFactory streamManagerFactory) {
     this.appFabricClient = appFabricClient;
     this.datasetFramework = datasetFramework;
     this.txSystemClient = txSystemClient;
     this.discoveryClient = discoveryClient;
     this.appManagerFactory = appManagerFactory;
     this.namespaceAdmin = namespaceAdmin;
+    this.streamManagerFactory = streamManagerFactory;
   }
 
   /**
@@ -226,4 +230,8 @@ public class UnitTestManager implements TestManager {
     namespaceAdmin.deleteNamespace(namespace);
   }
 
+  @Override
+  public StreamManager getStreamManager(Id.Stream streamId) {
+    return streamManagerFactory.create(streamId);
+  }
 }

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultStreamManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultStreamManager.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.test.internal;
+
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.flow.flowlet.StreamEvent;
+import co.cask.cdap.common.stream.StreamEventTypeAdapter;
+import co.cask.cdap.data.stream.service.StreamFetchHandler;
+import co.cask.cdap.data.stream.service.StreamHandler;
+import co.cask.cdap.internal.io.SchemaTypeAdapter;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.test.StreamManager;
+import com.google.common.base.Throwables;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+import com.google.inject.Inject;
+import com.google.inject.assistedinject.Assisted;
+import org.jboss.netty.handler.codec.http.DefaultHttpRequest;
+import org.jboss.netty.handler.codec.http.HttpMethod;
+import org.jboss.netty.handler.codec.http.HttpRequest;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+import org.jboss.netty.handler.codec.http.HttpVersion;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Default implementation of {@link StreamManager} for use in tests
+ */
+public class DefaultStreamManager implements StreamManager {
+  private static final Gson GSON = StreamEventTypeAdapter.register(
+    new GsonBuilder().registerTypeAdapter(Schema.class, new SchemaTypeAdapter())).create();
+
+  private final Id.Stream streamId;
+  // TODO: CDAP-2171 Move all functionality from StreamWriter here and deprecate StreamWriter
+  private final StreamHandler streamHandler;
+  private final StreamFetchHandler streamFetchHandler;
+
+  @Inject
+  public DefaultStreamManager(StreamHandler streamHandler, StreamFetchHandler streamFetchHandler,
+                              @Assisted("streamId") Id.Stream streamId) {
+    this.streamHandler = streamHandler;
+    this.streamFetchHandler = streamFetchHandler;
+    this.streamId = streamId;
+  }
+
+  @Override
+  public void createStream() throws IOException {
+    String path = String.format("/v3/namespaces/%s/streams/%s", streamId.getNamespaceId(), streamId.getId());
+    HttpRequest httpRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, path);
+
+    MockResponder responder = new MockResponder();
+    try {
+      streamHandler.create(httpRequest, responder, streamId.getNamespaceId(), streamId.getId());
+    } catch (Exception e) {
+      Throwables.propagateIfPossible(e, IOException.class);
+      throw Throwables.propagate(e);
+    }
+    if (responder.getStatus() != HttpResponseStatus.OK) {
+      throw new IOException("Failed to create stream. Status = " + responder.getStatus());
+    }
+  }
+
+  @Override
+  public List<StreamEvent> getEvents(long startTime, long endTime, int limit) throws IOException {
+    return getEvents(streamId, startTime, endTime, limit);
+  }
+
+  private List<StreamEvent> getEvents(Id.Stream streamId, long startTime, long endTime, int limit) throws IOException {
+    String path = String.format("/v3/namespaces/%s/streams/%s/events?start=%d&end=%d&limit=%d",
+                                streamId.getNamespaceId(), streamId.getId(), startTime, endTime, limit);
+    HttpRequest httpRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, path);
+
+    MockResponder responder = new MockResponder();
+    try {
+      streamFetchHandler.fetch(httpRequest, responder, streamId.getNamespaceId(), streamId.getId(),
+                               startTime, endTime, limit);
+    } catch (Exception e) {
+      Throwables.propagateIfPossible(e, IOException.class);
+      throw Throwables.propagate(e);
+    }
+    if (responder.getStatus() != HttpResponseStatus.OK) {
+      throw new IOException("Failed to read from stream. Status = " + responder.getStatus());
+    }
+
+    return responder.decodeResponseContent(new TypeToken<List<StreamEvent>>() { }, GSON);
+  }
+}

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/LocalStreamWriter.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/LocalStreamWriter.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.test.internal;
+
+import co.cask.cdap.api.data.stream.StreamBatchWriter;
+import co.cask.cdap.api.data.stream.StreamWriter;
+import co.cask.cdap.api.stream.StreamEventData;
+import co.cask.cdap.proto.Id;
+import com.google.inject.Inject;
+import com.google.inject.assistedinject.Assisted;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Map;
+
+/**
+ * Implements {@link StreamWriter} to enable you to write to streams in tests without making HTTP requests
+ */
+public class LocalStreamWriter implements StreamWriter {
+
+  private final StreamWriterFactory streamWriterFactory;
+  private final String namespaceId;
+
+  @Inject
+  public LocalStreamWriter(@Assisted("namespaceId") String namespaceId, StreamWriterFactory streamWriterFactory) {
+    this.namespaceId = namespaceId;
+    this.streamWriterFactory = streamWriterFactory;
+  }
+
+  @Override
+  public void write(String stream, String data) throws IOException {
+    streamWriterFactory.create(Id.Stream.from(namespaceId, stream)).send(data);
+  }
+
+  @Override
+  public void write(String stream, String data, Map<String, String> headers) throws IOException {
+    streamWriterFactory.create(Id.Stream.from(namespaceId, stream)).send(headers, data);
+  }
+
+  @Override
+  public void write(String stream, ByteBuffer data) throws IOException {
+    streamWriterFactory.create(Id.Stream.from(namespaceId, stream)).send(data);
+  }
+
+  @Override
+  public void write(String stream, StreamEventData data) throws IOException {
+    streamWriterFactory.create(Id.Stream.from(namespaceId, stream)).send(data.getHeaders(), data.getBody());
+  }
+
+  @Override
+  public void writeFile(String stream, File file, String contentType) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public StreamBatchWriter createBatchWriter(String stream, String contentType) throws IOException {
+    return null;
+  }
+}

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/StreamManagerFactory.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/StreamManagerFactory.java
@@ -14,26 +14,21 @@
  * the License.
  */
 
-package co.cask.cdap.templates.etl.realtime.sinks;
+package co.cask.cdap.test.internal;
 
-import co.cask.cdap.templates.etl.api.StageConfigurer;
-import co.cask.cdap.templates.etl.api.realtime.DataWriter;
-import co.cask.cdap.templates.etl.api.realtime.RealtimeSink;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.test.StreamManager;
+import com.google.inject.assistedinject.Assisted;
 
 /**
- * Generic NoOp Sink.
- *
- * @param <T> any object
+ * Factory to create {@link StreamManager} objects
  */
-public class NoOpSink<T> extends RealtimeSink<T> {
-
-  @Override
-  public void configure(StageConfigurer configurer) {
-    configurer.setName(NoOpSink.class.getSimpleName());
-  }
-
-  @Override
-  public int write(Iterable<T> objects, DataWriter dataWriter) throws Exception {
-    return 0;
-  }
+public interface StreamManagerFactory {
+  /**
+   * Return a {@link StreamManager} for the specified stream
+   *
+   * @param streamId {@link Id.Stream} of the stream for which a {@link StreamManager} is requested
+   * @return {@link StreamManager} for the specified stream
+   */
+  StreamManager create(@Assisted("streamId") Id.Stream streamId);
 }


### PR DESCRIPTION
* Adds a real-time Stream sink
* PR looks large because of the two following changes in the CDAP platform:
1. ``BasicWorkerContext`` used to ``new DefaultStreamWriter()`` earlier. Which meant that it always depended on the Stream Service to be up and running, even in tests. In ``TestBase``, however, we do not start Stream Service, so all calls to write to streams failed because Stream Service could not be discovered. Fixed this by adding a Guice Factory for ``StreamWriter``, that accepts an ``@Assisted String namespaceId``. ``StreamWriterFactory`` is now injected into ``WorkerProgramRunner`` and made available to ``BasicWorkerContext`` to create a ``DefaultStreamWriter`` for the required namespace.
2. In ``TestBase``, there was no way to read from a stream. Introduced a ``StreamManager`` and a Guice factory ``StreamManagerFactory`` to be able to (for now) create a stream and read events from it using the ``TestBase`` classes. Eventually, as part of [CDAP-2171](https://issues.cask.co/browse/CDAP-2171), we should deprecate the existing ``StreamWriter`` and move all its functionality to ``StreamManager``, as also move streams outside of ``ApplicationManager``. However, this will come in a later PR.
* Another related change, made ``MockResponder`` update its contents on ``sendChunk`` calls.

- [x] End-to-end unit test from ``TestSource`` to ``StreamSink`` works
- [x] Tested the above scenario on Standalone as well
- [x] Cluster testing 

CDAP Build: http://builds.cask.co/browse/CDAP-DUT1516
Templates Build: http://builds.cask.co/browse/CDAP-DT32 (Compilation failure here because it needs a class in CDAP framework that was added by this PR. Investigating how to fix the build)
Jira: [CDAP-2062](https://issues.cask.co/browse/CDAP-2062)