### PR TITLE
(CDAP-1917) Refactor program TwillApplication and distributed ProgramRunner

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractProgramTwillApplication.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractProgramTwillApplication.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.distributed;
+
+import co.cask.cdap.api.Resources;
+import co.cask.cdap.app.program.Program;
+import co.cask.cdap.proto.ProgramType;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
+import org.apache.twill.api.EventHandler;
+import org.apache.twill.api.ResourceSpecification;
+import org.apache.twill.api.TwillApplication;
+import org.apache.twill.api.TwillRunnable;
+import org.apache.twill.api.TwillSpecification;
+import org.apache.twill.api.TwillSpecification.Builder;
+import org.apache.twill.filesystem.Location;
+
+import java.io.File;
+import java.util.Map;
+
+/**
+ * An abstract base class for all program {@link TwillApplication}.
+ */
+public abstract class AbstractProgramTwillApplication implements TwillApplication {
+
+  private final Program program;
+  private final Map<String, File> localizeFiles;
+  private final EventHandler eventHandler;
+
+  protected AbstractProgramTwillApplication(Program program,
+                                            Map<String, File> localizeFiles, EventHandler eventHandler) {
+    this.program = program;
+    this.localizeFiles = localizeFiles;
+    this.eventHandler = eventHandler;
+  }
+
+  /**
+   * Returns type of the program started by this {@link TwillApplication}.
+   */
+  protected abstract ProgramType getType();
+
+  /**
+   * Adds {@link TwillRunnable} to the application.
+   *
+   * @param runnables map for adding {@link TwillRunnable} and resource requirements.
+   */
+  protected abstract void addRunnables(Map<String, RunnableResource> runnables);
+
+  /**
+   * Applies start ordering to the runnables added to this application. By default is any order.
+   */
+  protected Builder.AfterOrder applyOrder(Builder.RunnableSetter runnableSetter) {
+    return runnableSetter.anyOrder();
+  }
+
+  /**
+   * Returns a {@link ResourceSpecification} created from the given {@link Resources} and number of instances.
+   */
+  protected final ResourceSpecification createResourceSpec(Resources resources, int instances) {
+    return ResourceSpecification.Builder.with()
+      .setVirtualCores(resources.getVirtualCores())
+      .setMemory(resources.getMemoryMB(), ResourceSpecification.SizeUnit.MEGA)
+      .setInstances(instances)
+      .build();
+  }
+
+  @Override
+  public final TwillSpecification configure() {
+    Map<String, RunnableResource> runnables = Maps.newHashMap();
+    addRunnables(runnables);
+
+    Builder.MoreRunnable moreRunnable = Builder.with()
+      .setName(String.format("%s.%s.%s.%s",
+                             getType().name().toLowerCase(),
+                             program.getNamespaceId(), program.getApplicationId(), program.getName()))
+      .withRunnable();
+
+    Builder.RunnableSetter runnableSetter = null;
+    for (Map.Entry<String, RunnableResource> entry : runnables.entrySet()) {
+      runnableSetter = localizeFiles(moreRunnable.add(entry.getKey(),
+                                                      entry.getValue().getRunnable(),
+                                                      entry.getValue().getResources()).withLocalFiles());
+      moreRunnable = runnableSetter;
+    }
+
+    Preconditions.checkState(runnableSetter != null, "No TwillRunnables for distributed program.");
+    return applyOrder(runnableSetter).withEventHandler(eventHandler).build();
+  }
+
+  /**
+   * Request localization of the program jar and all other files.
+   */
+  private Builder.RunnableSetter localizeFiles(Builder.LocalFileAdder fileAdder) {
+    Location programLocation = program.getJarLocation();
+
+    Builder.MoreFile moreFile = fileAdder.add(programLocation.getName(), programLocation.toURI());
+    for (Map.Entry<String, File> entry : localizeFiles.entrySet()) {
+      moreFile.add(entry.getKey(), entry.getValue().toURI());
+    }
+    return moreFile.apply();
+  }
+
+  /**
+   * Container class for holding TwillRunnable and ResourceSpecification together.
+   */
+  protected static final class RunnableResource {
+    private final TwillRunnable runnable;
+    private final ResourceSpecification resources;
+
+    public RunnableResource(TwillRunnable runnable, ResourceSpecification resources) {
+      this.runnable = runnable;
+      this.resources = resources;
+    }
+
+    public TwillRunnable getRunnable() {
+      return runnable;
+    }
+
+    public ResourceSpecification getResources() {
+      return resources;
+    }
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedFlowProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedFlowProgramRunner.java
@@ -15,11 +15,13 @@
  */
 package co.cask.cdap.internal.app.runtime.distributed;
 
+import co.cask.cdap.api.flow.Flow;
 import co.cask.cdap.api.flow.FlowSpecification;
 import co.cask.cdap.app.ApplicationSpecification;
 import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.app.runtime.ProgramOptions;
+import co.cask.cdap.app.runtime.ProgramRunner;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.queue.QueueName;
@@ -41,9 +43,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.util.Map;
 
 /**
- *
+ * A {@link ProgramRunner} to start a {@link Flow} program in distributed mode.
  */
 public final class DistributedFlowProgramRunner extends AbstractDistributedProgramRunner {
 
@@ -65,7 +68,7 @@ public final class DistributedFlowProgramRunner extends AbstractDistributedProgr
 
   @Override
   protected ProgramController launch(Program program, ProgramOptions options,
-                                     File hConfFile, File cConfFile, ApplicationLauncher launcher) {
+                                     Map<String, File> localizeFiles, ApplicationLauncher launcher) {
     // Extract and verify parameters
     ApplicationSpecification appSpec = program.getApplicationSpecification();
     Preconditions.checkNotNull(appSpec, "Missing application specification.");
@@ -86,7 +89,7 @@ public final class DistributedFlowProgramRunner extends AbstractDistributedProgr
       LOG.info("Launching distributed flow: " + program.getName() + ":" + flowSpec.getName());
 
       TwillController controller = launcher.launch(new FlowTwillApplication(program, flowSpec,
-                                                                            hConfFile, cConfFile, eventHandler));
+                                                                            localizeFiles, eventHandler));
       DistributedFlowletInstanceUpdater instanceUpdater =
         new DistributedFlowletInstanceUpdater(program, controller, queueAdmin,
                                               streamAdmin, flowletQueues, txExecutorFactory);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedMapReduceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedMapReduceProgramRunner.java
@@ -31,6 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.util.Map;
 
 /**
  * Runs Mapreduce programm in distributed environment
@@ -46,7 +47,7 @@ public final class DistributedMapReduceProgramRunner extends AbstractDistributed
 
   @Override
   protected ProgramController launch(Program program, ProgramOptions options,
-                                     File hConfFile, File cConfFile, ApplicationLauncher launcher) {
+                                     Map<String, File> localizeFiles, ApplicationLauncher launcher) {
     // Extract and verify parameters
     ApplicationSpecification appSpec = program.getApplicationSpecification();
     Preconditions.checkNotNull(appSpec, "Missing application specification.");
@@ -60,7 +61,7 @@ public final class DistributedMapReduceProgramRunner extends AbstractDistributed
 
     LOG.info("Launching MapReduce program: " + program.getName() + ":" + spec.getName());
     TwillController controller = launcher.launch(new MapReduceTwillApplication(program, spec,
-                                                                               hConfFile, cConfFile, eventHandler));
+                                                                               localizeFiles, eventHandler));
 
     return new MapReduceTwillProgramController(program.getName(), controller).startListen();
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedServiceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedServiceProgramRunner.java
@@ -35,6 +35,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.util.Map;
 
 /**
  * Distributed ProgramRunner for Service.
@@ -49,8 +50,8 @@ public class DistributedServiceProgramRunner extends AbstractDistributedProgramR
   }
 
   @Override
-  protected ProgramController launch(Program program, ProgramOptions options, File hConfFile, File cConfFile,
-                                     ApplicationLauncher launcher) {
+  protected ProgramController launch(Program program, ProgramOptions options,
+                                     Map<String, File> localizeFiles, ApplicationLauncher launcher) {
     // Extract and verify parameters
     ApplicationSpecification appSpec = program.getApplicationSpecification();
     Preconditions.checkNotNull(appSpec, "Missing application specification.");
@@ -65,8 +66,8 @@ public class DistributedServiceProgramRunner extends AbstractDistributedProgramR
     // Launch service runnables program runners
     LOG.info("Launching distributed service: {}:{}", program.getName(), serviceSpec.getName());
 
-    TwillController controller = launcher.launch(new ServiceTwillApplication(program, serviceSpec, hConfFile,
-                                                                             cConfFile, eventHandler));
+    TwillController controller = launcher.launch(new ServiceTwillApplication(program, serviceSpec,
+                                                                             localizeFiles, eventHandler));
 
     DistributedServiceRunnableInstanceUpdater instanceUpdater = new DistributedServiceRunnableInstanceUpdater(
       program, controller);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWebappProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWebappProgramRunner.java
@@ -30,6 +30,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.util.Map;
 
 /**
  * Distributed program runner for webapp.
@@ -45,7 +46,7 @@ public final class DistributedWebappProgramRunner extends AbstractDistributedPro
 
   @Override
   protected ProgramController launch(Program program, ProgramOptions options,
-                                     File hConfFile, File cConfFile, ApplicationLauncher launcher) {
+                                     Map<String, File> localizeFiles, ApplicationLauncher launcher) {
     // Extract and verify parameters
     ApplicationSpecification appSpec = program.getApplicationSpecification();
     Preconditions.checkNotNull(appSpec, "Missing application specification.");
@@ -55,8 +56,7 @@ public final class DistributedWebappProgramRunner extends AbstractDistributedPro
     Preconditions.checkArgument(processorType == ProgramType.WEBAPP, "Only WEBAPP process type is supported.");
 
     LOG.info("Launching distributed webapp: " + program.getName());
-    TwillController controller = launcher.launch(new WebappTwillApplication(program, hConfFile,
-                                                                            cConfFile, eventHandler));
+    TwillController controller = launcher.launch(new WebappTwillApplication(program, localizeFiles, eventHandler));
     return new WebappTwillProgramController(program.getName(), controller).startListen();
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWorkerProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWorkerProgramRunner.java
@@ -38,6 +38,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.util.Map;
 
 /**
  * Distributed ProgramRunner for Worker.
@@ -53,8 +54,8 @@ public class DistributedWorkerProgramRunner extends AbstractDistributedProgramRu
   }
 
   @Override
-  protected ProgramController launch(Program program, ProgramOptions options, File hConfFile, File cConfFile,
-                                     ApplicationLauncher launcher) {
+  protected ProgramController launch(Program program, ProgramOptions options,
+                                     Map<String, File> localizeFiles, ApplicationLauncher launcher) {
     ApplicationSpecification appSpec = program.getApplicationSpecification();
     Preconditions.checkNotNull(appSpec, "Missing application specification.");
 
@@ -79,7 +80,7 @@ public class DistributedWorkerProgramRunner extends AbstractDistributedProgramRu
     LOG.info("Launching distributed worker {}", program.getName());
 
     TwillController controller = launcher.launch(new WorkerTwillApplication(program, newWorkerSpec,
-                                                                            hConfFile, cConfFile, eventHandler));
+                                                                            localizeFiles, eventHandler));
     return new WorkerTwillProgramController(program.getName(), controller).startListen();
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWorkflowProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWorkflowProgramRunner.java
@@ -15,11 +15,13 @@
  */
 package co.cask.cdap.internal.app.runtime.distributed;
 
+import co.cask.cdap.api.workflow.Workflow;
 import co.cask.cdap.api.workflow.WorkflowSpecification;
 import co.cask.cdap.app.ApplicationSpecification;
 import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.app.runtime.ProgramOptions;
+import co.cask.cdap.app.runtime.ProgramRunner;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.proto.ProgramType;
 import com.google.common.base.Preconditions;
@@ -31,9 +33,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.util.Map;
 
 /**
- *
+ * A {@link ProgramRunner} to start a {@link Workflow} program in distributed mode.
  */
 public final class DistributedWorkflowProgramRunner extends AbstractDistributedProgramRunner {
 
@@ -46,7 +49,7 @@ public final class DistributedWorkflowProgramRunner extends AbstractDistributedP
 
   @Override
   protected ProgramController launch(Program program, ProgramOptions options,
-                                     File hConfFile, File cConfFile, ApplicationLauncher launcher) {
+                                     Map<String, File> localizeFiles, ApplicationLauncher launcher) {
     // Extract and verify parameters
     ApplicationSpecification appSpec = program.getApplicationSpecification();
     Preconditions.checkNotNull(appSpec, "Missing application specification.");
@@ -60,7 +63,7 @@ public final class DistributedWorkflowProgramRunner extends AbstractDistributedP
 
     LOG.info("Launching distributed workflow: " + program.getName() + ":" + workflowSpec.getName());
     TwillController controller = launcher.launch(new WorkflowTwillApplication(program, workflowSpec,
-                                                                              hConfFile, cConfFile, eventHandler));
+                                                                              localizeFiles, eventHandler));
     return new WorkflowTwillProgramController(program.getName(), controller).startListen();
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/ServiceTwillApplication.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/ServiceTwillApplication.java
@@ -16,81 +16,50 @@
 
 package co.cask.cdap.internal.app.runtime.distributed;
 
-import co.cask.cdap.api.Resources;
+import co.cask.cdap.api.service.Service;
 import co.cask.cdap.api.service.ServiceSpecification;
 import co.cask.cdap.api.service.ServiceWorkerSpecification;
 import co.cask.cdap.app.program.Program;
 import co.cask.cdap.proto.ProgramType;
 import org.apache.twill.api.EventHandler;
-import org.apache.twill.api.ResourceSpecification;
 import org.apache.twill.api.TwillApplication;
-import org.apache.twill.api.TwillSpecification;
-import org.apache.twill.filesystem.Location;
 
 import java.io.File;
 import java.util.Map;
 
 /**
- * TwillApplication for service. Used to localize program jar location before running the TwillApplication.
+ * The {@link TwillApplication} for running {@link Service} in distributed mode.
  */
-public class ServiceTwillApplication implements TwillApplication {
+public class ServiceTwillApplication extends AbstractProgramTwillApplication {
 
   private final ServiceSpecification spec;
-  private final Program program;
-  private final File hConfig;
-  private final File cConfig;
-  private final EventHandler eventHandler;
 
-  public ServiceTwillApplication(Program program, ServiceSpecification spec, File hConfig, File cConfig,
-                                 EventHandler eventHandler) {
-    this.program = program;
+  public ServiceTwillApplication(Program program, ServiceSpecification spec,
+                                 Map<String, File> localizeFiles, EventHandler eventHandler) {
+    super(program, localizeFiles, eventHandler);
     this.spec = spec;
-    this.hConfig = hConfig;
-    this.cConfig = cConfig;
-    this.eventHandler = eventHandler;
   }
 
   @Override
-  public TwillSpecification configure() {
-    TwillSpecification.Builder.MoreRunnable moreRunnable = TwillSpecification.Builder.with()
-      .setName(String.format("%s.%s.%s.%s", ProgramType.SERVICE.name().toLowerCase(), program.getNamespaceId(),
-                             program.getApplicationId(), spec.getName()))
-      .withRunnable();
+  protected ProgramType getType() {
+    return ProgramType.SERVICE;
+  }
 
-    Location programLocation = program.getJarLocation();
-    String programName = programLocation.getName();
-
+  @Override
+  protected void addRunnables(Map<String, RunnableResource> runnables) {
     // Add a runnable for the service handler
-    Resources resources = spec.getResources();
-    TwillSpecification.Builder.RunnableSetter runnableSetter;
-    runnableSetter = moreRunnable.add(spec.getName(),
-                                      new ServiceTwillRunnable(spec.getName(), "hConf.xml", "cConf.xml"),
-                                      createResourceSpec(resources, spec.getInstances()))
-                                  .withLocalFiles()
-                                    .add(programName, programLocation.toURI())
-                                    .add("hConf.xml", hConfig.toURI())
-                                    .add("cConf.xml", cConfig.toURI()).apply();
+    runnables.put(spec.getName(), new RunnableResource(
+      new ServiceTwillRunnable(spec.getName(), "hConf.xml", "cConf.xml"),
+      createResourceSpec(spec.getResources(), spec.getInstances())
+    ));
 
     // Add runnables for all workers
     for (Map.Entry<String, ServiceWorkerSpecification> entry : spec.getWorkers().entrySet()) {
       ServiceWorkerSpecification workerSpec = entry.getValue();
-      runnableSetter = runnableSetter.add(workerSpec.getName(),
-                                          new ServiceTwillRunnable(workerSpec.getName(), "hConf.xml", "cConf.xml"),
-                                          createResourceSpec(workerSpec.getResources(), workerSpec.getInstances()))
-                                     .withLocalFiles()
-                                       .add(programName, programLocation.toURI())
-                                       .add("hConf.xml", hConfig.toURI())
-                                       .add("cConf.xml", cConfig.toURI()).apply();
+      runnables.put(workerSpec.getName(), new RunnableResource(
+        new ServiceTwillRunnable(workerSpec.getName(), "hConf.xml", "cConf.xml"),
+        createResourceSpec(workerSpec.getResources(), workerSpec.getInstances())
+      ));
     }
-
-    return runnableSetter.anyOrder().withEventHandler(eventHandler).build();
-  }
-
-  private ResourceSpecification createResourceSpec(Resources resources, int instances) {
-    return ResourceSpecification.Builder.with()
-      .setVirtualCores(resources.getVirtualCores())
-      .setMemory(resources.getMemoryMB(), ResourceSpecification.SizeUnit.MEGA)
-      .setInstances(instances)
-      .build();
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/WebappTwillApplication.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/WebappTwillApplication.java
@@ -21,53 +21,42 @@ import co.cask.cdap.proto.ProgramType;
 import com.google.common.base.Throwables;
 import org.apache.twill.api.EventHandler;
 import org.apache.twill.api.ResourceSpecification;
-import org.apache.twill.api.TwillApplication;
-import org.apache.twill.api.TwillSpecification;
-import org.apache.twill.filesystem.Location;
 
 import java.io.File;
+import java.util.Map;
 
 
 /**
  * Twill application wrapper for webapp.
  */
-public final class WebappTwillApplication implements TwillApplication {
+public final class WebappTwillApplication extends AbstractProgramTwillApplication {
 
   private final Program program;
-  private final File hConfig;
-  private final File cConfig;
-  private final EventHandler eventHandler;
 
-  public WebappTwillApplication(Program program, File hConfig, File cConfig, EventHandler eventHandler) {
+  protected WebappTwillApplication(Program program, Map<String, File> localizeFiles, EventHandler eventHandler) {
+    super(program, localizeFiles, eventHandler);
     this.program = program;
-    this.hConfig = hConfig;
-    this.cConfig = cConfig;
-    this.eventHandler = eventHandler;
   }
 
   @Override
-  public TwillSpecification configure() {
+  protected ProgramType getType() {
+    return ProgramType.WEBAPP;
+  }
+
+  @Override
+  protected void addRunnables(Map<String, RunnableResource> runnables) {
     ResourceSpecification resourceSpec = ResourceSpecification.Builder.with()
       .setVirtualCores(1)
       .setMemory(512, ResourceSpecification.SizeUnit.MEGA)
       .setInstances(1)
       .build();
 
-    Location programLocation = program.getJarLocation();
-
     try {
       String serviceName = WebappProgramRunner.getServiceName(ProgramType.WEBAPP, program);
-
-      return TwillSpecification.Builder.with()
-        .setName(serviceName)
-        .withRunnable()
-          .add(serviceName, new WebappTwillRunnable(serviceName, "hConf.xml", "cConf.xml"),
-               resourceSpec)
-          .withLocalFiles()
-            .add(programLocation.getName(), programLocation.toURI())
-            .add("hConf.xml", hConfig.toURI())
-            .add("cConf.xml", cConfig.toURI()).apply()
-        .anyOrder().withEventHandler(eventHandler).build();
+      runnables.put(serviceName, new RunnableResource(
+        new WebappTwillRunnable(serviceName, "hConf.xml", "cConf.xml"),
+        resourceSpec
+      ));
     } catch (Exception e) {
       throw Throwables.propagate(e);
     }


### PR DESCRIPTION
- Removed bunch of duplicated code by introducing an AbstractProgramTwillApplication
- Generalize file localize rather than a hard coded three files (program JAR, hConf and cConf)
  - Prepare the path for adding plugin files localization.