### PR TITLE
Remove duplicate dependency declaration on hadoop-mapreduce-client-core in cdap-etl-lib module

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/pom.xml
@@ -132,10 +132,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-mapreduce-client-core</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
     </dependency>
@@ -164,10 +160,6 @@
           <artifactId>log4j</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-mapreduce-client-core</artifactId>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Looks like there duplicates of hadoop-mapreduce-client-core in cdap-etl-lib module pom.xml.

This causes warning messages when compile:

[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.apache.hadoop:hadoop-mapreduce-client-core:jar -> duplicate declaration of version (?) @ co.cask.cdap:cdap-etl-lib:[unknown-version], /Users/henrysaputra/open/cask/cdap/cdap-app-templates/cdap-etl/cdap-etl-lib/pom.xml, line 134, column 17
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.apache.hadoop:hadoop-mapreduce-client-core:jar -> duplicate declaration of version (?) @ co.cask.cdap:cdap-etl-lib:[unknown-version], /Users/henrysaputra/open/cask/cdap/cdap-app-templates/cdap-etl/cdap-etl-lib/pom.xml, line 168, column 17