### PR TITLE
create namespace before initializing DSFramework

### DIFF
--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
@@ -337,8 +337,8 @@ public class UpgradeTool {
     // Start all the services.
     zkClientService.startAndWait();
     txService.startAndWait();
-    initializeDSFramework(cConf, dsFramework);
     createNamespaces();
+    initializeDSFramework(cConf, dsFramework);
   }
 
   /**


### PR DESCRIPTION
The system namespace must be created before we setup DSFramework 