### PR TITLE
add runtime arguments and hash partitioning to CountRandom; update docs

### DIFF
--- a/cdap-docs/examples-manual/source/examples/count-random.rst
+++ b/cdap-docs/examples-manual/source/examples/count-random.rst
@@ -13,11 +13,11 @@ A Cask Data Application Platform (CDAP) Example demonstrating the ``@Tick`` feat
 Overview
 ====================
 
-This application does not have a Stream, instead it uses a Tick annotation in the ``source`` flowlet to generate data:
+This application does not have a Stream, instead it uses a Tick annotation in the ``source`` Flowlet to generate data:
 
-- The ``generate`` method of the  ``source`` flowlet has a ``@Tick`` annotation which specifies how frequently the method will be called.
-- The ``source`` flowlet generates a random integer in the range {1..10000} and emits it to the next flowlet ``splitter``.
-- The ``splitter`` flowlet splits the number into digits, and emits these digits to the next stage.
+- The ``generate`` method of the  ``source`` Flowlet has a ``@Tick`` annotation which specifies how frequently the method will be called.
+- The ``source`` Flowlet generates a random integer in the range {1..10000} and emits it to the next Flowlet ``splitter``.
+- The ``splitter`` Flowlet splits the number into digits, and emits these digits to the next stage.
 - The ``counter`` increments the count of the received number in the KeyValueTable.
 
 Let's look at some of these components, and then run the Application and see the results.
@@ -34,7 +34,7 @@ of the Application are tied together by the class ``CountRandom``:
    :language: java
    :lines: 24-
 
-The Flow contains three flowlets:
+The Flow contains three Flowlets:
 
 .. literalinclude:: /../../../cdap-examples/CountRandom/src/main/java/co/cask/cdap/examples/countrandom/CountRandomFlow.java
    :language: java
@@ -43,22 +43,22 @@ The Flow contains three flowlets:
 The *source* Flowlet generates random numbers every 1 millisecond. It can also be configured through runtime
 arguments:
 
-- whether to emit events or not
-- to sleep for an additional delay after each event
+- whether to emit events or not; and
+- whether to sleep for an additional delay after each event.
 
 .. literalinclude:: /../../../cdap-examples/CountRandom/src/main/java/co/cask/cdap/examples/countrandom/RandomSource.java
    :language: java
    :lines: 29-
 
-The *splitter* Flowlet emits four numbers four every number that it receives.
+The *splitter* Flowlet emits four numbers for every number that it receives.
 
 .. literalinclude:: /../../../cdap-examples/CountRandom/src/main/java/co/cask/cdap/examples/countrandom/NumberSplitter.java
    :language: java
    :lines: 25-
 
-Note that this flowlet associates a hash value named *n* with every number that it emits. That allows the *counter*
-flowlet to use a hash partitioning strategy when consuming the numbers it receives. This ensures that there are no
-transaction conflicts if the flowlet is scaled to multiple instances:
+Note that this Flowlet associates a hash value named *n* with every number that it emits. That allows the *counter*
+Flowlet to use a hash partitioning strategy when consuming the numbers it receives. This ensures that there are no
+transaction conflicts if the Flowlet is scaled to multiple instances:
 
 .. literalinclude:: /../../../cdap-examples/CountRandom/src/main/java/co/cask/cdap/examples/countrandom/NumberCounter.java
    :language: java
@@ -104,8 +104,8 @@ Once the application is deployed:
     * - On Windows:
       - ``> bin\cdap-cli.bat start flow CountRandom.CountRandom``    
 
-Once you start the flow, the *source* flowlet will continuously generate data. You can see this by observing the counters
-for each flowlet in the flow visualization. Even though you are not injecting any data into the flow, the counters increase steadily.
+Once you start the flow, the *source* Flowlet will continuously generate data. You can see this by observing the counters
+for each Flowlet in the flow visualization. Even though you are not injecting any data into the flow, the counters increase steadily.
 
 Stopping the Application
 -------------------------------

--- a/cdap-docs/examples-manual/source/examples/count-random.rst
+++ b/cdap-docs/examples-manual/source/examples/count-random.rst
@@ -40,11 +40,29 @@ The Flow contains three flowlets:
    :language: java
    :lines: 25-
 
-The Flowlet (*source*) that generates random numbers every 1 millisecond:
+The *source* Flowlet generates random numbers every 1 millisecond. It can also be configured through runtime
+arguments:
+
+- whether to emit events or not
+- to sleep for an additional delay after each event
 
 .. literalinclude:: /../../../cdap-examples/CountRandom/src/main/java/co/cask/cdap/examples/countrandom/RandomSource.java
    :language: java
-   :lines: 28-
+   :lines: 29-
+
+The *splitter* Flowlet emits four numbers four every number that it receives.
+
+.. literalinclude:: /../../../cdap-examples/CountRandom/src/main/java/co/cask/cdap/examples/countrandom/NumberSplitter.java
+   :language: java
+   :lines: 25-
+
+Note that this flowlet associates a hash value named *n* with every number that it emits. That allows the *counter*
+flowlet to use a hash partitioning strategy when consuming the numbers it receives. This ensures that there are no
+transaction conflicts if the flowlet is scaled to multiple instances:
+
+.. literalinclude:: /../../../cdap-examples/CountRandom/src/main/java/co/cask/cdap/examples/countrandom/NumberCounter.java
+   :language: java
+   :lines: 27-
 
 Building and Starting
 =================================

--- a/cdap-examples/CountRandom/src/main/java/co/cask/cdap/examples/countrandom/NumberCounter.java
+++ b/cdap-examples/CountRandom/src/main/java/co/cask/cdap/examples/countrandom/NumberCounter.java
@@ -15,6 +15,7 @@
  */
 package co.cask.cdap.examples.countrandom;
 
+import co.cask.cdap.api.annotation.HashPartition;
 import co.cask.cdap.api.annotation.ProcessInput;
 import co.cask.cdap.api.annotation.UseDataSet;
 import co.cask.cdap.api.dataset.lib.KeyValueTable;
@@ -29,6 +30,7 @@ public class NumberCounter extends AbstractFlowlet {
   KeyValueTable counters;
 
   @ProcessInput
+  @HashPartition("n")
   public void process(Integer number) {
     counters.increment(number.toString().getBytes(), 1L);
   }

--- a/cdap-examples/CountRandom/src/main/java/co/cask/cdap/examples/countrandom/NumberSplitter.java
+++ b/cdap-examples/CountRandom/src/main/java/co/cask/cdap/examples/countrandom/NumberSplitter.java
@@ -27,10 +27,15 @@ public class NumberSplitter extends AbstractFlowlet {
 
   @ProcessInput
   public void process(Integer number)  {
-    output.emit(new Integer(number % 10000));
-    output.emit(new Integer(number % 1000));
-    output.emit(new Integer(number % 100));
-    output.emit(new Integer(number % 10));
+    emit(number % 10000);
+    emit(number % 1000);
+    emit(number % 100);
+    emit(number % 10);
+  }
+
+  private void emit(Integer i) {
+    // emit i with a hash key named "n" and value i
+    output.emit(i, "n", i);
   }
 }
 

--- a/cdap-examples/CountRandom/src/main/java/co/cask/cdap/examples/countrandom/RandomSource.java
+++ b/cdap-examples/CountRandom/src/main/java/co/cask/cdap/examples/countrandom/RandomSource.java
@@ -17,6 +17,7 @@ package co.cask.cdap.examples.countrandom;
 
 import co.cask.cdap.api.annotation.Tick;
 import co.cask.cdap.api.flow.flowlet.AbstractFlowlet;
+import co.cask.cdap.api.flow.flowlet.FlowletContext;
 import co.cask.cdap.api.flow.flowlet.OutputEmitter;
 
 import java.util.Random;
@@ -29,9 +30,29 @@ public class RandomSource extends AbstractFlowlet {
   private OutputEmitter<Integer> randomOutput;
 
   private final Random random = new Random();
+  private long delay = 0;
+  private boolean emit = true;
+
+  @Override
+  public void initialize(FlowletContext context) throws Exception {
+    super.initialize(context);
+    String delayStr = context.getRuntimeArguments().get("delay");
+    if (delayStr != null) {
+      delay = Long.parseLong(delayStr);
+    }
+    String emitStr = context.getRuntimeArguments().get("emit");
+    if (emitStr != null) {
+      emit = Boolean.parseBoolean(emitStr);
+    }
+  }
 
   @Tick(delay = 1L, unit = TimeUnit.MILLISECONDS)
   public void generate() throws InterruptedException {
-    randomOutput.emit(random.nextInt(10000));
+    if (emit) {
+      randomOutput.emit(random.nextInt(10000));
+    }
+    if (delay > 0) {
+      TimeUnit.MILLISECONDS.sleep(delay);
+    }
   }
 }


### PR DESCRIPTION
There is no Jira for this. But I added these to CountRandom for my manual testing of CDAP-2259 and thought it might be useful to add that to the example in the release, because we have no examples yet that use runtime arguments or hash partitioning. 