### PR TITLE
CDAP-2105: Queue introspection

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/collect/AllPairCollector.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/collect/AllPairCollector.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.collect;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * This collector will collect every entry.
+ *
+ * @param <KEY> Type of key
+ * @param <VALUE> Type of value
+ */
+public class AllPairCollector<KEY, VALUE> implements PairCollector<KEY, VALUE> {
+
+  private final Multimap<KEY, VALUE> elements = HashMultimap.create();
+
+  @Override
+  public boolean addElement(Map.Entry<KEY, VALUE> entry) {
+    elements.put(entry.getKey(), entry.getValue());
+    return true;
+  }
+
+  @Override
+  public <T extends Multimap<? super KEY, ? super VALUE>> T finishMultimap(T map) {
+    map.putAll(elements);
+    elements.clear();
+    return map;
+  }
+
+  @Override
+  public <T extends Collection<? super Map.Entry<KEY, VALUE>>> T finish(T collection) {
+    collection.addAll(elements.entries());
+    elements.clear();
+    return collection;
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/collect/PairCollector.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/collect/PairCollector.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.collect;
+
+import com.google.common.collect.Multimap;
+
+import java.util.Map;
+
+/**
+ * This can be used to collect with different strategies while iterating
+ * over a stream of elements. For every element in the stream, add the
+ * element to the collector. The collector then indicates whether more
+ * elements are needed (for instance, to collect the first N elements only,
+ * use a collector that returns false after the Nth element has been added.
+ *
+ * @param <KEY> Type of key.
+ * @param <VALUE> Type of value.
+ */
+public interface PairCollector<KEY, VALUE> extends Collector<Map.Entry<KEY, VALUE>> {
+
+  /**
+   * Finish collection of elements and add all collected elements into the given {@link Multimap}.
+   *
+   * @param map {@link Multimap} for storing collected elements.
+   * @param <T> Type of collection
+   * @return The same {@link Multimap} instance given in the parameter.
+   */
+  <T extends Multimap<? super KEY, ? super VALUE>> T finishMultimap(T map);
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/queue/ConsumerConfig.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/queue/ConsumerConfig.java
@@ -23,6 +23,13 @@ import com.google.common.base.Preconditions;
  */
 public final class ConsumerConfig extends ConsumerGroupConfig {
 
+  /**
+   * Instance ID, derived from {@link #groupSize}.
+   *
+   * <p>
+   * e.g. if {@link #groupSize} is 4, then within that group, there would be instance IDs of 0, 1, 2, and 3.
+   * </p>
+   */
   private final int instanceId;
 
   public ConsumerConfig(ConsumerGroupConfig groupConfig, int instanceId) {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/AbstractQueueConsumer.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/AbstractQueueConsumer.java
@@ -331,7 +331,7 @@ public abstract class AbstractQueueConsumer implements QueueConsumer, Transactio
         }
 
         // Row key is queue_name + writePointer + counter
-        long writePointer = Bytes.toLong(rowKey, queueRowPrefix.length, Longs.BYTES);
+        long writePointer = QueueEntryRow.getWritePointer(rowKey, queueRowPrefix.length);
 
         // If it is first row returned by the scanner and was written before the earliest in progress,
         // it's safe to advance scanStartRow to current row because nothing can be written before this row.

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/QueueEntryRow.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/QueueEntryRow.java
@@ -318,4 +318,12 @@ public class QueueEntryRow {
     byte state = stateBytes[Longs.BYTES + Ints.BYTES];
     return state == ConsumerEntryState.PROCESSED.getState();
   }
+
+  /**
+   * Gets the write pointer for a row.
+   */
+  public static long getWritePointer(byte[] rowKey, int queueRowPrefixLength) {
+    // Row key is queue_name + writePointer + counter
+    return Bytes.toLong(rowKey, queueRowPrefixLength, Longs.BYTES);
+  }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueAdmin.java
@@ -272,7 +272,7 @@ public class HBaseQueueAdmin extends AbstractQueueAdmin {
     }
   }
 
-  HBaseConsumerStateStore getConsumerStateStore(QueueName queueName) throws Exception {
+  public HBaseConsumerStateStore getConsumerStateStore(QueueName queueName) throws Exception {
     Id.DatasetInstance stateStoreId = getStateStoreId(queueName.getFirstComponent());
     Map<String, String> args = ImmutableMap.of(HBaseQueueDatasetModule.PROPERTY_QUEUE_NAME, queueName.toString());
     HBaseConsumerStateStore stateStore = datasetFramework.getDataset(stateStoreId, args, null);
@@ -406,7 +406,7 @@ public class HBaseQueueAdmin extends AbstractQueueAdmin {
     return getDataTableId(queueName, type);
   }
 
-  TableId getDataTableId(QueueName queueName, QueueConstants.QueueType queueType) {
+  public TableId getDataTableId(QueueName queueName, QueueConstants.QueueType queueType) {
     if (!queueName.isQueue()) {
       throw new IllegalArgumentException("'" + queueName + "' is not a valid name for a queue.");
     }
@@ -416,7 +416,7 @@ public class HBaseQueueAdmin extends AbstractQueueAdmin {
                           queueType);
   }
 
-  TableId getDataTableId(String namespaceId, String app, String flow, QueueConstants.QueueType queueType) {
+  public TableId getDataTableId(String namespaceId, String app, String flow, QueueConstants.QueueType queueType) {
     String tableName = String.format("%s.%s.%s.%s", Constants.SYSTEM_NAMESPACE, queueType, app, flow);
     return TableId.from(namespaceId, tableName);
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueClientFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueClientFactory.java
@@ -223,7 +223,7 @@ public class HBaseQueueClientFactory implements QueueClientFactory {
    * @throws IOException
    */
   private HBaseQueueAdmin ensureTableExists(QueueName queueName) throws IOException {
-    HBaseQueueAdmin admin = queueName.isStream() ? streamAdmin : queueAdmin;
+    HBaseQueueAdmin admin = get(queueName);
     try {
       if (!admin.exists(queueName)) {
         admin.create(queueName);
@@ -234,7 +234,16 @@ public class HBaseQueueClientFactory implements QueueClientFactory {
     return admin;
   }
 
-  private HTable createHTable(TableId tableId) throws IOException {
+  /**
+   * Helper method to select the queue or stream admin.
+   * @param queueName name of the queue to be opened.
+   * @return the queue admin for that queue.
+   */
+  public HBaseQueueAdmin get(QueueName queueName) {
+    return queueName.isStream() ? streamAdmin : queueAdmin;
+  }
+
+  public HTable createHTable(TableId tableId) throws IOException {
     HTable consumerTable = hBaseTableUtil.createHTable(hConf, tableId);
     // TODO: make configurable
     consumerTable.setWriteBufferSize(DEFAULT_WRITE_BUFFER_SIZE);
@@ -242,7 +251,7 @@ public class HBaseQueueClientFactory implements QueueClientFactory {
     return consumerTable;
   }
 
-  private int getDistributorBuckets(HTableDescriptor htd) {
+  public int getDistributorBuckets(HTableDescriptor htd) {
     String value = htd.getValue(QueueConstants.DISTRIBUTOR_BUCKETS);
     // If the setting is not in the table meta, this is a old table, hence use the value in the cConf
     if (value == null) {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/QueueBarrier.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/QueueBarrier.java
@@ -24,7 +24,7 @@ import com.google.common.base.Objects;
  * Representing queue barrier information. It contains the consumer group information for
  * queue entry that are enqueue after the given start row.
  */
-final class QueueBarrier {
+public final class QueueBarrier {
   private final ConsumerGroupConfig groupConfig;
   private final byte[] startRow;
 

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/HBaseQueueDebugger.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/HBaseQueueDebugger.java
@@ -1,0 +1,325 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data.tools;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.common.guice.ConfigModule;
+import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
+import co.cask.cdap.common.guice.LocationRuntimeModule;
+import co.cask.cdap.common.guice.ZKClientModule;
+import co.cask.cdap.common.queue.QueueName;
+import co.cask.cdap.common.utils.ImmutablePair;
+import co.cask.cdap.data.runtime.DataSetsModules;
+import co.cask.cdap.data2.queue.ConsumerConfig;
+import co.cask.cdap.data2.queue.ConsumerGroupConfig;
+import co.cask.cdap.data2.queue.DequeueStrategy;
+import co.cask.cdap.data2.queue.QueueClientFactory;
+import co.cask.cdap.data2.transaction.Transactions;
+import co.cask.cdap.data2.transaction.queue.ConsumerEntryState;
+import co.cask.cdap.data2.transaction.queue.QueueAdmin;
+import co.cask.cdap.data2.transaction.queue.QueueConstants;
+import co.cask.cdap.data2.transaction.queue.QueueEntryRow;
+import co.cask.cdap.data2.transaction.queue.QueueScanner;
+import co.cask.cdap.data2.transaction.queue.hbase.HBaseConsumerStateStore;
+import co.cask.cdap.data2.transaction.queue.hbase.HBaseQueueAdmin;
+import co.cask.cdap.data2.transaction.queue.hbase.HBaseQueueClientFactory;
+import co.cask.cdap.data2.transaction.queue.hbase.QueueBarrier;
+import co.cask.cdap.data2.transaction.queue.hbase.ShardedHBaseQueueStrategy;
+import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
+import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
+import co.cask.cdap.internal.app.runtime.flow.FlowUtils;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.ProgramType;
+import co.cask.tephra.Transaction;
+import co.cask.tephra.TransactionExecutor;
+import co.cask.tephra.TransactionExecutorFactory;
+import co.cask.tephra.runtime.TransactionClientModule;
+import co.cask.tephra.runtime.TransactionModules;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.PeekingIterator;
+import com.google.common.util.concurrent.AbstractIdleService;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Singleton;
+import org.apache.hadoop.hbase.client.HTable;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.twill.zookeeper.ZKClientService;
+
+import java.net.URI;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+/**
+ * Debugging tool for queues in hbase.
+ */
+public class HBaseQueueDebugger extends AbstractIdleService {
+
+  private final HBaseQueueAdmin queueAdmin;
+  private final ZKClientService zkClientService;
+  private final HBaseQueueClientFactory queueClientFactory;
+  private final TransactionExecutorFactory txExecutorFactory;
+
+  @Inject
+  public HBaseQueueDebugger(HBaseQueueAdmin queueAdmin,
+                            HBaseQueueClientFactory queueClientFactory,
+                            ZKClientService zkClientService,
+                            TransactionExecutorFactory txExecutorFactory) {
+    this.queueAdmin = queueAdmin;
+    this.queueClientFactory = queueClientFactory;
+    this.zkClientService = zkClientService;
+    this.txExecutorFactory = txExecutorFactory;
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    zkClientService.startAndWait();
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    zkClientService.stopAndWait();
+  }
+
+  /**
+   * Only works for {@link co.cask.cdap.data2.transaction.queue.hbase.ShardedHBaseQueueStrategy}.
+   */
+  private QueueStatistics scanQueue(final QueueName queueName, @Nullable Long consumerGroupId) throws Exception {
+    HBaseConsumerStateStore stateStore = queueAdmin.getConsumerStateStore(queueName);
+
+    TransactionExecutor txExecutor = Transactions.createTransactionExecutor(txExecutorFactory, stateStore);
+    Multimap<Long, QueueBarrier> barriers = txExecutor.execute(
+      new TransactionExecutor.Function<HBaseConsumerStateStore, Multimap<Long, QueueBarrier>>() {
+        @Override
+        public Multimap<Long, QueueBarrier> apply(HBaseConsumerStateStore input) throws Exception {
+          return input.getAllBarriers();
+        }
+      }, stateStore);
+    System.out.printf("Got %d barriers\n", barriers.size());
+
+    QueueStatistics stats = new QueueStatistics();
+    int currentSection = 1;
+
+    Set<Long> groupIds;
+    if (consumerGroupId != null) {
+      groupIds = ImmutableSet.of(consumerGroupId);
+    } else {
+      groupIds = barriers.keySet();
+    }
+
+    for (Long groupId : groupIds) {
+      System.out.printf("Scanning barriers for group %s\n", groupId);
+      Collection<QueueBarrier> groupBarriers = barriers.get(groupId);
+      PeekingIterator<QueueBarrier> barrierIterator = Iterators.peekingIterator(groupBarriers.iterator());
+      while (barrierIterator.hasNext()) {
+        QueueBarrier start = barrierIterator.next();
+        QueueBarrier end = barrierIterator.hasNext() ? barrierIterator.peek() : null;
+
+        System.out.printf("Scanning section %d/%d...\n", currentSection, barriers.size());
+        scanQueue(txExecutor, stateStore, queueName, start, end, stats);
+        System.out.printf("Current results: %s\n", stats.getReport());
+        currentSection++;
+      }
+      System.out.println("Scanning complete");
+    }
+
+    System.out.printf("Total results: %s\n", stats.getReport());
+    return stats;
+  }
+
+  private void scanQueue(TransactionExecutor txExecutor, HBaseConsumerStateStore stateStore,
+                         QueueName queueName, QueueBarrier start,
+                         @Nullable QueueBarrier end, final QueueStatistics outStats) throws Exception {
+
+    final byte[] queueRowPrefix = QueueEntryRow.getQueueRowPrefix(queueName);
+
+    ConsumerGroupConfig groupConfig = start.getGroupConfig();
+    System.out.printf("Got consumer group config: %s\n", groupConfig);
+
+    HBaseQueueAdmin admin = queueClientFactory.get(queueName);
+    TableId tableId = admin.getDataTableId(queueName, QueueConstants.QueueType.SHARDED_QUEUE);
+    HTable hTable = queueClientFactory.createHTable(tableId);
+
+    System.out.printf("Looking at HBase table: %s\n", Bytes.toString(hTable.getTableName()));
+
+    final byte[] stateColumnName = Bytes.add(QueueEntryRow.STATE_COLUMN_PREFIX,
+                                             Bytes.toBytes(groupConfig.getGroupId()));
+
+    int distributorBuckets = queueClientFactory.getDistributorBuckets(hTable.getTableDescriptor());
+    ShardedHBaseQueueStrategy queueStrategy = new ShardedHBaseQueueStrategy(distributorBuckets);
+
+    Scan scan = new Scan();
+    scan.setStartRow(start.getStartRow());
+    if (end != null) {
+      scan.setStopRow(end.getStartRow());
+    }
+    scan.addColumn(QueueEntryRow.COLUMN_FAMILY, QueueEntryRow.DATA_COLUMN);
+    scan.addColumn(QueueEntryRow.COLUMN_FAMILY, QueueEntryRow.META_COLUMN);
+    scan.addColumn(QueueEntryRow.COLUMN_FAMILY, stateColumnName);
+    scan.setMaxVersions(1);
+
+    System.out.printf("Scanning section with scan: %s\n", scan.toString());
+
+    List<Integer> instanceIds = Lists.newArrayList();
+    if (groupConfig.getDequeueStrategy() == DequeueStrategy.FIFO) {
+      instanceIds.add(0);
+    } else {
+      for (int instanceId = 0; instanceId < groupConfig.getGroupSize(); instanceId++) {
+        instanceIds.add(instanceId);
+      }
+    }
+
+    for (int instanceId : instanceIds) {
+      System.out.printf("Processing instance %d\n", instanceId);
+      ConsumerConfig consConfig = new ConsumerConfig(groupConfig, instanceId);
+      final QueueScanner scanner = queueStrategy.createScanner(consConfig, hTable, scan, 100);
+      txExecutor.execute(new TransactionExecutor.Procedure<HBaseConsumerStateStore>() {
+        @Override
+        public void apply(HBaseConsumerStateStore input) throws Exception {
+          ImmutablePair<byte[], Map<byte[], byte[]>> result;
+          while ((result = scanner.next()) != null) {
+            byte[] rowKey = result.getFirst();
+            Map<byte[], byte[]> columns = result.getSecond();
+            visitRow(outStats, input.getTransaction(), rowKey, columns.get(stateColumnName), queueRowPrefix.length);
+          }
+        }
+      }, stateStore);
+    }
+  }
+
+  /**
+   * @param tx the transaction
+   * @param rowKey the key of the row
+   * @param stateValue the value of the state column in the row
+   * @param queueRowPrefixLength length of the queueRowPrefix
+   */
+  private void visitRow(QueueStatistics stats, Transaction tx, byte[] rowKey,
+                        byte[] stateValue, int queueRowPrefixLength) {
+    if (stateValue == null) {
+      stats.countUnprocessed(1);
+      return;
+    }
+
+    ConsumerEntryState state = QueueEntryRow.getState(stateValue);
+    if (state == ConsumerEntryState.PROCESSED) {
+      long writePointer = QueueEntryRow.getWritePointer(rowKey, queueRowPrefixLength);
+      if (tx.isVisible(writePointer)) {
+        stats.countProcessedAndVisible(1);
+      } else {
+        stats.countProcessedAndNotVisible(1);
+      }
+    }
+  }
+
+  /**
+   *
+   */
+  private static final class QueueStatistics {
+
+    private long unprocessed;
+    private long processedAndVisible;
+    private long processedAndNotVisible;
+
+    private QueueStatistics() {
+    }
+
+    public void countUnprocessed(long count) {
+      unprocessed += count;
+    }
+
+    public void countProcessedAndVisible(long count) {
+      processedAndVisible += count;
+    }
+
+    public void countProcessedAndNotVisible(long count) {
+      processedAndNotVisible += count;
+    }
+
+    public long getUnprocessed() {
+      return unprocessed;
+    }
+
+    public long getProcessedAndVisible() {
+      return processedAndVisible;
+    }
+
+    public long getProcessedAndNotVisible() {
+      return processedAndNotVisible;
+    }
+
+    public long getTotal() {
+      return unprocessed + processedAndVisible + processedAndNotVisible;
+    }
+
+    public String getReport() {
+      return String.format("unprocessed: %d; processed and visible: %d; processed and not visible: %d; total: %d",
+                           getUnprocessed(), getProcessedAndVisible(), getProcessedAndNotVisible(), getTotal());
+    }
+  }
+
+  public static void main(String[] args) throws Exception {
+    // TODO: Use commons-cli for parsing command-line args
+    if (args.length == 0) {
+      System.out.println("Expected arguments: <queue-uri> [consumer-flowlet]");
+      System.out.println("queue-uri: queue:///<namespace>/<app>/<flow>/<flowlet>/<queue>");
+      System.out.println("consumer-flowlet: <flowlet>");
+      System.out.println("Example: queue:///default/PurchaseHistory/PurchaseFlow/reader/queue collector");
+      System.exit(1);
+    }
+
+    // e.g. "queue:///default/PurchaseHistory/PurchaseFlow/reader/queue"
+    final QueueName queueName = QueueName.from(URI.create(args[0]));
+    Long consumerGroupId = null;
+    if (args.length >= 2) {
+      String consumerFlowlet = args[1];
+      Id.Program flowId = Id.Program.from(queueName.getFirstComponent(), queueName.getSecondComponent(),
+                                          ProgramType.FLOW, queueName.getThirdComponent());
+      consumerGroupId = FlowUtils.generateConsumerGroupId(flowId, consumerFlowlet);
+    }
+
+    Injector injector = Guice.createInjector(
+      new ConfigModule(),
+      new ZKClientModule(),
+      new TransactionClientModule(),
+      new AbstractModule() {
+        @Override
+        protected void configure() {
+          bind(QueueClientFactory.class).to(HBaseQueueClientFactory.class).in(Singleton.class);
+          bind(QueueAdmin.class).to(HBaseQueueAdmin.class).in(Singleton.class);
+          bind(HBaseTableUtil.class).toProvider(HBaseTableUtilFactory.class);
+        }
+      },
+      new DiscoveryRuntimeModule().getDistributedModules(),
+      new LocationRuntimeModule().getDistributedModules(),
+      new DataSetsModules().getDistributedModules(),
+      new TransactionModules().getDistributedModules()
+    );
+
+    HBaseQueueDebugger debugger = injector.getInstance(HBaseQueueDebugger.class);
+    debugger.startAndWait();
+    debugger.scanQueue(queueName, consumerGroupId);
+    debugger.stopAndWait();
+  }
+}


### PR DESCRIPTION
Also opened here: https://github.com/caskdata/cdap/pull/2268

After installing CDAP on a cluster, you can run the tool using the following java command from `/opt/cdap/master`:

```
java -cp `hbase classpath`:"lib/*:../hbase-compat-0.98/lib/*":/etc/cdap/conf/* co.cask.cdap.data2.transaction.queue.hbase.HBaseQueueDebugger queue:///default/PurchaseHistory/PurchaseFlow/reader/queue
```