### PR TITLE
Fix/ui etl fancy edit properties

### DIFF
--- a/cdap-ui/Gulpfile.js
+++ b/cdap-ui/Gulpfile.js
@@ -126,7 +126,9 @@ gulp.task('js:lib', function() {
       './bower_components/node-uuid/uuid.js',
       './bower_components/angular-ui-select/dist/select.js',
       './bower_components/angular-cookies/angular-cookies.min.js',
-      './bower_components/c3/c3.js'
+      './bower_components/c3/c3.js',
+      './bower_components/ace-builds/src-min-noconflict/ace.js',
+      './bower_components/angular-ui-ace/ui-ace.js'
 
 
     ].concat([

--- a/cdap-ui/app/directives/widget-container/widget-container.js
+++ b/cdap-ui/app/directives/widget-container/widget-container.js
@@ -1,0 +1,40 @@
+angular.module(PKG.name + '.commons')
+  .directive('widgetContainer', function($compile) {
+    var registry = {
+      'textbox': 'textbox'
+    };
+
+    return {
+      restrict: 'A',
+      scope: {
+        name: '=',
+        model: '=',
+        myconfig: '='
+      },
+      replace: false,
+      link: function (scope, element, attrs) {
+        var angularElement;
+        switch(scope.myconfig[scope.name].type) {
+          case 'textbox':
+            angularElement = angular.element('<input class="form-control" ng-model="model"/>');
+            angularElement.attr('placeholder', scope.myconfig[scope.name].info);
+            element.append(angularElement);
+            break;
+          case 'password':
+            angularElement = angular.element('<input class="form-control" ng-model="model"/>');
+            angularElement.attr('type', 'password');
+            angularElement.attr('placeholder', scope.myconfig[scope.name].info);
+            element.append(angularElement);
+            break;
+          case 'textarea':
+            angularElement = angular.element('<textarea class="form-control" ng-model="model"></textarea>');
+            angularElement.attr('placeholder', scope.myconfig[scope.name].info);
+            element.append(angularElement);
+            break;
+        }
+        element.removeAttr('widget-container');
+        $compile(element)(scope);
+      }
+    };
+
+  });

--- a/cdap-ui/app/directives/widget-container/widget-container.js
+++ b/cdap-ui/app/directives/widget-container/widget-container.js
@@ -31,6 +31,15 @@ angular.module(PKG.name + '.commons')
             angularElement.attr('placeholder', scope.myconfig[scope.name].info);
             element.append(angularElement);
             break;
+          case 'json-editor':
+            angularElement = angular.element('<textarea class="form-control" cask-json-edit="model"></textarea>');
+            angularElement.attr('placeholder', scope.myconfig[scope.name].info);
+            element.append(angularElement);
+            break;
+          case 'javascript-editor':
+            angularElement = angular.element('<div style="width: 400px;height: 300px;" ui-ace></div>');
+            element.append(angularElement);
+            break;
         }
         element.removeAttr('widget-container');
         $compile(element)(scope);

--- a/cdap-ui/app/features/etlapps/controllers/create-ctrl.js
+++ b/cdap-ui/app/features/etlapps/controllers/create-ctrl.js
@@ -1,11 +1,7 @@
 angular.module(PKG.name + '.feature.etlapps')
   .controller('ETLAppsCreateController', function($scope, $q, $alert, $state, ETLAppsApiFactory, mySettings, $filter, $rootScope) {
     var apiFactory = new ETLAppsApiFactory($scope);
-    $scope.ETLMetadataTabOpen = true;
-    $scope.ETLSourcesTabOpen = true;
-    $scope.ETLTransformsTabOpen = true;
-    $scope.ETLSinksTabOpen = true;
-    $scope.isSaved = false;
+
     // Loading flag to indicate source & sinks have
     // not been loaded yet (after/before choosing an etl template)
     $scope.loadingEtlSourceProps = false;

--- a/cdap-ui/app/features/etlapps/controllers/source-edit-ctrl.js
+++ b/cdap-ui/app/features/etlapps/controllers/source-edit-ctrl.js
@@ -1,0 +1,21 @@
+angular.module(PKG.name + '.feature.etlapps')
+  .controller('SourceEditController', function($scope, MyDataSource, PluginConfigFactory) {
+    $scope.somethingfetched = false;
+    PluginConfigFactory.fetch($scope, 'etlRealtime', 'TwitterSource')
+      .then(function(res) {
+        var something = {};
+         var combined = angular.extend({}, res.groups.group1.fields, res.groups.group2.fields);
+         angular.forEach(combined, function(value, key) {
+           something[key] = {
+             description: value['widget-description'],
+             info: value['widget-info'],
+             label: value['widget-label'],
+             properties: value['widget-properties'],
+             type: value['widget-type']
+           };
+         });
+         $scope.somethingfetched = true;
+         $scope.something = something;
+         console.info("Something:", something);
+      });
+  });

--- a/cdap-ui/app/features/etlapps/services/etl-plugin-config-factory.js
+++ b/cdap-ui/app/features/etlapps/services/etl-plugin-config-factory.js
@@ -1,0 +1,24 @@
+angular.module(PKG.name + '.feature.etlapps')
+  .service('PluginConfigFactory', function(MyDataSource, $q) {
+    this.plugins = {};
+
+    this.fetch = function(scope, templateid, pluginid) {
+      var dataSrc = new MyDataSource(scope);
+      var defer = $q.defer();
+
+      if (this.plugins[templateid+pluginid]) {
+        return $q.when(this.plugins[templateid+pluginid]);
+      }
+
+      dataSrc.config({
+        templateid: templateid, //'etlRealtime',
+        pluginid: pluginid //'TwitterSource'
+      })
+        .then(function(res) {
+          this.plugins[templateid+pluginid] = res;
+          defer.resolve(this.plugins[templateid+pluginid]);
+        }.bind(this));
+      return defer.promise;
+    };
+
+  });

--- a/cdap-ui/app/features/etlapps/templates/create.html
+++ b/cdap-ui/app/features/etlapps/templates/create.html
@@ -1,6 +1,6 @@
 <div class="row">
 
-    <div class="panel panel-default">
+    <div class="panel panel-default" ng-init="ETLMetadataTabOpen=true">
       <div class="panel-heading clearfix" ng-click="ETLMetadataTabOpen = !ETLMetadataTabOpen">
         <span class="pull-left"> Metadata</span>
         <i class="fa fa-fw pull-right"
@@ -43,7 +43,7 @@
 
 <div class="row">
 
-    <div class="panel panel-default">
+    <div class="panel panel-default" ng-init="ETLConfigTabOpen=false">
       <div class="panel-heading clearfix" ng-click="ETLConfigTabOpen = !ETLConfigTabOpen">
         <span class="pull-left">Configurations</span>
         <i class="fa fa-fw pull-right"

--- a/cdap-ui/app/features/etlapps/templates/create/plugins.html
+++ b/cdap-ui/app/features/etlapps/templates/create/plugins.html
@@ -1,7 +1,7 @@
 <div class="row">
   <div class="plugins">
     <div class="col-xs-4">
-      <div class="panel panel-default">
+      <div class="panel panel-default" ng-init="ETLSourcesTabOpen=true">
         <div class="panel-heading clearfix" ng-click="ETLSourcesTabOpen = !ETLSourcesTabOpen">
           <span class="pull-left"> Source</span>
           <i class="fa fa-fw pull-right"
@@ -26,7 +26,7 @@
 
     </div>
     <div class="col-xs-4">
-      <div class="panel panel-default">
+      <div class="panel panel-default" ng-init="ETLTransformsTabOpen=true">
         <div class="panel-heading clearfix" ng-click="ETLTransformsTabOpen =!ETLTransformsTabOpen">
           <span class="pull-left"> Transforms</span>
           <i class="fa fa-fw pull-right"
@@ -50,7 +50,7 @@
       </div>
     </div>
     <div class="col-xs-4">
-      <div class="panel panel-default">
+      <div class="panel panel-default" ng-init="ETLSinksTabOpen=true">
         <div class="panel-heading clearfix" ng-click="ETLSinksTabOpen = !ETLSinksTabOpen">
           <span class="pull-left"> Sinks</span>
           <i class="fa fa-fw pull-right"

--- a/cdap-ui/app/features/etlapps/templates/create/tabs/sourcePropertyEdit.html
+++ b/cdap-ui/app/features/etlapps/templates/create/tabs/sourcePropertyEdit.html
@@ -1,28 +1,31 @@
-<div class="container">
-  <div class="row" ng-init="isSaved=false">
-    <div class="col-xs-12">
-      <h3>Editing {{source.name}} Properties</h3>
-      <div class="text-success" ng-if="isSaved">
-        Saved!
-      </div>
-      <form class="form-horizontal">
+<h3>Editing {{source.name}} Properties</h3>
+<div class="row">
+  <div class="col-xs-6" ng-init="isSaved=false">
+    <div class="text-success" ng-if="isSaved">
+      Saved!
+    </div>
+    <form class="form-horizontal" ng-controller="SourceEditController">
+      <div ng-if="somethingfetched">
         <div ng-repeat="(name, value) in source.properties track by $index">
           <div class="form-group">
-            <label class="col-xs-12">{{ name | caskCapitalizeFilter}}</label>
-            <div class="col-sm-10">
-              <input type="text"
-                      class="form-control"
-                      ng-model="source.properties[name]"
-                      ng-change="$parent.isSaved=false"
-                      />
+            <label class="control-label col-sm-5">{{ name | caskCapitalizeFilter}}</label>
+            <div class="col-sm-7">
+              <div
+                  widget-container
+                  data-name="name"
+                  data-myproperty="name"
+                  data-model="source.properties[name]"
+                  data-myconfig="something"
+                  >
+              </div>
             </div>
           </div>
         </div>
-      </form>
-      <div class="btn-group pull-right">
-        <button type="button" class="btn btn-success" ng-click="isSaved=true">Save</button>
-        <button type="button" class="btn btn-default" ng-click="closeTab(tabIndex)">Close</button>
       </div>
+    </form>
+    <div class="btn-group pull-right">
+      <button type="button" class="btn btn-success" ng-click="isSaved=true">Save</button>
+      <button type="button" class="btn btn-default" ng-click="closeTab(tabIndex)">Close</button>
     </div>
   </div>
 </div>

--- a/cdap-ui/app/features/etlapps/templates/create/tabs/sourcePropertyEdit.html
+++ b/cdap-ui/app/features/etlapps/templates/create/tabs/sourcePropertyEdit.html
@@ -5,7 +5,7 @@
       Saved!
     </div>
     <form class="form-horizontal" ng-controller="SourceEditController">
-      <div ng-if="somethingfetched">
+      <div ng-if="somethingfetched" class="am-fade-and-slide-right">
         <div ng-repeat="(name, value) in source.properties track by $index">
           <div class="form-group">
             <label class="control-label col-sm-5">{{ name | caskCapitalizeFilter}}</label>

--- a/cdap-ui/app/main.js
+++ b/cdap-ui/app/main.js
@@ -63,7 +63,8 @@ angular
 
       'ncy-angular-breadcrumb',
       'angularMoment',
-      'ui.select'
+      'ui.select',
+      'ui.ace'
 
     ]).name,
 
@@ -130,11 +131,11 @@ angular
         });
       }
 
-      // The user doesn't need to know that the backend node 
+      // The user doesn't need to know that the backend node
       // is unable to connect to CDAP. Error messages add no
-      // more value than the pop showing that the FE is waiting 
-      // for system to come back up. Most of the issues are with 
-      // connect, other than that pass everything else to user. 
+      // more value than the pop showing that the FE is waiting
+      // for system to come back up. Most of the issues are with
+      // connect, other than that pass everything else to user.
       if(data.warning && data.error.syscall !== 'connect') {
         myAlert({
           content: data.warning,

--- a/cdap-ui/app/services/data/datasource.js
+++ b/cdap-ui/app/services/data/datasource.js
@@ -84,7 +84,8 @@ angular.module(PKG.name+'.services')
           self = this;
 
       if(instances[id]) {
-        throw new Error('multiple DataSource for scope', id);
+        // Reuse the same instance if already created.
+        return instances[id];
       }
       instances[id] = self;
 

--- a/cdap-ui/bower.json
+++ b/cdap-ui/bower.json
@@ -34,7 +34,8 @@
     "node-uuid": "~1.4.3",
     "angular-ui-select": "~0.11.2",
     "angular-cookies": "~1.3.15",
-    "c3": "~0.4.10"
+    "c3": "~0.4.10",
+    "angular-ui-ace": "bower"
   },
   "resolutions": {
     "angular": "1.3.14",

--- a/cdap-ui/templates/etlRealtime/JmsSource.json
+++ b/cdap-ui/templates/etlRealtime/JmsSource.json
@@ -1,32 +1,32 @@
 {
-  'id': 'JmsSource',
-  'groups' : {
-    'position': [ 'group1' ],
-    'group1': {
-       'display' : 'JMS Configuration',
-       'position' : [ 'jms.destination.name', 'jms.messages.receive' ],
-       'fields' : {
-          'jms.destination.name' : {
-             'widget-type': 'textbox',
-             'widget-label': 'JMS Destination Name',
-             'widget-description' : 'Specify the destination name for JMS',
-             'widget-info' : 'E.g. host:2181,host2:2181,host3:2181',
-             'widget-properties': {
-               'width': 'medium'
-             },
+  "id": "JmsSource",
+  "groups" : {
+    "position": [ "group1" ],
+    "group1": {
+       "display" : "JMS Configuration",
+       "position" : [ "jms.destination.name", "jms.messages.receive" ],
+       "fields" : {
+          "jms.destination.name" : {
+             "widget-type": "textbox",
+             "widget-label": "JMS Destination Name",
+             "widget-description" : "Specify the destination name for JMS",
+             "widget-info" : "E.g. host:2181,host2:2181,host3:2181",
+             "widget-properties": {
+               "width": "medium"
+             }
           },
 
-          'jms.messages.receive' : {
-             'widget-type': 'number',
-             'widget-label': 'Number of message to receive at once from JMS',
-             'widget-description': 'Specific the number of messages to be received from JMS',
-             'widget-info': '',
-             'widget-properties': {
-               'width': 'extra-small',
-               'default': 1
-             }
-             'max': 999,
-             'min': 1
+          "jms.messages.receive" : {
+             "widget-type": "number",
+             "widget-label": "Number of message to receive at once from JMS",
+             "widget-description": "Specific the number of messages to be received from JMS",
+             "widget-info": "",
+             "widget-properties": {
+               "width": "extra-small",
+               "default": 1
+             },
+             "max": 999,
+             "min": 1
           }
        }
     }

--- a/cdap-ui/templates/etlRealtime/KafkaSource.json
+++ b/cdap-ui/templates/etlRealtime/KafkaSource.json
@@ -1,65 +1,65 @@
 {
-  'id': 'KafkaSource',
-  'groups' : {
-    'position': [ 'group1' ],
-    'group1': {
-       'display' : 'Kafka Configuration',
-       'position' : [ 'kafka.zookeeper', 'kafka.brokers', 'kafka.partitions', 'kafka.topic', 'kafka.default.offset' ],
-       'fields' : {
-          'kafka.zookeeper' : {
-             'widget-type': 'textbox',
-             'widget-label': 'Zookeeper Qorum'
-             'widget-description' : 'Specify the zookeeper connection string.',
-             'widget-info' : 'E.g. host:2181,host2:2181,host3:2181',
-             'widget-properties': {
-               'width': 'large'
-             },
-          },
-
-          'kafka.brokers' : {
-             'widget-type': 'csv',
-             'widget-label': 'Kafka Brokers',
-             'widget-description' : 'Server names on which kafka server is running',
-             'widget-info' : 'Kafka is run as a cluster comprised of one or more servers each of which is called broker',
-             'widget-properties': {
-               'width': 'medium'
-             },
-             'delimiter' : ','
-          },
-
-          'kafka.partitions' : {
-             'widget-type': 'number',
-             'widget-label': 'Number of Partitions',
-             'widget-description': 'Specific the number of partitions',
-             'widget-info': 'Each partition is an ordered, immutable sequence of messages that is continually appended to—a commit log. The messages in the partitions are each assigned a sequential id number called the offset that uniquely identifies each message within the partition',
-             'widget-properties': {
-               'width': 'extra-small',
-               'default': 1
+  "id": "KafkaSource",
+  "groups" : {
+    "position": [ "group1" ],
+    "group1": {
+       "display" : "Kafka Configuration",
+       "position" : [ "kafka.zookeeper", "kafka.brokers", "kafka.partitions", "kafka.topic", "kafka.default.offset" ],
+       "fields" : {
+          "kafka.zookeeper" : {
+             "widget-type": "textbox",
+             "widget-label": "Zookeeper Qorum",
+             "widget-description" : "Specify the zookeeper connection string.",
+             "widget-info" : "E.g. host:2181,host2:2181,host3:2181",
+             "widget-properties": {
+               "width": "large"
              }
-             'max': 999,
-             'min': 1
           },
 
-          'kafka.topic' : {
-             'widget-type': 'textbox',
-             'widget-label': 'Topic',
-             'widget-description' : 'Specify the topic you want to subscribe to',
-             'widget-info' : 'Kafka maintains feeds of messages in categories called topics',
-             'widget-properties': {
-               'width': 'medium'
+          "kafka.brokers" : {
+             "widget-type": "csv",
+             "widget-label": "Kafka Brokers",
+             "widget-description" : "Server names on which kafka server is running",
+             "widget-info" : "Kafka is run as a cluster comprised of one or more servers each of which is called broker",
+             "widget-properties": {
+               "width": "medium"
              },
+             "delimiter" : ","
           },
 
-          'kafka.default.offset' : {
-             'widget-type': 'number',
-             'widget-label': 'Offset to start processing from',
-             'widget-description': 'Integer specifying the offset to start processing from',
-             'widget-info': '',
-             'widget-properties': {
-               'width': 'extra-small',
-               'default': 1
+          "kafka.partitions" : {
+             "widget-type": "number",
+             "widget-label": "Number of Partitions",
+             "widget-description": "Specific the number of partitions",
+             "widget-info": "Each partition is an ordered, immutable sequence of messages that is continually appended to—a commit log. The messages in the partitions are each assigned a sequential id number called the offset that uniquely identifies each message within the partition",
+             "widget-properties": {
+               "width": "extra-small",
+               "default": 1
+             },
+             "max": 999,
+             "min": 1
+          },
+
+          "kafka.topic" : {
+             "widget-type": "textbox",
+             "widget-label": "Topic",
+             "widget-description" : "Specify the topic you want to subscribe to",
+             "widget-info" : "Kafka maintains feeds of messages in categories called topics",
+             "widget-properties": {
+               "width": "medium"
              }
-             'min': 1
+          },
+
+          "kafka.default.offset" : {
+             "widget-type": "number",
+             "widget-label": "Offset to start processing from",
+             "widget-description": "Integer specifying the offset to start processing from",
+             "widget-info": "",
+             "widget-properties": {
+               "width": "extra-small",
+               "default": 1
+             },
+             "min": 1
           }
        }
     }

--- a/cdap-ui/templates/etlRealtime/TwitterSource.json
+++ b/cdap-ui/templates/etlRealtime/TwitterSource.json
@@ -1,54 +1,53 @@
 {
-  'id': 'TwitterSource',
-  'groups' : {
-    'position': [ 'group1', 'group2' ],
-    'group1': {
-       'display' : 'Twitter Account Info',
-       'position' : [ 'AccessToken', 'AccessTokenSecret' ],
-       'fields' : {
-          'AccessToken' : {
-             'widget-type': 'textbox',
-             'widget-label': 'Access Token'
-             'widget-description' : 'Twitter Access Token.',
-             'widget-info' : 'Here is where you can get it',
-             'widget-properties': {
-               'width': 'medium'
-             },
+  "id": "TwitterSource",
+  "groups" : {
+    "position": [ "group1", "group2" ],
+    "group1": {
+       "display" : "Twitter Account Info",
+       "position" : [ "AccessToken", "AccessTokenSecret" ],
+       "fields" : {
+          "AccessToken" : {
+             "widget-type": "textarea",
+             "widget-label": "Access Token",
+             "widget-description" : "Twitter Access Token.",
+             "widget-info" : "Here is where you can get it",
+             "widget-properties": {
+               "width": "medium"
+             }
           },
-          'AccessTokenSecret' : {
-             'widget-type': 'password',
-             'widget-label': 'Access Token Secret'
-             'widget-description' : 'Twitter Access Token Secret.',
-             'widget-info' : 'Here is where you can get it',
-             'widget-properties': {
-               'width': 'medium'
-             },
+          "AccessTokenSecret" : {
+             "widget-type": "password",
+             "widget-label": "Access Token Secret",
+             "widget-description" : "Twitter Access Token Secret.",
+             "widget-info" : "Here is where you can get it",
+             "widget-properties": {
+               "width": "medium"
+             }
           }
        }
     },
-
-    'group2' : {
-      'display' : 'Twitter Consumer Key & Tokens',
-      'position' : [ 'ConsumerKey', 'ConsumerSecret' ],
-      'fields' : {
-          'ConsumerKey' : {
-             'widget-type': 'textbox',
-             'widget-label': 'Consumer Key',
-             'widget-description' : 'Twitter Access Token.',
-             'widget-info' : 'Here is where you can get it',
-             'widget-properties': {
-               'width': 'medium'
-             },
+    "group2" : {
+      "display" : "Twitter Consumer Key & Tokens",
+      "position" : [ "ConsumerKey", "ConsumerSecret" ],
+      "fields" : {
+          "ConsumerKey" : {
+             "widget-type": "textbox",
+             "widget-label": "Consumer Key",
+             "widget-description" : "Twitter Access Token.",
+             "widget-info" : "Here is where you can get it",
+             "widget-properties": {
+               "width": "medium"
+             }
           },
-          'ConsumerSecret' : {
-             'widget-type': 'password',
-             'widget-label': 'Consumer Secret',
-             'widget-description' : 'Twitter Consumer Secret',
-             'widget-info' : 'Here is where you can get it',
-             'widget-properties': {
-               'width': 'medium'
-             },
-          },
+          "ConsumerSecret" : {
+             "widget-type": "password",
+             "widget-label": "Consumer Secret",
+             "widget-description" : "Twitter Consumer Secret",
+             "widget-info" : "Here is where you can get it",
+             "widget-properties": {
+               "width": "medium"
+             }
+          }
        }
     }
   }


### PR DESCRIPTION
- Minor cleanup of ETL App Create view
- First draft of ```widget-container```. A basic widget container that given a type, property and config renders the appropriate ui element.
- Adds json & javascript editor widgets to be used in editing properties.

NOTE:
 - Right now all input type elements are bound to a model. Javascript editor is yet to be bounded to a model (ng-model). Will split it in next PR.
 - Doing it only for Source Properties. Will add Sink configuration json files to be used in editing sink properties (and eventually transforms).