### PR TITLE
Add cdap-api and cdap-unit-test modules to templates mvn profile.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1456,6 +1456,8 @@
     <profile>
       <id>templates</id>
       <modules>
+        <module>cdap-api</module>
+        <module>cdap-unit-test</module>
         <module>cdap-app-templates</module>
       </modules>
     </profile>


### PR DESCRIPTION
Just in case we make changes to the class in those module dependencies we do not need to
rely on snapshots build to happen to make the CI build for feature-adapter branches to pass.