### PR TITLE
(CDAP-1917) Integrate plugin support to adapter

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceContext.java
@@ -26,13 +26,14 @@ import co.cask.cdap.api.data.batch.OutputFormatProvider;
 import co.cask.cdap.api.data.batch.Split;
 import co.cask.cdap.api.data.stream.StreamBatchReadable;
 import co.cask.cdap.api.dataset.Dataset;
+import co.cask.cdap.api.templates.AdapterContext;
 
 import java.util.List;
 
 /**
  * MapReduce job execution context.
  */
-public interface MapReduceContext extends RuntimeContext, DatasetContext, ServiceDiscoverer {
+public interface MapReduceContext extends RuntimeContext, DatasetContext, ServiceDiscoverer, AdapterContext {
   /**
    * @return The specification used to configure this {@link MapReduce} job instance.
    */

--- a/cdap-api/src/main/java/co/cask/cdap/api/templates/AdapterConfigurer.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/templates/AdapterConfigurer.java
@@ -31,35 +31,35 @@ import java.util.Map;
  * Currently, only Worker or Workflow can be used in the execution.
  */
 @Beta
-public interface AdapterConfigurer {
+public interface AdapterConfigurer extends AdapterPluginRegistry {
 
   /**
    * Set the schedule for the program. Must be set for Workflows and is not valid for other program types.
    *
    * @param schedule {@link Schedule}
    */
-  public void setSchedule(Schedule schedule);
+  void setSchedule(Schedule schedule);
 
   /**
    * Set the number of instances of the program. Valid only for Workers and defaults to 1.
    *
    * @param instances number of instances
    */
-  public void setInstances(int instances);
+  void setInstances(int instances);
 
   /**
    * Set the resources the program should use.
    *
    * @param resources the resources the program should use
    */
-  public void setResources(Resources resources);
+  void setResources(Resources resources);
 
   /**
    * Add arguments to be passed to the program as runtime arguments.
    *
    * @param arguments the runtime arguments to add to the program
    */
-  public void addRuntimeArguments(Map<String, String> arguments);
+  void addRuntimeArguments(Map<String, String> arguments);
 
   /**
    * Add argument to be passed to the program as runtime arguments.
@@ -67,7 +67,7 @@ public interface AdapterConfigurer {
    * @param key the runtime argument key
    * @param value the runtime argument value
    */
-  public void addRuntimeArgument(String key, String value);
+  void addRuntimeArgument(String key, String value);
 
   /**
    * Adds a {@link Stream} to the Adapter. The stream will be created during adapter creation if it does not
@@ -112,7 +112,5 @@ public interface AdapterConfigurer {
    * @param datasetClass dataset class to create the Dataset type from
    * @param props dataset instance properties
    */
-  void createDataset(String datasetName,
-                     Class<? extends Dataset> datasetClass,
-                     DatasetProperties props);
+  void createDataset(String datasetName, Class<? extends Dataset> datasetClass, DatasetProperties props);
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/templates/AdapterContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/templates/AdapterContext.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.api.templates;
+
+import co.cask.cdap.api.annotation.Beta;
+import co.cask.cdap.api.templates.plugins.PluginConfig;
+import co.cask.cdap.api.templates.plugins.PluginProperties;
+
+/**
+ * Provides access to template adapter context when a program is executing as an adapter.
+ */
+@Beta
+public interface AdapterContext {
+
+  /**
+   * Gets the {@link PluginProperties} associated with the given plugin type and name in the adapter context.
+   *
+   * @param pluginId the unique identifier provide when declaring plugin usage in {@link AdapterConfigurer}.
+   * @return the {@link PluginProperties}.
+   * @throws IllegalArgumentException if no plugin for the given type and name
+   * @throws UnsupportedOperationException if the program is not running under the adapter context
+   */
+  PluginProperties getPluginProperties(String pluginId);
+
+  /**
+   * Loads and returns a plugin class as specified by the given type and name.
+   *
+   * @param pluginId the unique identifier provide when declaring plugin usage in {@link AdapterConfigurer}.
+   * @param <T> the class type of the plugin
+   * @return the resulting plugin {@link Class}.
+   * @throws IllegalArgumentException if no plugin for the given type and name
+   * @throws UnsupportedOperationException if the program is not running under the adapter context
+   */
+  <T> Class<T> loadPluginClass(String pluginId);
+
+  /**
+   * Creates a new instance of a plugin. The instance returned will have the {@link PluginConfig} setup with
+   * {@link PluginProperties} provided at the time when the
+   * {@link AdapterConfigurer#usePlugin(String, String, String, PluginProperties)} was called during the
+   * {@link ApplicationTemplate#configureAdapter(String, Object, AdapterConfigurer)} time.
+   *
+   * @param pluginId the unique identifier provide when declaring plugin usage in {@link AdapterConfigurer}.
+   * @param <T> the class type of the plugin
+   * @return A new instance of the plugin being specified by the arguments
+   *
+   * @throws InstantiationException if failed create a new instance.
+   * @throws UnsupportedOperationException if the program is not running under the adapter context
+   * @throws IllegalArgumentException if no plugin for the given type and name
+   */
+  <T> T newPluginInstance(String pluginId) throws InstantiationException;
+}

--- a/cdap-api/src/main/java/co/cask/cdap/api/templates/AdapterPluginRegistry.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/templates/AdapterPluginRegistry.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.api.templates;
+
+import co.cask.cdap.api.templates.plugins.PluginProperties;
+import co.cask.cdap.api.templates.plugins.PluginSelector;
+
+import javax.annotation.Nullable;
+
+/**
+ * This interface provides method to register plugin usage for an adapter. The registered plugins
+ * will be available at runtime of the adapter.
+ */
+public interface AdapterPluginRegistry {
+
+  /**
+   * Adds a Plugin usage to the Adapter and create a new instance.
+   * The Plugin will be accessible at execution time via the {@link AdapterContext}.
+   *
+   * @param pluginType plugin type name
+   * @param pluginName plugin name
+   * @param pluginId an unique identifier for this usage. The same id is used to get the plugin at execution time.
+   * @param properties properties for the plugin. The same set of properties will be used to instantiate the plugin
+   *                   instance at execution time
+   * @param <T> type of the plugin class
+   * @return A new instance of the plugin class or {@code null} if no plugin was found
+   */
+  @Nullable
+  <T> T usePlugin(String pluginType, String pluginName, String pluginId, PluginProperties properties);
+
+  /**
+   * Adds a Plugin usage to the Adapter and create a new instance.
+   * The Plugin will be accessible at execution time via the {@link AdapterContext}.
+   *
+   * @param pluginType plugin type name
+   * @param pluginName plugin name
+   * @param pluginId an unique identifier for this usage. The same id is used to get the plugin at execution time.
+   * @param properties properties for the plugin. The same set of properties will be used to instantiate the plugin
+   *                   instance at execution time
+   * @param selector for selecting which plugin to use
+   * @param <T> type of the plugin class
+   * @return A new instance of the plugin class or {@code null} if no plugin was found
+   */
+  @Nullable
+  <T> T usePlugin(String pluginType, String pluginName,
+                  String pluginId, PluginProperties properties, PluginSelector selector);
+
+  /**
+   * Adds a Plugin usage to the Adapter.
+   * The Plugin will be accessible at execution time via the {@link AdapterContext}.
+   *
+   * @param pluginType plugin type name
+   * @param pluginName plugin name
+   * @param pluginId an unique identifier for this usage. The same id is used to get the plugin at execution time.
+   * @param properties properties for the plugin. The same set of properties will be used to instantiate the plugin
+   *                   instance at execution time
+   * @param <T> type of the plugin class
+   * @return A {@link Class} for the plugin class or {@code null} if no plugin was found
+   */
+  @Nullable
+  <T> Class<T> usePluginClass(String pluginType, String pluginName, String pluginId, PluginProperties properties);
+
+  /**
+   * Adds a Plugin usage to the Adapter.
+   * The Plugin will be accessible at execution time via the {@link AdapterContext}.
+   *
+   * @param pluginType plugin type name
+   * @param pluginName plugin name
+   * @param pluginId an unique identifier for this usage. The same id is used to get the plugin at execution time.
+   * @param properties properties for the plugin. The same set of properties will be used to instantiate the plugin
+   *                   instance at execution time
+   * @param selector for selecting which plugin to use
+   * @param <T> type of the plugin class
+   * @return A {@link Class} for the plugin class or {@code null} if no plugin was found
+   */
+  @Nullable
+  <T> Class<T> usePluginClass(String pluginType, String pluginName,
+                              String pluginId, PluginProperties properties, PluginSelector selector);
+}

--- a/cdap-api/src/main/java/co/cask/cdap/api/templates/plugins/PluginClass.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/templates/plugins/PluginClass.java
@@ -16,12 +16,15 @@
 
 package co.cask.cdap.api.templates.plugins;
 
+import co.cask.cdap.api.annotation.Beta;
+
 import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
  * Contains information about a plugin class.
  */
+@Beta
 public class PluginClass {
 
   private final String type;
@@ -129,5 +132,17 @@ public class PluginClass {
     result = 31 * result + (configFieldName != null ? configFieldName.hashCode() : 0);
     result = 31 * result + properties.hashCode();
     return result;
+  }
+
+  @Override
+  public String toString() {
+    return "PluginClass{" +
+      "className='" + className + '\'' +
+      ", type='" + type + '\'' +
+      ", name='" + name + '\'' +
+      ", description='" + description + '\'' +
+      ", configFieldName='" + configFieldName + '\'' +
+      ", properties=" + properties +
+      '}';
   }
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/templates/plugins/PluginInfo.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/templates/plugins/PluginInfo.java
@@ -16,9 +16,12 @@
 
 package co.cask.cdap.api.templates.plugins;
 
+import co.cask.cdap.api.annotation.Beta;
+
 /**
  * Contains plugin information.
  */
+@Beta
 public final class PluginInfo implements Comparable<PluginInfo> {
 
   private final String fileName;
@@ -65,8 +68,9 @@ public final class PluginInfo implements Comparable<PluginInfo> {
   @Override
   public String toString() {
     return "PluginInfo{" +
-      "name='" + name + '\'' +
-      ", version='" + version + '\'' +
+      "fileName='" + fileName + '\'' +
+      ", name='" + name + '\'' +
+      ", version=" + version +
       '}';
   }
 

--- a/cdap-api/src/main/java/co/cask/cdap/api/templates/plugins/PluginProperties.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/templates/plugins/PluginProperties.java
@@ -16,6 +16,8 @@
 
 package co.cask.cdap.api.templates.plugins;
 
+import co.cask.cdap.api.annotation.Beta;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -23,6 +25,7 @@ import java.util.Map;
 /**
  * Plugin instance properties.
  */
+@Beta
 public class PluginProperties {
 
   // Currently only support String->String map.

--- a/cdap-api/src/main/java/co/cask/cdap/api/templates/plugins/PluginPropertyField.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/templates/plugins/PluginPropertyField.java
@@ -16,9 +16,12 @@
 
 package co.cask.cdap.api.templates.plugins;
 
+import co.cask.cdap.api.annotation.Beta;
+
 /**
  * Contains information about a property used by a plugin.
  */
+@Beta
 public class PluginPropertyField {
 
   private final String name;

--- a/cdap-api/src/main/java/co/cask/cdap/api/templates/plugins/PluginSelector.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/templates/plugins/PluginSelector.java
@@ -18,18 +18,23 @@ package co.cask.cdap.api.templates.plugins;
 
 import co.cask.cdap.api.annotation.Beta;
 
+import java.util.Map;
+import java.util.SortedMap;
+
 /**
- * Base class for writing configuration class for template plugin.
+ * Represents class for selecting plugin.
  */
 @Beta
-public abstract class PluginConfig {
-
-  private PluginProperties properties;
+public class PluginSelector {
 
   /**
-   * Returns the {@link PluginProperties}.
+   * Selects a plugin. The default implementation returns the last entry in the given map.
+   *
+   * @param plugins set of available plugins. The {@link PluginInfo} is sorted in ascending order of plugin jar
+   *                name followed by plugin version.
+   * @return a {@link Map.Entry} for the selected plugin.
    */
-  public final PluginProperties getProperties() {
-    return properties;
+  public Map.Entry<PluginInfo, PluginClass> select(SortedMap<PluginInfo, PluginClass> plugins) {
+    return plugins.tailMap(plugins.lastKey()).entrySet().iterator().next();
   }
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/worker/WorkerContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/worker/WorkerContext.java
@@ -20,11 +20,12 @@ import co.cask.cdap.api.RuntimeContext;
 import co.cask.cdap.api.ServiceDiscoverer;
 import co.cask.cdap.api.TxRunnable;
 import co.cask.cdap.api.data.stream.StreamWriter;
+import co.cask.cdap.api.templates.AdapterContext;
 
 /**
  * Context for {@link Worker}.
  */
-public interface WorkerContext extends RuntimeContext, ServiceDiscoverer, StreamWriter {
+public interface WorkerContext extends RuntimeContext, ServiceDiscoverer, StreamWriter, AdapterContext {
 
   /**
    * Returns the specification used to configure {@link Worker} bounded to this context.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -55,6 +55,7 @@ import co.cask.cdap.internal.app.deploy.pipeline.adapter.AdapterDeploymentInfo;
 import co.cask.cdap.internal.app.namespace.DefaultNamespaceAdmin;
 import co.cask.cdap.internal.app.namespace.NamespaceAdmin;
 import co.cask.cdap.internal.app.runtime.adapter.AdapterService;
+import co.cask.cdap.internal.app.runtime.adapter.PluginRepository;
 import co.cask.cdap.internal.app.runtime.batch.InMemoryTransactionServiceManager;
 import co.cask.cdap.internal.app.runtime.distributed.TransactionServiceManager;
 import co.cask.cdap.internal.app.runtime.schedule.DistributedSchedulerService;
@@ -284,6 +285,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
 
       bind(Store.class).to(DefaultStore.class);
       bind(AdapterService.class).in(Scopes.SINGLETON);
+      bind(PluginRepository.class).in(Scopes.SINGLETON);
       bind(NamespaceAdmin.class).to(DefaultNamespaceAdmin.class).in(Scopes.SINGLETON);
 
       Multibinder<HttpHandler> handlerBinder = Multibinder.newSetBinder(

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/InMemoryAdapterConfigurator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/InMemoryAdapterConfigurator.java
@@ -22,15 +22,19 @@ import co.cask.cdap.app.deploy.ConfigResponse;
 import co.cask.cdap.app.deploy.Configurator;
 import co.cask.cdap.app.program.Archive;
 import co.cask.cdap.app.program.ManifestFields;
+import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.lang.jar.BundleJarUtil;
 import co.cask.cdap.common.utils.DirUtils;
 import co.cask.cdap.internal.app.ApplicationSpecificationAdapter;
+import co.cask.cdap.internal.app.runtime.adapter.PluginInstantiator;
+import co.cask.cdap.internal.app.runtime.adapter.PluginRepository;
 import co.cask.cdap.proto.AdapterConfig;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.templates.AdapterSpecification;
 import co.cask.cdap.templates.DefaultAdapterConfigurer;
 import com.google.common.base.Preconditions;
 import com.google.common.io.CharStreams;
+import com.google.common.io.Closeables;
 import com.google.common.io.Files;
 import com.google.common.reflect.TypeToken;
 import com.google.common.util.concurrent.Futures;
@@ -56,24 +60,28 @@ import java.util.jar.Manifest;
 public final class InMemoryAdapterConfigurator implements Configurator {
   private static final Gson GSON = ApplicationSpecificationAdapter.addTypeAdapters(new GsonBuilder()).create();
   private static final Logger LOG = LoggerFactory.getLogger(InMemoryAdapterConfigurator.class);
-  /**
-   * JAR file path.
-   */
+
+  private final CConfiguration cConf;
+  private final Id.Namespace namespaceId;
   private final Location archive;
   private final AdapterConfig adapterConfig;
   private final ApplicationSpecification templateSpec;
   private final String adapterName;
-  private final Id.Namespace namespaceId;
+  private final PluginRepository pluginRepository;
 
-  public InMemoryAdapterConfigurator(Id.Namespace id, Location archive, String adapterName,
-                                     AdapterConfig adapterConfig, ApplicationSpecification templateSpec) {
+  public InMemoryAdapterConfigurator(CConfiguration cConf, Id.Namespace id, Location archive, String adapterName,
+                                     AdapterConfig adapterConfig, ApplicationSpecification templateSpec,
+                                     PluginRepository pluginRepository) {
     Preconditions.checkNotNull(id);
     Preconditions.checkNotNull(archive);
+
+    this.cConf = cConf;
     this.namespaceId = id;
     this.archive = archive;
     this.adapterConfig = adapterConfig;
     this.templateSpec = templateSpec;
     this.adapterName = adapterName;
+    this.pluginRepository = pluginRepository;
   }
 
   /**
@@ -105,22 +113,28 @@ public final class InMemoryAdapterConfigurator implements Configurator {
         }
 
         ApplicationTemplate template = (ApplicationTemplate) appMain;
-        DefaultAdapterConfigurer configurer = new DefaultAdapterConfigurer(namespaceId, adapterName, adapterConfig,
-                                                                           templateSpec);
-
-        TypeToken typeToken = TypeToken.of(template.getClass());
-        TypeToken<?> resultToken = typeToken.resolveType(ApplicationTemplate.class.getTypeParameters()[0]);
-        Type configType;
-        // if the user parameterized their template, like 'xyz extends ApplicationTemplate<T>',
-        // we can deserialize the config into that object. Otherwise it'll just be an Object
-        if (resultToken.getType() instanceof Class) {
-          configType = resultToken.getType();
-        } else {
-          configType = Object.class;
+        PluginInstantiator pluginInstantiator = new PluginInstantiator(cConf, adapterConfig.getTemplate(),
+                                                                       template.getClass().getClassLoader());
+        try {
+          DefaultAdapterConfigurer configurer = new DefaultAdapterConfigurer(namespaceId, adapterName,
+                                                                             adapterConfig, templateSpec,
+                                                                             pluginRepository, pluginInstantiator);
+          TypeToken typeToken = TypeToken.of(template.getClass());
+          TypeToken<?> resultToken = typeToken.resolveType(ApplicationTemplate.class.getTypeParameters()[0]);
+          Type configType;
+          // if the user parameterized their template, like 'xyz extends ApplicationTemplate<T>',
+          // we can deserialize the config into that object. Otherwise it'll just be an Object
+          if (resultToken.getType() instanceof Class) {
+            configType = resultToken.getType();
+          } else {
+            configType = Object.class;
+          }
+          template.configureAdapter(adapterName, GSON.fromJson(adapterConfig.getConfig(), configType), configurer);
+          AdapterSpecification spec = configurer.createSpecification();
+          result.set(new DefaultConfigResponse(0, CharStreams.newReaderSupplier(GSON.toJson(spec))));
+        } finally {
+          Closeables.closeQuietly(pluginInstantiator);
         }
-        template.configureAdapter(adapterName, GSON.fromJson(adapterConfig.getConfig(), configType), configurer);
-        AdapterSpecification spec = configurer.createSpecification();
-        result.set(new DefaultConfigResponse(0, CharStreams.newReaderSupplier(GSON.toJson(spec))));
       } finally {
         removeDir(unpackedJarDir);
       }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/LocalAdapterManager.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/LocalAdapterManager.java
@@ -30,6 +30,7 @@ import co.cask.cdap.internal.app.deploy.pipeline.adapter.ConfigureAdapterStage;
 import co.cask.cdap.internal.app.deploy.pipeline.adapter.CreateAdapterDatasetInstancesStage;
 import co.cask.cdap.internal.app.deploy.pipeline.adapter.CreateAdapterStreamsStage;
 import co.cask.cdap.internal.app.deploy.pipeline.adapter.DeployAdapterDatasetModulesStage;
+import co.cask.cdap.internal.app.runtime.adapter.PluginRepository;
 import co.cask.cdap.pipeline.Pipeline;
 import co.cask.cdap.pipeline.PipelineFactory;
 import co.cask.cdap.proto.Id;
@@ -52,13 +53,14 @@ public class LocalAdapterManager implements Manager<AdapterDeploymentInfo, Adapt
   private final DatasetFramework datasetFramework;
   private final DatasetFramework inMemoryDatasetFramework;
   private final Store store;
+  private final PluginRepository pluginRepository;
 
   @Inject
   public LocalAdapterManager(CConfiguration configuration, PipelineFactory pipelineFactory,
                              DatasetFramework datasetFramework,
                              @Named("datasetMDS") DatasetFramework inMemoryDatasetFramework,
                              StreamAdmin streamAdmin, ExploreFacade exploreFacade,
-                             Store store) {
+                             Store store, PluginRepository pluginRepository) {
     this.configuration = configuration;
     this.pipelineFactory = pipelineFactory;
     this.datasetFramework = datasetFramework;
@@ -66,6 +68,7 @@ public class LocalAdapterManager implements Manager<AdapterDeploymentInfo, Adapt
     this.streamAdmin = streamAdmin;
     this.exploreFacade = exploreFacade;
     this.store = store;
+    this.pluginRepository = pluginRepository;
     this.exploreEnabled = configuration.getBoolean(Constants.Explore.EXPLORE_ENABLED);
   }
 
@@ -75,7 +78,7 @@ public class LocalAdapterManager implements Manager<AdapterDeploymentInfo, Adapt
     Location templateJarLocation =
       new LocalLocationFactory().create(input.getTemplateInfo().getFile().toURI());
     Pipeline<AdapterSpecification> pipeline = pipelineFactory.getPipeline();
-    pipeline.addLast(new ConfigureAdapterStage(namespace, id, templateJarLocation));
+    pipeline.addLast(new ConfigureAdapterStage(configuration, namespace, id, templateJarLocation, pluginRepository));
     pipeline.addLast(new AdapterVerificationStage(input.getTemplateSpec()));
     pipeline.addLast(new DeployAdapterDatasetModulesStage(configuration, namespace, templateJarLocation,
                                                           datasetFramework, inMemoryDatasetFramework));

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/adapter/ConfigureAdapterStage.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/adapter/ConfigureAdapterStage.java
@@ -17,10 +17,12 @@
 package co.cask.cdap.internal.app.deploy.pipeline.adapter;
 
 import co.cask.cdap.app.deploy.ConfigResponse;
+import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.internal.app.ApplicationSpecificationAdapter;
 import co.cask.cdap.internal.app.deploy.InMemoryAdapterConfigurator;
 import co.cask.cdap.internal.app.deploy.InMemoryConfigurator;
 import co.cask.cdap.internal.app.deploy.pipeline.ApplicationDeployable;
+import co.cask.cdap.internal.app.runtime.adapter.PluginRepository;
 import co.cask.cdap.pipeline.AbstractStage;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.templates.AdapterSpecification;
@@ -44,18 +46,24 @@ import java.util.concurrent.TimeUnit;
  */
 public class ConfigureAdapterStage extends AbstractStage<AdapterDeploymentInfo> {
   private static final Gson GSON = ApplicationSpecificationAdapter.addTypeAdapters(new GsonBuilder()).create();
+
+  private final CConfiguration cConf;
   private final Id.Namespace namespace;
   private final String adapterName;
   private final Location templateJarLocation;
+  private final PluginRepository pluginRepository;
 
   /**
    * Constructor with hit for handling type.
    */
-  public ConfigureAdapterStage(Id.Namespace namespace, String adapterName, Location templateJarLocation) {
+  public ConfigureAdapterStage(CConfiguration cConf, Id.Namespace namespace, String adapterName,
+                               Location templateJarLocation, PluginRepository pluginRepository) {
     super(TypeToken.of(AdapterDeploymentInfo.class));
+    this.cConf = cConf;
     this.namespace = namespace;
     this.adapterName = adapterName;
     this.templateJarLocation = templateJarLocation;
+    this.pluginRepository = pluginRepository;
   }
 
   /**
@@ -67,8 +75,9 @@ public class ConfigureAdapterStage extends AbstractStage<AdapterDeploymentInfo> 
   @Override
   public void process(AdapterDeploymentInfo deploymentInfo) throws Exception {
     InMemoryAdapterConfigurator inMemoryAdapterConfigurator =
-      new InMemoryAdapterConfigurator(namespace, templateJarLocation, adapterName,
-                                      deploymentInfo.getAdapterConfig(), deploymentInfo.getTemplateSpec());
+      new InMemoryAdapterConfigurator(cConf, namespace, templateJarLocation, adapterName,
+                                      deploymentInfo.getAdapterConfig(), deploymentInfo.getTemplateSpec(),
+                                      pluginRepository);
 
     ConfigResponse configResponse;
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/ProgramOptionConstants.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/ProgramOptionConstants.java
@@ -51,5 +51,7 @@ public final class ProgramOptionConstants {
 
   public static final String ADAPTER_NAME = "adapterName";
 
+  public static final String ADAPTER_SPEC = "adapterSpec";
+
   public static final String RESOURCES = "resources";
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/PluginInstantiator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/PluginInstantiator.java
@@ -95,6 +95,22 @@ public class PluginInstantiator implements Closeable {
   }
 
   /**
+   * Loads and returns the {@link Class} of the given plugin class.
+   *
+   * @param pluginInfo information about the plugin. It is used for creating the ClassLoader for the plugin.
+   * @param pluginClass information about the plugin class
+   * @param <T> Type of the plugin
+   * @return the plugin Class
+   * @throws IOException if failed to expand the plugin jar to create the plugin ClassLoader
+   * @throws ClassNotFoundException if failed to load the given plugin class
+   */
+  @SuppressWarnings("unchecked")
+  public <T> Class<T> loadClass(PluginInfo pluginInfo,
+                                PluginClass pluginClass) throws IOException, ClassNotFoundException {
+    return (Class<T>) getPluginClassLoader(pluginInfo).loadClass(pluginClass.getClassName());
+  }
+
+  /**
    * Creates a new instance of the given plugin class.
    *
    * @param pluginInfo information about the plugin. It is used for creating the ClassLoader for the plugin.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/AbstractMapReduceContextBuilder.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/AbstractMapReduceContextBuilder.java
@@ -24,7 +24,9 @@ import co.cask.cdap.app.metrics.MapReduceMetrics;
 import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.runtime.Arguments;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.internal.app.runtime.adapter.PluginInstantiator;
 import co.cask.cdap.internal.app.runtime.workflow.WorkflowMapReduceProgram;
+import co.cask.cdap.templates.AdapterSpecification;
 import co.cask.tephra.Transaction;
 import co.cask.tephra.TransactionAware;
 import com.google.common.base.Preconditions;
@@ -69,7 +71,8 @@ public abstract class AbstractMapReduceContextBuilder {
                                      @Nullable String inputDataSetName,
                                      @Nullable List<Split> inputSplits,
                                      @Nullable String outputDataSetName,
-                                     @Nullable String adapterName) {
+                                     @Nullable AdapterSpecification adapterSpec,
+                                     @Nullable PluginInstantiator pluginInstantiator) {
     Injector injector = prepare();
 
     // Initializing Program
@@ -107,7 +110,7 @@ public abstract class AbstractMapReduceContextBuilder {
     BasicMapReduceContext context =
       new BasicMapReduceContext(program, type, RunIds.fromString(runId), taskId, runtimeArguments, datasets, spec,
                                 logicalStartTime, workflowBatch, discoveryServiceClient, metricsCollectionService,
-                                datasetFramework, adapterName);
+                                datasetFramework, adapterSpec, pluginInstantiator);
 
     // propagating tx to all txAware guys
     // NOTE: tx will be committed by client code

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
@@ -36,7 +36,10 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.logging.LoggingContext;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.internal.app.runtime.AbstractContext;
+import co.cask.cdap.internal.app.runtime.adapter.PluginInstantiator;
 import co.cask.cdap.logging.context.MapReduceLoggingContext;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.templates.AdapterSpecification;
 import co.cask.tephra.TransactionAware;
 import com.google.common.collect.Maps;
 import org.apache.hadoop.mapreduce.Job;
@@ -59,7 +62,6 @@ public class BasicMapReduceContext extends AbstractContext implements MapReduceC
   private final String workflowBatch;
   private final Metrics userMetrics;
   private final MetricsCollectionService metricsCollectionService;
-  private final String adapterName;
 
   private String inputDatasetName;
   private List<Split> inputDataSelection;
@@ -81,13 +83,13 @@ public class BasicMapReduceContext extends AbstractContext implements MapReduceC
                                DiscoveryServiceClient discoveryServiceClient,
                                MetricsCollectionService metricsCollectionService,
                                DatasetFramework dsFramework,
-                               @Nullable String adapterName) {
+                               @Nullable AdapterSpecification adapterSpec,
+                               @Nullable PluginInstantiator pluginInstantiator) {
     super(program, runId, runtimeArguments, datasets,
-          getMetricCollector(program, runId.getId(), taskId, metricsCollectionService, type, adapterName),
-          dsFramework, discoveryServiceClient);
+          getMetricCollector(program, runId.getId(), taskId, metricsCollectionService, type, adapterSpec),
+          dsFramework, discoveryServiceClient, adapterSpec, pluginInstantiator);
     this.logicalStartTime = logicalStartTime;
     this.workflowBatch = workflowBatch;
-    this.adapterName = adapterName;
     this.metricsCollectionService = metricsCollectionService;
 
     if (metricsCollectionService != null) {
@@ -95,14 +97,20 @@ public class BasicMapReduceContext extends AbstractContext implements MapReduceC
     } else {
       this.userMetrics = null;
     }
-    this.loggingContext = new MapReduceLoggingContext(getNamespaceId(), getApplicationId(), getProgramName(),
-                                                      getRunId().getId(), getAdapterName());
+    this.loggingContext = createLoggingContext(program.getId(), runId, adapterSpec);
     this.spec = spec;
     this.mapperResources = spec.getMapperResources();
     this.reducerResources = spec.getReducerResources();
     // initialize input/output to what the spec says. These can be overwritten at runtime.
     this.inputDatasetName = spec.getInputDataSet();
     this.outputDatasetName = spec.getOutputDataSet();
+  }
+
+  private LoggingContext createLoggingContext(Id.Program programId, RunId runId,
+                                              @Nullable AdapterSpecification adapterSpec) {
+    String adapterName = adapterSpec == null ? null : adapterSpec.getName();
+    return new MapReduceLoggingContext(programId.getNamespaceId(), programId.getApplicationId(),
+                                       programId.getId(), runId.getId(), adapterName);
   }
 
   @Override
@@ -126,14 +134,6 @@ public class BasicMapReduceContext extends AbstractContext implements MapReduceC
    */
   public String getWorkflowBatch() {
     return workflowBatch;
-  }
-
-  /**
-   * @return the adapter name if run from within adapter, otherwise null
-   */
-  @Nullable
-  public String getAdapterName() {
-    return adapterName;
   }
 
   public void setJob(Job job) {
@@ -251,7 +251,7 @@ public class BasicMapReduceContext extends AbstractContext implements MapReduceC
   private static MetricsCollector getMetricCollector(Program program, String runId, String taskId,
                                                      @Nullable MetricsCollectionService service,
                                                      @Nullable MapReduceMetrics.TaskType type,
-                                                     @Nullable String adapterName) {
+                                                     @Nullable AdapterSpecification adapterSpec) {
     if (service == null) {
       return null;
     }
@@ -268,8 +268,8 @@ public class BasicMapReduceContext extends AbstractContext implements MapReduceC
       tags.putAll(getMetricsContext(program, runId));
     }
 
-    if (adapterName != null) {
-      tags.put(Constants.Metrics.Tag.ADAPTER, adapterName);
+    if (adapterSpec != null) {
+      tags.put(Constants.Metrics.Tag.ADAPTER, adapterSpec.getName());
     }
 
     return service.getCollector(tags);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/DynamicMapReduceContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/DynamicMapReduceContext.java
@@ -30,6 +30,8 @@ import co.cask.cdap.app.runtime.Arguments;
 import co.cask.cdap.data2.dataset2.DatasetCacheKey;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.DynamicDatasetContext;
+import co.cask.cdap.internal.app.runtime.adapter.PluginInstantiator;
+import co.cask.cdap.templates.AdapterSpecification;
 import co.cask.tephra.TransactionContext;
 import co.cask.tephra.TransactionSystemClient;
 import com.google.common.cache.CacheBuilder;
@@ -71,13 +73,16 @@ public class DynamicMapReduceContext extends BasicMapReduceContext implements Da
                                  RunId runId, String taskId,
                                  Arguments runtimeArguments,
                                  MapReduceSpecification spec,
-                                 long logicalStartTime, String workflowBatch, String adapterName,
+                                 long logicalStartTime, String workflowBatch,
                                  DiscoveryServiceClient discoveryServiceClient,
                                  MetricsCollectionService metricsCollectionService,
                                  TransactionSystemClient txClient,
-                                 DatasetFramework dsFramework) {
+                                 DatasetFramework dsFramework,
+                                 @Nullable AdapterSpecification adapterSpec,
+                                 @Nullable PluginInstantiator pluginInstantiator) {
     super(program, type, runId, taskId, runtimeArguments, Collections.<String>emptySet(), spec,
-          logicalStartTime, workflowBatch, discoveryServiceClient, metricsCollectionService, dsFramework, adapterName);
+          logicalStartTime, workflowBatch, discoveryServiceClient, metricsCollectionService,
+          dsFramework, adapterSpec, pluginInstantiator);
     this.datasetsCache = CacheBuilder.newBuilder()
       .removalListener(new RemovalListener<Long, Map<DatasetCacheKey, Dataset>>() {
         @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextConfig.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextConfig.java
@@ -23,6 +23,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.internal.app.runtime.BasicArguments;
 import co.cask.cdap.internal.app.runtime.batch.dataset.DataSetInputFormat;
 import co.cask.cdap.internal.app.runtime.batch.dataset.DataSetOutputFormat;
+import co.cask.cdap.templates.AdapterSpecification;
 import co.cask.tephra.Transaction;
 import com.google.common.base.Throwables;
 import com.google.common.reflect.TypeToken;
@@ -41,6 +42,7 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Helper class for getting and setting specific config settings for a job context.
@@ -53,7 +55,7 @@ public final class MapReduceContextConfig {
   private static final String HCONF_ATTR_RUN_ID = "hconf.program.run.id";
   private static final String HCONF_ATTR_LOGICAL_START_TIME = "hconf.program.logical.start.time";
   private static final String HCONF_ATTR_WORKFLOW_BATCH = "hconf.program.workflow.batch";
-  private static final String HCONF_ATTR_ADAPTER_NAME = "hconf.program.adapter.name";
+  private static final String HCONF_ATTR_ADAPTER_SPEC = "hconf.program.adapter.spec";
   private static final String HCONF_ATTR_ARGS = "hconf.program.args";
   private static final String HCONF_ATTR_PROGRAM_JAR_URI = "hconf.program.jar.uri";
   private static final String HCONF_ATTR_CCONF = "hconf.cconf";
@@ -71,23 +73,16 @@ public final class MapReduceContextConfig {
     return hConf;
   }
 
-  public void set(BasicMapReduceContext context, CConfiguration conf,
-                  Transaction tx, URI programJarURI) {
+  public void set(BasicMapReduceContext context, CConfiguration conf, Transaction tx, URI programJarURI) {
     setRunId(context.getRunId().getId());
     setLogicalStartTime(context.getLogicalStartTime());
-    if (context.getWorkflowBatch() != null) {
-      setWorkflowBatch(context.getWorkflowBatch());
-    }
-    if (context.getAdapterName() != null) {
-      setAdapterName(context.getAdapterName());
-    }
+    setWorkflowBatch(context.getWorkflowBatch());
+    setAdapterSpec(context.getAdapterSpec());
     setArguments(context.getRuntimeArguments());
     setProgramJarURI(programJarURI);
     setConf(conf);
     setTx(tx);
-    if (context.getInputDataSelection() != null) {
-      setInputSelection(context.getInputDataSelection());
-    }
+    setInputSelection(context.getInputDataSelection());
   }
 
   private void setArguments(Map<String, String> arguments) {
@@ -116,20 +111,29 @@ public final class MapReduceContextConfig {
     return hConf.getLong(HCONF_ATTR_LOGICAL_START_TIME, System.currentTimeMillis());
   }
 
-  private void setWorkflowBatch(String workflowBatch) {
-    hConf.set(HCONF_ATTR_WORKFLOW_BATCH, workflowBatch);
+  private void setWorkflowBatch(@Nullable String workflowBatch) {
+    if (workflowBatch != null) {
+      hConf.set(HCONF_ATTR_WORKFLOW_BATCH, workflowBatch);
+    }
   }
 
   public String getWorkflowBatch() {
     return hConf.get(HCONF_ATTR_WORKFLOW_BATCH);
   }
 
-  private void setAdapterName(String adapterName) {
-    hConf.set(HCONF_ATTR_ADAPTER_NAME, adapterName);
+  private void setAdapterSpec(@Nullable AdapterSpecification adapterSpec) {
+    if (adapterSpec != null) {
+      hConf.set(HCONF_ATTR_ADAPTER_SPEC, GSON.toJson(adapterSpec));
+    }
   }
 
-  public String getAdapterName() {
-    return hConf.get(HCONF_ATTR_ADAPTER_NAME);
+  @Nullable
+  public AdapterSpecification getAdapterSpec() {
+    String spec = hConf.get(HCONF_ATTR_ADAPTER_SPEC);
+    if (spec == null) {
+      return null;
+    }
+    return GSON.fromJson(spec, AdapterSpecification.class);
   }
 
   private void setProgramJarURI(URI programJarURI) {
@@ -148,7 +152,10 @@ public final class MapReduceContextConfig {
     return hConf.get(DataSetInputFormat.HCONF_ATTR_INPUT_DATASET);
   }
 
-  private void setInputSelection(List<Split> splits) {
+  private void setInputSelection(@Nullable List<Split> splits) {
+    if (splits == null) {
+      return;
+    }
     // todo: this is ugly
     Class<? extends Split> splitClass;
     if (splits.size() > 0) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractProgramTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractProgramTwillRunnable.java
@@ -181,6 +181,12 @@ public abstract class AbstractProgramTwillRunnable<T extends ProgramRunner> impl
       cConf.clear();
       cConf.addResource(new File(configs.get("cConf")).toURI().toURL());
 
+      // Alter the template directory to only the name part in the container directory.
+      // It works in pair with the ProgramRunner.
+      // See AbstractDistributedProgramRunner
+      File templateDir = new File(cConf.get(Constants.AppFabric.APP_TEMPLATE_DIR));
+      cConf.set(Constants.AppFabric.APP_TEMPLATE_DIR, templateDir.getName());
+
       injector = Guice.createInjector(createModule(context));
 
       zkClientService = injector.getInstance(ZKClientService.class);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/BasicWorkerContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/BasicWorkerContext.java
@@ -37,8 +37,10 @@ import co.cask.cdap.data2.dataset2.DatasetCacheKey;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.DynamicDatasetContext;
 import co.cask.cdap.internal.app.runtime.AbstractContext;
+import co.cask.cdap.internal.app.runtime.adapter.PluginInstantiator;
 import co.cask.cdap.logging.context.WorkerLoggingContext;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.templates.AdapterSpecification;
 import co.cask.tephra.TransactionContext;
 import co.cask.tephra.TransactionFailureException;
 import co.cask.tephra.TransactionSystemClient;
@@ -60,6 +62,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 /**
@@ -85,10 +88,12 @@ public class BasicWorkerContext extends AbstractContext implements WorkerContext
                             DatasetFramework datasetFramework,
                             TransactionSystemClient transactionSystemClient,
                             DiscoveryServiceClient discoveryServiceClient,
-                            StreamWriterFactory streamWriterFactory) {
+                            StreamWriterFactory streamWriterFactory,
+                            @Nullable AdapterSpecification adapterSpec,
+                            @Nullable PluginInstantiator pluginInstantiator) {
     super(program, runId, runtimeArgs, spec.getDatasets(),
           getMetricCollector(metricsCollectionService, program, runId.getId(), instanceId),
-          datasetFramework, discoveryServiceClient);
+          datasetFramework, discoveryServiceClient, adapterSpec, pluginInstantiator);
     this.program = program;
     this.specification = spec;
     this.instanceId = instanceId;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/templates/AdapterPlugin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/templates/AdapterPlugin.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.templates;
+
+import co.cask.cdap.api.templates.plugins.PluginClass;
+import co.cask.cdap.api.templates.plugins.PluginInfo;
+import co.cask.cdap.api.templates.plugins.PluginProperties;
+
+/**
+ * A container class for holding plugin information for an adapter instance.
+ */
+public final class AdapterPlugin {
+  private final PluginInfo pluginInfo;
+  private final PluginClass pluginClass;
+  private final PluginProperties properties;
+
+  AdapterPlugin(PluginInfo pluginInfo, PluginClass pluginClass, PluginProperties properties) {
+    this.pluginInfo = pluginInfo;
+    this.pluginClass = pluginClass;
+    this.properties = properties;
+  }
+
+  /**
+   * Returns the plugin information.
+   */
+  public PluginInfo getPluginInfo() {
+    return pluginInfo;
+  }
+
+  /**
+   * Returns the plugin class information.
+   */
+  public PluginClass getPluginClass() {
+    return pluginClass;
+  }
+
+  /**
+   * Returns the set of properties available for the plugin when the adapter was created.
+   */
+  public PluginProperties getProperties() {
+    return properties;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    AdapterPlugin that = (AdapterPlugin) o;
+
+    return pluginInfo.equals(that.pluginInfo)
+      && pluginClass.equals(that.pluginClass)
+      && properties.equals(that.properties);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = pluginInfo.hashCode();
+    result = 31 * result + pluginClass.hashCode();
+    result = 31 * result + properties.hashCode();
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "AdapterPlugin{" +
+      "pluginClass=" + pluginClass +
+      ", pluginInfo=" + pluginInfo +
+      ", properties=" + properties +
+      '}';
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/templates/AdapterSpecification.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/templates/AdapterSpecification.java
@@ -19,6 +19,7 @@ package co.cask.cdap.templates;
 import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.data.stream.StreamSpecification;
 import co.cask.cdap.api.schedule.ScheduleSpecification;
+import co.cask.cdap.api.templates.plugins.PluginInfo;
 import co.cask.cdap.data.dataset.DatasetCreationSpec;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramType;
@@ -29,6 +30,8 @@ import com.google.gson.JsonElement;
 
 import java.util.EnumSet;
 import java.util.Map;
+import java.util.NavigableSet;
+import java.util.TreeSet;
 import javax.annotation.Nullable;
 
 /**
@@ -47,6 +50,7 @@ public final class AdapterSpecification {
   private final Map<String, DatasetCreationSpec> datasets;
   private final Map<String, String> datasetModules;
   private final Map<String, String> runtimeArgs;
+  private final Map<String, AdapterPlugin> plugins;
   private final Resources resources;
   // this is a json representation of some config that templates will use to configure
   // an adapter. At configuration time it will be translated into the correct object,
@@ -58,18 +62,20 @@ public final class AdapterSpecification {
                                Map<String, StreamSpecification> streams,
                                Map<String, DatasetCreationSpec> datasets,
                                Map<String, String> datasetModules,
-                               Map<String, String> runtimeArgs, Resources resources,
+                               Map<String, String> runtimeArgs,
+                               Map<String, AdapterPlugin> plugins,
+                               Resources resources,
                                JsonElement config) {
     this.name = name;
     this.description = description;
     this.program = program;
     this.scheduleSpec = scheduleSpec;
     this.instances = instances;
-    this.streams = streams == null ? ImmutableMap.<String, StreamSpecification>of() : ImmutableMap.copyOf(streams);
-    this.datasets = datasets == null ? ImmutableMap.<String, DatasetCreationSpec>of() : ImmutableMap.copyOf(datasets);
-    this.datasetModules = datasetModules == null ?
-      ImmutableMap.<String, String>of() : ImmutableMap.copyOf(datasetModules);
-    this.runtimeArgs = runtimeArgs == null ? ImmutableMap.<String, String>of() : ImmutableMap.copyOf(runtimeArgs);
+    this.streams = streams;
+    this.datasets = datasets;
+    this.datasetModules = datasetModules;
+    this.runtimeArgs = runtimeArgs;
+    this.plugins = plugins;
     this.config = config;
     this.resources = resources;
   }
@@ -111,6 +117,21 @@ public final class AdapterSpecification {
     return datasetModules;
   }
 
+  public Map<String, AdapterPlugin> getPlugins() {
+    return plugins;
+  }
+
+  /**
+   * Returns set of {@link PluginInfo} for the plugins in this specification.
+   */
+  public NavigableSet<PluginInfo> getPluginInfos() {
+    NavigableSet<PluginInfo> result = new TreeSet<PluginInfo>();
+    for (AdapterPlugin plugin : plugins.values()) {
+      result.add(plugin.getPluginInfo());
+    }
+    return result;
+  }
+
   @Nullable
   public Integer getInstances() {
     return instances;
@@ -136,10 +157,11 @@ public final class AdapterSpecification {
     private final Id.Program program;
     private String description;
     private ScheduleSpecification schedule;
-    private Map<String, String> runtimeArgs;
-    private Map<String, StreamSpecification> streams;
-    private Map<String, DatasetCreationSpec> datasets;
-    private Map<String, String> datasetModules;
+    private Map<String, String> runtimeArgs = ImmutableMap.of();
+    private Map<String, StreamSpecification> streams = ImmutableMap.of();
+    private Map<String, DatasetCreationSpec> datasets = ImmutableMap.of();
+    private Map<String, String> datasetModules = ImmutableMap.of();
+    private Map<String, AdapterPlugin> plugins = ImmutableMap.of();
     private int instances;
     private Resources resources;
     private JsonElement config;
@@ -166,22 +188,27 @@ public final class AdapterSpecification {
     }
 
     public Builder setRuntimeArgs(Map<String, String> runtimeArgs) {
-      this.runtimeArgs = runtimeArgs;
+      this.runtimeArgs = ImmutableMap.copyOf(runtimeArgs);
       return this;
     }
 
     public Builder setStreams(Map<String, StreamSpecification> streams) {
-      this.streams = streams;
+      this.streams = ImmutableMap.copyOf(streams);
       return this;
     }
 
     public Builder setDatasets(Map<String, DatasetCreationSpec> datasets) {
-      this.datasets = datasets;
+      this.datasets = ImmutableMap.copyOf(datasets);
       return this;
     }
 
     public Builder setDatasetModules(Map<String, String> modules) {
-      this.datasetModules = modules;
+      this.datasetModules = ImmutableMap.copyOf(modules);
+      return this;
+    }
+
+    public Builder setPlugins(Map<String, AdapterPlugin> plugins) {
+      this.plugins = ImmutableMap.copyOf(plugins);
       return this;
     }
 
@@ -202,7 +229,7 @@ public final class AdapterSpecification {
 
     public AdapterSpecification build() {
       return new AdapterSpecification(name, description, program, schedule, instances,
-                                      streams, datasets, datasetModules, runtimeArgs, resources, config);
+                                      streams, datasets, datasetModules, runtimeArgs, plugins, resources, config);
     }
   }
 
@@ -226,13 +253,14 @@ public final class AdapterSpecification {
       Objects.equal(streams, that.streams) &&
       Objects.equal(datasets, that.datasets) &&
       Objects.equal(datasetModules, that.datasetModules) &&
-      Objects.equal(instances, that.instances);
+      Objects.equal(instances, that.instances) &&
+      Objects.equal(plugins, that.plugins);
   }
 
   @Override
   public int hashCode() {
     return Objects.hashCode(name, description, program, config, scheduleSpec, runtimeArgs,
-                            streams, datasets, datasetModules, instances);
+                            streams, datasets, datasetModules, instances, plugins);
   }
 
   @Override
@@ -248,6 +276,8 @@ public final class AdapterSpecification {
       .add("datasets", datasets)
       .add("datasetModules", datasetModules)
       .add("instances", instances)
+      .add("plugins", plugins)
       .toString();
   }
+
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/adapter/PluginTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/adapter/PluginTest.java
@@ -21,6 +21,8 @@ import co.cask.cdap.api.templates.plugins.PluginClass;
 import co.cask.cdap.api.templates.plugins.PluginInfo;
 import co.cask.cdap.api.templates.plugins.PluginProperties;
 import co.cask.cdap.api.templates.plugins.PluginPropertyField;
+import co.cask.cdap.api.templates.plugins.PluginSelector;
+import co.cask.cdap.api.templates.plugins.PluginVersion;
 import co.cask.cdap.app.program.ManifestFields;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
@@ -31,16 +33,19 @@ import co.cask.cdap.common.lang.jar.BundleJarUtil;
 import co.cask.cdap.common.utils.DirUtils;
 import co.cask.cdap.internal.app.plugins.test.TestPlugin;
 import co.cask.cdap.internal.test.AppJarHelper;
+import co.cask.cdap.proto.ProgramType;
 import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
+import com.google.common.hash.Hashing;
 import com.google.common.io.Files;
 import com.google.gson.Gson;
 import org.apache.twill.filesystem.LocalLocationFactory;
 import org.apache.twill.filesystem.Location;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -51,6 +56,7 @@ import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -58,6 +64,7 @@ import java.io.InputStream;
 import java.io.Writer;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedMap;
 import java.util.concurrent.Callable;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
@@ -74,11 +81,14 @@ public class PluginTest {
 
   private static CConfiguration cConf;
   private static File appTemplateJar;
+  private static ApplicationTemplateInfo appTemplateInfo;
   private static File templatePluginDir;
   private static ClassLoader templateClassLoader;
 
   @BeforeClass
   public static void setup() throws IOException, ClassNotFoundException {
+    LoggerFactory.getLogger(PluginTest.class).info("Testing {}", cConf);
+
     cConf = CConfiguration.create();
     cConf.set(Constants.CFG_LOCAL_DATA_DIR, TMP_FOLDER.newFolder().getAbsolutePath());
 
@@ -87,6 +97,8 @@ public class PluginTest {
     // Create the template jar
     File appTemplateDir = new File(cConf.get(Constants.AppFabric.APP_TEMPLATE_DIR));
     appTemplateJar = createJar(PluginTestAppTemplate.class, new File(appTemplateDir, "PluginTest-1.0.jar"));
+    appTemplateInfo = new ApplicationTemplateInfo(appTemplateJar, TEMPLATE_NAME, TEMPLATE_NAME,
+                                                  ProgramType.WORKER, Files.hash(appTemplateJar, Hashing.md5()));
 
     templateClassLoader = createAppClassLoader(appTemplateJar);
 
@@ -99,6 +111,15 @@ public class PluginTest {
     generateClass(EmptyClass.class, "test.EmptyClass", libDir);
     createJar(new DirectoryClassLoader(libDir, null).loadClass("test.EmptyClass"),
               new File(new File(templatePluginDir, "lib"), "common.jar"));
+  }
+
+  @After
+  public void cleanupPlugins() throws IOException {
+    // Cleanup the jars in the plugin directory for the template,
+    // as each test creates plugin jar for different kind of testing
+    for (File jarFile : DirUtils.listFiles(templatePluginDir, "jar")) {
+      jarFile.delete();
+    }
   }
 
   @Test
@@ -119,10 +140,7 @@ public class PluginTest {
 
     // Build up the plugin repository.
     PluginRepository repository = new PluginRepository(cConf);
-    repository.inspectPlugins(ImmutableMap.of(TEMPLATE_NAME, appTemplateJar));
-
-    // Retrieve plugin info
-    Multimap<PluginInfo, PluginClass> pluginInfos = repository.getPlugins(TEMPLATE_NAME);
+    Multimap<PluginInfo, PluginClass> pluginInfos = repository.inspectPlugins(TEMPLATE_NAME, appTemplateJar);
     Assert.assertEquals(2, pluginInfos.size());
 
     // Instantiate the plugins and execute them
@@ -161,10 +179,9 @@ public class PluginTest {
 
     // Build up the plugin repository.
     PluginRepository repository = new PluginRepository(cConf);
-    repository.inspectPlugins(ImmutableMap.of(TEMPLATE_NAME, appTemplateJar));
+    Multimap<PluginInfo, PluginClass> plugins = repository.inspectPlugins(TEMPLATE_NAME, appTemplateJar);
 
     // There should be one for the external-plugin
-    Multimap<PluginInfo, PluginClass> plugins = repository.getPlugins(TEMPLATE_NAME);
     Map.Entry<PluginInfo, PluginClass> pluginEntry = null;
     for (Map.Entry<PluginInfo, PluginClass> entry : plugins.entries()) {
       if (entry.getKey().getName().equals("external-plugin")) {
@@ -177,6 +194,50 @@ public class PluginTest {
     // There should be exactly one plugin class for the external plugin.
     Assert.assertEquals(1, plugins.get(pluginEntry.getKey()).size());
     Assert.assertEquals(pluginClass, pluginEntry.getValue());
+  }
+
+  @Test
+  public void testPluginSelector() throws IOException {
+    PluginRepository repository = new PluginRepository(cConf);
+
+    // No plugin yet
+    Map.Entry<PluginInfo, PluginClass> plugin = repository.findPlugin(TEMPLATE_NAME,
+                                                                      "plugin", "TestPlugin2", new PluginSelector());
+    Assert.assertNull(plugin);
+
+    // Create a plugin jar
+    Manifest manifest = createManifest(ManifestFields.EXPORT_PACKAGE, TestPlugin.class.getPackage().getName());
+    createJar(TestPlugin.class, new File(templatePluginDir, "myPlugin-1.0.jar"), manifest);
+
+    // Build up the plugin repository.
+    repository.inspectPlugins(ImmutableList.of(appTemplateInfo));
+
+    // Should get the only version.
+    plugin = repository.findPlugin(TEMPLATE_NAME, "plugin", "TestPlugin2", new PluginSelector());
+    Assert.assertNotNull(plugin);
+    Assert.assertEquals(new PluginVersion("1.0"), plugin.getKey().getVersion());
+    Assert.assertEquals("TestPlugin2", plugin.getValue().getName());
+
+    // Create another plugin jar with later version and update the repository
+    createJar(TestPlugin.class, new File(templatePluginDir, "myPlugin-2.0.jar"), manifest);
+    repository.inspectPlugins(ImmutableList.of(appTemplateInfo));
+
+    // Should select the latest version
+    plugin = repository.findPlugin(TEMPLATE_NAME, "plugin", "TestPlugin2", new PluginSelector());
+    Assert.assertNotNull(plugin);
+    Assert.assertEquals(new PluginVersion("2.0"), plugin.getKey().getVersion());
+    Assert.assertEquals("TestPlugin2", plugin.getValue().getName());
+
+    // Use a custom plugin selector to select with smallest version
+    plugin = repository.findPlugin(TEMPLATE_NAME, "plugin", "TestPlugin2", new PluginSelector() {
+      @Override
+      public Map.Entry<PluginInfo, PluginClass> select(SortedMap<PluginInfo, PluginClass> plugins) {
+        return plugins.entrySet().iterator().next();
+      }
+    });
+    Assert.assertNotNull(plugin);
+    Assert.assertEquals(new PluginVersion("1.0"), plugin.getKey().getVersion());
+    Assert.assertEquals("TestPlugin2", plugin.getValue().getName());
   }
 
   private static ClassLoader createAppClassLoader(File jarFile) throws IOException {

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/templates/etl/common/MockAdapterConfigurer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/templates/etl/common/MockAdapterConfigurer.java
@@ -24,6 +24,8 @@ import co.cask.cdap.api.dataset.lib.KeyValue;
 import co.cask.cdap.api.dataset.module.DatasetModule;
 import co.cask.cdap.api.schedule.Schedule;
 import co.cask.cdap.api.templates.AdapterConfigurer;
+import co.cask.cdap.api.templates.plugins.PluginProperties;
+import co.cask.cdap.api.templates.plugins.PluginSelector;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -101,6 +103,31 @@ public class MockAdapterConfigurer implements AdapterConfigurer {
   @Override
   public void createDataset(String datasetName, Class<? extends Dataset> datasetClass, DatasetProperties props) {
     datasetInstances.put(datasetName, new KeyValue<String, DatasetProperties>(datasetClass.getName(), props));
+  }
+
+  @Override
+  public <T> T usePlugin(String pluginType, String pluginName, String plugId, PluginProperties properties) {
+    return usePlugin(pluginType, pluginName, plugId, properties, new PluginSelector());
+  }
+
+  @Override
+  public <T> T usePlugin(String pluginType, String pluginName,
+                         String pluginId, PluginProperties properties, PluginSelector acceptor) {
+    // TODO: Implement it when converting existing app-template to use plugin
+    return null;
+  }
+
+  @Override
+  public <T> Class<T> usePluginClass(String pluginType, String pluginName,
+                                     String pluginId, PluginProperties properties) {
+    return usePluginClass(pluginType, pluginName, pluginId, properties, new PluginSelector());
+  }
+
+  @Override
+  public <T> Class<T> usePluginClass(String pluginType, String pluginName,
+                                     String pluginId, PluginProperties properties, PluginSelector acceptor) {
+    // TODO: Implement it when converting existing app-template to use plugin
+    return null;
   }
 
   public Schedule getSchedule() {

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/CConfiguration.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/CConfiguration.java
@@ -38,6 +38,10 @@ public class CConfiguration extends Configuration {
     // Shouldn't be used other than in this class.
   }
 
+  private CConfiguration(Configuration other) {
+    super(other);
+  }
+
   /**
    * Creates an instance of configuration.
    *
@@ -50,5 +54,12 @@ public class CConfiguration extends Configuration {
     conf.addResource("cdap-default.xml");
     conf.addResource("cdap-site.xml");
     return conf;
+  }
+
+  /**
+   * Creates a new instance which clones all configurations from another {@link CConfiguration}.
+   */
+  public static CConfiguration copy(CConfiguration other) {
+    return new CConfiguration(other);
   }
 }


### PR DESCRIPTION
Public API changes:

- Modifed AdapterConfigurer to have methods for declaring plugins usage.
- Introduce a PluginSelector class for selecting plugin at configure adapter time
- Added AdapterContext to expose access to plugin classes at runtime.
- Have MapReduceContext and WorkerContext to implements AdapterContext for exposing plugin access

Implementation details:

- Have AbstractContext implements AdapterContext.
  - Children classes can provide Adapter spec and PluginInstantiator to enable plugin support
- Modify AbstractDistributedProgramRunner to localize plugin jars to twill container
- Modify AbstractProgramTwillRunnable to setup plugin path in cConf
- Update WorkerProgramRunner to create WorkerContext with plugin support
- Update MapReduceProgramRunner to enable plugin support
  - Involves updating multiple MapReduce context related classes
  - Have the plugin jars send to MR DistributedCache so that all task containers have access to plugins