### PR TITLE
CDAP-2283: separate MetricStore TagValue from Cube API

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/cube/AbstractCubeHttpHandler.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/cube/AbstractCubeHttpHandler.java
@@ -67,15 +67,16 @@ public abstract class AbstractCubeHttpHandler extends AbstractHttpServiceHandler
   }
 
   /**
-   * Searches tags in a {@link Cube} as defined by {@link Cube#findNextAvailableTags(CubeExploreQuery)}.
+   * Searches dimension values in a {@link Cube} as defined by
+   * {@link Cube#findDimensionValues(CubeExploreQuery)}.
    */
-  @Path("searchTag")
+  @Path("searchDimensionValue")
   @POST
-  public void searchTag(HttpServiceRequest request, HttpServiceResponder responder) {
+  public void searchDimensionValue(HttpServiceRequest request, HttpServiceResponder responder) {
     try {
       String body = Bytes.toString(request.getContent());
       CubeExploreQuery query = new Gson().fromJson(body, CubeExploreQuery.class);
-      Collection<TagValue> result = getCube().findNextAvailableTags(query);
+      Collection<DimensionValue> result = getCube().findDimensionValues(query);
       responder.sendJson(result);
     } catch (Throwable th) {
       LOG.error("Error while executing request", th);
@@ -101,7 +102,7 @@ public abstract class AbstractCubeHttpHandler extends AbstractHttpServiceHandler
   }
 
   /**
-   * Searches tags in a {@link Cube} as defined by {@link Cube#findNextAvailableTags(CubeExploreQuery)}.
+   * Queries data in a {@link Cube} as defined by {@link Cube#query(CubeQuery)}.
    */
   @Path("query")
   @POST

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/cube/Cube.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/cube/Cube.java
@@ -61,12 +61,12 @@ public interface Cube extends Dataset, BatchWritable<Object, CubeFact> {
   void delete(CubeDeleteQuery query);
 
   /**
-   * Queries data for next available tags after the given list of tags specified by
-   * {@link CubeExploreQuery}
+   * Finds dimension values, each of which is present in aggregated data selection defined with
+   * {@link CubeExploreQuery}.
    * @param query query to perform
-   * @return {@link Collection} of {@link TagValue} that are result of the query
+   * @return {@link Collection} of {@link DimensionValue} that are result of the query
    */
-  Collection<TagValue> findNextAvailableTags(CubeExploreQuery query);
+  Collection<DimensionValue> findDimensionValues(CubeExploreQuery query);
 
   /**
    * Queries data for available measureNames for the query specified by {@link CubeExploreQuery}

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/cube/CubeDeleteQuery.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/cube/CubeDeleteQuery.java
@@ -22,7 +22,6 @@ import com.google.common.collect.ImmutableList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -35,23 +34,23 @@ public class CubeDeleteQuery {
   private final long endTs;
   private final int resolution;
   private final Collection<String> measureNames;
-  private final Map<String, String> sliceByTagValues;
+  private final Map<String, String> dimensionValues;
 
   /**
    * Creates instance of {@link CubeDeleteQuery} that defines selection of data to delete from {@link Cube}.
    * @param startTs start time of the data selection, in seconds since epoch
    * @param endTs end time of the data selection, in seconds since epoch
    * @param resolution resolution of the aggregations to delete from
-   * @param sliceByTagValues tag name, tag value pairs that define the data selection
+   * @param dimensionValues dimension name, dimension value pairs that define the data selection
    * @param measureNames name of the measures to delete, {@code null} means delete all
    */
   public CubeDeleteQuery(long startTs, long endTs, int resolution,
-                         Map<String, String> sliceByTagValues, Collection<String> measureNames) {
+                         Map<String, String> dimensionValues, Collection<String> measureNames) {
     this.startTs = startTs;
     this.endTs = endTs;
     this.resolution = resolution;
     this.measureNames = measureNames;
-    this.sliceByTagValues = Collections.unmodifiableMap(new HashMap<String, String>(sliceByTagValues));
+    this.dimensionValues = Collections.unmodifiableMap(new HashMap<String, String>(dimensionValues));
   }
 
 
@@ -60,13 +59,13 @@ public class CubeDeleteQuery {
    * @param startTs start time of the data selection, in seconds since epoch
    * @param endTs end time of the data selection, in seconds since epoch
    * @param resolution resolution of the aggregations to delete from
-   * @param sliceByTagValues tag name, tag value pairs that define the data selection
+   * @param dimensionValues dimension name, dimension value pairs that define the data selection
    * @param measureName name of the measure to delete, {@code null} means delete all
    */
   public CubeDeleteQuery(long startTs, long endTs, int resolution,
-                         Map<String, String> sliceByTagValues, @Nullable String measureName) {
+                         Map<String, String> dimensionValues, @Nullable String measureName) {
 
-    this(startTs, endTs, resolution, sliceByTagValues,
+    this(startTs, endTs, resolution, dimensionValues,
          measureName == null ? ImmutableList.<String>of() : ImmutableList.of(measureName));
   }
 
@@ -75,12 +74,12 @@ public class CubeDeleteQuery {
    * @param startTs start time of the data selection, in seconds since epoch
    * @param endTs end time of the data selection, in seconds since epoch
    * @param resolution resolution of the aggregations to delete from
-   * @param sliceByTagValues tag name, tag value pairs that define the data selection
+   * @param dimensionValues dimension name, dimension value pairs that define the data selection
    */
   public CubeDeleteQuery(long startTs, long endTs, int resolution,
-                         Map<String, String> sliceByTagValues) {
+                         Map<String, String> dimensionValues) {
 
-    this(startTs, endTs, resolution, sliceByTagValues, ImmutableList.<String>of());
+    this(startTs, endTs, resolution, dimensionValues, ImmutableList.<String>of());
   }
 
   public long getStartTs() {
@@ -99,8 +98,8 @@ public class CubeDeleteQuery {
     return measureNames;
   }
 
-  public Map<String, String> getSliceByTags() {
-    return sliceByTagValues;
+  public Map<String, String> getDimensionValues() {
+    return dimensionValues;
   }
 
   @Override
@@ -111,7 +110,7 @@ public class CubeDeleteQuery {
     sb.append(", endTs=").append(endTs);
     sb.append(", resolution=").append(resolution);
     sb.append(", measureNames=").append(measureNames == null ? "null" : measureNames);
-    sb.append(", sliceByTagValues=").append(sliceByTagValues);
+    sb.append(", dimensionValues=").append(dimensionValues);
     sb.append('}');
     return sb.toString();
   }

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/cube/CubeExploreQuery.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/cube/CubeExploreQuery.java
@@ -23,7 +23,8 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * Defines a query to perform exploration of the {@link Cube} data, e.g. to find tag name and values and measure names.
+ * Defines a query to perform exploration of the {@link Cube} data, e.g. to find dimension name and values and
+ * measure names.
  */
 @Beta
 public class CubeExploreQuery {
@@ -31,21 +32,21 @@ public class CubeExploreQuery {
   private final long endTs;
   private final int resolution;
   private final int limit;
-  private final List<TagValue> tagValues;
+  private final List<DimensionValue> dimensionValues;
 
   /**
    * Creates instance of {@link CubeExploreQuery} that defines selection of data of {@link Cube} to explore in.
    * @param startTs start time of the data selection, inclusive, in seconds since epoch
    * @param endTs end time of the data selection, exclusive, in seconds since epoch
    * @param resolution resolution of the aggregations explore
-   * @param tagValues tag name, tag value pairs that define the data selection
+   * @param dimensionValues dimension name, dimension value pairs that define the data selection
    */
-  public CubeExploreQuery(long startTs, long endTs, int resolution, int limit, List<TagValue> tagValues) {
+  public CubeExploreQuery(long startTs, long endTs, int resolution, int limit, List<DimensionValue> dimensionValues) {
     this.startTs = startTs;
     this.endTs = endTs;
     this.resolution = resolution;
     this.limit = limit;
-    this.tagValues = Collections.unmodifiableList(new ArrayList<TagValue>(tagValues));
+    this.dimensionValues = Collections.unmodifiableList(new ArrayList<DimensionValue>(dimensionValues));
   }
 
   public long getStartTs() {
@@ -64,8 +65,8 @@ public class CubeExploreQuery {
     return limit;
   }
 
-  public List<TagValue> getTagValues() {
-    return tagValues;
+  public List<DimensionValue> getDimensionValues() {
+    return dimensionValues;
   }
 
   @Override
@@ -76,7 +77,7 @@ public class CubeExploreQuery {
     sb.append(", endTs=").append(endTs);
     sb.append(", resolution=").append(resolution);
     sb.append(", limit=").append(limit);
-    sb.append(", tagValues=").append(tagValues);
+    sb.append(", dimensionValues=").append(dimensionValues);
     sb.append('}');
     return sb.toString();
   }

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/cube/CubeFact.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/cube/CubeFact.java
@@ -25,48 +25,48 @@ import java.util.LinkedList;
 import java.util.Map;
 
 /**
- * Time-based measurement with associated tags (dimensions) to be stored in {@link Cube}.
+ * Time-based measurement with associated dimensionValues (dimensions) to be stored in {@link Cube}.
  * <p/>
  * See also {@link Cube#add(CubeFact)}.
  */
 @Beta
 public class CubeFact {
   private final long timestamp;
-  private final Map<String, String> tags;
+  private final Map<String, String> dimensionValues;
   private final Collection<Measurement> measurements;
 
   /**
-   * Creates an instance of {@link CubeFact} with no tags and no measurements.
+   * Creates an instance of {@link CubeFact} with no dimensionValues and no measurements.
    * <p/>
-   * After creation, you can add tags e.g. via {@link #addTag(String, String)}
+   * After creation, you can add dimensionValues e.g. via {@link #addDimensionValue(String, String)}
    * and add measurements e.g. via {@link #addMeasurement(String, MeasureType, long)}.
    *
    * @param timestamp timestamp (epoch in sec) of the measurements
    */
   public CubeFact(long timestamp) {
-    this.tags = new HashMap<String, String>();
+    this.dimensionValues = new HashMap<String, String>();
     this.measurements = new LinkedList<Measurement>();
     this.timestamp = timestamp;
   }
 
   /**
-   * Adds tag to this {@link CubeFact}.
-   * @param name name of the tag
-   * @param value value of the tag
+   * Adds dimension value to this {@link CubeFact}.
+   * @param name name of the dimension
+   * @param value value of the dimension
    * @return this {@link CubeFact}
    */
-  public CubeFact addTag(String name, String value) {
-    tags.put(name, value);
+  public CubeFact addDimensionValue(String name, String value) {
+    dimensionValues.put(name, value);
     return this;
   }
 
   /**
-   * Adds multiple tags to this {@link CubeFact}.
-   * @param tags tags to add
+   * Adds multiple dimensionValues to this {@link CubeFact}.
+   * @param dimensionValues dimensionValues to add
    * @return this {@link CubeFact}
    */
-  public CubeFact addTags(Map<String, String> tags) {
-    this.tags.putAll(tags);
+  public CubeFact addDimensionValues(Map<String, String> dimensionValues) {
+    this.dimensionValues.putAll(dimensionValues);
     return this;
   }
 
@@ -110,10 +110,10 @@ public class CubeFact {
   }
 
   /**
-   * @return tags of this {@link CubeFact}
+   * @return dimensionValues of this {@link CubeFact}
    */
-  public Map<String, String> getTags() {
-    return Collections.unmodifiableMap(tags);
+  public Map<String, String> getDimensionValues() {
+    return Collections.unmodifiableMap(dimensionValues);
   }
 
   /**

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/cube/DimensionValue.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/cube/DimensionValue.java
@@ -21,14 +21,14 @@ import co.cask.cdap.api.annotation.Beta;
 import javax.annotation.Nullable;
 
 /**
- * Represents tag and its value associated with {@link CubeFact}.
+ * Represents dimension and its value associated with {@link CubeFact}.
  */
 @Beta
-public final class TagValue {
+public final class DimensionValue {
   private final String name;
   private final String value;
 
-  public TagValue(String name, @Nullable String value) {
+  public DimensionValue(String name, @Nullable String value) {
     this.name = name;
     this.value = value;
   }
@@ -52,10 +52,10 @@ public final class TagValue {
       return false;
     }
 
-    TagValue tagValue = (TagValue) o;
+    DimensionValue dimensionValue = (DimensionValue) o;
 
-    boolean result = value == null ? tagValue.value == null : value.equals(tagValue.value);
-    return result && name.equals(tagValue.name);
+    boolean result = value == null ? dimensionValue.value == null : value.equals(dimensionValue.value);
+    return result && name.equals(dimensionValue.name);
   }
 
   @Override
@@ -66,7 +66,7 @@ public final class TagValue {
   @Override
   public String toString() {
     final StringBuilder sb = new StringBuilder();
-    sb.append("TagValue");
+    sb.append("DimensionValue");
     sb.append("{name='").append(name).append('\'');
     sb.append(", value='").append(value == null ? "null" : value).append('\'');
     sb.append('}');

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/cube/Interpolator.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/cube/Interpolator.java
@@ -28,11 +28,11 @@ public interface Interpolator {
   /**
    * Given start and end TimeValues, and a time in-between the two, return a TimeValue for the in-between time.
    */
-  public long interpolate(TimeValue start, TimeValue end, long ts);
+  long interpolate(TimeValue start, TimeValue end, long ts);
 
   /**
    * Data points that are more than this many seconds apart will not cause interpolation to occur and will instead
    * return 0 for any point in between.
    */
-  public long getMaxAllowedGap();
+  long getMaxAllowedGap();
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/cube/TimeSeries.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/cube/TimeSeries.java
@@ -25,17 +25,17 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Represents a single time series defined by a measure name and set of tag values.
+ * Represents a single time series defined by a measure name and set of dimension values.
  */
 @Beta
 public final class TimeSeries {
   private final String measureName;
-  private final Map<String, String> tagValues;
+  private final Map<String, String> dimensionValues;
   private final List<TimeValue> timeValues;
 
-  public TimeSeries(String measureName, Map<String, String> tagValues, List<TimeValue> timeValues) {
+  public TimeSeries(String measureName, Map<String, String> dimensionValues, List<TimeValue> timeValues) {
     this.measureName = measureName;
-    this.tagValues = Collections.unmodifiableMap(new HashMap<String, String>(tagValues));
+    this.dimensionValues = Collections.unmodifiableMap(new HashMap<String, String>(dimensionValues));
     this.timeValues = Collections.unmodifiableList(timeValues);
   }
 
@@ -43,8 +43,8 @@ public final class TimeSeries {
     return measureName;
   }
 
-  public Map<String, String> getTagValues() {
-    return tagValues;
+  public Map<String, String> getDimensionValues() {
+    return dimensionValues;
   }
 
   public List<TimeValue> getTimeValues() {
@@ -63,13 +63,13 @@ public final class TimeSeries {
     TimeSeries that = (TimeSeries) o;
 
     return Objects.equal(measureName, that.measureName) &&
-      Objects.equal(tagValues, that.tagValues) &&
+      Objects.equal(dimensionValues, that.dimensionValues) &&
       Objects.equal(timeValues, that.timeValues);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(measureName, tagValues, timeValues);
+    return Objects.hashCode(measureName, dimensionValues, timeValues);
   }
 
   @Override
@@ -77,7 +77,7 @@ public final class TimeSeries {
     final StringBuilder sb = new StringBuilder();
     sb.append("TimeSeries");
     sb.append("{measureName='").append(measureName).append('\'');
-    sb.append(", tagValues=").append(tagValues);
+    sb.append(", dimensionValues=").append(dimensionValues);
     sb.append(", timeValues=").append(timeValues);
     sb.append('}');
     return sb.toString();

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/cube/Aggregation.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/cube/Aggregation.java
@@ -23,24 +23,24 @@ import java.util.List;
 /**
  * Defines an aggregation in {@link DefaultCube}.
  * <p/>
- * Aggregation usually defines a list of tags, or dimensions that are extracted from the
+ * Aggregation usually defines a list of dimensions, or dimensions that are extracted from the
  * {@link co.cask.cdap.api.dataset.lib.cube.CubeFact} when it is
  * added to the {@link co.cask.cdap.api.dataset.lib.cube.Cube}. Configuring a
  * {@link co.cask.cdap.api.dataset.lib.cube.Cube} to compute an aggregation allows later querying for data based
- * on those tags the data is aggregated for. See also {@link co.cask.cdap.api.dataset.lib.cube.CubeQuery}.
+ * on those dimensions the data is aggregated for. See also {@link co.cask.cdap.api.dataset.lib.cube.CubeQuery}.
  */
 public interface Aggregation {
   /**
-   * Defines the tags to do the aggregation for.
+   * Defines the dimensions to do the aggregation for.
    * <p/>
    * Depending on the implementation of a {@link co.cask.cdap.api.dataset.lib.cube.Cube},
-   * the order of the tag names can be used as is to form a row key.
-   * That in turn may affect the performance of the querying. Usually you want to put most frequently defined tags
-   * (tags with values to slice by in {@link co.cask.cdap.api.dataset.lib.cube.CubeQuery} to be in front.
+   * the order of the dimension names can be used as is to form a row key.
+   * That in turn may affect the performance of the querying. Usually you want to put most frequently defined dimensions
+   * (dimensions with values to slice by in {@link co.cask.cdap.api.dataset.lib.cube.CubeQuery} to be in front.
    *
-   * @return list of tags (dimensions) to aggregate by
+   * @return list of dimensions (dimensions) to aggregate by
    */
-  List<String> getTagNames();
+  List<String> getDimensionNames();
 
   /**
    * Filters out {@link co.cask.cdap.api.dataset.lib.cube.CubeFact}s which should not be added into this aggregation.

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/cube/CubeDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/cube/CubeDataset.java
@@ -23,7 +23,7 @@ import co.cask.cdap.api.dataset.lib.cube.CubeDeleteQuery;
 import co.cask.cdap.api.dataset.lib.cube.CubeExploreQuery;
 import co.cask.cdap.api.dataset.lib.cube.CubeFact;
 import co.cask.cdap.api.dataset.lib.cube.CubeQuery;
-import co.cask.cdap.api.dataset.lib.cube.TagValue;
+import co.cask.cdap.api.dataset.lib.cube.DimensionValue;
 import co.cask.cdap.api.dataset.lib.cube.TimeSeries;
 import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.data2.dataset2.lib.timeseries.EntityTable;
@@ -78,8 +78,8 @@ public class CubeDataset extends AbstractDataset implements Cube {
   }
 
   @Override
-  public Collection<TagValue> findNextAvailableTags(CubeExploreQuery query) {
-    return cube.findNextAvailableTags(query);
+  public Collection<DimensionValue> findDimensionValues(CubeExploreQuery query) {
+    return cube.findDimensionValues(query);
   }
 
   @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/cube/DefaultAggregation.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/cube/DefaultAggregation.java
@@ -29,42 +29,42 @@ import java.util.Set;
  * Default implementation of {@link Aggregation}.
  */
 public class DefaultAggregation implements Aggregation {
-  private final List<String> aggregateTags;
-  private final Set<String> requiredTags;
+  private final List<String> aggregateDimensions;
+  private final Set<String> requiredDimensions;
 
   /**
    * Creates instance of {@link DefaultAggregation} with all tags being optional.
-   * @param aggregateTags tags to be included in aggregation.
+   * @param aggregateDimensions tags to be included in aggregation.
    */
-  public DefaultAggregation(List<String> aggregateTags) {
-    this(aggregateTags, new HashSet<String>());
+  public DefaultAggregation(List<String> aggregateDimensions) {
+    this(aggregateDimensions, new HashSet<String>());
   }
 
   /**
    * Creates instance of {@link DefaultAggregation}.
    * <p/>
-   * See also {@link Aggregation#getTagNames()} for more info on aggregateTags.
+   * See also {@link Aggregation#getDimensionNames()} for more info on aggregateDimensions.
    *
-   * @param aggregateTags tags to be included in aggregation.
-   * @param requiredTags tags that must be present in {@link co.cask.cdap.api.dataset.lib.cube.CubeFact}
+   * @param aggregateDimensions dimensions to be included in aggregation.
+   * @param requiredDimensions dimensions that must be present in {@link co.cask.cdap.api.dataset.lib.cube.CubeFact}
    *                     for aggregated value to be stored.
    */
-  public DefaultAggregation(List<String> aggregateTags, Collection<String> requiredTags) {
-    this.aggregateTags = ImmutableList.copyOf(aggregateTags);
-    this.requiredTags = ImmutableSet.copyOf(requiredTags);
+  public DefaultAggregation(List<String> aggregateDimensions, Collection<String> requiredDimensions) {
+    this.aggregateDimensions = ImmutableList.copyOf(aggregateDimensions);
+    this.requiredDimensions = ImmutableSet.copyOf(requiredDimensions);
   }
 
   @Override
-  public List<String> getTagNames() {
-    return aggregateTags;
+  public List<String> getDimensionNames() {
+    return aggregateDimensions;
   }
 
-  public Set<String> getRequiredTags() {
-    return requiredTags;
+  public Set<String> getRequiredDimensions() {
+    return requiredDimensions;
   }
 
   @Override
   public boolean accept(CubeFact fact) {
-    return fact.getTags().keySet().containsAll(requiredTags);
+    return fact.getDimensionValues().keySet().containsAll(requiredDimensions);
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/cube/DefaultCube.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/cube/DefaultCube.java
@@ -203,7 +203,7 @@ public class DefaultCube implements Cube {
     // todo: the passed query should have map instead
     LinkedHashMap<String, String> slice = Maps.newLinkedHashMap();
     for (TagValue tagValue : query.getTagValues()) {
-      slice.put(tagValue.getTagName(), tagValue.getValue());
+      slice.put(tagValue.getName(), tagValue.getValue());
     }
 
     FactTable table = resolutionToFactTable.get(query.getResolution());
@@ -227,7 +227,7 @@ public class DefaultCube implements Cube {
     // todo: the passed query should have map instead
     LinkedHashMap<String, String> slice = Maps.newLinkedHashMap();
     for (TagValue tagValue : query.getTagValues()) {
-      slice.put(tagValue.getTagName(), tagValue.getValue());
+      slice.put(tagValue.getName(), tagValue.getValue());
     }
 
     FactTable table = resolutionToFactTable.get(query.getResolution());
@@ -273,7 +273,7 @@ public class DefaultCube implements Cube {
       for (String tagName : query.getGroupByTags()) {
         // todo: use Map<String, String> instead of List<TagValue> into a String, String, everywhere
         for (TagValue tagValue : next.getTagValues()) {
-          if (tagName.equals(tagValue.getTagName())) {
+          if (tagName.equals(tagValue.getName())) {
             if (tagValue.getValue() == null) {
               // Currently, we do NOT return null as grouped by value.
               // Depending on whether tag is required or not the records with null value in it may or may not be in
@@ -366,7 +366,7 @@ public class DefaultCube implements Cube {
   private static final class TagValueComparator implements Comparator<TagValue> {
     @Override
     public int compare(TagValue t1, TagValue t2) {
-      int cmp = t1.getTagName().compareTo(t2.getTagName());
+      int cmp = t1.getName().compareTo(t2.getName());
       if (cmp != 0) {
         return cmp;
       }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/timeseries/Fact.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/timeseries/Fact.java
@@ -16,8 +16,8 @@
 
 package co.cask.cdap.data2.dataset2.lib.timeseries;
 
+import co.cask.cdap.api.dataset.lib.cube.DimensionValue;
 import co.cask.cdap.api.dataset.lib.cube.Measurement;
-import co.cask.cdap.api.dataset.lib.cube.TagValue;
 import com.google.common.collect.ImmutableList;
 
 import java.util.Collection;
@@ -25,28 +25,28 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * Represents measure in time with tags assigned to it
+ * Represents measure in time with dimension values assigned to it
  */
 public final class Fact {
   /** in seconds */
   private final long timestamp;
-  private final List<TagValue> tagValues;
+  private final List<DimensionValue> dimensionValues;
   private final Collection<Measurement> measurements;
 
-  public Fact(long timestamp, List<TagValue> tagValues, Collection<Measurement> measurements) {
+  public Fact(long timestamp, List<DimensionValue> dimensionValues, Collection<Measurement> measurements) {
     this.timestamp = timestamp;
-    this.tagValues = ImmutableList.copyOf(tagValues);
+    this.dimensionValues = ImmutableList.copyOf(dimensionValues);
     this.measurements = measurements;
   }
 
-  public Fact(long timestamp, List<TagValue> tagValues, Measurement measurement) {
+  public Fact(long timestamp, List<DimensionValue> dimensionValues, Measurement measurement) {
     this.timestamp = timestamp;
-    this.tagValues = ImmutableList.copyOf(tagValues);
+    this.dimensionValues = ImmutableList.copyOf(dimensionValues);
     this.measurements = ImmutableList.of(measurement);
   }
 
-  public List<TagValue> getTagValues() {
-    return Collections.unmodifiableList(tagValues);
+  public List<DimensionValue> getDimensionValues() {
+    return Collections.unmodifiableList(dimensionValues);
   }
 
   public Collection<Measurement> getMeasurements() {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/timeseries/FactCodec.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/timeseries/FactCodec.java
@@ -115,7 +115,7 @@ public class FactCodec {
     for (TagValue tagValue : tagValues) {
       if (tagValue.getValue() != null) {
         // encoded value is unique within values of the tag name
-        offset = writeEncoded(tagValue.getTagName(), tagValue.getValue(), rowKey, offset);
+        offset = writeEncoded(tagValue.getName(), tagValue.getValue(), rowKey, offset);
       } else {
         // todo: this is only applicable for constructing scan, throw smth if constructing key for writing data
         // writing "ANY" as a value
@@ -254,7 +254,7 @@ public class FactCodec {
     // aggregation group is defined by list of tag names
     StringBuilder sb = new StringBuilder();
     for (TagValue tagValue : tagValues) {
-      sb.append(tagValue.getTagName()).append(".");
+      sb.append(tagValue.getName()).append(".");
     }
 
     return writeEncoded(TYPE_TAGS_GROUP, sb.toString(), rowKey, offset);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/timeseries/FactScan.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/timeseries/FactScan.java
@@ -16,7 +16,7 @@
 
 package co.cask.cdap.data2.dataset2.lib.timeseries;
 
-import co.cask.cdap.api.dataset.lib.cube.TagValue;
+import co.cask.cdap.api.dataset.lib.cube.DimensionValue;
 import com.google.common.collect.ImmutableList;
 
 import java.util.Collection;
@@ -25,31 +25,33 @@ import java.util.List;
 /**
  * Defines a scan over facts in a {@link FactTable}.
  * <p/>
- * NOTE: it will only scan those facts that at the time of writing had all given tags (some could have null values).
+ * NOTE: it will only scan those facts that at the time of writing had all given dimensions (some could have
+ *       null values).
  */
 public final class FactScan {
-  private final List<TagValue> tagValues;
+  private final List<DimensionValue> dimensionValues;
   private final Collection<String> measureNames;
   private final long startTs;
   private final long endTs;
 
-  public FactScan(long startTs, long endTs, Collection<String> measureNames, List<TagValue> tagValues) {
+  public FactScan(long startTs, long endTs, Collection<String> measureNames, List<DimensionValue> dimensionValues) {
     this.endTs = endTs;
     this.startTs = startTs;
     this.measureNames = measureNames;
-    this.tagValues = ImmutableList.copyOf(tagValues);
+    this.dimensionValues = ImmutableList.copyOf(dimensionValues);
   }
 
-  public FactScan(long startTs, long endTs, String measureName, List<TagValue> tagValues) {
-    this(startTs, endTs, measureName == null ? ImmutableList.<String>of() : ImmutableList.of(measureName), tagValues);
+  public FactScan(long startTs, long endTs, String measureName, List<DimensionValue> dimensionValues) {
+    this(startTs, endTs,
+         measureName == null ? ImmutableList.<String>of() : ImmutableList.of(measureName), dimensionValues);
   }
 
-  public FactScan(long startTs, long endTs, List<TagValue> tagValues) {
-    this(startTs, endTs, ImmutableList.<String>of(), tagValues);
+  public FactScan(long startTs, long endTs, List<DimensionValue> dimensionValues) {
+    this(startTs, endTs, ImmutableList.<String>of(), dimensionValues);
   }
 
-  public List<TagValue> getTagValues() {
-    return tagValues;
+  public List<DimensionValue> getDimensionValues() {
+    return dimensionValues;
   }
 
   public Collection<String> getMeasureNames() {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/timeseries/FactScanResult.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/timeseries/FactScanResult.java
@@ -16,7 +16,7 @@
 
 package co.cask.cdap.data2.dataset2.lib.timeseries;
 
-import co.cask.cdap.api.dataset.lib.cube.TagValue;
+import co.cask.cdap.api.dataset.lib.cube.DimensionValue;
 import co.cask.cdap.api.dataset.lib.cube.TimeValue;
 
 import java.util.Iterator;
@@ -27,12 +27,12 @@ import java.util.List;
  */
 public final class FactScanResult implements Iterable<TimeValue> {
   private final String measureName;
-  private final List<TagValue> tagValues;
+  private final List<DimensionValue> dimensionValues;
   private final Iterable<TimeValue> timeValues;
 
-  public FactScanResult(String measureName, List<TagValue> tagValues, Iterable<TimeValue> timeValues) {
+  public FactScanResult(String measureName, List<DimensionValue> dimensionValues, Iterable<TimeValue> timeValues) {
     this.measureName = measureName;
-    this.tagValues = tagValues;
+    this.dimensionValues = dimensionValues;
     this.timeValues = timeValues;
   }
 
@@ -40,8 +40,8 @@ public final class FactScanResult implements Iterable<TimeValue> {
     return measureName;
   }
 
-  public List<TagValue> getTagValues() {
-    return tagValues;
+  public List<DimensionValue> getDimensionValues() {
+    return dimensionValues;
   }
 
   @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/timeseries/FactScanner.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/timeseries/FactScanner.java
@@ -17,7 +17,7 @@
 package co.cask.cdap.data2.dataset2.lib.timeseries;
 
 import co.cask.cdap.api.common.Bytes;
-import co.cask.cdap.api.dataset.lib.cube.TagValue;
+import co.cask.cdap.api.dataset.lib.cube.DimensionValue;
 import co.cask.cdap.api.dataset.lib.cube.TimeValue;
 import co.cask.cdap.api.dataset.table.Row;
 import co.cask.cdap.api.dataset.table.Scanner;
@@ -101,10 +101,10 @@ public final class FactScanner implements Iterator<FactScanResult> {
           if (!measureNames.isEmpty() && !measureNames.contains(measureName)) {
             continue;
           }
-          // todo: codec.getTagValues(rowKey) needs to un-encode tag names which may result in read in entity table
-          //       (depending on the cache and its state). To avoid that, we can pass to scanner the list of tag names
-          //       as we *always* know it (it is given) at the time of scanning
-          List<TagValue> tagValues = codec.getTagValues(rowKey);
+          // todo: codec.getDimensionValues(rowKey) needs to un-encode dimension names which may result in read in
+          //       entity table (depending on the cache and its state). To avoid that, we can pass to scanner the
+          //       list of dimension names as we *always* know it (it is given) at the time of scanning
+          List<DimensionValue> dimensionValues = codec.getDimensionValues(rowKey);
 
           boolean exhausted = false;
           List<TimeValue> timeValues = Lists.newLinkedList();
@@ -130,7 +130,7 @@ public final class FactScanner implements Iterator<FactScanResult> {
           }
 
           // todo: can return empty list, if all data is < startTs or > endTs
-          return new FactScanResult(measureName, tagValues, timeValues);
+          return new FactScanResult(measureName, dimensionValues, timeValues);
         }
 
         scanner.close();

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/cube/AbstractCubeTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/cube/AbstractCubeTest.java
@@ -47,14 +47,14 @@ public abstract class AbstractCubeTest {
 
   @Test
   public void testBasics() throws Exception {
-    Aggregation agg1 = new DefaultAggregation(ImmutableList.of("tag1", "tag2", "tag3"),
-                                              ImmutableList.of("tag1", "tag2"));
-    Aggregation agg2 = new DefaultAggregation(ImmutableList.of("tag1", "tag2"),
-                                              ImmutableList.of("tag1"));
+    Aggregation agg1 = new DefaultAggregation(ImmutableList.of("dim1", "dim2", "dim3"),
+                                              ImmutableList.of("dim1", "dim2"));
+    Aggregation agg2 = new DefaultAggregation(ImmutableList.of("dim1", "dim2"),
+                                              ImmutableList.of("dim1"));
 
     int resolution = 1;
     Cube cube = getCube("myCube", new int[] {resolution},
-                        ImmutableMap.<String, Aggregation>of("agg1", agg1, "agg2", agg2));
+                        ImmutableMap.of("agg1", agg1, "agg2", agg2));
 
     // write some data
     // NOTE: we mostly use different ts, as we are interested in checking incs not at persist, but rather at query time
@@ -84,68 +84,68 @@ public abstract class AbstractCubeTest {
     // todo: do some write instead of increments - test those as well
 
     // now let's query!
-    verifyCountQuery(cube, 0, 15, resolution, "metric1", ImmutableMap.of("tag1", "1"), ImmutableList.of("tag2"),
+    verifyCountQuery(cube, 0, 15, resolution, "metric1", ImmutableMap.of("dim1", "1"), ImmutableList.of("dim2"),
                      ImmutableList.of(
-                       new TimeSeries("metric1", tagValues("tag2", "1"), timeValues(1, 2, 7, 3, 10, 2, 11, 3)),
-                       new TimeSeries("metric1", tagValues("tag2", "2"), timeValues(3, 8))));
+                       new TimeSeries("metric1", dimensionValues("dim2", "1"), timeValues(1, 2, 7, 3, 10, 2, 11, 3)),
+                       new TimeSeries("metric1", dimensionValues("dim2", "2"), timeValues(3, 8))));
 
-    verifyCountQuery(cube, 0, 15, resolution, "metric1", ImmutableMap.of("tag1", "1", "tag2", "1", "tag3", "1"),
+    verifyCountQuery(cube, 0, 15, resolution, "metric1", ImmutableMap.of("dim1", "1", "dim2", "1", "dim3", "1"),
                      new ArrayList<String>(),
                      ImmutableList.of(
                        new TimeSeries("metric1", new HashMap<String, String>(), timeValues(1, 2, 10, 2, 11, 3))));
 
-    verifyCountQuery(cube, 0, 15, resolution, "metric1", new HashMap<String, String>(), ImmutableList.of("tag1"),
+    verifyCountQuery(cube, 0, 15, resolution, "metric1", new HashMap<String, String>(), ImmutableList.of("dim1"),
                      ImmutableList.of(
-                       new TimeSeries("metric1", tagValues("tag1", "1"),
+                       new TimeSeries("metric1", dimensionValues("dim1", "1"),
                                       timeValues(1, 2, 3, 8, 4, 4, 6, 6, 7, 3, 10, 2, 11, 3)),
-                       new TimeSeries("metric1", tagValues("tag1", "2"),
+                       new TimeSeries("metric1", dimensionValues("dim1", "2"),
                                       timeValues(3, 7, 12, 4))));
 
-    verifyCountQuery(cube, 0, 15, resolution, "metric1", ImmutableMap.of("tag3", "3"), new ArrayList<String>(),
+    verifyCountQuery(cube, 0, 15, resolution, "metric1", ImmutableMap.of("dim3", "3"), new ArrayList<String>(),
                      ImmutableList.of(
                        new TimeSeries("metric1", new HashMap<String, String>(), timeValues(3, 5))));
 
 
     // test querying specific aggregations
-    verifyCountQuery(cube, "agg1", 0, 15, resolution, "metric1", ImmutableMap.of("tag1", "1"), new ArrayList<String>(),
+    verifyCountQuery(cube, "agg1", 0, 15, resolution, "metric1", ImmutableMap.of("dim1", "1"), new ArrayList<String>(),
                      ImmutableList.of(new TimeSeries("metric1", new HashMap<String, String>(),
                                                      timeValues(1, 2, 3, 8, 7, 3, 10, 2, 11, 3))));
-    verifyCountQuery(cube, "agg2", 0, 15, resolution, "metric1", ImmutableMap.of("tag1", "1"), new ArrayList<String>(),
+    verifyCountQuery(cube, "agg2", 0, 15, resolution, "metric1", ImmutableMap.of("dim1", "1"), new ArrayList<String>(),
                      ImmutableList.of(new TimeSeries("metric1", new HashMap<String, String>(),
                                                      timeValues(1, 2, 3, 8, 4, 4, 6, 6, 7, 3, 10, 2, 11, 3))));
 
 
-    // delete cube data for "metric1" for tag->1,tag2->1,tag3->1 for timestamp 1 - 8 and
+    // delete cube data for "metric1" for dim->1,dim2->1,dim3->1 for timestamp 1 - 8 and
     // check data for other timestamp is available
 
     CubeDeleteQuery query = new CubeDeleteQuery(0, 8, resolution,
-                                                ImmutableMap.of("tag1", "1", "tag2", "1", "tag3", "1"),
+                                                ImmutableMap.of("dim1", "1", "dim2", "1", "dim3", "1"),
                                                 "metric1");
     cube.delete(query);
 
-    verifyCountQuery(cube, 0, 15, resolution, "metric1", ImmutableMap.of("tag1", "1", "tag2", "1", "tag3", "1"),
+    verifyCountQuery(cube, 0, 15, resolution, "metric1", ImmutableMap.of("dim1", "1", "dim2", "1", "dim3", "1"),
                      ImmutableList.<String>of(),
                      ImmutableList.of(
                        new TimeSeries("metric1", new HashMap<String, String>(), timeValues(10, 2, 11, 3))));
 
-    // delete cube data for "metric1" for tag1->1 and tag2->1  and check by scanning tag1->1 and tag2->1 is empty,
+    // delete cube data for "metric1" for dim1->1 and dim2->1  and check by scanning dim1->1 and dim2->1 is empty,
 
-    query = new CubeDeleteQuery(0, 15, resolution, ImmutableMap.of("tag1", "1", "tag2", "1"),
+    query = new CubeDeleteQuery(0, 15, resolution, ImmutableMap.of("dim1", "1", "dim2", "1"),
                                 "metric1");
     cube.delete(query);
 
-    verifyCountQuery(cube, 0, 15, resolution, "metric1", ImmutableMap.of("tag1", "1", "tag2", "1"),
+    verifyCountQuery(cube, 0, 15, resolution, "metric1", ImmutableMap.of("dim1", "1", "dim2", "1"),
                      ImmutableList.<String>of(), ImmutableList.<TimeSeries>of());
 
   }
 
   @Test
   public void testInterpolate() throws Exception {
-    Aggregation agg1 = new DefaultAggregation(ImmutableList.of("tag1", "tag2", "tag3"),
-                                              ImmutableList.of("tag1", "tag2", "tag3"));
+    Aggregation agg1 = new DefaultAggregation(ImmutableList.of("dim1", "dim2", "dim3"),
+                                              ImmutableList.of("dim1", "dim2", "dim3"));
     int resolution = 1;
     Cube cube = getCube("myInterpolatedCube", new int[] {resolution},
-                        ImmutableMap.<String, Aggregation>of("agg1", agg1));
+                        ImmutableMap.of("agg1", agg1));
     // test step interpolation
     long startTs = 1;
     long endTs = 10;
@@ -157,14 +157,14 @@ public abstract class AbstractCubeTest {
     }
     expectedTimeValues.add(new TimeValue(endTs, 3));
     verifyCountQuery(cube, startTs, endTs, resolution, "metric1",
-                     ImmutableMap.of("tag1", "1", "tag2", "1", "tag3", "1"),
+                     ImmutableMap.of("dim1", "1", "dim2", "1", "dim3", "1"),
                      new ArrayList<String>(),
                      ImmutableList.of(
                        new TimeSeries("metric1", new HashMap<String, String>(), expectedTimeValues)),
                      new Interpolators.Step());
 
     CubeDeleteQuery query = new CubeDeleteQuery(startTs, endTs, resolution,
-                                                ImmutableMap.of("tag1", "1", "tag2", "1", "tag3", "1"),
+                                                ImmutableMap.of("dim1", "1", "dim2", "1", "dim3", "1"),
                                                 "metric1");
     cube.delete(query);
     //test small-slope linear interpolation
@@ -173,7 +173,7 @@ public abstract class AbstractCubeTest {
     writeInc(cube, "metric1",  startTs,  5,  "1",  "1",  "1");
     writeInc(cube, "metric1",  endTs,  3,  "1",  "1",  "1");
     verifyCountQuery(cube, startTs, endTs, resolution, "metric1",
-                     ImmutableMap.of("tag1", "1", "tag2", "1", "tag3", "1"),
+                     ImmutableMap.of("dim1", "1", "dim2", "1", "dim3", "1"),
                      new ArrayList<String>(),
                      ImmutableList.of(
                        new TimeSeries("metric1", new HashMap<String, String>(), timeValues(1, 5, 2, 5, 3, 4,
@@ -181,7 +181,7 @@ public abstract class AbstractCubeTest {
                      new Interpolators.Linear());
 
     query = new CubeDeleteQuery(startTs, endTs, resolution,
-                                ImmutableMap.of("tag1", "1", "tag2", "1", "tag3", "1"),
+                                ImmutableMap.of("dim1", "1", "dim2", "1", "dim3", "1"),
                                 "metric1");
     cube.delete(query);
 
@@ -189,7 +189,7 @@ public abstract class AbstractCubeTest {
     writeInc(cube, "metric1",  startTs,  100,  "1",  "1",  "1");
     writeInc(cube, "metric1",  endTs,  500,  "1",  "1",  "1");
     verifyCountQuery(cube, startTs, endTs, resolution, "metric1",
-                     ImmutableMap.of("tag1", "1", "tag2", "1", "tag3", "1"),
+                     ImmutableMap.of("dim1", "1", "dim2", "1", "dim3", "1"),
                      new ArrayList<String>(),
                      ImmutableList.of(
                        new TimeSeries("metric1", new HashMap<String, String>(), timeValues(1, 100, 2, 200, 3, 300,
@@ -208,7 +208,7 @@ public abstract class AbstractCubeTest {
       expectedTimeValues.add(new TimeValue(i, 0));
     }
     expectedTimeValues.add(new TimeValue(limit + 1, 50));
-    verifyCountQuery(cube, 0, 21, resolution, "metric1", ImmutableMap.of("tag1", "1", "tag2", "1", "tag3", "1"),
+    verifyCountQuery(cube, 0, 21, resolution, "metric1", ImmutableMap.of("dim1", "1", "dim2", "1", "dim3", "1"),
                      new ArrayList<String>(),
                      ImmutableList.of(
                        new TimeSeries("metric1", new HashMap<String, String>(), expectedTimeValues)),
@@ -217,61 +217,63 @@ public abstract class AbstractCubeTest {
   }
 
 
-  private void writeInc(Cube cube, String measureName, long ts, long value, String... tags) throws Exception {
-    cube.add(getFact(measureName, ts, value, tags));
+  private void writeInc(Cube cube, String measureName, long ts, long value, String... dims) throws Exception {
+    cube.add(getFact(measureName, ts, value, dims));
   }
 
   private void writeIncViaBatchWritable(Cube cube, String measureName, long ts,
-                                        long value, String... tags) throws Exception {
+                                        long value, String... dims) throws Exception {
     // null for key: it is ignored
-    cube.write(null, getFact(measureName, ts, value, tags));
+    cube.write(null, getFact(measureName, ts, value, dims));
   }
 
-  private CubeFact getFact(String measureName, long ts, long value, String... tags) {
-    return new CubeFact(ts).addTags(tagValuesByValues(tags)).addMeasurement(measureName, MeasureType.COUNTER, value);
+  private CubeFact getFact(String measureName, long ts, long value, String... dims) {
+    return new CubeFact(ts)
+      .addDimensionValues(dimValuesByValues(dims))
+      .addMeasurement(measureName, MeasureType.COUNTER, value);
   }
 
-  private Map<String, String> tagValuesByValues(String... tags) {
-    Map<String, String> tagValues = Maps.newHashMap();
-    for (int i = 0; i < tags.length; i++) {
-      if (tags[i] != null) {
-        // +1 to start with "tag1"
-        tagValues.put("tag" + (i + 1), tags[i]);
+  private Map<String, String> dimValuesByValues(String... dims) {
+    Map<String, String> dimValues = Maps.newHashMap();
+    for (int i = 0; i < dims.length; i++) {
+      if (dims[i] != null) {
+        // +1 to start with "dim1"
+        dimValues.put("dim" + (i + 1), dims[i]);
       }
     }
-    return tagValues;
+    return dimValues;
   }
 
   private void verifyCountQuery(Cube cube, String aggregation, long startTs, long endTs, int resolution,
-                                String measureName, Map<String, String> sliceByTagValues, List<String> groupByTags,
+                                String measureName, Map<String, String> dimValues, List<String> groupByDims,
                                 Collection<TimeSeries> expected) throws Exception {
 
     verifyCountQuery(cube, aggregation, startTs, endTs, resolution,
-                     measureName, sliceByTagValues, groupByTags, expected, null);
+                     measureName, dimValues, groupByDims, expected, null);
   }
 
   private void verifyCountQuery(Cube cube, long startTs, long endTs, int resolution, String measureName,
-                                Map<String, String> sliceByTagValues, List<String> groupByTags,
+                                Map<String, String> dimValues, List<String> groupByDims,
                                 Collection<TimeSeries> expected) throws Exception {
 
     verifyCountQuery(cube, null, startTs, endTs, resolution,
-                     measureName, sliceByTagValues, groupByTags, expected, null);
+                     measureName, dimValues, groupByDims, expected, null);
   }
 
   private void verifyCountQuery(Cube cube, long startTs, long endTs, int resolution,
-                                String measureName, Map<String, String> sliceByTagValues, List<String> groupByTags,
+                                String measureName, Map<String, String> dimValues, List<String> groupByDims,
                                 Collection<TimeSeries> expected, Interpolator interpolator) throws Exception {
 
     verifyCountQuery(cube, null, startTs, endTs, resolution,
-                     measureName, sliceByTagValues, groupByTags, expected, interpolator);
+                     measureName, dimValues, groupByDims, expected, interpolator);
   }
 
   private void verifyCountQuery(Cube cube, String aggregation, long startTs, long endTs, int resolution,
-                                String measureName, Map<String, String> sliceByTagValues, List<String> groupByTags,
+                                String measureName, Map<String, String> dimValues, List<String> groupByDims,
                                 Collection<TimeSeries> expected, Interpolator interpolator) throws Exception {
 
     CubeQuery query = new CubeQuery(aggregation, startTs, endTs, resolution, Integer.MAX_VALUE,
-                                    measureName, MeasureType.COUNTER, sliceByTagValues, groupByTags, interpolator);
+                                    measureName, MeasureType.COUNTER, dimValues, groupByDims, interpolator);
 
     Collection<TimeSeries> result = cube.query(query);
     Assert.assertEquals(expected.size(), result.size());
@@ -286,11 +288,11 @@ public abstract class AbstractCubeTest {
     return timeValues;
   }
 
-  private Map<String, String> tagValues(String... tags) {
-    Map<String, String> tagValues = Maps.newTreeMap();
-    for (int i = 0; i < tags.length; i += 2) {
-      tagValues.put(tags[i], tags[i + 1]);
+  private Map<String, String> dimensionValues(String... dims) {
+    Map<String, String> dimValues = Maps.newTreeMap();
+    for (int i = 0; i < dims.length; i += 2) {
+      dimValues.put(dims[i], dims[i + 1]);
     }
-    return tagValues;
+    return dimValues;
   }
 }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/cube/CubeDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/cube/CubeDatasetTest.java
@@ -23,7 +23,7 @@ import co.cask.cdap.api.dataset.lib.cube.CubeDeleteQuery;
 import co.cask.cdap.api.dataset.lib.cube.CubeExploreQuery;
 import co.cask.cdap.api.dataset.lib.cube.CubeFact;
 import co.cask.cdap.api.dataset.lib.cube.CubeQuery;
-import co.cask.cdap.api.dataset.lib.cube.TagValue;
+import co.cask.cdap.api.dataset.lib.cube.DimensionValue;
 import co.cask.cdap.api.dataset.lib.cube.TimeSeries;
 import co.cask.cdap.data2.dataset2.DatasetFrameworkTestUtil;
 import co.cask.cdap.proto.Id;
@@ -70,8 +70,8 @@ public class CubeDatasetTest extends AbstractCubeTest {
       // NOTE: at this moment we support only DefaultAggregation, so all other tests in AbstractCubeTest must be skipped
       DefaultAggregation defAgg = (DefaultAggregation) entry.getValue();
       String aggPropertyPrefix = CubeDatasetDefinition.PROPERTY_AGGREGATION_PREFIX + (entry.getKey());
-      builder.add(aggPropertyPrefix + ".tags", Joiner.on(",").join(defAgg.getTagNames()));
-      builder.add(aggPropertyPrefix + ".requiredTags", Joiner.on(",").join(defAgg.getRequiredTags()));
+      builder.add(aggPropertyPrefix + ".dimensions", Joiner.on(",").join(defAgg.getDimensionNames()));
+      builder.add(aggPropertyPrefix + ".requiredDimensions", Joiner.on(",").join(defAgg.getRequiredDimensions()));
     }
 
     return builder.build();
@@ -127,11 +127,11 @@ public class CubeDatasetTest extends AbstractCubeTest {
     }
 
     @Override
-    public Collection<TagValue> findNextAvailableTags(final CubeExploreQuery query) {
-      return txnl.executeUnchecked(new Callable<Collection<TagValue>>() {
+    public Collection<DimensionValue> findDimensionValues(final CubeExploreQuery query) {
+      return txnl.executeUnchecked(new Callable<Collection<DimensionValue>>() {
         @Override
-        public Collection<TagValue> call() {
-          return delegate.findNextAvailableTags(query);
+        public Collection<DimensionValue> call() {
+          return delegate.findDimensionValues(query);
         }
       });
     }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/timeseries/FactCodecTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/timeseries/FactCodecTest.java
@@ -16,7 +16,7 @@
 
 package co.cask.cdap.data2.dataset2.lib.timeseries;
 
-import co.cask.cdap.api.dataset.lib.cube.TagValue;
+import co.cask.cdap.api.dataset.lib.cube.DimensionValue;
 import co.cask.cdap.common.utils.ImmutablePair;
 import co.cask.cdap.data2.dataset2.lib.table.FuzzyRowFilter;
 import co.cask.cdap.data2.dataset2.lib.table.MetricsTable;
@@ -41,116 +41,116 @@ public class FactCodecTest {
     int rollTimebaseInterval = 2;
     FactCodec codec = new FactCodec(new EntityTable(table), resolution, rollTimebaseInterval);
 
-    // testing encoding with multiple tags
-    List<TagValue> tagValues = ImmutableList.of(new TagValue("tag1", "value1"),
-                                                new TagValue("tag2", "value2"),
-                                                new TagValue("tag3", "value3"));
+    // testing encoding with multiple dimensions
+    List<DimensionValue> dimensionValues = ImmutableList.of(new DimensionValue("dimension1", "value1"),
+                                                new DimensionValue("dimension2", "value2"),
+                                                new DimensionValue("dimension3", "value3"));
     // note: we use seconds everywhere and rely on this
     long ts = 1422312915;
-    byte[] rowKey = codec.createRowKey(tagValues, "myMetric", ts);
+    byte[] rowKey = codec.createRowKey(dimensionValues, "myMetric", ts);
     byte[] column = codec.createColumn(ts);
 
     Assert.assertEquals((ts / resolution) * resolution, codec.getTimestamp(rowKey, column));
-    Assert.assertEquals(tagValues, codec.getTagValues(rowKey));
+    Assert.assertEquals(dimensionValues, codec.getDimensionValues(rowKey));
     Assert.assertEquals("myMetric", codec.getMeasureName(rowKey));
 
-    // testing encoding without one tag
-    tagValues = ImmutableList.of(new TagValue("myTag", "myValue"));
-    rowKey = codec.createRowKey(tagValues, "mySingleTagMetric", ts);
+    // testing encoding without one dimension
+    dimensionValues = ImmutableList.of(new DimensionValue("myTag", "myValue"));
+    rowKey = codec.createRowKey(dimensionValues, "mySingleTagMetric", ts);
     Assert.assertEquals((ts / resolution) * resolution, codec.getTimestamp(rowKey, column));
-    Assert.assertEquals(tagValues, codec.getTagValues(rowKey));
+    Assert.assertEquals(dimensionValues, codec.getDimensionValues(rowKey));
     Assert.assertEquals("mySingleTagMetric", codec.getMeasureName(rowKey));
 
-    // testing encoding without empty tags
-    rowKey = codec.createRowKey(new ArrayList<TagValue>(), "myNoTagsMetric", ts);
+    // testing encoding without empty dimensions
+    rowKey = codec.createRowKey(new ArrayList<DimensionValue>(), "myNoTagsMetric", ts);
     Assert.assertEquals((ts / resolution) * resolution, codec.getTimestamp(rowKey, column));
-    Assert.assertEquals(new ArrayList<TagValue>(), codec.getTagValues(rowKey));
+    Assert.assertEquals(new ArrayList<DimensionValue>(), codec.getDimensionValues(rowKey));
     Assert.assertEquals("myNoTagsMetric", codec.getMeasureName(rowKey));
 
     // testing null metric
-    tagValues = ImmutableList.of(new TagValue("myTag", "myValue"));
-    rowKey = codec.createRowKey(tagValues, "mySingleTagMetric", ts);
+    dimensionValues = ImmutableList.of(new DimensionValue("myTag", "myValue"));
+    rowKey = codec.createRowKey(dimensionValues, "mySingleTagMetric", ts);
     Assert.assertEquals((ts / resolution) * resolution, codec.getTimestamp(rowKey, column));
-    Assert.assertEquals(tagValues, codec.getTagValues(rowKey));
+    Assert.assertEquals(dimensionValues, codec.getDimensionValues(rowKey));
     Assert.assertEquals("mySingleTagMetric", codec.getMeasureName(rowKey));
 
     // testing null value
-    tagValues = ImmutableList.of(new TagValue("tag1", "value1"),
-                                 new TagValue("tag2", null),
-                                 new TagValue("tag3", "value3"));
-    rowKey = codec.createRowKey(tagValues, "myNullTagMetric", ts);
+    dimensionValues = ImmutableList.of(new DimensionValue("dimension1", "value1"),
+                                 new DimensionValue("dimension2", null),
+                                 new DimensionValue("dimension3", "value3"));
+    rowKey = codec.createRowKey(dimensionValues, "myNullTagMetric", ts);
     Assert.assertEquals((ts / resolution) * resolution, codec.getTimestamp(rowKey, column));
-    Assert.assertEquals(tagValues, codec.getTagValues(rowKey));
+    Assert.assertEquals(dimensionValues, codec.getDimensionValues(rowKey));
     Assert.assertEquals("myNullTagMetric", codec.getMeasureName(rowKey));
 
     // testing fuzzy mask for fuzzy stuff in row key
-    tagValues = ImmutableList.of(new TagValue("tag1", "value1"),
-                                 new TagValue("tag2", null), // any value is accepted
-                                 new TagValue("tag3", "value3"));
-    byte[] mask = codec.createFuzzyRowMask(tagValues, "myMetric");
-    rowKey = codec.createRowKey(tagValues, "myMetric", ts);
+    dimensionValues = ImmutableList.of(new DimensionValue("dimension1", "value1"),
+                                 new DimensionValue("dimension2", null), // any value is accepted
+                                 new DimensionValue("dimension3", "value3"));
+    byte[] mask = codec.createFuzzyRowMask(dimensionValues, "myMetric");
+    rowKey = codec.createRowKey(dimensionValues, "myMetric", ts);
     FuzzyRowFilter filter = new FuzzyRowFilter(ImmutableList.of(new ImmutablePair<byte[], byte[]>(rowKey, mask)));
 
-    tagValues = ImmutableList.of(new TagValue("tag1", "value1"),
-                                 new TagValue("tag2", "annnnnnnnnny"),
-                                 new TagValue("tag3", "value3"));
-    rowKey = codec.createRowKey(tagValues, "myMetric", ts);
+    dimensionValues = ImmutableList.of(new DimensionValue("dimension1", "value1"),
+                                 new DimensionValue("dimension2", "annnnnnnnnny"),
+                                 new DimensionValue("dimension3", "value3"));
+    rowKey = codec.createRowKey(dimensionValues, "myMetric", ts);
     Assert.assertEquals(FuzzyRowFilter.ReturnCode.INCLUDE, filter.filterRow(rowKey));
 
-    tagValues = ImmutableList.of(new TagValue("tag1", "value12"),
-                                 new TagValue("tag2", "value2"),
-                                 new TagValue("tag3", "value3"));
-    rowKey = codec.createRowKey(tagValues, "myMetric", ts);
+    dimensionValues = ImmutableList.of(new DimensionValue("dimension1", "value12"),
+                                 new DimensionValue("dimension2", "value2"),
+                                 new DimensionValue("dimension3", "value3"));
+    rowKey = codec.createRowKey(dimensionValues, "myMetric", ts);
     Assert.assertTrue(FuzzyRowFilter.ReturnCode.INCLUDE != filter.filterRow(rowKey));
 
-    tagValues = ImmutableList.of(new TagValue("tag1", "value1"),
-                                 new TagValue("tag2", "value2"),
-                                 new TagValue("tag3", "value13"));
-    rowKey = codec.createRowKey(tagValues, "myMetric", ts);
+    dimensionValues = ImmutableList.of(new DimensionValue("dimension1", "value1"),
+                                 new DimensionValue("dimension2", "value2"),
+                                 new DimensionValue("dimension3", "value13"));
+    rowKey = codec.createRowKey(dimensionValues, "myMetric", ts);
     Assert.assertTrue(FuzzyRowFilter.ReturnCode.INCLUDE != filter.filterRow(rowKey));
 
-    tagValues = ImmutableList.of(new TagValue("tag1", "value1"),
-                                 new TagValue("tag3", "value3"));
-    rowKey = codec.createRowKey(tagValues, "myMetric", ts);
+    dimensionValues = ImmutableList.of(new DimensionValue("dimension1", "value1"),
+                                 new DimensionValue("dimension3", "value3"));
+    rowKey = codec.createRowKey(dimensionValues, "myMetric", ts);
     Assert.assertTrue(FuzzyRowFilter.ReturnCode.INCLUDE != filter.filterRow(rowKey));
 
     // fuzzy in value should match the "null" value
-    tagValues = ImmutableList.of(new TagValue("tag1", "value1"),
-                                 new TagValue("tag2", null),
-                                 new TagValue("tag3", "value3"));
-    rowKey = codec.createRowKey(tagValues, "myMetric", ts);
+    dimensionValues = ImmutableList.of(new DimensionValue("dimension1", "value1"),
+                                 new DimensionValue("dimension2", null),
+                                 new DimensionValue("dimension3", "value3"));
+    rowKey = codec.createRowKey(dimensionValues, "myMetric", ts);
     Assert.assertEquals(FuzzyRowFilter.ReturnCode.INCLUDE, filter.filterRow(rowKey));
 
-    tagValues = ImmutableList.of(new TagValue("tag1", "value1"),
-                                 new TagValue("tag2", "value2"),
-                                 new TagValue("tag3", "value3"));
-    rowKey = codec.createRowKey(tagValues, "myMetric2", ts);
+    dimensionValues = ImmutableList.of(new DimensionValue("dimension1", "value1"),
+                                 new DimensionValue("dimension2", "value2"),
+                                 new DimensionValue("dimension3", "value3"));
+    rowKey = codec.createRowKey(dimensionValues, "myMetric2", ts);
     Assert.assertTrue(FuzzyRowFilter.ReturnCode.INCLUDE != filter.filterRow(rowKey));
 
-    rowKey = codec.createRowKey(tagValues, null, ts);
+    rowKey = codec.createRowKey(dimensionValues, null, ts);
     Assert.assertTrue(FuzzyRowFilter.ReturnCode.INCLUDE != filter.filterRow(rowKey));
 
-    rowKey = codec.createRowKey(new ArrayList<TagValue>(), "myMetric", ts);
+    rowKey = codec.createRowKey(new ArrayList<DimensionValue>(), "myMetric", ts);
     Assert.assertTrue(FuzzyRowFilter.ReturnCode.INCLUDE != filter.filterRow(rowKey));
 
     // testing fuzzy mask for fuzzy metric
-    tagValues = ImmutableList.of(new TagValue("myTag", "myValue"));
-    rowKey = codec.createRowKey(tagValues, null, ts);
-    mask = codec.createFuzzyRowMask(tagValues, null);
+    dimensionValues = ImmutableList.of(new DimensionValue("myTag", "myValue"));
+    rowKey = codec.createRowKey(dimensionValues, null, ts);
+    mask = codec.createFuzzyRowMask(dimensionValues, null);
     filter = new FuzzyRowFilter(ImmutableList.of(new ImmutablePair<byte[], byte[]>(rowKey, mask)));
 
-    rowKey = codec.createRowKey(tagValues, "annyyy", ts);
+    rowKey = codec.createRowKey(dimensionValues, "annyyy", ts);
     Assert.assertEquals(FuzzyRowFilter.ReturnCode.INCLUDE, filter.filterRow(rowKey));
 
-    rowKey = codec.createRowKey(tagValues, "zzzzzzzzzzzz", ts);
+    rowKey = codec.createRowKey(dimensionValues, "zzzzzzzzzzzz", ts);
     Assert.assertEquals(FuzzyRowFilter.ReturnCode.INCLUDE, filter.filterRow(rowKey));
 
-    tagValues = ImmutableList.of(new TagValue("myTag", "myValue2"));
-    rowKey = codec.createRowKey(tagValues, "metric", ts);
+    dimensionValues = ImmutableList.of(new DimensionValue("myTag", "myValue2"));
+    rowKey = codec.createRowKey(dimensionValues, "metric", ts);
     Assert.assertTrue(FuzzyRowFilter.ReturnCode.INCLUDE != filter.filterRow(rowKey));
 
 
-    // todo: test prefix of multi tag valued row key is not same one tag valued row key
+    // todo: test prefix of multi dimension valued row key is not same one dimension valued row key
     // todo: test that rollTimebaseInterval applies well
   }
 }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/timeseries/FactTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/timeseries/FactTableTest.java
@@ -15,9 +15,9 @@
  */
 package co.cask.cdap.data2.dataset2.lib.timeseries;
 
+import co.cask.cdap.api.dataset.lib.cube.DimensionValue;
 import co.cask.cdap.api.dataset.lib.cube.MeasureType;
 import co.cask.cdap.api.dataset.lib.cube.Measurement;
-import co.cask.cdap.api.dataset.lib.cube.TagValue;
 import co.cask.cdap.api.dataset.lib.cube.TimeValue;
 import co.cask.cdap.data2.dataset2.lib.table.inmemory.InMemoryMetricsTable;
 import co.cask.cdap.data2.dataset2.lib.table.inmemory.InMemoryTableService;
@@ -56,10 +56,10 @@ public class FactTableTest {
     // "/1000" because time is expected to be in seconds
     long ts = ((System.currentTimeMillis() / 1000) / resolution) * resolution;
 
-    // testing encoding with multiple tags
-    List<TagValue> tagValues = ImmutableList.of(new TagValue("tag1", "value1"),
-                                                new TagValue("tag2", "value2"),
-                                                new TagValue("tag3", "value3"));
+    // testing encoding with multiple dims
+    List<DimensionValue> dimensionValues = ImmutableList.of(new DimensionValue("dim1", "value1"),
+                                                new DimensionValue("dim2", "value2"),
+                                                new DimensionValue("dim3", "value3"));
 
 
     // trying adding one by one, in same (first) time resolution bucket
@@ -67,14 +67,15 @@ public class FactTableTest {
       for (int k = 1; k < 4; k++) {
         // note: "+i" here and below doesn't affect results, just to confirm
         //       that data points are rounded to the resolution
-        table.add(ImmutableList.of(new Fact(ts + i, tagValues, new Measurement("metric" + k, MeasureType.COUNTER, k))));
+        table.add(ImmutableList.of(new Fact(ts + i, dimensionValues,
+                                            new Measurement("metric" + k, MeasureType.COUNTER, k))));
       }
     }
 
     // trying adding one by one, in different time resolution buckets
     for (int i = 0; i < 3; i++) {
       for (int k = 1; k < 4; k++) {
-        table.add(ImmutableList.of(new Fact(ts + resolution * i + i, tagValues,
+        table.add(ImmutableList.of(new Fact(ts + resolution * i + i, dimensionValues,
                                             new Measurement("metric" + k, MeasureType.COUNTER, 2 * k))));
       }
     }
@@ -84,13 +85,14 @@ public class FactTableTest {
     List<Fact> aggs = Lists.newArrayList();
     for (int i = 0; i < 7; i++) {
       for (int k = 1; k < 4; k++) {
-        aggs.add(new Fact(ts + resolution, tagValues, new Measurement("metric" + k, MeasureType.COUNTER, 3 * k)));
+        aggs.add(new Fact(ts + resolution, dimensionValues, new Measurement("metric" + k, MeasureType.COUNTER, 3 * k)));
       }
     }
     // then incs in different time resolution buckets
     for (int i = 0; i < 3; i++) {
       for (int k = 1; k < 4; k++) {
-        aggs.add(new Fact(ts + resolution * i, tagValues, new Measurement("metric" + k, MeasureType.COUNTER, 4 * k)));
+        aggs.add(new Fact(ts + resolution * i, dimensionValues,
+                          new Measurement("metric" + k, MeasureType.COUNTER, 4 * k)));
       }
     }
 
@@ -98,9 +100,9 @@ public class FactTableTest {
 
     // verify each metric
     for (int k = 1; k < 4; k++) {
-      FactScan scan = new FactScan(ts - 2 * resolution, ts + 3 * resolution, "metric" + k, tagValues);
-      Table<String, List<TagValue>, List<TimeValue>> expected = HashBasedTable.create();
-      expected.put("metric" + k, tagValues, ImmutableList.of(new TimeValue(ts, 11 * k),
+      FactScan scan = new FactScan(ts - 2 * resolution, ts + 3 * resolution, "metric" + k, dimensionValues);
+      Table<String, List<DimensionValue>, List<TimeValue>> expected = HashBasedTable.create();
+      expected.put("metric" + k, dimensionValues, ImmutableList.of(new TimeValue(ts, 11 * k),
                                                              new TimeValue(ts + resolution, 27 * k),
                                                              new TimeValue(ts + 2 * resolution, 6 * k)));
       assertScan(table, expected, scan);
@@ -108,92 +110,93 @@ public class FactTableTest {
 
     // verify each metric within a single timeBase
     for (int k = 1; k < 4; k++) {
-      FactScan scan = new FactScan(ts, ts + resolution - 1, "metric" + k, tagValues);
-      Table<String, List<TagValue>, List<TimeValue>> expected = HashBasedTable.create();
-      expected.put("metric" + k, tagValues, ImmutableList.of(new TimeValue(ts, 11 * k)));
+      FactScan scan = new FactScan(ts, ts + resolution - 1, "metric" + k, dimensionValues);
+      Table<String, List<DimensionValue>, List<TimeValue>> expected = HashBasedTable.create();
+      expected.put("metric" + k, dimensionValues, ImmutableList.of(new TimeValue(ts, 11 * k)));
       assertScan(table, expected, scan);
     }
 
     // verify all metrics with fuzzy metric in scan
-    Table<String, List<TagValue>, List<TimeValue>> expected = HashBasedTable.create();
+    Table<String, List<DimensionValue>, List<TimeValue>> expected = HashBasedTable.create();
     for (int k = 1; k < 4; k++) {
-      expected.put("metric" + k, tagValues, ImmutableList.of(new TimeValue(ts, 11 * k),
+      expected.put("metric" + k, dimensionValues, ImmutableList.of(new TimeValue(ts, 11 * k),
                                                              new TimeValue(ts + resolution, 27 * k),
                                                              new TimeValue(ts + 2 * resolution, 6 * k)));
     }
     // metric = null means "all"
-    FactScan scan = new FactScan(ts - 2 * resolution, ts + 3 * resolution, tagValues);
+    FactScan scan = new FactScan(ts - 2 * resolution, ts + 3 * resolution, dimensionValues);
     assertScan(table, expected, scan);
 
     // delete metric test
     expected.clear();
 
     // delete the metrics data at (timestamp + 20) resolution
-    scan = new FactScan(ts + resolution * 2, ts + resolution * 3, tagValues);
+    scan = new FactScan(ts + resolution * 2, ts + resolution * 3, dimensionValues);
     table.delete(scan);
     for (int k = 1; k < 4; k++) {
-      expected.put("metric" + k, tagValues, ImmutableList.of(new TimeValue(ts, 11 * k),
+      expected.put("metric" + k, dimensionValues, ImmutableList.of(new TimeValue(ts, 11 * k),
                                                              new TimeValue(ts + resolution, 27 * k)));
     }
     // verify deletion
-    scan = new FactScan(ts - 2 * resolution, ts + 3 * resolution, tagValues);
+    scan = new FactScan(ts - 2 * resolution, ts + 3 * resolution, dimensionValues);
     assertScan(table, expected, scan);
 
     // delete metrics for "metric1" at ts0 and verify deletion
-    scan = new FactScan(ts, ts + 1, "metric1", tagValues);
+    scan = new FactScan(ts, ts + 1, "metric1", dimensionValues);
     table.delete(scan);
     expected.clear();
-    expected.put("metric1", tagValues, ImmutableList.of(new TimeValue(ts + resolution, 27)));
-    scan = new FactScan(ts - 2 * resolution, ts + 3 * resolution, "metric1", tagValues);
+    expected.put("metric1", dimensionValues, ImmutableList.of(new TimeValue(ts + resolution, 27)));
+    scan = new FactScan(ts - 2 * resolution, ts + 3 * resolution, "metric1", dimensionValues);
     assertScan(table, expected, scan);
 
-    // verify the next tags search
-    Collection<TagValue> nextTags =
-      table.findSingleTagValue(ImmutableList.of("tag1", "tag2", "tag3"), ImmutableMap.of("tag1", "value1"), ts, ts + 1);
-    Assert.assertEquals(ImmutableSet.of(new TagValue("tag2", "value2")), nextTags);
+    // verify the next dims search
+    Collection<DimensionValue> nextTags =
+      table.findSingleDimensionValue(ImmutableList.of("dim1", "dim2", "dim3"),
+                                     ImmutableMap.of("dim1", "value1"), ts, ts + 1);
+    Assert.assertEquals(ImmutableSet.of(new DimensionValue("dim2", "value2")), nextTags);
 
     Map<String, String> slice = Maps.newHashMap();
-    slice.put("tag1", null);
-    nextTags = table.findSingleTagValue(ImmutableList.of("tag1", "tag2", "tag3"), slice, ts, ts + 1);
-    Assert.assertEquals(ImmutableSet.of(new TagValue("tag2", "value2")), nextTags);
+    slice.put("dim1", null);
+    nextTags = table.findSingleDimensionValue(ImmutableList.of("dim1", "dim2", "dim3"), slice, ts, ts + 1);
+    Assert.assertEquals(ImmutableSet.of(new DimensionValue("dim2", "value2")), nextTags);
 
-    nextTags = table.findSingleTagValue(ImmutableList.of("tag1", "tag2", "tag3"),
-                                        ImmutableMap.of("tag1", "value1", "tag2", "value2"), ts, ts + 3);
-    Assert.assertEquals(ImmutableSet.of(new TagValue("tag3", "value3")), nextTags);
+    nextTags = table.findSingleDimensionValue(ImmutableList.of("dim1", "dim2", "dim3"),
+                                              ImmutableMap.of("dim1", "value1", "dim2", "value2"), ts, ts + 3);
+    Assert.assertEquals(ImmutableSet.of(new DimensionValue("dim3", "value3")), nextTags);
 
-    // add new tag values
-    tagValues = ImmutableList.of(new TagValue("tag1", "value1"),
-                                 new TagValue("tag2", "value5"),
-                                 new TagValue("tag3", null));
-    table.add(ImmutableList.of(new Fact(ts, tagValues, new Measurement("metric", MeasureType.COUNTER, 10))));
+    // add new dim values
+    dimensionValues = ImmutableList.of(new DimensionValue("dim1", "value1"),
+                                 new DimensionValue("dim2", "value5"),
+                                 new DimensionValue("dim3", null));
+    table.add(ImmutableList.of(new Fact(ts, dimensionValues, new Measurement("metric", MeasureType.COUNTER, 10))));
 
-    tagValues = ImmutableList.of(new TagValue("tag1", "value1"),
-                                 new TagValue("tag2", null),
-                                 new TagValue("tag3", "value3"));
-    table.add(ImmutableList.of(new Fact(ts, tagValues, new Measurement("metric", MeasureType.COUNTER, 10))));
+    dimensionValues = ImmutableList.of(new DimensionValue("dim1", "value1"),
+                                 new DimensionValue("dim2", null),
+                                 new DimensionValue("dim3", "value3"));
+    table.add(ImmutableList.of(new Fact(ts, dimensionValues, new Measurement("metric", MeasureType.COUNTER, 10))));
 
-    nextTags = table.findSingleTagValue(ImmutableList.of("tag1", "tag2", "tag3"),
-                                        ImmutableMap.of("tag1", "value1"), ts, ts + 1);
-    Assert.assertEquals(ImmutableSet.of(new TagValue("tag2", "value2"),
-                                        new TagValue("tag2", "value5"),
-                                        new TagValue("tag3", "value3")), nextTags);
+    nextTags = table.findSingleDimensionValue(ImmutableList.of("dim1", "dim2", "dim3"),
+                                              ImmutableMap.of("dim1", "value1"), ts, ts + 1);
+    Assert.assertEquals(ImmutableSet.of(new DimensionValue("dim2", "value2"),
+                                        new DimensionValue("dim2", "value5"),
+                                        new DimensionValue("dim3", "value3")), nextTags);
 
-    // search for metric names given tags list and verify
+    // search for metric names given dims list and verify
 
     Collection<String> metricNames =
-      table.findMeasureNames(ImmutableList.of("tag1", "tag2", "tag3"),
-                             ImmutableMap.of("tag1", "value1", "tag2", "value2", "tag3", "value3"), ts, ts + 1);
+      table.findMeasureNames(ImmutableList.of("dim1", "dim2", "dim3"),
+                             ImmutableMap.of("dim1", "value1", "dim2", "value2", "dim3", "value3"), ts, ts + 1);
     Assert.assertEquals(ImmutableSet.of("metric2", "metric3"), metricNames);
 
-    metricNames = table.findMeasureNames(ImmutableList.of("tag1", "tag2", "tag3"),
-                                         ImmutableMap.of("tag1", "value1"), ts, ts + 1);
+    metricNames = table.findMeasureNames(ImmutableList.of("dim1", "dim2", "dim3"),
+                                         ImmutableMap.of("dim1", "value1"), ts, ts + 1);
     Assert.assertEquals(ImmutableSet.of("metric", "metric2", "metric3"), metricNames);
 
-    metricNames = table.findMeasureNames(ImmutableList.of("tag1", "tag2", "tag3"),
-                                         ImmutableMap.of("tag2", "value2"), ts, ts + 1);
+    metricNames = table.findMeasureNames(ImmutableList.of("dim1", "dim2", "dim3"),
+                                         ImmutableMap.of("dim2", "value2"), ts, ts + 1);
     Assert.assertEquals(ImmutableSet.of("metric2", "metric3"), metricNames);
 
-    metricNames = table.findMeasureNames(ImmutableList.of("tag1", "tag2", "tag3"),
+    metricNames = table.findMeasureNames(ImmutableList.of("dim1", "dim2", "dim3"),
                                          slice, ts, ts + 1);
     Assert.assertEquals(ImmutableSet.of("metric", "metric2", "metric3"), metricNames);
   }
@@ -212,48 +215,48 @@ public class FactTableTest {
     // aligned to start of resolution bucket
     // "/1000" because time is expected to be in seconds
     long ts = ((System.currentTimeMillis() / 1000) / resolution) * resolution;
-    List<String> aggregationList = ImmutableList.of("tag1", "tag2", "tag3", "tag4");
+    List<String> aggregationList = ImmutableList.of("dim1", "dim2", "dim3", "dim4");
 
     for (int i = 0; i < 2; i++) {
         writeInc(table, "metric-a" + i, ts  + i,  i,
-                 "tag1", "value1", "tag2", "value2", "tag3", "value3", "tag4", "value4");
+                 "dim1", "value1", "dim2", "value2", "dim3", "value3", "dim4", "value4");
         writeInc(table, "metric-b" + i, ts  + i,  i,
-                 "tag1", "value2", "tag2", "value2", "tag3", "x3", "tag4", "x4");
+                 "dim1", "value2", "dim2", "value2", "dim3", "x3", "dim4", "x4");
         writeInc(table, "metric-c" + i, ts  + i,  i,
-                 "tag1", "value2", "tag2", "value2", "tag3", null, "tag4", "y4");
+                 "dim1", "value2", "dim2", "value2", "dim3", null, "dim4", "y4");
         writeInc(table, "metric-d" + i, ts + i,  i,
-                 "tag1", "value1", "tag2", "value3", "tag3", "y3", "tag4", null);
+                 "dim1", "value1", "dim2", "value3", "dim3", "y3", "dim4", null);
     }
 
     Map<String, String> slice = Maps.newHashMap();
-    slice.put("tag1", "value2");
-    slice.put("tag2", "value2");
-    slice.put("tag3", null);
-    // verify search tags
-    testTagSearch(table, aggregationList, ImmutableMap.of("tag2", "value2"),
-                  ImmutableSet.of(new TagValue("tag1", "value1"), new TagValue("tag1", "value2")));
+    slice.put("dim1", "value2");
+    slice.put("dim2", "value2");
+    slice.put("dim3", null);
+    // verify search dims
+    testTagSearch(table, aggregationList, ImmutableMap.of("dim2", "value2"),
+                  ImmutableSet.of(new DimensionValue("dim1", "value1"), new DimensionValue("dim1", "value2")));
 
-    testTagSearch(table, aggregationList, ImmutableMap.of("tag1", "value1"),
-                  ImmutableSet.of(new TagValue("tag2", "value2"), new TagValue("tag2", "value3")));
+    testTagSearch(table, aggregationList, ImmutableMap.of("dim1", "value1"),
+                  ImmutableSet.of(new DimensionValue("dim2", "value2"), new DimensionValue("dim2", "value3")));
 
     testTagSearch(table, aggregationList, ImmutableMap.<String, String>of(),
-                  ImmutableSet.of(new TagValue("tag1", "value1"), new TagValue("tag1", "value2")));
+                  ImmutableSet.of(new DimensionValue("dim1", "value1"), new DimensionValue("dim1", "value2")));
 
-    testTagSearch(table, aggregationList, ImmutableMap.of("tag1", "value2", "tag2", "value2"),
-                  ImmutableSet.of(new TagValue("tag3", "x3"), new TagValue("tag4", "y4")));
+    testTagSearch(table, aggregationList, ImmutableMap.of("dim1", "value2", "dim2", "value2"),
+                  ImmutableSet.of(new DimensionValue("dim3", "x3"), new DimensionValue("dim4", "y4")));
 
     testTagSearch(table, aggregationList, slice,
-                  ImmutableSet.of(new TagValue("tag4", "x4"), new TagValue("tag4", "y4")));
+                  ImmutableSet.of(new DimensionValue("dim4", "x4"), new DimensionValue("dim4", "y4")));
 
-    testTagSearch(table, aggregationList, ImmutableMap.of("tag1", "value2", "tag2", "value3", "tag3", "y3"),
-                  ImmutableSet.<TagValue>of());
+    testTagSearch(table, aggregationList, ImmutableMap.of("dim1", "value2", "dim2", "value3", "dim3", "y3"),
+                  ImmutableSet.<DimensionValue>of());
 
     // verify search metrics
 
-    testMetricNamesSearch(table, aggregationList, ImmutableMap.of("tag1", "value1", "tag2", "value2", "tag3", "value3"),
+    testMetricNamesSearch(table, aggregationList, ImmutableMap.of("dim1", "value1", "dim2", "value2", "dim3", "value3"),
                           ImmutableSet.<String>of("metric-a0", "metric-a1"));
 
-    testMetricNamesSearch(table, aggregationList, ImmutableMap.of("tag2", "value2"),
+    testMetricNamesSearch(table, aggregationList, ImmutableMap.of("dim2", "value2"),
                           ImmutableSet.<String>of("metric-a0", "metric-a1", "metric-b0", "metric-b1",
                                                   "metric-c0", "metric-c1"));
 
@@ -271,10 +274,10 @@ public class FactTableTest {
   }
 
   private void testTagSearch(FactTable table, List<String> aggregation, Map<String, String> sliceBy,
-                             Set<TagValue> expectedResult) throws Exception {
+                             Set<DimensionValue> expectedResult) throws Exception {
     // using 0, 1 as start and endTs as resolution is INT_MAX
-    Collection<TagValue> nextTags =
-      table.findSingleTagValue(aggregation, sliceBy, 0 , 1);
+    Collection<DimensionValue> nextTags =
+      table.findSingleDimensionValue(aggregation, sliceBy, 0, 1);
     Assert.assertEquals(expectedResult, nextTags);
   }
   @Test
@@ -296,16 +299,16 @@ public class FactTableTest {
       for (int k = 1; k < 3; k++) {
         // note: "+i" to ts here and below doesn't affect results, just to confirm
         //       that data points are rounded to the resolution
-        writeInc(table, "metric" + k, ts + i * resolution + i, k + i, "tag1", "value1", "tag2", "value2");
-        writeInc(table, "metric" + k, ts + i * resolution + i, 2 * k + i, "tag1", "value2", "tag2", "value2");
-        writeInc(table, "metric" + k, ts + i * resolution + i, 3 * k + i, "tag1", "value2", "tag2", "value1");
-        writeInc(table, "metric" + k, ts + i * resolution + i, 4 * k + i, "tag1", "value1", "tag2", "value3");
-        // null value in tag matches only fuzzy ("any")
-        writeInc(table, "metric" + k, ts + i * resolution + i, 5 * k + i, "tag1", null, "tag2", "value3");
+        writeInc(table, "metric" + k, ts + i * resolution + i, k + i, "dim1", "value1", "dim2", "value2");
+        writeInc(table, "metric" + k, ts + i * resolution + i, 2 * k + i, "dim1", "value2", "dim2", "value2");
+        writeInc(table, "metric" + k, ts + i * resolution + i, 3 * k + i, "dim1", "value2", "dim2", "value1");
+        writeInc(table, "metric" + k, ts + i * resolution + i, 4 * k + i, "dim1", "value1", "dim2", "value3");
+        // null value in dim matches only fuzzy ("any")
+        writeInc(table, "metric" + k, ts + i * resolution + i, 5 * k + i, "dim1", null, "dim2", "value3");
       }
     }
 
-    Table<String, List<TagValue>, List<TimeValue>> expected;
+    Table<String, List<DimensionValue>, List<TimeValue>> expected;
     FactScan scan;
 
     // simple single metric scan
@@ -313,153 +316,153 @@ public class FactTableTest {
     for (int i = 1; i < 3; i++) {
       // all time points
       scan = new FactScan(ts - resolution, ts + 3 * resolution,
-                          "metric" + i, tagValues("tag1", "value1", "tag2", "value2"));
+                          "metric" + i, dimValues("dim1", "value1", "dim2", "value2"));
 
       expected = HashBasedTable.create();
-      expected.put("metric" + i, tagValues("tag1", "value1", "tag2", "value2"),
+      expected.put("metric" + i, dimValues("dim1", "value1", "dim2", "value2"),
                    timeValues(ts, resolution, i, i + 1, i + 2));
 
       assertScan(table, expected, scan);
 
       // time points since second interval
       scan = new FactScan(ts + resolution, ts + 3 * resolution,
-                          "metric" + i, tagValues("tag1", "value1", "tag2", "value2"));
+                          "metric" + i, dimValues("dim1", "value1", "dim2", "value2"));
 
       expected = HashBasedTable.create();
-      expected.put("metric" + i, tagValues("tag1", "value1", "tag2", "value2"),
+      expected.put("metric" + i, dimValues("dim1", "value1", "dim2", "value2"),
                    timeValues(ts + resolution, resolution, i + 1, i + 2));
 
       assertScan(table, expected, scan);
 
       // time points before third interval
       scan = new FactScan(ts - resolution, ts + resolution,
-                          "metric" + i, tagValues("tag1", "value1", "tag2", "value2"));
+                          "metric" + i, dimValues("dim1", "value1", "dim2", "value2"));
 
       expected = HashBasedTable.create();
-      expected.put("metric" + i, tagValues("tag1", "value1", "tag2", "value2"),
+      expected.put("metric" + i, dimValues("dim1", "value1", "dim2", "value2"),
                    timeValues(ts, resolution, i, i + 1));
 
       assertScan(table, expected, scan);
 
-      // time points for fuzzy tag2 since second interval
+      // time points for fuzzy dim2 since second interval
       scan = new FactScan(ts + resolution, ts + 3 * resolution,
                             // null stands for any
-                            "metric" + i, tagValues("tag1", "value1", "tag2", null));
+                            "metric" + i, dimValues("dim1", "value1", "dim2", null));
 
       expected = HashBasedTable.create();
-      expected.put("metric" + i, tagValues("tag1", "value1", "tag2", "value2"),
+      expected.put("metric" + i, dimValues("dim1", "value1", "dim2", "value2"),
                    timeValues(ts + resolution, resolution, i + 1, i + 2));
-      expected.put("metric" + i, tagValues("tag1", "value1", "tag2", "value3"),
+      expected.put("metric" + i, dimValues("dim1", "value1", "dim2", "value3"),
                    timeValues(ts + resolution, resolution, 4 * i + 1, 4 * i + 2));
 
       assertScan(table, expected, scan);
 
-      // time points for fuzzy tag1 before third interval
+      // time points for fuzzy dim1 before third interval
       scan = new FactScan(ts - resolution, ts + resolution,
                             // null stands for any
-                            "metric" + i, tagValues("tag1", null, "tag2", "value3"));
+                            "metric" + i, dimValues("dim1", null, "dim2", "value3"));
 
       expected = HashBasedTable.create();
-      expected.put("metric" + i, tagValues("tag1", "value1", "tag2", "value3"),
+      expected.put("metric" + i, dimValues("dim1", "value1", "dim2", "value3"),
                    timeValues(ts, resolution, 4 * i, 4 * i + 1));
-      expected.put("metric" + i, tagValues("tag1", null, "tag2", "value3"),
+      expected.put("metric" + i, dimValues("dim1", null, "dim2", "value3"),
                    timeValues(ts, resolution, 5 * i, 5 * i + 1));
 
       assertScan(table, expected, scan);
 
-      // time points for both fuzzy tags before third interval
+      // time points for both fuzzy dims before third interval
       scan = new FactScan(ts - resolution, ts + resolution,
                           // null stands for any
-                          "metric" + i, tagValues("tag1", null, "tag2", null));
+                          "metric" + i, dimValues("dim1", null, "dim2", null));
 
       expected = HashBasedTable.create();
-      expected.put("metric" + i, tagValues("tag1", "value1", "tag2", "value2"),
+      expected.put("metric" + i, dimValues("dim1", "value1", "dim2", "value2"),
                    timeValues(ts, resolution, i, i + 1));
-      expected.put("metric" + i, tagValues("tag1", "value2", "tag2", "value1"),
+      expected.put("metric" + i, dimValues("dim1", "value2", "dim2", "value1"),
                    timeValues(ts, resolution, 3 * i, 3 * i + 1));
-      expected.put("metric" + i, tagValues("tag1", "value2", "tag2", "value2"),
+      expected.put("metric" + i, dimValues("dim1", "value2", "dim2", "value2"),
                    timeValues(ts, resolution, 2 * i, 2 * i + 1));
-      expected.put("metric" + i, tagValues("tag1", "value1", "tag2", "value3"),
+      expected.put("metric" + i, dimValues("dim1", "value1", "dim2", "value3"),
                    timeValues(ts, resolution, 4 * i, 4 * i + 1));
-      expected.put("metric" + i, tagValues("tag1", null, "tag2", "value3"),
+      expected.put("metric" + i, dimValues("dim1", null, "dim2", "value3"),
                    timeValues(ts, resolution, 5 * i, 5 * i + 1));
 
       assertScan(table, expected, scan);
 
-      // time points for both fuzzy tags since third interval
+      // time points for both fuzzy dims since third interval
       scan = new FactScan(ts + resolution, ts + 3 * resolution,
                           // null stands for any
-                          "metric" + i, tagValues("tag1", null, "tag2", null));
+                          "metric" + i, dimValues("dim1", null, "dim2", null));
 
       expected = HashBasedTable.create();
-      expected.put("metric" + i, tagValues("tag1", "value1", "tag2", "value2"),
+      expected.put("metric" + i, dimValues("dim1", "value1", "dim2", "value2"),
                    timeValues(ts + resolution, resolution, i + 1, i + 2));
-      expected.put("metric" + i, tagValues("tag1", "value2", "tag2", "value1"),
+      expected.put("metric" + i, dimValues("dim1", "value2", "dim2", "value1"),
                    timeValues(ts + resolution, resolution, 3 * i + 1, 3 * i + 2));
-      expected.put("metric" + i, tagValues("tag1", "value2", "tag2", "value2"),
+      expected.put("metric" + i, dimValues("dim1", "value2", "dim2", "value2"),
                    timeValues(ts + resolution, resolution, 2 * i + 1, 2 * i + 2));
-      expected.put("metric" + i, tagValues("tag1", "value1", "tag2", "value3"),
+      expected.put("metric" + i, dimValues("dim1", "value1", "dim2", "value3"),
                    timeValues(ts + resolution, resolution, 4 * i + 1, 4 * i + 2));
-      expected.put("metric" + i, tagValues("tag1", null, "tag2", "value3"),
+      expected.put("metric" + i, dimValues("dim1", null, "dim2", "value3"),
                    timeValues(ts + resolution, resolution, 5 * i + 1, 5 * i + 2));
 
       assertScan(table, expected, scan);
     }
 
     // all time points
-    scan = new FactScan(ts - resolution, ts + 3 * resolution, tagValues("tag1", "value1", "tag2", "value2"));
+    scan = new FactScan(ts - resolution, ts + 3 * resolution, dimValues("dim1", "value1", "dim2", "value2"));
 
     expected = HashBasedTable.create();
     for (int i = 1; i < 3; i++) {
-      expected.put("metric" + i, tagValues("tag1", "value1", "tag2", "value2"),
+      expected.put("metric" + i, dimValues("dim1", "value1", "dim2", "value2"),
                    timeValues(ts, resolution, i, i + 1, i + 2));
     }
 
     assertScan(table, expected, scan);
 
     // time points since second interval
-    scan = new FactScan(ts + resolution, ts + 3 * resolution, tagValues("tag1", "value1", "tag2", "value2"));
+    scan = new FactScan(ts + resolution, ts + 3 * resolution, dimValues("dim1", "value1", "dim2", "value2"));
 
     expected = HashBasedTable.create();
     for (int i = 1; i < 3; i++) {
-      expected.put("metric" + i, tagValues("tag1", "value1", "tag2", "value2"),
+      expected.put("metric" + i, dimValues("dim1", "value1", "dim2", "value2"),
                    timeValues(ts + resolution, resolution, i + 1, i + 2));
     }
 
     assertScan(table, expected, scan);
 
     // time points before third interval
-    scan = new FactScan(ts - resolution, ts + resolution, tagValues("tag1", "value1", "tag2", "value2"));
+    scan = new FactScan(ts - resolution, ts + resolution, dimValues("dim1", "value1", "dim2", "value2"));
 
     expected = HashBasedTable.create();
     for (int i = 1; i < 3; i++) {
-      expected.put("metric" + i, tagValues("tag1", "value1", "tag2", "value2"),
+      expected.put("metric" + i, dimValues("dim1", "value1", "dim2", "value2"),
                    timeValues(ts, resolution, i, i + 1));
     }
 
     assertScan(table, expected, scan);
 
-    // time points for fuzzy tag2 since second interval
-    scan = new FactScan(ts + resolution, ts + 3 * resolution, tagValues("tag1", "value1", "tag2", null));
+    // time points for fuzzy dim2 since second interval
+    scan = new FactScan(ts + resolution, ts + 3 * resolution, dimValues("dim1", "value1", "dim2", null));
 
     expected = HashBasedTable.create();
     for (int i = 1; i < 3; i++) {
-      expected.put("metric" + i, tagValues("tag1", "value1", "tag2", "value2"),
+      expected.put("metric" + i, dimValues("dim1", "value1", "dim2", "value2"),
                    timeValues(ts + resolution, resolution, i + 1, i + 2));
-      expected.put("metric" + i, tagValues("tag1", "value1", "tag2", "value3"),
+      expected.put("metric" + i, dimValues("dim1", "value1", "dim2", "value3"),
                    timeValues(ts + resolution, resolution, 4 * i + 1, 4 * i + 2));
     }
 
     assertScan(table, expected, scan);
 
-    // time points for fuzzy tag1 before third interval (very important case - caught some bugs)
-    scan = new FactScan(ts - resolution, ts + resolution, tagValues("tag1", null, "tag2", "value3"));
+    // time points for fuzzy dim1 before third interval (very important case - caught some bugs)
+    scan = new FactScan(ts - resolution, ts + resolution, dimValues("dim1", null, "dim2", "value3"));
 
     expected = HashBasedTable.create();
     for (int i = 1; i < 3; i++) {
-      expected.put("metric" + i, tagValues("tag1", "value1", "tag2", "value3"),
+      expected.put("metric" + i, dimValues("dim1", "value1", "dim2", "value3"),
                    timeValues(ts, resolution, 4 * i, 4 * i + 1));
-      expected.put("metric" + i, tagValues("tag1", null, "tag2", "value3"),
+      expected.put("metric" + i, dimValues("dim1", null, "dim2", "value3"),
                    timeValues(ts, resolution, 5 * i, 5 * i + 1));
     }
 
@@ -486,16 +489,16 @@ public class FactTableTest {
     for (int i = 0; i < count; i++) {
       for (int k = 0; k < 10; k++) {
         // shift one day
-        writeInc(table, "metric" + k, ts + i * 60 * 60 * 24, i * k, "tag" + k, "value" + k);
+        writeInc(table, "metric" + k, ts + i * 60 * 60 * 24, i * k, "dim" + k, "value" + k);
       }
     }
 
     for (int k = 0; k < 10; k++) {
       // 0, 0 should match timestamp of all data points
-      FactScan scan = new FactScan(0, 0, "metric" + k, tagValues("tag" + k, "value" + k));
+      FactScan scan = new FactScan(0, 0, "metric" + k, dimValues("dim" + k, "value" + k));
 
-      Table<String, List<TagValue>, List<TimeValue>> expected = HashBasedTable.create();
-      expected.put("metric" + k, tagValues("tag" + k, "value" + k),
+      Table<String, List<DimensionValue>, List<TimeValue>> expected = HashBasedTable.create();
+      expected.put("metric" + k, dimValues("dim" + k, "value" + k),
                    ImmutableList.of(new TimeValue(0, k * count * (count - 1) / 2)));
 
       assertScan(table, expected, scan);
@@ -510,31 +513,31 @@ public class FactTableTest {
     return timeValues;
   }
 
-  private void writeInc(FactTable table, String metric, long ts, int value, String... tags)
+  private void writeInc(FactTable table, String metric, long ts, int value, String... dims)
     throws Exception {
 
-    table.add(ImmutableList.of(new Fact(ts, tagValues(tags), new Measurement(metric, MeasureType.COUNTER, value))));
+    table.add(ImmutableList.of(new Fact(ts, dimValues(dims), new Measurement(metric, MeasureType.COUNTER, value))));
   }
 
-  private List<TagValue> tagValues(String... tags) {
-    List<TagValue> tagValues = Lists.newArrayList();
-    for (int i = 0; i < tags.length; i += 2) {
-      tagValues.add(new TagValue(tags[i], tags[i + 1]));
+  private List<DimensionValue> dimValues(String... dims) {
+    List<DimensionValue> dimensionValues = Lists.newArrayList();
+    for (int i = 0; i < dims.length; i += 2) {
+      dimensionValues.add(new DimensionValue(dims[i], dims[i + 1]));
     }
-    return tagValues;
+    return dimensionValues;
   }
 
-  private void assertScan(FactTable table,
-                          Table<String, List<TagValue>, List<TimeValue>> expected, FactScan scan) throws Exception {
-    Table<String, List<TagValue>, List<TimeValue>> resultTable = HashBasedTable.create();
+  private void assertScan(FactTable table, Table<String, List<DimensionValue>, List<TimeValue>> expected,
+                          FactScan scan) throws Exception {
+    Table<String, List<DimensionValue>, List<TimeValue>> resultTable = HashBasedTable.create();
     FactScanner scanner = table.scan(scan);
     try {
       while (scanner.hasNext()) {
         FactScanResult result = scanner.next();
-        List<TimeValue> timeValues = resultTable.get(result.getMeasureName(), result.getTagValues());
+        List<TimeValue> timeValues = resultTable.get(result.getMeasureName(), result.getDimensionValues());
         if (timeValues == null) {
           timeValues = Lists.newArrayList();
-          resultTable.put(result.getMeasureName(), result.getTagValues(), timeValues);
+          resultTable.put(result.getMeasureName(), result.getDimensionValues(), timeValues);
         }
         timeValues.addAll(Lists.newArrayList(result.iterator()));
       }

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/metrics/MetricsHandlerTestRun.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/metrics/MetricsHandlerTestRun.java
@@ -533,7 +533,7 @@ public class MetricsHandlerTestRun extends MetricsSuiteTestBase {
 
 
   /**
-   * Helper class to construct json for QueryRequest for batch queries
+   * Helper class to construct json for MetricQueryRequest for batch queries
    */
   private class QueryRequestFormat {
     Map<String, String> tags;

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/metrics/MetricsHandlerTestRun.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/metrics/MetricsHandlerTestRun.java
@@ -260,7 +260,7 @@ public class MetricsHandlerTestRun extends MetricsSuiteTestBase {
       i++;
     } while (i < parts.length);
   }
-  
+
   // can remove this test after context (query-param) based searching is removed
   @Test
   public void testSearchContext() throws Exception {

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/metrics/MetricsHandlerTestRun.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/metrics/MetricsHandlerTestRun.java
@@ -260,8 +260,7 @@ public class MetricsHandlerTestRun extends MetricsSuiteTestBase {
       i++;
     } while (i < parts.length);
   }
-
-
+  
   // can remove this test after context (query-param) based searching is removed
   @Test
   public void testSearchContext() throws Exception {

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/MetricQueryRequest.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/MetricQueryRequest.java
@@ -26,7 +26,7 @@ import javax.annotation.Nullable;
 /**
  * Metrics Query Request format
  */
-public class QueryRequest {
+public class MetricQueryRequest {
   /**
    * Format for metrics query in batched queries
    */
@@ -35,7 +35,7 @@ public class QueryRequest {
   List<String> groupBy;
   TimeRange timeRange;
 
-  public QueryRequest(Map<String, String> tags, List<String> metrics, List<String> groupBy) {
+  public MetricQueryRequest(Map<String, String> tags, List<String> metrics, List<String> groupBy) {
     this.tags = tags;
     this.metrics = metrics;
     this.groupBy = groupBy;

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/MetricTagValue.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/MetricTagValue.java
@@ -16,12 +16,10 @@
 
 package co.cask.cdap.proto;
 
-import co.cask.cdap.api.dataset.lib.cube.CubeFact;
-
 import javax.annotation.Nullable;
 
 /**
- * Represents tag and its value associated with {@link CubeFact}.
+ * Represents tag and its value associated with metrics data points.
  */
 public final class MetricTagValue {
   private final String name;
@@ -65,7 +63,7 @@ public final class MetricTagValue {
   @Override
   public String toString() {
     final StringBuilder sb = new StringBuilder();
-    sb.append("TagValue");
+    sb.append("MetricTagValue");
     sb.append("{name='").append(name).append('\'');
     sb.append(", value='").append(value == null ? "null" : value).append('\'');
     sb.append('}');

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/MetricTagValue.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/MetricTagValue.java
@@ -14,21 +14,20 @@
  * the License.
  */
 
-package co.cask.cdap.api.dataset.lib.cube;
+package co.cask.cdap.proto;
 
-import co.cask.cdap.api.annotation.Beta;
+import co.cask.cdap.api.dataset.lib.cube.CubeFact;
 
 import javax.annotation.Nullable;
 
 /**
  * Represents tag and its value associated with {@link CubeFact}.
  */
-@Beta
-public final class TagValue {
+public final class MetricTagValue {
   private final String name;
   private final String value;
 
-  public TagValue(String name, @Nullable String value) {
+  public MetricTagValue(String name, @Nullable String value) {
     this.name = name;
     this.value = value;
   }
@@ -52,7 +51,7 @@ public final class TagValue {
       return false;
     }
 
-    TagValue tagValue = (TagValue) o;
+    MetricTagValue tagValue = (MetricTagValue) o;
 
     boolean result = value == null ? tagValue.value == null : value.equals(tagValue.value);
     return result && name.equals(tagValue.name);

--- a/cdap-unit-test/src/test/java/co/cask/cdap/spark/metrics/SparkMetricsIntegrationTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/spark/metrics/SparkMetricsIntegrationTestRun.java
@@ -16,12 +16,12 @@
 
 package co.cask.cdap.spark.metrics;
 
-import co.cask.cdap.api.dataset.lib.cube.TagValue;
 import co.cask.cdap.api.dataset.lib.cube.TimeValue;
 import co.cask.cdap.api.metrics.MetricDataQuery;
 import co.cask.cdap.api.metrics.MetricSearchQuery;
 import co.cask.cdap.api.metrics.MetricTimeSeries;
 import co.cask.cdap.api.metrics.MetricType;
+import co.cask.cdap.api.metrics.TagValue;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.RuntimeStats;

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/AppWithCube.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/AppWithCube.java
@@ -33,8 +33,8 @@ public class AppWithCube extends AbstractApplication {
   public void configure() {
     DatasetProperties props = DatasetProperties.builder()
       .add("dataset.cube.resolutions", "1,60")
-      .add("dataset.cube.aggregation.agg1.tags", "user,action")
-      .add("dataset.cube.aggregation.agg1.requiredTags", "user,action").build();
+      .add("dataset.cube.aggregation.agg1.dimensions", "user,action")
+      .add("dataset.cube.aggregation.agg1.requiredDimensions", "user,action").build();
     createDataset(CUBE_NAME, Cube.class, props);
 
     addService(SERVICE_NAME, new CubeHandler());

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestAppWithCube.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestAppWithCube.java
@@ -87,7 +87,7 @@ public class TestAppWithCube extends TestBase {
         searchTag(url, new CubeExploreQuery(tsInSec - 60, tsInSec + 60, 1, 100, new ArrayList<TagValue>()));
       Assert.assertEquals(1, tags.size());
       TagValue tv = tags.iterator().next();
-      Assert.assertEquals("user", tv.getTagName());
+      Assert.assertEquals("user", tv.getName());
       Assert.assertEquals("alex", tv.getValue());
 
       tags = searchTag(url, new CubeExploreQuery(tsInSec - 60, tsInSec + 60, 1, 100,
@@ -95,10 +95,10 @@ public class TestAppWithCube extends TestBase {
       Assert.assertEquals(2, tags.size());
       Iterator<TagValue> iterator = tags.iterator();
       tv = iterator.next();
-      Assert.assertEquals("action", tv.getTagName());
+      Assert.assertEquals("action", tv.getName());
       Assert.assertEquals("back", tv.getValue());
       tv = iterator.next();
-      Assert.assertEquals("action", tv.getTagName());
+      Assert.assertEquals("action", tv.getName());
       Assert.assertEquals("click", tv.getValue());
 
       // search for measures

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestAppWithCube.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestAppWithCube.java
@@ -19,8 +19,8 @@ package co.cask.cdap.test.app;
 import co.cask.cdap.api.dataset.lib.cube.CubeExploreQuery;
 import co.cask.cdap.api.dataset.lib.cube.CubeFact;
 import co.cask.cdap.api.dataset.lib.cube.CubeQuery;
+import co.cask.cdap.api.dataset.lib.cube.DimensionValue;
 import co.cask.cdap.api.dataset.lib.cube.MeasureType;
-import co.cask.cdap.api.dataset.lib.cube.TagValue;
 import co.cask.cdap.api.dataset.lib.cube.TimeSeries;
 import co.cask.cdap.api.dataset.lib.cube.TimeValue;
 import co.cask.cdap.test.ApplicationManager;
@@ -69,31 +69,32 @@ public class TestAppWithCube extends TestBase {
 
       // add couple facts
       add(url, ImmutableList.of(new CubeFact(tsInSec)
-                                  .addTag("user", "alex").addTag("action", "click")
+                                  .addDimensionValue("user", "alex").addDimensionValue("action", "click")
                                   .addMeasurement("count", MeasureType.COUNTER, 1)));
 
       add(url, ImmutableList.of(new CubeFact(tsInSec)
-                                  .addTag("user", "alex").addTag("action", "click")
+                                  .addDimensionValue("user", "alex").addDimensionValue("action", "click")
                                   .addMeasurement("count", MeasureType.COUNTER, 1),
                                 new CubeFact(tsInSec + 1)
-                                  .addTag("user", "alex").addTag("action", "back")
+                                  .addDimensionValue("user", "alex").addDimensionValue("action", "back")
                                   .addMeasurement("count", MeasureType.COUNTER, 1),
                                 new CubeFact(tsInSec + 2)
-                                  .addTag("user", "alex").addTag("action", "click")
+                                  .addDimensionValue("user", "alex").addDimensionValue("action", "click")
                                   .addMeasurement("count", MeasureType.COUNTER, 1)));
 
       // search for tags
-      Collection<TagValue> tags =
-        searchTag(url, new CubeExploreQuery(tsInSec - 60, tsInSec + 60, 1, 100, new ArrayList<TagValue>()));
+      Collection<DimensionValue> tags =
+        searchDimensionValue(url, new CubeExploreQuery(tsInSec - 60, tsInSec + 60, 1, 100,
+                                                       new ArrayList<DimensionValue>()));
       Assert.assertEquals(1, tags.size());
-      TagValue tv = tags.iterator().next();
+      DimensionValue tv = tags.iterator().next();
       Assert.assertEquals("user", tv.getName());
       Assert.assertEquals("alex", tv.getValue());
 
-      tags = searchTag(url, new CubeExploreQuery(tsInSec - 60, tsInSec + 60, 1, 100,
-                                                 ImmutableList.of(new TagValue("user", "alex"))));
+      tags = searchDimensionValue(url, new CubeExploreQuery(tsInSec - 60, tsInSec + 60, 1, 100,
+                                                            ImmutableList.of(new DimensionValue("user", "alex"))));
       Assert.assertEquals(2, tags.size());
-      Iterator<TagValue> iterator = tags.iterator();
+      Iterator<DimensionValue> iterator = tags.iterator();
       tv = iterator.next();
       Assert.assertEquals("action", tv.getName());
       Assert.assertEquals("back", tv.getValue());
@@ -104,7 +105,7 @@ public class TestAppWithCube extends TestBase {
       // search for measures
       Collection<String> measures =
         searchMeasure(url, new CubeExploreQuery(tsInSec - 60, tsInSec + 60, 1, 100,
-                                                ImmutableList.of(new TagValue("user", "alex"))));
+                                                ImmutableList.of(new DimensionValue("user", "alex"))));
       Assert.assertEquals(1, measures.size());
       String measure = measures.iterator().next();
       Assert.assertEquals("count", measure);
@@ -151,12 +152,12 @@ public class TestAppWithCube extends TestBase {
     Assert.assertEquals(200, response.getResponseCode());
   }
 
-  private Collection<TagValue> searchTag(URL serviceUrl, CubeExploreQuery query) throws IOException {
-    URL url = new URL(serviceUrl, "searchTag");
+  private Collection<DimensionValue> searchDimensionValue(URL serviceUrl, CubeExploreQuery query) throws IOException {
+    URL url = new URL(serviceUrl, "searchDimensionValue");
     HttpRequest request = HttpRequest.post(url).withBody(GSON.toJson(query)).build();
     HttpResponse response = HttpRequests.execute(request);
     Assert.assertEquals(200, response.getResponseCode());
-    return GSON.fromJson(response.getResponseBodyAsString(), new TypeToken<Collection<TagValue>>() { }.getType());
+    return GSON.fromJson(response.getResponseBodyAsString(), new TypeToken<Collection<DimensionValue>>() { }.getType());
   }
 
   private Collection<String> searchMeasure(URL serviceUrl, CubeExploreQuery query) throws IOException {

--- a/cdap-watchdog-api/src/main/java/co/cask/cdap/api/metrics/MetricSearchQuery.java
+++ b/cdap-watchdog-api/src/main/java/co/cask/cdap/api/metrics/MetricSearchQuery.java
@@ -16,7 +16,6 @@
 
 package co.cask.cdap.api.metrics;
 
-import co.cask.cdap.api.dataset.lib.cube.TagValue;
 import com.google.common.base.Joiner;
 import com.google.common.base.Objects;
 
@@ -24,7 +23,7 @@ import java.util.List;
 
 /**
  * Defines a query to perform Exploration and Search on {@link MetricStore} data.
- * Given a list of {@link co.cask.cdap.api.dataset.lib.cube.TagValue} this explore query can be used
+ * Given a list of {@link TagValue}s this explore query can be used
  * to find next set of tags available or the measureNames belonging to this tag list.
  */
 public class MetricSearchQuery {

--- a/cdap-watchdog-api/src/main/java/co/cask/cdap/api/metrics/MetricStore.java
+++ b/cdap-watchdog-api/src/main/java/co/cask/cdap/api/metrics/MetricStore.java
@@ -17,7 +17,6 @@
 package co.cask.cdap.api.metrics;
 
 import java.util.Collection;
-import java.util.Map;
 
 /**
  * Stores and provides access to metrics data.
@@ -69,7 +68,7 @@ public interface MetricStore {
    * @param query specifies where to search
    * @return collection of tag value pairs in no particular order
    */
-  Map<String, String> findNextAvailableTags(MetricSearchQuery query) throws Exception;
+  Collection<TagValue> findNextAvailableTags(MetricSearchQuery query) throws Exception;
 
   /**
    * Given a list of tags in the {@link MetricSearchQuery}, returns the list of measures available

--- a/cdap-watchdog-api/src/main/java/co/cask/cdap/api/metrics/MetricStore.java
+++ b/cdap-watchdog-api/src/main/java/co/cask/cdap/api/metrics/MetricStore.java
@@ -16,9 +16,8 @@
 
 package co.cask.cdap.api.metrics;
 
-import co.cask.cdap.api.dataset.lib.cube.TagValue;
-
 import java.util.Collection;
+import java.util.Map;
 
 /**
  * Stores and provides access to metrics data.
@@ -70,7 +69,7 @@ public interface MetricStore {
    * @param query specifies where to search
    * @return collection of tag value pairs in no particular order
    */
-  Collection<TagValue> findNextAvailableTags(MetricSearchQuery query) throws Exception;
+  Map<String, String> findNextAvailableTags(MetricSearchQuery query) throws Exception;
 
   /**
    * Given a list of tags in the {@link MetricSearchQuery}, returns the list of measures available

--- a/cdap-watchdog-api/src/main/java/co/cask/cdap/api/metrics/TagValue.java
+++ b/cdap-watchdog-api/src/main/java/co/cask/cdap/api/metrics/TagValue.java
@@ -14,14 +14,14 @@
  * the License.
  */
 
-package co.cask.cdap.api.dataset.lib.cube;
+package co.cask.cdap.api.metrics;
 
 import co.cask.cdap.api.annotation.Beta;
 
 import javax.annotation.Nullable;
 
 /**
- * Represents tag and its value associated with {@link CubeFact}.
+ * Represents tag and its value associated with {@link MetricValues}.
  */
 @Beta
 public final class TagValue {

--- a/cdap-watchdog-api/src/main/java/co/cask/cdap/api/metrics/TagValue.java
+++ b/cdap-watchdog-api/src/main/java/co/cask/cdap/api/metrics/TagValue.java
@@ -66,7 +66,7 @@ public final class TagValue {
   @Override
   public String toString() {
     final StringBuilder sb = new StringBuilder();
-    sb.append("TagValue");
+    sb.append("DimensionValue");
     sb.append("{name='").append(name).append('\'');
     sb.append(", value='").append(value == null ? "null" : value).append('\'');
     sb.append('}');

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/MetricsHandler.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/MetricsHandler.java
@@ -508,7 +508,7 @@ public class MetricsHandler extends AuthenticatedHttpHandler {
       // limit is -1 , to include the entire search result.
       MetricSearchQuery searchQuery = new MetricSearchQuery(0, Integer.MAX_VALUE, -1,
                                                             toTagValues(humanToTagNames(parseTagValues(tags))));
-      Map<String, String> nextTags = metricStore.findNextAvailableTags(searchQuery);
+      Collection<TagValue> nextTags = metricStore.findNextAvailableTags(searchQuery);
       responder.sendJson(HttpResponseStatus.OK, tagValuesToHuman(nextTags));
     } catch (IllegalArgumentException e) {
       LOG.warn("Invalid request", e);
@@ -548,15 +548,15 @@ public class MetricsHandler extends AuthenticatedHttpHandler {
     // limit is -1 , to include the entire search result.
     MetricSearchQuery searchQuery = new MetricSearchQuery(0, Integer.MAX_VALUE, -1,
                                                           toTagValues(humanToTagNames(tagValues)));
-    Map<String, String> nextTags = metricStore.findNextAvailableTags(searchQuery);
+    Collection<TagValue> nextTags = metricStore.findNextAvailableTags(searchQuery);
 
     contextPrefix = toCanonicalContext(tagValues);
     Collection<String> result = Lists.newArrayList();
-    for (Map.Entry<String, String> tag : nextTags.entrySet()) {
+    for (TagValue tag : nextTags) {
       // for now, if tag value is null, we use ANY_TAG_VALUE as returned for convenience: this allows to easy build UI
       // and do simple copy-pasting when accessing HTTP endpoint via e.g. curl
       String value = tag.getValue() == null ? ANY_TAG_VALUE : tag.getValue();
-      String name = tagNameToHuman(tag.getKey());
+      String name = tagNameToHuman(tag.getName());
       String tagValue = encodeTag(name) + TAG_DELIM + encodeTag(value);
       String resultTag = contextPrefix.length() == 0 ? tagValue : contextPrefix + TAG_DELIM + tagValue;
       result.add(resultTag);
@@ -564,11 +564,11 @@ public class MetricsHandler extends AuthenticatedHttpHandler {
     return result;
   }
 
-  private List<MetricTagValue> tagValuesToHuman(Map<String, String> tagValues) {
+  private List<MetricTagValue> tagValuesToHuman(Collection<TagValue> tagValues) {
     List<MetricTagValue> result = Lists.newArrayList();
-    for (Map.Entry<String, String> tagValue : tagValues.entrySet()) {
-      String human = tagNameToHuman.get(tagValue.getKey());
-      human = human != null ? human : tagValue.getKey();
+    for (TagValue tagValue : tagValues) {
+      String human = tagNameToHuman.get(tagValue.getName());
+      human = human != null ? human : tagValue.getName();
       String value = tagValue.getValue() == null ? ANY_TAG_VALUE : tagValue.getValue();
       result.add(new MetricTagValue(human, value));
     }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/MetricsHandler.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/MetricsHandler.java
@@ -18,19 +18,20 @@ package co.cask.cdap.metrics.query;
 
 import co.cask.cdap.api.dataset.lib.cube.Interpolator;
 import co.cask.cdap.api.dataset.lib.cube.Interpolators;
-import co.cask.cdap.api.dataset.lib.cube.TagValue;
 import co.cask.cdap.api.dataset.lib.cube.TimeValue;
 import co.cask.cdap.api.metrics.MetricDataQuery;
 import co.cask.cdap.api.metrics.MetricSearchQuery;
 import co.cask.cdap.api.metrics.MetricStore;
 import co.cask.cdap.api.metrics.MetricTimeSeries;
 import co.cask.cdap.api.metrics.MetricType;
+import co.cask.cdap.api.metrics.TagValue;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.utils.TimeMathParser;
 import co.cask.cdap.gateway.auth.Authenticator;
 import co.cask.cdap.gateway.handlers.AuthenticatedHttpHandler;
+import co.cask.cdap.proto.MetricQueryRequest;
 import co.cask.cdap.proto.MetricQueryResult;
-import co.cask.cdap.proto.QueryRequest;
+import co.cask.cdap.proto.MetricTagValue;
 import co.cask.http.HttpResponder;
 import com.google.common.base.Charsets;
 import com.google.common.base.Function;
@@ -181,14 +182,14 @@ public class MetricsHandler extends AuthenticatedHttpHandler {
     }
   }
 
-  private List<TagValue> parseTagValues(List<String> tags) {
-    List<TagValue> result = Lists.newArrayList();
+  private List<MetricTagValue> parseTagValues(List<String> tags) {
+    List<MetricTagValue> result = Lists.newArrayList();
     for (String tag : tags) {
       // split by ':' and add the tagValue to result list
       String[] tagSplit = tag.split(":", 2);
       if (tagSplit.length == 2) {
         String value = tagSplit[1].equals(ANY_TAG_VALUE) ? null : tagSplit[1];
-        result.add(new TagValue(tagSplit[0], value));
+        result.add(new MetricTagValue(tagSplit[0], value));
       }
     }
     return result;
@@ -227,7 +228,7 @@ public class MetricsHandler extends AuthenticatedHttpHandler {
 
         Map<String, MetricQueryResult> queryFinalResponse = Maps.newHashMap();
         for (Map.Entry<String, QueryRequestFormat> query : queries.entrySet()) {
-          QueryRequest queryRequest = getQueryRequestFromFormat(query.getValue());
+          MetricQueryRequest queryRequest = getQueryRequestFromFormat(query.getValue());
           queryFinalResponse.put(query.getKey(), executeQuery(queryRequest));
         }
         responder.sendJson(HttpResponseStatus.OK, queryFinalResponse);
@@ -243,14 +244,14 @@ public class MetricsHandler extends AuthenticatedHttpHandler {
     }
   }
 
-  private QueryRequest getQueryRequestFromFormat(QueryRequestFormat queryRequestFormat) {
+  private MetricQueryRequest getQueryRequestFromFormat(QueryRequestFormat queryRequestFormat) {
     Map<String, List<String>> queryParams = Maps.newHashMap();
 
     for (Map.Entry<String, String> entry : queryRequestFormat.getTimeRange().entrySet()) {
       queryParams.put(entry.getKey(), ImmutableList.of(entry.getValue()));
     }
 
-    QueryRequest queryRequest = new QueryRequest(queryRequestFormat.getTags(),
+    MetricQueryRequest queryRequest = new MetricQueryRequest(queryRequestFormat.getTags(),
                                                  queryRequestFormat.getMetrics(), queryRequestFormat.getGroupBy());
     setTimeRangeInQueryRequest(queryRequest, queryParams);
     return queryRequest;
@@ -288,7 +289,7 @@ public class MetricsHandler extends AuthenticatedHttpHandler {
   private MetricQueryResult executeQuery(HttpRequest request, Map<String, String> sliceByTags,
                                          List<String> groupByTags, List<String> metrics) {
     try {
-      QueryRequest queryRequest = new QueryRequest(sliceByTags, metrics, groupByTags);
+      MetricQueryRequest queryRequest = new MetricQueryRequest(sliceByTags, metrics, groupByTags);
       setTimeRangeInQueryRequest(queryRequest, new QueryStringDecoder(request.getUri()).getParameters());
       return executeQuery(queryRequest);
     } catch (IllegalArgumentException e) {
@@ -298,7 +299,7 @@ public class MetricsHandler extends AuthenticatedHttpHandler {
     }
   }
 
-  private void setTimeRangeInQueryRequest(QueryRequest request, Map<String, List<String>> queryTimeParams) {
+  private void setTimeRangeInQueryRequest(MetricQueryRequest request, Map<String, List<String>> queryTimeParams) {
     Long start =
       queryTimeParams.containsKey(PARAM_START_TIME) ?
         TimeMathParser.parseTime(queryTimeParams.get(PARAM_START_TIME).get(0)) : null;
@@ -372,7 +373,7 @@ public class MetricsHandler extends AuthenticatedHttpHandler {
     }
   }
 
-  private MetricQueryResult executeQuery(QueryRequest queryRequest) {
+  private MetricQueryResult executeQuery(MetricQueryRequest queryRequest) {
     try {
       if (queryRequest.getMetrics().size() == 0) {
         throw new IllegalArgumentException("Missing metrics parameter in the query");
@@ -380,7 +381,7 @@ public class MetricsHandler extends AuthenticatedHttpHandler {
 
       Map<String, String> tagsSliceBy = humanToTagNames(transformTagMap(queryRequest.getTags()));
 
-      QueryRequest.TimeRange timeRange = queryRequest.getTimeRange();
+      MetricQueryRequest.TimeRange timeRange = queryRequest.getTimeRange();
 
       MetricDataQuery query = new MetricDataQuery(timeRange.getStart(), timeRange.getEnd(),
                                                   timeRange.getResolutionInSeconds(),
@@ -397,8 +398,7 @@ public class MetricsHandler extends AuthenticatedHttpHandler {
         endTime = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis());
       }
 
-      MetricQueryResult result = decorate(queryResult, timeRange.getStart(), endTime);
-      return result;
+      return decorate(queryResult, timeRange.getStart(), endTime);
     } catch (IllegalArgumentException e) {
       throw Throwables.propagate(e);
     } catch (Exception e) {
@@ -471,11 +471,11 @@ public class MetricsHandler extends AuthenticatedHttpHandler {
   }
 
   private Map<String, String> parseTagValuesAsMap(List<String> tags) {
-    List<TagValue> tagValues = parseTagValues(tags);
+    List<MetricTagValue> tagValues = parseTagValues(tags);
 
     Map<String, String> result = Maps.newHashMap();
-    for (TagValue tagValue : tagValues) {
-      result.put(tagValue.getTagName(), tagValue.getValue());
+    for (MetricTagValue tagValue : tagValues) {
+      result.put(tagValue.getName(), tagValue.getValue());
     }
     return result;
   }
@@ -507,8 +507,8 @@ public class MetricsHandler extends AuthenticatedHttpHandler {
       // we want to search the entire range, so startTimestamp is '0' and end Timestamp is Integer.MAX_VALUE and
       // limit is -1 , to include the entire search result.
       MetricSearchQuery searchQuery = new MetricSearchQuery(0, Integer.MAX_VALUE, -1,
-                                                            humanToTagNames(parseTagValues(tags)));
-      Collection<TagValue> nextTags = metricStore.findNextAvailableTags(searchQuery);
+                                                            toTagValues(humanToTagNames(parseTagValues(tags))));
+      Map<String, String> nextTags = metricStore.findNextAvailableTags(searchQuery);
       responder.sendJson(HttpResponseStatus.OK, tagValuesToHuman(nextTags));
     } catch (IllegalArgumentException e) {
       LOG.warn("Invalid request", e);
@@ -531,32 +531,32 @@ public class MetricsHandler extends AuthenticatedHttpHandler {
     }
   }
 
-  private List<TagValue> parseTagValues(String contextPrefix) throws Exception {
+  private List<MetricTagValue> parseTagValues(String contextPrefix) throws Exception {
     Map<String, String> map = parseTagValuesAsMap(contextPrefix);
-    List<TagValue> contextTags = Lists.newArrayList();
+    List<MetricTagValue> contextTags = Lists.newArrayList();
     for (Map.Entry<String, String> entry : map.entrySet()) {
-      contextTags.add(new TagValue(entry.getKey(), entry.getValue()));
+      contextTags.add(new MetricTagValue(entry.getKey(), entry.getValue()));
     }
 
     return contextTags;
   }
 
   private Collection<String> searchChildContext(String contextPrefix) throws Exception {
-    List<TagValue> tagValues = parseTagValues(contextPrefix);
+    List<MetricTagValue> tagValues = parseTagValues(contextPrefix);
 
     // we want to search the entire range, so startTimestamp is '0' and endTimestamp is Integer.MAX_VALUE and
     // limit is -1 , to include the entire search result.
     MetricSearchQuery searchQuery = new MetricSearchQuery(0, Integer.MAX_VALUE, -1,
-                                                          humanToTagNames(tagValues));
-    Collection<TagValue> nextTags = metricStore.findNextAvailableTags(searchQuery);
+                                                          toTagValues(humanToTagNames(tagValues)));
+    Map<String, String> nextTags = metricStore.findNextAvailableTags(searchQuery);
 
     contextPrefix = toCanonicalContext(tagValues);
     Collection<String> result = Lists.newArrayList();
-    for (TagValue tag : nextTags) {
+    for (Map.Entry<String, String> tag : nextTags.entrySet()) {
       // for now, if tag value is null, we use ANY_TAG_VALUE as returned for convenience: this allows to easy build UI
       // and do simple copy-pasting when accessing HTTP endpoint via e.g. curl
       String value = tag.getValue() == null ? ANY_TAG_VALUE : tag.getValue();
-      String name = tagNameToHuman(tag);
+      String name = tagNameToHuman(tag.getKey());
       String tagValue = encodeTag(name) + TAG_DELIM + encodeTag(value);
       String resultTag = contextPrefix.length() == 0 ? tagValue : contextPrefix + TAG_DELIM + tagValue;
       result.add(resultTag);
@@ -564,27 +564,41 @@ public class MetricsHandler extends AuthenticatedHttpHandler {
     return result;
   }
 
-  private List<TagValue> tagValuesToHuman(Collection<TagValue> tagValues) {
-    List<TagValue> result = Lists.newArrayList();
-    for (TagValue tagValue : tagValues) {
-      String human = tagNameToHuman.get(tagValue.getTagName());
-      human = human != null ? human : tagValue.getTagName();
+  private List<MetricTagValue> tagValuesToHuman(Map<String, String> tagValues) {
+    List<MetricTagValue> result = Lists.newArrayList();
+    for (Map.Entry<String, String> tagValue : tagValues.entrySet()) {
+      String human = tagNameToHuman.get(tagValue.getKey());
+      human = human != null ? human : tagValue.getKey();
       String value = tagValue.getValue() == null ? ANY_TAG_VALUE : tagValue.getValue();
-      result.add(new TagValue(human, value));
+      result.add(new MetricTagValue(human, value));
     }
     return result;
   }
 
-  private String tagNameToHuman(TagValue tag) {
-    String human = tagNameToHuman.get(tag.getTagName());
-    return human != null ? human : tag.getTagName();
+  private String tagNameToHuman(String tagName) {
+    String human = tagNameToHuman.get(tagName);
+    return human != null ? human : tagName;
   }
 
-  private List<TagValue> humanToTagNames(List<TagValue> tagValues) {
-    List<TagValue> result = Lists.newArrayList();
-    for (TagValue tagValue : tagValues) {
-      String tagName = humanToTagName(tagValue.getTagName());
-      result.add(new TagValue(tagName, tagValue.getValue()));
+  private List<TagValue> toTagValues(List<MetricTagValue> tagValues) {
+    return Lists.transform(tagValues, new Function<MetricTagValue, TagValue>() {
+      @Nullable
+      @Override
+      public TagValue apply(@Nullable MetricTagValue input) {
+        if (input == null) {
+          // SHOULD NEVER happen
+          throw new NullPointerException();
+        }
+        return new TagValue(input.getName(), input.getValue());
+      }
+    });
+  }
+
+  private List<MetricTagValue> humanToTagNames(List<MetricTagValue> tagValues) {
+    List<MetricTagValue> result = Lists.newArrayList();
+    for (MetricTagValue tagValue : tagValues) {
+      String tagName = humanToTagName(tagValue.getName());
+      result.add(new MetricTagValue(tagName, tagValue.getValue()));
     }
     return result;
   }
@@ -602,30 +616,30 @@ public class MetricsHandler extends AuthenticatedHttpHandler {
     return result;
   }
 
-  private String toCanonicalContext(List<TagValue> tagValues) {
+  private String toCanonicalContext(List<MetricTagValue> tagValues) {
     StringBuilder sb = new StringBuilder();
     boolean first = true;
-    for (TagValue tv : tagValues) {
+    for (MetricTagValue tv : tagValues) {
       if (!first) {
         sb.append(TAG_DELIM);
       }
       first = false;
-      sb.append(encodeTag(tv.getTagName())).append(TAG_DELIM)
+      sb.append(encodeTag(tv.getName())).append(TAG_DELIM)
         .append(tv.getValue() == null ? ANY_TAG_VALUE : encodeTag(tv.getValue()));
     }
     return sb.toString();
   }
 
   private Collection<String> searchMetric(String contextPrefix) throws Exception {
-    List<TagValue> tagValues = humanToTagNames(parseTagValues(contextPrefix));
+    List<MetricTagValue> tagValues = humanToTagNames(parseTagValues(contextPrefix));
     return getMetrics(tagValues);
   }
 
-  private Collection<String> getMetrics(List<TagValue> tagValues) throws Exception {
+  private Collection<String> getMetrics(List<MetricTagValue> tagValues) throws Exception {
     // we want to search the entire range, so startTimestamp is '0' and end Timestamp is Integer.MAX_VALUE and
     // limit is -1 , to include the entire search result.
     MetricSearchQuery searchQuery =
-      new MetricSearchQuery(0, Integer.MAX_VALUE, -1, tagValues);
+      new MetricSearchQuery(0, Integer.MAX_VALUE, -1, toTagValues(tagValues));
     Collection<String> metricNames = metricStore.findMetricNames(searchQuery);
     return Lists.newArrayList(Iterables.filter(metricNames, Predicates.notNull()));
   }
@@ -660,7 +674,7 @@ public class MetricsHandler extends AuthenticatedHttpHandler {
 
   /**
    * Helper class to Deserialize Query requests and based on this
-   * {@link co.cask.cdap.proto.QueryRequest} will be constructed
+   * {@link MetricQueryRequest} will be constructed
    */
   private class QueryRequestFormat {
     Map<String, String> tags;
@@ -686,8 +700,8 @@ public class MetricsHandler extends AuthenticatedHttpHandler {
      * time range has aggregate=true or {start, end, count, resolution, interpolate} parameters,
      * since start, end can be represented as 'now ('+' or '-')' and not just absolute timestamp,
      * we use this format to get those strings and after parsing and determining other parameters, we can construct
-     * {@link co.cask.cdap.proto.QueryRequest} , similar for resolution.
-     * @return
+     * {@link MetricQueryRequest} , similar for resolution.
+     * @return time range prameters
      */
     public Map<String, String> getTimeRange() {
       timeRange = (timeRange == null || timeRange.size() == 0) ? ImmutableMap.of("aggregate", "true") : timeRange;

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/store/DefaultMetricStore.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/store/DefaultMetricStore.java
@@ -266,11 +266,11 @@ public class DefaultMetricStore implements MetricStore {
   }
 
   @Override
-  public Map<String, String> findNextAvailableTags(MetricSearchQuery query) throws Exception {
+  public Collection<co.cask.cdap.api.metrics.TagValue> findNextAvailableTags(MetricSearchQuery query) throws Exception {
     Collection<TagValue> tags = cube.get().findNextAvailableTags(buildCubeSearchQuery(query));
-    Map<String, String> result = Maps.newHashMap();
+    Collection<co.cask.cdap.api.metrics.TagValue> result = Lists.newArrayList();
     for (TagValue tagValue : tags) {
-      result.put(tagValue.getName(), tagValue.getValue());
+      result.add(new co.cask.cdap.api.metrics.TagValue(tagValue.getName(), tagValue.getValue()));
     }
     return result;
   }


### PR DESCRIPTION
Two changes:

* created MetricTagValue in proto, to isolate HTTP APIs from internally used classes
* created TagValue in watchdog-api to separate from one that is used in Cube API
The TagValue in Cube API will be renamed to DimValue, i.e. dimension value

Update: added commit that renames tag to dimension in Cube: https://github.com/caskdata/cdap/commit/dbb2514957b9f365fcb15b4de4667548f6d05913