### PR TITLE
(CDAP-332) Added a REST endpoint for deleting a stream

### DIFF
--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeleteStreamCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeleteStreamCommand.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.cli.command;
+
+import co.cask.cdap.cli.ArgumentName;
+import co.cask.cdap.cli.CLIConfig;
+import co.cask.cdap.cli.ElementType;
+import co.cask.cdap.cli.english.Article;
+import co.cask.cdap.cli.english.Fragment;
+import co.cask.cdap.cli.util.AbstractAuthCommand;
+import co.cask.cdap.client.StreamClient;
+import co.cask.common.cli.Arguments;
+import com.google.inject.Inject;
+
+import java.io.PrintStream;
+
+/**
+ * Command for deleting a stream.
+ */
+public class DeleteStreamCommand extends AbstractAuthCommand {
+
+  private final StreamClient streamClient;
+
+  @Inject
+  public DeleteStreamCommand(StreamClient streamClient, CLIConfig cliConfig) {
+    super(cliConfig);
+    this.streamClient = streamClient;
+  }
+
+  @Override
+  public void perform(Arguments arguments, PrintStream output) throws Exception {
+    String streamId = arguments.get(ArgumentName.STREAM.toString());
+    streamClient.delete(streamId);
+    output.printf("Successfully deleted stream '%s'\n", streamId);
+  }
+
+  @Override
+  public String getPattern() {
+    return String.format("delete stream <%s>", ArgumentName.STREAM);
+  }
+
+  @Override
+  public String getDescription() {
+    return String.format("Deletes %s.", Fragment.of(Article.A, ElementType.STREAM.getTitleName()));
+  }
+}

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/commandset/StreamCommands.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/commandset/StreamCommands.java
@@ -19,6 +19,7 @@ package co.cask.cdap.cli.commandset;
 import co.cask.cdap.cli.Categorized;
 import co.cask.cdap.cli.CommandCategory;
 import co.cask.cdap.cli.command.CreateStreamCommand;
+import co.cask.cdap.cli.command.DeleteStreamCommand;
 import co.cask.cdap.cli.command.DescribeStreamCommand;
 import co.cask.cdap.cli.command.GetStreamEventsCommand;
 import co.cask.cdap.cli.command.GetStreamStatsCommand;
@@ -54,6 +55,7 @@ public class StreamCommands extends CommandSet<Command> implements Categorized {
         .add(injector.getInstance(SetStreamNotificationThresholdCommand.class))
         .add(injector.getInstance(SetStreamPropertiesCommand.class))
         .add(injector.getInstance(TruncateStreamCommand.class))
+        .add(injector.getInstance(DeleteStreamCommand.class))
         .add(injector.getInstance(SendStreamEventCommand.class))
         .add(injector.getInstance(LoadStreamCommand.class))
         .add(injector.getInstance(GetStreamStatsCommand.class))

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/StreamClientTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/StreamClientTestRun.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -184,6 +184,44 @@ public class StreamClientTestRun extends ClientTestBase {
   @Test
   public void testSendLargeFile() throws Exception {
     testSendFile(500000);
+  }
+
+  @Test
+  public void testDelete() throws Exception {
+    String streamId = "testDelete";
+    streamClient.create(streamId);
+
+    // Send an event and get it back
+    String msg = "Test Delete";
+    streamClient.sendEvent(streamId, msg);
+    List<StreamEvent> events = Lists.newArrayList();
+    streamClient.getEvents(streamId, 0, Long.MAX_VALUE, Integer.MAX_VALUE, events);
+    Assert.assertEquals(1, events.size());
+    Assert.assertEquals(msg, Charsets.UTF_8.decode(events.get(0).getBody()).toString());
+
+    // Delete the stream
+    streamClient.delete(streamId);
+    // Try to get info, it should throw a StreamNotFoundException
+    try {
+      streamClient.getConfig(streamId);
+      Assert.fail();
+    } catch (StreamNotFoundException e) {
+      // Expected
+    }
+
+    // Try to get events, it should throw a StreamNotFoundException
+    try {
+      streamClient.getEvents(streamId, 0, Long.MAX_VALUE, Integer.MAX_VALUE, events);
+      Assert.fail();
+    } catch (StreamNotFoundException e) {
+      // Expected
+    }
+
+    // Create the stream again, it should returns empty events
+    streamClient.create(streamId);
+    events.clear();
+    streamClient.getEvents(streamId, 0, Long.MAX_VALUE, Integer.MAX_VALUE, events);
+    Assert.assertTrue(events.isEmpty());
   }
 
 

--- a/cdap-client/src/main/java/co/cask/cdap/client/StreamClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/StreamClient.java
@@ -228,6 +228,23 @@ public class StreamClient {
   }
 
   /**
+   * Deletes a stream.
+   *
+   * @param streamId ID of the stream to truncate
+   * @throws IOException if a network error occurred
+   * @throws StreamNotFoundException if the stream with the specified name was not found
+   */
+  public void delete(String streamId) throws IOException, StreamNotFoundException, UnauthorizedException {
+    Id.Stream stream = Id.Stream.from(config.getNamespace(), streamId);
+    URL url = config.resolveNamespacedURLV3(String.format("streams/%s", streamId));
+    HttpResponse response = restClient.execute(HttpMethod.DELETE, url, config.getAccessToken(),
+                                               HttpURLConnection.HTTP_NOT_FOUND);
+    if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
+      throw new StreamNotFoundException(stream);
+    }
+  }
+
+  /**
    * Sets the Time-to-Live (TTL) of a stream. TTL governs how long stream events are readable.
    *
    * @param streamId ID of the stream

--- a/cdap-common/src/main/java/co/cask/cdap/common/io/Locations.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/io/Locations.java
@@ -257,6 +257,19 @@ public final class Locations {
   }
 
   /**
+   * Deletes the content of the given location, but keeping the location itself.
+   */
+  public static void deleteContent(Location location) {
+    try {
+      for (Location child : location.list()) {
+        deleteQuietly(child, true);
+      }
+    } catch (IOException e) {
+      LOG.error("IOException while deleting content of {}", location, e);
+    }
+  }
+
+  /**
    * Converts the given file into a local {@link Location}.
    */
   public static Location toLocation(File file) {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/ConcurrentStreamWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/ConcurrentStreamWriter.java
@@ -88,7 +88,6 @@ public final class ConcurrentStreamWriter implements Closeable {
 
   private final StreamCoordinatorClient streamCoordinatorClient;
   private final StreamAdmin streamAdmin;
-  private final StreamMetaStore streamMetaStore;
   private final int workerThreads;
   private final StreamMetricsCollectorFactory metricsCollectorFactory;
   private final ConcurrentMap<Id.Stream, EventQueue> eventQueues;
@@ -98,11 +97,10 @@ public final class ConcurrentStreamWriter implements Closeable {
   private final Lock createLock;
 
   ConcurrentStreamWriter(StreamCoordinatorClient streamCoordinatorClient, StreamAdmin streamAdmin,
-                         StreamMetaStore streamMetaStore, StreamFileWriterFactory writerFactory,
-                         int workerThreads, StreamMetricsCollectorFactory metricsCollectorFactory) {
+                         StreamFileWriterFactory writerFactory, int workerThreads,
+                         StreamMetricsCollectorFactory metricsCollectorFactory) {
     this.streamCoordinatorClient = streamCoordinatorClient;
     this.streamAdmin = streamAdmin;
-    this.streamMetaStore = streamMetaStore;
     this.workerThreads = workerThreads;
     this.metricsCollectorFactory = metricsCollectorFactory;
     this.eventQueues = new MapMaker().concurrencyLevel(workerThreads).makeMap();
@@ -221,7 +219,7 @@ public final class ConcurrentStreamWriter implements Closeable {
         return eventQueue;
       }
 
-      if (!streamMetaStore.streamExists(streamId)) {
+      if (!streamAdmin.exists(streamId)) {
         throw new IllegalArgumentException("Stream not exists");
       }
       StreamUtils.ensureExists(streamAdmin, streamId);


### PR DESCRIPTION
- Added the DELETE /streams/{stream-id} endpoint
- Includes some code cleanup to unify StreamMetaStore usage
- For stream not found, throw the NotFoundException to simplify code.
- Implements delete by moving the stream directory into a special .deleted directory
  - Stream file janitor is responsible to cleanup that .delete directory
  - Adjusted code that do raw list of stream directories to one filterd out special directory