### PR TITLE
Fixes two Javadoc warnings.

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/data/stream/StreamBatchReadable.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/data/stream/StreamBatchReadable.java
@@ -51,10 +51,10 @@ import java.util.Map;
  *
  * <pre>
  * {@code
- *
- * class MyMapReduce implements MapReduce {
- *    public void beforeSubmit(MapReduceContext context) {
- *      context.setInput(new StreamBatchReadable("mystream"));
+ *    class MyMapReduce implements MapReduce {
+ *        public void beforeSubmit(MapReduceContext context) {
+ *          context.setInput(new StreamBatchReadable("mystream"));
+ *        }
  *    }
  * }
  * </pre>

--- a/cdap-api/src/main/java/co/cask/cdap/api/templates/plugins/PluginSelector.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/templates/plugins/PluginSelector.java
@@ -32,7 +32,7 @@ public class PluginSelector {
    *
    * @param plugins set of available plugins. The {@link PluginInfo} is sorted in ascending order of plugin jar
    *                name followed by plugin version.
-   * @return a {@link Map.Entry} for the selected plugin.
+   * @return a {@link java.util.Map.Entry} for the selected plugin.
    */
   public Map.Entry<PluginInfo, PluginClass> select(SortedMap<PluginInfo, PluginClass> plugins) {
     return plugins.tailMap(plugins.lastKey()).entrySet().iterator().next();


### PR DESCRIPTION
Fixes these two warnings:
```
2 warnings
[WARNING] Javadoc Warnings
[WARNING] /Users/john/Source/cdap/cdap-api/src/main/java/co/cask/cdap/api/data/stream/StreamBatchReadable.java:63: warning - End Delimiter } missing for possible See Tag in comment string: "This class is for using a Stream as input for a MapReduce job. An instance of this class should be set in the
[WARNING] {@code MapReduceContext} of the {@code beforeSubmit} method to use the Stream as input.
[WARNING] <pre>
[WARNING] {@code
[WARNING] class MyMapReduce implements MapReduce {
[WARNING] public void beforeSubmit(MapReduceContext context) {
[WARNING] context.setInput(new StreamBatchReadable("mystream"));
[WARNING] }
[WARNING] }
[WARNING] </pre>"
[WARNING] /Users/john/Source/cdap/cdap-api/src/main/java/co/cask/cdap/api/templates/plugins/PluginSelector.java:37: warning - Tag @link: reference not found: Map.Entry
```