### PR TITLE
CDAP-2198 fix a bug in stop adapter where the deletion of the

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/AdapterService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/AdapterService.java
@@ -452,6 +452,8 @@ public class AdapterService extends AbstractIdleService {
       // was some failure stopping the active run.  In that case, the next time stop is called
       // the schedule will not be present. We don't want to fail in that scenario, so its ok if the
       // schedule was not found.
+      LOG.trace("Could not delete adapter workflow schedule {} because it does not exist. Ignoring and moving on.",
+                workflowId, e);
     }
     List<RunRecord> activeRuns = getRuns(namespace, adapterSpec.getName(), ProgramRunStatus.RUNNING, 0, Long.MAX_VALUE,
                                          Integer.MAX_VALUE);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedProgramRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedProgramRuntimeService.java
@@ -169,8 +169,8 @@ public final class DistributedProgramRuntimeService extends AbstractProgramRunti
     }
     Id.Program programId = Id.Program.from(matcher.group(2), matcher.group(3), type, matcher.group(4));
 
+    runtimeInfo = createRuntimeInfo(type, programId, controller);
     if (runtimeInfo != null) {
-      runtimeInfo = createRuntimeInfo(type, programId, controller);
       updateRuntimeInfo(type, runId, runtimeInfo);
       return runtimeInfo;
     } else {


### PR DESCRIPTION
schedule could succeed but the stopping of active runs could fail.
In that scenario, the stop fails and every subsequent stop will
fail because the schedule isn't found when we try to delete it.

Also fixing a bug in DistributedProgramRuntimeService where it
could not look up runtime info of programs that were not already
in memory.