### PR TITLE
Make Flow start/stop button dependent on .../flows/<flow-id>/status endp...

### DIFF
--- a/cdap-ui/app/features/flows/controllers/detail-ctrl.js
+++ b/cdap-ui/app/features/flows/controllers/detail-ctrl.js
@@ -1,27 +1,29 @@
 angular.module(PKG.name + '.feature.flows')
-  .controller('FlowsDetailController', function($scope, MyDataSource, $state, FlowDiagramData, myHelpers, $timeout) {
-    $scope.status = null;
+  .controller('FlowsDetailController', function($scope, MyDataSource, $state) {
     var dataSrc = new MyDataSource($scope),
-        basePath = '/apps/' + $state.params.appId + '/flows/' + $state.params.programId;
+        path = '/apps/' +
+          $state.params.appId + '/flows/' +
+          $state.params.programId;
 
-
-    dataSrc.poll({
-      _cdapNsPath: basePath + '/runs?status=running'
-    }, function(res) {
-        $scope.activeRuns = res.length;
-      });
-
-
-    $scope.do = function(action) {
-      $scope.status = action;
+    $scope.start = function() {
+      $scope.status = 'STARTING';
       dataSrc.request({
-        _cdapNsPath: basePath + '/' + action,
+        _cdapNsPath: path + '/start',
         method: 'POST'
-      }).then(function() {
-        $timeout(function() {
-          $scope.status = null;
-          $state.go($state.current, $state.params, { reload: true });
-        });
       });
     };
+
+    $scope.stop = function() {
+      $scope.status = 'STOPPING';
+      dataSrc.request({
+        _cdapNsPath: path + '/stop',
+        method: 'POST'
+      });
+    };
+
+    dataSrc.poll({
+      _cdapNsPath: path + '/status'
+    }, function(res) {
+      $scope.status = res.status;
+    });
   });

--- a/cdap-ui/app/features/flows/templates/detail.html
+++ b/cdap-ui/app/features/flows/templates/detail.html
@@ -10,23 +10,22 @@
     </div>
   </div>
   <div class="col-sm-6 text-right">
-    <div ng-show="activeRuns === 0 && status === null"
-         class="btn btn-success btn-md"
-         ng-click="do('start')">
-      <span class="fa fa-play"></span>
-      <span>Start</span>
-    </div>
-
-    <div ng-show="activeRuns > 0 && status === null"
-         class="btn btn-default btn-md"
-         ng-click="do('stop')">
-      <span class="fa fa-stop"></span>
+    <div ng-show="status == 'RUNNING'"
+         class="btn btn-danger btn-md"
+         ng-click="stop()">
+      <span class="fa fa-stop"> </span>
       <span>Stop</span>
     </div>
 
-    <div ng-show="status == 'start' || status == 'stop'"
-          ng-class="{'btn-success': status === 'start', 'btn-primary': status === 'stop'}"
-          class="btn btn-md">
+    <div ng-show="status == 'STOPPED'"
+         class="btn btn-success btn-md"
+         ng-click="start()">
+      <span class="fa fa-play"> </span>
+      <span>Start</span>
+    </div>
+    <div ng-show="status == 'STARTING' || status == 'STOPPING'"
+         class="btn btn-md"
+         ng-class="{'btn-success': status === 'STARTING', 'btn-danger': status === 'STOPPING'}">
       <span class="fa fa-refresh fa-spin"></span>
       <span>{{status | caskCapitalizeFilter}}</span>
     </div>
@@ -34,17 +33,13 @@
 </div>
 
 <div class="cdap-subnav-end"></div>
-
 <ul class="nav nav-tabs slanted-tabs" role="tablist">
-
   <li role="presentation" ui-sref-active="active">
     <a ui-sref="flows.detail.runs" role="tab">Runs</a>
   </li>
-
   <li role="presentation" ui-sref-active="active">
     <a ui-sref="flows.detail.history" role="tab">History</a>
   </li>
-
 </ul>
 
 <br />

--- a/cdap-ui/app/features/services/controllers/detail-ctrl.js
+++ b/cdap-ui/app/features/services/controllers/detail-ctrl.js
@@ -24,6 +24,6 @@ angular.module(PKG.name + '.feature.services')
     dataSrc.poll({
       _cdapNsPath: path + '/status'
     }, function(res) {
-      $scope.status = res.status || 'Unknown';
+      $scope.status = res.status;
     });
   });


### PR DESCRIPTION
Make Flow start/stop button dependent on `.../flows/<flow-id>/status` endpoint, instead of count of RunRecords that are `RUNNING`.

Note: It is now very similar to the corresponding Services details view/controller.

This is needed because RunRecords can be inaccurate.
For instance, if CDAP master is stopped before the program stops, in which case the stop Run Record is not accurate. The RunRecords would give the impression that the Flow is running and only a STOP button would appear.

[JIRA issue CDAP-2202 created.](https://issues.cask.co/browse/CDAP-2202)