### PR TITLE
CDAP-2169: Delete the app if the last adapter got deleted

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/util/AbstractAppFabricHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/util/AbstractAppFabricHttpHandler.java
@@ -93,7 +93,7 @@ public abstract class AbstractAppFabricHttpHandler extends AuthenticatedHttpHand
   /**
    * Class to represent status of programs.
    */
-  public static final class AppFabricServiceStatus {
+  protected static final class AppFabricServiceStatus {
 
     public static final AppFabricServiceStatus OK = new AppFabricServiceStatus(HttpResponseStatus.OK, "");
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/util/AbstractAppFabricHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/util/AbstractAppFabricHttpHandler.java
@@ -93,7 +93,7 @@ public abstract class AbstractAppFabricHttpHandler extends AuthenticatedHttpHand
   /**
    * Class to represent status of programs.
    */
-  protected static final class AppFabricServiceStatus {
+  public static final class AppFabricServiceStatus {
 
     public static final AppFabricServiceStatus OK = new AppFabricServiceStatus(HttpResponseStatus.OK, "");
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/AdapterService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/AdapterService.java
@@ -319,6 +319,8 @@ public class AdapterService extends AbstractIdleService {
     throws AdapterNotFoundException, CannotBeDeletedException {
 
     AdapterStatus adapterStatus = getAdapterStatus(namespace, adapterName);
+    // TODO: The logic is not transactional and there can be race that one thread is creating and the other
+    // thread is deleting.
     AdapterSpecification adapterSpec = getAdapter(namespace, adapterName);
     Id.Application applicationId = Id.Application.from(namespace, adapterSpec.getTemplate());
     if (adapterStatus != AdapterStatus.STOPPED) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AppFabricServer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AppFabricServer.java
@@ -68,6 +68,7 @@ public final class AppFabricServer extends AbstractIdleService {
   private final InetAddress hostname;
   private final SchedulerService schedulerService;
   private final ProgramRuntimeService programRuntimeService;
+  private final ApplicationLifecycleService applicationLifecycleService;
   private final AdapterService adapterService;
   private final NotificationService notificationService;
   private final Set<String> servicesNames;
@@ -90,6 +91,7 @@ public final class AppFabricServer extends AbstractIdleService {
                          @Named(Constants.AppFabric.HANDLERS_BINDING) Set<HttpHandler> handlers,
                          @Nullable MetricsCollectionService metricsCollectionService,
                          ProgramRuntimeService programRuntimeService, AdapterService adapterService,
+                         ApplicationLifecycleService applicationLifecycleService,
                          StreamCoordinatorClient streamCoordinatorClient,
                          @Named("appfabric.services.names") Set<String> servicesNames,
                          @Named("appfabric.handler.hooks") Set<String> handlerHookNames,
@@ -106,6 +108,7 @@ public final class AppFabricServer extends AbstractIdleService {
     this.servicesNames = servicesNames;
     this.handlerHookNames = handlerHookNames;
     this.namespaceAdmin = namespaceAdmin;
+    this.applicationLifecycleService = applicationLifecycleService;
     this.streamCoordinatorClient = streamCoordinatorClient;
   }
 
@@ -124,6 +127,7 @@ public final class AppFabricServer extends AbstractIdleService {
 
     notificationService.start();
     schedulerService.start();
+    applicationLifecycleService.start();
     adapterService.start();
     programRuntimeService.start();
     streamCoordinatorClient.start();
@@ -209,6 +213,7 @@ public final class AppFabricServer extends AbstractIdleService {
     httpService.stopAndWait();
     programRuntimeService.stopAndWait();
     schedulerService.stopAndWait();
+    applicationLifecycleService.stopAndWait();
     adapterService.stopAndWait();
     notificationService.stopAndWait();
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ApplicationLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ApplicationLifecycleService.java
@@ -1,0 +1,312 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.services;
+
+import co.cask.cdap.api.ProgramSpecification;
+import co.cask.cdap.api.flow.FlowSpecification;
+import co.cask.cdap.api.flow.FlowletConnection;
+import co.cask.cdap.api.metrics.MetricDeleteQuery;
+import co.cask.cdap.api.metrics.MetricStore;
+import co.cask.cdap.api.schedule.SchedulableProgramType;
+import co.cask.cdap.api.workflow.WorkflowSpecification;
+import co.cask.cdap.app.ApplicationSpecification;
+import co.cask.cdap.app.program.Programs;
+import co.cask.cdap.app.runtime.ProgramRuntimeService;
+import co.cask.cdap.app.store.Store;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.namespace.NamespacedLocationFactory;
+import co.cask.cdap.config.PreferencesStore;
+import co.cask.cdap.data2.registry.UsageRegistry;
+import co.cask.cdap.data2.transaction.queue.QueueAdmin;
+import co.cask.cdap.data2.transaction.stream.StreamConsumerFactory;
+import co.cask.cdap.gateway.handlers.AppLifecycleHttpHandler;
+import co.cask.cdap.gateway.handlers.util.AbstractAppFabricHttpHandler;
+import co.cask.cdap.internal.app.runtime.flow.FlowUtils;
+import co.cask.cdap.internal.app.runtime.schedule.Scheduler;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.ProgramTypes;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Predicate;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import com.google.common.util.concurrent.AbstractIdleService;
+import com.google.inject.Inject;
+import org.apache.twill.filesystem.Location;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Service that manage lifecycle of Applications
+ * TODO: Currently this only handles the  deletion of the application. The code from {@link AppLifecycleHttpHandler}
+ * should be moved here and the calls should be delegated to this class.
+ */
+public class ApplicationLifecycleService extends AbstractIdleService {
+  private static final Logger LOG = LoggerFactory.getLogger(ApplicationLifecycleService.class);
+
+  /**
+   * Runtime program service for running and managing programs.
+   */
+  private final ProgramRuntimeService runtimeService;
+
+  /**
+   * Store manages non-runtime lifecycle.
+   */
+  private final Store store;
+  private final CConfiguration configuration;
+  private final Scheduler scheduler;
+  private final QueueAdmin queueAdmin;
+  private final NamespacedLocationFactory namespacedLocationFactory;
+  private final StreamConsumerFactory streamConsumerFactory;
+  private final UsageRegistry usageRegistry;
+  private final PreferencesStore preferencesStore;
+  private final MetricStore metricStore;
+
+  @Inject
+  public ApplicationLifecycleService(ProgramRuntimeService runtimeService, Store store, CConfiguration configuration,
+                                     Scheduler scheduler, QueueAdmin queueAdmin,
+                                     NamespacedLocationFactory namespacedLocationFactory,
+                                     StreamConsumerFactory streamConsumerFactory, UsageRegistry usageRegistry,
+                                     PreferencesStore preferencesStore, MetricStore metricStore) {
+    this.runtimeService = runtimeService;
+    this.store = store;
+    this.configuration = configuration;
+    this.scheduler = scheduler;
+    this.queueAdmin = queueAdmin;
+    this.namespacedLocationFactory = namespacedLocationFactory;
+    this.streamConsumerFactory = streamConsumerFactory;
+    this.usageRegistry = usageRegistry;
+    this.preferencesStore = preferencesStore;
+    this.metricStore = metricStore;
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    LOG.info("Starting ProgramLifecycleService");
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    LOG.info("Shutting down ProgramLifecycleService");
+  }
+
+  /**
+   * Remove all the applications inside the given {@link Id.Namespace}
+   *
+   * @param identifier the {@link Id.Namespace} under which all application should be deleted
+   * @return and appropriate {@link AbstractAppFabricHttpHandler.AppFabricServiceStatus}
+   * @throws Exception
+   */
+  public AbstractAppFabricHttpHandler.AppFabricServiceStatus removeAll(Id.Namespace identifier) throws Exception {
+    List<ApplicationSpecification> allSpecs = new ArrayList<ApplicationSpecification>(
+      store.getAllApplications(identifier));
+
+    //Check if any program associated with this namespace is running
+    final Id.Namespace accId = Id.Namespace.from(identifier.getId());
+    boolean appRunning = runtimeService.checkAnyRunning(new Predicate<Id.Program>() {
+      @Override
+      public boolean apply(Id.Program programId) {
+        return programId.getApplication().getNamespace().equals(accId);
+      }
+    }, ProgramType.values());
+
+    if (appRunning) {
+      return AbstractAppFabricHttpHandler.AppFabricServiceStatus.PROGRAM_STILL_RUNNING;
+    }
+
+    //All Apps are STOPPED, delete them
+    for (ApplicationSpecification appSpec : allSpecs) {
+      Id.Application id = Id.Application.from(identifier.getId(), appSpec.getName());
+      removeApplication(id);
+    }
+
+    return AbstractAppFabricHttpHandler.AppFabricServiceStatus.OK;
+  }
+
+  /**
+   * Delete an application specified by appId.
+   *
+   * @param appId the {@link Id.Application} of the application to be removed
+   * @return an appropriate {@link AbstractAppFabricHttpHandler.AppFabricServiceStatus}
+   * @throws Exception
+   */
+  public AbstractAppFabricHttpHandler.AppFabricServiceStatus removeApplication(final Id.Application appId) throws Exception {
+    //Check if all are stopped.
+    boolean appRunning = runtimeService.checkAnyRunning(new Predicate<Id.Program>() {
+      @Override
+      public boolean apply(Id.Program programId) {
+        return programId.getApplication().equals(appId);
+      }
+    }, ProgramType.values());
+
+    if (appRunning) {
+      return AbstractAppFabricHttpHandler.AppFabricServiceStatus.PROGRAM_STILL_RUNNING;
+    }
+
+    ApplicationSpecification spec = store.getApplication(appId);
+    if (spec == null) {
+      return AbstractAppFabricHttpHandler.AppFabricServiceStatus.PROGRAM_NOT_FOUND;
+    }
+
+    //Delete the schedules
+    for (WorkflowSpecification workflowSpec : spec.getWorkflows().values()) {
+      Id.Program workflowProgramId = Id.Program.from(appId, ProgramType.WORKFLOW, workflowSpec.getName());
+      scheduler.deleteSchedules(workflowProgramId, SchedulableProgramType.WORKFLOW);
+    }
+
+    deleteMetrics(appId.getNamespaceId(), appId.getId());
+
+    //Delete all preferences of the application and of all its programs
+    deletePreferences(appId);
+
+    // Delete all streams and queues state of each flow
+    // TODO: This should be unified with the DeletedProgramHandlerStage
+    for (FlowSpecification flowSpecification : spec.getFlows().values()) {
+      Id.Program flowProgramId = Id.Program.from(appId, ProgramType.FLOW, flowSpecification.getName());
+
+      // Collects stream name to all group ids consuming that stream
+      Multimap<String, Long> streamGroups = HashMultimap.create();
+      for (FlowletConnection connection : flowSpecification.getConnections()) {
+        if (connection.getSourceType() == FlowletConnection.Type.STREAM) {
+          long groupId = FlowUtils.generateConsumerGroupId(flowProgramId, connection.getTargetName());
+          streamGroups.put(connection.getSourceName(), groupId);
+        }
+      }
+      // Remove all process states and group states for each stream
+      String namespace = String.format("%s.%s", flowProgramId.getApplicationId(), flowProgramId.getId());
+      for (Map.Entry<String, Collection<Long>> entry : streamGroups.asMap().entrySet()) {
+        streamConsumerFactory.dropAll(Id.Stream.from(appId.getNamespaceId(), entry.getKey()),
+                                      namespace, entry.getValue());
+      }
+
+      queueAdmin.dropAllForFlow(appId.getNamespaceId(), appId.getId(), flowSpecification.getName());
+    }
+    deleteProgramLocations(appId);
+
+    Location appArchive = store.getApplicationArchiveLocation(appId);
+    Preconditions.checkNotNull(appArchive, "Could not find the location of application", appId.getId());
+    appArchive.delete();
+    store.removeApplication(appId);
+
+    try {
+      usageRegistry.unregister(appId);
+    } catch (Exception e) {
+      LOG.warn("Failed to unregister usage of app: {}", appId, e);
+    }
+
+    return AbstractAppFabricHttpHandler.AppFabricServiceStatus.OK;
+  }
+
+  /**
+   * Delete the jar location of the program.
+   *
+   * @param appId applicationId.
+   * @throws IOException if there are errors with location IO
+   */
+  private void deleteProgramLocations(Id.Application appId) throws IOException {
+    Iterable<ProgramSpecification> programSpecs = getProgramSpecs(appId);
+    String appFabricDir = configuration.get(Constants.AppFabric.OUTPUT_DIR);
+    for (ProgramSpecification spec : programSpecs) {
+      ProgramType type = ProgramTypes.fromSpecification(spec);
+      Id.Program programId = Id.Program.from(appId, type, spec.getName());
+      try {
+        Location location = Programs.programLocation(namespacedLocationFactory, appFabricDir, programId, type);
+        location.delete();
+      } catch (FileNotFoundException e) {
+        LOG.warn("Program jar for program {} not found.", programId.toString(), e);
+      }
+    }
+
+    // Delete webapp
+    // TODO: this will go away once webapp gets a spec
+    try {
+      Id.Program programId = Id.Program.from(appId.getNamespaceId(), appId.getId(),
+                                             ProgramType.WEBAPP, ProgramType.WEBAPP.name().toLowerCase());
+      Location location = Programs.programLocation(namespacedLocationFactory, appFabricDir, programId,
+                                                   ProgramType.WEBAPP);
+      location.delete();
+    } catch (FileNotFoundException e) {
+      // expected exception when webapp is not present.
+    }
+  }
+
+  private Iterable<ProgramSpecification> getProgramSpecs(Id.Application appId) {
+    ApplicationSpecification appSpec = store.getApplication(appId);
+    return Iterables.concat(appSpec.getFlows().values(),
+                            appSpec.getMapReduce().values(),
+                            appSpec.getServices().values(),
+                            appSpec.getSpark().values(),
+                            appSpec.getWorkers().values(),
+                            appSpec.getWorkflows().values());
+  }
+
+  /**
+   * Delete the metrics for an application, or if null is provided as the application ID, for all apps.
+   *
+   * @param applicationId the application to delete metrics for.
+   * If null, metrics for all applications in the namespace are deleted.
+   */
+  private void deleteMetrics(String namespaceId, String applicationId) throws Exception {
+    Collection<ApplicationSpecification> applications = Lists.newArrayList();
+    if (applicationId == null) {
+      applications = this.store.getAllApplications(new Id.Namespace(namespaceId));
+    } else {
+      ApplicationSpecification spec = this.store.getApplication
+        (new Id.Application(new Id.Namespace(namespaceId), applicationId));
+      applications.add(spec);
+    }
+
+    long endTs = System.currentTimeMillis() / 1000;
+    Map<String, String> tags = Maps.newHashMap();
+    tags.put(Constants.Metrics.Tag.NAMESPACE, namespaceId);
+    for (ApplicationSpecification application : applications) {
+      // add or replace application name in the tagMap
+      tags.put(Constants.Metrics.Tag.APP, application.getName());
+      MetricDeleteQuery deleteQuery = new MetricDeleteQuery(0, endTs, tags);
+      metricStore.delete(deleteQuery);
+    }
+  }
+
+  /**
+   * Delete stored Preferences of the application and all its programs.
+   *
+   * @param appId applicationId
+   */
+  private void deletePreferences(Id.Application appId) {
+    Iterable<ProgramSpecification> programSpecs = getProgramSpecs(appId);
+    for (ProgramSpecification spec : programSpecs) {
+
+      preferencesStore.deleteProperties(appId.getNamespaceId(), appId.getId(),
+                                        ProgramTypes.fromSpecification(spec).getCategoryName(), spec.getName());
+      LOG.trace("Deleted Preferences of Program : {}, {}, {}, {}", appId.getNamespaceId(), appId.getId(),
+                ProgramTypes.fromSpecification(spec).getCategoryName(), spec.getName());
+    }
+    preferencesStore.deleteProperties(appId.getNamespaceId(), appId.getId());
+    LOG.trace("Deleted Preferences of Application : {}, {}", appId.getNamespaceId(), appId.getId());
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/adapter/AdapterServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/adapter/AdapterServiceTest.java
@@ -41,6 +41,7 @@ import co.cask.cdap.proto.RunRecord;
 import co.cask.cdap.templates.AdapterDefinition;
 import com.google.common.collect.Iterables;
 import com.google.common.io.Files;
+import com.google.gson.JsonObject;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import org.apache.http.HttpResponse;
 import org.apache.twill.filesystem.Location;
@@ -128,10 +129,11 @@ public class AdapterServiceTest extends AppFabricTestBase {
                                                  adapterConfig.getTemplate(), DummyBatchTemplate.AdapterWorkflow.NAME));
     Assert.assertEquals(HttpResponseStatus.FORBIDDEN.code(), response.getStatusLine().getStatusCode());
 
-    // But should be able to delete the application
+    // the deletion of the only adapter using the application should have deleted the app and an attempt to delete the
+    // application should reutrn not found
     response = doDelete(String.format("%s/namespaces/%s/apps/%s", Constants.Gateway.API_VERSION_3, TEST_NAMESPACE1,
                                       adapterConfig.getTemplate()));
-    Assert.assertEquals(HttpResponseStatus.OK.code(), response.getStatusLine().getStatusCode());
+    Assert.assertEquals(HttpResponseStatus.NOT_FOUND.code(), response.getStatusLine().getStatusCode());
 
     String workerAdapter = "workAdapter";
     DummyWorkerTemplate.Config config1 = new DummyWorkerTemplate.Config(2);
@@ -208,7 +210,16 @@ public class AdapterServiceTest extends AppFabricTestBase {
 
     // Delete Adapter
     adapterService.removeAdapter(NAMESPACE, adapter1);
+
+    // check the template still exists
+    List<JsonObject> deployedApps = getAppList(NAMESPACE.getId());
+    Assert.assertEquals(1, deployedApps.size());
+
     adapterService.removeAdapter(NAMESPACE, adapter2);
+
+    // check if the template got deleted when we deleted the second and last adapter of that type
+    deployedApps = getAppList(NAMESPACE.getId());
+    Assert.assertEquals(0, deployedApps.size());
 
     try {
       adapterService.getAdapter(NAMESPACE, adapter1);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/adapter/AdapterServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/adapter/AdapterServiceTest.java
@@ -89,6 +89,7 @@ public class AdapterServiceTest extends AppFabricTestBase {
     AdapterConfig adapterConfig = new AdapterConfig("desc", ExtendedBatchTemplate.class.getSimpleName(),
                                                     GSON.toJsonTree(config));
     adapterService.createAdapter(Id.Namespace.from(TEST_NAMESPACE1), "myAdap", adapterConfig);
+    adapterService.removeAdapter(Id.Namespace.from(TEST_NAMESPACE1), "myAdap");
   }
 
   @Test(expected = RuntimeException.class)


### PR DESCRIPTION
- Introduces ApplicationLifecycleService which is responsible for managing ApplicationLifecycle. Currently, I have refactored out the code of removal of application from AppLifecycleHttpHandler to this class and AppLifecycleHttpHandler delegates to ApplicationLifecycleService for removing applications.

- This also allow AdapterService to delete the application using ApplicationLifecycleService if the deleted adapter was the last associated adapter of the application (template)

Build: http://builds.cask.co/browse/CDAP-DUT1598-1
