### PR TITLE
CDAP-2283: separate MetricStore TagValue from Cube API

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/cube/DefaultCube.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/cube/DefaultCube.java
@@ -203,7 +203,7 @@ public class DefaultCube implements Cube {
     // todo: the passed query should have map instead
     LinkedHashMap<String, String> slice = Maps.newLinkedHashMap();
     for (TagValue tagValue : query.getTagValues()) {
-      slice.put(tagValue.getTagName(), tagValue.getValue());
+      slice.put(tagValue.getName(), tagValue.getValue());
     }
 
     FactTable table = resolutionToFactTable.get(query.getResolution());
@@ -227,7 +227,7 @@ public class DefaultCube implements Cube {
     // todo: the passed query should have map instead
     LinkedHashMap<String, String> slice = Maps.newLinkedHashMap();
     for (TagValue tagValue : query.getTagValues()) {
-      slice.put(tagValue.getTagName(), tagValue.getValue());
+      slice.put(tagValue.getName(), tagValue.getValue());
     }
 
     FactTable table = resolutionToFactTable.get(query.getResolution());
@@ -273,7 +273,7 @@ public class DefaultCube implements Cube {
       for (String tagName : query.getGroupByTags()) {
         // todo: use Map<String, String> instead of List<TagValue> into a String, String, everywhere
         for (TagValue tagValue : next.getTagValues()) {
-          if (tagName.equals(tagValue.getTagName())) {
+          if (tagName.equals(tagValue.getName())) {
             if (tagValue.getValue() == null) {
               // Currently, we do NOT return null as grouped by value.
               // Depending on whether tag is required or not the records with null value in it may or may not be in
@@ -366,7 +366,7 @@ public class DefaultCube implements Cube {
   private static final class TagValueComparator implements Comparator<TagValue> {
     @Override
     public int compare(TagValue t1, TagValue t2) {
-      int cmp = t1.getTagName().compareTo(t2.getTagName());
+      int cmp = t1.getName().compareTo(t2.getName());
       if (cmp != 0) {
         return cmp;
       }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/timeseries/FactCodec.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/timeseries/FactCodec.java
@@ -115,7 +115,7 @@ public class FactCodec {
     for (TagValue tagValue : tagValues) {
       if (tagValue.getValue() != null) {
         // encoded value is unique within values of the tag name
-        offset = writeEncoded(tagValue.getTagName(), tagValue.getValue(), rowKey, offset);
+        offset = writeEncoded(tagValue.getName(), tagValue.getValue(), rowKey, offset);
       } else {
         // todo: this is only applicable for constructing scan, throw smth if constructing key for writing data
         // writing "ANY" as a value
@@ -254,7 +254,7 @@ public class FactCodec {
     // aggregation group is defined by list of tag names
     StringBuilder sb = new StringBuilder();
     for (TagValue tagValue : tagValues) {
-      sb.append(tagValue.getTagName()).append(".");
+      sb.append(tagValue.getName()).append(".");
     }
 
     return writeEncoded(TYPE_TAGS_GROUP, sb.toString(), rowKey, offset);

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/metrics/MetricsHandlerTestRun.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/metrics/MetricsHandlerTestRun.java
@@ -533,7 +533,7 @@ public class MetricsHandlerTestRun extends MetricsSuiteTestBase {
 
 
   /**
-   * Helper class to construct json for QueryRequest for batch queries
+   * Helper class to construct json for MetricQueryRequest for batch queries
    */
   private class QueryRequestFormat {
     Map<String, String> tags;

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/MetricQueryRequest.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/MetricQueryRequest.java
@@ -26,7 +26,7 @@ import javax.annotation.Nullable;
 /**
  * Metrics Query Request format
  */
-public class QueryRequest {
+public class MetricQueryRequest {
   /**
    * Format for metrics query in batched queries
    */
@@ -35,7 +35,7 @@ public class QueryRequest {
   List<String> groupBy;
   TimeRange timeRange;
 
-  public QueryRequest(Map<String, String> tags, List<String> metrics, List<String> groupBy) {
+  public MetricQueryRequest(Map<String, String> tags, List<String> metrics, List<String> groupBy) {
     this.tags = tags;
     this.metrics = metrics;
     this.groupBy = groupBy;

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/MetricTagValue.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/MetricTagValue.java
@@ -14,21 +14,20 @@
  * the License.
  */
 
-package co.cask.cdap.api.dataset.lib.cube;
+package co.cask.cdap.proto;
 
-import co.cask.cdap.api.annotation.Beta;
+import co.cask.cdap.api.dataset.lib.cube.CubeFact;
 
 import javax.annotation.Nullable;
 
 /**
  * Represents tag and its value associated with {@link CubeFact}.
  */
-@Beta
-public final class TagValue {
+public final class MetricTagValue {
   private final String name;
   private final String value;
 
-  public TagValue(String name, @Nullable String value) {
+  public MetricTagValue(String name, @Nullable String value) {
     this.name = name;
     this.value = value;
   }
@@ -52,7 +51,7 @@ public final class TagValue {
       return false;
     }
 
-    TagValue tagValue = (TagValue) o;
+    MetricTagValue tagValue = (MetricTagValue) o;
 
     boolean result = value == null ? tagValue.value == null : value.equals(tagValue.value);
     return result && name.equals(tagValue.name);

--- a/cdap-unit-test/src/test/java/co/cask/cdap/spark/metrics/SparkMetricsIntegrationTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/spark/metrics/SparkMetricsIntegrationTestRun.java
@@ -16,12 +16,12 @@
 
 package co.cask.cdap.spark.metrics;
 
-import co.cask.cdap.api.dataset.lib.cube.TagValue;
 import co.cask.cdap.api.dataset.lib.cube.TimeValue;
 import co.cask.cdap.api.metrics.MetricDataQuery;
 import co.cask.cdap.api.metrics.MetricSearchQuery;
 import co.cask.cdap.api.metrics.MetricTimeSeries;
 import co.cask.cdap.api.metrics.MetricType;
+import co.cask.cdap.api.metrics.TagValue;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.RuntimeStats;

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestAppWithCube.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestAppWithCube.java
@@ -87,7 +87,7 @@ public class TestAppWithCube extends TestBase {
         searchTag(url, new CubeExploreQuery(tsInSec - 60, tsInSec + 60, 1, 100, new ArrayList<TagValue>()));
       Assert.assertEquals(1, tags.size());
       TagValue tv = tags.iterator().next();
-      Assert.assertEquals("user", tv.getTagName());
+      Assert.assertEquals("user", tv.getName());
       Assert.assertEquals("alex", tv.getValue());
 
       tags = searchTag(url, new CubeExploreQuery(tsInSec - 60, tsInSec + 60, 1, 100,
@@ -95,10 +95,10 @@ public class TestAppWithCube extends TestBase {
       Assert.assertEquals(2, tags.size());
       Iterator<TagValue> iterator = tags.iterator();
       tv = iterator.next();
-      Assert.assertEquals("action", tv.getTagName());
+      Assert.assertEquals("action", tv.getName());
       Assert.assertEquals("back", tv.getValue());
       tv = iterator.next();
-      Assert.assertEquals("action", tv.getTagName());
+      Assert.assertEquals("action", tv.getName());
       Assert.assertEquals("click", tv.getValue());
 
       // search for measures

--- a/cdap-watchdog-api/src/main/java/co/cask/cdap/api/metrics/MetricSearchQuery.java
+++ b/cdap-watchdog-api/src/main/java/co/cask/cdap/api/metrics/MetricSearchQuery.java
@@ -16,7 +16,6 @@
 
 package co.cask.cdap.api.metrics;
 
-import co.cask.cdap.api.dataset.lib.cube.TagValue;
 import com.google.common.base.Joiner;
 import com.google.common.base.Objects;
 
@@ -24,7 +23,7 @@ import java.util.List;
 
 /**
  * Defines a query to perform Exploration and Search on {@link MetricStore} data.
- * Given a list of {@link co.cask.cdap.api.dataset.lib.cube.TagValue} this explore query can be used
+ * Given a list of {@link TagValue}s this explore query can be used
  * to find next set of tags available or the measureNames belonging to this tag list.
  */
 public class MetricSearchQuery {

--- a/cdap-watchdog-api/src/main/java/co/cask/cdap/api/metrics/MetricStore.java
+++ b/cdap-watchdog-api/src/main/java/co/cask/cdap/api/metrics/MetricStore.java
@@ -16,9 +16,8 @@
 
 package co.cask.cdap.api.metrics;
 
-import co.cask.cdap.api.dataset.lib.cube.TagValue;
-
 import java.util.Collection;
+import java.util.Map;
 
 /**
  * Stores and provides access to metrics data.
@@ -70,7 +69,7 @@ public interface MetricStore {
    * @param query specifies where to search
    * @return collection of tag value pairs in no particular order
    */
-  Collection<TagValue> findNextAvailableTags(MetricSearchQuery query) throws Exception;
+  Map<String, String> findNextAvailableTags(MetricSearchQuery query) throws Exception;
 
   /**
    * Given a list of tags in the {@link MetricSearchQuery}, returns the list of measures available

--- a/cdap-watchdog-api/src/main/java/co/cask/cdap/api/metrics/TagValue.java
+++ b/cdap-watchdog-api/src/main/java/co/cask/cdap/api/metrics/TagValue.java
@@ -14,14 +14,14 @@
  * the License.
  */
 
-package co.cask.cdap.api.dataset.lib.cube;
+package co.cask.cdap.api.metrics;
 
 import co.cask.cdap.api.annotation.Beta;
 
 import javax.annotation.Nullable;
 
 /**
- * Represents tag and its value associated with {@link CubeFact}.
+ * Represents tag and its value associated with {@link MetricValues}.
  */
 @Beta
 public final class TagValue {

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/MetricsHandler.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/MetricsHandler.java
@@ -18,19 +18,20 @@ package co.cask.cdap.metrics.query;
 
 import co.cask.cdap.api.dataset.lib.cube.Interpolator;
 import co.cask.cdap.api.dataset.lib.cube.Interpolators;
-import co.cask.cdap.api.dataset.lib.cube.TagValue;
 import co.cask.cdap.api.dataset.lib.cube.TimeValue;
 import co.cask.cdap.api.metrics.MetricDataQuery;
 import co.cask.cdap.api.metrics.MetricSearchQuery;
 import co.cask.cdap.api.metrics.MetricStore;
 import co.cask.cdap.api.metrics.MetricTimeSeries;
 import co.cask.cdap.api.metrics.MetricType;
+import co.cask.cdap.api.metrics.TagValue;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.utils.TimeMathParser;
 import co.cask.cdap.gateway.auth.Authenticator;
 import co.cask.cdap.gateway.handlers.AuthenticatedHttpHandler;
+import co.cask.cdap.proto.MetricQueryRequest;
 import co.cask.cdap.proto.MetricQueryResult;
-import co.cask.cdap.proto.QueryRequest;
+import co.cask.cdap.proto.MetricTagValue;
 import co.cask.http.HttpResponder;
 import com.google.common.base.Charsets;
 import com.google.common.base.Function;
@@ -181,14 +182,14 @@ public class MetricsHandler extends AuthenticatedHttpHandler {
     }
   }
 
-  private List<TagValue> parseTagValues(List<String> tags) {
-    List<TagValue> result = Lists.newArrayList();
+  private List<MetricTagValue> parseTagValues(List<String> tags) {
+    List<MetricTagValue> result = Lists.newArrayList();
     for (String tag : tags) {
       // split by ':' and add the tagValue to result list
       String[] tagSplit = tag.split(":", 2);
       if (tagSplit.length == 2) {
         String value = tagSplit[1].equals(ANY_TAG_VALUE) ? null : tagSplit[1];
-        result.add(new TagValue(tagSplit[0], value));
+        result.add(new MetricTagValue(tagSplit[0], value));
       }
     }
     return result;
@@ -227,7 +228,7 @@ public class MetricsHandler extends AuthenticatedHttpHandler {
 
         Map<String, MetricQueryResult> queryFinalResponse = Maps.newHashMap();
         for (Map.Entry<String, QueryRequestFormat> query : queries.entrySet()) {
-          QueryRequest queryRequest = getQueryRequestFromFormat(query.getValue());
+          MetricQueryRequest queryRequest = getQueryRequestFromFormat(query.getValue());
           queryFinalResponse.put(query.getKey(), executeQuery(queryRequest));
         }
         responder.sendJson(HttpResponseStatus.OK, queryFinalResponse);
@@ -243,14 +244,14 @@ public class MetricsHandler extends AuthenticatedHttpHandler {
     }
   }
 
-  private QueryRequest getQueryRequestFromFormat(QueryRequestFormat queryRequestFormat) {
+  private MetricQueryRequest getQueryRequestFromFormat(QueryRequestFormat queryRequestFormat) {
     Map<String, List<String>> queryParams = Maps.newHashMap();
 
     for (Map.Entry<String, String> entry : queryRequestFormat.getTimeRange().entrySet()) {
       queryParams.put(entry.getKey(), ImmutableList.of(entry.getValue()));
     }
 
-    QueryRequest queryRequest = new QueryRequest(queryRequestFormat.getTags(),
+    MetricQueryRequest queryRequest = new MetricQueryRequest(queryRequestFormat.getTags(),
                                                  queryRequestFormat.getMetrics(), queryRequestFormat.getGroupBy());
     setTimeRangeInQueryRequest(queryRequest, queryParams);
     return queryRequest;
@@ -288,7 +289,7 @@ public class MetricsHandler extends AuthenticatedHttpHandler {
   private MetricQueryResult executeQuery(HttpRequest request, Map<String, String> sliceByTags,
                                          List<String> groupByTags, List<String> metrics) {
     try {
-      QueryRequest queryRequest = new QueryRequest(sliceByTags, metrics, groupByTags);
+      MetricQueryRequest queryRequest = new MetricQueryRequest(sliceByTags, metrics, groupByTags);
       setTimeRangeInQueryRequest(queryRequest, new QueryStringDecoder(request.getUri()).getParameters());
       return executeQuery(queryRequest);
     } catch (IllegalArgumentException e) {
@@ -298,7 +299,7 @@ public class MetricsHandler extends AuthenticatedHttpHandler {
     }
   }
 
-  private void setTimeRangeInQueryRequest(QueryRequest request, Map<String, List<String>> queryTimeParams) {
+  private void setTimeRangeInQueryRequest(MetricQueryRequest request, Map<String, List<String>> queryTimeParams) {
     Long start =
       queryTimeParams.containsKey(PARAM_START_TIME) ?
         TimeMathParser.parseTime(queryTimeParams.get(PARAM_START_TIME).get(0)) : null;
@@ -372,7 +373,7 @@ public class MetricsHandler extends AuthenticatedHttpHandler {
     }
   }
 
-  private MetricQueryResult executeQuery(QueryRequest queryRequest) {
+  private MetricQueryResult executeQuery(MetricQueryRequest queryRequest) {
     try {
       if (queryRequest.getMetrics().size() == 0) {
         throw new IllegalArgumentException("Missing metrics parameter in the query");
@@ -380,7 +381,7 @@ public class MetricsHandler extends AuthenticatedHttpHandler {
 
       Map<String, String> tagsSliceBy = humanToTagNames(transformTagMap(queryRequest.getTags()));
 
-      QueryRequest.TimeRange timeRange = queryRequest.getTimeRange();
+      MetricQueryRequest.TimeRange timeRange = queryRequest.getTimeRange();
 
       MetricDataQuery query = new MetricDataQuery(timeRange.getStart(), timeRange.getEnd(),
                                                   timeRange.getResolutionInSeconds(),
@@ -397,8 +398,7 @@ public class MetricsHandler extends AuthenticatedHttpHandler {
         endTime = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis());
       }
 
-      MetricQueryResult result = decorate(queryResult, timeRange.getStart(), endTime);
-      return result;
+      return decorate(queryResult, timeRange.getStart(), endTime);
     } catch (IllegalArgumentException e) {
       throw Throwables.propagate(e);
     } catch (Exception e) {
@@ -471,11 +471,11 @@ public class MetricsHandler extends AuthenticatedHttpHandler {
   }
 
   private Map<String, String> parseTagValuesAsMap(List<String> tags) {
-    List<TagValue> tagValues = parseTagValues(tags);
+    List<MetricTagValue> tagValues = parseTagValues(tags);
 
     Map<String, String> result = Maps.newHashMap();
-    for (TagValue tagValue : tagValues) {
-      result.put(tagValue.getTagName(), tagValue.getValue());
+    for (MetricTagValue tagValue : tagValues) {
+      result.put(tagValue.getName(), tagValue.getValue());
     }
     return result;
   }
@@ -507,8 +507,8 @@ public class MetricsHandler extends AuthenticatedHttpHandler {
       // we want to search the entire range, so startTimestamp is '0' and end Timestamp is Integer.MAX_VALUE and
       // limit is -1 , to include the entire search result.
       MetricSearchQuery searchQuery = new MetricSearchQuery(0, Integer.MAX_VALUE, -1,
-                                                            humanToTagNames(parseTagValues(tags)));
-      Collection<TagValue> nextTags = metricStore.findNextAvailableTags(searchQuery);
+                                                            toTagValues(humanToTagNames(parseTagValues(tags))));
+      Map<String, String> nextTags = metricStore.findNextAvailableTags(searchQuery);
       responder.sendJson(HttpResponseStatus.OK, tagValuesToHuman(nextTags));
     } catch (IllegalArgumentException e) {
       LOG.warn("Invalid request", e);
@@ -531,32 +531,32 @@ public class MetricsHandler extends AuthenticatedHttpHandler {
     }
   }
 
-  private List<TagValue> parseTagValues(String contextPrefix) throws Exception {
+  private List<MetricTagValue> parseTagValues(String contextPrefix) throws Exception {
     Map<String, String> map = parseTagValuesAsMap(contextPrefix);
-    List<TagValue> contextTags = Lists.newArrayList();
+    List<MetricTagValue> contextTags = Lists.newArrayList();
     for (Map.Entry<String, String> entry : map.entrySet()) {
-      contextTags.add(new TagValue(entry.getKey(), entry.getValue()));
+      contextTags.add(new MetricTagValue(entry.getKey(), entry.getValue()));
     }
 
     return contextTags;
   }
 
   private Collection<String> searchChildContext(String contextPrefix) throws Exception {
-    List<TagValue> tagValues = parseTagValues(contextPrefix);
+    List<MetricTagValue> tagValues = parseTagValues(contextPrefix);
 
     // we want to search the entire range, so startTimestamp is '0' and endTimestamp is Integer.MAX_VALUE and
     // limit is -1 , to include the entire search result.
     MetricSearchQuery searchQuery = new MetricSearchQuery(0, Integer.MAX_VALUE, -1,
-                                                          humanToTagNames(tagValues));
-    Collection<TagValue> nextTags = metricStore.findNextAvailableTags(searchQuery);
+                                                          toTagValues(humanToTagNames(tagValues)));
+    Map<String, String> nextTags = metricStore.findNextAvailableTags(searchQuery);
 
     contextPrefix = toCanonicalContext(tagValues);
     Collection<String> result = Lists.newArrayList();
-    for (TagValue tag : nextTags) {
+    for (Map.Entry<String, String> tag : nextTags.entrySet()) {
       // for now, if tag value is null, we use ANY_TAG_VALUE as returned for convenience: this allows to easy build UI
       // and do simple copy-pasting when accessing HTTP endpoint via e.g. curl
       String value = tag.getValue() == null ? ANY_TAG_VALUE : tag.getValue();
-      String name = tagNameToHuman(tag);
+      String name = tagNameToHuman(tag.getKey());
       String tagValue = encodeTag(name) + TAG_DELIM + encodeTag(value);
       String resultTag = contextPrefix.length() == 0 ? tagValue : contextPrefix + TAG_DELIM + tagValue;
       result.add(resultTag);
@@ -564,27 +564,41 @@ public class MetricsHandler extends AuthenticatedHttpHandler {
     return result;
   }
 
-  private List<TagValue> tagValuesToHuman(Collection<TagValue> tagValues) {
-    List<TagValue> result = Lists.newArrayList();
-    for (TagValue tagValue : tagValues) {
-      String human = tagNameToHuman.get(tagValue.getTagName());
-      human = human != null ? human : tagValue.getTagName();
+  private List<MetricTagValue> tagValuesToHuman(Map<String, String> tagValues) {
+    List<MetricTagValue> result = Lists.newArrayList();
+    for (Map.Entry<String, String> tagValue : tagValues.entrySet()) {
+      String human = tagNameToHuman.get(tagValue.getKey());
+      human = human != null ? human : tagValue.getKey();
       String value = tagValue.getValue() == null ? ANY_TAG_VALUE : tagValue.getValue();
-      result.add(new TagValue(human, value));
+      result.add(new MetricTagValue(human, value));
     }
     return result;
   }
 
-  private String tagNameToHuman(TagValue tag) {
-    String human = tagNameToHuman.get(tag.getTagName());
-    return human != null ? human : tag.getTagName();
+  private String tagNameToHuman(String tagName) {
+    String human = tagNameToHuman.get(tagName);
+    return human != null ? human : tagName;
   }
 
-  private List<TagValue> humanToTagNames(List<TagValue> tagValues) {
-    List<TagValue> result = Lists.newArrayList();
-    for (TagValue tagValue : tagValues) {
-      String tagName = humanToTagName(tagValue.getTagName());
-      result.add(new TagValue(tagName, tagValue.getValue()));
+  private List<TagValue> toTagValues(List<MetricTagValue> tagValues) {
+    return Lists.transform(tagValues, new Function<MetricTagValue, TagValue>() {
+      @Nullable
+      @Override
+      public TagValue apply(@Nullable MetricTagValue input) {
+        if (input == null) {
+          // SHOULD NEVER happen
+          throw new NullPointerException();
+        }
+        return new TagValue(input.getName(), input.getValue());
+      }
+    });
+  }
+
+  private List<MetricTagValue> humanToTagNames(List<MetricTagValue> tagValues) {
+    List<MetricTagValue> result = Lists.newArrayList();
+    for (MetricTagValue tagValue : tagValues) {
+      String tagName = humanToTagName(tagValue.getName());
+      result.add(new MetricTagValue(tagName, tagValue.getValue()));
     }
     return result;
   }
@@ -602,30 +616,30 @@ public class MetricsHandler extends AuthenticatedHttpHandler {
     return result;
   }
 
-  private String toCanonicalContext(List<TagValue> tagValues) {
+  private String toCanonicalContext(List<MetricTagValue> tagValues) {
     StringBuilder sb = new StringBuilder();
     boolean first = true;
-    for (TagValue tv : tagValues) {
+    for (MetricTagValue tv : tagValues) {
       if (!first) {
         sb.append(TAG_DELIM);
       }
       first = false;
-      sb.append(encodeTag(tv.getTagName())).append(TAG_DELIM)
+      sb.append(encodeTag(tv.getName())).append(TAG_DELIM)
         .append(tv.getValue() == null ? ANY_TAG_VALUE : encodeTag(tv.getValue()));
     }
     return sb.toString();
   }
 
   private Collection<String> searchMetric(String contextPrefix) throws Exception {
-    List<TagValue> tagValues = humanToTagNames(parseTagValues(contextPrefix));
+    List<MetricTagValue> tagValues = humanToTagNames(parseTagValues(contextPrefix));
     return getMetrics(tagValues);
   }
 
-  private Collection<String> getMetrics(List<TagValue> tagValues) throws Exception {
+  private Collection<String> getMetrics(List<MetricTagValue> tagValues) throws Exception {
     // we want to search the entire range, so startTimestamp is '0' and end Timestamp is Integer.MAX_VALUE and
     // limit is -1 , to include the entire search result.
     MetricSearchQuery searchQuery =
-      new MetricSearchQuery(0, Integer.MAX_VALUE, -1, tagValues);
+      new MetricSearchQuery(0, Integer.MAX_VALUE, -1, toTagValues(tagValues));
     Collection<String> metricNames = metricStore.findMetricNames(searchQuery);
     return Lists.newArrayList(Iterables.filter(metricNames, Predicates.notNull()));
   }
@@ -660,7 +674,7 @@ public class MetricsHandler extends AuthenticatedHttpHandler {
 
   /**
    * Helper class to Deserialize Query requests and based on this
-   * {@link co.cask.cdap.proto.QueryRequest} will be constructed
+   * {@link MetricQueryRequest} will be constructed
    */
   private class QueryRequestFormat {
     Map<String, String> tags;
@@ -686,8 +700,8 @@ public class MetricsHandler extends AuthenticatedHttpHandler {
      * time range has aggregate=true or {start, end, count, resolution, interpolate} parameters,
      * since start, end can be represented as 'now ('+' or '-')' and not just absolute timestamp,
      * we use this format to get those strings and after parsing and determining other parameters, we can construct
-     * {@link co.cask.cdap.proto.QueryRequest} , similar for resolution.
-     * @return
+     * {@link MetricQueryRequest} , similar for resolution.
+     * @return time range prameters
      */
     public Map<String, String> getTimeRange() {
       timeRange = (timeRange == null || timeRange.size() == 0) ? ImmutableMap.of("aggregate", "true") : timeRange;


### PR DESCRIPTION
Two changes:
* created MetricTagValue in proto, to isolate HTTP APIs from internally used classes
* created TagValue in watchdog-api to separate from one that is used in Cube API

The TagValue in Cube API will be renamed to DimValue, i.e. dimension value