### PR TITLE
Fix/etl apps save as draft

### DIFF
--- a/cdap-ui/Gulpfile.js
+++ b/cdap-ui/Gulpfile.js
@@ -17,7 +17,8 @@ gulp.task('css:lib', ['fonts'], function() {
       './bower_components/angular-motion/dist/angular-motion.min.css',
       './bower_components/font-awesome/css/font-awesome.min.css',
       './bower_components/epoch/epoch.min.css',
-      './bower_components/ng-sortable/dist/ng-sortable.min.css'
+      './bower_components/ng-sortable/dist/ng-sortable.min.css',
+      './bower_components/angular-ui-select/dist/select.min.css'
     ].concat(mainBowerFiles({
       filter: /cask\-angular\-[^\/]+\/.*\.(css|less)$/
     })))
@@ -121,7 +122,8 @@ gulp.task('js:lib', function() {
       './bower_components/angular-moment/angular-moment.js',
       './bower_components/angular-bootstrap/ui-bootstrap-tpls.js',
 
-      './bower_components/node-uuid/uuid.js'
+      './bower_components/node-uuid/uuid.js',
+      './bower_components/angular-ui-select/dist/select.js'
 
 
     ].concat([

--- a/cdap-ui/app/features/etlapps/controllers/list-ctrl.js
+++ b/cdap-ui/app/features/etlapps/controllers/list-ctrl.js
@@ -3,13 +3,13 @@ angular.module(PKG.name + '.feature.etlapps')
     var dataSrc = new MyDataSource($scope);
     $scope.etlapps  = [];
     dataSrc.request({
-      _cdapNsPath: '/adapters?template=etl.batch'
+      _cdapNsPath: '/adapters?template=etlbatch'
     })
       .then(function(res) {
         if (!res.length) {
           return;
         }
-        $scope.etlapps = res;
+        $scope.etlapps = $scope.etlapps.concat(res);
         angular.forEach($scope.etlapps, function(app) {
           app.status =  (Date.now()/2)? 'Running': 'Stopped';
           app.description = 'Something something dark.Something Something something dark';
@@ -29,4 +29,12 @@ angular.module(PKG.name + '.feature.etlapps')
           });
         }
       });
+    $scope.dragdrop = {
+      dragStart: function (drag) {
+        console.log('dragStart', drag.source, drag.dest);
+      },
+      dragEnd: function (drag) {
+        console.log('dragEnd', drag.source, drag.dest);
+      }
+    };
   });

--- a/cdap-ui/app/features/etlapps/controllers/list-ctrl.js
+++ b/cdap-ui/app/features/etlapps/controllers/list-ctrl.js
@@ -1,15 +1,32 @@
 angular.module(PKG.name + '.feature.etlapps')
-  .controller('EtlAppsListController', function($scope, MyDataSource) {
+  .controller('EtlAppsListController', function($scope, MyDataSource, mySettings) {
     var dataSrc = new MyDataSource($scope);
     $scope.etlapps  = [];
     dataSrc.request({
-      _cdapNsPath: '/adapters?template=etl.realtime'
+      _cdapNsPath: '/adapters?template=etl.batch'
     })
       .then(function(res) {
+        if (!res.length) {
+          return;
+        }
         $scope.etlapps = res;
         angular.forEach($scope.etlapps, function(app) {
           app.status =  (Date.now()/2)? 'Running': 'Stopped';
           app.description = 'Something something dark.Something Something something dark';
         });
+      });
+    mySettings.get('etldrafts')
+      .then(function(res) {
+        if (Object.keys(res).length) {
+          angular.forEach(res, function(value, key) {
+            $scope.etlapps.push({
+              isdraft: true,
+              name: key,
+              template: value.config.metadata.type,
+              status: (Date.now()/2)? 'Running': 'Stopped',
+              description: 'Something something dark.Something Something something dark'
+            });
+          });
+        }
       });
   });

--- a/cdap-ui/app/features/etlapps/etlapps.less
+++ b/cdap-ui/app/features/etlapps/etlapps.less
@@ -135,16 +135,18 @@ body.theme-cdap.state-etlapps-create {
 }
 
 body.theme-cdap.state-etlapps-list {
+  a {
+    text-decoration: none;
+  }
   [etl-apps-list] {
     [etl-add-app] {
       cursor: pointer;
-      height: 155px;
-      border: 2px dashed;
-      margin-top: 0;
-      h1 {
-        margin-top: 5px;
-        margin-bottom: 5px;
-        transform: translate(0%, 150%);
+      .well.well-lg {
+        border: 2px dashed;
+        margin-bottom: 0;
+        h1 {
+          margin-bottom: 13px;
+        }
       }
     }
     [class*="col-"] {

--- a/cdap-ui/app/features/etlapps/etlapps.less
+++ b/cdap-ui/app/features/etlapps/etlapps.less
@@ -136,6 +136,17 @@ body.theme-cdap.state-etlapps-create {
 
 body.theme-cdap.state-etlapps-list {
   [etl-apps-list] {
+    [etl-add-app] {
+      cursor: pointer;
+      height: 155px;
+      border: 2px dashed;
+      margin-top: 0;
+      h1 {
+        margin-top: 5px;
+        margin-bottom: 5px;
+        transform: translate(0%, 150%);
+      }
+    }
     [class*="col-"] {
       padding-left: 5px;
       padding-right: 5px;

--- a/cdap-ui/app/features/etlapps/etlapps.less
+++ b/cdap-ui/app/features/etlapps/etlapps.less
@@ -1,7 +1,7 @@
 @import '../../styles/variables.less';
 
 @font-size: 18px;
-body.theme-cdap.state-etlapps-create {
+body.theme-cdap.state-adapters-create {
 
   .as-sortable-drag {
     &.template {
@@ -134,7 +134,7 @@ body.theme-cdap.state-etlapps-create {
   }
 }
 
-body.theme-cdap.state-etlapps-list {
+body.theme-cdap.state-adapters-list {
   a {
     text-decoration: none;
   }

--- a/cdap-ui/app/features/etlapps/routes.js
+++ b/cdap-ui/app/features/etlapps/routes.js
@@ -1,8 +1,8 @@
 angular.module(PKG.name + '.feature.etlapps')
   .config(function($stateProvider, $urlRouterProvider, MYAUTH_ROLE) {
     $stateProvider
-      .state('etlapps', {
-        url: '/etlapps',
+      .state('adapters', {
+        url: '/adapters',
         abstract: true,
         parent: 'apps',
         data: {
@@ -12,13 +12,13 @@ angular.module(PKG.name + '.feature.etlapps')
         template: '<ui-view/>'
       })
 
-        .state('etlapps.list', {
+        .state('adapters.list', {
           url: '',
           templateUrl: '/assets/features/etlapps/templates/list.html',
           controller: 'EtlAppsListController'
         })
 
-        .state('etlapps.create', {
+        .state('adapters.create', {
           url: '/create',
           params: {
             data: null
@@ -27,9 +27,9 @@ angular.module(PKG.name + '.feature.etlapps')
           controller: 'ETLAppsCreateController'
         })
 
-        .state('etlapps.detail', {
-          url: '/:etlappid',
-          template: '<h2> EtlApps detail</h2>'
+        .state('adapters.detail', {
+          url: '/:adapterid',
+          template: '<h2> Adapter detail</h2>'
         })
 
 

--- a/cdap-ui/app/features/etlapps/routes.js
+++ b/cdap-ui/app/features/etlapps/routes.js
@@ -20,6 +20,9 @@ angular.module(PKG.name + '.feature.etlapps')
 
         .state('etlapps.create', {
           url: '/create',
+          params: {
+            data: null
+          },
           templateUrl: '/assets/features/etlapps/templates/create.html',
           controller: 'ETLAppsCreateController'
         })

--- a/cdap-ui/app/features/etlapps/services/etl-create-factory.js
+++ b/cdap-ui/app/features/etlapps/services/etl-create-factory.js
@@ -1,5 +1,5 @@
 angular.module(PKG.name + '.feature.etlapps')
-  .factory('ETLAppsApiFactory', function(MyDataSource, $filter, $state, $alert, $timeout) {
+  .factory('ETLAppsApiFactory', function(MyDataSource, $filter, $state, $alert, $timeout, mySettings) {
     var filterFilter = $filter('filter');
     function ETLAppsApiFactory(scope) {
       this.scope = scope;
@@ -92,13 +92,17 @@ angular.module(PKG.name + '.feature.etlapps')
         body: data
       })
         .then(function(res) {
-          $timeout(function() {
-            $state.go('etlapps.list', $state.params, {reload: true});
-          });
-          $alert({
-            type: 'success',
-            content: 'ETL Template: ' + this.scope.metadata.name + ' created successfully!'
-          });
+          delete this.scope.etlDrafts[this.scope.metadata.name];
+          mySettings.set('etldrafts', this.scope.etlDrafts)
+            .then(function() {
+              $timeout(function() {
+                $state.go('etlapps.list', $state.params, {reload: true});
+              });
+              $alert({
+                type: 'success',
+                content: 'ETL Template created successfully!'
+              });
+            })
         }.bind(this));
     }
     return ETLAppsApiFactory;

--- a/cdap-ui/app/features/etlapps/templates/create.html
+++ b/cdap-ui/app/features/etlapps/templates/create.html
@@ -18,14 +18,21 @@
         </div>
         <div class="col-lg-4 col-md-4 col-xs-12">
           <label for="etlAdapaterName" class="control-label">Name</label>
-          <input type="text"
-                  name="etlAdapaterName"
-                  class="form-control"
-                  id="etlAdapaterName"
-                  ng-model="metadata.name">
+          <ui-select ng-model="selectedEtlDraft"
+             on-select="onDraftChange($item, $model)"
+             theme="bootstrap"
+             ng-disabled="disabled"
+             tagging-tokens="ENTER|TAB"
+             tagging tagging-label="(custom 'new' label)"
+             reset-search-input="false"
+             title="Create/Choose a ETL Template to Create">
+            <ui-select-match placeholder="Create/Edit already saved ETL Drafts" > {{selectedEtlDraft}}</ui-select-match>
+            <ui-select-choices repeat="etl in etlDraftList| filter: $select.search">
+              <div ng-bind-html="etl | highlight: $select.search"></div>
+            </ui-select-choices>
+          </ui-select>
         </div>
         <div class="col-lg-4">
-
         </div>
       </div>
     </div>
@@ -57,12 +64,18 @@
     <div class="panel panel-default">
       <div class="panel-heading clearfix">
         <span class=pull-left>{{metadata.name}}</span>
-        <button type="button"
-                name="button"
-                class="btn btn-success pull-right"
-                ng-click="doSave()">
-            Create!
-        </button>
+        <div class="btn-group pull-right" role="group" aria-label="...">
+          <button type="button"
+                  class="btn btn-default"
+                  ng-click="doSave()">
+              Create!
+          </button>
+          <button type="button"
+                  class="btn btn-default"
+                  ng-click="saveAsDraft()">
+            Save As Draft
+          </button>
+        </div>
       </div>
       <div class="panel-body">
         <div class="col-lg-12 col-md-12 col-sm-12">

--- a/cdap-ui/app/features/etlapps/templates/list.html
+++ b/cdap-ui/app/features/etlapps/templates/list.html
@@ -1,13 +1,6 @@
 <div class="row">
   <div class="col-xs-6">
-    <h2 class="pull-left"> ETL Apps List </h2>
-  </div>
-  <div class="col-xs-6">
-    <a ui-sref="etlapps.create"
-        class="btn btn-default pull-right h2">
-      <span class="fa fa-plus"></span>
-       Create ETL App
-    </a>
+    <h2 class="pull-left"> ETL Templates List </h2>
   </div>
 </div>
 
@@ -16,9 +9,13 @@
   <div class="col-lg-2 col-md-3 col-sm-3 col-xs-6 text-center"
         ng-click="$state.go('^.create')"
         etl-add-app>
-    <h1>
-      <span class="fa fa-plus"></span>
-    </h1>
+    <div class="well well-lg">
+      <br/>
+      <h1>
+        <span class="fa fa-plus"></span>
+      </h1>
+      <br/>
+    </div>
   </div>
   <div class="col-lg-2 col-md-3 col-sm-3 col-xs-6" ng-repeat="app in etlapps">
     <div class="well well-md">
@@ -27,10 +24,11 @@
             <i class="fa fa-heartbeat"></i>
             {{::app.name | caskCapitalizeFilter | myEllipsis:9}}
             <small>
-              <span ng-if="app.isdraft"
+              <a ng-if="app.isdraft"
                   class="fa fa-pencil text-primary"
+                  href
                   ng-click="$state.go('^.create', {data: app.name})">
-              </span>
+              </a>
             </small>
           </h3>
           <small> Type: {{::app.template}}  </small>

--- a/cdap-ui/app/features/etlapps/templates/list.html
+++ b/cdap-ui/app/features/etlapps/templates/list.html
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="col-xs-6">
-    <h2 class="pull-left"> ETL Templates List </h2>
+    <h2 class="pull-left"> All Adapters </h2>
   </div>
 </div>
 
@@ -17,30 +17,34 @@
       <br/>
     </div>
   </div>
-  <div class="col-lg-2 col-md-3 col-sm-3 col-xs-6" ng-repeat="app in etlapps">
-    <div class="well well-md">
-        <div>
-          <h3 tooltip="{{::app.name}}">
-            <i class="fa fa-heartbeat"></i>
-            {{::app.name | caskCapitalizeFilter | myEllipsis:9}}
-            <small>
-              <a ng-if="app.isdraft"
-                  class="fa fa-pencil text-primary"
-                  href
-                  ng-click="$state.go('^.create', {data: app.name})">
-              </a>
-            </small>
-          </h3>
-          <small> Type: {{::app.template}}  </small>
+  <div as-sortable="dragdrop"
+        ng-model="etlapps">
+    <div class="col-lg-2 col-md-3 col-sm-3 col-xs-6"
+         ng-repeat="app in etlapps">
+      <div class="well well-md" as-sortable-item>
+          <div>
+            <h3 tooltip="{{::app.name}}" as-sortable-item-handle>
+              <i class="fa fa-heartbeat"></i>
+              {{::app.name | caskCapitalizeFilter | myEllipsis:9}}
+              <small>
+                <a ng-if="app.isdraft"
+                    class="fa fa-pencil text-primary"
+                    href
+                    ng-click="$state.go('^.create', {data: app.name})">
+                </a>
+              </small>
+            </h3>
+            <small> Type: {{::app.template}}  </small>
+          </div>
+        <div ng-class="{'running': app.status === 'Running', 'stopped': app.status === 'Stopped'}">
+          <i class="fa fa-circle"></i>
+          <span> {{::app.status}} </span>
         </div>
-      <div ng-class="{'running': app.status === 'Running', 'stopped': app.status === 'Stopped'}">
-        <i class="fa fa-circle"></i>
-        <span> {{::app.status}} </span>
-      </div>
-      <p class="description" tooltip="{{::app.description}}">
-        {{::app.description | myEllipsis: 50}}
-      </p>
+        <p class="description" tooltip="{{::app.description}}">
+          {{::app.description | myEllipsis: 50}}
+        </p>
 
+      </div>
     </div>
   </div>
 </div>

--- a/cdap-ui/app/features/etlapps/templates/list.html
+++ b/cdap-ui/app/features/etlapps/templates/list.html
@@ -13,12 +13,25 @@
 
 <br/>
 <div class="row" etl-apps-list>
+  <div class="col-lg-2 col-md-3 col-sm-3 col-xs-6 text-center"
+        ng-click="$state.go('^.create')"
+        etl-add-app>
+    <h1>
+      <span class="fa fa-plus"></span>
+    </h1>
+  </div>
   <div class="col-lg-2 col-md-3 col-sm-3 col-xs-6" ng-repeat="app in etlapps">
     <div class="well well-md">
         <div>
           <h3 tooltip="{{::app.name}}">
             <i class="fa fa-heartbeat"></i>
             {{::app.name | caskCapitalizeFilter | myEllipsis:9}}
+            <small>
+              <span ng-if="app.isdraft"
+                  class="fa fa-pencil text-primary"
+                  ng-click="$state.go('^.create', {data: app.name})">
+              </span>
+            </small>
           </h3>
           <small> Type: {{::app.template}}  </small>
         </div>

--- a/cdap-ui/app/features/overview/templates/data-apps.html
+++ b/cdap-ui/app/features/overview/templates/data-apps.html
@@ -79,9 +79,9 @@
               <span class="fa fa-list-ul"></span>
                <span>All Apps</span>
             </a>
-            <a ui-sref="etlapps.list" class="btn btn-default">
+            <a ui-sref="adapters.list" class="btn btn-default">
               <span class="fa fa-list-ul"></span>
-               All ETL Apps
+               All Adapters
             </a>
 <!--             <a ui-sref="apps.list" class="btn btn-default">
               <span class="fa fa-pencil-square-o"></span>
@@ -122,7 +122,7 @@
             data-button-icon="fa-plus"
             on-file-select="onFileSelected($files)">
         </my-file-select>
-        <a ui-sref="etlapps.create" class="btn btn-default">
+        <a ui-sref="adapters.create" class="btn btn-default">
           <span class="fa fa-plus"></span>
           <span>Add ETL App</span>
         </a>

--- a/cdap-ui/app/main.js
+++ b/cdap-ui/app/main.js
@@ -61,7 +61,8 @@ angular
       'mgcrea.ngStrap.modal',
 
       'ncy-angular-breadcrumb',
-      'angularMoment'
+      'angularMoment',
+      'ui.select'
 
     ]).name,
 

--- a/cdap-ui/bower.json
+++ b/cdap-ui/bower.json
@@ -31,7 +31,8 @@
     "d3-tip": "~0.6.6",
     "angular-moment": "~0.9.0",
     "angular-bootstrap": "~0.12.1",
-    "node-uuid": "~1.4.3"
+    "node-uuid": "~1.4.3",
+    "angular-ui-select": "~0.11.2"
   },
   "resolutions": {
     "angular": "1.3.14",


### PR DESCRIPTION
- Adds ability to save etl adapters as draft
- Syncs (deletes) adapters from user store once saved.
- Changes etlapps routes to adapters route
- Adds a non-functional sort for adapters list (in list view)