### PR TITLE
Rename AdapterSpecification to AdapterDefinition

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -77,7 +77,7 @@ import co.cask.cdap.logging.run.LogSaverStatusServiceManager;
 import co.cask.cdap.metrics.runtime.MetricsProcessorStatusServiceManager;
 import co.cask.cdap.metrics.runtime.MetricsServiceManager;
 import co.cask.cdap.pipeline.PipelineFactory;
-import co.cask.cdap.templates.AdapterSpecification;
+import co.cask.cdap.templates.AdapterDefinition;
 import co.cask.http.HttpHandler;
 import com.google.common.base.Supplier;
 import com.google.common.base.Throwables;
@@ -277,9 +277,9 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
       );
       install(
         new FactoryModuleBuilder()
-          .implement(new TypeLiteral<Manager<AdapterDeploymentInfo, AdapterSpecification>> () { },
+          .implement(new TypeLiteral<Manager<AdapterDeploymentInfo, AdapterDefinition>> () { },
                      LocalAdapterManager.class)
-          .build(Key.get(new TypeLiteral<ManagerFactory<AdapterDeploymentInfo, AdapterSpecification>>() { },
+          .build(Key.get(new TypeLiteral<ManagerFactory<AdapterDeploymentInfo, AdapterDefinition>>() { },
                          Names.named("adapters")))
       );
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/Store.java
@@ -30,7 +30,7 @@ import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.RunRecord;
-import co.cask.cdap.templates.AdapterSpecification;
+import co.cask.cdap.templates.AdapterDefinition;
 import org.apache.twill.filesystem.Location;
 
 import java.io.IOException;
@@ -371,17 +371,17 @@ public interface Store {
    * @param id Namespace id
    * @param adapterSpec adapter specification of the adapter being added
    */
-  void addAdapter(Id.Namespace id, AdapterSpecification adapterSpec);
+  void addAdapter(Id.Namespace id, AdapterDefinition adapterSpec);
 
   /**
    * Fetch the adapter identified by the name in a give namespace.
    *
    * @param id  Namespace id.
    * @param name Adapter name
-   * @return an instance of {@link AdapterSpecification}.
+   * @return an instance of {@link AdapterDefinition}.
    */
   @Nullable
-  AdapterSpecification getAdapter(Id.Namespace id, String name);
+  AdapterDefinition getAdapter(Id.Namespace id, String name);
 
   /**
    * Fetch the status for an adapter identified by the name in a give namespace.
@@ -410,7 +410,7 @@ public interface Store {
    * @param id Namespace id.
    * @return {@link Collection} of Adapter Specifications.
    */
-  Collection<AdapterSpecification> getAllAdapters(Id.Namespace id);
+  Collection<AdapterDefinition> getAllAdapters(Id.Namespace id);
 
   /**
    * Remove the adapter specified by the name in a given namespace.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AdapterHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AdapterHttpHandler.java
@@ -32,7 +32,7 @@ import co.cask.cdap.proto.AdapterConfig;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.RunRecord;
-import co.cask.cdap.templates.AdapterSpecification;
+import co.cask.cdap.templates.AdapterDefinition;
 import co.cask.http.HttpResponder;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -130,7 +130,7 @@ public class AdapterHttpHandler extends AbstractAppFabricHttpHandler {
                          @PathParam("namespace-id") String namespaceId,
                          @PathParam("adapter-id") String adapterName) {
     try {
-      AdapterSpecification adapterSpec = adapterService.getAdapter(Id.Namespace.from(namespaceId), adapterName);
+      AdapterDefinition adapterSpec = adapterService.getAdapter(Id.Namespace.from(namespaceId), adapterName);
       responder.sendJson(HttpResponseStatus.OK, adapterSpec);
     } catch (AdapterNotFoundException e) {
       responder.sendString(HttpResponseStatus.NOT_FOUND, e.getMessage());

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/InMemoryAdapterConfigurator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/InMemoryAdapterConfigurator.java
@@ -30,7 +30,7 @@ import co.cask.cdap.internal.app.runtime.adapter.PluginInstantiator;
 import co.cask.cdap.internal.app.runtime.adapter.PluginRepository;
 import co.cask.cdap.proto.AdapterConfig;
 import co.cask.cdap.proto.Id;
-import co.cask.cdap.templates.AdapterSpecification;
+import co.cask.cdap.templates.AdapterDefinition;
 import co.cask.cdap.templates.DefaultAdapterConfigurer;
 import com.google.common.base.Preconditions;
 import com.google.common.io.CharStreams;
@@ -130,7 +130,7 @@ public final class InMemoryAdapterConfigurator implements Configurator {
             configType = Object.class;
           }
           template.configureAdapter(adapterName, GSON.fromJson(adapterConfig.getConfig(), configType), configurer);
-          AdapterSpecification spec = configurer.createSpecification();
+          AdapterDefinition spec = configurer.createSpecification();
           result.set(new DefaultConfigResponse(0, CharStreams.newReaderSupplier(GSON.toJson(spec))));
         } finally {
           Closeables.closeQuietly(pluginInstantiator);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/LocalAdapterManager.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/LocalAdapterManager.java
@@ -34,7 +34,7 @@ import co.cask.cdap.internal.app.runtime.adapter.PluginRepository;
 import co.cask.cdap.pipeline.Pipeline;
 import co.cask.cdap.pipeline.PipelineFactory;
 import co.cask.cdap.proto.Id;
-import co.cask.cdap.templates.AdapterSpecification;
+import co.cask.cdap.templates.AdapterDefinition;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
@@ -44,7 +44,7 @@ import org.apache.twill.filesystem.Location;
 /**
  * This class is concrete implementation of {@link Manager} that deploys an Adapter.
  */
-public class LocalAdapterManager implements Manager<AdapterDeploymentInfo, AdapterSpecification> {
+public class LocalAdapterManager implements Manager<AdapterDeploymentInfo, AdapterDefinition> {
   private final CConfiguration configuration;
   private final PipelineFactory pipelineFactory;
   private final StreamAdmin streamAdmin;
@@ -73,11 +73,11 @@ public class LocalAdapterManager implements Manager<AdapterDeploymentInfo, Adapt
   }
 
   @Override
-  public ListenableFuture<AdapterSpecification> deploy(Id.Namespace namespace, String id,
+  public ListenableFuture<AdapterDefinition> deploy(Id.Namespace namespace, String id,
                                                        AdapterDeploymentInfo input) throws Exception {
     Location templateJarLocation =
       new LocalLocationFactory().create(input.getTemplateInfo().getFile().toURI());
-    Pipeline<AdapterSpecification> pipeline = pipelineFactory.getPipeline();
+    Pipeline<AdapterDefinition> pipeline = pipelineFactory.getPipeline();
     pipeline.addLast(new ConfigureAdapterStage(configuration, namespace, id, templateJarLocation, pluginRepository));
     pipeline.addLast(new AdapterVerificationStage(input.getTemplateSpec()));
     pipeline.addLast(new DeployAdapterDatasetModulesStage(configuration, namespace, templateJarLocation,

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/DeployDatasetModulesStage.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/DeployDatasetModulesStage.java
@@ -17,12 +17,11 @@
 package co.cask.cdap.internal.app.deploy.pipeline;
 
 import co.cask.cdap.api.dataset.module.DatasetModule;
-import co.cask.cdap.app.ApplicationSpecification;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.pipeline.AbstractStage;
 import co.cask.cdap.proto.Id;
-import co.cask.cdap.templates.AdapterSpecification;
+import co.cask.cdap.templates.AdapterDefinition;
 import com.google.common.reflect.TypeToken;
 
 /**
@@ -42,7 +41,7 @@ public class DeployDatasetModulesStage extends AbstractStage<ApplicationDeployab
   /**
    * Deploys dataset modules specified in the given adapter spec.
    *
-   * @param input An instance of {@link AdapterSpecification}
+   * @param input An instance of {@link AdapterDefinition}
    */
   @Override
   public void process(ApplicationDeployable input) throws Exception {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/adapter/AdapterRegistrationStage.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/adapter/AdapterRegistrationStage.java
@@ -19,24 +19,24 @@ package co.cask.cdap.internal.app.deploy.pipeline.adapter;
 import co.cask.cdap.app.store.Store;
 import co.cask.cdap.pipeline.AbstractStage;
 import co.cask.cdap.proto.Id;
-import co.cask.cdap.templates.AdapterSpecification;
+import co.cask.cdap.templates.AdapterDefinition;
 import com.google.common.reflect.TypeToken;
 
 /**
  * Adds a configured adapter to the store.
  */
-public class AdapterRegistrationStage extends AbstractStage<AdapterSpecification> {
+public class AdapterRegistrationStage extends AbstractStage<AdapterDefinition> {
   private final Store store;
   private final Id.Namespace namespace;
 
   public AdapterRegistrationStage(Id.Namespace namespace, Store store) {
-    super(TypeToken.of(AdapterSpecification.class));
+    super(TypeToken.of(AdapterDefinition.class));
     this.store = store;
     this.namespace = namespace;
   }
 
   @Override
-  public void process(AdapterSpecification input) throws Exception {
+  public void process(AdapterDefinition input) throws Exception {
     store.addAdapter(namespace, input);
     emit(input);
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/adapter/AdapterVerificationStage.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/adapter/AdapterVerificationStage.java
@@ -18,18 +18,18 @@ package co.cask.cdap.internal.app.deploy.pipeline.adapter;
 
 import co.cask.cdap.app.ApplicationSpecification;
 import co.cask.cdap.pipeline.AbstractStage;
-import co.cask.cdap.templates.AdapterSpecification;
+import co.cask.cdap.templates.AdapterDefinition;
 import com.google.common.base.Preconditions;
 import com.google.common.reflect.TypeToken;
 
 /**
  * This {@link co.cask.cdap.pipeline.Stage} is responsible for verifying an adapter specification.
  */
-public class AdapterVerificationStage extends AbstractStage<AdapterSpecification> {
+public class AdapterVerificationStage extends AbstractStage<AdapterDefinition> {
   private final ApplicationSpecification templateSpec;
 
   public AdapterVerificationStage(ApplicationSpecification templateSpec) {
-    super(TypeToken.of(AdapterSpecification.class));
+    super(TypeToken.of(AdapterDefinition.class));
     this.templateSpec = templateSpec;
   }
 
@@ -38,10 +38,10 @@ public class AdapterVerificationStage extends AbstractStage<AdapterSpecification
    * Receives an input containing adapter specification and location
    * and verifies both.
    *
-   * @param input An instance of {@link AdapterSpecification}
+   * @param input An instance of {@link AdapterDefinition}
    */
   @Override
-  public void process(AdapterSpecification input) throws Exception {
+  public void process(AdapterDefinition input) throws Exception {
     Preconditions.checkNotNull(input);
 
     // if this adapter uses a workflow, a schedule should be set

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/adapter/ConfigureAdapterStage.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/adapter/ConfigureAdapterStage.java
@@ -25,7 +25,7 @@ import co.cask.cdap.internal.app.deploy.pipeline.ApplicationDeployable;
 import co.cask.cdap.internal.app.runtime.adapter.PluginRepository;
 import co.cask.cdap.pipeline.AbstractStage;
 import co.cask.cdap.proto.Id;
-import co.cask.cdap.templates.AdapterSpecification;
+import co.cask.cdap.templates.AdapterDefinition;
 import com.google.common.io.Closeables;
 import com.google.common.io.InputSupplier;
 import com.google.common.reflect.TypeToken;
@@ -68,7 +68,7 @@ public class ConfigureAdapterStage extends AbstractStage<AdapterDeploymentInfo> 
 
   /**
    * Creates a {@link InMemoryConfigurator} to run through
-   * the process of generation of {@link AdapterSpecification}
+   * the process of generation of {@link AdapterDefinition}
    *
    * @param deploymentInfo Location of the input and output location
    */
@@ -95,7 +95,7 @@ public class ConfigureAdapterStage extends AbstractStage<AdapterDeploymentInfo> 
     }
     Reader reader = configSupplier.getInput();
     try {
-      emit(GSON.fromJson(reader, AdapterSpecification.class));
+      emit(GSON.fromJson(reader, AdapterDefinition.class));
     } finally {
       Closeables.closeQuietly(reader);
     }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/adapter/CreateAdapterDatasetInstancesStage.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/adapter/CreateAdapterDatasetInstancesStage.java
@@ -21,29 +21,29 @@ import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.internal.app.deploy.pipeline.DatasetInstanceCreator;
 import co.cask.cdap.pipeline.AbstractStage;
 import co.cask.cdap.proto.Id;
-import co.cask.cdap.templates.AdapterSpecification;
+import co.cask.cdap.templates.AdapterDefinition;
 import com.google.common.reflect.TypeToken;
 
 /**
  * This {@link co.cask.cdap.pipeline.Stage} is responsible for automatic
  * deploy of the {@link co.cask.cdap.api.dataset.module.DatasetModule}s specified by application.
  */
-public class CreateAdapterDatasetInstancesStage extends AbstractStage<AdapterSpecification> {
+public class CreateAdapterDatasetInstancesStage extends AbstractStage<AdapterDefinition> {
   private final DatasetInstanceCreator datasetInstanceCreator;
 
   public CreateAdapterDatasetInstancesStage(CConfiguration configuration, DatasetFramework datasetFramework,
                                             Id.Namespace namespace) {
-    super(TypeToken.of(AdapterSpecification.class));
+    super(TypeToken.of(AdapterDefinition.class));
     this.datasetInstanceCreator = new DatasetInstanceCreator(configuration, datasetFramework, namespace);
   }
 
   /**
    * Creates the dataset instances contained in the give adapter specification.
    *
-   * @param input An instance of {@link AdapterSpecification}
+   * @param input An instance of {@link AdapterDefinition}
    */
   @Override
-  public void process(AdapterSpecification input) throws Exception {
+  public void process(AdapterDefinition input) throws Exception {
     datasetInstanceCreator.createInstances(input.getDatasets());
 
     // Emit the input to next stage.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/adapter/CreateAdapterStreamsStage.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/adapter/CreateAdapterStreamsStage.java
@@ -21,29 +21,29 @@ import co.cask.cdap.explore.client.ExploreFacade;
 import co.cask.cdap.internal.app.deploy.pipeline.StreamCreator;
 import co.cask.cdap.pipeline.AbstractStage;
 import co.cask.cdap.proto.Id;
-import co.cask.cdap.templates.AdapterSpecification;
+import co.cask.cdap.templates.AdapterDefinition;
 import com.google.common.reflect.TypeToken;
 
 /**
  * This {@link co.cask.cdap.pipeline.Stage} is responsible for automatic creation of any new streams specified by the
  * application. Additionally, it will enable exploration of those streams if exploration is enabled.
  */
-public class CreateAdapterStreamsStage extends AbstractStage<AdapterSpecification> {
+public class CreateAdapterStreamsStage extends AbstractStage<AdapterDefinition> {
   private final StreamCreator streamCreator;
 
   public CreateAdapterStreamsStage(Id.Namespace namespace, StreamAdmin streamAdmin, ExploreFacade exploreFacade,
                                    boolean enableExplore) {
-    super(TypeToken.of(AdapterSpecification.class));
+    super(TypeToken.of(AdapterDefinition.class));
     this.streamCreator = new StreamCreator(namespace, streamAdmin, exploreFacade, enableExplore);
   }
 
   /**
    * Create any streams in the given specification.
    *
-   * @param input An instance of {@link AdapterSpecification}
+   * @param input An instance of {@link AdapterDefinition}
    */
   @Override
-  public void process(AdapterSpecification input) throws Exception {
+  public void process(AdapterDefinition input) throws Exception {
     streamCreator.createStreams(input.getStreams().keySet());
 
     // Emit the input to next stage.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/adapter/DeployAdapterDatasetModulesStage.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/adapter/DeployAdapterDatasetModulesStage.java
@@ -22,7 +22,7 @@ import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.internal.app.deploy.pipeline.DatasetModulesDeployer;
 import co.cask.cdap.pipeline.AbstractStage;
 import co.cask.cdap.proto.Id;
-import co.cask.cdap.templates.AdapterSpecification;
+import co.cask.cdap.templates.AdapterDefinition;
 import com.google.common.reflect.TypeToken;
 import org.apache.twill.filesystem.Location;
 
@@ -30,7 +30,7 @@ import org.apache.twill.filesystem.Location;
  * This {@link co.cask.cdap.pipeline.Stage} is responsible for automatic
  * deploy of the {@link DatasetModule}s specified by an adapter.
  */
-public class DeployAdapterDatasetModulesStage extends AbstractStage<AdapterSpecification> {
+public class DeployAdapterDatasetModulesStage extends AbstractStage<AdapterDefinition> {
   private final DatasetModulesDeployer datasetModulesDeployer;
   private final Location templateJarLocation;
 
@@ -39,7 +39,7 @@ public class DeployAdapterDatasetModulesStage extends AbstractStage<AdapterSpeci
                                           Location templateJarLocation,
                                           DatasetFramework datasetFramework,
                                           DatasetFramework inMemoryDatasetFramework) {
-    super(TypeToken.of(AdapterSpecification.class));
+    super(TypeToken.of(AdapterDefinition.class));
     this.datasetModulesDeployer = new DatasetModulesDeployer(datasetFramework, inMemoryDatasetFramework,
                                                              namespace, configuration);
     this.templateJarLocation = templateJarLocation;
@@ -48,10 +48,10 @@ public class DeployAdapterDatasetModulesStage extends AbstractStage<AdapterSpeci
   /**
    * Deploys dataset modules present in the given adapter spec.
    *
-   * @param input An instance of {@link AdapterSpecification}
+   * @param input An instance of {@link AdapterDefinition}
    */
   @Override
-  public void process(AdapterSpecification input) throws Exception {
+  public void process(AdapterDefinition input) throws Exception {
 
     datasetModulesDeployer.deployModules(input.getDatasetModules(), templateJarLocation);
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractContext.java
@@ -33,8 +33,8 @@ import co.cask.cdap.data.dataset.DatasetInstantiator;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.internal.app.program.ProgramTypeMetricTag;
 import co.cask.cdap.internal.app.runtime.adapter.PluginInstantiator;
+import co.cask.cdap.templates.AdapterDefinition;
 import co.cask.cdap.templates.AdapterPlugin;
-import co.cask.cdap.templates.AdapterSpecification;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
@@ -68,7 +68,7 @@ public abstract class AbstractContext extends AbstractServiceDiscoverer
   private final DatasetInstantiator dsInstantiator;
   private final DiscoveryServiceClient discoveryServiceClient;
 
-  private final AdapterSpecification adapterSpec;
+  private final AdapterDefinition adapterSpec;
   private final PluginInstantiator pluginInstantiator;
 
   /**
@@ -87,7 +87,7 @@ public abstract class AbstractContext extends AbstractServiceDiscoverer
   protected AbstractContext(Program program, RunId runId, Arguments arguments,
                             Set<String> datasets, MetricsCollector metricsCollector,
                             DatasetFramework dsFramework, DiscoveryServiceClient discoveryServiceClient,
-                            @Nullable AdapterSpecification adapterSpec,
+                            @Nullable AdapterDefinition adapterSpec,
                             @Nullable PluginInstantiator pluginInstantiator) {
     super(program);
     this.program = program;
@@ -109,7 +109,7 @@ public abstract class AbstractContext extends AbstractServiceDiscoverer
   public abstract Metrics getMetrics();
 
   @Nullable
-  public AdapterSpecification getAdapterSpec() {
+  public AdapterDefinition getAdapterSpec() {
     return adapterSpec;
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/AdapterService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/AdapterService.java
@@ -52,7 +52,7 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.RunRecord;
-import co.cask.cdap.templates.AdapterSpecification;
+import co.cask.cdap.templates.AdapterDefinition;
 import com.clearspring.analytics.util.Preconditions;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
@@ -98,7 +98,7 @@ public class AdapterService extends AbstractIdleService {
   private static final Logger LOG = LoggerFactory.getLogger(AdapterService.class);
   private static final Gson GSON = ApplicationSpecificationAdapter.addTypeAdapters(new GsonBuilder()).create();
   private final ManagerFactory<DeploymentInfo, ApplicationWithPrograms> templateManagerFactory;
-  private final ManagerFactory<AdapterDeploymentInfo, AdapterSpecification> adapterManagerFactory;
+  private final ManagerFactory<AdapterDeploymentInfo, AdapterDefinition> adapterManagerFactory;
   private final CConfiguration configuration;
   private final Scheduler scheduler;
   private final ProgramLifecycleService lifecycleService;
@@ -117,7 +117,7 @@ public class AdapterService extends AbstractIdleService {
                         @Named("templates")
                         ManagerFactory<DeploymentInfo, ApplicationWithPrograms> templateManagerFactory,
                         @Named("adapters")
-                        ManagerFactory<AdapterDeploymentInfo, AdapterSpecification> adapterManagerFactory,
+                        ManagerFactory<AdapterDeploymentInfo, AdapterDefinition> adapterManagerFactory,
                         NamespacedLocationFactory namespacedLocationFactory, ProgramLifecycleService lifecycleService,
                         PropertiesResolver resolver,
                         PluginRepository pluginRepository) {
@@ -197,8 +197,8 @@ public class AdapterService extends AbstractIdleService {
    * @return requested {@link AdapterConfig} or null if no such AdapterInfo exists
    * @throws AdapterNotFoundException if the requested adapter is not found
    */
-  public AdapterSpecification getAdapter(Id.Namespace namespace, String adapterName) throws AdapterNotFoundException {
-    AdapterSpecification adapterSpec = store.getAdapter(namespace, adapterName);
+  public AdapterDefinition getAdapter(Id.Namespace namespace, String adapterName) throws AdapterNotFoundException {
+    AdapterDefinition adapterSpec = store.getAdapter(namespace, adapterName);
     if (adapterSpec == null) {
       throw new AdapterNotFoundException(Id.Adapter.from(namespace, adapterName));
     }
@@ -222,7 +222,7 @@ public class AdapterService extends AbstractIdleService {
   }
 
   public boolean canDeleteApp(Id.Application id) {
-    Collection<AdapterSpecification> adapterSpecs = getAdapters(id.getNamespace(), id.getId());
+    Collection<AdapterDefinition> adapterSpecs = getAdapters(id.getNamespace(), id.getId());
     return adapterSpecs.isEmpty();
   }
 
@@ -249,7 +249,7 @@ public class AdapterService extends AbstractIdleService {
    * @param namespace the namespace to look up the adapters
    * @return {@link Collection} of {@link AdapterConfig}
    */
-  public Collection<AdapterSpecification> getAdapters(Id.Namespace namespace) {
+  public Collection<AdapterDefinition> getAdapters(Id.Namespace namespace) {
     return store.getAllAdapters(namespace);
   }
 
@@ -260,12 +260,12 @@ public class AdapterService extends AbstractIdleService {
    * @param template the template of requested adapters
    * @return Collection of requested {@link AdapterConfig}
    */
-  public Collection<AdapterSpecification> getAdapters(Id.Namespace namespace, final String template) {
+  public Collection<AdapterDefinition> getAdapters(Id.Namespace namespace, final String template) {
     // Alternative is to construct the key using adapterType as well, when storing the the adapterSpec. That approach
     // will make lookup by adapterType simpler, but it will increase the complexity of lookup by namespace + adapterName
-    List<AdapterSpecification> adaptersByType = Lists.newArrayList();
-    Collection<AdapterSpecification> adapters = store.getAllAdapters(namespace);
-    for (AdapterSpecification adapterSpec : adapters) {
+    List<AdapterDefinition> adaptersByType = Lists.newArrayList();
+    Collection<AdapterDefinition> adapters = store.getAllAdapters(namespace);
+    for (AdapterDefinition adapterSpec : adapters) {
       if (adapterSpec.getTemplate().equals(template)) {
         adaptersByType.add(adapterSpec);
       }
@@ -342,7 +342,7 @@ public class AdapterService extends AbstractIdleService {
       throw new InvalidAdapterOperationException("Adapter is already stopped.");
     }
 
-    AdapterSpecification adapterSpec = getAdapter(namespace, adapterName);
+    AdapterDefinition adapterSpec = getAdapter(namespace, adapterName);
 
     LOG.info("Received request to stop Adapter {} in namespace {}", adapterName, namespace.getId());
     ProgramType programType = adapterSpec.getProgram().getType();
@@ -376,7 +376,7 @@ public class AdapterService extends AbstractIdleService {
       throw new InvalidAdapterOperationException("Adapter is already started.");
     }
 
-    AdapterSpecification adapterSpec = getAdapter(namespace, adapterName);
+    AdapterDefinition adapterSpec = getAdapter(namespace, adapterName);
 
     ProgramType programType = adapterSpec.getProgram().getType();
     if (programType == ProgramType.WORKFLOW) {
@@ -433,7 +433,7 @@ public class AdapterService extends AbstractIdleService {
     return getProgramId(namespace, getAdapter(namespace, adapterName));
   }
 
-  private Id.Program getProgramId(Id.Namespace namespace, AdapterSpecification adapterSpec) throws NotFoundException {
+  private Id.Program getProgramId(Id.Namespace namespace, AdapterDefinition adapterSpec) throws NotFoundException {
     Id.Application appId = Id.Application.from(namespace, adapterSpec.getTemplate());
     ApplicationSpecification appSpec = store.getApplication(appId);
     if (appSpec == null) {
@@ -443,7 +443,7 @@ public class AdapterService extends AbstractIdleService {
                            adapterSpec.getProgram().getType(), adapterSpec.getProgram().getId());
   }
 
-  private void startWorkflowAdapter(Id.Namespace namespace, AdapterSpecification adapterSpec)
+  private void startWorkflowAdapter(Id.Namespace namespace, AdapterDefinition adapterSpec)
     throws NotFoundException, SchedulerException {
     Id.Program workflowId = getProgramId(namespace, adapterSpec);
     ScheduleSpecification scheduleSpec = adapterSpec.getScheduleSpec();
@@ -456,7 +456,7 @@ public class AdapterService extends AbstractIdleService {
     store.addSchedule(workflowId, scheduleSpec);
   }
 
-  private void stopWorkflowAdapter(Id.Namespace namespace, AdapterSpecification adapterSpec)
+  private void stopWorkflowAdapter(Id.Namespace namespace, AdapterDefinition adapterSpec)
     throws NotFoundException, SchedulerException, ExecutionException, InterruptedException {
     Id.Program workflowId = getProgramId(namespace, adapterSpec);
     String scheduleName = adapterSpec.getScheduleSpec().getSchedule().getName();
@@ -479,7 +479,7 @@ public class AdapterService extends AbstractIdleService {
     }
   }
 
-  private void startWorkerAdapter(Id.Namespace namespace, AdapterSpecification adapterSpec) throws NotFoundException,
+  private void startWorkerAdapter(Id.Namespace namespace, AdapterDefinition adapterSpec) throws NotFoundException,
     IOException {
     final Id.Adapter adapterId = Id.Adapter.from(namespace.getId(), adapterSpec.getName());
     final Id.Program workerId = getProgramId(namespace, adapterSpec);
@@ -536,7 +536,7 @@ public class AdapterService extends AbstractIdleService {
     }
   }
 
-  private void stopWorkerAdapter(Id.Namespace namespace, AdapterSpecification adapterSpec) throws NotFoundException,
+  private void stopWorkerAdapter(Id.Namespace namespace, AdapterDefinition adapterSpec) throws NotFoundException,
     ExecutionException, InterruptedException {
     final Id.Program workerId = getProgramId(namespace, adapterSpec);
     List<RunRecord> runRecords = store.getRuns(workerId, ProgramRunStatus.RUNNING, 0, Long.MAX_VALUE, Integer.MAX_VALUE,
@@ -550,12 +550,12 @@ public class AdapterService extends AbstractIdleService {
 
   // deploys an adapter. This will call configureAdapter() on the adapter's template. It may create
   // datasets and streams. At the end it will write to the store with the adapter spec.
-  private AdapterSpecification deployAdapter(Id.Namespace namespace, String adapterName,
+  private AdapterDefinition deployAdapter(Id.Namespace namespace, String adapterName,
                                              ApplicationTemplateInfo applicationTemplateInfo,
                                              ApplicationSpecification templateSpec,
                                              AdapterConfig adapterConfig) throws IllegalArgumentException {
 
-    Manager<AdapterDeploymentInfo, AdapterSpecification> manager = adapterManagerFactory.create(
+    Manager<AdapterDeploymentInfo, AdapterDefinition> manager = adapterManagerFactory.create(
       new ProgramTerminator() {
         @Override
         public void stop(Id.Namespace id, Id.Program programId, ProgramType type) throws ExecutionException {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/AbstractMapReduceContextBuilder.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/AbstractMapReduceContextBuilder.java
@@ -26,7 +26,7 @@ import co.cask.cdap.app.runtime.Arguments;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.internal.app.runtime.adapter.PluginInstantiator;
 import co.cask.cdap.internal.app.runtime.workflow.WorkflowMapReduceProgram;
-import co.cask.cdap.templates.AdapterSpecification;
+import co.cask.cdap.templates.AdapterDefinition;
 import co.cask.tephra.Transaction;
 import co.cask.tephra.TransactionAware;
 import com.google.common.base.Preconditions;
@@ -71,7 +71,7 @@ public abstract class AbstractMapReduceContextBuilder {
                                      @Nullable String inputDataSetName,
                                      @Nullable List<Split> inputSplits,
                                      @Nullable String outputDataSetName,
-                                     @Nullable AdapterSpecification adapterSpec,
+                                     @Nullable AdapterDefinition adapterSpec,
                                      @Nullable PluginInstantiator pluginInstantiator) {
     Injector injector = prepare();
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
@@ -39,7 +39,7 @@ import co.cask.cdap.internal.app.runtime.AbstractContext;
 import co.cask.cdap.internal.app.runtime.adapter.PluginInstantiator;
 import co.cask.cdap.logging.context.MapReduceLoggingContext;
 import co.cask.cdap.proto.Id;
-import co.cask.cdap.templates.AdapterSpecification;
+import co.cask.cdap.templates.AdapterDefinition;
 import co.cask.tephra.TransactionAware;
 import com.google.common.collect.Maps;
 import org.apache.hadoop.mapreduce.Job;
@@ -83,7 +83,7 @@ public class BasicMapReduceContext extends AbstractContext implements MapReduceC
                                DiscoveryServiceClient discoveryServiceClient,
                                MetricsCollectionService metricsCollectionService,
                                DatasetFramework dsFramework,
-                               @Nullable AdapterSpecification adapterSpec,
+                               @Nullable AdapterDefinition adapterSpec,
                                @Nullable PluginInstantiator pluginInstantiator) {
     super(program, runId, runtimeArguments, datasets,
           getMetricCollector(program, runId.getId(), taskId, metricsCollectionService, type, adapterSpec),
@@ -107,7 +107,7 @@ public class BasicMapReduceContext extends AbstractContext implements MapReduceC
   }
 
   private LoggingContext createLoggingContext(Id.Program programId, RunId runId,
-                                              @Nullable AdapterSpecification adapterSpec) {
+                                              @Nullable AdapterDefinition adapterSpec) {
     String adapterName = adapterSpec == null ? null : adapterSpec.getName();
     return new MapReduceLoggingContext(programId.getNamespaceId(), programId.getApplicationId(),
                                        programId.getId(), runId.getId(), adapterName);
@@ -251,7 +251,7 @@ public class BasicMapReduceContext extends AbstractContext implements MapReduceC
   private static MetricsCollector getMetricCollector(Program program, String runId, String taskId,
                                                      @Nullable MetricsCollectionService service,
                                                      @Nullable MapReduceMetrics.TaskType type,
-                                                     @Nullable AdapterSpecification adapterSpec) {
+                                                     @Nullable AdapterDefinition adapterSpec) {
     if (service == null) {
       return null;
     }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/DynamicMapReduceContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/DynamicMapReduceContext.java
@@ -31,7 +31,7 @@ import co.cask.cdap.data2.dataset2.DatasetCacheKey;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.DynamicDatasetContext;
 import co.cask.cdap.internal.app.runtime.adapter.PluginInstantiator;
-import co.cask.cdap.templates.AdapterSpecification;
+import co.cask.cdap.templates.AdapterDefinition;
 import co.cask.tephra.TransactionContext;
 import co.cask.tephra.TransactionSystemClient;
 import com.google.common.cache.CacheBuilder;
@@ -78,7 +78,7 @@ public class DynamicMapReduceContext extends BasicMapReduceContext implements Da
                                  MetricsCollectionService metricsCollectionService,
                                  TransactionSystemClient txClient,
                                  DatasetFramework dsFramework,
-                                 @Nullable AdapterSpecification adapterSpec,
+                                 @Nullable AdapterDefinition adapterSpec,
                                  @Nullable PluginInstantiator pluginInstantiator) {
     super(program, type, runId, taskId, runtimeArguments, Collections.<String>emptySet(), spec,
           logicalStartTime, workflowBatch, discoveryServiceClient, metricsCollectionService,

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextConfig.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextConfig.java
@@ -23,7 +23,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.internal.app.runtime.BasicArguments;
 import co.cask.cdap.internal.app.runtime.batch.dataset.DataSetInputFormat;
 import co.cask.cdap.internal.app.runtime.batch.dataset.DataSetOutputFormat;
-import co.cask.cdap.templates.AdapterSpecification;
+import co.cask.cdap.templates.AdapterDefinition;
 import co.cask.tephra.Transaction;
 import com.google.common.base.Throwables;
 import com.google.common.reflect.TypeToken;
@@ -121,19 +121,19 @@ public final class MapReduceContextConfig {
     return hConf.get(HCONF_ATTR_WORKFLOW_BATCH);
   }
 
-  private void setAdapterSpec(@Nullable AdapterSpecification adapterSpec) {
+  private void setAdapterSpec(@Nullable AdapterDefinition adapterSpec) {
     if (adapterSpec != null) {
       hConf.set(HCONF_ATTR_ADAPTER_SPEC, GSON.toJson(adapterSpec));
     }
   }
 
   @Nullable
-  public AdapterSpecification getAdapterSpec() {
+  public AdapterDefinition getAdapterSpec() {
     String spec = hConf.get(HCONF_ATTR_ADAPTER_SPEC);
     if (spec == null) {
       return null;
     }
-    return GSON.fromJson(spec, AdapterSpecification.class);
+    return GSON.fromJson(spec, AdapterDefinition.class);
   }
 
   private void setProgramJarURI(URI programJarURI) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
@@ -43,7 +43,7 @@ import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
 import co.cask.cdap.internal.app.runtime.adapter.PluginInstantiator;
 import co.cask.cdap.internal.lang.Reflections;
 import co.cask.cdap.proto.ProgramType;
-import co.cask.cdap.templates.AdapterSpecification;
+import co.cask.cdap.templates.AdapterDefinition;
 import co.cask.tephra.TransactionSystemClient;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
@@ -137,7 +137,7 @@ public class MapReduceProgramRunner implements ProgramRunner {
                                 : System.currentTimeMillis();
 
     String workflowBatch = arguments.getOption(ProgramOptionConstants.WORKFLOW_BATCH);
-    AdapterSpecification adapterSpec = getAdapterSpecification(arguments);
+    AdapterDefinition adapterSpec = getAdapterSpecification(arguments);
 
     MapReduce mapReduce;
     try {
@@ -226,15 +226,15 @@ public class MapReduceProgramRunner implements ProgramRunner {
   }
 
   @Nullable
-  private AdapterSpecification getAdapterSpecification(Arguments arguments) {
+  private AdapterDefinition getAdapterSpecification(Arguments arguments) {
     if (!arguments.hasOption(ProgramOptionConstants.ADAPTER_SPEC)) {
       return null;
     }
-    return GSON.fromJson(arguments.getOption(ProgramOptionConstants.ADAPTER_SPEC), AdapterSpecification.class);
+    return GSON.fromJson(arguments.getOption(ProgramOptionConstants.ADAPTER_SPEC), AdapterDefinition.class);
   }
 
   @Nullable
-  private PluginInstantiator createPluginInstantiator(@Nullable AdapterSpecification adapterSpec,
+  private PluginInstantiator createPluginInstantiator(@Nullable AdapterDefinition adapterSpec,
                                                       ClassLoader programClassLoader) {
     if (adapterSpec == null) {
       return null;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
@@ -49,7 +49,7 @@ import co.cask.cdap.internal.app.runtime.batch.dataset.DataSetInputFormat;
 import co.cask.cdap.internal.app.runtime.batch.dataset.DataSetOutputFormat;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramType;
-import co.cask.cdap.templates.AdapterSpecification;
+import co.cask.cdap.templates.AdapterDefinition;
 import co.cask.tephra.Transaction;
 import co.cask.tephra.TransactionContext;
 import co.cask.tephra.TransactionExecutor;
@@ -866,7 +866,7 @@ final class MapReduceRuntimeService extends AbstractExecutionThreadService {
    * @return the {@link Location} for the archive file or {@code null} if there is no plugin files need to be localized
    */
   @Nullable
-  private Location createPluginArchive(@Nullable AdapterSpecification adapterSpec,
+  private Location createPluginArchive(@Nullable AdapterDefinition adapterSpec,
                                        Id.Program programId) throws IOException {
     if (adapterSpec == null) {
       return null;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractDistributedProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractDistributedProgramRunner.java
@@ -33,7 +33,7 @@ import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
 import co.cask.cdap.internal.app.runtime.codec.ArgumentsCodec;
 import co.cask.cdap.internal.app.runtime.codec.ProgramOptionsCodec;
 import co.cask.cdap.proto.Id;
-import co.cask.cdap.templates.AdapterSpecification;
+import co.cask.cdap.templates.AdapterDefinition;
 import com.google.common.base.Charsets;
 import com.google.common.base.Throwables;
 import com.google.common.io.Files;
@@ -179,8 +179,8 @@ public abstract class AbstractDistributedProgramRunner implements ProgramRunner 
     }
 
     // Decode the adapter spec from program system argument
-    AdapterSpecification adapterSpec = GSON.fromJson(arguments.getOption(ProgramOptionConstants.ADAPTER_SPEC),
-                                                     AdapterSpecification.class);
+    AdapterDefinition adapterSpec = GSON.fromJson(arguments.getOption(ProgramOptionConstants.ADAPTER_SPEC),
+                                                     AdapterDefinition.class);
 
     // Get all unique PluginInfo from the adapter spec
     Set<PluginInfo> plugins = adapterSpec.getPluginInfos();

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/BasicWorkerContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/BasicWorkerContext.java
@@ -40,7 +40,7 @@ import co.cask.cdap.internal.app.runtime.AbstractContext;
 import co.cask.cdap.internal.app.runtime.adapter.PluginInstantiator;
 import co.cask.cdap.logging.context.WorkerLoggingContext;
 import co.cask.cdap.proto.Id;
-import co.cask.cdap.templates.AdapterSpecification;
+import co.cask.cdap.templates.AdapterDefinition;
 import co.cask.tephra.TransactionContext;
 import co.cask.tephra.TransactionFailureException;
 import co.cask.tephra.TransactionSystemClient;
@@ -89,7 +89,7 @@ public class BasicWorkerContext extends AbstractContext implements WorkerContext
                             TransactionSystemClient transactionSystemClient,
                             DiscoveryServiceClient discoveryServiceClient,
                             StreamWriterFactory streamWriterFactory,
-                            @Nullable AdapterSpecification adapterSpec,
+                            @Nullable AdapterDefinition adapterSpec,
                             @Nullable PluginInstantiator pluginInstantiator) {
     super(program, runId, runtimeArgs, spec.getDatasets(),
           getMetricCollector(metricsCollectionService, program, runId.getId(), instanceId),

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/WorkerProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/WorkerProgramRunner.java
@@ -33,7 +33,7 @@ import co.cask.cdap.internal.app.runtime.ProgramControllerServiceAdapter;
 import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
 import co.cask.cdap.internal.app.runtime.adapter.PluginInstantiator;
 import co.cask.cdap.proto.ProgramType;
-import co.cask.cdap.templates.AdapterSpecification;
+import co.cask.cdap.templates.AdapterDefinition;
 import co.cask.tephra.TransactionSystemClient;
 import com.google.common.base.Preconditions;
 import com.google.gson.Gson;
@@ -104,7 +104,7 @@ public class WorkerProgramRunner implements ProgramRunner {
                                                                 workerSpec.getDatasets(), newResources,
                                                                 Integer.valueOf(instances));
 
-    AdapterSpecification adapterSpec = getAdapterSpecification(options.getArguments());
+    AdapterDefinition adapterSpec = getAdapterSpecification(options.getArguments());
 
     BasicWorkerContext context = new BasicWorkerContext(
       newWorkerSpec, program, runId, instanceId, instanceCount,
@@ -121,16 +121,16 @@ public class WorkerProgramRunner implements ProgramRunner {
   }
 
   @Nullable
-  private AdapterSpecification getAdapterSpecification(Arguments arguments) {
+  private AdapterDefinition getAdapterSpecification(Arguments arguments) {
     // TODO: Refactor ProgramRunner class hierarchy to have common logic moved to a common parent.
     if (!arguments.hasOption(ProgramOptionConstants.ADAPTER_SPEC)) {
       return null;
     }
-    return GSON.fromJson(arguments.getOption(ProgramOptionConstants.ADAPTER_SPEC), AdapterSpecification.class);
+    return GSON.fromJson(arguments.getOption(ProgramOptionConstants.ADAPTER_SPEC), AdapterDefinition.class);
   }
 
   @Nullable
-  private PluginInstantiator createPluginInstantiator(@Nullable AdapterSpecification adapterSpec,
+  private PluginInstantiator createPluginInstantiator(@Nullable AdapterDefinition adapterSpec,
                                                       ClassLoader programClassLoader) {
     // TODO: Refactor ProgramRunner class hierarchy to have common logic moved to a common parent.
     if (adapterSpec == null) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/AdapterMeta.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/AdapterMeta.java
@@ -17,21 +17,21 @@
 package co.cask.cdap.internal.app.store;
 
 import co.cask.cdap.internal.app.runtime.adapter.AdapterStatus;
-import co.cask.cdap.templates.AdapterSpecification;
+import co.cask.cdap.templates.AdapterDefinition;
 
 /**
  * Holds adapter metadata
  */
 public class AdapterMeta {
-  private final AdapterSpecification spec;
+  private final AdapterDefinition spec;
   private final AdapterStatus status;
 
-  public AdapterMeta(AdapterSpecification spec, AdapterStatus status) {
+  public AdapterMeta(AdapterDefinition spec, AdapterStatus status) {
     this.spec = spec;
     this.status = status;
   }
 
-  public AdapterSpecification getSpec() {
+  public AdapterDefinition getSpec() {
     return spec;
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/AppMetadataStore.java
@@ -31,7 +31,7 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.RunRecord;
-import co.cask.cdap.templates.AdapterSpecification;
+import co.cask.cdap.templates.AdapterDefinition;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -472,14 +472,14 @@ public class AppMetadataStore extends MetadataStoreDataset {
     return list(getNamespaceKey(null), NamespaceMeta.class);
   }
 
-  public void writeAdapter(Id.Namespace id, AdapterSpecification adapterSpec,
+  public void writeAdapter(Id.Namespace id, AdapterDefinition adapterSpec,
                            AdapterStatus adapterStatus) {
     write(new MDSKey.Builder().add(TYPE_ADAPTER, id.getId(), adapterSpec.getName()).build(),
           new AdapterMeta(adapterSpec, adapterStatus));
   }
 
   @Nullable
-  public AdapterSpecification getAdapter(Id.Namespace id, String name) {
+  public AdapterDefinition getAdapter(Id.Namespace id, String name) {
     AdapterMeta adapterMeta = getAdapterMeta(id, name);
     return adapterMeta == null ?  null : adapterMeta.getSpec();
   }
@@ -506,8 +506,8 @@ public class AppMetadataStore extends MetadataStoreDataset {
     return getFirst(new MDSKey.Builder().add(TYPE_ADAPTER, id.getId(), name).build(), AdapterMeta.class);
   }
 
-  public List<AdapterSpecification> getAllAdapters(Id.Namespace id) {
-    List<AdapterSpecification> adapterSpecs = Lists.newArrayList();
+  public List<AdapterDefinition> getAllAdapters(Id.Namespace id) {
+    List<AdapterDefinition> adapterSpecs = Lists.newArrayList();
     List<AdapterMeta> adapterMetas = list(new MDSKey.Builder().add(TYPE_ADAPTER, id.getId()).build(),
                                           AdapterMeta.class);
     for (AdapterMeta adapterMeta : adapterMetas) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
@@ -17,7 +17,6 @@
 package co.cask.cdap.internal.app.store;
 
 import co.cask.cdap.api.ProgramSpecification;
-import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.data.stream.StreamSpecification;
 import co.cask.cdap.api.dataset.DatasetAdmin;
 import co.cask.cdap.api.dataset.DatasetDefinition;
@@ -51,7 +50,7 @@ import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.RunRecord;
-import co.cask.cdap.templates.AdapterSpecification;
+import co.cask.cdap.templates.AdapterDefinition;
 import co.cask.tephra.TransactionExecutor;
 import co.cask.tephra.TransactionExecutorFactory;
 import com.google.common.annotations.VisibleForTesting;
@@ -791,7 +790,7 @@ public class DefaultStore implements Store {
   }
 
   @Override
-  public void addAdapter(final Id.Namespace id, final AdapterSpecification adapterSpec) {
+  public void addAdapter(final Id.Namespace id, final AdapterDefinition adapterSpec) {
     txnl.executeUnchecked(new TransactionExecutor.Function<AppMds, Void>() {
       @Override
       public Void apply(AppMds mds) throws Exception {
@@ -803,10 +802,10 @@ public class DefaultStore implements Store {
 
   @Nullable
   @Override
-  public AdapterSpecification getAdapter(final Id.Namespace id, final String name) {
-    return txnl.executeUnchecked(new TransactionExecutor.Function<AppMds, AdapterSpecification>() {
+  public AdapterDefinition getAdapter(final Id.Namespace id, final String name) {
+    return txnl.executeUnchecked(new TransactionExecutor.Function<AppMds, AdapterDefinition>() {
       @Override
-      public AdapterSpecification apply(AppMds mds) throws Exception {
+      public AdapterDefinition apply(AppMds mds) throws Exception {
         return mds.apps.getAdapter(id, name);
       }
     });
@@ -835,10 +834,10 @@ public class DefaultStore implements Store {
   }
 
   @Override
-  public Collection<AdapterSpecification> getAllAdapters(final Id.Namespace id) {
-    return txnl.executeUnchecked(new TransactionExecutor.Function<AppMds, Collection<AdapterSpecification>>() {
+  public Collection<AdapterDefinition> getAllAdapters(final Id.Namespace id) {
+    return txnl.executeUnchecked(new TransactionExecutor.Function<AppMds, Collection<AdapterDefinition>>() {
       @Override
-      public Collection<AdapterSpecification> apply(AppMds mds) throws Exception {
+      public Collection<AdapterDefinition> apply(AppMds mds) throws Exception {
         return mds.apps.getAllAdapters(id);
       }
     });

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/templates/AdapterDefinition.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/templates/AdapterDefinition.java
@@ -37,7 +37,7 @@ import javax.annotation.Nullable;
 /**
  * Specification of an adapter.
  */
-public final class AdapterSpecification {
+public final class AdapterDefinition {
 
   private static final EnumSet<ProgramType> ADAPTER_PROGRAM_TYPES = EnumSet.of(ProgramType.WORKFLOW,
                                                                                ProgramType.WORKER);
@@ -57,15 +57,15 @@ public final class AdapterSpecification {
   // but the platform itself never interprets it but just passes it along.
   private final JsonElement config;
 
-  private AdapterSpecification(String name, String description, Id.Program program,
-                               ScheduleSpecification scheduleSpec, int instances,
-                               Map<String, StreamSpecification> streams,
-                               Map<String, DatasetCreationSpec> datasets,
-                               Map<String, String> datasetModules,
-                               Map<String, String> runtimeArgs,
-                               Map<String, AdapterPlugin> plugins,
-                               Resources resources,
-                               JsonElement config) {
+  private AdapterDefinition(String name, String description, Id.Program program,
+                            ScheduleSpecification scheduleSpec, int instances,
+                            Map<String, StreamSpecification> streams,
+                            Map<String, DatasetCreationSpec> datasets,
+                            Map<String, String> datasetModules,
+                            Map<String, String> runtimeArgs,
+                            Map<String, AdapterPlugin> plugins,
+                            Resources resources,
+                            JsonElement config) {
     this.name = name;
     this.description = description;
     this.program = program;
@@ -227,8 +227,8 @@ public final class AdapterSpecification {
       return this;
     }
 
-    public AdapterSpecification build() {
-      return new AdapterSpecification(name, description, program, schedule, instances,
+    public AdapterDefinition build() {
+      return new AdapterDefinition(name, description, program, schedule, instances,
                                       streams, datasets, datasetModules, runtimeArgs, plugins, resources, config);
     }
   }
@@ -242,7 +242,7 @@ public final class AdapterSpecification {
       return false;
     }
 
-    AdapterSpecification that = (AdapterSpecification) o;
+    AdapterDefinition that = (AdapterDefinition) o;
 
     return Objects.equal(name, that.name) &&
       Objects.equal(description, that.description) &&

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/templates/DefaultAdapterConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/templates/DefaultAdapterConfigurer.java
@@ -271,9 +271,9 @@ public class DefaultAdapterConfigurer implements AdapterConfigurer {
     runtimeArgs.put(key, value);
   }
 
-  public AdapterSpecification createSpecification() {
-    AdapterSpecification.Builder builder =
-      AdapterSpecification.builder(adapterName, programId)
+  public AdapterDefinition createSpecification() {
+    AdapterDefinition.Builder builder =
+      AdapterDefinition.builder(adapterName, programId)
         .setDescription(adapterConfig.getDescription())
         .setConfig(adapterConfig.getConfig())
         .setDatasets(dataSetInstances)

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/adapter/AdapterLifecycleTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/adapter/AdapterLifecycleTest.java
@@ -25,7 +25,7 @@ import co.cask.cdap.common.io.Locations;
 import co.cask.cdap.internal.app.services.http.AppFabricTestBase;
 import co.cask.cdap.internal.test.AppJarHelper;
 import co.cask.cdap.proto.AdapterConfig;
-import co.cask.cdap.templates.AdapterSpecification;
+import co.cask.cdap.templates.AdapterDefinition;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Files;
 import com.google.gson.Gson;
@@ -51,7 +51,7 @@ import java.util.Map;
 public class AdapterLifecycleTest extends AppFabricTestBase {
   private static final Gson GSON = new Gson();
   private static final Type ADAPTER_SPEC_LIST_TYPE =
-    new TypeToken<List<AdapterSpecification>>() { }.getType();
+    new TypeToken<List<AdapterDefinition>>() { }.getType();
   private static LocationFactory locationFactory;
   private static File adapterDir;
   private static AdapterService adapterService;
@@ -105,13 +105,13 @@ public class AdapterLifecycleTest extends AppFabricTestBase {
 
     response = listAdapters(namespaceId);
     Assert.assertEquals(200, response.getStatusLine().getStatusCode());
-    List<AdapterSpecification> list = readResponse(response, ADAPTER_SPEC_LIST_TYPE);
+    List<AdapterDefinition> list = readResponse(response, ADAPTER_SPEC_LIST_TYPE);
     Assert.assertEquals(1, list.size());
     checkIsExpected(adapterConfig, list.get(0));
 
     response = getAdapter(namespaceId, adapterName);
     Assert.assertEquals(200, response.getStatusLine().getStatusCode());
-    AdapterSpecification receivedAdapterConfig = readResponse(response, AdapterSpecification.class);
+    AdapterDefinition receivedAdapterConfig = readResponse(response, AdapterDefinition.class);
     checkIsExpected(adapterConfig, receivedAdapterConfig);
 
     List<JsonObject> deployedApps = getAppList(namespaceId);
@@ -172,7 +172,7 @@ public class AdapterLifecycleTest extends AppFabricTestBase {
     Assert.assertTrue(deployedApps.isEmpty());
   }
 
-  private void checkIsExpected(AdapterConfig config, AdapterSpecification spec) {
+  private void checkIsExpected(AdapterConfig config, AdapterDefinition spec) {
     Assert.assertEquals(config.getDescription(), spec.getDescription());
     Assert.assertEquals(config.getTemplate(), spec.getTemplate());
     Assert.assertEquals(config.getConfig(), spec.getConfig());
@@ -246,7 +246,7 @@ public class AdapterLifecycleTest extends AppFabricTestBase {
     // test get all endpoint
     HttpResponse response = listAdapters(namespaceId);
     Assert.assertEquals(200, response.getStatusLine().getStatusCode());
-    List<AdapterSpecification> list = readResponse(response, ADAPTER_SPEC_LIST_TYPE);
+    List<AdapterDefinition> list = readResponse(response, ADAPTER_SPEC_LIST_TYPE);
     Assert.assertEquals(2, list.size());
 
     // test get all for a template

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/adapter/AdapterServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/adapter/AdapterServiceTest.java
@@ -37,7 +37,7 @@ import co.cask.cdap.proto.AdapterConfig;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.RunRecord;
-import co.cask.cdap.templates.AdapterSpecification;
+import co.cask.cdap.templates.AdapterDefinition;
 import com.google.common.collect.Iterables;
 import com.google.common.io.Files;
 import io.netty.handler.codec.http.HttpResponseStatus;
@@ -107,7 +107,7 @@ public class AdapterServiceTest extends AppFabricTestBase {
 
     // Create an adapter to deploy template application.
     adapterService.createAdapter(NAMESPACE, adapterName, adapterConfig);
-    AdapterSpecification adapterSpec = adapterService.getAdapter(NAMESPACE, adapterName);
+    AdapterDefinition adapterSpec = adapterService.getAdapter(NAMESPACE, adapterName);
     Assert.assertNotNull(adapterSpec);
 
     // We should not be able to delete the application since we have created an adapter.
@@ -233,14 +233,14 @@ public class AdapterServiceTest extends AppFabricTestBase {
       // expected
     }
 
-    AdapterSpecification actualAdapterSpec = adapterService.getAdapter(NAMESPACE, adapterName);
+    AdapterDefinition actualAdapterSpec = adapterService.getAdapter(NAMESPACE, adapterName);
     Assert.assertNotNull(actualAdapterSpec);
     assertDummyConfigEquals(adapterConfig, actualAdapterSpec);
 
     // list all adapters
-    Collection<AdapterSpecification> adapters = adapterService.getAdapters(NAMESPACE, DummyBatchTemplate.NAME);
+    Collection<AdapterDefinition> adapters = adapterService.getAdapters(NAMESPACE, DummyBatchTemplate.NAME);
     Assert.assertEquals(1, adapters.size());
-    AdapterSpecification actual = adapters.iterator().next();
+    AdapterDefinition actual = adapters.iterator().next();
     assertDummyConfigEquals(adapterConfig, actual);
 
     // adapter should be stopped
@@ -291,7 +291,7 @@ public class AdapterServiceTest extends AppFabricTestBase {
     Assert.assertTrue(datasetExists(Id.DatasetInstance.from(NAMESPACE, tableName)));
   }
 
-  private void assertDummyConfigEquals(AdapterConfig expected, AdapterSpecification actual) {
+  private void assertDummyConfigEquals(AdapterConfig expected, AdapterDefinition actual) {
     Assert.assertEquals(expected.getDescription(), actual.getDescription());
     Assert.assertEquals(expected.getTemplate(), actual.getTemplate());
     Assert.assertEquals(expected.getConfig(), actual.getConfig());

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/DefaultStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/DefaultStoreTest.java
@@ -60,7 +60,7 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.RunRecord;
-import co.cask.cdap.templates.AdapterSpecification;
+import co.cask.cdap.templates.AdapterDefinition;
 import co.cask.cdap.test.internal.AppFabricTestHelper;
 import co.cask.cdap.test.internal.DefaultId;
 import com.google.common.base.Objects;
@@ -826,16 +826,16 @@ public class DefaultStoreTest {
   public void testAdapterMDSOperations() throws Exception {
     Id.Namespace namespaceId = new Id.Namespace("testAdapterMDS");
 
-    AdapterSpecification spec1 = AdapterSpecification.builder("spec1", Id.Program.from(namespaceId,
-                                                                                       "template1",
-                                                                                       ProgramType.WORKFLOW,
-                                                                                       "program1"))
+    AdapterDefinition spec1 = AdapterDefinition.builder("spec1", Id.Program.from(namespaceId,
+                                                                                 "template1",
+                                                                                 ProgramType.WORKFLOW,
+                                                                                 "program1"))
       .setConfig(GSON.toJsonTree(ImmutableMap.of("k1", "v1")).getAsJsonObject())
       .build();
 
     TemplateConf templateConf = new TemplateConf(5, "5", ImmutableMap.of("123", "456"));
-    AdapterSpecification spec2 = AdapterSpecification.builder("spec2", Id.Program.from(namespaceId, "template2",
-                                                                                       ProgramType.WORKER, "program2"))
+    AdapterDefinition spec2 = AdapterDefinition.builder("spec2", Id.Program.from(namespaceId, "template2",
+                                                                                 ProgramType.WORKER, "program2"))
       .setConfig(GSON.toJsonTree(templateConf).getAsJsonObject())
       .build();
 
@@ -843,13 +843,13 @@ public class DefaultStoreTest {
     store.addAdapter(namespaceId, spec2);
 
     // check get all adapters
-    Collection<AdapterSpecification> adapters = store.getAllAdapters(namespaceId);
+    Collection<AdapterDefinition> adapters = store.getAllAdapters(namespaceId);
     Assert.assertEquals(2, adapters.size());
     // apparently JsonObjects can be equal, but have different hash codes which means we can't just put
     // them in a set and compare...
-    Iterator<AdapterSpecification> iter = adapters.iterator();
-    AdapterSpecification actual1 = iter.next();
-    AdapterSpecification actual2 = iter.next();
+    Iterator<AdapterDefinition> iter = adapters.iterator();
+    AdapterDefinition actual1 = iter.next();
+    AdapterDefinition actual2 = iter.next();
     // since order is not guaranteed...
     if (actual1.getName().equals(spec1.getName())) {
       Assert.assertEquals(actual1, spec1);
@@ -860,11 +860,11 @@ public class DefaultStoreTest {
     }
 
     // Get non existing spec
-    AdapterSpecification retrievedAdapter = store.getAdapter(namespaceId, "nonExistingAdapter");
+    AdapterDefinition retrievedAdapter = store.getAdapter(namespaceId, "nonExistingAdapter");
     Assert.assertNull(retrievedAdapter);
 
     //Retrieve specs
-    AdapterSpecification retrievedSpec1 = store.getAdapter(namespaceId, spec1.getName());
+    AdapterDefinition retrievedSpec1 = store.getAdapter(namespaceId, spec1.getName());
     Assert.assertEquals(spec1, retrievedSpec1);
     // Remove spec
     store.removeAdapter(namespaceId, spec1.getName());
@@ -874,7 +874,7 @@ public class DefaultStoreTest {
     Assert.assertNull(retrievedAdapter);
 
     // verify the other adapter still exists
-    AdapterSpecification retrievedSpec2 = store.getAdapter(namespaceId, spec2.getName());
+    AdapterDefinition retrievedSpec2 = store.getAdapter(namespaceId, spec2.getName());
     Assert.assertEquals(spec2, retrievedSpec2);
 
     // remove all

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
@@ -70,7 +70,7 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.ScheduledRuntime;
-import co.cask.cdap.templates.AdapterSpecification;
+import co.cask.cdap.templates.AdapterDefinition;
 import co.cask.tephra.TransactionExecutorFactory;
 import co.cask.tephra.distributed.TransactionService;
 import com.google.common.base.Throwables;
@@ -478,11 +478,11 @@ public class UpgradeTool {
     List<NamespaceMeta> namespaceMetas = namespaceAdmin.listNamespaces();
     for (NamespaceMeta namespaceMeta : namespaceMetas) {
       String namespace = namespaceMeta.getName();
-      Collection<AdapterSpecification> adapters = adapterService.getAdapters(Id.Namespace
+      Collection<AdapterDefinition> adapters = adapterService.getAdapters(Id.Namespace
                                                                                .from(namespace));
       Id.Program program = Id.Program.from(namespace, "stream-conversion", ProgramType.WORKFLOW,
                                            "StreamConversionWorkflow");
-      for (AdapterSpecification adapter : adapters) {
+      for (AdapterDefinition adapter : adapters) {
         TriggerKey triggerKey = new TriggerKey(AbstractSchedulerService.scheduleIdFor(
           program, SchedulableProgramType.WORKFLOW, adapter.getName() + "StreamConversionWorkflow"));
         if (datasetBasedTimeScheduleStore.removeTrigger(triggerKey)) {


### PR DESCRIPTION
- This is a step to have AdapterSpecification to be available in cdap-api
- The rename is needed so that the AdapterDefinition can be kept as an internal class
  - It has things like Id.Program, DatasetCreationSpec, etc that are internal
- A new AdapterSpecification class will be introduced in cdap-api, which the AdapterDefinition will be extended from.