### PR TITLE
remove duplicate aggregation, we already have handler + method aggregation

### DIFF
--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/store/DefaultMetricStore.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/store/DefaultMetricStore.java
@@ -132,16 +132,6 @@ public class DefaultMetricStore implements MetricStore {
       ImmutableList.of(Constants.Metrics.Tag.NAMESPACE, Constants.Metrics.Tag.APP,
                        Constants.Metrics.Tag.SERVICE)));
 
-    // service -- todo : can remove the above service aggregation after CDAP-1544
-    aggs.put("service", new DefaultAggregation(
-      ImmutableList.of(Constants.Metrics.Tag.NAMESPACE, Constants.Metrics.Tag.APP,
-                       Constants.Metrics.Tag.SERVICE, Constants.Metrics.Tag.DATASET,
-                       Constants.Metrics.Tag.RUN_ID, Constants.Metrics.Tag.HANDLER,
-                       Constants.Metrics.Tag.INSTANCE_ID),
-      // i.e. for service only
-      ImmutableList.of(Constants.Metrics.Tag.NAMESPACE, Constants.Metrics.Tag.APP,
-                       Constants.Metrics.Tag.SERVICE)));
-
     // worker
     aggs.put("worker", new DefaultAggregation(
       ImmutableList.of(Constants.Metrics.Tag.NAMESPACE, Constants.Metrics.Tag.APP,


### PR DESCRIPTION
https://github.com/caskdata/cdap/pull/1775/ added handler + method aggregation in DefaultMetricStore and my recent merge https://github.com/caskdata/cdap/pull/2185 added a duplicate for that. so removing the duplicate aggregation rule.