### PR TITLE
Usage dataset

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/MDSKey.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/MDSKey.java
@@ -196,6 +196,11 @@ public final class MDSKey {
       return this;
     }
 
+    public Builder append(MDSKey mdsKey) {
+      key = Bytes.add(key, mdsKey.getKey());
+      return this;
+    }
+
     public MDSKey build() {
       return new MDSKey(key);
     }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/UsageDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/UsageDataset.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.registry;
+
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.data2.dataset2.lib.table.MDSKey;
+import co.cask.cdap.data2.dataset2.lib.table.MetadataStoreDataset;
+import co.cask.cdap.data2.registry.internal.keymaker.AdapterKeyMaker;
+import co.cask.cdap.data2.registry.internal.keymaker.DatasetKeyMaker;
+import co.cask.cdap.data2.registry.internal.keymaker.ProgramKeyMaker;
+import co.cask.cdap.data2.registry.internal.keymaker.StreamKeyMaker;
+import co.cask.cdap.data2.registry.internal.pair.KeyMaker;
+import co.cask.cdap.data2.registry.internal.pair.OrderedPair;
+import co.cask.cdap.data2.registry.internal.pair.OrderedPairs;
+import co.cask.cdap.proto.Id;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Stores program/adapter -> dataset/stream usage information.
+ * It stores the mapping as an {@link OrderedPair} in {@link MetadataStoreDataset}.
+ */
+public class UsageDataset extends MetadataStoreDataset {
+  // The following constans are used as row key prefixes. Any changes to these will make existing data unusable.
+  private static final String PROGRAM = "p";
+  private static final String ADAPTER = "a";
+  private static final String DATASET = "d";
+  private static final String STREAM = "s";
+
+  private final OrderedPairs orderedPairs;
+
+  public UsageDataset(Table table) {
+    super(table);
+
+    Map<String, KeyMaker<? extends Id>> keyMakers =
+      ImmutableMap.<String, KeyMaker<? extends Id>>builder()
+        .put(PROGRAM, new ProgramKeyMaker())
+        .put(ADAPTER, new AdapterKeyMaker())
+        .put(DATASET, new DatasetKeyMaker())
+        .put(STREAM, new StreamKeyMaker())
+        .build();
+    orderedPairs = new OrderedPairs(keyMakers);
+  }
+
+  /**
+   * Registers usage of a dataset by a program.
+   * @param programId program
+   * @param datasetInstanceId dataset
+   */
+  public void register(Id.Program programId, Id.DatasetInstance datasetInstanceId) {
+    write(orderedPairs.get(PROGRAM, DATASET).makeKey(programId, datasetInstanceId), true);
+    write(orderedPairs.get(DATASET, PROGRAM).makeKey(datasetInstanceId, programId), true);
+  }
+
+  /**
+   * Registers usage of a dataset by an adapter.
+   * @param adapterId adapter
+   * @param datasetInstanceId dataset
+   */
+  public void register(Id.Adapter adapterId, Id.DatasetInstance datasetInstanceId) {
+    write(orderedPairs.get(ADAPTER, DATASET).makeKey(adapterId, datasetInstanceId), true);
+    write(orderedPairs.get(DATASET, ADAPTER).makeKey(datasetInstanceId, adapterId), true);
+  }
+
+  /**
+   * Registers usage of a stream by a program.
+   * @param programId program
+   * @param streamId stream
+   */
+  public void register(Id.Program programId, Id.Stream streamId) {
+    write(orderedPairs.get(PROGRAM, STREAM).makeKey(programId, streamId), true);
+    write(orderedPairs.get(STREAM, PROGRAM).makeKey(streamId, programId), true);
+  }
+
+  /**
+   * Registers usage of a stream by an adapter.
+   * @param adapterId adapter
+   * @param streamId stream
+   */
+  public void register(Id.Adapter adapterId, Id.Stream streamId) {
+    write(orderedPairs.get(ADAPTER, STREAM).makeKey(adapterId, streamId), true);
+    write(orderedPairs.get(STREAM, ADAPTER).makeKey(streamId, adapterId), true);
+  }
+
+  /**
+   * Unregisters all usage information of an application.
+   * @param applicationId application
+   */
+  public void unregister(Id.Application applicationId) {
+    Id.Program programId = ProgramKeyMaker.getProgramId(applicationId);
+
+    // Delete datasets associated with applicationId
+    for (Id.DatasetInstance datasetInstanceId : getDatasets(applicationId)) {
+      deleteAll(orderedPairs.get(DATASET, PROGRAM).makeKey(datasetInstanceId, programId));
+    }
+
+    // Delete streams associated with applicationId
+    for (Id.Stream streamId : getStreams(applicationId)) {
+      deleteAll(orderedPairs.get(STREAM, PROGRAM).makeKey(streamId, programId));
+    }
+
+    // Delete all mappings for applicationId
+    deleteAll(orderedPairs.get(PROGRAM, DATASET).makeScanKey(programId));
+    deleteAll(orderedPairs.get(PROGRAM, STREAM).makeScanKey(programId));
+  }
+
+  /**
+   * Unregisters all usage information of an adapter.
+   * @param adapterId adapter
+   */
+  public void unregister(Id.Adapter adapterId) {
+    // Delete datasets associated with adapterId
+    for (Id.DatasetInstance datasetInstanceId : getDatasets(adapterId)) {
+      deleteAll(orderedPairs.get(DATASET, ADAPTER).makeKey(datasetInstanceId, adapterId));
+    }
+
+    // Delete streams associated with adapterId
+    for (Id.Stream streamId : getStreams(adapterId)) {
+      deleteAll(orderedPairs.get(STREAM, ADAPTER).makeKey(streamId, adapterId));
+    }
+
+    // Delete all mappings for adapterId
+    deleteAll(orderedPairs.get(ADAPTER, DATASET).makeScanKey(adapterId));
+    deleteAll(orderedPairs.get(ADAPTER, STREAM).makeScanKey(adapterId));
+  }
+
+  /**
+   * Returns datasets used by a program.
+   * @param programId program
+   * @return datasets used by programId
+   */
+  public Set<Id.DatasetInstance> getDatasets(Id.Program programId) {
+    OrderedPair<Id.Program, Id.DatasetInstance> orderedPair = orderedPairs.get(PROGRAM, DATASET);
+    Map<MDSKey, Boolean> datasetKeys = listKV(orderedPair.makeScanKey(programId), Boolean.TYPE);
+    return orderedPair.getSecond(datasetKeys.keySet());
+  }
+
+  /**
+   * Returns datasets used by an application.
+   * @param applicationId application
+   * @return datasets used by applicaionId
+   */
+  public Set<Id.DatasetInstance> getDatasets(Id.Application applicationId) {
+    Id.Program programId = ProgramKeyMaker.getProgramId(applicationId);
+    OrderedPair<Id.Program, Id.DatasetInstance> orderedPair = orderedPairs.get(PROGRAM, DATASET);
+    Map<MDSKey, Boolean> datasetKeys = listKV(orderedPair.makeScanKey(programId), Boolean.TYPE);
+    return orderedPair.getSecond(datasetKeys.keySet());
+  }
+
+  /**
+   * Returns datasets used by an adapter.
+   * @param adapterId adapter
+   * @return datasets used by adapterId
+   */
+  public Set<Id.DatasetInstance> getDatasets(Id.Adapter adapterId) {
+    OrderedPair<Id.Adapter, Id.DatasetInstance> orderedPair = orderedPairs.get(ADAPTER, DATASET);
+    Map<MDSKey, Boolean> datasetKeys = listKV(orderedPair.makeScanKey(adapterId), Boolean.TYPE);
+    return orderedPair.getSecond(datasetKeys.keySet());
+  }
+
+  /**
+   * Returns streams used by a program.
+   * @param programId program
+   * @return streams used by programId
+   */
+  public Set<Id.Stream> getStreams(Id.Program programId) {
+    OrderedPair<Id.Program, Id.Stream> orderedPair = orderedPairs.get(PROGRAM, STREAM);
+    Map<MDSKey, Boolean> datasetKeys = listKV(orderedPair.makeScanKey(programId), Boolean.TYPE);
+    return orderedPair.getSecond(datasetKeys.keySet());
+  }
+
+  /**
+   * Returns streams used by an application.
+   * @param applicationId application
+   * @return streams used by applicaionId
+   */
+  public Set<Id.Stream> getStreams(Id.Application applicationId) {
+    Id.Program programId = ProgramKeyMaker.getProgramId(applicationId);
+    OrderedPair<Id.Program, Id.Stream> orderedPair = orderedPairs.get(PROGRAM, STREAM);
+    Map<MDSKey, Boolean> datasetKeys = listKV(orderedPair.makeScanKey(programId), Boolean.TYPE);
+    return orderedPair.getSecond(datasetKeys.keySet());
+  }
+
+  /**
+   * Returns sterams used by an adapter.
+   * @param adapterId adapter
+   * @return streams used by adapterId
+   */
+  public Set<Id.Stream> getStreams(Id.Adapter adapterId) {
+    OrderedPair<Id.Adapter, Id.Stream> orderedPair = orderedPairs.get(ADAPTER, STREAM);
+    Map<MDSKey, Boolean> datasetKeys = listKV(orderedPair.makeScanKey(adapterId), Boolean.TYPE);
+    return orderedPair.getSecond(datasetKeys.keySet());
+  }
+
+  /**
+   * Returns programs using dataset.
+   * @param datasetInstanceId dataset
+   * @return programs using datasetInstanceId
+   */
+  public Set<Id.Program> getPrograms(Id.DatasetInstance datasetInstanceId) {
+    OrderedPair<Id.DatasetInstance, Id.Program> orderedPair = orderedPairs.get(DATASET, PROGRAM);
+    Map<MDSKey, Boolean> programKeys = listKV(orderedPair.makeScanKey(datasetInstanceId), Boolean.TYPE);
+    return orderedPair.getSecond(programKeys.keySet());
+  }
+
+  /**
+   * Returns programs using stream.
+   * @param streamId stream
+   * @return programs using streamId
+   */
+  public Set<Id.Program> getPrograms(Id.Stream streamId) {
+    OrderedPair<Id.Stream, Id.Program> orderedPair = orderedPairs.get(STREAM, PROGRAM);
+    Map<MDSKey, Boolean> programKeys = listKV(orderedPair.makeScanKey(streamId), Boolean.TYPE);
+    return orderedPair.getSecond(programKeys.keySet());
+  }
+
+  /**
+   * Returns adapters using dataset.
+   * @param datasetInstanceId dataset
+   * @return adapters using datasetInstanceId
+   */
+  public Set<Id.Adapter> getAdapters(Id.DatasetInstance datasetInstanceId) {
+    OrderedPair<Id.DatasetInstance, Id.Adapter> orderedPair = orderedPairs.get(DATASET, ADAPTER);
+    Map<MDSKey, Boolean> programKeys = listKV(orderedPair.makeScanKey(datasetInstanceId), Boolean.TYPE);
+    return orderedPair.getSecond(programKeys.keySet());
+  }
+
+  /**
+   * Returns adapters using stream.
+   * @param streamId stream
+   * @return adapters using streamId
+   */
+  public Set<Id.Adapter> getAdapters(Id.Stream streamId) {
+    OrderedPair<Id.Stream, Id.Adapter> orderedPair = orderedPairs.get(STREAM, ADAPTER);
+    Map<MDSKey, Boolean> programKeys = listKV(orderedPair.makeScanKey(streamId), Boolean.TYPE);
+    return orderedPair.getSecond(programKeys.keySet());
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/UsageDatasets.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/UsageDatasets.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.registry;
+
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.table.ConflictDetection;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.dataset2.DatasetManagementException;
+import co.cask.cdap.proto.Id;
+import com.google.common.annotations.VisibleForTesting;
+
+import java.io.IOException;
+
+/**
+ * Utility to create {@link UsageDataset}.
+ */
+public class UsageDatasets {
+  private static final Id.DatasetInstance USAGE_INSTANCE_ID =
+    Id.DatasetInstance.from(Constants.SYSTEM_NAMESPACE_ID, "usage.registry");
+
+  public static UsageDataset get(DatasetFramework framework) throws IOException, DatasetManagementException {
+    return get(framework, USAGE_INSTANCE_ID);
+  }
+
+  @VisibleForTesting
+  static UsageDataset get(DatasetFramework framework, Id.DatasetInstance id)
+    throws IOException, DatasetManagementException {
+    // Use ConflictDetection.NONE as we only need a flag whether a program uses a dataset/stream.
+    // Having conflict detection will lead to failures when programs start, and all try to register at the same time.
+    DatasetProperties properties = DatasetProperties.builder()
+      .add(Table.PROPERTY_CONFLICT_LEVEL, ConflictDetection.NONE.name())
+      .build();
+
+    Table table = DatasetsUtil.getOrCreateDataset(framework, id, Table.class.getName(), properties, null, null);
+    return new UsageDataset(table);
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/internal/keymaker/AdapterKeyMaker.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/internal/keymaker/AdapterKeyMaker.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.registry.internal.keymaker;
+
+import co.cask.cdap.data2.dataset2.lib.table.MDSKey;
+import co.cask.cdap.data2.registry.internal.pair.KeyMaker;
+import co.cask.cdap.proto.Id;
+
+/**
+ * {@link KeyMaker} for {@link Id.Adapter}.
+ */
+public class AdapterKeyMaker implements KeyMaker<Id.Adapter> {
+  @Override
+  public MDSKey getKey(Id.Adapter adapterId) {
+    return new MDSKey.Builder()
+      .add(adapterId.getNamespaceId())
+      .add(adapterId.getId())
+      .build();
+  }
+
+  @Override
+  public void skipKey(MDSKey.Splitter splitter) {
+    splitter.skipString(); // namespace
+    splitter.skipString(); // adapter
+  }
+
+  @Override
+  public Id.Adapter getElement(MDSKey.Splitter splitter) {
+    return Id.Adapter.from(splitter.getString(), splitter.getString());
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/internal/keymaker/DatasetKeyMaker.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/internal/keymaker/DatasetKeyMaker.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.registry.internal.keymaker;
+
+import co.cask.cdap.data2.dataset2.lib.table.MDSKey;
+import co.cask.cdap.data2.registry.internal.pair.KeyMaker;
+import co.cask.cdap.proto.Id;
+
+/**
+ * {@link KeyMaker} for {@link Id.DatasetInstance}.
+ */
+public class DatasetKeyMaker implements KeyMaker<Id.DatasetInstance> {
+  @Override
+  public MDSKey getKey(Id.DatasetInstance datasetInstance) {
+    return new MDSKey.Builder()
+      .add(datasetInstance.getNamespaceId())
+      .add(datasetInstance.getId())
+      .build();
+  }
+
+  @Override
+  public void skipKey(MDSKey.Splitter splitter) {
+    splitter.skipString(); // namespace
+    splitter.skipString(); // dataset
+  }
+
+  @Override
+  public Id.DatasetInstance getElement(MDSKey.Splitter splitter) {
+    return Id.DatasetInstance.from(splitter.getString(), splitter.getString());
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/internal/keymaker/ProgramKeyMaker.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/internal/keymaker/ProgramKeyMaker.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.registry.internal.keymaker;
+
+import co.cask.cdap.data2.dataset2.lib.table.MDSKey;
+import co.cask.cdap.data2.registry.internal.pair.KeyMaker;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.ProgramType;
+
+/**
+ * {@link KeyMaker} for {@link Id.Program}.
+ */
+public class ProgramKeyMaker implements KeyMaker<Id.Program> {
+
+  public static Id.Program getProgramId(Id.Application applicationId) {
+    // Use empty programId to denote applicationId
+    return Id.Program.from(applicationId, ProgramType.FLOW, "");
+  }
+
+  @Override
+  public MDSKey getKey(Id.Program programId) {
+    MDSKey.Builder keyBuilder = new MDSKey.Builder()
+      .add(programId.getNamespaceId())
+      .add(programId.getApplicationId());
+
+    // If programId is empty, this is actually applicationId
+    if (!programId.getId().isEmpty()) {
+      keyBuilder.add(programId.getType().getCategoryName());
+      keyBuilder.add(programId.getId());
+    }
+
+    return keyBuilder.build();
+  }
+
+  @Override
+  public void skipKey(MDSKey.Splitter splitter) {
+    splitter.skipString(); // namespace
+    splitter.skipString(); // app
+    splitter.skipString(); // type
+    splitter.skipString(); // program
+  }
+
+  @Override
+  public Id.Program getElement(MDSKey.Splitter splitter) {
+    return Id.Program.from(splitter.getString(), splitter.getString(),
+                           ProgramType.valueOfCategoryName(splitter.getString()),
+                           splitter.getString());
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/internal/keymaker/StreamKeyMaker.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/internal/keymaker/StreamKeyMaker.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.registry.internal.keymaker;
+
+import co.cask.cdap.data2.dataset2.lib.table.MDSKey;
+import co.cask.cdap.data2.registry.internal.pair.KeyMaker;
+import co.cask.cdap.proto.Id;
+
+/**
+ * {@link KeyMaker} for {@link Id.Stream}.
+ */
+public class StreamKeyMaker implements KeyMaker<Id.Stream> {
+  @Override
+  public MDSKey getKey(Id.Stream streamId) {
+    return new MDSKey.Builder()
+      .add(streamId.getNamespaceId())
+      .add(streamId.getId())
+      .build();
+  }
+
+  @Override
+  public void skipKey(MDSKey.Splitter splitter) {
+    splitter.skipString(); // namespace
+    splitter.skipString(); // stream
+  }
+
+  @Override
+  public Id.Stream getElement(MDSKey.Splitter splitter) {
+    return Id.Stream.from(splitter.getString(), splitter.getString());
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/internal/pair/KeyMaker.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/internal/pair/KeyMaker.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.registry.internal.pair;
+
+import co.cask.cdap.data2.dataset2.lib.table.MDSKey;
+import co.cask.cdap.proto.Id;
+
+/**
+ * Used to serialize/deserialize {@link Id}s into {@link MDSKey}.
+ *
+ * @param <T> type of Id.
+ */
+public interface KeyMaker<T extends Id> {
+  /**
+   * Serializes Id as MDSKey.
+   *
+   * @param id id
+   * @return MDSKey for id
+   */
+  public MDSKey getKey(T id);
+
+  /**
+   * Given a {@link MDSKey.Splitter}, deserialize Id from it.
+   *
+   * @param splitter splitter for id
+   * @return id
+   */
+  public T getElement(MDSKey.Splitter splitter);
+
+  /**
+   * Given {@link MDSKey.Splitter}, skip the fields of Id. This is used during de-serialization.
+   *
+   * @param splitter splitter for id
+   */
+  public void skipKey(MDSKey.Splitter splitter);
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/internal/pair/OrderedPair.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/internal/pair/OrderedPair.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.registry.internal.pair;
+
+import co.cask.cdap.data2.dataset2.lib.table.MDSKey;
+import co.cask.cdap.proto.Id;
+import com.google.common.collect.Sets;
+
+import java.util.Set;
+
+/**
+ * Represents a mapping between two {@link Id}s - FIRST and SECOND using MDSKey.
+ * Uses {@link KeyMaker} to serialize/deserialzie ids into MDSKey.
+ *
+ * @param <FIRST> type of first element
+ * @param <SECOND> type of second element
+ */
+public class OrderedPair<FIRST extends Id, SECOND extends Id> {
+  private final KeyMaker<FIRST> keyMaker1;
+  private final KeyMaker<SECOND> keyMaker2;
+  private final String prefix;
+
+  public OrderedPair(KeyMaker<FIRST> keyMaker1, KeyMaker<SECOND> keyMaker2, String prefix) {
+    this.keyMaker1 = keyMaker1;
+    this.keyMaker2 = keyMaker2;
+    this.prefix = prefix;
+  }
+
+  public String getPrefix() {
+    return prefix;
+  }
+
+  public MDSKey makeKey(FIRST first, SECOND second) {
+    return new MDSKey.Builder()
+      .add(getPrefix())
+      .append(keyMaker1.getKey(first))
+      .append(keyMaker2.getKey(second))
+      .build();
+  }
+
+  public MDSKey makeScanKey(FIRST first) {
+    return new MDSKey.Builder()
+      .add(getPrefix())
+      .append(keyMaker1.getKey(first))
+      .build();
+  }
+
+  public Set<SECOND> getSecond(Set<MDSKey> mdsKeys) {
+    Set<SECOND> secondSet = Sets.newHashSetWithExpectedSize(mdsKeys.size());
+    for (MDSKey mdsKey : mdsKeys) {
+      MDSKey.Splitter splitter = mdsKey.split();
+      splitter.skipString(); // prefix
+      keyMaker1.skipKey(splitter);
+      secondSet.add(this.keyMaker2.getElement(splitter));
+    }
+    return secondSet;
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/internal/pair/OrderedPairs.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/internal/pair/OrderedPairs.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.registry.internal.pair;
+
+import co.cask.cdap.proto.Id;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
+/**
+ * Registry of {@link KeyMaker}s for {@link Id}s.
+ */
+public class OrderedPairs {
+  private final Map<String, KeyMaker<? extends Id>> keyMakers;
+
+  public OrderedPairs(Map<String, KeyMaker<? extends Id>> keyMakers) {
+    this.keyMakers = ImmutableMap.copyOf(keyMakers);
+  }
+
+  public <FIRST extends Id, SECOND extends Id>
+  OrderedPair<FIRST, SECOND> get(String first, String second) {
+    @SuppressWarnings("unchecked")
+    KeyMaker<FIRST> keyMaker1 = (KeyMaker<FIRST>) keyMakers.get(first);
+    @SuppressWarnings("unchecked")
+    KeyMaker<SECOND> keyMaker2 = (KeyMaker<SECOND>) keyMakers.get(second);
+    return new OrderedPair<FIRST, SECOND>(keyMaker1, keyMaker2, first + second);
+  }
+}

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/DatasetFrameworkTestUtil.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/DatasetFrameworkTestUtil.java
@@ -116,6 +116,10 @@ public final class DatasetFrameworkTestUtil extends ExternalResource {
     }
   }
 
+  public DatasetFramework getFramework() {
+    return framework;
+  }
+
   public void addModule(Id.DatasetModule moduleId, DatasetModule module) throws DatasetManagementException {
     framework.addModule(moduleId, module);
   }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/MDSKeyTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/MDSKeyTest.java
@@ -153,4 +153,23 @@ public class MDSKeyTest {
     } catch (BufferUnderflowException expected) {
     }
   }
+
+  @Test
+  public void testAppend() {
+    MDSKey mdsKey1 = new MDSKey.Builder().add("ab").add(3L).add(new byte[]{'x', 'y'}).build();
+    MDSKey mdsKey2 = new MDSKey.Builder().add("bd").add(5).append(mdsKey1).add(new byte[]{'z', 'z'}).build();
+    MDSKey mdsKey3 = new MDSKey.Builder().add(2).add(new byte[]{'w'}).append(mdsKey2).add(8L).build();
+
+    // Assert
+    MDSKey.Splitter splitter = mdsKey3.split();
+    Assert.assertEquals(2, splitter.getInt());
+    Assert.assertArrayEquals(new byte[]{'w'}, splitter.getBytes());
+    Assert.assertEquals("bd", splitter.getString());
+    Assert.assertEquals(5, splitter.getInt());
+    Assert.assertEquals("ab", splitter.getString());
+    Assert.assertEquals(3L, splitter.getLong());
+    Assert.assertArrayEquals(new byte[]{'x', 'y'}, splitter.getBytes());
+    Assert.assertArrayEquals(new byte[]{'z', 'z'}, splitter.getBytes());
+    Assert.assertEquals(8L, splitter.getLong());
+  }
 }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/registry/UsageDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/registry/UsageDatasetTest.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.registry;
+
+import co.cask.cdap.data2.dataset2.DatasetFrameworkTestUtil;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.ProgramType;
+import com.google.common.collect.ImmutableSet;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class UsageDatasetTest {
+  @ClassRule
+  public static DatasetFrameworkTestUtil dsFrameworkUtil = new DatasetFrameworkTestUtil();
+
+  private final Id.Program flow11 = Id.Program.from("ns1", "app1", ProgramType.FLOW, "flow11");
+  private final Id.Program flow12 = Id.Program.from("ns1", "app1", ProgramType.FLOW, "flow12");
+  private final Id.Program service11 = Id.Program.from("ns1", "app1", ProgramType.SERVICE, "service11");
+
+  private final Id.Program flow21 = Id.Program.from("ns1", "app2", ProgramType.FLOW, "flow21");
+  private final Id.Program flow22 = Id.Program.from("ns1", "app2", ProgramType.FLOW, "flow22");
+  private final Id.Program service21 = Id.Program.from("ns1", "app2", ProgramType.SERVICE, "service21");
+
+  private final Id.DatasetInstance datasetInstance1 = Id.DatasetInstance.from("ns1", "ds1");
+  private final Id.DatasetInstance datasetInstance2 = Id.DatasetInstance.from("ns1", "ds2");
+  private final Id.DatasetInstance datasetInstance3 = Id.DatasetInstance.from("ns1", "ds3");
+
+  private final Id.Stream stream1 = Id.Stream.from("ns1", "s1");
+  private final Id.Stream stream2 = Id.Stream.from("ns2", "s1");
+
+  private final Id.Adapter adapter1 = Id.Adapter.from("ns1", "adapter1");
+  private final Id.Adapter adapter2 = Id.Adapter.from("ns2", "adapter1");
+
+  @Test
+  public void testOneMapping() throws Exception {
+    UsageDataset usageDataset = getUsageDataset("testOneMapping");
+
+    // Add mapping
+    usageDataset.register(flow11, datasetInstance1);
+
+    // Verify mapping
+    Assert.assertEquals(ImmutableSet.of(datasetInstance1), usageDataset.getDatasets(flow11));
+  }
+
+  @Test
+  public void testProgramDatasetMapping() throws Exception {
+    UsageDataset usageDataset = getUsageDataset("testProgramDatasetMapping");
+
+    // Add mappings
+    usageDataset.register(flow11, datasetInstance1);
+    usageDataset.register(flow11, datasetInstance3);
+    usageDataset.register(flow12, datasetInstance2);
+    usageDataset.register(service11, datasetInstance1);
+
+    usageDataset.register(flow21, datasetInstance2);
+    usageDataset.register(service21, datasetInstance1);
+
+    // Verify program mappings
+    Assert.assertEquals(ImmutableSet.of(datasetInstance1, datasetInstance3), usageDataset.getDatasets(flow11));
+    Assert.assertEquals(ImmutableSet.of(datasetInstance2), usageDataset.getDatasets(flow12));
+    Assert.assertEquals(ImmutableSet.of(datasetInstance1), usageDataset.getDatasets(service11));
+
+    Assert.assertEquals(ImmutableSet.of(datasetInstance2), usageDataset.getDatasets(flow21));
+    Assert.assertEquals(ImmutableSet.of(datasetInstance1), usageDataset.getDatasets(service21));
+
+    // Verify app mappings
+    Assert.assertEquals(ImmutableSet.of(datasetInstance1, datasetInstance2, datasetInstance3),
+                        usageDataset.getDatasets(flow11.getApplication()));
+    Assert.assertEquals(ImmutableSet.of(datasetInstance1, datasetInstance2),
+                        usageDataset.getDatasets(flow21.getApplication()));
+
+    // Verify dataset mappings
+    Assert.assertEquals(ImmutableSet.of(flow11, service11, service21), usageDataset.getPrograms(datasetInstance1));
+    Assert.assertEquals(ImmutableSet.of(flow12, flow21), usageDataset.getPrograms(datasetInstance2));
+    Assert.assertEquals(ImmutableSet.of(flow11), usageDataset.getPrograms(datasetInstance3));
+
+    // --------- Delete app1 -----------
+    usageDataset.unregister(flow11.getApplication());
+
+    // There should be no mappings for programs of app1 now
+    Assert.assertEquals(ImmutableSet.<Id.DatasetInstance>of(), usageDataset.getDatasets(flow11));
+    Assert.assertEquals(ImmutableSet.<Id.DatasetInstance>of(), usageDataset.getDatasets(flow12));
+    Assert.assertEquals(ImmutableSet.<Id.DatasetInstance>of(), usageDataset.getDatasets(service11));
+
+    Assert.assertEquals(ImmutableSet.of(datasetInstance2), usageDataset.getDatasets(flow21));
+    Assert.assertEquals(ImmutableSet.of(datasetInstance1), usageDataset.getDatasets(service21));
+
+    // Verify app mappings
+    Assert.assertEquals(ImmutableSet.<Id.DatasetInstance>of(), usageDataset.getDatasets(flow11.getApplication()));
+    Assert.assertEquals(ImmutableSet.of(datasetInstance1, datasetInstance2),
+                        usageDataset.getDatasets(flow21.getApplication()));
+
+    // Verify dataset mappings
+    Assert.assertEquals(ImmutableSet.of(service21), usageDataset.getPrograms(datasetInstance1));
+    Assert.assertEquals(ImmutableSet.of(flow21), usageDataset.getPrograms(datasetInstance2));
+    Assert.assertEquals(ImmutableSet.<Id.Program>of(), usageDataset.getPrograms(datasetInstance3));
+  }
+
+  @Test
+  public void testAllMappings() throws Exception {
+    UsageDataset usageDataset = getUsageDataset("testAllMappings");
+
+    // Add mappings
+    usageDataset.register(flow11, datasetInstance1);
+    usageDataset.register(service21, datasetInstance3);
+
+    usageDataset.register(adapter1, datasetInstance1);
+    usageDataset.register(adapter1, datasetInstance2);
+
+    usageDataset.register(flow12, stream1);
+    usageDataset.register(adapter2, stream2);
+
+    // Verify app/adapter mappings
+    Assert.assertEquals(ImmutableSet.of(datasetInstance1), usageDataset.getDatasets(flow11));
+    Assert.assertEquals(ImmutableSet.<Id.DatasetInstance>of(), usageDataset.getDatasets(flow12));
+    Assert.assertEquals(ImmutableSet.of(datasetInstance3), usageDataset.getDatasets(service21));
+
+    Assert.assertEquals(ImmutableSet.of(datasetInstance1, datasetInstance2), usageDataset.getDatasets(adapter1));
+
+    Assert.assertEquals(ImmutableSet.of(stream1), usageDataset.getStreams(flow12));
+    Assert.assertEquals(ImmutableSet.<Id.Stream>of(), usageDataset.getStreams(flow22));
+    Assert.assertEquals(ImmutableSet.of(stream2), usageDataset.getStreams(adapter2));
+
+    // Verify dataset/stream mappings
+    Assert.assertEquals(ImmutableSet.of(flow11), usageDataset.getPrograms(datasetInstance1));
+    Assert.assertEquals(ImmutableSet.of(adapter1), usageDataset.getAdapters(datasetInstance1));
+    Assert.assertEquals(ImmutableSet.of(flow12), usageDataset.getPrograms(stream1));
+    Assert.assertEquals(ImmutableSet.<Id.Program>of(), usageDataset.getPrograms(stream2));
+    Assert.assertEquals(ImmutableSet.of(adapter2), usageDataset.getAdapters(stream2));
+
+    // --------- Delete app1 -----------
+    usageDataset.unregister(flow11.getApplication());
+
+    // Verify app/adapter mappings
+    Assert.assertEquals(ImmutableSet.<Id.DatasetInstance>of(), usageDataset.getDatasets(flow11));
+    Assert.assertEquals(ImmutableSet.<Id.DatasetInstance>of(), usageDataset.getDatasets(flow12));
+    Assert.assertEquals(ImmutableSet.of(datasetInstance3), usageDataset.getDatasets(service21));
+
+    Assert.assertEquals(ImmutableSet.of(datasetInstance1, datasetInstance2), usageDataset.getDatasets(adapter1));
+
+    Assert.assertEquals(ImmutableSet.<Id.Stream>of(), usageDataset.getStreams(flow12));
+    Assert.assertEquals(ImmutableSet.<Id.Stream>of(), usageDataset.getStreams(flow22));
+    Assert.assertEquals(ImmutableSet.of(stream2), usageDataset.getStreams(adapter2));
+
+    // Verify dataset/stream mappings
+    Assert.assertEquals(ImmutableSet.<Id.Program>of(), usageDataset.getPrograms(datasetInstance1));
+    Assert.assertEquals(ImmutableSet.of(adapter1), usageDataset.getAdapters(datasetInstance1));
+    Assert.assertEquals(ImmutableSet.<Id.Program>of(), usageDataset.getPrograms(stream1));
+    Assert.assertEquals(ImmutableSet.<Id.Program>of(), usageDataset.getPrograms(stream2));
+    Assert.assertEquals(ImmutableSet.of(adapter2), usageDataset.getAdapters(stream2));
+
+    // --------- Delete adapter1 -----------
+    usageDataset.unregister(adapter1);
+
+    // Verify app/adapter mappings
+    Assert.assertEquals(ImmutableSet.<Id.DatasetInstance>of(), usageDataset.getDatasets(flow11));
+    Assert.assertEquals(ImmutableSet.<Id.DatasetInstance>of(), usageDataset.getDatasets(flow12));
+    Assert.assertEquals(ImmutableSet.of(datasetInstance3), usageDataset.getDatasets(service21));
+
+    Assert.assertEquals(ImmutableSet.<Id.DatasetInstance>of(), usageDataset.getDatasets(adapter1));
+
+    Assert.assertEquals(ImmutableSet.<Id.Stream>of(), usageDataset.getStreams(flow12));
+    Assert.assertEquals(ImmutableSet.<Id.Stream>of(), usageDataset.getStreams(flow22));
+    Assert.assertEquals(ImmutableSet.of(stream2), usageDataset.getStreams(adapter2));
+
+    // Verify dataset/stream mappings
+    Assert.assertEquals(ImmutableSet.<Id.Program>of(), usageDataset.getPrograms(datasetInstance1));
+    Assert.assertEquals(ImmutableSet.<Id.Adapter>of(), usageDataset.getAdapters(datasetInstance1));
+    Assert.assertEquals(ImmutableSet.<Id.Program>of(), usageDataset.getPrograms(stream1));
+    Assert.assertEquals(ImmutableSet.<Id.Program>of(), usageDataset.getPrograms(stream2));
+    Assert.assertEquals(ImmutableSet.of(adapter2), usageDataset.getAdapters(stream2));
+
+    // --------- Delete adapter2 -----------
+    usageDataset.unregister(adapter2);
+
+    // Verify app/adapter mappings
+    Assert.assertEquals(ImmutableSet.<Id.DatasetInstance>of(), usageDataset.getDatasets(flow11));
+    Assert.assertEquals(ImmutableSet.<Id.DatasetInstance>of(), usageDataset.getDatasets(flow12));
+    Assert.assertEquals(ImmutableSet.of(datasetInstance3), usageDataset.getDatasets(service21));
+
+    Assert.assertEquals(ImmutableSet.<Id.DatasetInstance>of(), usageDataset.getDatasets(adapter1));
+
+    Assert.assertEquals(ImmutableSet.<Id.Stream>of(), usageDataset.getStreams(flow12));
+    Assert.assertEquals(ImmutableSet.<Id.Stream>of(), usageDataset.getStreams(flow22));
+    Assert.assertEquals(ImmutableSet.<Id.Stream>of(), usageDataset.getStreams(adapter2));
+
+    // Verify dataset/stream mappings
+    Assert.assertEquals(ImmutableSet.<Id.Program>of(), usageDataset.getPrograms(datasetInstance1));
+    Assert.assertEquals(ImmutableSet.<Id.Adapter>of(), usageDataset.getAdapters(datasetInstance1));
+    Assert.assertEquals(ImmutableSet.<Id.Program>of(), usageDataset.getPrograms(stream1));
+    Assert.assertEquals(ImmutableSet.<Id.Program>of(), usageDataset.getPrograms(stream2));
+    Assert.assertEquals(ImmutableSet.<Id.Adapter>of(), usageDataset.getAdapters(stream2));
+
+    // --------- Delete app2 -----------
+    usageDataset.unregister(flow21.getApplication());
+    // Verify app/adapter mappings
+    Assert.assertEquals(ImmutableSet.<Id.DatasetInstance>of(), usageDataset.getDatasets(flow11));
+    Assert.assertEquals(ImmutableSet.<Id.DatasetInstance>of(), usageDataset.getDatasets(flow12));
+    Assert.assertEquals(ImmutableSet.<Id.DatasetInstance>of(), usageDataset.getDatasets(service21));
+
+    Assert.assertEquals(ImmutableSet.<Id.DatasetInstance>of(), usageDataset.getDatasets(adapter1));
+
+    Assert.assertEquals(ImmutableSet.<Id.Stream>of(), usageDataset.getStreams(flow12));
+    Assert.assertEquals(ImmutableSet.<Id.Stream>of(), usageDataset.getStreams(flow22));
+    Assert.assertEquals(ImmutableSet.<Id.Stream>of(), usageDataset.getStreams(adapter2));
+
+    // Verify dataset/stream mappings
+    Assert.assertEquals(ImmutableSet.<Id.Program>of(), usageDataset.getPrograms(datasetInstance1));
+    Assert.assertEquals(ImmutableSet.<Id.Adapter>of(), usageDataset.getAdapters(datasetInstance1));
+    Assert.assertEquals(ImmutableSet.<Id.Program>of(), usageDataset.getPrograms(stream1));
+    Assert.assertEquals(ImmutableSet.<Id.Program>of(), usageDataset.getPrograms(stream2));
+    Assert.assertEquals(ImmutableSet.<Id.Adapter>of(), usageDataset.getAdapters(stream2));
+  }
+
+  private static UsageDataset getUsageDataset(String instanceId) throws Exception {
+    Id.DatasetInstance id = Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, instanceId);
+    return UsageDatasets.get(dsFrameworkUtil.getFramework(), id);
+  }
+}


### PR DESCRIPTION
Implementation for Usage Dataset that stores what datasets/streams are used by what programs/adapters. It stores each usage as two mappings.
For example, if program P uses dataset D then P->D and D->P mappings are stored.

JIRA https://issues.cask.co/browse/CDAP-2095
