### PR TITLE
CDAP-2237: Adapter<->{Dataset,Stream} integration for usage registry

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/stream/DefaultStreamWriter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/stream/DefaultStreamWriter.java
@@ -107,7 +107,7 @@ public class DefaultStreamWriter implements StreamWriter {
 
     // prone being entered multiple times, but OK since usageRegistry.register is not an expensive operation
     if (!isStreamRegistered.containsKey(stream)) {
-      usageRegistry.register(owners, stream);
+      usageRegistry.registerAll(owners, stream);
       isStreamRegistered.put(stream, true);
     }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/stream/DefaultStreamWriter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/stream/DefaultStreamWriter.java
@@ -37,8 +37,6 @@ import com.google.inject.assistedinject.Assisted;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import org.apache.twill.discovery.Discoverable;
 import org.apache.twill.discovery.DiscoveryServiceClient;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -56,12 +54,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class DefaultStreamWriter implements StreamWriter {
 
-  private static final Logger LOG = LoggerFactory.getLogger(DefaultStreamWriter.class);
-
   private final EndpointStrategy endpointStrategy;
-  /**
-   * (stream, owner) -> bool
-   */
   private final ConcurrentMap<Id.Stream, Boolean> isStreamRegistered;
   private final UsageRegistry usageRegistry;
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/stream/StreamWriterFactory.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/stream/StreamWriterFactory.java
@@ -20,14 +20,17 @@ import co.cask.cdap.api.data.stream.StreamWriter;
 import co.cask.cdap.proto.Id;
 import com.google.inject.assistedinject.Assisted;
 
+import java.util.List;
+
 /**
  * Factory to create {@link StreamWriter} objects
  */
 public interface StreamWriterFactory {
   /**
-   * @param programId the programId that will be using the {@link StreamWriter}
+   * @param namespace the namespace that the {@link StreamWriter} belongs to
+   * @param owners the owners of the {@link StreamWriter}
    * @return a {@link StreamWriter} for the specified namespaceId
    */
-  StreamWriter create(@Assisted("programId") Id.Program programId);
+  StreamWriter create(@Assisted("namespace") Id.Namespace namespace, @Assisted("owners") List<Id> owners);
 }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractContext.java
@@ -99,8 +99,8 @@ public abstract class AbstractContext extends AbstractServiceDiscoverer
     this.discoveryServiceClient = discoveryServiceClient;
 
     this.programMetrics = metricsCollector;
-    this.dsInstantiator = new DatasetInstantiator(program.getId().getNamespace(), getOwners(), dsFramework,
-                                                  program.getClassLoader(), programMetrics);
+    this.dsInstantiator = new DatasetInstantiator(program.getId().getNamespace(), dsFramework,
+                                                  program.getClassLoader(), getOwners(), programMetrics);
 
     // todo: this should be instantiated on demand, at run-time dynamically. Esp. bad to do that in ctor...
     // todo: initialized datasets should be managed by DatasetContext (ie. DatasetInstantiator): refactor further

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractContext.java
@@ -33,10 +33,12 @@ import co.cask.cdap.data.dataset.DatasetInstantiator;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.internal.app.program.ProgramTypeMetricTag;
 import co.cask.cdap.internal.app.runtime.adapter.PluginInstantiator;
+import co.cask.cdap.proto.Id;
 import co.cask.cdap.templates.AdapterDefinition;
 import co.cask.cdap.templates.AdapterPlugin;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.io.Closeables;
@@ -47,6 +49,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -96,7 +99,7 @@ public abstract class AbstractContext extends AbstractServiceDiscoverer
     this.discoveryServiceClient = discoveryServiceClient;
 
     this.programMetrics = metricsCollector;
-    this.dsInstantiator = new DatasetInstantiator(program.getId().getNamespace(), program.getId(), dsFramework,
+    this.dsInstantiator = new DatasetInstantiator(program.getId().getNamespace(), getOwners(), dsFramework,
                                                   program.getClassLoader(), programMetrics);
 
     // todo: this should be instantiated on demand, at run-time dynamically. Esp. bad to do that in ctor...
@@ -104,6 +107,15 @@ public abstract class AbstractContext extends AbstractServiceDiscoverer
     this.datasets = Datasets.createDatasets(dsInstantiator, datasets, runtimeArguments);
     this.adapterSpec = adapterSpec;
     this.pluginInstantiator = pluginInstantiator;
+  }
+
+  public List<Id> getOwners() {
+    ImmutableList.Builder<Id> result = ImmutableList.builder();
+    result.add(program.getId());
+    if (adapterSpec != null) {
+      result.add(Id.Adapter.from(program.getId().getNamespace(), adapterSpec.getName()));
+    }
+    return result.build();
   }
 
   public abstract Metrics getMetrics();

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/DynamicMapReduceContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/DynamicMapReduceContext.java
@@ -107,8 +107,7 @@ public class DynamicMapReduceContext extends BasicMapReduceContext implements Da
         }
       });
     this.txContext = new TransactionContext(txClient);
-    this.dynamicDatasetContext = new DynamicDatasetContext(getProgram().getId().getNamespace(),
-                                                           getProgram().getId(),
+    this.dynamicDatasetContext = new DynamicDatasetContext(getProgram().getId().getNamespace(), getOwners(),
                                                            txContext, dsFramework,
                                                            program.getClassLoader(), null,
                                                            runtimeArguments.asMap()) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/DynamicMapReduceContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/DynamicMapReduceContext.java
@@ -107,10 +107,10 @@ public class DynamicMapReduceContext extends BasicMapReduceContext implements Da
         }
       });
     this.txContext = new TransactionContext(txClient);
-    this.dynamicDatasetContext = new DynamicDatasetContext(getProgram().getId().getNamespace(), getOwners(),
+    this.dynamicDatasetContext = new DynamicDatasetContext(getProgram().getId().getNamespace(),
                                                            txContext, dsFramework,
-                                                           program.getClassLoader(), null,
-                                                           runtimeArguments.asMap()) {
+                                                           program.getClassLoader(),
+                                                           runtimeArguments.asMap(), null, getOwners()) {
       @Nullable
       @Override
       protected LoadingCache<Long, Map<DatasetCacheKey, Dataset>> getDatasetsCache() {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/ConsumerSupplier.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/ConsumerSupplier.java
@@ -60,7 +60,8 @@ final class ConsumerSupplier<T> implements Supplier<T>, Closeable {
   static <T> ConsumerSupplier<T> create(Id.Namespace namespace, List<Id> owners, UsageRegistry usageRegistry,
                                         DataFabricFacade dataFabricFacade, QueueName queueName,
                                         ConsumerConfig consumerConfig, int numGroups) {
-    return new ConsumerSupplier<T>(namespace, owners, usageRegistry, dataFabricFacade, queueName, consumerConfig, numGroups);
+    return new ConsumerSupplier<T>(namespace, owners, usageRegistry, dataFabricFacade,
+                                   queueName, consumerConfig, numGroups);
   }
 
   private ConsumerSupplier(Id.Namespace namespace, List<Id> owners, UsageRegistry usageRegistry,

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/ConsumerSupplier.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/ConsumerSupplier.java
@@ -100,12 +100,7 @@ final class ConsumerSupplier<T> implements Supplier<T>, Closeable {
       } else {
         for (Id owner : owners) {
           try {
-            // TODO: redundant code
-            if (owner instanceof Id.Program) {
-              usageRegistry.register((Id.Program) owner, queueName.toStreamId());
-            } else if (owner instanceof Id.Adapter) {
-              usageRegistry.register((Id.Adapter) owner, queueName.toStreamId());
-            }
+            usageRegistry.register(owner, queueName.toStreamId());
           } catch (Exception e) {
             LOG.warn("Failed to register usage of {} -> {}", owner, queueName.toStreamId(), e);
           }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowletProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowletProgramRunner.java
@@ -500,7 +500,9 @@ public final class FlowletProgramRunner implements ProgramRunner {
               || inputNames.contains(FlowletDefinition.ANY_INPUT))) {
 
               if (entry.getKey().getType() == FlowletConnection.Type.STREAM) {
-                ConsumerSupplier<StreamConsumer> consumerSupplier = ConsumerSupplier.create(program, usageRegistry,
+                ConsumerSupplier<StreamConsumer> consumerSupplier = ConsumerSupplier.create(program.getNamespace(),
+                                                                                            flowletContext.getOwners(),
+                                                                                            usageRegistry,
                                                                                             dataFabricFacade,
                                                                                             queueName, consumerConfig);
                 queueConsumerSupplierBuilder.add(consumerSupplier);
@@ -521,7 +523,9 @@ public final class FlowletProgramRunner implements ProgramRunner {
                 Function<ByteBuffer, T> decoder =
                   wrapInputDecoder(flowletContext, queueName, createInputDatumDecoder(dataType, schema, schemaCache));
 
-                ConsumerSupplier<QueueConsumer> consumerSupplier = ConsumerSupplier.create(program, usageRegistry,
+                ConsumerSupplier<QueueConsumer> consumerSupplier = ConsumerSupplier.create(program.getNamespace(),
+                                                                                           flowletContext.getOwners(),
+                                                                                           usageRegistry,
                                                                                            dataFabricFacade, queueName,
                                                                                            consumerConfig, numGroups);
                 queueConsumerSupplierBuilder.add(consumerSupplier);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/AbstractSparkContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/AbstractSparkContext.java
@@ -160,7 +160,7 @@ abstract class AbstractSparkContext implements SparkContext {
 
     Id.Stream streamId = Id.Stream.from(basicSparkContext.getNamespaceId(), streamName);
     try {
-      basicSparkContext.getStreamAdmin().register(streamId, basicSparkContext.getOwners());
+      basicSparkContext.getStreamAdmin().register(basicSparkContext.getOwners(), streamId);
     } catch (Exception e) {
       LOG.info("Failed to registry usage of {} -> {}", GSON.toJson(basicSparkContext.getOwners()), streamId, e);
     }
@@ -222,7 +222,7 @@ abstract class AbstractSparkContext implements SparkContext {
     Id.Stream streamId = Id.Stream.from(basicSparkContext.getNamespaceId(), stream.getStreamName());
 
     try {
-      basicSparkContext.getStreamAdmin().register(streamId, basicSparkContext.getOwners());
+      basicSparkContext.getStreamAdmin().register(basicSparkContext.getOwners(), streamId);
     } catch (Exception e) {
       LOG.info("Failed to registry usage of {} -> {}", GSON.toJson(basicSparkContext.getOwners()), streamId, e);
     }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/AbstractSparkContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/AbstractSparkContext.java
@@ -61,6 +61,7 @@ import java.util.regex.Pattern;
 abstract class AbstractSparkContext implements SparkContext {
 
   private static final Logger LOG = LoggerFactory.getLogger(AbstractSparkContext.class);
+  private static final Gson GSON = new Gson();
   private static final Pattern SPACES = Pattern.compile("\\s+");
   private static final String[] NO_ARGS = {};
   private static final String SPARK_METRICS_CONF_KEY = "spark.metrics.conf";
@@ -159,9 +160,9 @@ abstract class AbstractSparkContext implements SparkContext {
 
     Id.Stream streamId = Id.Stream.from(basicSparkContext.getNamespaceId(), streamName);
     try {
-      basicSparkContext.getStreamAdmin().register(streamId, basicSparkContext.getProgram().getId());
+      basicSparkContext.getStreamAdmin().register(streamId, basicSparkContext.getOwners());
     } catch (Exception e) {
-      LOG.info("Failed to registry usage of {} -> {}", streamId, basicSparkContext.getProgram().getId(), e);
+      LOG.info("Failed to registry usage of {} -> {}", GSON.toJson(basicSparkContext.getOwners()), streamId, e);
     }
 
     return result;
@@ -221,9 +222,9 @@ abstract class AbstractSparkContext implements SparkContext {
     Id.Stream streamId = Id.Stream.from(basicSparkContext.getNamespaceId(), stream.getStreamName());
 
     try {
-      basicSparkContext.getStreamAdmin().register(streamId, basicSparkContext.getProgram().getId());
+      basicSparkContext.getStreamAdmin().register(streamId, basicSparkContext.getOwners());
     } catch (Exception e) {
-      LOG.info("Failed to registry usage of {} -> {}", streamId, basicSparkContext.getProgram().getId(), e);
+      LOG.info("Failed to registry usage of {} -> {}", GSON.toJson(basicSparkContext.getOwners()), streamId, e);
     }
 
     StreamConfig streamConfig = basicSparkContext.getStreamAdmin().getConfig(streamId);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/BasicWorkerContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/BasicWorkerContext.java
@@ -170,7 +170,7 @@ public class BasicWorkerContext extends AbstractContext implements WorkerContext
     final TransactionContext context = new TransactionContext(transactionSystemClient);
     try {
       context.start();
-      runnable.run(new DynamicDatasetContext(Id.Namespace.from(program.getNamespaceId()), program.getId(),
+      runnable.run(new DynamicDatasetContext(Id.Namespace.from(program.getNamespaceId()), getOwners(),
                                              context, datasetFramework,
                                              getProgram().getClassLoader(), null, runtimeArgs) {
         @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/BasicWorkerContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/BasicWorkerContext.java
@@ -103,7 +103,7 @@ public class BasicWorkerContext extends AbstractContext implements WorkerContext
     this.userMetrics = new ProgramUserMetrics(getMetricCollector(metricsCollectionService, program,
                                                                  runId.getId(), instanceId));
     this.runtimeArgs = runtimeArgs.asMap();
-    this.streamWriter = streamWriterFactory.create(program.getId());
+    this.streamWriter = streamWriterFactory.create(program.getId().getNamespace(), getOwners());
 
     // The cache expiry should be greater than (2 * transaction.timeout) and at least 2 hours.
     // This ensures that when a dataset instance is requested multiple times during a single transaction,

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/BasicWorkerContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/BasicWorkerContext.java
@@ -170,9 +170,9 @@ public class BasicWorkerContext extends AbstractContext implements WorkerContext
     final TransactionContext context = new TransactionContext(transactionSystemClient);
     try {
       context.start();
-      runnable.run(new DynamicDatasetContext(Id.Namespace.from(program.getNamespaceId()), getOwners(),
+      runnable.run(new DynamicDatasetContext(Id.Namespace.from(program.getNamespaceId()),
                                              context, datasetFramework,
-                                             getProgram().getClassLoader(), null, runtimeArgs) {
+                                             getProgram().getClassLoader(), runtimeArgs, null, getOwners()) {
         @Override
         protected LoadingCache<Long, Map<DatasetCacheKey, Dataset>> getDatasetsCache() {
           return datasetsCache;

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunnerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunnerTest.java
@@ -122,8 +122,9 @@ public class MapReduceProgramRunnerTest {
     txService = injector.getInstance(TransactionManager.class);
     txExecutorFactory = injector.getInstance(TransactionExecutorFactory.class);
     dsFramework = injector.getInstance(DatasetFramework.class);
-    datasetInstantiator = new DatasetInstantiator(DefaultId.NAMESPACE, null, dsFramework,
-                                                  MapReduceProgramRunnerTest.class.getClassLoader(), null);
+    datasetInstantiator = new DatasetInstantiator(DefaultId.NAMESPACE, dsFramework,
+                                                  MapReduceProgramRunnerTest.class.getClassLoader(),
+                                                  null, null);
 
     txService.startAndWait();
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceWithPartitionedTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceWithPartitionedTest.java
@@ -113,8 +113,9 @@ public class MapReduceWithPartitionedTest {
     txService = injector.getInstance(TransactionManager.class);
     txExecutorFactory = injector.getInstance(TransactionExecutorFactory.class);
     dsFramework = injector.getInstance(DatasetFramework.class);
-    datasetInstantiator = new DatasetInstantiator(DefaultId.NAMESPACE, null, dsFramework,
-                                                  MapReduceWithPartitionedTest.class.getClassLoader(), null);
+    datasetInstantiator = new DatasetInstantiator(DefaultId.NAMESPACE, dsFramework,
+                                                  MapReduceWithPartitionedTest.class.getClassLoader(),
+                                                  null, null);
 
     txService.startAndWait();
   }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/spark/SparkProgramRunnerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/spark/SparkProgramRunnerTest.java
@@ -17,7 +17,6 @@
 package co.cask.cdap.internal.app.runtime.spark;
 
 import co.cask.cdap.api.common.Bytes;
-import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.dataset.lib.KeyValueTable;
 import co.cask.cdap.api.dataset.lib.ObjectStore;
 import co.cask.cdap.app.program.Program;
@@ -107,8 +106,9 @@ public class SparkProgramRunnerTest {
     txService = injector.getInstance(TransactionManager.class);
     txExecutorFactory = injector.getInstance(TransactionExecutorFactory.class);
     dsFramework = injector.getInstance(DatasetFramework.class);
-    datasetInstantiator = new DatasetInstantiator(DefaultId.NAMESPACE, null, dsFramework,
-                                                  SparkProgramRunnerTest.class.getClassLoader(), null);
+    datasetInstantiator = new DatasetInstantiator(DefaultId.NAMESPACE, dsFramework,
+                                                  SparkProgramRunnerTest.class.getClassLoader(),
+                                                  null, null);
 
     txService.startAndWait();
   }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/runtime/MultiConsumerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/runtime/MultiConsumerTest.java
@@ -81,8 +81,8 @@ public class MultiConsumerTest {
 
     DatasetFramework datasetFramework = AppFabricTestHelper.getInjector().getInstance(DatasetFramework.class);
 
-    DatasetInstantiator datasetInstantiator = new DatasetInstantiator(DefaultId.NAMESPACE, null, datasetFramework,
-                                                                      getClass().getClassLoader(), null);
+    DatasetInstantiator datasetInstantiator = new DatasetInstantiator(DefaultId.NAMESPACE, datasetFramework,
+                                                                      getClass().getClassLoader(), null, null);
 
     final KeyValueTable accumulated = datasetInstantiator.getDataset("accumulated");
     TransactionExecutorFactory txExecutorFactory =

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -52,14 +52,6 @@ public final class Constants {
   }
 
   /**
-   * Header names.
-   */
-  public static final class Header {
-    /** Internal header used to pass dataset owner to DatasetInstanceHandler */
-    public static final String DATASET_OWNER = "CDAP-DatasetOwner";
-  }
-
-  /**
    * Zookeeper Configuration.
    */
   public static final class Zookeeper {

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -52,6 +52,14 @@ public final class Constants {
   }
 
   /**
+   * Header names.
+   */
+  public static final class Header {
+    /** Internal header used to pass dataset owner to DatasetInstanceHandler */
+    public static final String DATASET_OWNER = "CDAP-DatasetOwner";
+  }
+
+  /**
    * Zookeeper Configuration.
    */
   public static final class Zookeeper {

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/NoopStreamAdmin.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/NoopStreamAdmin.java
@@ -22,7 +22,6 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.StreamProperties;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import javax.annotation.Nullable;
@@ -79,6 +78,6 @@ public class NoopStreamAdmin implements StreamAdmin {
   }
 
   @Override
-  public void register(Id.Stream streamId, List<Id> owners) {
+  public void register(Iterable<? extends Id> owners, Id.Stream streamId) {
   }
 }

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/NoopStreamAdmin.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/NoopStreamAdmin.java
@@ -22,6 +22,7 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.StreamProperties;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import javax.annotation.Nullable;
@@ -78,6 +79,6 @@ public class NoopStreamAdmin implements StreamAdmin {
   }
 
   @Override
-  public void register(Id.Stream streamId, Id.Program programId) {
+  public void register(Id.Stream streamId, List<Id> owners) {
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/dataset/DatasetInstantiator.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/dataset/DatasetInstantiator.java
@@ -30,7 +30,6 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -58,7 +57,7 @@ public class DatasetInstantiator implements DatasetContext {
 
   private final MetricsCollector metricsCollector;
   private final Id.Namespace namespace;
-  private final List<? extends Id> owners;
+  private final Iterable<? extends Id> owners;
 
   /**
    * Constructor from data fabric.
@@ -69,11 +68,10 @@ public class DatasetInstantiator implements DatasetContext {
    *                    If null, then the default class loader is used
    */
   public DatasetInstantiator(Id.Namespace namespace,
-                             @Nullable List<? extends Id> owners,
                              DatasetFramework datasetFramework,
                              ClassLoader classLoader,
-                             @Nullable
-                             MetricsCollector metricsCollector) {
+                             @Nullable Iterable<? extends Id> owners,
+                             @Nullable MetricsCollector metricsCollector) {
     this.namespace = namespace;
     this.owners = owners;
     this.classLoader = classLoader;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/dataset/DatasetInstantiator.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/dataset/DatasetInstantiator.java
@@ -30,6 +30,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -57,24 +58,24 @@ public class DatasetInstantiator implements DatasetContext {
 
   private final MetricsCollector metricsCollector;
   private final Id.Namespace namespace;
-  private final Id ownerId;
+  private final List<? extends Id> owners;
 
   /**
    * Constructor from data fabric.
    *
    * @param namespace the {@link Id.Namespace} in which this dataset is used
-   * @param ownerId the {@link Id} which is using this dataset
+   * @param owners the {@link Id} which is using this dataset
    * @param classLoader the class loader to use for loading dataset classes.
    *                    If null, then the default class loader is used
    */
   public DatasetInstantiator(Id.Namespace namespace,
-                             @Nullable Id ownerId,
+                             @Nullable List<? extends Id> owners,
                              DatasetFramework datasetFramework,
                              ClassLoader classLoader,
                              @Nullable
                              MetricsCollector metricsCollector) {
     this.namespace = namespace;
-    this.ownerId = ownerId;
+    this.owners = owners;
     this.classLoader = classLoader;
     this.metricsCollector = metricsCollector;
     this.datasetFramework = datasetFramework;
@@ -98,7 +99,7 @@ public class DatasetInstantiator implements DatasetContext {
       }
 
       dataset = datasetFramework.getDataset(Id.DatasetInstance.from(namespace, name),
-                                            arguments, classLoader, ownerId);
+                                            arguments, classLoader, owners);
       if (dataset == null) {
         throw new DatasetInstantiationException("Failed to access dataset: " + name);
       }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
@@ -85,7 +85,7 @@ class DatasetServiceClient {
 
   @Nullable
   public DatasetMeta getInstance(String instanceName,
-                                 @Nullable List<? extends Id> owners) throws DatasetManagementException {
+                                 @Nullable Iterable<? extends Id> owners) throws DatasetManagementException {
 
     String query = "";
     if (owners != null) {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
@@ -39,9 +39,9 @@ import com.google.common.base.Charsets;
 import com.google.common.base.Joiner;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
-import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
 import com.google.common.io.InputSupplier;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
@@ -57,6 +57,7 @@ import java.net.InetSocketAddress;
 import java.net.URL;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
@@ -85,14 +86,17 @@ class DatasetServiceClient {
   @Nullable
   public DatasetMeta getInstance(String instanceName,
                                  @Nullable List<? extends Id> owners) throws DatasetManagementException {
-    Multimap<String, String> headers = HashMultimap.create();
+
+    String query = "";
     if (owners != null) {
+      Set<String> ownerParams = Sets.newHashSet();
       for (Id owner : owners) {
-        headers.put(Constants.Header.DATASET_OWNER, owner.getIdType() + "//" + owner.getIdRep());
+        ownerParams.add("owner=" + owner.getIdType() + "//" + owner.getIdRep());
       }
+      query = ownerParams.isEmpty() ? "" : "?" + Joiner.on("&").join(ownerParams);
     }
 
-    HttpResponse response = doGet("datasets/" + instanceName, headers);
+    HttpResponse response = doGet("datasets/" + instanceName + query);
     if (HttpResponseStatus.NOT_FOUND.getCode() == response.getResponseCode()) {
       return null;
     }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
@@ -83,7 +83,8 @@ class DatasetServiceClient {
   }
 
   @Nullable
-  public DatasetMeta getInstance(String instanceName, @Nullable List<Id> owners) throws DatasetManagementException {
+  public DatasetMeta getInstance(String instanceName,
+                                 @Nullable List<? extends Id> owners) throws DatasetManagementException {
     Multimap<String, String> headers = HashMultimap.create();
     if (owners != null) {
       for (Id owner : owners) {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
@@ -91,7 +91,7 @@ class DatasetServiceClient {
     if (owners != null) {
       Set<String> ownerParams = Sets.newHashSet();
       for (Id owner : owners) {
-        ownerParams.add("owner=" + owner.getIdType() + "//" + owner.getIdRep());
+        ownerParams.add("owner=" + owner.getIdType() + "::" + owner.getIdRep());
       }
       query = ownerParams.isEmpty() ? "" : "?" + Joiner.on("&").join(ownerParams);
     }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
@@ -196,8 +196,8 @@ class DatasetServiceClient {
     throws DatasetManagementException {
 
     HttpResponse response = doRequest(HttpMethod.PUT, "modules/" + moduleName,
-                           ImmutableMultimap.of("X-Class-Name", className),
-                           Locations.newInputSupplier(jarLocation));
+                                      ImmutableMultimap.of("X-Class-Name", className),
+                                      Locations.newInputSupplier(jarLocation));
 
     if (HttpResponseStatus.CONFLICT.getCode() == response.getResponseCode()) {
       throw new ModuleConflictException(String.format("Failed to add module %s due to conflict, details: %s",

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFramework.java
@@ -194,10 +194,10 @@ public class RemoteDatasetFramework implements DatasetFramework {
   public <T extends Dataset> T getDataset(
     Id.DatasetInstance datasetInstanceId, Map<String, String> arguments,
     @Nullable ClassLoader classLoader,
-    @Nullable Id owner) throws DatasetManagementException, IOException {
+    @Nullable List<? extends Id> owners) throws DatasetManagementException, IOException {
 
     DatasetMeta instanceInfo = clientCache.getUnchecked(datasetInstanceId.getNamespace())
-      .getInstance(datasetInstanceId.getId(), owner);
+      .getInstance(datasetInstanceId.getId(), owners);
     if (instanceInfo == null) {
       return null;
     }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFramework.java
@@ -194,7 +194,7 @@ public class RemoteDatasetFramework implements DatasetFramework {
   public <T extends Dataset> T getDataset(
     Id.DatasetInstance datasetInstanceId, Map<String, String> arguments,
     @Nullable ClassLoader classLoader,
-    @Nullable List<? extends Id> owners) throws DatasetManagementException, IOException {
+    @Nullable Iterable<? extends Id> owners) throws DatasetManagementException, IOException {
 
     DatasetMeta instanceInfo = clientCache.getUnchecked(datasetInstanceId.getNamespace())
       .getInstance(datasetInstanceId.getId(), owners);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandler.java
@@ -65,6 +65,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
 
 /**
  * Handles dataset instance management calls.
@@ -108,8 +109,10 @@ public class DatasetInstanceHandler extends AbstractHttpHandler {
 
   @GET
   @Path("/data/datasets/{name}")
-  public void getInfo(HttpRequest request, HttpResponder responder, @PathParam("namespace-id") String namespaceId,
-                      @PathParam("name") String name) {
+  public void getInfo(HttpRequest request, HttpResponder responder,
+                      @PathParam("namespace-id") String namespaceId,
+                      @PathParam("name") String name,
+                      @QueryParam("owner") List<String> owners) {
 
     Id.DatasetInstance datasetId = Id.DatasetInstance.from(namespaceId, name);
     DatasetSpecification spec = instanceManager.get(datasetId);
@@ -126,7 +129,6 @@ public class DatasetInstanceHandler extends AbstractHttpHandler {
       }
       // typeMeta is guaranteed to be non-null now.
       DatasetMeta info = new DatasetMeta(spec, typeMeta, null);
-      List<String> owners = request.getHeaders(Constants.Header.DATASET_OWNER);
       for (String owner : owners) {
         String[] parts = owner.split("//", 2);
         Preconditions.checkArgument(parts.length == 2);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandler.java
@@ -64,7 +64,6 @@ import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
-import javax.ws.rs.QueryParam;
 
 /**
  * Handles dataset instance management calls.
@@ -109,9 +108,7 @@ public class DatasetInstanceHandler extends AbstractHttpHandler {
   @GET
   @Path("/data/datasets/{name}")
   public void getInfo(HttpRequest request, HttpResponder responder, @PathParam("namespace-id") String namespaceId,
-                      @PathParam("name") String name,
-                      @Nullable @QueryParam("ownerType") String ownerType,
-                      @Nullable @QueryParam("ownerId") String ownerId) {
+                      @PathParam("name") String name) {
 
     Id.DatasetInstance datasetId = Id.DatasetInstance.from(namespaceId, name);
     DatasetSpecification spec = instanceManager.get(datasetId);
@@ -128,7 +125,11 @@ public class DatasetInstanceHandler extends AbstractHttpHandler {
       }
       // typeMeta is guaranteed to be non-null now.
       DatasetMeta info = new DatasetMeta(spec, typeMeta, null);
-      if (ownerType != null && ownerId != null) {
+      List<String> owners = request.getHeaders(Constants.Header.DATASET_OWNER);
+      for (String owner : owners) {
+        String[] parts = owner.split("//", 2);
+        String ownerType = parts[0];
+        String ownerId = parts[1];
         try {
           if (ownerType.equals(Id.getType(Id.Program.class))) {
             usageRegistry.register(Id.Program.fromStrings(ownerId.split("/")), datasetId);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandler.java
@@ -35,6 +35,7 @@ import co.cask.cdap.proto.DatasetTypeMeta;
 import co.cask.cdap.proto.Id;
 import co.cask.http.AbstractHttpHandler;
 import co.cask.http.HttpResponder;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.reflect.TypeToken;
@@ -128,6 +129,7 @@ public class DatasetInstanceHandler extends AbstractHttpHandler {
       List<String> owners = request.getHeaders(Constants.Header.DATASET_OWNER);
       for (String owner : owners) {
         String[] parts = owner.split("//", 2);
+        Preconditions.checkArgument(parts.length == 2);
         String ownerType = parts[0];
         String ownerId = parts[1];
         try {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandler.java
@@ -130,7 +130,7 @@ public class DatasetInstanceHandler extends AbstractHttpHandler {
       // typeMeta is guaranteed to be non-null now.
       DatasetMeta info = new DatasetMeta(spec, typeMeta, null);
       for (String owner : owners) {
-        String[] parts = owner.split("//", 2);
+        String[] parts = owner.split("::", 2);
         Preconditions.checkArgument(parts.length == 2);
         String ownerType = parts[0];
         String ownerId = parts[1];

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DatasetFramework.java
@@ -27,7 +27,6 @@ import com.google.common.annotations.VisibleForTesting;
 
 import java.io.IOException;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -203,7 +202,7 @@ public interface DatasetFramework {
    */
   @Nullable
   <T extends Dataset> T getDataset(Id.DatasetInstance datasetInstanceId, @Nullable Map<String, String> arguments,
-                                   @Nullable ClassLoader classLoader, @Nullable List<? extends Id> owners)
+                                   @Nullable ClassLoader classLoader, @Nullable Iterable<? extends Id> owners)
     throws DatasetManagementException, IOException;
 
   /**

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DatasetFramework.java
@@ -27,6 +27,7 @@ import com.google.common.annotations.VisibleForTesting;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -195,14 +196,14 @@ public interface DatasetFramework {
    * @param datasetInstanceId dataset instance id
    * @param arguments runtime arguments for the dataset instance
    * @param classLoader classLoader to be used to load classes or {@code null} to use system classLoader
-   * @param owner owner of the dataset
+   * @param owners owners of the dataset
    * @return instance of dataset or {@code null} if dataset instance of this name doesn't exist.
    * @throws DatasetManagementException when there's trouble getting dataset meta info
    * @throws IOException when there's trouble to instantiate {@link co.cask.cdap.api.dataset.Dataset}
    */
   @Nullable
   <T extends Dataset> T getDataset(Id.DatasetInstance datasetInstanceId, @Nullable Map<String, String> arguments,
-                                   @Nullable ClassLoader classLoader, @Nullable Id owner)
+                                   @Nullable ClassLoader classLoader, @Nullable List<Id> owners)
     throws DatasetManagementException, IOException;
 
   /**

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DatasetFramework.java
@@ -203,7 +203,7 @@ public interface DatasetFramework {
    */
   @Nullable
   <T extends Dataset> T getDataset(Id.DatasetInstance datasetInstanceId, @Nullable Map<String, String> arguments,
-                                   @Nullable ClassLoader classLoader, @Nullable List<Id> owners)
+                                   @Nullable ClassLoader classLoader, @Nullable List<? extends Id> owners)
     throws DatasetManagementException, IOException;
 
   /**

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DynamicDatasetContext.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DynamicDatasetContext.java
@@ -71,28 +71,30 @@ public abstract class DynamicDatasetContext implements DatasetContext {
     return RuntimeArguments.extractScope(Scope.DATASET, name, runtimeArguments);
   }
 
-  public DynamicDatasetContext(Id.Namespace namespace, @Nullable List<? extends Id> owners,
+  public DynamicDatasetContext(Id.Namespace namespace,
                                TransactionContext context, DatasetFramework datasetFramework,
                                ClassLoader classLoader) {
-    this(namespace, owners, context, datasetFramework, classLoader, null, EMPTY_MAP);
+    this(namespace, context, datasetFramework, classLoader, EMPTY_MAP, null, null);
   }
 
   /**
    * Create a dynamic dataset context that will get datasets and add them to the transaction context.
    *
    * @param namespace the {@link Id.Namespace} in which the transaction context is created
-   * @param owners the {@link Id}s which own this context
    * @param context the transaction context
    * @param datasetFramework the dataset framework for creating dataset instances
    * @param classLoader the classloader to use when creating dataset instances
-   * @param datasets the set of datasets that are allowed to be created. If null, any dataset can be created
    * @param runtimeArguments all runtime arguments that are available to datasets in the context. Runtime arguments
    *                         are expected to be scoped so that arguments for one dataset do not override arguments
+   * @param datasets the set of datasets that are allowed to be created. If null, any dataset can be created
+   * @param owners the {@link Id}s which own this context
    */
-  public DynamicDatasetContext(Id.Namespace namespace, @Nullable List<? extends Id> owners, TransactionContext context,
+  public DynamicDatasetContext(Id.Namespace namespace, TransactionContext context,
                                DatasetFramework datasetFramework,
-                               ClassLoader classLoader, @Nullable Set<String> datasets,
-                               Map<String, String> runtimeArguments) {
+                               ClassLoader classLoader,
+                               Map<String, String> runtimeArguments,
+                               @Nullable Set<String> datasets,
+                               @Nullable List<? extends Id> owners) {
     this.namespace = namespace;
     this.owners = owners == null ? ImmutableList.<Id>of() : ImmutableList.copyOf(owners);
     this.context = context;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DynamicDatasetContext.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DynamicDatasetContext.java
@@ -52,7 +52,7 @@ public abstract class DynamicDatasetContext implements DatasetContext {
   private final Map<String, String> runtimeArguments;
   private final Set<DatasetCacheKey> txnInProgressDatasets = Sets.newHashSet();
   private final Id.Namespace namespace;
-  private final List<? extends Id> owners;
+  private final List<Id> owners;
 
   @Nullable
   protected abstract LoadingCache<Long, Map<DatasetCacheKey, Dataset>> getDatasetsCache();

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/InMemoryDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/InMemoryDatasetFramework.java
@@ -361,7 +361,7 @@ public class InMemoryDatasetFramework implements DatasetFramework {
   public <T extends Dataset> T getDataset(Id.DatasetInstance datasetInstanceId,
                                           Map<String, String> arguments,
                                           @Nullable ClassLoader classLoader,
-                                          @Nullable Id owner) throws IOException {
+                                          @Nullable List<Id> owners) throws IOException {
     readLock.lock();
     try {
       DatasetSpecification spec = instances.get(datasetInstanceId.getNamespace(), datasetInstanceId);
@@ -372,11 +372,13 @@ public class InMemoryDatasetFramework implements DatasetFramework {
       DatasetDefinition def = createRegistry(availableModuleClasses, classLoader).get(spec.getType());
       T result = (T) (def.getDataset(DatasetContext.from(datasetInstanceId.getNamespaceId()),
                                      spec, arguments, classLoader));
-      if (owner != null) {
-        if (owner instanceof Id.Program) {
-          usageRegistry.register((Id.Program) owner, datasetInstanceId);
-        } else if (owner instanceof Id.Adapter) {
-          usageRegistry.register((Id.Adapter) owner, datasetInstanceId);
+      if (owners != null) {
+        for (Id owner : owners) {
+          if (owner instanceof Id.Program) {
+            usageRegistry.register((Id.Program) owner, datasetInstanceId);
+          } else if (owner instanceof Id.Adapter) {
+            usageRegistry.register((Id.Adapter) owner, datasetInstanceId);
+          }
         }
       }
       return result;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/InMemoryDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/InMemoryDatasetFramework.java
@@ -374,11 +374,7 @@ public class InMemoryDatasetFramework implements DatasetFramework {
                                      spec, arguments, classLoader));
       if (owners != null) {
         for (Id owner : owners) {
-          if (owner instanceof Id.Program) {
-            usageRegistry.register((Id.Program) owner, datasetInstanceId);
-          } else if (owner instanceof Id.Adapter) {
-            usageRegistry.register((Id.Adapter) owner, datasetInstanceId);
-          }
+          usageRegistry.register(owner, datasetInstanceId);
         }
       }
       return result;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/InMemoryDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/InMemoryDatasetFramework.java
@@ -361,7 +361,7 @@ public class InMemoryDatasetFramework implements DatasetFramework {
   public <T extends Dataset> T getDataset(Id.DatasetInstance datasetInstanceId,
                                           Map<String, String> arguments,
                                           @Nullable ClassLoader classLoader,
-                                          @Nullable List<? extends Id> owners) throws IOException {
+                                          @Nullable Iterable<? extends Id> owners) throws IOException {
     readLock.lock();
     try {
       DatasetSpecification spec = instances.get(datasetInstanceId.getNamespace(), datasetInstanceId);
@@ -373,9 +373,7 @@ public class InMemoryDatasetFramework implements DatasetFramework {
       T result = (T) (def.getDataset(DatasetContext.from(datasetInstanceId.getNamespaceId()),
                                      spec, arguments, classLoader));
       if (owners != null) {
-        for (Id owner : owners) {
-          usageRegistry.register(owner, datasetInstanceId);
-        }
+        usageRegistry.registerAll(owners, datasetInstanceId);
       }
       return result;
     } finally {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/InMemoryDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/InMemoryDatasetFramework.java
@@ -361,7 +361,7 @@ public class InMemoryDatasetFramework implements DatasetFramework {
   public <T extends Dataset> T getDataset(Id.DatasetInstance datasetInstanceId,
                                           Map<String, String> arguments,
                                           @Nullable ClassLoader classLoader,
-                                          @Nullable List<Id> owners) throws IOException {
+                                          @Nullable List<? extends Id> owners) throws IOException {
     readLock.lock();
     try {
       DatasetSpecification spec = instances.get(datasetInstanceId.getNamespace(), datasetInstanceId);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/StaticDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/StaticDatasetFramework.java
@@ -23,7 +23,6 @@ import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.dataset.module.DatasetDefinitionRegistry;
 import co.cask.cdap.api.dataset.module.DatasetModule;
 import co.cask.cdap.common.conf.CConfiguration;
-import co.cask.cdap.data2.registry.UsageRegistry;
 import co.cask.cdap.proto.DatasetSpecificationSummary;
 import co.cask.cdap.proto.Id;
 import co.cask.tephra.TransactionExecutorFactory;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/UsageRegistry.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/UsageRegistry.java
@@ -29,6 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Iterator;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -57,7 +58,42 @@ public class UsageRegistry {
   }
 
   /**
+   * Registers usage of a stream by multiple ids.
+   *
+   * @param owners the owners of the stream
+   * @param streamId the stream
+   */
+  public void register(List<Id> owners, Id.Stream streamId) {
+    for (Id owner : owners) {
+      // TODO: kind of hacky
+      if (owner instanceof Id.Program) {
+        register((Id.Program) owner, streamId);
+      } else if (owner instanceof Id.Adapter) {
+        register((Id.Adapter) owner, streamId);
+      }
+    }
+  }
+
+  /**
+   * Registers usage of a dataset by multiple ids.
+   *
+   * @param owners the owners of the dataset
+   * @param datasetId the dataset
+   */
+  public void register(List<Id> owners, Id.DatasetInstance datasetId) {
+    for (Id owner : owners) {
+      // TODO: kind of hacky
+      if (owner instanceof Id.Program) {
+        register((Id.Program) owner, datasetId);
+      } else if (owner instanceof Id.Adapter) {
+        register((Id.Adapter) owner, datasetId);
+      }
+    }
+  }
+
+  /**
    * Registers usage of a dataset by a program.
+   *
    * @param programId program
    * @param datasetInstanceId dataset
    */
@@ -73,6 +109,7 @@ public class UsageRegistry {
 
   /**
    * Registers usage of a dataset by an adapter.
+   *
    * @param adapterId adapter
    * @param datasetInstanceId dataset
    */
@@ -88,6 +125,7 @@ public class UsageRegistry {
 
   /**
    * Registers usage of a stream by a program.
+   *
    * @param programId program
    * @param streamId stream
    */
@@ -103,6 +141,7 @@ public class UsageRegistry {
 
   /**
    * Registers usage of a stream by an adapter.
+   *
    * @param adapterId adapter
    * @param streamId stream
    */
@@ -118,6 +157,7 @@ public class UsageRegistry {
 
   /**
    * Unregisters all usage information of an application.
+   *
    * @param applicationId application
    */
   public void unregister(final Id.Application applicationId) {
@@ -132,6 +172,7 @@ public class UsageRegistry {
 
   /**
    * Unregisters all usage information of an adapter.
+   *
    * @param adapterId application
    */
   public void unregister(final Id.Adapter adapterId) {
@@ -233,7 +274,6 @@ public class UsageRegistry {
       }
     });
   }
-
 
   /**
    * For passing {@link UsageDataset} to {@link Transactional#of}.

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/UsageRegistry.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/UsageRegistry.java
@@ -28,8 +28,8 @@ import com.google.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Set;
 
 /**
@@ -63,10 +63,21 @@ public class UsageRegistry {
    * @param users the users of the stream
    * @param streamId the stream
    */
-  public void registerAll(List<Id> users, Id.Stream streamId) {
-    for (Id user : users) {
-      register(user, streamId);
-    }
+  public void registerAll(final Iterable<? extends Id> users, final Id.Stream streamId) {
+    txnl.executeUnchecked(new TransactionExecutor.Function<UsageDatasetIterable, Void>() {
+      @Override
+      public Void apply(UsageDatasetIterable input) throws Exception {
+        for (Id user : users) {
+          // TODO: CDAP-2251: remove redundancy
+          if (user instanceof Id.Program) {
+            register((Id.Program) user, streamId);
+          } else if (user instanceof Id.Adapter) {
+            register((Id.Adapter) user, streamId);
+          }
+        }
+        return null;
+      }
+    });
   }
 
   /**
@@ -76,12 +87,7 @@ public class UsageRegistry {
    * @param streamId the stream
    */
   public void register(Id user, Id.Stream streamId) {
-    // TODO: kind of hacky
-    if (user instanceof Id.Program) {
-      register((Id.Program) user, streamId);
-    } else if (user instanceof Id.Adapter) {
-      register((Id.Adapter) user, streamId);
-    }
+    registerAll(Collections.singleton(user), streamId);
   }
 
   /**
@@ -90,10 +96,21 @@ public class UsageRegistry {
    * @param users the users of the dataset
    * @param datasetId the dataset
    */
-  public void registerAll(List<Id> users, Id.DatasetInstance datasetId) {
-    for (Id user : users) {
-      register(user, datasetId);
-    }
+  public void registerAll(final Iterable<? extends Id> users, final Id.DatasetInstance datasetId) {
+    txnl.executeUnchecked(new TransactionExecutor.Function<UsageDatasetIterable, Void>() {
+      @Override
+      public Void apply(UsageDatasetIterable input) throws Exception {
+        for (Id user : users) {
+          // TODO: CDAP-2251: remove redundancy
+          if (user instanceof Id.Program) {
+            register((Id.Program) user, datasetId);
+          } else if (user instanceof Id.Adapter) {
+            register((Id.Adapter) user, datasetId);
+          }
+        }
+        return null;
+      }
+    });
   }
 
   /**
@@ -103,12 +120,7 @@ public class UsageRegistry {
    * @param datasetId the dataset
    */
   public void register(Id user, Id.DatasetInstance datasetId) {
-    // TODO: kind of hacky
-    if (user instanceof Id.Program) {
-      register((Id.Program) user, datasetId);
-    } else if (user instanceof Id.Adapter) {
-      register((Id.Adapter) user, datasetId);
-    }
+    registerAll(Collections.singleton(user), datasetId);
   }
 
   /**

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/UsageRegistry.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/UsageRegistry.java
@@ -60,34 +60,54 @@ public class UsageRegistry {
   /**
    * Registers usage of a stream by multiple ids.
    *
-   * @param owners the owners of the stream
+   * @param users the users of the stream
    * @param streamId the stream
    */
-  public void register(List<Id> owners, Id.Stream streamId) {
-    for (Id owner : owners) {
-      // TODO: kind of hacky
-      if (owner instanceof Id.Program) {
-        register((Id.Program) owner, streamId);
-      } else if (owner instanceof Id.Adapter) {
-        register((Id.Adapter) owner, streamId);
-      }
+  public void registerAll(List<Id> users, Id.Stream streamId) {
+    for (Id user : users) {
+      register(user, streamId);
+    }
+  }
+
+  /**
+   * Register usage of a stream by an id.
+   *
+   * @param user the user of the stream
+   * @param streamId the stream
+   */
+  public void register(Id user, Id.Stream streamId) {
+    // TODO: kind of hacky
+    if (user instanceof Id.Program) {
+      register((Id.Program) user, streamId);
+    } else if (user instanceof Id.Adapter) {
+      register((Id.Adapter) user, streamId);
     }
   }
 
   /**
    * Registers usage of a dataset by multiple ids.
    *
-   * @param owners the owners of the dataset
+   * @param users the users of the dataset
    * @param datasetId the dataset
    */
-  public void register(List<Id> owners, Id.DatasetInstance datasetId) {
-    for (Id owner : owners) {
-      // TODO: kind of hacky
-      if (owner instanceof Id.Program) {
-        register((Id.Program) owner, datasetId);
-      } else if (owner instanceof Id.Adapter) {
-        register((Id.Adapter) owner, datasetId);
-      }
+  public void registerAll(List<Id> users, Id.DatasetInstance datasetId) {
+    for (Id user : users) {
+      register(user, datasetId);
+    }
+  }
+
+  /**
+   * Registers usage of a dataset by multiple ids.
+   *
+   * @param user the user of the dataset
+   * @param datasetId the dataset
+   */
+  public void register(Id user, Id.DatasetInstance datasetId) {
+    // TODO: kind of hacky
+    if (user instanceof Id.Program) {
+      register((Id.Program) user, datasetId);
+    } else if (user instanceof Id.Adapter) {
+      register((Id.Adapter) user, datasetId);
     }
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/inmemory/InMemoryStreamAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/inmemory/InMemoryStreamAdmin.java
@@ -28,7 +28,6 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import javax.annotation.Nullable;
@@ -106,7 +105,7 @@ public class InMemoryStreamAdmin extends InMemoryQueueAdmin implements StreamAdm
   }
 
   @Override
-  public void register(Id.Stream streamId, List<Id> owners) {
+  public void register(Iterable<? extends Id> owners, Id.Stream streamId) {
     usageRegistry.registerAll(owners, streamId);
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/inmemory/InMemoryStreamAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/inmemory/InMemoryStreamAdmin.java
@@ -28,6 +28,7 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import javax.annotation.Nullable;
@@ -105,7 +106,7 @@ public class InMemoryStreamAdmin extends InMemoryQueueAdmin implements StreamAdm
   }
 
   @Override
-  public void register(Id.Stream streamId, Id.Program programId) {
-    usageRegistry.register(programId, streamId);
+  public void register(Id.Stream streamId, List<Id> owners) {
+    usageRegistry.register(owners, streamId);
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/inmemory/InMemoryStreamAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/inmemory/InMemoryStreamAdmin.java
@@ -107,6 +107,6 @@ public class InMemoryStreamAdmin extends InMemoryQueueAdmin implements StreamAdm
 
   @Override
   public void register(Id.Stream streamId, List<Id> owners) {
-    usageRegistry.register(owners, streamId);
+    usageRegistry.registerAll(owners, streamId);
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/FileStreamAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/FileStreamAdmin.java
@@ -350,7 +350,7 @@ public class FileStreamAdmin implements StreamAdmin {
 
   @Override
   public void register(Id.Stream streamId, List<Id> owners) {
-    usageRegistry.register(owners, streamId);
+    usageRegistry.registerAll(owners, streamId);
   }
 
   /**

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/FileStreamAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/FileStreamAdmin.java
@@ -349,7 +349,7 @@ public class FileStreamAdmin implements StreamAdmin {
   }
 
   @Override
-  public void register(Id.Stream streamId, List<Id> owners) {
+  public void register(Iterable<? extends Id> owners, Id.Stream streamId) {
     usageRegistry.registerAll(owners, streamId);
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/FileStreamAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/FileStreamAdmin.java
@@ -349,8 +349,8 @@ public class FileStreamAdmin implements StreamAdmin {
   }
 
   @Override
-  public void register(Id.Stream streamId, Id.Program programId) {
-    usageRegistry.register(programId, streamId);
+  public void register(Id.Stream streamId, List<Id> owners) {
+    usageRegistry.register(owners, streamId);
   }
 
   /**

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/StreamAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/StreamAdmin.java
@@ -20,7 +20,6 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.StreamProperties;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import javax.annotation.Nullable;
@@ -109,8 +108,8 @@ public interface StreamAdmin {
   /**
    * Register stream used by program.
    *
-   * @param streamId the stream being used
    * @param owners the ids that are using the stream
+   * @param streamId the stream being used
    */
-  public void register(Id.Stream streamId, List<Id> owners);
+  public void register(Iterable<? extends Id> owners, Id.Stream streamId);
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/StreamAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/StreamAdmin.java
@@ -20,6 +20,7 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.StreamProperties;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import javax.annotation.Nullable;
@@ -109,7 +110,7 @@ public interface StreamAdmin {
    * Register stream used by program.
    *
    * @param streamId the stream being used
-   * @param programId the program that is using the stream
+   * @param owners the ids that are using the stream
    */
-  public void register(Id.Stream streamId, Id.Program programId);
+  public void register(Id.Stream streamId, List<Id> owners);
 }

--- a/cdap-notifications/src/main/java/co/cask/cdap/notifications/service/BasicNotificationContext.java
+++ b/cdap-notifications/src/main/java/co/cask/cdap/notifications/service/BasicNotificationContext.java
@@ -57,7 +57,7 @@ public final class BasicNotificationContext implements NotificationContext {
         final TransactionContext context = new TransactionContext(transactionSystemClient);
         try {
           context.start();
-          runnable.run(new DynamicDatasetContext(namespaceId, null, context, dsFramework,
+          runnable.run(new DynamicDatasetContext(namespaceId, context, dsFramework,
                                                  context.getClass().getClassLoader()) {
             @Nullable
             @Override

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/Id.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/Id.java
@@ -435,7 +435,7 @@ public abstract class Id {
 
     public static Adapter fromStrings(String[] strings, int position) {
       Preconditions.checkArgument(position == 1);
-      String[] tokens = strings[position - 1].split(":");
+      String[] tokens = strings[position].split(":");
       Preconditions.checkArgument(tokens.length == 2);
 
       String[] nextTokens = strings[position - 1].split(":");

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultApplicationManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultApplicationManager.java
@@ -40,7 +40,6 @@ import co.cask.tephra.TransactionSystemClient;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
 import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
@@ -52,6 +51,7 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
@@ -90,9 +90,10 @@ public class DefaultApplicationManager implements ApplicationManager {
       File tempDir = tempFolder.newFolder();
       BundleJarUtil.unpackProgramJar(deployedJar, tempDir);
       ClassLoader classLoader = ProgramClassLoader.create(tempDir, getClass().getClassLoader());
-      this.datasetInstantiator = new DatasetInstantiator(applicationId.getNamespace(), ImmutableList.of(applicationId),
+      this.datasetInstantiator = new DatasetInstantiator(applicationId.getNamespace(),
                                                          datasetFramework,
                                                          new DataSetClassLoader(classLoader),
+                                                         Collections.singleton(applicationId),
                                                          // todo: collect metrics for datasets outside programs too
                                                          null);
     } catch (IOException e) {

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultApplicationManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultApplicationManager.java
@@ -40,6 +40,7 @@ import co.cask.tephra.TransactionSystemClient;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
@@ -89,7 +90,7 @@ public class DefaultApplicationManager implements ApplicationManager {
       File tempDir = tempFolder.newFolder();
       BundleJarUtil.unpackProgramJar(deployedJar, tempDir);
       ClassLoader classLoader = ProgramClassLoader.create(tempDir, getClass().getClassLoader());
-      this.datasetInstantiator = new DatasetInstantiator(applicationId.getNamespace(), applicationId,
+      this.datasetInstantiator = new DatasetInstantiator(applicationId.getNamespace(), ImmutableList.of(applicationId),
                                                          datasetFramework,
                                                          new DataSetClassLoader(classLoader),
                                                          // todo: collect metrics for datasets outside programs too

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/LocalStreamWriter.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/LocalStreamWriter.java
@@ -34,32 +34,32 @@ import java.util.Map;
 public class LocalStreamWriter implements StreamWriter {
 
   private final StreamWriterFactory streamWriterFactory;
-  private final Id.Program programId;
+  private final Id.Namespace namespace;
 
   @Inject
-  public LocalStreamWriter(@Assisted("programId") Id.Program programId, StreamWriterFactory streamWriterFactory) {
-    this.programId = programId;
+  public LocalStreamWriter(@Assisted("namespace") Id.Namespace namespace, StreamWriterFactory streamWriterFactory) {
+    this.namespace = namespace;
     this.streamWriterFactory = streamWriterFactory;
   }
 
   @Override
   public void write(String stream, String data) throws IOException {
-    streamWriterFactory.create(Id.Stream.from(programId.getNamespace(), stream)).send(data);
+    streamWriterFactory.create(Id.Stream.from(namespace, stream)).send(data);
   }
 
   @Override
   public void write(String stream, String data, Map<String, String> headers) throws IOException {
-    streamWriterFactory.create(Id.Stream.from(programId.getNamespace(), stream)).send(headers, data);
+    streamWriterFactory.create(Id.Stream.from(namespace, stream)).send(headers, data);
   }
 
   @Override
   public void write(String stream, ByteBuffer data) throws IOException {
-    streamWriterFactory.create(Id.Stream.from(programId.getNamespace(), stream)).send(data);
+    streamWriterFactory.create(Id.Stream.from(namespace, stream)).send(data);
   }
 
   @Override
   public void write(String stream, StreamEventData data) throws IOException {
-    streamWriterFactory.create(Id.Stream.from(programId.getNamespace(), stream))
+    streamWriterFactory.create(Id.Stream.from(namespace, stream))
       .send(data.getHeaders(), data.getBody());
   }
 


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-2237
http://builds.cask.co/browse/CDAP-DUT1603

Changes
* Allow multiple owners (of a stream or dataset) to be registered (owners will be program + optional adapter)
* Added `AbstractContext.getOwners()` which returns `program.getId()` and `Id.Adapter.from(program.getId().getNamespace(), adapterSpec.getName())` (if adapterSpec is not null)
* Used `AbstractContext.getOwners()` instead of `Id.Program` to register usage

Haven't yet actually tested it manually, but assuming `adapterSpec` is passed correctly (which it should be), this will work.