### PR TITLE
CDAP-1784 adding a way to unit test adapters. TestBase now has

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/AdapterService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/AdapterService.java
@@ -172,12 +172,12 @@ public class AdapterService extends AbstractIdleService {
    */
   public void deployTemplate(Id.Namespace namespace, String templateName)
     throws NotFoundException, InterruptedException, ExecutionException, TimeoutException, IOException {
+    // make sure we're up to date on template info
+    registerTemplates();
     ApplicationTemplateInfo templateInfo = appTemplateInfos.get().get(templateName);
     if (templateInfo == null) {
       throw new NotFoundException(Id.ApplicationTemplate.from(templateName));
     }
-    // make sure we're up to date on template info
-    registerTemplates();
     deployTemplate(namespace, templateInfo);
   }
 
@@ -472,7 +472,9 @@ public class AdapterService extends AbstractIdleService {
     scheduler.schedule(workflowId, scheduleSpec.getProgram().getProgramType(), scheduleSpec.getSchedule(),
                        ImmutableMap.of(
                          ProgramOptionConstants.ADAPTER_NAME, adapterSpec.getName(),
-                         ProgramOptionConstants.ADAPTER_SPEC, GSON.toJson(adapterSpec)
+                         ProgramOptionConstants.ADAPTER_SPEC, GSON.toJson(adapterSpec),
+                         // hack for scheduler weirdness in unit tests, remove once CDAP-2281 is done
+                         Constants.Scheduler.IGNORE_LAZY_START, String.valueOf(true)
                        ));
     //TODO: Scheduler API should also manage the MDS.
     store.addSchedule(workflowId, scheduleSpec);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/test/internal/MockResponder.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/test/internal/MockResponder.java
@@ -21,7 +21,6 @@ import co.cask.http.HttpResponder;
 import com.google.common.base.Charsets;
 import com.google.common.collect.Multimap;
 import com.google.gson.Gson;
-import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import org.jboss.netty.buffer.ChannelBuffer;
 import org.jboss.netty.buffer.ChannelBufferInputStream;
@@ -31,6 +30,7 @@ import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.lang.reflect.Type;
 import java.nio.ByteBuffer;
 
 /**
@@ -45,14 +45,14 @@ public final class MockResponder extends AbstractHttpResponder {
     return status;
   }
 
-  public <T> T decodeResponseContent(TypeToken<T> type) {
+  public <T> T decodeResponseContent(Type type) {
     return decodeResponseContent(type, GSON);
   }
 
-  public <T> T decodeResponseContent(TypeToken<T> type, Gson gson) {
+  public <T> T decodeResponseContent(Type type, Gson gson) {
     JsonReader jsonReader = new JsonReader(new InputStreamReader
                                              (new ChannelBufferInputStream(content), Charsets.UTF_8));
-    return gson.fromJson(jsonReader, type.getType());
+    return gson.fromJson(jsonReader, type);
   }
 
   @Override

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -145,6 +145,11 @@ public final class Constants {
     public static final String CFG_SCHEDULER_MAX_THREAD_POOL_SIZE = "scheduler.max.thread.pool.size";
     public static final int DEFAULT_THREAD_POOL_SIZE = 30;
     public static final String SCHEDULERS_LAZY_START = "schedulers.lazy.start";
+    // TODO: CDAP-2281 remove once unit tests have a better way to handle schedules
+    // lazy start is set in some unit tests so that schedules are suspended right away when created.
+    // including this key with a true value as a schedule property will ignore the suspend behavior and schedules
+    // will be created normally.
+    public static final String IGNORE_LAZY_START = "scheduler.ignore.lazy.start";
   }
 
   /**

--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestManager.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestManager.java
@@ -21,7 +21,9 @@ import co.cask.cdap.api.app.ApplicationContext;
 import co.cask.cdap.api.dataset.DatasetAdmin;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.module.DatasetModule;
+import co.cask.cdap.api.templates.ApplicationTemplate;
 import co.cask.cdap.app.DefaultAppConfigurer;
+import co.cask.cdap.client.AdapterClient;
 import co.cask.cdap.client.ApplicationClient;
 import co.cask.cdap.client.MetaClient;
 import co.cask.cdap.client.NamespaceClient;
@@ -29,8 +31,10 @@ import co.cask.cdap.client.ProgramClient;
 import co.cask.cdap.client.config.ClientConfig;
 import co.cask.cdap.common.io.Locations;
 import co.cask.cdap.internal.test.AppJarHelper;
+import co.cask.cdap.proto.AdapterConfig;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.test.remote.RemoteAdapterManager;
 import co.cask.cdap.test.remote.RemoteApplicationManager;
 import com.google.common.base.Throwables;
 import com.google.common.io.Files;
@@ -40,6 +44,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.IOException;
 import java.sql.Connection;
 
 /**
@@ -55,6 +60,7 @@ public class IntegrationTestManager implements TestManager {
   private final LocationFactory locationFactory;
   private final ProgramClient programClient;
   private final NamespaceClient namespaceClient;
+  private final AdapterClient adapterClient;
 
   public IntegrationTestManager(ClientConfig clientConfig, LocationFactory locationFactory) {
     this.clientConfig = clientConfig;
@@ -63,6 +69,7 @@ public class IntegrationTestManager implements TestManager {
     this.applicationClient = new ApplicationClient(clientConfig);
     this.programClient = new ProgramClient(clientConfig);
     this.namespaceClient = new NamespaceClient(clientConfig);
+    this.adapterClient = new AdapterClient(clientConfig);
   }
 
   @Override
@@ -89,6 +96,24 @@ public class IntegrationTestManager implements TestManager {
     } catch (Exception e) {
       throw Throwables.propagate(e);
     }
+  }
+
+  @Override
+  public void deployTemplate(Id.Namespace namespace, Id.ApplicationTemplate templateId,
+                             Class<? extends ApplicationTemplate> templateClz) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void addTemplatePlugin(Id.ApplicationTemplate templateId, Class<?> pluginClz,
+                                String jarName) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public AdapterManager deployAdapter(Id.Adapter adapterId, AdapterConfig config) throws Exception {
+    adapterClient.create(adapterId.getId(), config);
+    return new RemoteAdapterManager(adapterId, adapterClient);
   }
 
   @Override

--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteAdapterManager.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteAdapterManager.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.test.remote;
+
+import co.cask.cdap.client.AdapterClient;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.RunRecord;
+import co.cask.cdap.test.AbstractAdapterManager;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ *
+ */
+public class RemoteAdapterManager extends AbstractAdapterManager {
+
+  protected final Id.Adapter adapterId;
+
+  private final AdapterClient adapterClient;
+
+  public RemoteAdapterManager(Id.Adapter adapterId, AdapterClient adapterClient) {
+    this.adapterId = adapterId;
+    this.adapterClient = adapterClient;
+  }
+
+  @Override
+  public void start() throws IOException {
+    // TODO: implement
+  }
+
+  @Override
+  public void stop() throws IOException {
+    // TODO: implement
+  }
+
+  @Override
+  public List<RunRecord> getRuns() {
+    // TODO: implement
+
+    return null;
+  }
+
+  @Override
+  public RunRecord getRun(String runId) {
+    // TODO: implement
+    return null;
+  }
+}

--- a/cdap-test/src/main/java/co/cask/cdap/test/AbstractAdapterManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/AbstractAdapterManager.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.test;
+
+import co.cask.cdap.proto.ProgramRunStatus;
+import co.cask.cdap.proto.RunRecord;
+import com.google.common.base.Stopwatch;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Base implementation of {@link ApplicationManager}.
+ */
+public abstract class AbstractAdapterManager implements AdapterManager {
+
+  @Override
+  public void waitForStatus(String runId, ProgramRunStatus status, long timeout,
+                            TimeUnit timeoutUnit) throws TimeoutException, InterruptedException {
+    RunRecord runRecord = getRun(runId);
+    // Min sleep time is 10ms, max sleep time is 1 seconds
+    long sleepMillis = getSleepTime(timeout, timeoutUnit);
+
+    Stopwatch stopwatch = new Stopwatch().start();
+    while (runRecord.getStatus() != status && stopwatch.elapsedTime(timeoutUnit) < timeout) {
+      TimeUnit.MILLISECONDS.sleep(sleepMillis);
+      runRecord = getRun(runId);
+    }
+
+    if (runRecord.getStatus() != status) {
+      throw new TimeoutException("Time limit reached.");
+    }
+  }
+
+  @Override
+  public void waitForOneRunToFinish(long timeout,
+                                    TimeUnit timeoutUnit) throws TimeoutException, InterruptedException {
+    waitForRunsToFinish(1, timeout, timeoutUnit);
+  }
+
+  @Override
+  public void waitForRunsToFinish(int numRuns, long timeout,
+                                  TimeUnit timeoutUnit) throws TimeoutException, InterruptedException {
+    long sleepMillis = getSleepTime(timeout, timeoutUnit);
+    int numFinished = 0;
+
+    Stopwatch stopwatch = new Stopwatch().start();
+    while (stopwatch.elapsedTime(timeoutUnit) < timeout) {
+      numFinished = 0;
+      for (RunRecord record : getRuns()) {
+        if (record.getStatus() != ProgramRunStatus.RUNNING) {
+          numFinished++;
+        }
+      }
+      if (numFinished < numRuns) {
+        TimeUnit.MILLISECONDS.sleep(sleepMillis);
+      } else {
+        break;
+      }
+    }
+
+    if (numFinished < numRuns) {
+      throw new TimeoutException("Time limit reached.");
+    }
+  }
+
+  private long getSleepTime(long timeout, TimeUnit timeoutUnit) {
+    // Min sleep time is 10ms, max sleep time is 1 seconds
+    return Math.max(10, Math.min(timeoutUnit.toMillis(timeout) / 10, TimeUnit.SECONDS.toMillis(1)));
+  }
+}

--- a/cdap-test/src/main/java/co/cask/cdap/test/AdapterManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/AdapterManager.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.test;
+
+import co.cask.cdap.proto.ProgramRunStatus;
+import co.cask.cdap.proto.RunRecord;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Instance of this class is for managing an adapter.
+ */
+public interface AdapterManager {
+
+  /**
+   * Starts the adapter.
+   */
+  void start() throws IOException;
+
+  /**
+   * Stops the adapter.
+   */
+  void stop() throws IOException;
+
+  /**
+   * Get the list of runs for the adapter.
+   *
+   * @return list of runs for the adapter
+   */
+  List<RunRecord> getRuns();
+
+  /**
+   * Get the run record for a specific run id.
+   *
+   * @param runId the id of the run to get
+   */
+  RunRecord getRun(String runId);
+
+  /**
+   * Blocks until a specific run of the adapter has the given status.
+   *
+   * @param runId the id of the run to wait for
+   * @param status the status to block for
+   * @param timeout amount of time units to wait
+   * @param timeoutUnit time unit type
+   * @throws TimeoutException if timeout reached
+   * @throws InterruptedException if execution is interrupted
+   */
+  void waitForStatus(String runId, ProgramRunStatus status, long timeout,
+                     TimeUnit timeoutUnit) throws TimeoutException, InterruptedException;
+
+  /**
+   * Blocks until a one run of the adapter has finished. If a run has already finished this will return right away.
+   * This should not be used on a Worker Adapter without calling {@link #stop()} first.
+   *
+   * @param timeout amount of time units to wait
+   * @param timeoutUnit time unit type
+   * @throws TimeoutException if timeout reached
+   * @throws InterruptedException if execution is interrupted
+   */
+  void waitForOneRunToFinish(long timeout, TimeUnit timeoutUnit) throws TimeoutException, InterruptedException;
+
+  /**
+   * Blocks until the specified number of runs of the adapter has finished.
+   * If that many runs have already finished, this will return right away.
+   * This should not be used on a Worker Adapter without calling {@link #stop()} first.
+   *
+   * @param numRuns the number of runs to wait to finish.
+   * @param timeout amount of time units to wait
+   * @param timeoutUnit time unit type
+   * @throws TimeoutException if timeout reached
+   * @throws InterruptedException if execution is interrupted
+   */
+  void waitForRunsToFinish(int numRuns, long timeout,
+                           TimeUnit timeoutUnit) throws TimeoutException, InterruptedException;
+}

--- a/cdap-test/src/main/java/co/cask/cdap/test/DataSetManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/DataSetManager.java
@@ -43,7 +43,8 @@ package co.cask.cdap.test;
 public interface DataSetManager<T> {
   /**
    * @return dataset instance.
-   * NOTE: the returned instance of dataset will see only changes made before it was acquired.
+   * NOTE: the returned instance of dataset will see only changes made before the manager was acquired, or before
+   * the latest call to {@link #flush()}.
    */
   T get();
 

--- a/cdap-test/src/main/java/co/cask/cdap/test/TestManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/TestManager.java
@@ -18,13 +18,18 @@ package co.cask.cdap.test;
 
 import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.app.Application;
+import co.cask.cdap.api.app.ApplicationConfigurer;
+import co.cask.cdap.api.app.ApplicationContext;
 import co.cask.cdap.api.dataset.DatasetAdmin;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.module.DatasetModule;
+import co.cask.cdap.api.templates.ApplicationTemplate;
+import co.cask.cdap.proto.AdapterConfig;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 
 import java.io.File;
+import java.io.IOException;
 import java.sql.Connection;
 
 /**
@@ -43,6 +48,37 @@ public interface TestManager {
    */
   ApplicationManager deployApplication(Id.Namespace namespace,
                                        Class<? extends Application> applicationClz, File... bundleEmbeddedJars);
+
+  /**
+   * Deploys an {@link ApplicationTemplate}. Only supported in unit tests.
+   *
+   * @param namespace The namespace to deploy to
+   * @param templateClz The template class
+   * @param templateId The id of the template. Must match the name set in
+   *                   {@link ApplicationTemplate#configure(ApplicationConfigurer, ApplicationContext)}
+   */
+  void deployTemplate(Id.Namespace namespace, Id.ApplicationTemplate templateId,
+                      Class<? extends ApplicationTemplate> templateClz) throws IOException;
+
+  /**
+   * Adds a plugin usable by the given template. Only supported in unit tests.
+   *
+   * @param templateId The id of the template to add the plugin for
+   * @param pluginClz The plugin class
+   * @param jarName The name to use for the plugin jar
+   * @throws IOException
+   */
+  void addTemplatePlugin(Id.ApplicationTemplate templateId, Class<?> pluginClz, String jarName) throws IOException;
+
+  /**
+   * Creates an adapter.
+   *
+   * @param adapterId The id of the adapter to create
+   * @param config The configuration for the adapter
+   * @return An {@link AdapterManager} to manage the deployed adapter.
+   * @throws Exception if there was an exception deploying the adapter.
+   */
+  AdapterManager deployAdapter(Id.Adapter adapterId, AdapterConfig config) throws Exception;
 
   /**
    * Clear the state of app fabric, by removing all deployed applications, Datasets and Streams.

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/UnitTestManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/UnitTestManager.java
@@ -22,17 +22,25 @@ import co.cask.cdap.api.app.ApplicationContext;
 import co.cask.cdap.api.dataset.DatasetAdmin;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.module.DatasetModule;
+import co.cask.cdap.api.templates.ApplicationTemplate;
 import co.cask.cdap.app.ApplicationSpecification;
 import co.cask.cdap.app.DefaultAppConfigurer;
+import co.cask.cdap.app.program.ManifestFields;
+import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.discovery.StickyEndpointStrategy;
+import co.cask.cdap.common.io.Locations;
+import co.cask.cdap.common.utils.DirUtils;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.explore.jdbc.ExploreDriver;
 import co.cask.cdap.internal.app.namespace.NamespaceAdmin;
+import co.cask.cdap.internal.test.AppJarHelper;
+import co.cask.cdap.proto.AdapterConfig;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.test.internal.AppFabricClient;
 import co.cask.cdap.test.internal.ApplicationManagerFactory;
+import co.cask.cdap.test.internal.DefaultAdapterManager;
 import co.cask.cdap.test.internal.StreamManagerFactory;
 import co.cask.tephra.TransactionAware;
 import co.cask.tephra.TransactionContext;
@@ -41,10 +49,12 @@ import co.cask.tephra.TransactionSystemClient;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
+import com.google.common.io.Files;
 import com.google.inject.Inject;
 import org.apache.twill.discovery.Discoverable;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.apache.twill.filesystem.Location;
+import org.apache.twill.filesystem.LocationFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -52,6 +62,7 @@ import java.net.InetSocketAddress;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.util.HashMap;
+import java.util.jar.Manifest;
 
 /**
  *
@@ -65,12 +76,19 @@ public class UnitTestManager implements TestManager {
   private final ApplicationManagerFactory appManagerFactory;
   private final NamespaceAdmin namespaceAdmin;
   private final StreamManagerFactory streamManagerFactory;
+  private final LocationFactory locationFactory;
+  private final File pluginsDir;
 
   @Inject
-  public UnitTestManager(AppFabricClient appFabricClient, DatasetFramework datasetFramework,
-                         TransactionSystemClient txSystemClient, DiscoveryServiceClient discoveryClient,
-                         ApplicationManagerFactory appManagerFactory, NamespaceAdmin namespaceAdmin,
-                         StreamManagerFactory streamManagerFactory) {
+  public UnitTestManager(AppFabricClient appFabricClient,
+                         DatasetFramework datasetFramework,
+                         TransactionSystemClient txSystemClient,
+                         DiscoveryServiceClient discoveryClient,
+                         ApplicationManagerFactory appManagerFactory,
+                         NamespaceAdmin namespaceAdmin,
+                         StreamManagerFactory streamManagerFactory,
+                         LocationFactory locationFactory,
+                         CConfiguration cConf) {
     this.appFabricClient = appFabricClient;
     this.datasetFramework = datasetFramework;
     this.txSystemClient = txSystemClient;
@@ -78,6 +96,9 @@ public class UnitTestManager implements TestManager {
     this.appManagerFactory = appManagerFactory;
     this.namespaceAdmin = namespaceAdmin;
     this.streamManagerFactory = streamManagerFactory;
+    this.locationFactory = locationFactory;
+    // this should have been set to a temp dir during injector setup
+    this.pluginsDir = new File(cConf.get(Constants.AppFabric.APP_TEMPLATE_DIR));
   }
 
   /**
@@ -107,6 +128,33 @@ public class UnitTestManager implements TestManager {
     } catch (Exception e) {
       throw Throwables.propagate(e);
     }
+  }
+
+  @Override
+  public void deployTemplate(Id.Namespace namespace, Id.ApplicationTemplate templateId,
+                             Class<? extends ApplicationTemplate> templateClz) throws IOException {
+    Location adapterJar = AppJarHelper.createDeploymentJar(locationFactory, templateClz);
+    File destination =  new File(String.format("%s/%s", pluginsDir.getAbsolutePath(), adapterJar.getName()));
+    Files.copy(Locations.newInputSupplier(adapterJar), destination);
+    appFabricClient.deployTemplate(namespace, templateId);
+  }
+
+  @Override
+  public void addTemplatePlugin(Id.ApplicationTemplate templateId, Class<?> pluginClz,
+                                String jarName) throws IOException {
+    Manifest manifest = new Manifest();
+    manifest.getMainAttributes().put(ManifestFields.EXPORT_PACKAGE, pluginClz.getPackage().getName());
+    Location pluginJar = AppJarHelper.createDeploymentJar(locationFactory, pluginClz, manifest);
+    File templateDir = new File(pluginsDir, templateId.getId());
+    DirUtils.mkdirs(templateDir);
+    File destination = new File(templateDir, jarName);
+    Files.copy(Locations.newInputSupplier(pluginJar), destination);
+  }
+
+  @Override
+  public AdapterManager deployAdapter(Id.Adapter adapterId, AdapterConfig config) {
+    appFabricClient.createAdapter(adapterId, config);
+    return new DefaultAdapterManager(appFabricClient, adapterId);
   }
 
   @Override

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultAdapterManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultAdapterManager.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.test.internal;
+
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.RunRecord;
+import co.cask.cdap.test.AbstractAdapterManager;
+import co.cask.cdap.test.ApplicationManager;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * A local implementation of {@link ApplicationManager}.
+ */
+public class DefaultAdapterManager extends AbstractAdapterManager {
+
+  private final AppFabricClient appFabricClient;
+  private final Id.Adapter adapterId;
+
+  public DefaultAdapterManager(AppFabricClient appFabricClient, Id.Adapter adapterId) {
+    this.adapterId = adapterId;
+    this.appFabricClient = appFabricClient;
+  }
+
+  @Override
+  public void start() throws IOException {
+    appFabricClient.startAdapter(adapterId);
+  }
+
+  @Override
+  public void stop() throws IOException {
+    appFabricClient.stopAdapter(adapterId);
+  }
+
+  @Override
+  public List<RunRecord> getRuns() {
+    return appFabricClient.getAdapterRuns(adapterId);
+  }
+
+  @Override
+  public RunRecord getRun(String runId) {
+    return appFabricClient.getAdapterRun(adapterId, runId);
+  }
+
+}

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultStreamManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultStreamManager.java
@@ -42,6 +42,7 @@ import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.jboss.netty.handler.codec.http.HttpVersion;
 
 import java.io.IOException;
+import java.lang.reflect.Type;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
@@ -52,6 +53,7 @@ import java.util.Map;
 public class DefaultStreamManager implements StreamManager {
   private static final Gson GSON = StreamEventTypeAdapter.register(
     new GsonBuilder().registerTypeAdapter(Schema.class, new SchemaTypeAdapter())).create();
+  private static final Type STREAM_EVENT_LIST_TYPE = new TypeToken<List<StreamEvent>>() { }.getType();
 
   private final Id.Stream streamId;
   private final StreamHandler streamHandler;
@@ -168,6 +170,6 @@ public class DefaultStreamManager implements StreamManager {
       throw new IOException("Failed to read from stream. Status = " + responder.getStatus());
     }
 
-    return responder.decodeResponseContent(new TypeToken<List<StreamEvent>>() { }, GSON);
+    return responder.decodeResponseContent(STREAM_EVENT_LIST_TYPE, GSON);
   }
 }

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestAdapterFrameworkTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestAdapterFrameworkTestRun.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.test.app;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.dataset.lib.KeyValueTable;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.proto.AdapterConfig;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.test.AdapterManager;
+import co.cask.cdap.test.DataSetManager;
+import co.cask.cdap.test.SlowTests;
+import co.cask.cdap.test.XSlowTests;
+import co.cask.cdap.test.base.TestFrameworkTestBase;
+import co.cask.cdap.test.template.WorkerTemplate;
+import co.cask.cdap.test.template.WorkflowTemplate;
+import co.cask.cdap.test.template.plugin.FlipPlugin;
+import co.cask.cdap.test.template.plugin.SquarePlugin;
+import com.google.gson.Gson;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ *
+ */
+@Category(SlowTests.class)
+public class TestAdapterFrameworkTestRun extends TestFrameworkTestBase {
+  private static final Gson GSON = new Gson();
+
+  @Category(XSlowTests.class)
+  @Test
+  public void testWorkflowAdapter() throws Exception {
+    Id.ApplicationTemplate templateId = Id.ApplicationTemplate.from(WorkflowTemplate.NAME);
+    addTemplatePlugin(templateId, FlipPlugin.class, "flip-1.0.jar");
+    deployTemplate(Constants.DEFAULT_NAMESPACE_ID, templateId, WorkflowTemplate.class);
+
+    DataSetManager<KeyValueTable> inputManager = getDataset(Constants.DEFAULT_NAMESPACE_ID, WorkflowTemplate.INPUT);
+    inputManager.get().write(Bytes.toBytes(1L), Bytes.toBytes(10L));
+    inputManager.flush();
+
+    WorkflowTemplate.Config config = new WorkflowTemplate.Config("flip");
+    Id.Adapter adapterId = Id.Adapter.from(Constants.DEFAULT_NAMESPACE_ID, "workflowX");
+    AdapterConfig adapterConfig = new AdapterConfig("description", WorkerTemplate.NAME, GSON.toJsonTree(config));
+    AdapterManager manager = deployAdapter(adapterId, adapterConfig);
+
+    manager.start();
+    // TODO: CDAP-2281 test schedules in a better way
+    // perhaps we get a special schedule that lets you trigger jobs on command
+    manager.waitForOneRunToFinish(4, TimeUnit.MINUTES);
+    manager.stop();
+
+    DataSetManager<KeyValueTable> outputManager = getDataset(Constants.DEFAULT_NAMESPACE_ID, WorkflowTemplate.OUTPUT);
+    long outputVal = Bytes.toLong(outputManager.get().read(Bytes.toBytes(1L)));
+    Assert.assertEquals(-10L, outputVal);
+  }
+
+  @Category(XSlowTests.class)
+  @Test
+  public void testWorkerAdapter() throws Exception {
+    Id.ApplicationTemplate templateId = Id.ApplicationTemplate.from(WorkerTemplate.NAME);
+    addTemplatePlugin(templateId, SquarePlugin.class, "square-1.0.jar");
+    deployTemplate(Constants.DEFAULT_NAMESPACE_ID, templateId, WorkerTemplate.class);
+
+    String tableName = "kvoutput";
+    WorkerTemplate.Config config = new WorkerTemplate.Config(tableName, "square", 5L);
+    Id.Adapter adapterId = Id.Adapter.from(Constants.DEFAULT_NAMESPACE_ID, "workerX");
+    AdapterConfig adapterConfig = new AdapterConfig("description", WorkerTemplate.NAME, GSON.toJsonTree(config));
+    AdapterManager manager = deployAdapter(adapterId, adapterConfig);
+
+    manager.start();
+
+    byte[] key = Bytes.toBytes(5L);
+    DataSetManager<KeyValueTable> kvTableManager = getDataset(Constants.DEFAULT_NAMESPACE_ID, tableName);
+    byte[] valBytes = kvTableManager.get().read(key);
+    while (valBytes == null) {
+      TimeUnit.MILLISECONDS.sleep(200);
+      valBytes = kvTableManager.get().read(key);
+      kvTableManager.flush();
+    }
+    manager.stop();
+
+    Assert.assertEquals(25L, Bytes.toLong(valBytes));
+  }
+}
+

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/template/WorkerTemplate.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/template/WorkerTemplate.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.test.template;
+
+import co.cask.cdap.api.TxRunnable;
+import co.cask.cdap.api.app.ApplicationConfigurer;
+import co.cask.cdap.api.app.ApplicationContext;
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.lib.KeyValueTable;
+import co.cask.cdap.api.templates.AdapterConfigurer;
+import co.cask.cdap.api.templates.ApplicationTemplate;
+import co.cask.cdap.api.templates.plugins.PluginProperties;
+import co.cask.cdap.api.worker.AbstractWorker;
+import co.cask.cdap.api.worker.WorkerContext;
+import com.google.gson.Gson;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+
+/**
+ * Application Template that uses a worker to write some data to a dataset for testing purposes.
+ */
+public class WorkerTemplate extends ApplicationTemplate<WorkerTemplate.Config> {
+  private static final Gson GSON = new Gson();
+  public static final String NAME = "workertemplate";
+
+  public static class Config {
+    private final String dsName;
+    private final String functionName;
+    private final long x;
+
+    public Config(String dsName, String functionName, long x) {
+      this.dsName = dsName;
+      this.functionName = functionName;
+      this.x = x;
+    }
+  }
+
+  @Override
+  public void configure(ApplicationConfigurer configurer, ApplicationContext context) {
+    configurer.setName(NAME);
+    configurer.addWorker(new Worker());
+  }
+
+  @Override
+  public void configureAdapter(String name, @Nullable Config config, AdapterConfigurer configurer) throws Exception {
+    String pluginId = "plugin123";
+    configurer.usePlugin("callable", config.functionName, pluginId,
+      PluginProperties.builder()
+        .add("x", String.valueOf(config.x))
+        .build());
+    configurer.addRuntimeArgument("pluginId", pluginId);
+    configurer.addRuntimeArgument("config", GSON.toJson(config));
+    configurer.createDataset(config.dsName, KeyValueTable.class.getName(), DatasetProperties.EMPTY);
+  }
+
+  public static class Worker extends AbstractWorker {
+    public static final String NAME = "worker";
+    private Config config;
+    private volatile boolean running;
+    private Callable<Long> plugin;
+
+    @Override
+    public void initialize(WorkerContext context) throws Exception {
+      super.initialize(context);
+      config = GSON.fromJson(context.getRuntimeArguments().get("config"), Config.class);
+      String pluginId = context.getRuntimeArguments().get("pluginId");
+      plugin = context.newPluginInstance(pluginId);
+      running = true;
+    }
+
+    @Override
+    public void configure() {
+      setName(NAME);
+    }
+
+    @Override
+    public void run() {
+      getContext().execute(new TxRunnable() {
+        @Override
+        public void run(DatasetContext context) throws Exception {
+          long y = plugin.call();
+          KeyValueTable table = context.getDataset(config.dsName);
+          table.write(Bytes.toBytes(config.x), Bytes.toBytes(y));
+        }
+      });
+      while (running) {
+        try {
+          TimeUnit.MILLISECONDS.sleep(100);
+        } catch (InterruptedException e) {
+          throw new RuntimeException(e);
+        }
+      }
+    }
+
+    @Override
+    public void stop() {
+      running = false;
+    }
+  }
+
+}

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/template/WorkflowTemplate.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/template/WorkflowTemplate.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.test.template;
+
+import co.cask.cdap.api.ProgramLifecycle;
+import co.cask.cdap.api.app.ApplicationConfigurer;
+import co.cask.cdap.api.app.ApplicationContext;
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.lib.KeyValueTable;
+import co.cask.cdap.api.mapreduce.AbstractMapReduce;
+import co.cask.cdap.api.mapreduce.MapReduceContext;
+import co.cask.cdap.api.schedule.Schedules;
+import co.cask.cdap.api.templates.AdapterConfigurer;
+import co.cask.cdap.api.templates.ApplicationTemplate;
+import co.cask.cdap.api.templates.plugins.PluginProperties;
+import co.cask.cdap.api.workflow.AbstractWorkflow;
+import com.google.common.base.Function;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.Mapper;
+
+import java.io.IOException;
+import javax.annotation.Nullable;
+
+/**
+ * Application Template that uses a worker to write some data to a dataset for testing purposes.
+ */
+public class WorkflowTemplate extends ApplicationTemplate<WorkflowTemplate.Config> {
+  public static final String NAME = "workertemplate";
+  public static final String INPUT = "workflow.in";
+  public static final String OUTPUT = "workflow.out";
+
+  public static class Config {
+    private final String functionName;
+
+    public Config(String functionName) {
+      this.functionName = functionName;
+    }
+  }
+
+  @Override
+  public void configure(ApplicationConfigurer configurer, ApplicationContext context) {
+    configurer.setName(NAME);
+    configurer.addWorkflow(new Workflow());
+    configurer.addMapReduce(new MapReduce());
+    configurer.createDataset(INPUT, KeyValueTable.class.getName(), DatasetProperties.EMPTY);
+    configurer.createDataset(OUTPUT, KeyValueTable.class.getName(), DatasetProperties.EMPTY);
+  }
+
+  @Override
+  public void configureAdapter(String name, @Nullable Config config, AdapterConfigurer configurer) throws Exception {
+    configurer.usePlugin("function", config.functionName, "func", PluginProperties.builder().build());
+    configurer.setSchedule(Schedules.createTimeSchedule("schedule", "description", "* * * * *"));
+  }
+
+  /**
+   *
+   */
+  public static class Workflow extends AbstractWorkflow {
+    public static final String NAME = "Workflow";
+    @Override
+    protected void configure() {
+      setName(NAME);
+      setDescription("Workflow to test Adapter");
+      addMapReduce(MapReduce.NAME);
+    }
+  }
+
+  /**
+   *
+   */
+  public static class MapReduce extends AbstractMapReduce {
+    public static final String NAME = "MapReduce";
+
+    @Override
+    protected void configure() {
+      setName(NAME);
+      setInputDataset(INPUT);
+      setOutputDataset(OUTPUT);
+    }
+
+    @Override
+    public void beforeSubmit(MapReduceContext context) throws Exception {
+      Job job = context.getHadoopJob();
+      job.setMapperClass(FunctionMapper.class);
+      job.setNumReduceTasks(0);
+    }
+  }
+
+  public static class FunctionMapper extends Mapper<byte[], byte[], byte[], byte[]>
+    implements ProgramLifecycle<MapReduceContext> {
+    Function<Long, Long> plugin;
+
+    @Override
+    public void map(byte[] key, byte[] val, Context context)
+      throws IOException, InterruptedException {
+      Long newVal = plugin.apply(Bytes.toLong(val));
+      context.write(key, Bytes.toBytes(newVal));
+    }
+
+    @Override
+    public void initialize(MapReduceContext context) throws Exception {
+      plugin = context.newPluginInstance("func");
+    }
+
+    @Override
+    public void destroy() {
+
+    }
+  }
+}

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/template/plugin/FlipPlugin.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/template/plugin/FlipPlugin.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.test.template.plugin;
+
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import com.google.common.base.Function;
+
+import javax.annotation.Nullable;
+
+/**
+ * Template plugin for tests
+ */
+@Plugin(type = "function")
+@Name("flip")
+public class FlipPlugin implements Function<Long, Long> {
+
+  @Nullable
+  @Override
+  public Long apply(Long input) {
+    return 0 - input;
+  }
+
+}

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/template/plugin/SquarePlugin.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/template/plugin/SquarePlugin.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.test.template.plugin;
+
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.templates.plugins.PluginConfig;
+
+import java.util.concurrent.Callable;
+
+/**
+ * Template plugin for tests
+ */
+@Plugin(type = "callable")
+@Name("square")
+public class SquarePlugin implements Callable<Long> {
+  private Config config;
+
+  @Override
+  public Long call() throws Exception {
+    return config.x * config.x;
+  }
+
+  public static final class Config extends PluginConfig {
+    @Name("x")
+    private Long x;
+  }
+}


### PR DESCRIPTION
access to methods to deploy a template, deploy template plugins,
and deploy an adapter. Deploying a template will build the
application jar, place it in the correct directory, and deploy
the template application. Deploying a template plugin will
build the plugin jar and place it in the correct diectory.
Deploying an adapter will create the adapter and return an
AdapterManager, which can be used to manage the adapter lifecycle.