### PR TITLE
[CDAP-2266] use version 1.2.0 of cdap-clients, which uses v3 APIs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
     <unboundid.version>2.3.6</unboundid.version>
     <zookeeper.version>3.4.5</zookeeper.version>
     <spark.version>1.2.0</spark.version>
-    <cdap.client.version>1.1.1</cdap.client.version>
+    <cdap.client.version>1.2.0</cdap.client.version>
     <twitter4j.version>4.0.3</twitter4j.version>
     <cask.packages.snapshot.repo>http://cask.invalid.snapshot.repo.co</cask.packages.snapshot.repo>
     <cask.packages.release.repo>http://cask.invalid.release.repo.co</cask.packages.release.repo>


### PR DESCRIPTION
title says it all. 
Build runs here: http://builds.cask.co/browse/CDAP-RBT226-1