### PR TITLE
[CDAP-2171] Deprecated StreamWriter in favor of StreamManager. This will...

### DIFF
--- a/cdap-adapters/src/test/java/co/cask/cdap/conversion/app/StreamConversionAdapterTest.java
+++ b/cdap-adapters/src/test/java/co/cask/cdap/conversion/app/StreamConversionAdapterTest.java
@@ -23,7 +23,7 @@ import co.cask.cdap.api.dataset.lib.TimePartitionedFileSet;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.DataSetManager;
 import co.cask.cdap.test.MapReduceManager;
-import co.cask.cdap.test.StreamWriter;
+import co.cask.cdap.test.StreamManager;
 import co.cask.cdap.test.TestBase;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
@@ -58,11 +58,11 @@ public class StreamConversionAdapterTest extends TestBase {
     ApplicationManager appManager = deployApplication(StreamConversionAdapter.class);
 
     // create and write to the stream
-    StreamWriter streamWriter = appManager.getStreamWriter(streamName);
-    streamWriter.createStream();
-    streamWriter.send(ImmutableMap.of("header1", "bar"), "AAPL,10,500.32");
-    streamWriter.send(ImmutableMap.of("header1", "baz", "header2", "foo"), "CASK,50,12345.67");
-    streamWriter.send(ImmutableMap.<String, String>of(), "YHOO,1,48.53");
+    StreamManager streamManager = getStreamManager(streamName);
+    streamManager.createStream();
+    streamManager.send(ImmutableMap.of("header1", "bar"), "AAPL,10,500.32");
+    streamManager.send(ImmutableMap.of("header1", "baz", "header2", "foo"), "CASK,50,12345.67");
+    streamManager.send(ImmutableMap.<String, String>of(), "YHOO,1,48.53");
 
     Schema bodySchema = Schema.recordOf(
       "event",

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/co/cask/cdap/templates/etl/batch/ETLStreamConversionTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/co/cask/cdap/templates/etl/batch/ETLStreamConversionTest.java
@@ -31,7 +31,7 @@ import co.cask.cdap.templates.etl.transforms.StructuredRecordToGenericRecordTran
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.DataSetManager;
 import co.cask.cdap.test.MapReduceManager;
-import co.cask.cdap.test.StreamWriter;
+import co.cask.cdap.test.StreamManager;
 import co.cask.cdap.test.TestBase;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
@@ -90,9 +90,9 @@ public class ETLStreamConversionTest extends TestBase {
       .build());
 
     ApplicationManager batchManager = deployApplication(ETLBatchTemplate.class);
-    StreamWriter streamWriter = batchManager.getStreamWriter("myStream");
-    streamWriter.createStream();
-    streamWriter.send(ImmutableMap.of("header1", "bar"), "AAPL|10|500.32");
+    StreamManager streamManager = getStreamManager("myStream");
+    streamManager.createStream();
+    streamManager.send(ImmutableMap.of("header1", "bar"), "AAPL|10|500.32");
 
     ApplicationTemplate<ETLBatchConfig> appTemplate = new ETLBatchTemplate();
     ETLBatchConfig adapterConfig = constructETLBatchConfig(filesetName);

--- a/cdap-examples/HelloWorld/src/test/java/co/cask/cdap/examples/helloworld/HelloWorldTest.java
+++ b/cdap-examples/HelloWorld/src/test/java/co/cask/cdap/examples/helloworld/HelloWorldTest.java
@@ -20,18 +20,16 @@ import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.FlowManager;
 import co.cask.cdap.test.RuntimeStats;
 import co.cask.cdap.test.ServiceManager;
-import co.cask.cdap.test.StreamWriter;
+import co.cask.cdap.test.StreamManager;
 import co.cask.cdap.test.TestBase;
 import com.google.common.base.Charsets;
 import com.google.common.io.ByteStreams;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 /**
  * Test for {@link HelloWorld}.
@@ -39,7 +37,7 @@ import java.util.concurrent.TimeoutException;
 public class HelloWorldTest extends TestBase {
 
   @Test
-  public void test() throws TimeoutException, InterruptedException, IOException {
+  public void test() throws Exception {
     // Deploy the HelloWorld application
     ApplicationManager appManager = deployApplication(HelloWorld.class);
 
@@ -48,12 +46,12 @@ public class HelloWorldTest extends TestBase {
     Assert.assertTrue(flowManager.isRunning());
 
     // Send stream events to the "who" Stream
-    StreamWriter streamWriter = appManager.getStreamWriter("who");
-    streamWriter.send("1");
-    streamWriter.send("2");
-    streamWriter.send("3");
-    streamWriter.send("4");
-    streamWriter.send("5");
+    StreamManager streamManager = getStreamManager("who");
+    streamManager.send("1");
+    streamManager.send("2");
+    streamManager.send("3");
+    streamManager.send("4");
+    streamManager.send("5");
 
     try {
       // Wait for the last Flowlet processing 5 events, or at most 5 seconds

--- a/cdap-examples/Purchase/src/test/java/co/cask/cdap/examples/purchase/PurchaseAppTest.java
+++ b/cdap-examples/Purchase/src/test/java/co/cask/cdap/examples/purchase/PurchaseAppTest.java
@@ -22,7 +22,7 @@ import co.cask.cdap.test.FlowManager;
 import co.cask.cdap.test.MapReduceManager;
 import co.cask.cdap.test.RuntimeStats;
 import co.cask.cdap.test.ServiceManager;
-import co.cask.cdap.test.StreamWriter;
+import co.cask.cdap.test.StreamManager;
 import co.cask.cdap.test.TestBase;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
@@ -31,11 +31,9 @@ import com.google.gson.Gson;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 /**
  * Test for {@link PurchaseApp}.
@@ -45,7 +43,7 @@ public class PurchaseAppTest extends TestBase {
   private static final Gson GSON = new Gson();
 
   @Test
-  public void test() throws TimeoutException, InterruptedException, IOException {
+  public void test() throws Exception {
     // Deploy the PurchaseApp application
     ApplicationManager appManager = deployApplication(PurchaseApp.class);
 
@@ -53,12 +51,12 @@ public class PurchaseAppTest extends TestBase {
     FlowManager flowManager = appManager.startFlow("PurchaseFlow");
 
     // Send stream events to the "purchaseStream" Stream
-    StreamWriter streamWriter = appManager.getStreamWriter("purchaseStream");
-    streamWriter.send("bob bought 3 apples for $30");
-    streamWriter.send("joe bought 1 apple for $100");
-    streamWriter.send("joe bought 10 pineapples for $20");
-    streamWriter.send("cat bought 3 bottles for $12");
-    streamWriter.send("cat bought 2 pops for $14");
+    StreamManager streamManager = getStreamManager("purchaseStream");
+    streamManager.send("bob bought 3 apples for $30");
+    streamManager.send("joe bought 1 apple for $100");
+    streamManager.send("joe bought 10 pineapples for $20");
+    streamManager.send("cat bought 3 bottles for $12");
+    streamManager.send("cat bought 2 pops for $14");
 
     try {
       // Wait for the last Flowlet processing 5 events, or at most 5 seconds

--- a/cdap-examples/SparkKMeans/src/test/java/co/cask/cdap/examples/sparkkmeans/SparkKMeansAppTest.java
+++ b/cdap-examples/SparkKMeans/src/test/java/co/cask/cdap/examples/sparkkmeans/SparkKMeansAppTest.java
@@ -22,7 +22,7 @@ import co.cask.cdap.test.FlowManager;
 import co.cask.cdap.test.RuntimeStats;
 import co.cask.cdap.test.ServiceManager;
 import co.cask.cdap.test.SparkManager;
-import co.cask.cdap.test.StreamWriter;
+import co.cask.cdap.test.StreamManager;
 import co.cask.cdap.test.TestBase;
 import com.google.common.base.Charsets;
 import com.google.common.io.ByteStreams;
@@ -46,12 +46,12 @@ public class SparkKMeansAppTest extends TestBase {
     // Start the Flow
     FlowManager flowManager = appManager.startFlow("PointsFlow");
     // Send a few points to the stream
-    StreamWriter streamWriter = appManager.getStreamWriter("pointsStream");
-    streamWriter.send("10.6 519.2 110.3");
-    streamWriter.send("10.6 518.1 110.1");
-    streamWriter.send("10.6 519.6 109.9");
-    streamWriter.send("10.6 517.9 108.9");
-    streamWriter.send("10.7 518 109.2");
+    StreamManager streamManager = getStreamManager("pointsStream");
+    streamManager.send("10.6 519.2 110.3");
+    streamManager.send("10.6 518.1 110.1");
+    streamManager.send("10.6 519.6 109.9");
+    streamManager.send("10.6 517.9 108.9");
+    streamManager.send("10.7 518 109.2");
 
     //  Wait for the events to be processed, or at most 5 seconds
     RuntimeMetrics metrics = RuntimeStats.getFlowletMetrics("SparkKMeans", "PointsFlow", "reader");

--- a/cdap-examples/SparkPageRank/src/test/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankAppTest.java
+++ b/cdap-examples/SparkPageRank/src/test/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankAppTest.java
@@ -19,7 +19,7 @@ package co.cask.cdap.examples.sparkpagerank;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.ServiceManager;
 import co.cask.cdap.test.SparkManager;
-import co.cask.cdap.test.StreamWriter;
+import co.cask.cdap.test.StreamManager;
 import co.cask.cdap.test.TestBase;
 import com.google.common.base.Charsets;
 import com.google.common.io.ByteStreams;
@@ -46,11 +46,11 @@ public class SparkPageRankAppTest extends TestBase {
     ApplicationManager appManager = deployApplication(SparkPageRankApp.class);
 
     // Send a stream events to the Stream
-    StreamWriter streamWriter = appManager.getStreamWriter("backlinkURLStream");
-    streamWriter.send(URL_PAIR12);
-    streamWriter.send(URL_PAIR13);
-    streamWriter.send(URL_PAIR21);
-    streamWriter.send(URL_PAIR31);
+    StreamManager streamManager = getStreamManager("backlinkURLStream");
+    streamManager.send(URL_PAIR12);
+    streamManager.send(URL_PAIR13);
+    streamManager.send(URL_PAIR21);
+    streamManager.send(URL_PAIR31);
 
     // Start GoogleTypePR
     ServiceManager transformServiceManager = appManager.startService(SparkPageRankApp.GOOGLE_TYPE_PR_SERVICE_NAME);

--- a/cdap-examples/StreamConversion/src/test/java/co/cask/cdap/examples/streamconversion/StreamConversionTest.java
+++ b/cdap-examples/StreamConversion/src/test/java/co/cask/cdap/examples/streamconversion/StreamConversionTest.java
@@ -23,7 +23,7 @@ import co.cask.cdap.common.utils.Tasks;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.DataSetManager;
 import co.cask.cdap.test.MapReduceManager;
-import co.cask.cdap.test.StreamWriter;
+import co.cask.cdap.test.StreamManager;
 import co.cask.cdap.test.TestBase;
 import org.junit.Assert;
 import org.junit.Test;
@@ -51,10 +51,10 @@ public class StreamConversionTest extends TestBase {
     ApplicationManager appManager = deployApplication(StreamConversionApp.class);
 
     // send some data to the events stream
-    StreamWriter streamWriter = appManager.getStreamWriter("events");
-    streamWriter.send("15");
-    streamWriter.send("16");
-    streamWriter.send("17");
+    StreamManager streamManager = getStreamManager("events");
+    streamManager.send("15");
+    streamManager.send("16");
+    streamManager.send("17");
 
     // record the current time
     final long startTime = System.currentTimeMillis();

--- a/cdap-examples/UserProfiles/src/test/java/co/cask/cdap/examples/profiles/UserProfilesTest.java
+++ b/cdap-examples/UserProfiles/src/test/java/co/cask/cdap/examples/profiles/UserProfilesTest.java
@@ -25,7 +25,7 @@ import co.cask.cdap.test.DataSetManager;
 import co.cask.cdap.test.FlowManager;
 import co.cask.cdap.test.RuntimeStats;
 import co.cask.cdap.test.ServiceManager;
-import co.cask.cdap.test.StreamWriter;
+import co.cask.cdap.test.StreamManager;
 import co.cask.cdap.test.TestBase;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
@@ -119,8 +119,8 @@ public class UserProfilesTest extends TestBase {
 
     // send an event to the stream
     long activeTime = System.currentTimeMillis();
-    StreamWriter streamWriter = applicationManager.getStreamWriter("events");
-    streamWriter.send(new Gson().toJson(new Event(activeTime, "1234", "/some/path")));
+    StreamManager streamManager = getStreamManager("events");
+    streamManager.send(new Gson().toJson(new Event(activeTime, "1234", "/some/path")));
 
     try {
       // Wait for the last Flowlet processing 1 events, or at most 5 seconds

--- a/cdap-examples/WebAnalytics/src/test/java/co/cask/cdap/examples/webanalytics/WebAnalyticsTest.java
+++ b/cdap-examples/WebAnalytics/src/test/java/co/cask/cdap/examples/webanalytics/WebAnalyticsTest.java
@@ -19,7 +19,7 @@ package co.cask.cdap.examples.webanalytics;
 import co.cask.cdap.api.metrics.RuntimeMetrics;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.RuntimeStats;
-import co.cask.cdap.test.StreamWriter;
+import co.cask.cdap.test.StreamManager;
 import co.cask.cdap.test.TestBase;
 import org.junit.Assert;
 import org.junit.Test;
@@ -43,14 +43,14 @@ public class WebAnalyticsTest extends TestBase {
     appManager.startFlow("WebAnalyticsFlow");
 
     // Send events to the Stream
-    StreamWriter writer = appManager.getStreamWriter("log");
+    StreamManager streamManager = getStreamManager("log");
     BufferedReader reader = new BufferedReader(new InputStreamReader(getClass().getResourceAsStream("/access.log"),
                                                                      "UTF-8"));
     int lines = 0;
     try {
       String line = reader.readLine();
       while (line != null) {
-        writer.send(line);
+        streamManager.send(line);
         lines++;
         line = reader.readLine();
       }

--- a/cdap-examples/WordCount/src/test/java/co/cask/cdap/examples/wordcount/WordCountTest.java
+++ b/cdap-examples/WordCount/src/test/java/co/cask/cdap/examples/wordcount/WordCountTest.java
@@ -20,7 +20,7 @@ import co.cask.cdap.api.metrics.RuntimeMetrics;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.RuntimeStats;
 import co.cask.cdap.test.ServiceManager;
-import co.cask.cdap.test.StreamWriter;
+import co.cask.cdap.test.StreamManager;
 import co.cask.cdap.test.TestBase;
 import com.google.common.base.Charsets;
 import com.google.common.io.ByteStreams;
@@ -35,20 +35,17 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 /**
  * Word Count main test.
  */
 public class WordCountTest extends TestBase {
 
-  static Type stringMapType = new TypeToken<Map<String, String>>() {
-  }.getType();
-  static Type objectMapType = new TypeToken<Map<String, Object>>() {
-  }.getType();
+  static Type stringMapType = new TypeToken<Map<String, String>>() { }.getType();
+  static Type objectMapType = new TypeToken<Map<String, Object>>() { }.getType();
 
   @Test
-  public void testWordCount() throws IOException, TimeoutException, InterruptedException {
+  public void testWordCount() throws Exception {
     // Deploy the Application
     ApplicationManager appManager = deployApplication(WordCount.class);
 
@@ -56,10 +53,10 @@ public class WordCountTest extends TestBase {
     appManager.startFlow("WordCounter");
 
     // Send a few events to the stream
-    StreamWriter writer = appManager.getStreamWriter("wordStream");
-    writer.send("hello world");
-    writer.send("a wonderful world");
-    writer.send("the world says hello");
+    StreamManager streamManager = getStreamManager("wordStream");
+    streamManager.send("hello world");
+    streamManager.send("a wonderful world");
+    streamManager.send("the world says hello");
 
     // Wait for the events to be processed, or at most 5 seconds
     RuntimeMetrics metrics = RuntimeStats.getFlowletMetrics("WordCount", "WordCounter", "associator");

--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteApplicationManager.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteApplicationManager.java
@@ -326,8 +326,9 @@ public class RemoteApplicationManager implements ApplicationManager {
   }
 
   @Override
+  @Deprecated
   public StreamWriter getStreamWriter(String streamName) {
-    return new RemoteStreamWriter(clientConfig, streamName);
+    return new RemoteStreamWriter(new RemoteStreamManager(clientConfig, streamName));
   }
 
   @Override

--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteStreamManager.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteStreamManager.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.test.remote;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.flow.flowlet.StreamEvent;
+import co.cask.cdap.client.StreamClient;
+import co.cask.cdap.client.config.ClientConfig;
+import co.cask.cdap.common.exception.StreamNotFoundException;
+import co.cask.cdap.test.StreamManager;
+import com.google.common.base.Charsets;
+import com.google.common.base.Throwables;
+import com.google.common.collect.Lists;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Implementation of {@link StreamManager} that interacts with stream service via HTTP calls
+ */
+public class RemoteStreamManager implements StreamManager {
+  private final StreamClient streamClient;
+  private final String streamName;
+
+  public RemoteStreamManager(ClientConfig clientConfig, String streamName) {
+    this.streamClient = new StreamClient(clientConfig);
+    this.streamName = streamName;
+  }
+
+  @Override
+  public void createStream() throws IOException {
+    try {
+      streamClient.create(streamName);
+    } catch (IOException e) {
+      throw e;
+    } catch (Exception e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  @Override
+  public void send(String content) throws IOException {
+    try {
+      streamClient.sendEvent(streamName, content);
+    } catch (IOException e) {
+      throw e;
+    } catch (Exception e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  @Override
+  public void send(byte[] content) throws IOException {
+    try {
+      streamClient.sendEvent(streamName, new String(content, Charsets.UTF_8));
+    } catch (IOException e) {
+      throw e;
+    } catch (Exception e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  @Override
+  public void send(byte[] content, int off, int len) throws IOException {
+    try {
+      streamClient.sendEvent(streamName, new String(content, off, len, Charsets.UTF_8));
+    } catch (IOException e) {
+      throw e;
+    } catch (Exception e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  @Override
+  public void send(ByteBuffer buffer) throws IOException {
+    try {
+      streamClient.sendEvent(streamName, Bytes.toString(buffer));
+    } catch (IOException e) {
+      throw e;
+    } catch (Exception e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  @Override
+  public void send(Map<String, String> headers, String content) throws IOException {
+    throw new UnsupportedOperationException("TODO");
+  }
+
+  @Override
+  public void send(Map<String, String> headers, byte[] content) throws IOException {
+    throw new UnsupportedOperationException("TODO");
+  }
+
+  @Override
+  public void send(Map<String, String> headers, byte[] content, int off, int len) throws IOException {
+    throw new UnsupportedOperationException("TODO");
+  }
+
+  @Override
+  public void send(Map<String, String> headers, ByteBuffer buffer) throws IOException {
+    throw new UnsupportedOperationException("TODO");
+  }
+
+  @Override
+  public List<StreamEvent> getEvents(long startTime, long endTime, int limit) throws IOException {
+    List<StreamEvent> results = Lists.newArrayList();
+    try {
+      streamClient.getEvents(streamName, startTime, endTime, limit, results);
+    } catch (StreamNotFoundException e) {
+      throw new IOException(e);
+    } catch (Exception e) {
+      throw Throwables.propagate(e);
+    }
+    return results;
+  }
+}

--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteStreamWriter.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteStreamWriter.java
@@ -17,101 +17,67 @@
 package co.cask.cdap.test.remote;
 
 import co.cask.cdap.api.common.Bytes;
-import co.cask.cdap.client.StreamClient;
-import co.cask.cdap.client.config.ClientConfig;
 import co.cask.cdap.test.StreamWriter;
 import com.google.common.base.Charsets;
-import com.google.common.base.Throwables;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Map;
 
 /**
- *
+ * @deprecated Use {@link RemoteStreamManager} instead
  */
+@Deprecated
 public class RemoteStreamWriter implements StreamWriter {
 
-  private final StreamClient streamClient;
-  private final String streamName;
+  private final RemoteStreamManager remoteStreamManager;
 
-  public RemoteStreamWriter(ClientConfig clientConfig, String streamName) {
-    this.streamClient = new StreamClient(clientConfig);
-    this.streamName = streamName;
+  public RemoteStreamWriter(RemoteStreamManager remoteStreamManager) {
+    this.remoteStreamManager = remoteStreamManager;
   }
 
   @Override
   public void createStream() throws IOException {
-    try {
-      streamClient.create(streamName);
-    } catch (IOException e) {
-      throw e;
-    } catch (Exception e) {
-      throw Throwables.propagate(e);
-    }
+    remoteStreamManager.createStream();
   }
 
   @Override
   public void send(String content) throws IOException {
-    try {
-      streamClient.sendEvent(streamName, content);
-    } catch (IOException e) {
-      throw e;
-    } catch (Exception e) {
-      throw Throwables.propagate(e);
-    }
+    remoteStreamManager.send(content);
   }
 
   @Override
   public void send(byte[] content) throws IOException {
-    try {
-      streamClient.sendEvent(streamName, new String(content, Charsets.UTF_8));
-    } catch (IOException e) {
-      throw e;
-    } catch (Exception e) {
-      throw Throwables.propagate(e);
-    }
+    remoteStreamManager.send(content);
   }
 
   @Override
   public void send(byte[] content, int off, int len) throws IOException {
-    try {
-      streamClient.sendEvent(streamName, new String(content, off, len, Charsets.UTF_8));
-    } catch (IOException e) {
-      throw e;
-    } catch (Exception e) {
-      throw Throwables.propagate(e);
-    }
+    remoteStreamManager.send(new String(content, off, len, Charsets.UTF_8));
   }
 
   @Override
   public void send(ByteBuffer buffer) throws IOException {
-    try {
-      streamClient.sendEvent(streamName, Bytes.toString(buffer));
-    } catch (IOException e) {
-      throw e;
-    } catch (Exception e) {
-      throw Throwables.propagate(e);
-    }
+    remoteStreamManager.send(Bytes.toString(buffer));
   }
 
   @Override
   public void send(Map<String, String> headers, String content) throws IOException {
-    throw new UnsupportedOperationException("TODO");
+    remoteStreamManager.send(headers, content);
   }
 
   @Override
   public void send(Map<String, String> headers, byte[] content) throws IOException {
-    throw new UnsupportedOperationException("TODO");
+    remoteStreamManager.send(headers, content);
   }
 
   @Override
   public void send(Map<String, String> headers, byte[] content, int off, int len) throws IOException {
-    throw new UnsupportedOperationException("TODO");
+    remoteStreamManager.send(headers, content, off, len);
   }
 
   @Override
   public void send(Map<String, String> headers, ByteBuffer buffer) throws IOException {
-    throw new UnsupportedOperationException("TODO");
+    remoteStreamManager.send(headers, buffer);
   }
 }

--- a/cdap-test/src/main/java/co/cask/cdap/test/ApplicationManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/ApplicationManager.java
@@ -72,7 +72,10 @@ public interface ApplicationManager {
    * Gets a {@link StreamWriter} for writing data to the given stream.
    * @param streamName Name of the stream to write to.
    * @return A {@link StreamWriter}.
+   *
+   * @deprecated use TestBase#getStreamMaanger(String streamName)
    */
+  @Deprecated
   StreamWriter getStreamWriter(String streamName);
 
   /**
@@ -83,7 +86,7 @@ public interface ApplicationManager {
    * @param <T> Type of the dataset.
    * @return A {@link DataSetManager} instance.
    * @deprecated As of version 2.8.0, replaced by
-   *             {@link TestBase#getDataset(co.cask.cdap.proto.Id.Namespace, String)}
+   *             TestBase#getDataset(co.cask.cdap.proto.Id.Namespace, String)
    */
   @Deprecated
   <T> DataSetManager<T> getDataSet(String dataSetName) throws Exception;

--- a/cdap-test/src/main/java/co/cask/cdap/test/StreamManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/StreamManager.java
@@ -20,12 +20,12 @@ import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.flow.flowlet.StreamEvent;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.Map;
 
 /**
- * This interface allows you to interact with streams.
- * Currently, it only exposes methods to read from a stream.
- * Eventually, {@link StreamWriter} should be deprecated and all its functionality moved here
+ * This interface helps to interact with streams.
  */
 @Beta
 public interface StreamManager {
@@ -36,6 +36,74 @@ public interface StreamManager {
    * @throws java.io.IOException If there is an error creating the stream.
    */
   void createStream() throws IOException;
+
+  /**
+   * Sends a UTF-8 encoded string to the stream.
+   * @param content Data to be sent.
+   * @throws java.io.IOException If there is error writing to the stream.
+   */
+  void send(String content) throws IOException;
+
+  /**
+   * Sends a byte array to the stream. Same as calling {@link #send(byte[], int, int) send(content, 0, content.length)}.
+   * @param content Data to be sent.
+   * @throws java.io.IOException If there is error writing to the stream.
+   */
+  void send(byte[] content) throws IOException;
+
+  /**
+   * Sends a byte array to the stream.
+   * @param content Data to be sent.
+   * @param off Offset in the array to start with
+   * @param len Number of bytes to sent starting from {@code off}.
+   * @throws java.io.IOException If there is error writing to the stream.
+   */
+  void send(byte[] content, int off, int len) throws IOException;
+
+  /**
+   * Sends the content of a {@link java.nio.ByteBuffer} to the stream.
+   * @param buffer Data to be sent.
+   * @throws java.io.IOException If there is error writing to the stream.
+   */
+  void send(ByteBuffer buffer) throws IOException;
+
+  /**
+   * Sends a UTF-8 encoded string to the stream.
+   * @param headers Key-value pairs to be sent as
+   *                headers of {@link co.cask.cdap.api.flow.flowlet.StreamEvent StreamEvent}.
+   * @param content Data to be sent.
+   * @throws java.io.IOException If there is error writing to the stream.
+   */
+  void send(Map<String, String> headers, String content) throws IOException;
+
+  /**
+   * Sends a byte array to the stream. Same as calling {@link #send(byte[], int, int) send(content, 0, content.length)}.
+   * @param headers Key-value pairs to be sent as
+   *                headers of {@link co.cask.cdap.api.flow.flowlet.StreamEvent StreamEvent}.
+   * @param content Data to be sent.
+   * @throws java.io.IOException If there is error writing to the stream.
+   */
+  void send(Map<String, String> headers, byte[] content) throws IOException;
+
+  /**
+   * Sends a byte array to the stream.
+   * @param headers Key-value pairs to be sent as
+   *                headers of {@link co.cask.cdap.api.flow.flowlet.StreamEvent StreamEvent}.
+   * @param content Data to be sent.
+   * @param off Offset in the array to start with
+   * @param len Number of bytes to sent starting from {@code off}.
+   * @throws java.io.IOException If there is error writing to the stream.
+   */
+  void send(Map<String, String> headers, byte[] content, int off, int len) throws IOException;
+
+  /**
+   * Sends the content of a {@link java.nio.ByteBuffer} to the stream.
+   * @param headers Key-value pairs to be sent as
+   *                headers of {@link co.cask.cdap.api.flow.flowlet.StreamEvent StreamEvent}.
+   * @param buffer Data to be sent.
+   * @throws java.io.IOException If there is error writing to the stream.
+   */
+  void send(Map<String, String> headers, ByteBuffer buffer) throws IOException;
 
   /**
    * Get events from the specified stream in the specified interval

--- a/cdap-test/src/main/java/co/cask/cdap/test/StreamWriter.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/StreamWriter.java
@@ -22,7 +22,10 @@ import java.util.Map;
 
 /**
  * This interface defines ways to send data to a stream.
+ * @deprecated
+ * Use {@link StreamManager} instead
  */
+@Deprecated
 public interface StreamWriter {
 
   /**

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/ConfigurableTestBase.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/ConfigurableTestBase.java
@@ -24,7 +24,6 @@ import co.cask.cdap.api.metrics.MetricStore;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.app.guice.AppFabricServiceRuntimeModule;
 import co.cask.cdap.app.guice.InMemoryProgramRunnerModule;
-import co.cask.cdap.app.guice.ProgramRunnerRuntimeModule;
 import co.cask.cdap.app.guice.ServiceStoreModules;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
@@ -502,6 +501,22 @@ public class ConfigurableTestBase {
     return getQueryClient(Constants.DEFAULT_NAMESPACE_ID);
   }
 
+  /**
+   * Returns a {@link StreamManager} for the specified stream in the default namespace
+   *
+   * @param streamName the specified stream
+   * @return {@link StreamManager} for the specified stream in the default namespace
+   */
+  protected final StreamManager getStreamManager(String streamName) throws Exception {
+    return getStreamManager(Constants.DEFAULT_NAMESPACE_ID, streamName);
+  }
+
+  /**
+   * Returns a {@link StreamManager} for the specified stream in the specified namespace
+   *
+   * @param streamName the specified stream
+   * @return {@link StreamManager} for the specified stream in the specified namespace
+   */
   protected final StreamManager getStreamManager(Id.Namespace namespace, String streamName) throws Exception {
     return getTestManager().getStreamManager(Id.Stream.from(namespace, streamName));
   }

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultApplicationManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultApplicationManager.java
@@ -306,6 +306,7 @@ public class DefaultApplicationManager implements ApplicationManager {
   }
 
   @Override
+  @Deprecated
   public StreamWriter getStreamWriter(String streamName) {
     Id.Stream streamId = Id.Stream.from(applicationId.getNamespace(), streamName);
     return streamWriterFactory.create(streamId);

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultStreamWriter.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultStreamWriter.java
@@ -16,43 +16,30 @@
 
 package co.cask.cdap.test.internal;
 
-import co.cask.cdap.data.stream.service.StreamHandler;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.test.StreamManager;
 import co.cask.cdap.test.StreamWriter;
 import com.google.common.base.Charsets;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
-import org.jboss.netty.buffer.ChannelBuffer;
-import org.jboss.netty.buffer.ChannelBuffers;
-import org.jboss.netty.handler.codec.http.DefaultHttpRequest;
-import org.jboss.netty.handler.codec.http.HttpHeaders;
-import org.jboss.netty.handler.codec.http.HttpMethod;
-import org.jboss.netty.handler.codec.http.HttpRequest;
-import org.jboss.netty.handler.codec.http.HttpResponseStatus;
-import org.jboss.netty.handler.codec.http.HttpVersion;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Map;
 
 /**
- *
+ * @deprecated Use {@link DefaultStreamManager} instead
  */
+@Deprecated
 public final class DefaultStreamWriter implements StreamWriter {
 
-  private final Id.Stream streamId;
-  private final StreamHandler streamHandler;
   private final StreamManager streamManager;
 
   @Inject
-  public DefaultStreamWriter(StreamHandler streamHandler, StreamManagerFactory streamManagerFactory,
+  public DefaultStreamWriter(StreamManagerFactory streamManagerFactory,
                              @Assisted Id.Stream streamId) throws IOException {
-    this.streamHandler = streamHandler;
     this.streamManager = streamManagerFactory.create(streamId);
-    this.streamId = streamId;
   }
 
   @Override
@@ -97,26 +84,7 @@ public final class DefaultStreamWriter implements StreamWriter {
 
   @Override
   public void send(Map<String, String> headers, ByteBuffer buffer) throws IOException {
-    String path = String.format("/v3/namespaces/%s/streams/%s", streamId.getNamespaceId(), streamId.getId());
-    HttpRequest httpRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, path);
-
-    for (Map.Entry<String, String> entry : headers.entrySet()) {
-      httpRequest.setHeader(streamId.getId() + "." + entry.getKey(), entry.getValue());
-    }
-    ChannelBuffer content = ChannelBuffers.wrappedBuffer(buffer);
-    httpRequest.setContent(content);
-    httpRequest.setHeader(HttpHeaders.Names.CONTENT_LENGTH, content.readableBytes());
-
-    MockResponder responder = new MockResponder();
-    try {
-      streamHandler.enqueue(httpRequest, responder, streamId.getNamespaceId(), streamId.getId());
-    } catch (Exception e) {
-      Throwables.propagateIfPossible(e, IOException.class);
-      throw Throwables.propagate(e);
-    }
-    if (responder.getStatus() != HttpResponseStatus.OK) {
-      throw new IOException("Failed to write to stream. Status = " + responder.getStatus());
-    }
+    streamManager.send(headers, buffer);
   }
 
   @Override

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/StreamWriterFactory.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/StreamWriterFactory.java
@@ -21,7 +21,9 @@ import co.cask.cdap.test.StreamWriter;
 
 /**
  * This interface is using Guice assisted inject to create {@link co.cask.cdap.test.StreamWriter}.
+ * @deprecated use {@link StreamManagerFactory} instead
  */
+@Deprecated
 public interface StreamWriterFactory {
 
   StreamWriter create(Id.Stream streamId);

--- a/cdap-unit-test/src/test/java/co/cask/cdap/batch/stream/BatchStreamIntegrationTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/batch/stream/BatchStreamIntegrationTestRun.java
@@ -21,7 +21,7 @@ import co.cask.cdap.api.dataset.lib.KeyValueTable;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.DataSetManager;
 import co.cask.cdap.test.MapReduceManager;
-import co.cask.cdap.test.StreamWriter;
+import co.cask.cdap.test.StreamManager;
 import co.cask.cdap.test.XSlowTests;
 import co.cask.cdap.test.base.TestFrameworkTestBase;
 import com.google.common.base.Charsets;
@@ -66,9 +66,9 @@ public class BatchStreamIntegrationTestRun extends TestFrameworkTestBase {
   private void submitAndVerifyStreamBatchJob(Class<? extends AbstractApplication> appClass,
                                              String streamWriter, String mapReduceName, int timeout) throws Exception {
     ApplicationManager applicationManager = deployApplication(appClass);
-    StreamWriter writer = applicationManager.getStreamWriter(streamWriter);
+    StreamManager streamManager = getStreamManager(streamWriter);
     for (int i = 0; i < 50; i++) {
-      writer.send(String.valueOf(i));
+      streamManager.send(String.valueOf(i));
     }
 
     MapReduceManager mapReduceManager = applicationManager.startMapReduce(mapReduceName);

--- a/cdap-unit-test/src/test/java/co/cask/cdap/flow/stream/FlowStreamIntegrationTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/flow/stream/FlowStreamIntegrationTestRun.java
@@ -20,7 +20,7 @@ import co.cask.cdap.api.metrics.RuntimeMetrics;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.RuntimeStats;
 import co.cask.cdap.test.SlowTests;
-import co.cask.cdap.test.StreamWriter;
+import co.cask.cdap.test.StreamManager;
 import co.cask.cdap.test.base.TestFrameworkTestBase;
 import org.junit.Assert;
 import org.junit.Test;
@@ -36,7 +36,7 @@ public class FlowStreamIntegrationTestRun extends TestFrameworkTestBase {
   @Test
   public void testStreamBatch() throws Exception {
     ApplicationManager applicationManager = deployApplication(TestFlowStreamIntegrationApp.class);
-    StreamWriter s1 = applicationManager.getStreamWriter("s1");
+    StreamManager s1 = getStreamManager("s1");
     for (int i = 0; i < 50; i++) {
       s1.send(String.valueOf(i));
     }

--- a/cdap-unit-test/src/test/java/co/cask/cdap/mapreduce/MapReduceStreamInputTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/mapreduce/MapReduceStreamInputTestRun.java
@@ -18,7 +18,7 @@ import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.dataset.lib.KeyValueTable;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.MapReduceManager;
-import co.cask.cdap.test.StreamWriter;
+import co.cask.cdap.test.StreamManager;
 import co.cask.cdap.test.base.TestFrameworkTestBase;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericDatumWriter;
@@ -44,15 +44,15 @@ public class MapReduceStreamInputTestRun extends TestFrameworkTestBase {
 
     ApplicationManager applicationManager = deployApplication(AppWithMapReduceUsingStream.class);
     Schema schema = new Schema.Parser().parse(AppWithMapReduceUsingStream.SCHEMA.toString());
-    StreamWriter streamWriter = applicationManager.getStreamWriter("mrStream");
-    streamWriter.send(createEvent(schema, "YHOO", 100, 10.0f));
-    streamWriter.send(createEvent(schema, "YHOO", 10, 10.1f));
-    streamWriter.send(createEvent(schema, "YHOO", 13, 9.9f));
+    StreamManager streamManager = getStreamManager("mrStream");
+    streamManager.send(createEvent(schema, "YHOO", 100, 10.0f));
+    streamManager.send(createEvent(schema, "YHOO", 10, 10.1f));
+    streamManager.send(createEvent(schema, "YHOO", 13, 9.9f));
     float yhooTotal = 100 * 10.0f + 10 * 10.1f + 13 * 9.9f;
-    streamWriter.send(createEvent(schema, "AAPL", 5, 300.0f));
-    streamWriter.send(createEvent(schema, "AAPL", 3, 298.34f));
-    streamWriter.send(createEvent(schema, "AAPL", 50, 305.23f));
-    streamWriter.send(createEvent(schema, "AAPL", 1000, 284.13f));
+    streamManager.send(createEvent(schema, "AAPL", 5, 300.0f));
+    streamManager.send(createEvent(schema, "AAPL", 3, 298.34f));
+    streamManager.send(createEvent(schema, "AAPL", 50, 305.23f));
+    streamManager.send(createEvent(schema, "AAPL", 1000, 284.13f));
     float aaplTotal = 5 * 300.0f + 3 * 298.34f + 50 * 305.23f + 1000 * 284.13f;
 
     MapReduceManager mrManager = applicationManager.startMapReduce("BodyTracker");

--- a/cdap-unit-test/src/test/java/co/cask/cdap/spark/stream/SparkStreamIntegrationTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/spark/stream/SparkStreamIntegrationTestRun.java
@@ -20,7 +20,7 @@ import co.cask.cdap.api.dataset.lib.KeyValueTable;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.DataSetManager;
 import co.cask.cdap.test.SparkManager;
-import co.cask.cdap.test.StreamWriter;
+import co.cask.cdap.test.StreamManager;
 import co.cask.cdap.test.XSlowTests;
 import co.cask.cdap.test.base.TestFrameworkTestBase;
 import com.google.common.base.Charsets;
@@ -39,9 +39,9 @@ public class SparkStreamIntegrationTestRun extends TestFrameworkTestBase {
   @Test
   public void testSparkWithStream() throws Exception {
     ApplicationManager applicationManager = deployApplication(TestSparkStreamIntegrationApp.class);
-    StreamWriter writer = applicationManager.getStreamWriter("testStream");
+    StreamManager streamManager = getStreamManager("testStream");
     for (int i = 0; i < 50; i++) {
-      writer.send(String.valueOf(i));
+      streamManager.send(String.valueOf(i));
     }
 
     SparkManager sparkManager = applicationManager.startSpark("SparkStreamProgram");

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
@@ -36,7 +36,7 @@ import co.cask.cdap.test.MapReduceManager;
 import co.cask.cdap.test.RuntimeStats;
 import co.cask.cdap.test.ServiceManager;
 import co.cask.cdap.test.SlowTests;
-import co.cask.cdap.test.StreamWriter;
+import co.cask.cdap.test.StreamManager;
 import co.cask.cdap.test.WorkerManager;
 import co.cask.cdap.test.WorkflowManager;
 import co.cask.cdap.test.XSlowTests;
@@ -99,7 +99,7 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     args.put("threshold", "10");
     applicationManager.startFlow("FilterFlow", args);
 
-    StreamWriter input = applicationManager.getStreamWriter("input");
+    StreamManager input = getStreamManager("input");
     input.send("1");
     input.send("11");
 
@@ -217,13 +217,13 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
   @Test(timeout = 240000)
   @Ignore
   // TODO: Investigate why this fails in Bamboo, but not locally
-  public void testMultiInput() throws InterruptedException, IOException, TimeoutException {
+  public void testMultiInput() throws Exception {
     ApplicationManager applicationManager = deployApplication(JoinMultiStreamApp.class);
     applicationManager.startFlow("JoinMultiFlow");
 
-    StreamWriter s1 = applicationManager.getStreamWriter("s1");
-    StreamWriter s2 = applicationManager.getStreamWriter("s2");
-    StreamWriter s3 = applicationManager.getStreamWriter("s3");
+    StreamManager s1 = getStreamManager("s1");
+    StreamManager s2 = getStreamManager("s2");
+    StreamManager s3 = getStreamManager("s3");
 
     s1.send("testing 1");
     s2.send("testing 2");
@@ -542,9 +542,9 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     applicationManager.startFlow("WordCountFlow");
 
     // Send some inputs to streams
-    StreamWriter streamWriter = applicationManager.getStreamWriter(streamName);
+    StreamManager streamManager = getStreamManager(streamName);
     for (int i = 0; i < 100; i++) {
-      streamWriter.send(ImmutableMap.of("title", "title " + i), "testing message " + i);
+      streamManager.send(ImmutableMap.of("title", "title " + i), "testing message " + i);
     }
 
     // Check the flowlet metrics

--- a/cdap-unit-test/src/test/java/net/fake/test/app/TestBundleJarApp.java
+++ b/cdap-unit-test/src/test/java/net/fake/test/app/TestBundleJarApp.java
@@ -22,7 +22,7 @@ import co.cask.cdap.test.FlowManager;
 import co.cask.cdap.test.RuntimeStats;
 import co.cask.cdap.test.ServiceManager;
 import co.cask.cdap.test.SlowTests;
-import co.cask.cdap.test.StreamWriter;
+import co.cask.cdap.test.StreamManager;
 import co.cask.cdap.test.TestBase;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
@@ -36,11 +36,9 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 /**
  * Tests bundle jar feature, in which the application jar contains
@@ -50,13 +48,13 @@ import java.util.concurrent.TimeoutException;
 public class TestBundleJarApp extends TestBase {
 
   @Test
-  public void testBundleJar() throws IOException, URISyntaxException, TimeoutException, InterruptedException {
+  public void testBundleJar() throws Exception {
     File helloWorldJar = new File(TestBundleJarApp.class.getClassLoader().getResource("helloworld.jar").toURI());
     ApplicationManager applicationManager = deployApplication(BundleJarApp.class, helloWorldJar);
     FlowManager flowManager = applicationManager.startFlow("SimpleFlow");
-    StreamWriter streamWriter = applicationManager.getStreamWriter("simpleInputStream");
+    StreamManager streamManager = getStreamManager("simpleInputStream");
     for (int i = 0; i < 5; i++) {
-      streamWriter.send("test" + i + ":" + i);
+      streamManager.send("test" + i + ":" + i);
     }
 
     // Check the flowlet metrics


### PR DESCRIPTION
... also allow users to create/manage streams outside apps in TestBase

Issues this PR addresses:
1. In ``TestBase``, you could only interact with streams using the ``StreamWriter`` interface. Also, it wasn't strictly a writer, since it also had a ``create()`` method. However, it was missing a method to read events. #2145 already added a ``StreamManager`` that had ``create`` and ``read`` methods. This PR ports all the write functionality from ``StreamWriter`` into ``StreamManager``.
2. Currently, the only way to get access to the ``StreamWriter`` is through an ``ApplicationManager``. With this PR, you can directly access ``StreamManager`` via a method in ``TestBase``.


Also ported all usages of ``StreamWriter`` in the current tests to use ``StreamManager`` instead. We can remove ``StreamWriter`` in a later release.


Jira: [CDAP-2171](https://issues.cask.co/browse/CDAP-2171)
Build: http://builds.cask.co/browse/CDAP-DUT1566