### PR TITLE
CDAP-2169 delete app through AppLifeCycleHttpHandler

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/AdapterService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/AdapterService.java
@@ -305,8 +305,6 @@ public class AdapterService extends AbstractIdleService {
       throw new CannotBeDeletedException(Id.Adapter.from(namespace, adapterName));
     }
     store.removeAdapter(namespace, adapterName);
-
-    // TODO: Delete the application if this is the last adapter
   }
 
   /**


### PR DESCRIPTION
Delete the template (app) when all the associated adapters are deleted.
I am doing it through the AppLifecycleHttpHandler and want to get feedback if its a clean way to do it.
Testing on cluster pending. 