### PR TITLE
Feature/cdap ui pkg replace

### DIFF
--- a/cdap-ui/pom.xml
+++ b/cdap-ui/pom.xml
@@ -115,7 +115,7 @@
     <profile>
       <id>dist</id>
       <properties>
-        <package.depends>--depends cdap --replaces cdap-web-app</package.depends>
+        <package.depends>--depends cdap --replaces cdap-web-app --conflicts cdap-web-app</package.depends>
       </properties>
       <build>
         <plugins>

--- a/cdap-ui/pom.xml
+++ b/cdap-ui/pom.xml
@@ -114,6 +114,9 @@
   <profiles>
     <profile>
       <id>dist</id>
+      <properties>
+        <package.depends>--depends cdap --replaces cdap-web-app</package.depends>
+      </properties>
       <build>
         <plugins>
           <plugin>


### PR DESCRIPTION
maven updates to add ``replaces`` and ``conflicts`` package dependencies for ``cdap-web-app -> cdap-ui``.  The ``conflicts`` is needed for debian

rpm:
```
# yum localinstall ~derek/pkgs2/cdap-ui-3.0.0.1429744218456-1.noarch.rpm 
Loaded plugins: downloadonly, fastestmirror, security
Setting up Local Package Process
Examining /home/derek/pkgs2/cdap-ui-3.0.0.1429744218456-1.noarch.rpm: cdap-ui-3.0.0.1429744218456-1.noarch
Marking /home/derek/pkgs2/cdap-ui-3.0.0.1429744218456-1.noarch.rpm to be installed
Loading mirror speeds from cached hostfile
 * base: mirror.sanctuaryhost.com
 * epel: mirror.nexcess.net
 * extras: mirror.cs.uwp.edu
 * updates: mirrors.chkhosting.com
Resolving Dependencies
--> Running transaction check
---> Package cdap-ui.noarch 0:3.0.0.1429744218456-1 will be obsoleting
---> Package cdap-web-app.noarch 0:2.8.0-1 will be obsoleted
--> Finished Dependency Resolution

Dependencies Resolved

====================================================================================================================================================================================
 Package                         Arch                           Version                                         Repository                                                     Size
====================================================================================================================================================================================
Installing:
 cdap-ui                         noarch                         3.0.0.1429744218456-1                           /cdap-ui-3.0.0.1429744218456-1.noarch                          49 M
     replacing  cdap-web-app.noarch 2.8.0-1

Transaction Summary
====================================================================================================================================================================================
Install       1 Package(s)

Total size: 49 M
Is this ok [y/N]: y
Downloading Packages:
Running rpm_check_debug
Running Transaction Test
Transaction Test Succeeded
Running Transaction
  Installing : cdap-ui-3.0.0.1429744218456-1.noarch                                                                                                                             1/2 
  Erasing    : cdap-web-app-2.8.0-1.noarch                                                                                                                                      2/2 
  Verifying  : cdap-ui-3.0.0.1429744218456-1.noarch                                                                                                                             1/2 
  Verifying  : cdap-web-app-2.8.0-1.noarch                                                                                                                                      2/2 

Installed:
  cdap-ui.noarch 0:3.0.0.1429744218456-1                                                                                                                                            

Replaced:
  cdap-web-app.noarch 0:2.8.0-1                                                                                                                                                     

Complete!

```

deb:
```
# dpkg -i /home/derek/pkgs/cdap-ui_3.0.0.1429744218456-1_all.deb 
Selecting previously unselected package cdap-ui.
dpkg: considering removing cdap-web-app in favour of cdap-ui ...
dpkg: yes, will remove cdap-web-app in favour of cdap-ui.
(Reading database ... 66346 files and directories currently installed.)
Unpacking cdap-ui (from .../cdap-ui_3.0.0.1429744218456-1_all.deb) ...
nothing to stop because no pid file /var/cdap/run/web-app-cdap.pid
Setting up cdap-ui (3.0.0.1429744218456-1) ...
Processing triggers for ureadahead ...
```

note, on deb, cdap-web-app is left in a 'ic' state (only config files installed, however there are no config files)