### PR TITLE
CDAP-2196 Add bounded message buffer to JMS poll to emit some messages instead of just one per poll from adapter

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/sources/JmsSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/sources/JmsSource.java
@@ -142,13 +142,7 @@ public class JmsSource extends RealtimeSource<String> {
             LOG.trace("Process JMS TextMessage : ", text);
           } else if (message instanceof BytesMessage) {
             BytesMessage bytesMessage = (BytesMessage) message;
-            int bodyLength = (int) bytesMessage.getBodyLength();
-            byte[] data = new byte[bodyLength];
-            int bytesRead = bytesMessage.readBytes(data);
-            if (bytesRead != bodyLength) {
-              LOG.warn("Number of bytes read {} not same as expected {}", bytesRead, bodyLength);
-            }
-            text = new String(data).intern();
+            text = bytesMessage.readUTF();
             LOG.trace("Processing JMS ByteMessage : {}", text);
           } else {
             // Different kind of messages, just get String for now

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/sources/JmsSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/sources/JmsSource.java
@@ -44,15 +44,18 @@ import javax.jms.TextMessage;
 public class JmsSource extends RealtimeSource<String> {
   private static final Logger LOG = LoggerFactory.getLogger(JmsSource.class);
 
-  private static final long JMS_CONSUMER_TIMEOUT_MS = 30000;
+  private static final long JMS_CONSUMER_TIMEOUT_MS = 2000;
   private static final String CDAP_JMS_SOURCE_NAME = "JMS Realtime Source";
+  private static final String JMS_MESSAGES_TO_RECEIVE = "jms.messages.receive";
 
   private int jmsAcknowledgeMode = Session.AUTO_ACKNOWLEDGE;
   private JmsProvider jmsProvider;
 
   private transient Connection connection;
   private transient Session session;
-  private MessageConsumer consumer;
+  private transient MessageConsumer consumer;
+
+  private int messagesToReceive = 50;
 
   /**
    * Configure the JMS Source.
@@ -72,6 +75,10 @@ public class JmsSource extends RealtimeSource<String> {
    */
   public void initialize(RealtimeContext context) throws Exception {
     super.initialize(context);
+
+    if (context.getRuntimeArguments().get(JMS_MESSAGES_TO_RECEIVE) != null) {
+      messagesToReceive = Integer.valueOf(context.getRuntimeArguments().get(JMS_MESSAGES_TO_RECEIVE));
+    }
 
     // Bootstrap the JMS consumer
     initializeJMSConnection();
@@ -118,43 +125,46 @@ public class JmsSource extends RealtimeSource<String> {
   public SourceState poll(Emitter<String> writer, SourceState currentState) {
     // Try to get message from Queue
     Message message = null;
-    try {
-      message = consumer.receive(JMS_CONSUMER_TIMEOUT_MS);
-    } catch (JMSException e) {
-      LOG.warn("Exception when trying to receive message from JMS consumer: {}", CDAP_JMS_SOURCE_NAME);
-    }
-    if (message == null) {
-      return currentState;
-    }
 
-    String text;
-    try {
-      if (message instanceof TextMessage) {
-        TextMessage textMessage = (TextMessage) message;
-        text = textMessage.getText();
-        LOG.trace("Process JMS TextMessage : ", text);
-      } else if (message instanceof BytesMessage) {
-        BytesMessage bytesMessage = (BytesMessage) message;
-        int bodyLength = (int) bytesMessage.getBodyLength();
-        byte[] data = new byte[bodyLength];
-        int bytesRead = bytesMessage.readBytes(data);
-        if (bytesRead != bodyLength) {
-          LOG.warn("Number of bytes read {} not same as expected {}", bytesRead, bodyLength);
-        }
-        text = new String(data).intern();
-        LOG.trace("Processing JMS ByteMessage : {}", text);
-      } else {
-        // Different kind of messages, just get String for now
-        // TODO Process different kind of JMS messages
-        text = message.toString();
-        LOG.trace("Processing JMS message : ", text);
+    int count = 0;
+    do {
+      try {
+        message = consumer.receive(JMS_CONSUMER_TIMEOUT_MS);
+      } catch (JMSException e) {
+        LOG.warn("Exception when trying to receive message from JMS consumer: {}", CDAP_JMS_SOURCE_NAME);
       }
-    }  catch (JMSException e) {
-      LOG.error("Unable to read text from a JMS Message.");
-      return currentState;
-    }
+      if (message != null) {
+        String text;
+        try {
+          if (message instanceof TextMessage) {
+            TextMessage textMessage = (TextMessage) message;
+            text = textMessage.getText();
+            LOG.trace("Process JMS TextMessage : ", text);
+          } else if (message instanceof BytesMessage) {
+            BytesMessage bytesMessage = (BytesMessage) message;
+            int bodyLength = (int) bytesMessage.getBodyLength();
+            byte[] data = new byte[bodyLength];
+            int bytesRead = bytesMessage.readBytes(data);
+            if (bytesRead != bodyLength) {
+              LOG.warn("Number of bytes read {} not same as expected {}", bytesRead, bodyLength);
+            }
+            text = new String(data).intern();
+            LOG.trace("Processing JMS ByteMessage : {}", text);
+          } else {
+            // Different kind of messages, just get String for now
+            // TODO Process different kind of JMS messages
+            text = message.toString();
+            LOG.trace("Processing JMS message : ", text);
+          }
+        } catch (JMSException e) {
+          LOG.error("Unable to read text from a JMS Message.");
+          continue;
+        }
 
-    writer.emit(text);
+        writer.emit(text);
+        count++;
+      }
+    } while (message != null && count < messagesToReceive);
 
     return new SourceState(currentState.getState());
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/templates/etl/realtime/sources/JmsMessageToStringSourceTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/templates/etl/realtime/sources/JmsMessageToStringSourceTest.java
@@ -16,12 +16,18 @@
 
 package co.cask.cdap.templates.etl.realtime.sources;
 
+import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.templates.etl.api.Emitter;
 import co.cask.cdap.templates.etl.api.Property;
 import co.cask.cdap.templates.etl.api.StageConfigurer;
+import co.cask.cdap.templates.etl.api.StageSpecification;
+import co.cask.cdap.templates.etl.api.realtime.RealtimeContext;
 import co.cask.cdap.templates.etl.api.realtime.SourceState;
-import co.cask.cdap.templates.etl.common.MockRealtimeContext;
 import co.cask.cdap.templates.etl.realtime.jms.JmsProvider;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -30,6 +36,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
+import java.util.Map;
 import javax.jms.Connection;
 import javax.jms.ConnectionFactory;
 import javax.jms.Destination;
@@ -95,8 +102,6 @@ public class JmsMessageToStringSourceTest {
     jmsProvider = new MockJmsProvider("dynamicQueues/CDAP.QUEUE");
     jmsSource.setJmsProvider(jmsProvider);
     jmsSource.setSessionAcknowledgeMode(sessionAckMode);
-
-
     jmsSource.initialize(new MockRealtimeContext());
 
     ConnectionFactory connectionFactory = jmsProvider.getConnectionFactory();
@@ -110,7 +115,7 @@ public class JmsMessageToStringSourceTest {
       sendMessage(queueConn, queueDestination, "Queue:" + queueDestination.getQueueName());
 
       // Verify if it is valid
-      verifyEmittedText(jmsSource, 5, 4000);
+      verifyEmittedText(jmsSource);
 
     } finally {
       if (queueConn != null) {
@@ -128,7 +133,6 @@ public class JmsMessageToStringSourceTest {
     jmsProvider = new MockJmsProvider("dynamicTopics/CDAP.TOPIC");
     jmsSource.setJmsProvider(jmsProvider);
     jmsSource.setSessionAcknowledgeMode(sessionAckMode);
-
     jmsSource.initialize(new MockRealtimeContext());
 
     ConnectionFactory connectionFactory = jmsProvider.getConnectionFactory();
@@ -143,7 +147,7 @@ public class JmsMessageToStringSourceTest {
       sendMessage(topicConn, topicDestination, "Topic:" + topicDestination.getTopicName());
 
       // Verify if it is valid
-      verifyEmittedText(jmsSource, 5, 4000);
+      verifyEmittedText(jmsSource);
     } finally {
       if (topicConn != null) {
         try {
@@ -170,37 +174,24 @@ public class JmsMessageToStringSourceTest {
   }
 
   // Helper method to verify
-  private void verifyEmittedText(JmsSource source, int numTries, long sleepMilis) {
+  private void verifyEmittedText(JmsSource source) {
     // Lets verify from JMS source
     MockEmitter emitter = new MockEmitter();
     SourceState sourceState = new SourceState();
     source.poll(emitter, sourceState);
 
-    int i = 1;
-    while (i < numTries) {
-      if (emitter.getCurrentValue() == null) {
-        try {
-          Thread.sleep(sleepMilis);
-        } catch (InterruptedException e) {
-          // no-op
-        }
-        source.poll(emitter, sourceState);
-        i++;
-      } else {
-        break;
-      }
-    }
-    String emitterValue = emitter.getCurrentValue();
-    Assert.assertEquals(originalMessage, emitterValue);
+    for (String val : emitter.getCurrentValues()) {
+      Assert.assertEquals(originalMessage, val);
 
-    System.out.println("Getting JMS Message in emitter with value: " + emitterValue);
+      System.out.println("Getting JMS Message in emitter with value: " + val);
+    }
   }
 
   /**
    * Helper class to emit JMS message to next stage
    */
   private static class MockEmitter implements Emitter<String> {
-    private String currentValue;
+    private List<String> currentValues = Lists.newLinkedList();
 
     /**
      * Emit objects to the next stage.
@@ -209,11 +200,40 @@ public class JmsMessageToStringSourceTest {
      */
     @Override
     public void emit(String value) {
-      currentValue = value;
+      currentValues.add(value);
     }
 
-    String getCurrentValue() {
-      return currentValue;
+    List<String> getCurrentValues() {
+      return currentValues;
+    }
+  }
+
+  public static class MockRealtimeContext implements RealtimeContext {
+    private final Map<String, String> runtimeArgs = Maps.newHashMap();
+
+    @Override
+    public int getInstanceId() {
+      return 0;
+    }
+
+    @Override
+    public int getInstanceCount() {
+      return 1;
+    }
+
+    @Override
+    public Map<String, String> getRuntimeArguments() {
+      return runtimeArgs;
+    }
+
+    @Override
+    public StageSpecification getSpecification() {
+      return null;
+    }
+
+    @Override
+    public Metrics getMetrics() {
+      return null;
     }
   }
 }


### PR DESCRIPTION
The PR contains some changes to help buffer some bulk messages from JMS sync:
-) Fix the consumer timeout from 30s to 2s
-) Add small buffer for 50 messages or if no more messages within the receive call.
   The default message could be set by "jms.messages.receive" runtime arg.
   This will allow more buffering to emitted messages when adapter poll to the JMS source.