### PR TITLE
CDA-2269 use source:sourceId and sink:sinkId as the pluginId for source,...

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/templates/etl/common/ETLTemplate.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/templates/etl/common/ETLTemplate.java
@@ -67,8 +67,10 @@ public abstract class ETLTemplate<T> extends ApplicationTemplate<T> {
     ETLStage sourceConfig = etlConfig.getSource();
     ETLStage sinkConfig = etlConfig.getSink();
     List<ETLStage> transformConfigs = etlConfig.getTransforms();
-    String sourcePluginId = sourceConfig.getName();
-    String sinkPluginId = sinkConfig.getName();
+    String sourcePluginId = String.format("%s%s%s", Constants.Source.PLUGINTYPE, Constants.ID_SEPARATOR,
+                                          sourceConfig.getName());
+    String sinkPluginId = String.format("%s%s%s", Constants.Sink.PLUGINTYPE, Constants.ID_SEPARATOR,
+                                        sinkConfig.getName());
 
     // Instantiate Source, Transforms, Sink stages.
     // Use the plugin name as the plugin id for source and sink stages since there can be only one source and one sink.


### PR DESCRIPTION
... sink instead of sourceId and sinkId since sourceId and sinkId can be the same

Build : http://builds.cask.co/browse/CDAP-RT3-1
JIRA : https://issues.cask.co/browse/CDAP-2269