### PR TITLE
if no metrics are provided in metrics query, send bad request

### DIFF
--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/metrics/MetricsHandlerTestRun.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/metrics/MetricsHandlerTestRun.java
@@ -500,10 +500,26 @@ public class MetricsHandlerTestRun extends MetricsSuiteTestBase {
     );
 
     batchTest(ImmutableMap.of("testQuery3", query3, "testQuery4", query4), expected);
+  }
 
-
+  @Test
+  public void testInvalidRequest() throws Exception {
     // test invalid request - query without any query Params and body content
     HttpResponse response = doPost("/v3/metrics/query", null);
+    Assert.assertEquals(400, response.getStatusLine().getStatusCode());
+
+    // batch query with empty metrics list
+    QueryRequestFormat invalidQuery = new QueryRequestFormat(
+      ImmutableMap.of("namespace", "myspace", "app", "WordCount1", "flow", "WordCounter", "flowlet", "splitter"),
+      ImmutableList.<String>of(), ImmutableList.<String>of(), ImmutableMap.of("aggregate", "true"));
+
+    response = doPost("/v3/metrics/query", GSON.toJson(ImmutableMap.of("invalid", invalidQuery)));
+    Assert.assertEquals(400, response.getStatusLine().getStatusCode());
+
+    // test invalid request - query without any metric Params
+    response = doPost("/v3/metrics/query?context=namespace.default", null);
+    Assert.assertEquals(400, response.getStatusLine().getStatusCode());
+    response = doPost("/v3/metrics/query?tag=namespace.default", null);
     Assert.assertEquals(400, response.getStatusLine().getStatusCode());
   }
 


### PR DESCRIPTION
bugfix: https://issues.cask.co/browse/CDAP-2157

we send badRequest when there are no metric query param for the /query endpoint, but missed that for the /query endpoint with context query param (deprecated). this solves that issue. 

build running : http://builds.cask.co/browse/CDAP-RBT218-1