### PR TITLE
CDAP-1878 Add Kafka realtime source

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/pom.xml
@@ -140,6 +140,7 @@
       <artifactId>avro-mapred</artifactId>
       <classifier>hadoop2</classifier>
     </dependency>
+    <!-- Start for JMS Source -->
     <dependency>
       <groupId>org.apache.geronimo.specs</groupId>
       <artifactId>geronimo-jms_1.1_spec</artifactId>
@@ -161,6 +162,26 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <!-- Start for Kafka Source -->
+    <dependency>
+      <groupId>org.apache.twill</groupId>
+      <artifactId>twill-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.twill</groupId>
+      <artifactId>twill-core</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.kafka</groupId>
+          <artifactId>kafka_2.10</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka_2.10</artifactId>
+    </dependency>
+    <!-- End for Kafka Source -->
   </dependencies>
 
 </project>

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/pom.xml
@@ -165,10 +165,6 @@
     <!-- Start for Kafka Source -->
     <dependency>
       <groupId>org.apache.twill</groupId>
-      <artifactId>twill-common</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.twill</groupId>
       <artifactId>twill-core</artifactId>
       <exclusions>
         <exclusion>

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/kafka/DefaultKafkaConfigurer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/kafka/DefaultKafkaConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/kafka/DefaultKafkaConfigurer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/kafka/DefaultKafkaConfigurer.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.templates.etl.realtime.kafka;
+
+import com.google.common.collect.Maps;
+import org.apache.twill.kafka.client.TopicPartition;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Default implementation of {@link KafkaConfigurer}.
+ */
+final class DefaultKafkaConfigurer implements KafkaConfigurer {
+
+  private String zookeeper;
+  private String brokers;
+  private final Map<TopicPartition, Integer> topicPartitions = Maps.newHashMap();
+
+  @Override
+  public void setZooKeeper(String zookeeper) {
+    this.zookeeper = zookeeper;
+  }
+
+  @Override
+  public void setBrokers(String brokers) {
+    this.brokers = brokers;
+  }
+
+  @Override
+  public void addTopicPartition(String topic, int partition) {
+    addTopicPartition(topic, partition, DEFAULT_FETCH_SIZE);
+  }
+
+  @Override
+  public void addTopicPartition(String topic, int partition, int fetchSize) {
+    topicPartitions.put(new TopicPartition(topic, partition), fetchSize);
+  }
+
+  String getBrokers() {
+    return brokers;
+  }
+
+  String getZookeeper() {
+    return zookeeper;
+  }
+
+  Map<TopicPartition, Integer> getTopicPartitions() {
+    return Collections.unmodifiableMap(topicPartitions);
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/kafka/Kafka08SimpleApiConsumer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/kafka/Kafka08SimpleApiConsumer.java
@@ -1,0 +1,405 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.templates.etl.realtime.kafka;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.templates.etl.api.Emitter;
+import co.cask.cdap.templates.etl.api.realtime.SourceContext;
+
+import com.google.common.base.Splitter;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.RemovalListener;
+import com.google.common.cache.RemovalNotification;
+import com.google.common.collect.AbstractIterator;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterators;
+import kafka.api.FetchRequest;
+import kafka.api.FetchRequestBuilder;
+import kafka.api.PartitionOffsetRequestInfo;
+import kafka.cluster.Broker;
+import kafka.common.ErrorMapping;
+import kafka.common.TopicAndPartition;
+import kafka.javaapi.FetchResponse;
+import kafka.javaapi.OffsetRequest;
+import kafka.javaapi.OffsetResponse;
+import kafka.javaapi.PartitionMetadata;
+import kafka.javaapi.TopicMetadata;
+import kafka.javaapi.TopicMetadataRequest;
+import kafka.javaapi.TopicMetadataResponse;
+import kafka.javaapi.consumer.SimpleConsumer;
+import kafka.message.Message;
+import kafka.message.MessageAndOffset;
+import org.apache.twill.kafka.client.BrokerInfo;
+import org.apache.twill.kafka.client.BrokerService;
+import org.apache.twill.kafka.client.TopicPartition;
+import org.apache.twill.zookeeper.RetryStrategies;
+import org.apache.twill.zookeeper.ZKClient;
+import org.apache.twill.zookeeper.ZKClientService;
+import org.apache.twill.zookeeper.ZKClientServices;
+import org.apache.twill.zookeeper.ZKClients;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Constructor;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * <p>
+ *  The {@link KafkaSimpleApiConsumer} compatible mode for {@code Kafka} 0.8.x releases.
+ *
+ *  The class expect several runtime arguments:
+ *  -) kafka.zookeeper - the location of Kafka Zookeeper
+ *  -) kafka.brokers - comma separate list of Kafka brokers
+ *  -) kafka.partitions - the number of partitions of the topic
+ *  -) kafka.topic - the Kafka topic to get messages for
+ * </p>
+ */
+public class Kafka08SimpleApiConsumer extends KafkaSimpleApiConsumer<String, ByteBuffer, Long>  {
+  private static final Logger LOG = LoggerFactory.getLogger(Kafka08SimpleApiConsumer.class);
+
+  private ZKClientService zkClient;
+  private BrokerService brokerService;
+  private Cache<TopicPartition, SimpleConsumer> kafkaConsumers;
+
+  @Override
+  protected void configureKafka(KafkaConfigurer configurer) {
+    Map<String, String> runtimeArgs = getContext().getRuntimeArguments();
+    if (runtimeArgs.containsKey("kafka.zookeeper")) {
+      configurer.setZooKeeper(runtimeArgs.get("kafka.zookeeper"));
+    } else if (runtimeArgs.containsKey("kafka.brokers")) {
+      configurer.setBrokers(runtimeArgs.get("kafka.brokers"));
+    }
+    setupTopicPartitions(configurer, runtimeArgs);
+  }
+
+  private void setupTopicPartitions(KafkaConsumerConfigurer configurer, Map<String, String> runtimeArgs) {
+    int partitions = Integer.parseInt(runtimeArgs.get("kafka.partitions"));
+    int instanceId = getContext().getInstanceId();
+    int instances = getContext().getInstanceCount();
+    String kafkaTopic = runtimeArgs.get("kafka.topic");
+    for (int i = 0; i < partitions; i++) {
+      if ((i % instances) == instanceId) {
+        configurer.addTopicPartition(kafkaTopic, i);
+      }
+    }
+  }
+
+  @Override
+  protected Iterator<KafkaMessage<Long>> readMessages(KafkaConsumerInfo<Long> consumerInfo) {
+    final TopicPartition topicPartition = consumerInfo.getTopicPartition();
+    String topic = topicPartition.getTopic();
+    int partition = topicPartition.getPartition();
+
+    // Fetch message from Kafka.
+    final SimpleConsumer consumer = getConsumer(consumerInfo);
+    if (consumer == null) {
+      return Iterators.emptyIterator();
+    }
+
+    long readOffset = consumerInfo.getReadOffset();
+    if (readOffset < 0) {
+      readOffset = getReadOffset(consumer, topic, partition, readOffset);
+      consumerInfo.setReadOffset(readOffset);
+    }
+
+    FetchRequest fetchRequest = new FetchRequestBuilder()
+      .clientId(consumer.clientId())
+      .addFetch(topic, partition, readOffset, consumerInfo.getFetchSize())
+      .build();
+    FetchResponse response = consumer.fetch(fetchRequest);
+
+    // Fetch failed
+    if (response.hasError()) {
+      handleFetchError(consumerInfo, consumer, readOffset, response.errorCode(topic, partition));
+      return Iterators.emptyIterator();
+    }
+
+    // Returns an Iterator of message
+    final long fetchReadOffset = readOffset;
+    final Iterator<MessageAndOffset> messages = response.messageSet(topic, partition).iterator();
+    return new AbstractIterator<KafkaMessage<Long>>() {
+      @Override
+      protected KafkaMessage<Long> computeNext() {
+        while (messages.hasNext()) {
+          MessageAndOffset messageAndOffset = messages.next();
+          if (messageAndOffset.offset() < fetchReadOffset) {
+            // Older message read (which is valid in Kafka), skip it.
+            continue;
+          }
+
+          // Lets get the Kafka message based on last offset
+          Message message = messageAndOffset.message();
+          return new KafkaMessage<Long>(topicPartition, messageAndOffset.nextOffset(), message.key(),
+                                        message.payload());
+        }
+        return endOfData();
+      }
+    };
+  }
+
+  @Override
+  public void initialize(SourceContext context) throws Exception {
+    super.initialize(context);
+
+    // Setting up ZK for 08 version of Apache Kafka
+    String kafkaZKConnect = getKafkaConfig().getZookeeper();
+    if (kafkaZKConnect != null) {
+      zkClient = ZKClientServices.delegate(
+        ZKClients.reWatchOnExpire(
+          ZKClients.retryOnFailure(ZKClientService.Builder.of(kafkaZKConnect).build(),
+                                   RetryStrategies.fixDelay(2, TimeUnit.SECONDS))
+        ));
+      zkClient.startAndWait();
+
+      brokerService = createBrokerService(zkClient);
+      brokerService.startAndWait();
+    }
+
+    kafkaConsumers = CacheBuilder.newBuilder()
+      .concurrencyLevel(1)
+      .expireAfterAccess(60, TimeUnit.SECONDS)
+      .removalListener(consumerCacheRemovalListener())
+      .build();
+  }
+
+  /**
+   * Creates a {@link RemovalListener} to close {@link SimpleConsumer} when it is evicted from the consumer cache.
+   */
+  private RemovalListener<TopicPartition, SimpleConsumer> consumerCacheRemovalListener() {
+    return new RemovalListener<TopicPartition, SimpleConsumer>() {
+      @Override
+      public void onRemoval(RemovalNotification<TopicPartition, SimpleConsumer> notification) {
+        SimpleConsumer consumer = notification.getValue();
+        if (consumer == null) {
+          return;
+        }
+        try {
+          consumer.close();
+        } catch (Throwable t) {
+          LOG.error("Exception when closing Kafka consumer.", t);
+        }
+      }
+    };
+  }
+
+  @Override
+  public void destroy() {
+    super.destroy();
+    if (kafkaConsumers != null) {
+      kafkaConsumers.invalidateAll();
+      kafkaConsumers.cleanUp();
+    }
+
+    if (brokerService != null) {
+      stopService(brokerService);
+    }
+    if (zkClient != null) {
+      stopService(zkClient);
+    }
+  }
+
+  @Override
+  protected void processMessage(ByteBuffer payload , Emitter<ByteBuffer> emitter) {
+    emitter.emit(payload);
+  }
+
+  @Override
+  protected Long getBeginOffset(TopicPartition topicPartition) {
+    Map<String, byte[]> offsetStore  = getOffsetStore();
+    if (offsetStore == null) {
+      return getDefaultOffset(topicPartition);
+    }
+
+    // The value is simply a 8-bytes long representing the offset
+    byte[] value = offsetStore.get(getStoreKey(topicPartition));
+    if (value == null || value.length != Bytes.SIZEOF_LONG) {
+      return getDefaultOffset(topicPartition);
+    }
+    return Bytes.toLong(value);
+  }
+
+  @Override
+  protected void saveReadOffsets(Map<TopicPartition, Long> offsets) {
+    Map<String, byte[]> offsetStore  = getOffsetStore();
+    if (offsetStore == null) {
+      return;
+    }
+
+    for (Map.Entry<TopicPartition, Long> entry : offsets.entrySet()) {
+      offsetStore.put(getStoreKey(entry.getKey()), Bytes.toBytes(entry.getValue()));
+    }
+  }
+
+  @Override
+  protected long getDefaultOffset(TopicPartition topicPartition) {
+    String argValue = getContext().getRuntimeArguments().get("kafka.default.offset");
+    if (argValue != null) {
+      return Long.valueOf(argValue);
+    } else {
+      return kafka.api.OffsetRequest.EarliestTime();
+    }
+  }
+
+  private long getReadOffset(SimpleConsumer consumer, String topic, int partition, long time) {
+    OffsetRequest offsetRequest = new OffsetRequest(
+      ImmutableMap.of(new TopicAndPartition(topic, partition), new PartitionOffsetRequestInfo(time, 1)),
+      kafka.api.OffsetRequest.CurrentVersion(), consumer.clientId());
+
+    OffsetResponse response = consumer.getOffsetsBefore(offsetRequest);
+    if (response.hasError()) {
+      LOG.error("Failed to fetch offset from broker {}:{} for topic-partition {}-{} with error code {}",
+                consumer.host(), consumer.port(), topic, partition, response.errorCode(topic, partition));
+      return 0L;
+    }
+    return response.offsets(topic, partition)[0];
+  }
+
+  /**
+   * Returns a {@link SimpleConsumer} for the given consumer info or {@code null} if no leader broker is currently
+   * available.
+   */
+  private SimpleConsumer getConsumer(KafkaConsumerInfo<Long> consumerInfo) {
+    TopicPartition topicPartition = consumerInfo.getTopicPartition();
+    SimpleConsumer consumer = kafkaConsumers.getIfPresent(topicPartition);
+    if (consumer != null) {
+      return consumer;
+    }
+
+    InetSocketAddress leader = getLeader(topicPartition.getTopic(), topicPartition.getPartition());
+    if (leader == null) {
+      return null;
+    }
+    String consumerName = String.format("%s-%d-kafka-consumer", getName(), getContext().getInstanceId());
+    consumer = new SimpleConsumer(leader.getHostName(), leader.getPort(),
+                                  SO_TIMEOUT, consumerInfo.getFetchSize(), consumerName);
+    kafkaConsumers.put(topicPartition, consumer);
+
+    return consumer;
+  }
+
+  /**
+   * Handles fetch failure.
+   *
+   * @param consumerInfo information on what and how to consume
+   * @param consumer consumer to talk to Kafka
+   * @param readOffset the beginning read offset
+   * @param errorCode error code for the fetch.
+   */
+  private void handleFetchError(KafkaConsumerInfo<Long> consumerInfo,
+                                SimpleConsumer consumer, long readOffset, short errorCode) {
+    TopicPartition topicPartition = consumerInfo.getTopicPartition();
+    String topic = topicPartition.getTopic();
+    int partition = topicPartition.getPartition();
+
+    LOG.error("Failed to fetch from broker {}:{} for topic-partition {}-{} with error code {}",
+              consumer.host(), consumer.port(), topic, partition, errorCode);
+    if (errorCode == ErrorMapping.OffsetOutOfRangeCode()) {
+      // Get the earliest offset
+      long earliest = getReadOffset(consumer, topic, partition, kafka.api.OffsetRequest.EarliestTime());
+      // If the current read offset is smaller than the earliest one, use the earliest offset in next fetch
+      if (readOffset < earliest) {
+        consumerInfo.setReadOffset(earliest);
+      } else {
+        // Otherwise the read offset must be larger than the latest (otherwise it won't have the out of range error)
+        consumerInfo.setReadOffset(getReadOffset(consumer, topic, partition, kafka.api.OffsetRequest.LatestTime()));
+      }
+    } else {
+      // For other type of error, invalid it from cache so that a new one will be created in next iteration
+      kafkaConsumers.invalidate(topicPartition);
+    }
+  }
+
+  /**
+   * Creates a Kafka {@link BrokerService}.
+   */
+  private BrokerService createBrokerService(ZKClient zkClient) throws Exception {
+    Class<? extends BrokerService> brokerClass = loadBrokerServiceClass(BrokerService.class.getClassLoader());
+    Constructor<? extends BrokerService> constructor = brokerClass.getDeclaredConstructor(ZKClient.class);
+    constructor.setAccessible(true);
+    return constructor.newInstance(zkClient);
+  }
+
+
+  /**
+   * Loads the class that implements {@link BrokerService}.
+   */
+  @SuppressWarnings("unchecked")
+  private <T> Class<T> loadBrokerServiceClass(ClassLoader classLoader) throws ClassNotFoundException {
+    // TODO: Hacky way to construct ZKBrokerService from Twill as it's a protected class
+    // Need Twill update to resolve this hack
+    return (Class<T>) classLoader.loadClass("org.apache.twill.internal.kafka.client.ZKBrokerService");
+  }
+
+  /**
+   * Gets the address of the leader broker for the given topic and partition
+   *
+   * @return the address for the leader broker or {@code null} if no leader is currently available.
+   */
+  private InetSocketAddress getLeader(String topic, int partition) {
+    // If BrokerService is available, it will use information from ZooKeeper
+    if (brokerService != null) {
+      BrokerInfo brokerInfo = brokerService.getLeader(topic, partition);
+      return (brokerInfo == null) ? null : new InetSocketAddress(brokerInfo.getHost(), brokerInfo.getPort());
+    }
+
+    // Otherwise use broker list to discover leader
+    return findLeader(getKafkaConfig().getBrokers(), topic, partition);
+  }
+
+  /**
+   * Finds the leader broker address for the given topic partition.
+   *
+   * @return the address for the leader broker or {@code null} if no leader is currently available.
+   */
+  private InetSocketAddress findLeader(String brokers, String topic, int partition) {
+    // Splits the broker list of format "host:port,host:port" into a map<host, port>
+    Map<String, String> brokerMap = Splitter.on(',').withKeyValueSeparator(":").split(brokers);
+
+    // Go through the broker list and try to find a leader for the given topic partition.
+    for (Map.Entry<String, String> broker : brokerMap.entrySet()) {
+      try {
+        SimpleConsumer consumer = new SimpleConsumer(broker.getKey(), Integer.parseInt(broker.getValue()), SO_TIMEOUT,
+                                                     KafkaConsumerConfigurer.DEFAULT_FETCH_SIZE, "leaderLookup");
+        try {
+          TopicMetadataRequest request = new TopicMetadataRequest(ImmutableList.of(topic));
+          TopicMetadataResponse response = consumer.send(request);
+          for (TopicMetadata topicData : response.topicsMetadata()) {
+            for (PartitionMetadata partitionData : topicData.partitionsMetadata()) {
+              if (partitionData.partitionId() == partition) {
+                Broker leader = partitionData.leader();
+                return new InetSocketAddress(leader.host(), leader.port());
+              }
+            }
+          }
+
+        } finally {
+          consumer.close();
+        }
+      } catch (Exception e) {
+        LOG.error("Failed to communicate with broker {}:{} for leader lookup for topic-partition {}-{}",
+                  broker.getKey(), broker.getValue(), topic, partition, e);
+      }
+    }
+    return null;
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/kafka/Kafka08SimpleApiConsumer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/kafka/Kafka08SimpleApiConsumer.java
@@ -18,7 +18,7 @@ package co.cask.cdap.templates.etl.realtime.kafka;
 
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.templates.etl.api.Emitter;
-import co.cask.cdap.templates.etl.api.realtime.SourceContext;
+import co.cask.cdap.templates.etl.api.realtime.RealtimeContext;
 
 import com.google.common.base.Splitter;
 import com.google.common.cache.Cache;
@@ -29,6 +29,7 @@ import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterators;
+
 import kafka.api.FetchRequest;
 import kafka.api.FetchRequestBuilder;
 import kafka.api.PartitionOffsetRequestInfo;
@@ -45,6 +46,7 @@ import kafka.javaapi.TopicMetadataResponse;
 import kafka.javaapi.consumer.SimpleConsumer;
 import kafka.message.Message;
 import kafka.message.MessageAndOffset;
+
 import org.apache.twill.kafka.client.BrokerInfo;
 import org.apache.twill.kafka.client.BrokerService;
 import org.apache.twill.kafka.client.TopicPartition;
@@ -72,6 +74,7 @@ import java.util.concurrent.TimeUnit;
  *  -) kafka.brokers - comma separate list of Kafka brokers
  *  -) kafka.partitions - the number of partitions of the topic
  *  -) kafka.topic - the Kafka topic to get messages for
+ *  -) kafka.default.offset - the default offset for the partition
  * </p>
  */
 public class Kafka08SimpleApiConsumer extends KafkaSimpleApiConsumer<String, ByteBuffer, Long>  {
@@ -158,7 +161,7 @@ public class Kafka08SimpleApiConsumer extends KafkaSimpleApiConsumer<String, Byt
   }
 
   @Override
-  public void initialize(SourceContext context) throws Exception {
+  public void initialize(RealtimeContext context) throws Exception {
     super.initialize(context);
 
     // Setting up ZK for 08 version of Apache Kafka

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/kafka/KafkaBrokerConfigurer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/kafka/KafkaBrokerConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/kafka/KafkaBrokerConfigurer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/kafka/KafkaBrokerConfigurer.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.templates.etl.realtime.kafka;
+
+/**
+ * This class is for configuring Kafka broker information for {@link KafkaSimpleApiConsumer}.
+ */
+public interface KafkaBrokerConfigurer {
+
+  /**
+   * Sets the ZooKeeper quorum string that Kafka is running with. If this is set, then ZooKeeper will be used
+   * for discovery of Kafka brokers, regardless of what's being set by {@link #setBrokers(String)}.
+   */
+  void setZooKeeper(String zookeeper);
+
+  /**
+   * Sets the Kafka broker list. The format of the broker list is based on the Kafka version.
+   */
+  void setBrokers(String brokers);
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/kafka/KafkaConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/kafka/KafkaConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/kafka/KafkaConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/kafka/KafkaConfig.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.templates.etl.realtime.kafka;
+
+/**
+ * Contains information about Kafka cluster as configured by user.
+ */
+public class KafkaConfig {
+
+  private final String zookeeper;
+  private final String brokers;
+
+  public KafkaConfig(String zookeeper, String brokers) {
+    this.zookeeper = zookeeper;
+    this.brokers = brokers;
+  }
+
+  /**
+   * Returns the ZooKeeper connection string as set through {@link KafkaConsumerConfigurer#setZooKeeper(String)}
+   * or {@code null}.
+   */
+  public String getZookeeper() {
+    return zookeeper;
+  }
+
+  /**
+   * Returns brokers information as set through {@link KafkaConsumerConfigurer#setBrokers(String)} or {@code null}.
+   */
+  public String getBrokers() {
+    return brokers;
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/kafka/KafkaConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/kafka/KafkaConfig.java
@@ -16,10 +16,12 @@
 
 package co.cask.cdap.templates.etl.realtime.kafka;
 
+import javax.annotation.Nullable;
+
 /**
  * Contains information about Kafka cluster as configured by user.
  */
-public class KafkaConfig {
+public final class KafkaConfig {
 
   private final String zookeeper;
   private final String brokers;
@@ -33,6 +35,7 @@ public class KafkaConfig {
    * Returns the ZooKeeper connection string as set through {@link KafkaConsumerConfigurer#setZooKeeper(String)}
    * or {@code null}.
    */
+  @Nullable
   public String getZookeeper() {
     return zookeeper;
   }
@@ -40,6 +43,7 @@ public class KafkaConfig {
   /**
    * Returns brokers information as set through {@link KafkaConsumerConfigurer#setBrokers(String)} or {@code null}.
    */
+  @Nullable
   public String getBrokers() {
     return brokers;
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/kafka/KafkaConfigurer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/kafka/KafkaConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/kafka/KafkaConfigurer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/kafka/KafkaConfigurer.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.templates.etl.realtime.kafka;
+
+/**
+ * This class is for configuring both Kafka broker and consumer information for {@link KafkaSimpleApiConsumer}.
+ */
+public interface KafkaConfigurer extends KafkaBrokerConfigurer, KafkaConsumerConfigurer {
+  // No method define as it's just for gathering methods defined in super interfaces to one place
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/kafka/KafkaConsumerConfigurer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/kafka/KafkaConsumerConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/kafka/KafkaConsumerConfigurer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/kafka/KafkaConsumerConfigurer.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.templates.etl.realtime.kafka;
+
+/**
+ * This class is for configuring Kafka consumer information for {@link KafkaSimpleApiConsumer}.
+ */
+public interface KafkaConsumerConfigurer {
+
+  /**
+   * Default message fetch size in bytes when making Kafka fetch request.
+   */
+  int DEFAULT_FETCH_SIZE = 1048576;  // 1M
+
+  /**
+   * Adds a topic partition to consume message from. Same as calling
+   *
+   * {@link #addTopicPartition(String, int, int) addTopicPartition(topic, partition, DEFAULT_FETCH_SIZE)}
+   *
+   * @param topic name of the Kafka topic
+   * @param partition partition number
+   */
+  void addTopicPartition(String topic, int partition);
+
+  /**
+   * Adds a topic partition to consumer message from, using the given fetch size for each fetch request.
+   *
+   * @param topic name of the Kafka topic
+   * @param partition partition number
+   * @param fetchSize maximum number of bytes to fetch per request
+   */
+  void addTopicPartition(String topic, int partition, int fetchSize);
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/kafka/KafkaConsumerInfo.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/kafka/KafkaConsumerInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/kafka/KafkaConsumerInfo.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/kafka/KafkaConsumerInfo.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.templates.etl.realtime.kafka;
+
+import org.apache.twill.kafka.client.TopicPartition;
+
+/**
+ * Helper class to carry information about a Kafka consumer of a particular topic partition.
+ *
+ * @param <OFFSET> Type of the offset object
+ */
+public final class KafkaConsumerInfo<OFFSET> {
+  private final TopicPartition topicPartition;
+  private final int fetchSize;
+  private OFFSET readOffset;
+  private OFFSET pendingReadOffset;
+
+  public KafkaConsumerInfo(TopicPartition topicPartition, int fetchSize, OFFSET readOffset) {
+    this.topicPartition = topicPartition;
+    this.fetchSize = fetchSize;
+    this.readOffset = readOffset;
+  }
+
+  public TopicPartition getTopicPartition() {
+    return topicPartition;
+  }
+
+  public int getFetchSize() {
+    return fetchSize;
+  }
+
+  public OFFSET getReadOffset() {
+    return pendingReadOffset != null ? pendingReadOffset : readOffset;
+  }
+
+  public void setReadOffset(OFFSET readOffset) {
+    this.pendingReadOffset = readOffset;
+  }
+
+  public boolean hasPendingChanges() {
+    return this.pendingReadOffset != null;
+  }
+
+  void commitReadOffset() {
+    if (pendingReadOffset != null) {
+      readOffset = pendingReadOffset;
+      pendingReadOffset = null;
+    }
+  }
+
+  void rollbackReadOffset() {
+    pendingReadOffset = null;
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/kafka/KafkaMessage.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/kafka/KafkaMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/kafka/KafkaMessage.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/kafka/KafkaMessage.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.templates.etl.realtime.kafka;
+
+import org.apache.twill.kafka.client.TopicPartition;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Represents a Kafka message.
+ *
+ * @param <OFFSET> Type of message offset
+ */
+public class KafkaMessage<OFFSET> {
+
+  private final TopicPartition topicPartition;
+  private final OFFSET nextOffset;
+  private final ByteBuffer key;
+  private final ByteBuffer payload;
+
+  public KafkaMessage(TopicPartition topicPartition, OFFSET nextOffset, ByteBuffer key, ByteBuffer payload) {
+    this.topicPartition = topicPartition;
+    this.nextOffset = nextOffset;
+    this.key = key;
+    this.payload = payload;
+  }
+
+  public TopicPartition getTopicPartition() {
+    return topicPartition;
+  }
+
+  public OFFSET getNextOffset() {
+    return nextOffset;
+  }
+
+  public ByteBuffer getKey() {
+    return key;
+  }
+
+  public ByteBuffer getPayload() {
+    return payload;
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/kafka/KafkaMessage.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/kafka/KafkaMessage.java
@@ -25,7 +25,7 @@ import java.nio.ByteBuffer;
  *
  * @param <OFFSET> Type of message offset
  */
-public class KafkaMessage<OFFSET> {
+public final class KafkaMessage<OFFSET> {
 
   private final TopicPartition topicPartition;
   private final OFFSET nextOffset;

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/kafka/KafkaSimpleApiConsumer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/kafka/KafkaSimpleApiConsumer.java
@@ -1,0 +1,394 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.templates.etl.realtime.kafka;
+
+import co.cask.cdap.templates.etl.api.Emitter;
+import co.cask.cdap.templates.etl.api.realtime.SourceContext;
+import co.cask.cdap.templates.etl.api.realtime.SourceState;
+
+import com.google.common.base.Charsets;
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import com.google.common.reflect.TypeToken;
+import com.google.common.util.concurrent.Service;
+
+import org.apache.twill.kafka.client.TopicPartition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.nio.ByteBuffer;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * <p>
+ *   Wrapper class for {@code Apache Kafka} consumer using the simple APIs to manage the last offset for a particular
+ *   partition of a topic.
+ *
+ *   Most of the code are borrowed from the {@code cdap-kafka-pack} project and modified to be suit the stream source.
+ * </p>
+ *
+ * @param <KEY> Type of message key
+ * @param <PAYLOAD> Type of message value
+ * @param <OFFSET> Type of offset object
+ */
+public abstract class KafkaSimpleApiConsumer<KEY, PAYLOAD, OFFSET> {
+  private static final Logger LOG = LoggerFactory.getLogger(KafkaSimpleApiConsumer.class);
+
+  protected static final int SO_TIMEOUT = 5 * 1000;           // 5 seconds.
+
+  private final Function<KafkaConsumerInfo<OFFSET>, OFFSET> consumerToOffset =
+    new Function<KafkaConsumerInfo<OFFSET>, OFFSET>() {
+      @Override
+      public OFFSET apply(KafkaConsumerInfo<OFFSET> input) {
+        return input.getReadOffset();
+      }
+    };
+
+  private Function<ByteBuffer, KEY> keyDecoder;
+  private Function<ByteBuffer, PAYLOAD> payloadDecoder;
+  private KafkaConfig kafkaConfig;
+  private Map<TopicPartition, KafkaConsumerInfo<OFFSET>> consumerInfos;
+  private Map<String, byte[]> offsetStore;
+
+  protected SourceContext sourceContext;
+
+  /**
+   * <p>
+   *   The method should be called to initialized the consumer when being used by the {@code RealtimeSource}
+   * </p>
+   *
+   * @param context
+   * @throws Exception
+   */
+  public void initialize(SourceContext context) throws Exception {
+    sourceContext = context;
+
+    // Tries to detect key and payload decoder based on the class parameterized type.
+    Type superType = TypeToken.of(getClass()).getSupertype(KafkaSimpleApiConsumer.class).getType();
+
+    // Tries to detect Key and Payload type for creating decoder for them
+    if (superType instanceof ParameterizedType) {
+      // Extract Key and Payload types
+      Type[] typeArgs = ((ParameterizedType) superType).getActualTypeArguments();
+
+      keyDecoder = createKeyDecoder(typeArgs[0]);
+      payloadDecoder = createPayloadDecoder(typeArgs[1]);
+    }
+
+    // Configure kafka
+    DefaultKafkaConfigurer kafkaConfigurer = new DefaultKafkaConfigurer();
+    configureKafka(kafkaConfigurer);
+
+    if (kafkaConfigurer.getZookeeper() == null && kafkaConfigurer.getBrokers() == null) {
+      throw new IllegalStateException("Kafka not configured. Must provide either zookeeper or broker list.");
+    }
+
+    kafkaConfig = new KafkaConfig(kafkaConfigurer.getZookeeper(), kafkaConfigurer.getBrokers());
+    consumerInfos = createConsumerInfos(kafkaConfigurer.getTopicPartitions());
+  }
+
+  public SourceContext getContext() {
+    return sourceContext;
+  }
+
+  public String getName() {
+    return getClass().getSimpleName();
+  }
+
+  /**
+   * WIll be called by external source to start poll the Kafka messages one at the time.
+   *
+   * @throws Exception
+   */
+  public void pollMessages(Emitter<ByteBuffer> emitter, SourceState currentState) {
+    // Update the internal state
+    offsetStore = currentState.getState();
+
+    boolean infosUpdated = false;
+    // Poll for messages from Kafka
+    for (KafkaConsumerInfo<OFFSET> info : consumerInfos.values()) {
+      Iterator<KafkaMessage<OFFSET>> iterator = readMessages(info);
+      while (iterator.hasNext()) {
+        KafkaMessage<OFFSET> message = iterator.next();
+        processMessage(message, emitter);
+
+        // Update the read offset
+        info.setReadOffset(message.getNextOffset());
+      }
+      if (info.hasPendingChanges()) {
+        infosUpdated = true;
+      }
+    }
+
+    // Save new offset if there is at least one message processed, or even if the offset simply changed.
+    if (infosUpdated) {
+      saveReadOffsets(Maps.transformValues(consumerInfos, consumerToOffset));
+    }
+  }
+
+  /**
+   * Configure Kafka consumer. This method will be called during the initialize phase
+   *
+   * @param configurer    for configuring consuming from Kafka
+   */
+  protected abstract void configureKafka(KafkaConfigurer configurer);
+
+  /**
+   * Read messages from Kafka.
+   *
+   * @param consumerInfo Contains information about where to fetch messages from
+   * @return An {@link Iterator} containing sequence of messages read from Kafka. The first message must
+   *         has offset no earlier than the {@link KafkaConsumerInfo#getReadOffset()} as given in the parameter.
+   */
+  protected abstract Iterator<KafkaMessage<OFFSET>> readMessages(KafkaConsumerInfo<OFFSET> consumerInfo);
+
+  /**
+   * Returns the read offsets to start with for the given {@link TopicPartition}.
+   */
+  protected abstract OFFSET getBeginOffset(TopicPartition topicPartition);
+
+  /**
+   * Persists read offsets for all topic-partition that this Flowlet consumes from Kafka.
+   */
+  protected abstract void saveReadOffsets(Map<TopicPartition, OFFSET> offsets);
+
+  /**
+   * Should be called for clean up.
+   */
+  public void destroy() {
+    // no-op
+  }
+
+  /**
+   * Returns a Kafka configuration.
+   */
+  protected final KafkaConfig getKafkaConfig() {
+    return kafkaConfig;
+  }
+
+  /**
+   * Overrides this method if interested in the raw Kafka message.
+   *
+   * @param message The message fetched from Kafka.
+   * @param emitter The emitter to push the message
+   */
+  protected void processMessage(KafkaMessage<OFFSET> message, Emitter<ByteBuffer> emitter) {
+    // Should only receive messages from partitions that it can process
+    int partition = message.getTopicPartition().getPartition();
+    if ((partition % getContext().getInstanceCount()) != getContext().getInstanceId()) {
+      throw new IllegalArgumentException("Received unexpected partition " + partition);
+    }
+
+    processMessage(decodeKey(message.getKey()), decodePayload(message.getPayload()), emitter);
+  }
+
+  /**
+   * Override this method if interested in both the key and payload of a message read from Kafka.
+   *
+   * @param key Key decoded from the message
+   * @param payload Payload decoded from the message
+   * @param emitter The emitter to push the message
+   */
+  protected void processMessage(KEY key, PAYLOAD payload, Emitter<ByteBuffer> emitter) {
+    processMessage(payload, emitter);
+  }
+
+  /**
+   * Override this method if only interested in the payload of a message read from Kafka.
+   *
+   * @param payload Payload decoded from the message
+   * @param emitter The emitter to push the message
+   */
+  protected abstract void processMessage(PAYLOAD payload, Emitter<ByteBuffer> emitter);
+
+  /**
+   * Returns the default value of offset to start with when encounter a new broker for a given topic partition.
+   * <p/>
+   * By default, it is {@link kafka.api.OffsetRequest#EarliestTime()}. Sub-classes can override this to return
+   * different value (for example {@link kafka.api.OffsetRequest#LatestTime()}).
+   */
+  protected abstract long getDefaultOffset(TopicPartition topicPartition);
+
+  /**
+   * Override this method to provide custom decoding of a message key.
+   *
+   * @param buffer The bytes representing the key in the Kafka message
+   * @return The decoded key
+   */
+  protected KEY decodeKey(ByteBuffer buffer) {
+    return (keyDecoder != null) ? keyDecoder.apply(buffer) : null;
+  }
+
+  /**
+   * Override this method to provide custom decoding of a message payload.
+   *
+   * @param buffer The bytes representing the payload in the Kafka message
+   * @return The decoded payload
+   */
+  protected PAYLOAD decodePayload(ByteBuffer buffer) {
+    return (payloadDecoder != null) ? payloadDecoder.apply(buffer) : null;
+  }
+
+  /**
+   * Stops a {@link Service} and waits for the completion. If there is exception during stop, it will get logged.
+   */
+  protected final void stopService(Service service) {
+    try {
+      service.stopAndWait();
+    } catch (Throwable t) {
+      LOG.error("Failed when stopping service {}", service, t);
+    }
+  }
+
+  /**
+   * Returns the key to be used when persisting offsets into the {@link SourceState}.
+   */
+  protected String getStoreKey(TopicPartition topicPartition) {
+    return topicPartition.getTopic() + ":" + topicPartition.getPartition();
+  }
+
+  protected Map<String, byte[]> getOffsetStore() {
+    return offsetStore;
+  }
+
+  /**
+   * Creates a decoder for the key type.
+   *
+   * @param type type to decode to
+   */
+  private Function<ByteBuffer, KEY> createKeyDecoder(Type type) {
+    return createDecoder(type, "No decoder for decoding message key");
+  }
+
+  /**
+   * Creates a decoder for the payload type.
+   *
+   * @param type type to decode to
+   */
+  private Function<ByteBuffer, PAYLOAD> createPayloadDecoder(Type type) {
+    return createDecoder(type, "No decoder for decoding message payload");
+  }
+
+  /**
+   * Creates a decoder for decoding {@link ByteBuffer} for known type. It supports
+   * <p/>
+   * <pre>
+   * - String (assuming UTF-8)
+   * - byte[]
+   * - ByteBuffer
+   * </pre>
+   *
+   * @param type type to decode to
+   * @param failureDecodeMessage message for the exception if decoding of the given type is not supported
+   * @param <T> Type of the decoded type
+   * @return A {@link Function} that decode {@link ByteBuffer} into the given type or a failure decoder created through
+   *         {@link #createFailureDecoder(String)} if the type is not support
+   */
+  @SuppressWarnings("unchecked")
+  private <T> Function<ByteBuffer, T> createDecoder(Type type, String failureDecodeMessage) {
+    if (String.class.equals(type)) {
+      return (Function<ByteBuffer, T>) createStringDecoder();
+    }
+    if (ByteBuffer.class.equals(type)) {
+      return (Function<ByteBuffer, T>) createByteBufferDecoder();
+    }
+    if (byte[].class.equals(type) || (type instanceof GenericArrayType &&
+      byte.class.equals(((GenericArrayType) type).getGenericComponentType()))) {
+      return (Function<ByteBuffer, T>) createBytesDecoder();
+    }
+    return createFailureDecoder(failureDecodeMessage);
+  }
+
+  /**
+   * Creates a decoder that convert the input {@link ByteBuffer} into UTF-8 String. The input {@link ByteBuffer}
+   * will not be consumed after the call.
+   */
+  private Function<ByteBuffer, String> createStringDecoder() {
+    return new Function<ByteBuffer, String>() {
+      @Override
+      public String apply(ByteBuffer input) {
+        input.mark();
+        String result = Charsets.UTF_8.decode(input).toString();
+        input.reset();
+        return result;
+      }
+    };
+  }
+
+  /**
+   * Creates a decoder that returns the same input {@link ByteBuffer}.
+   */
+  private Function<ByteBuffer, ByteBuffer> createByteBufferDecoder() {
+    return new Function<ByteBuffer, ByteBuffer>() {
+      @Override
+      public ByteBuffer apply(ByteBuffer input) {
+        return input;
+      }
+    };
+  }
+
+  /**
+   * Creates a decoder that reads {@link ByteBuffer} content and return it as {@code byte[]}. The
+   * input {@link ByteBuffer} will not be consumed after the call.
+   */
+  private Function<ByteBuffer, byte[]> createBytesDecoder() {
+    return new Function<ByteBuffer, byte[]>() {
+      @Override
+      public byte[] apply(ByteBuffer input) {
+        byte[] bytes = new byte[input.remaining()];
+        input.mark();
+        input.get(bytes);
+        input.reset();
+        return bytes;
+      }
+    };
+  }
+
+  /**
+   * Creates a decoder that always decode fail by raising an {@link IllegalStateException}.
+   */
+  private <T> Function<ByteBuffer, T> createFailureDecoder(final String failureMessage) {
+    return new Function<ByteBuffer, T>() {
+      @Override
+      public T apply(ByteBuffer input) {
+        throw new IllegalStateException(failureMessage);
+      }
+    };
+  }
+
+  /**
+   * Helper method to create new {@link KafkaConsumerInfo} for map of topic partitions.
+   *
+   * @param config
+   * @return
+   */
+  private Map<TopicPartition, KafkaConsumerInfo<OFFSET>> createConsumerInfos(Map<TopicPartition, Integer> config) {
+    ImmutableMap.Builder<TopicPartition, KafkaConsumerInfo<OFFSET>> consumers = ImmutableMap.builder();
+
+    for (Map.Entry<TopicPartition, Integer> entry : config.entrySet()) {
+      consumers.put(entry.getKey(),
+                    new KafkaConsumerInfo<OFFSET>(entry.getKey(), entry.getValue(), getBeginOffset(entry.getKey())));
+    }
+    return consumers.build();
+  }
+
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/sources/KafkaSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/sources/KafkaSource.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.templates.etl.realtime.sources;
+
+import co.cask.cdap.templates.etl.api.Emitter;
+import co.cask.cdap.templates.etl.api.StageConfigurer;
+import co.cask.cdap.templates.etl.api.realtime.RealtimeSource;
+import co.cask.cdap.templates.etl.api.realtime.SourceContext;
+import co.cask.cdap.templates.etl.api.realtime.SourceState;
+
+import co.cask.cdap.templates.etl.realtime.kafka.Kafka08SimpleApiConsumer;
+import co.cask.cdap.templates.etl.realtime.kafka.KafkaSimpleApiConsumer;
+import com.google.common.collect.Maps;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.ByteBuffer;
+
+import javax.annotation.Nullable;
+
+/**
+ * <p>
+ *  Implementation of {@link RealtimeSource} that reads data from Kafka API and emit {@code ByteBuffer} as the
+ *  output via {@link Emitter}.
+ *
+ *  This implementation have dependency on {@code Kafka} version 0.8.x.
+ * </p>
+ */
+public class KafkaSource extends RealtimeSource<ByteBuffer> {
+  private static final Logger LOG = LoggerFactory.getLogger(KafkaSource.class);
+
+  private static final String CDAP_KAFKA_SOURCE_NAME = "Kafka Realtime Source";
+
+  private KafkaSimpleApiConsumer kafkaConsumer;
+
+  @Override
+  public void configure(StageConfigurer configurer) {
+    configurer.setName(CDAP_KAFKA_SOURCE_NAME);
+    configurer.setDescription(CDAP_KAFKA_SOURCE_NAME);
+  }
+
+  @Override
+  public void initialize(SourceContext context) throws Exception {
+    super.initialize(context);
+
+    kafkaConsumer = new Kafka08SimpleApiConsumer();
+    kafkaConsumer.initialize(context);
+  }
+
+  @Nullable
+  @Override
+  public SourceState poll(Emitter<ByteBuffer> writer, SourceState currentState) {
+    kafkaConsumer.pollMessages(writer, currentState);
+    return new SourceState(Maps.newHashMap(currentState.getState()));
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/sources/KafkaSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/sources/KafkaSource.java
@@ -17,18 +17,23 @@
 package co.cask.cdap.templates.etl.realtime.sources;
 
 import co.cask.cdap.templates.etl.api.Emitter;
+import co.cask.cdap.templates.etl.api.PipelineConfigurer;
 import co.cask.cdap.templates.etl.api.Property;
 import co.cask.cdap.templates.etl.api.StageConfigurer;
+import co.cask.cdap.templates.etl.api.config.ETLStage;
 import co.cask.cdap.templates.etl.api.realtime.RealtimeContext;
 import co.cask.cdap.templates.etl.api.realtime.RealtimeSource;
 import co.cask.cdap.templates.etl.api.realtime.SourceState;
 import co.cask.cdap.templates.etl.realtime.kafka.Kafka08SimpleApiConsumer;
 import co.cask.cdap.templates.etl.realtime.kafka.KafkaSimpleApiConsumer;
 
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.ByteBuffer;
+import java.util.Map;
 
 import javax.annotation.Nullable;
 
@@ -43,19 +48,38 @@ import javax.annotation.Nullable;
 public class KafkaSource extends RealtimeSource<ByteBuffer> {
   private static final Logger LOG = LoggerFactory.getLogger(KafkaSource.class);
 
+  public static final String KAFKA_PARTITIONS = "kafka.partitions";
+  public static final String KAFKA_TOPIC = "kafka.topic";
+  public static final String KAFKA_ZOOKEEPER = "kafka.zookeeper";
+  public static final String KAFKA_BROKERS = "kafka.brokers";
+  public static final String KAFKA_DEFAULT_OFFSET = "kafka.default.offset";
+
   private static final String CDAP_KAFKA_SOURCE_NAME = "Kafka Realtime Source";
 
   private KafkaSimpleApiConsumer kafkaConsumer;
 
   @Override
   public void configure(StageConfigurer configurer) {
-    configurer.setName(CDAP_KAFKA_SOURCE_NAME);
+    configurer.setName(getClass().getSimpleName());
     configurer.setDescription(CDAP_KAFKA_SOURCE_NAME);
-    configurer.addProperty(new Property("kafka.zookeeper ", "The connect string location of Kafka Zookeeper", false));
-    configurer.addProperty(new Property("kafka.brokers", "Comma separate list of Kafka brokers", false));
-    configurer.addProperty(new Property("kafka.partitions", "Number of partitions" , true));
-    configurer.addProperty(new Property("kafka.topic", "Topic of the messages", true));
-    configurer.addProperty(new Property("kafka.default.offset", "The default offset for the partition", false));
+    configurer.addProperty(new Property(KAFKA_ZOOKEEPER, "The connect string location of Kafka Zookeeper", false));
+    configurer.addProperty(new Property(KAFKA_BROKERS, "Comma separate list of Kafka brokers", false));
+    configurer.addProperty(new Property(KAFKA_PARTITIONS, "Number of partitions" , true));
+    configurer.addProperty(new Property(KAFKA_TOPIC, "Topic of the messages", true));
+    configurer.addProperty(new Property(KAFKA_DEFAULT_OFFSET, "The default offset for the partition", false));
+  }
+
+  @Override
+  public void configurePipeline(ETLStage stageConfig, PipelineConfigurer pipelineConfigurer) {
+    Map<String, String> properties = stageConfig.getProperties();
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(properties.get(KAFKA_PARTITIONS)),
+                                "Number of partitions for Kafka topic need to specified.");
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(properties.get(KAFKA_TOPIC)),
+                                "The topic name of Kafka messages need to specified.");
+    String zk = properties.get(KAFKA_ZOOKEEPER);
+    String brokers = properties.get(KAFKA_BROKERS);
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(properties.get(zk)) || !Strings.isNullOrEmpty(brokers),
+                                "Either Zookeeper connect info or list of brokers need to exists.");
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/templates/etl/realtime/sources/KafkaSourceTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/templates/etl/realtime/sources/KafkaSourceTest.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.templates.etl.realtime.sources;
+
+import co.cask.cdap.api.metrics.Metrics;
+import co.cask.cdap.templates.etl.api.Emitter;
+import co.cask.cdap.templates.etl.api.StageSpecification;
+import co.cask.cdap.templates.etl.api.realtime.RealtimeContext;
+import co.cask.cdap.templates.etl.api.realtime.SourceState;
+
+import com.google.common.base.Charsets;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.util.concurrent.Uninterruptibles;
+
+import org.apache.twill.internal.kafka.EmbeddedKafkaServer;
+import org.apache.twill.internal.kafka.client.ZKKafkaClientService;
+import org.apache.twill.internal.utils.Networks;
+import org.apache.twill.internal.zookeeper.InMemoryZKServer;
+import org.apache.twill.kafka.client.Compression;
+import org.apache.twill.kafka.client.KafkaClientService;
+import org.apache.twill.kafka.client.KafkaPublisher;
+import org.apache.twill.zookeeper.ZKClientService;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * <p>
+ *  Unit test for {@link KafkaSource} ETL realtime source class.
+ *
+ *  The base code is borrowed from {@code cdap-kafka-pack} project.
+ * </p>
+ */
+public class KafkaSourceTest {
+
+  private static ZKClientService zkClient;
+  private static KafkaClientService kafkaClient;
+
+  @ClassRule
+  public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
+
+  protected static final int PARTITIONS = 1;
+
+  protected static InMemoryZKServer zkServer;
+  protected static EmbeddedKafkaServer kafkaServer;
+  protected static int kafkaPort;
+
+  private KafkaSource kafkaSource;
+
+  @BeforeClass
+  public static void beforeClass() throws IOException {
+    zkServer = InMemoryZKServer.builder().setDataDir(TMP_FOLDER.newFolder()).build();
+    zkServer.startAndWait();
+
+    kafkaPort = Networks.getRandomPort();
+    kafkaServer = new EmbeddedKafkaServer(generateKafkaConfig(zkServer.getConnectionStr(),
+                                                              kafkaPort, TMP_FOLDER.newFolder()));
+    kafkaServer.startAndWait();
+
+    zkClient = ZKClientService.Builder.of(zkServer.getConnectionStr()).build();
+    zkClient.startAndWait();
+
+    kafkaClient = new ZKKafkaClientService(zkClient);
+    kafkaClient.startAndWait();
+  }
+
+  @AfterClass
+  public static void afterClass() {
+    kafkaServer.stopAndWait();
+    zkServer.stopAndWait();
+    kafkaClient.stopAndWait();
+    zkClient.stopAndWait();
+  }
+
+  @Before
+  public void beforeTest() {
+    kafkaSource = new KafkaSource();
+  }
+
+  @After
+  public void afterTest() {
+    if (kafkaSource != null) {
+      kafkaSource.destroy();
+    }
+  }
+
+  @Test
+  public void testKafkaConsumerSimple() throws Exception {
+    final String topic = "testKafkaConsumerSimple";
+    RealtimeContext sourceContext = new RealtimeContext() {
+
+      @Override
+      public StageSpecification getSpecification() {
+        return null;
+      }
+
+      @Override
+      public Metrics getMetrics() {
+        return null;
+      }
+
+      @Override
+      public int getInstanceId() {
+        return 0;
+      }
+
+      @Override
+      public int getInstanceCount() {
+        return PARTITIONS;
+      }
+
+      @Override
+      public Map<String, String> getRuntimeArguments() {
+        return getRuntimeArgs(topic, PARTITIONS, false);
+      }
+    };
+
+    kafkaSource.initialize(sourceContext);
+
+    // Publish 5 messages to Kafka, the source should consume them
+    int msgCount = 5;
+    Map<String, String> messages = Maps.newHashMap();
+    for (int i = 0; i < msgCount; i++) {
+      messages.put(Integer.toString(i), "Message " + i);
+    }
+    sendMessage(topic, messages);
+
+    TimeUnit.SECONDS.sleep(2);
+
+    verifyEmittedMessages(kafkaSource, msgCount);
+  }
+
+  // Helper method to verify
+  private void verifyEmittedMessages(KafkaSource source, int msgCount)  {
+    MockEmitter emitter = new MockEmitter();
+    SourceState sourceState = source.poll(emitter, new SourceState());
+
+    System.out.println("Message sent out: " + msgCount);
+    System.out.println("Message being emitted by Kafka realtime source: " + emitter.getInternalSize());
+
+    Assert.assertTrue(sourceState.getState() != null && !sourceState.getState().isEmpty());
+    Assert.assertTrue(emitter.getInternalSize() == msgCount);
+  }
+
+  protected void sendMessage(String topic, Map<String, String> messages) {
+    // Publish a message to Kafka, the flow should consume it
+    KafkaPublisher publisher = kafkaClient.getPublisher(KafkaPublisher.Ack.ALL_RECEIVED, Compression.NONE);
+
+    // If publish failed, retry up to 20 times, with 100ms delay between each retry
+    // This is because leader election in Kafka 08 takes time when a topic is being created upon publish request.
+    int count = 0;
+    do {
+      KafkaPublisher.Preparer preparer = publisher.prepare(topic);
+      for (Map.Entry<String, String> entry : messages.entrySet()) {
+        preparer.add(Charsets.UTF_8.encode(entry.getValue()), entry.getKey());
+      }
+      try {
+        preparer.send().get();
+        break;
+      } catch (Exception e) {
+        // Backoff if send failed.
+        Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
+      }
+    } while (count++ < 20);
+  }
+
+  protected boolean supportBrokerList() {
+    return true;
+  }
+
+  protected Map<String, String> getRuntimeArgs(String topic, int partitions, boolean preferZK, long startOffset) {
+    Map<String, String> args = getRuntimeArgs(topic, partitions, preferZK);
+    args.put("kafka.default.offset", Long.toString(startOffset));
+    return args;
+  }
+
+  private Map<String, String> getRuntimeArgs(String topic, int partitions, boolean preferZK) {
+    Map<String, String> args = Maps.newHashMap();
+
+    args.put("kafka.topic", topic);
+    if (!supportBrokerList() || preferZK) {
+      args.put("kafka.zookeeper", zkServer.getConnectionStr());
+    } else {
+      args.put("kafka.brokers", "localhost:" + kafkaPort);
+    }
+    args.put("kafka.partitions", Integer.toString(partitions));
+    return args;
+  }
+
+  private static Properties generateKafkaConfig(String zkConnectStr, int port, File logDir) {
+    // Note: the log size properties below have been set so that we can have log rollovers
+    // and log deletions in a minute.
+    Properties prop = new Properties();
+    prop.setProperty("log.dir", logDir.getAbsolutePath());
+    prop.setProperty("port", Integer.toString(port));
+    prop.setProperty("broker.id", "1");
+    prop.setProperty("socket.send.buffer.bytes", "1048576");
+    prop.setProperty("socket.receive.buffer.bytes", "1048576");
+    prop.setProperty("socket.request.max.bytes", "104857600");
+    prop.setProperty("num.partitions", Integer.toString(PARTITIONS));
+    prop.setProperty("log.retention.hours", "24");
+    prop.setProperty("log.flush.interval.messages", "10");
+    prop.setProperty("log.flush.interval.ms", "1000");
+    prop.setProperty("log.segment.bytes", "100");
+    prop.setProperty("zookeeper.connect", zkConnectStr);
+    prop.setProperty("zookeeper.connection.timeout.ms", "1000000");
+    prop.setProperty("default.replication.factor", "1");
+    prop.setProperty("log.retention.bytes", "1000");
+    prop.setProperty("log.retention.check.interval.ms", "60000");
+
+    return prop;
+  }
+
+  /**
+   * Helper class to emit message to next stage
+   */
+  private static class MockEmitter implements Emitter<ByteBuffer> {
+    private final List<ByteBuffer> entryList = Lists.newArrayList();
+
+    @Override
+    public void emit(ByteBuffer value) {
+      entryList.add(value);
+    }
+
+    public int getInternalSize() {
+      return entryList.size();
+    }
+
+    public void reset() {
+      entryList.clear();
+    }
+  }
+
+}


### PR DESCRIPTION
The PR contains first drop supporting Kafka as realtime source:
-) The Kafka consumer are borrowed from cdap-kafka-pack/cdap-kafka-flow project leveraging Kafka Simple Consumer. The logic is modified and simplify to fit the scenario of realtime source which is less complicated that CDAP Flow and Flowlets.
-) The Kafka source only support latest Kafka version supported by CDAP which is 0.8.x (as long as Kafka does not have API change within minor releases). 
-) The Kafka realtime source also leverages library from Twill to start and stop ZK server and client and manage the Topic partition and offset.
-) Add unit test to test single partition with single broker list for send and receive Kafka messages. 

TODO: 
-) Will add more tests such as to use ZK as connection broker