### PR TITLE
Re-factor to allow run id time ranges

### DIFF
--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/LogHandler.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/LogHandler.java
@@ -25,7 +25,9 @@ import co.cask.cdap.logging.LoggingConfiguration;
 import co.cask.cdap.logging.context.LoggingContextHelper;
 import co.cask.cdap.logging.filter.Filter;
 import co.cask.cdap.logging.filter.FilterParser;
+import co.cask.cdap.logging.read.LogOffset;
 import co.cask.cdap.logging.read.LogReader;
+import co.cask.cdap.logging.read.ReadRange;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.http.HttpHandler;
 import co.cask.http.HttpResponder;
@@ -155,8 +157,9 @@ public class LogHandler extends AuthenticatedHttpHandler {
 
       LogReaderCallback logCallback = new LogReaderCallback(responder, logPattern, escape);
 
-      logReader.getLogNext(loggingContext, FormattedLogEvent.parseLogOffset(fromOffsetStr),
-                           maxEvents, filter, logCallback);
+      LogOffset logOffset = FormattedLogEvent.parseLogOffset(fromOffsetStr);
+      ReadRange readRange = ReadRange.createFromRange(logOffset);
+      logReader.getLogNext(loggingContext, readRange, maxEvents, filter, logCallback);
     } catch (SecurityException e) {
       responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);
     } catch (IllegalArgumentException e) {
@@ -203,7 +206,9 @@ public class LogHandler extends AuthenticatedHttpHandler {
       Filter filter = FilterParser.parse(filterStr);
 
       LogReaderCallback logCallback = new LogReaderCallback(responder, logPattern, escape);
-      logReader.getLogPrev(loggingContext, FormattedLogEvent.parseLogOffset(fromOffsetStr),
+      LogOffset logOffset = FormattedLogEvent.parseLogOffset(fromOffsetStr);
+      ReadRange readRange = ReadRange.createToRange(logOffset);
+      logReader.getLogPrev(loggingContext, readRange,
                            maxEvents, filter, logCallback);
     } catch (SecurityException e) {
       responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);
@@ -303,7 +308,9 @@ public class LogHandler extends AuthenticatedHttpHandler {
       LoggingContext loggingContext = LoggingContextHelper.getLoggingContext(Constants.SYSTEM_NAMESPACE, componentId,
                                                                              serviceId);
       LogReaderCallback logCallback = new LogReaderCallback(responder, logPattern, escape);
-      logReader.getLogNext(loggingContext, FormattedLogEvent.parseLogOffset(fromOffsetStr),
+      LogOffset logOffset = FormattedLogEvent.parseLogOffset(fromOffsetStr);
+      ReadRange readRange = ReadRange.createFromRange(logOffset);
+      logReader.getLogNext(loggingContext, readRange,
                            maxEvents, filter, logCallback);
     } catch (IllegalArgumentException e) {
       responder.sendString(HttpResponseStatus.BAD_REQUEST, e.getMessage());
@@ -326,7 +333,9 @@ public class LogHandler extends AuthenticatedHttpHandler {
       LoggingContext loggingContext = LoggingContextHelper.getLoggingContext(Constants.SYSTEM_NAMESPACE, componentId,
                                                                              serviceId);
       LogReaderCallback logCallback = new LogReaderCallback(responder, logPattern, escape);
-      logReader.getLogPrev(loggingContext, FormattedLogEvent.parseLogOffset(fromOffsetStr),
+      LogOffset logOffset = FormattedLogEvent.parseLogOffset(fromOffsetStr);
+      ReadRange readRange = ReadRange.createToRange(logOffset);
+      logReader.getLogPrev(loggingContext, readRange,
                            maxEvents, filter, logCallback);
     } catch (IllegalArgumentException e) {
       responder.sendString(HttpResponseStatus.BAD_REQUEST, e.getMessage());

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/read/DistributedLogReader.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/read/DistributedLogReader.java
@@ -52,14 +52,14 @@ public final class DistributedLogReader implements LogReader {
   }
 
   @Override
-  public void getLogNext(final LoggingContext loggingContext, final LogOffset fromOffset, final int maxEvents,
+  public void getLogNext(final LoggingContext loggingContext, final ReadRange readRange, final int maxEvents,
                               final Filter filter, final Callback callback) {
     // If latest logs are not requested, try reading from file.
-    if (fromOffset != LogOffset.LATEST_OFFSET) {
+    if (readRange != ReadRange.LATEST) {
       long checkpointTime = getCheckpointTime(loggingContext);
       // Read from file only if logs are saved for the loggingContext until fromTime
-      if (fromOffset.getTime() < checkpointTime) {
-        fileLogReader.getLogNext(loggingContext, fromOffset, maxEvents, filter, callback);
+      if (readRange.getFromMillis() < checkpointTime) {
+        fileLogReader.getLogNext(loggingContext, readRange, maxEvents, filter, callback);
         // If there are events from fileLogReader, return. Otherwise try in kafkaLogReader.
         if (callback.getCount() != 0) {
           return;
@@ -67,23 +67,23 @@ public final class DistributedLogReader implements LogReader {
       }
     }
 
-    kafkaLogReader.getLogNext(loggingContext, fromOffset, maxEvents, filter, callback);
+    kafkaLogReader.getLogNext(loggingContext, readRange, maxEvents, filter, callback);
   }
 
   @Override
-  public void getLogPrev(final LoggingContext loggingContext, final LogOffset fromOffset, final int maxEvents,
+  public void getLogPrev(final LoggingContext loggingContext, final ReadRange readRange, final int maxEvents,
                               final Filter filter, final Callback callback) {
     // If latest logs are not requested, try reading from file.
-    if (fromOffset != LogOffset.LATEST_OFFSET) {
+    if (readRange != ReadRange.LATEST) {
       long checkpointTime = getCheckpointTime(loggingContext);
       // Read from file only if logs are saved for the loggingContext until fromTime
-      if (fromOffset.getTime() < checkpointTime) {
-        fileLogReader.getLogPrev(loggingContext, fromOffset, maxEvents, filter, callback);
+      if (readRange.getToMillis() < checkpointTime) {
+        fileLogReader.getLogPrev(loggingContext, readRange, maxEvents, filter, callback);
         return;
       }
     }
 
-    kafkaLogReader.getLogPrev(loggingContext, fromOffset, maxEvents, filter, callback);
+    kafkaLogReader.getLogPrev(loggingContext, readRange, maxEvents, filter, callback);
   }
 
   @Override

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/read/LogReader.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/read/LogReader.java
@@ -25,27 +25,24 @@ import co.cask.cdap.logging.filter.Filter;
 public interface LogReader {
   /**
    * Read log events of a Flow or Map Reduce program after a given offset.
-   *
    * @param loggingContext context to look up log events.
-   * @param fromOffset offset after which to start reading.
-   *                   Use {@link LogOffset#LATEST_OFFSET} to get the latest log events.
+   * @param readRange range for reading log events. Use {@link ReadRange#LATEST} to get the latest log events.
    * @param maxEvents max log events to return.
    * @param filter filter to select log events
    * @param callback callback to handle the log events.
    */
-  void getLogNext(LoggingContext loggingContext, LogOffset fromOffset, int maxEvents, Filter filter,
+  void getLogNext(LoggingContext loggingContext, ReadRange readRange, int maxEvents, Filter filter,
                        Callback callback);
 
   /**
    * Read log events of a Flow or Map Reduce program before a given offset.
    * @param loggingContext context to look up log events.
-   * @param fromOffset offset before which to start reading.
-   *                   Use {@link LogOffset#LATEST_OFFSET} to get the latest log events.
+   * @param readRange range for reading log events. Use {@link ReadRange#LATEST} to get the latest log events.
    * @param maxEvents max log events to return.
    * @param filter filter to select log events
    * @param callback callback to handle the log events.
    */
-  void getLogPrev(LoggingContext loggingContext, LogOffset fromOffset, int maxEvents, Filter filter,
+  void getLogPrev(LoggingContext loggingContext, ReadRange readRange, int maxEvents, Filter filter,
                        Callback callback);
 
   /**

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/read/ReadRange.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/read/ReadRange.java
@@ -19,34 +19,47 @@ package co.cask.cdap.logging.read;
 import com.google.common.base.Objects;
 
 /**
- * Represents log offset containing Kafka offset and time of logging event.
+ * Boundary of a log read request.
  */
-public class LogOffset {
-  public static final long LATEST_KAFKA_OFFSET = -1;
-  public static final LogOffset LATEST_OFFSET = new LogOffset(-1, LATEST_KAFKA_OFFSET);
-  public static final long INVALID_KAFKA_OFFSET = -10000;
+public class ReadRange {
+  public static final ReadRange LATEST = new ReadRange(-1, Long.MAX_VALUE, LogOffset.LATEST_KAFKA_OFFSET);
 
+  private final long fromMillis;
+  private final long toMillis;
   private final long kafkaOffset;
-  private final long time;
 
-  public LogOffset(long kafkaOffset, long time) {
+  public ReadRange(long fromMillis, long toMillis, long kafkaOffset) {
+    this.fromMillis = fromMillis;
+    this.toMillis = toMillis;
     this.kafkaOffset = kafkaOffset;
-    this.time = time;
+  }
+
+  public long getFromMillis() {
+    return fromMillis;
+  }
+
+  public long getToMillis() {
+    return toMillis;
   }
 
   public long getKafkaOffset() {
     return kafkaOffset;
   }
 
-  public long getTime() {
-    return time;
+  public static ReadRange createFromRange(LogOffset logOffset) {
+    return new ReadRange(logOffset.getTime(), Long.MAX_VALUE, logOffset.getKafkaOffset());
+  }
+
+  public static ReadRange createToRange(LogOffset logOffset) {
+    return new ReadRange(-1, logOffset.getTime(), logOffset.getKafkaOffset());
   }
 
   @Override
   public String toString() {
     return Objects.toStringHelper(this)
+      .add("fromMillis", fromMillis)
+      .add("toMillis", toMillis)
       .add("kafkaOffset", kafkaOffset)
-      .add("time", time)
       .toString();
   }
 }

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/TestResilientLogging.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/TestResilientLogging.java
@@ -44,7 +44,7 @@ import co.cask.cdap.logging.filter.Filter;
 import co.cask.cdap.logging.guice.LoggingModules;
 import co.cask.cdap.logging.read.FileLogReader;
 import co.cask.cdap.logging.read.LogEvent;
-import co.cask.cdap.logging.read.LogOffset;
+import co.cask.cdap.logging.read.ReadRange;
 import co.cask.tephra.TransactionManager;
 import com.google.common.collect.Iterables;
 import com.google.inject.Guice;
@@ -166,7 +166,7 @@ public class TestResilientLogging {
     LoggingContext loggingContext = new FlowletLoggingContext("TRL_ACCT_1", "APP_1", "FLOW_1", "", "RUN", "INSTANCE");
     FileLogReader logTail = injector.getInstance(FileLogReader.class);
     LoggingTester.LogCallback logCallback1 = new LoggingTester.LogCallback();
-    logTail.getLogPrev(loggingContext, LogOffset.LATEST_OFFSET, 10, Filter.EMPTY_FILTER,
+    logTail.getLogPrev(loggingContext, ReadRange.LATEST, 10, Filter.EMPTY_FILTER,
                        logCallback1);
     List<LogEvent> allEvents = logCallback1.getEvents();
     Assert.assertTrue(allEvents.toString(), allEvents.size() >= 5);

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/file/TestFileLogging.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/file/TestFileLogging.java
@@ -34,7 +34,7 @@ import co.cask.cdap.logging.filter.Filter;
 import co.cask.cdap.logging.guice.LoggingModules;
 import co.cask.cdap.logging.read.FileLogReader;
 import co.cask.cdap.logging.read.LogEvent;
-import co.cask.cdap.logging.read.LogOffset;
+import co.cask.cdap.logging.read.ReadRange;
 import co.cask.tephra.TransactionManager;
 import co.cask.tephra.runtime.TransactionModules;
 import com.google.inject.AbstractModule;
@@ -128,7 +128,7 @@ public class TestFileLogging {
     LoggingContext loggingContext = new FlowletLoggingContext("TFL_NS_1", "APP_1", "FLOW_1", "", "RUN1", "INSTANCE1");
     FileLogReader logTail = injector.getInstance(FileLogReader.class);
     LoggingTester.LogCallback logCallback1 = new LoggingTester.LogCallback();
-    logTail.getLogPrev(loggingContext, LogOffset.LATEST_OFFSET, 60, Filter.EMPTY_FILTER,
+    logTail.getLogPrev(loggingContext, ReadRange.LATEST, 60, Filter.EMPTY_FILTER,
                        logCallback1);
     List<LogEvent> allEvents = logCallback1.getEvents();
     Assert.assertEquals(60, allEvents.size());


### PR DESCRIPTION
LogReader interface takes in ReadRange instead of LogOffset. This allows to take in a time boundary to bound the log search.

JIRA - https://issues.cask.co/browse/CDAP-2053