### PR TITLE
remove info logging in pingHandler 

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/gateway/handlers/PingHandler.java
+++ b/cdap-common/src/main/java/co/cask/cdap/gateway/handlers/PingHandler.java
@@ -35,7 +35,7 @@ public class PingHandler extends AbstractHttpHandler {
   @Path("/ping")
   @GET
   public void ping(@SuppressWarnings("UnusedParameters") HttpRequest request, HttpResponder responder) {
-    LOG.info("Received ping request");
+    LOG.trace("Ping request received");
     responder.sendString(HttpResponseStatus.OK, "OK.\n");
   }
 

--- a/cdap-gateway/src/test/resources/logback-test.xml
+++ b/cdap-gateway/src/test/resources/logback-test.xml
@@ -24,13 +24,13 @@
 <!--                                                                         -->
 
 <configuration>
+    <logger name="co.cask.cdap.gateway.handlers.PingHandler" level="TRACE"/>
+    <logger name="co.cask.cdap.gateway" level="DEBUG" />
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%d{ISO8601} - %-5p [%thread] [%t:%C{1}@%L] - %m%n</pattern>
         </encoder>
     </appender>
-
-    <logger name="co.cask.cdap.gateway" level="DEBUG" />
 
     <root level="WARN">
         <appender-ref ref="STDOUT"/>


### PR DESCRIPTION
ping endpoint is called frequently and was causing log.saver overflow. so removing the log message. 