### PR TITLE
Made TestSource customizable so it can emit StructuredRecords that can b...

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/sources/TestSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/sources/TestSource.java
@@ -17,31 +17,52 @@
 package co.cask.cdap.templates.etl.realtime.sources;
 
 import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.templates.etl.api.Emitter;
+import co.cask.cdap.templates.etl.api.Property;
 import co.cask.cdap.templates.etl.api.StageConfigurer;
 import co.cask.cdap.templates.etl.api.realtime.RealtimeSource;
+import co.cask.cdap.templates.etl.api.realtime.SourceContext;
 import co.cask.cdap.templates.etl.api.realtime.SourceState;
+import com.google.common.base.Charsets;
+import com.google.common.collect.ImmutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.ByteBuffer;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
 /**
- * Realtime TestSource that emits a string with a delay.
+ * Realtime TestSource that emits {@link StructuredRecord} objects as needed for testing.
  */
-public class TestSource extends RealtimeSource<String> {
+public class TestSource extends RealtimeSource<StructuredRecord> {
   private static final Logger LOG = LoggerFactory.getLogger(TestSource.class);
   private static final String COUNT = "count";
+  public static final String PROPERTY_TYPE = "type";
+  public static final String STREAM_TYPE = "stream";
+  public static final String TABLE_TYPE = "table";
+
+  private String type;
 
   @Override
   public void configure(StageConfigurer configurer) {
-    configurer.setName(TestSource.class.getSimpleName());
+    configurer.setDescription("Source that can generate test data for Real-time Stream and Table Sinks");
+    configurer.addProperty(new Property(PROPERTY_TYPE, "The type of data to be generated. Currently, only two types" +
+      " - 'stream' and 'table' are supported. By default, it generates a structured record containing one field - " +
+      "'data' of type String with value 'Hello'", false));
+  }
+
+  @Override
+  public void initialize(SourceContext context) throws Exception {
+    super.initialize(context);
+    type = context.getRuntimeArguments().get("type");
   }
 
   @Nullable
   @Override
-  public SourceState poll(Emitter<String> writer, SourceState currentState) {
+  public SourceState poll(Emitter<StructuredRecord> writer, SourceState currentState) {
     try {
       TimeUnit.MILLISECONDS.sleep(100);
     } catch (InterruptedException e) {
@@ -60,7 +81,69 @@ public class TestSource extends RealtimeSource<String> {
     }
 
     LOG.info("Emitting data! {}", prevCount);
-    writer.emit("Hello");
+
+    if (type == null) {
+      writeDefaultRecords(writer);
+    } else if (STREAM_TYPE.equals(type)) {
+      writeRecordsForStreamConsumption(writer);
+    } else if (TABLE_TYPE.equals(type)) {
+      writeRecordsForTableConsumption(writer);
+    }
     return currentState;
+  }
+
+  private void writeDefaultRecords(Emitter<StructuredRecord> writer) {
+    Schema.Field dataField = Schema.Field.of("data", Schema.of(Schema.Type.STRING));
+    StructuredRecord.Builder recordBuilder = StructuredRecord.builder(Schema.recordOf("defaultRecord", dataField));
+    recordBuilder.set("data", "Hello");
+    writer.emit(recordBuilder.build());
+  }
+
+  private void writeRecordsForStreamConsumption(Emitter<StructuredRecord> writer) {
+    Schema.Field dataField = Schema.Field.of("data", Schema.of(Schema.Type.STRING));
+    Schema.Field headersField = Schema.Field.of("headers", Schema.mapOf(Schema.of(Schema.Type.STRING),
+                                                                        Schema.of(Schema.Type.STRING)));
+    Schema.Field tsField = Schema.Field.of("timestamp", Schema.of(Schema.Type.LONG));
+    // emit only string
+    StructuredRecord.Builder recordBuilder = StructuredRecord.builder(Schema.recordOf("StringRecord", dataField));
+    recordBuilder.set("data", "Hello");
+    writer.emit(recordBuilder.build());
+    // emit string + headers
+    recordBuilder = StructuredRecord.builder(Schema.recordOf("StringHeadersRecord", dataField, headersField));
+    recordBuilder.set("data", "Hello");
+    recordBuilder.set("headers", ImmutableMap.of("h1", "v1"));
+    writer.emit(recordBuilder.build());
+    // byte array + headers
+    dataField = Schema.Field.of("data", Schema.of(Schema.Type.BYTES));
+    recordBuilder = StructuredRecord.builder(Schema.recordOf("ByteArrayHeadersRecord", dataField, headersField));
+    recordBuilder.set("data", "Hello".getBytes(Charsets.UTF_8));
+    recordBuilder.set("headers", ImmutableMap.of("h1", "v1"));
+    writer.emit(recordBuilder.build());
+    // ByteBuffer + headers + timestamp
+    recordBuilder = StructuredRecord.builder(Schema.recordOf("ByteBufferHeadersTsRecord", dataField, headersField,
+                                                             tsField));
+    recordBuilder.set("data", ByteBuffer.wrap("Hello".getBytes(Charsets.UTF_8)));
+    recordBuilder.set("headers", ImmutableMap.of("h1", "v1"));
+    recordBuilder.set("timestamp", System.currentTimeMillis());
+    writer.emit(recordBuilder.build());
+  }
+
+  private void writeRecordsForTableConsumption(Emitter<StructuredRecord> writer) {
+    Schema.Field idField = Schema.Field.of("id", Schema.of(Schema.Type.INT));
+    Schema.Field nameField = Schema.Field.of("name", Schema.of(Schema.Type.STRING));
+    Schema.Field scoreField = Schema.Field.of("score", Schema.of(Schema.Type.DOUBLE));
+    Schema.Field graduatedField = Schema.Field.of("graduated", Schema.of(Schema.Type.BOOLEAN));
+    Schema.Field binaryNameField = Schema.Field.of("binary", Schema.of(Schema.Type.BYTES));
+    Schema.Field timeField = Schema.Field.of("time", Schema.of(Schema.Type.LONG));
+    StructuredRecord.Builder recordBuilder = StructuredRecord.builder(
+      Schema.recordOf("tableRecord", idField, nameField, scoreField, graduatedField, binaryNameField, timeField));
+    recordBuilder
+      .set("id", 1)
+      .set("name", "Bob").
+      set("score", 3.4)
+      .set("graduated", false)
+      .set("binary", "Bob".getBytes(Charsets.UTF_8))
+      .set("time", System.currentTimeMillis());
+    writer.emit(recordBuilder.build());
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/test/resources/logback-test.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/test/resources/logback-test.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Copyright © 2014 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+  -->
+
+<!--                                                                         -->
+<!-- AppFabric Logging Configuration                                         -->
+<!--                                                                         -->
+<!-- We use the LogBack project for logging in AppFabric. The manual for     -->
+<!-- Logback can be found here: http://logback.qos.ch/manual                 -->
+<!--                                                                         -->
+
+<configuration>
+    <!--Supressing some chatty loggers -->
+    <logger name="org.apache.hadoop" level="INFO"/>
+    <logger name="org.mortbay.log" level="INFO"/>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{ISO8601} - %-5p [%t:%C{1}@%L] - %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="CLOG" class="co.cask.cdap.common.logging.logback.CAppender">              
+        <layout>                      
+            <!-- Note: we don't insert new line in the pattern as this is done on higher level (in old back-end) -->
+            <pattern>%d{ISO8601} - %-5p [%t:%C{1}@%L] - %m</pattern>       
+        </layout>
+    </appender>
+
+    <logger name="co.cask.cdap" level="INFO" />
+
+    <root level="WARN">
+        <appender-ref ref="CLOG"/>
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+</configuration>


### PR DESCRIPTION
...e used to test Stream as well as Table Sink


No Jira for this one, this merely helps you customize test data according to specific needs of the sink that you wish to test. 

Wanted to make #2062 an upcoming PR for TableSink less dense.

Build: http://builds.cask.co/browse/CDAP-DT40-1