### PR TITLE
Convert the ETL Template adapter JMS source to plugin

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/sources/JmsSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/sources/JmsSource.java
@@ -98,12 +98,13 @@ public class JmsSource extends RealtimeSource<StructuredRecord> {
     super.initialize(context);
     Map<String, String> runtimeArguments = context.getPluginProperties().getProperties();
 
-    if (runtimeArguments.get(JMS_MESSAGES_TO_RECEIVE) != null) {
-      messagesToReceive = Integer.parseInt(runtimeArguments.get(JMS_MESSAGES_TO_RECEIVE));
+    Integer configMessagesToReceive = config.messagesToReceive;
+    if (configMessagesToReceive != null) {
+      messagesToReceive = configMessagesToReceive.intValue();
     }
 
     // Try get the destination name
-    String destinationName = runtimeArguments.get(JMS_DESTINATION_NAME);
+    String destinationName = config.destinationName;
 
     // Get environment vars - this would be prefixed with java.naming.*
     final Hashtable<String, String> envVars = new Hashtable<String, String>();

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/sources/JmsSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/sources/JmsSource.java
@@ -76,8 +76,7 @@ public class JmsSource extends RealtimeSource<StructuredRecord> {
   private transient Session session;
   private transient MessageConsumer consumer;
 
-  private int messagesToReceive = 50;
-
+  private int messagesToReceive;
   private StructuredRecord.Builder recordBuilder;
 
   /**
@@ -99,9 +98,7 @@ public class JmsSource extends RealtimeSource<StructuredRecord> {
     Map<String, String> runtimeArguments = context.getPluginProperties().getProperties();
 
     Integer configMessagesToReceive = config.messagesToReceive;
-    if (configMessagesToReceive != null) {
-      messagesToReceive = configMessagesToReceive.intValue();
-    }
+    messagesToReceive = configMessagesToReceive.intValue();
 
     // Try get the destination name
     String destinationName = config.destinationName;
@@ -284,19 +281,25 @@ public class JmsSource extends RealtimeSource<StructuredRecord> {
    * Config class for {@link JmsSource}.
    */
   public static class JmsConfig extends PluginConfig {
+    private static final Integer DEFAULT_MESSAGE_RECEIVE = 50;
+
     @Name(JMS_DESTINATION_NAME)
     @Description("Name of the destination to get messages")
     private final String destinationName;
 
     @Name(JMS_MESSAGES_TO_RECEIVE)
-    @Description("Max number messages should be retrieved per poll.")
+    @Description("Max number messages should be retrieved per poll. The default value is 50.")
     @Nullable
     private final Integer messagesToReceive;
 
     public JmsConfig(String destinationName, Integer messagesToReceive) {
       this.destinationName = destinationName;
-      this.messagesToReceive = messagesToReceive;
+      if (messagesToReceive == null) {
+        this.messagesToReceive = DEFAULT_MESSAGE_RECEIVE;
+      } else {
+        this.messagesToReceive = messagesToReceive;
+      }
+
     }
   }
-
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/templates/etl/realtime/sources/JmsMessageToStringSourceTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/templates/etl/realtime/sources/JmsMessageToStringSourceTest.java
@@ -63,29 +63,7 @@ public class JmsMessageToStringSourceTest {
 
   @Before
   public void beforeTest() {
-    jmsSource = new JmsSource();
-
-    jmsSource.configure(new StageConfigurer() {
-      @Override
-      public void setName(String name) {
-        // no-op
-      }
-
-      @Override
-      public void setDescription(String description) {
-        // no-op
-      }
-
-      @Override
-      public void addProperties(Collection<Property> properties) {
-        // no-op
-      }
-
-      @Override
-      public void addProperty(Property property) {
-        // no-op
-      }
-    });
+    jmsSource = null;
   }
 
   @After
@@ -98,6 +76,8 @@ public class JmsMessageToStringSourceTest {
 
   @Test
   public void testSimpleQueueMessages() throws Exception {
+    initializeJmsSource("dynamicQueues/CDAP.QUEUE", 50);
+
     jmsProvider = new MockJmsProvider("dynamicQueues/CDAP.QUEUE");
     jmsSource.setJmsProvider(jmsProvider);
     jmsSource.setSessionAcknowledgeMode(sessionAckMode);
@@ -129,6 +109,8 @@ public class JmsMessageToStringSourceTest {
 
   @Test
   public void testSimpleTopicMessages() throws Exception {
+    initializeJmsSource("dynamicTopics/CDAP.TOPIC", 50);
+
     jmsProvider = new MockJmsProvider("dynamicTopics/CDAP.TOPIC");
     jmsSource.setJmsProvider(jmsProvider);
     jmsSource.setSessionAcknowledgeMode(sessionAckMode);
@@ -160,6 +142,8 @@ public class JmsMessageToStringSourceTest {
 
   @Test
   public void testJndiBasedJmsProvider() throws Exception {
+    initializeJmsSource("dynamicQueues/CDAP.QUEUE", 50);
+
     // Create ActiveMQ ConnectionFactory for the JNDI based JmsProvider
     final Map<String, String> contextEnv = new HashMap<String, String>();
     contextEnv.put(Context.INITIAL_CONTEXT_FACTORY, "org.apache.activemq.jndi.ActiveMQInitialContextFactory");
@@ -221,6 +205,32 @@ public class JmsMessageToStringSourceTest {
 
       System.out.println("Getting JMS Message in emitter with value: " + val.get(JmsSource.MESSAGE));
     }
+  }
+
+  private void initializeJmsSource(String destination, int messageReceive) {
+    jmsSource = new JmsSource(new JmsSource.JmsConfig(destination, messageReceive));
+
+    jmsSource.configure(new StageConfigurer() {
+      @Override
+      public void setName(String name) {
+        // no-op
+      }
+
+      @Override
+      public void setDescription(String description) {
+        // no-op
+      }
+
+      @Override
+      public void addProperties(Collection<Property> properties) {
+        // no-op
+      }
+
+      @Override
+      public void addProperty(Property property) {
+        // no-op
+      }
+    });
   }
 
   /**

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/templates/etl/realtime/sources/JmsMessageToStringSourceTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/templates/etl/realtime/sources/JmsMessageToStringSourceTest.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.templates.etl.realtime.sources;
 
+import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.templates.etl.api.Emitter;
 import co.cask.cdap.templates.etl.api.Property;
 import co.cask.cdap.templates.etl.api.StageConfigurer;
@@ -155,7 +156,6 @@ public class JmsMessageToStringSourceTest {
         }
       }
     }
-
   }
 
   @Test
@@ -215,18 +215,19 @@ public class JmsMessageToStringSourceTest {
     SourceState sourceState = new SourceState();
     source.poll(emitter, sourceState);
 
-    for (String val : emitter.getCurrentValues()) {
-      Assert.assertEquals(originalMessage, val);
+    for (StructuredRecord val : emitter.getCurrentValues()) {
+      String message = val.get(JmsSource.MESSAGE);
+      Assert.assertEquals(originalMessage, message);
 
-      System.out.println("Getting JMS Message in emitter with value: " + val);
+      System.out.println("Getting JMS Message in emitter with value: " + val.get(JmsSource.MESSAGE));
     }
   }
 
   /**
    * Helper class to emit JMS message to next stage
    */
-  private static class MockEmitter implements Emitter<String> {
-    private List<String> currentValues = Lists.newLinkedList();
+  private static class MockEmitter implements Emitter<StructuredRecord> {
+    private List<StructuredRecord> currentValues = Lists.newLinkedList();
 
     /**
      * Emit objects to the next stage.
@@ -234,11 +235,11 @@ public class JmsMessageToStringSourceTest {
      * @param value data object.
      */
     @Override
-    public void emit(String value) {
+    public void emit(StructuredRecord value) {
       currentValues.add(value);
     }
 
-    List<String> getCurrentValues() {
+    List<StructuredRecord> getCurrentValues() {
       return currentValues;
     }
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/templates/etl/realtime/sources/JmsSourceTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/templates/etl/realtime/sources/JmsSourceTest.java
@@ -51,8 +51,8 @@ import javax.naming.Context;
 /**
  * Unit test for JMS ETL realtime source
  */
-public class JmsMessageToStringSourceTest {
-  private static final Logger LOG = LoggerFactory.getLogger(JmsMessageToStringSourceTest.class);
+public class JmsSourceTest {
+  private static final Logger LOG = LoggerFactory.getLogger(JmsSourceTest.class);
 
   private final int sessionAckMode = Session.AUTO_ACKNOWLEDGE;
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/templates/etl/realtime/sources/JmsSourceTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/templates/etl/realtime/sources/JmsSourceTest.java
@@ -209,28 +209,6 @@ public class JmsSourceTest {
 
   private void initializeJmsSource(String destination, int messageReceive) {
     jmsSource = new JmsSource(new JmsSource.JmsConfig(destination, messageReceive));
-
-    jmsSource.configure(new StageConfigurer() {
-      @Override
-      public void setName(String name) {
-        // no-op
-      }
-
-      @Override
-      public void setDescription(String description) {
-        // no-op
-      }
-
-      @Override
-      public void addProperties(Collection<Property> properties) {
-        // no-op
-      }
-
-      @Override
-      public void addProperty(Property property) {
-        // no-op
-      }
-    });
   }
 
   /**

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/templates/etl/realtime/sources/MockJmsProvider.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/templates/etl/realtime/sources/MockJmsProvider.java
@@ -29,12 +29,13 @@ import javax.naming.NamingException;
  * This class is used to provide mock JMS ConnectionFactory for testing JMS realtime template source.
  */
 public class MockJmsProvider implements JmsProvider {
+  public static final String CONNECTION_URL = "vm://localhost?broker.persistent=false&broker.useJmx=false";
 
   private ConnectionFactory connectionFactory;
   private Destination destination;
 
   public MockJmsProvider(String destinationName) throws NamingException {
-    connectionFactory =  new ActiveMQConnectionFactory("vm://localhost?broker.persistent=false");
+    connectionFactory =  new ActiveMQConnectionFactory(CONNECTION_URL);
 
     // Set JNDI Context
     Context jndiContext = new InitialContext();


### PR DESCRIPTION
The PR contains changes to move JMS realtime source to plugin mode.

Change the Emitter to emit StructuredRecord with message String inside.

Updated the tests to reflect this changes.