### PR TITLE
(CDAP-2275) Make plugin classes exposed to MR framework.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractContext.java
@@ -41,7 +41,6 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
-import com.google.common.io.Closeables;
 import org.apache.twill.api.RunId;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.slf4j.Logger;
@@ -125,6 +124,14 @@ public abstract class AbstractContext extends AbstractServiceDiscoverer
     return adapterSpec;
   }
 
+  /**
+   * Returns the {@link PluginInstantiator} used by this context or {@code null} if there is no plugin supported.
+   */
+  @Nullable
+  public PluginInstantiator getPluginInstantiator() {
+    return pluginInstantiator;
+  }
+
   @Override
   public String toString() {
     return String.format("namespaceId=%s, applicationId=%s, program=%s, runid=%s",
@@ -192,14 +199,8 @@ public abstract class AbstractContext extends AbstractServiceDiscoverer
    * method to release additional resources.
    */
   public void close() {
-    try {
-      for (Closeable ds : datasets.values()) {
-        closeDataSet(ds);
-      }
-    } finally {
-      if (pluginInstantiator != null) {
-        Closeables.closeQuietly(pluginInstantiator);
-      }
+    for (Closeable ds : datasets.values()) {
+      closeDataSet(ds);
     }
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/PluginClassLoader.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/PluginClassLoader.java
@@ -62,10 +62,23 @@ import java.util.jar.Manifest;
  */
 public class PluginClassLoader extends DirectoryClassLoader {
 
+  private final Set<String> exportPackages;
+
+  /**
+   * Creates a ClassLoader for the given plugin
+   *
+   * @param unpackedDir directory where the plugin jar get expanded to
+   * @param pluginLibDir the plugin lib directory
+   * @param templateClassLoader the program ClassLoader for the app template
+   * @return A ClassLoader for the given plugin
+   */
   public static PluginClassLoader create(File unpackedDir, File pluginLibDir, ClassLoader templateClassLoader) {
     return new PluginClassLoader(unpackedDir, createParent(pluginLibDir, templateClassLoader));
   }
 
+  /**
+   * Creates the parent ClassLoader for the plugin ClassLoader. See javadoc of this class for details.
+   */
   private static ClassLoader createParent(File pluginLibDir, ClassLoader templateClassLoader) {
 
     // Find the ProgramClassLoader from the template ClassLoader
@@ -93,5 +106,14 @@ public class PluginClassLoader extends DirectoryClassLoader {
 
   private PluginClassLoader(File directory, ClassLoader parent) {
     super(directory, parent, "lib");
+    this.exportPackages = ManifestFields.getExportPackages(getManifest());
+  }
+
+  /**
+   * Creates a new {@link ClassLoader} that only exposes classes in packages declared by "Export-Package"
+   * in the manifest.
+   */
+  public ClassLoader getExportPackagesClassLoader() {
+    return new PackageFilterClassLoader(this, Predicates.in(exportPackages));
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/PluginInstantiator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/PluginInstantiator.java
@@ -186,7 +186,12 @@ public class PluginInstantiator implements Closeable {
   public void close() throws IOException {
     // Cleanup the ClassLoader cache and the temporary directoy for the expanded plugin jar.
     classLoaders.invalidateAll();
-    DirUtils.deleteDirectoryContents(tmpDir);
+    try {
+      DirUtils.deleteDirectoryContents(tmpDir);
+    } catch (IOException e) {
+      // It's the cleanup step. Nothing much can be done if cleanup failed.
+      LOG.warn("Failed to delete directory {}", tmpDir);
+    }
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/PluginRepository.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/PluginRepository.java
@@ -209,7 +209,7 @@ public class PluginRepository {
           }
         }
       } finally {
-        pluginInstantiator.close();
+        Closeables.closeQuietly(pluginInstantiator);
       }
     } finally {
       templateClassLoader.close();
@@ -329,7 +329,12 @@ public class PluginRepository {
               }
 
               try {
-                classIterator = DirUtils.list(new File(packageResource.toURI()), "class").iterator();
+                // Only inspect classes in the top level jar file for Plugins.
+                // The jar manifest may have packages in Export-Package that are loadable from the bundled jar files,
+                // which is for classloading purpose. Those classes won't be inspected for plugin classes.
+                if (packageResource.getProtocol().equals("file")) {
+                  classIterator = DirUtils.list(new File(packageResource.toURI()), "class").iterator();
+                }
               } catch (URISyntaxException e) {
                 // Cannot happen
                 throw Throwables.propagate(e);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceClassLoader.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceClassLoader.java
@@ -16,17 +16,31 @@
 
 package co.cask.cdap.internal.app.runtime.batch;
 
+import co.cask.cdap.api.templates.plugins.PluginInfo;
 import co.cask.cdap.common.lang.CombineClassLoader;
+import co.cask.cdap.common.lang.FilterClassLoader;
 import co.cask.cdap.common.lang.ProgramClassLoader;
 import co.cask.cdap.common.lang.jar.BundleJarUtil;
 import co.cask.cdap.common.utils.DirUtils;
+import co.cask.cdap.internal.app.runtime.adapter.PluginClassLoader;
+import co.cask.cdap.internal.app.runtime.adapter.PluginInstantiator;
 import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.templates.AdapterDefinition;
+import co.cask.cdap.templates.AdapterPlugin;
+import com.google.common.base.Function;
+import com.google.common.base.Predicates;
 import com.google.common.base.Throwables;
+import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Multimap;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapreduce.MRJobConfig;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import org.apache.hadoop.yarn.util.ApplicationClassLoader;
 import org.apache.twill.filesystem.LocalLocationFactory;
 import org.apache.twill.filesystem.Location;
 import org.slf4j.Logger;
@@ -34,49 +48,244 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
  * A {@link ClassLoader} for YARN application isolation. Classes from
  * the application JARs are loaded in preference to the parent loader.
+ *
+ * The delegation order is:
+ *
+ * ProgramClassLoader -> Plugin Lib ClassLoader -> Plugins Export-Package ClassLoaders -> System ClassLoader
  */
 public class MapReduceClassLoader extends CombineClassLoader {
 
   private static final Logger LOG = LoggerFactory.getLogger(MapReduceClassLoader.class);
+  private static final Function<String, String> CLASS_TO_RESOURCE_NAME = new Function<String, String>() {
+    @Override
+    public String apply(String className) {
+      return className.replace('.', '/') + ".class";
+    }
+  };
 
-  public MapReduceClassLoader() {
-    this(createProgramClassLoader());
-  }
+  private final Parameters paramters;
 
-  public MapReduceClassLoader(ClassLoader programClassLoader) {
-    super(null, ImmutableList.of(programClassLoader, MapReduceClassLoader.class.getClassLoader()));
-  }
-
-  public ClassLoader getProgramClassLoader() {
-    return getDelegates().get(0);
+  /**
+   * Constructor called by children classes only. Mainly called by {@link ApplicationClassLoader} from
+   * the MR framework in distributed mode.
+   */
+  protected MapReduceClassLoader() {
+    this(new Parameters());
   }
 
   /**
-   * Creates a program {@link ClassLoader} based on the MR job config.
+   * Constructor for using the given program ClassLoader to have higher precedence than the system ClassLoader.
    */
-  private static ClassLoader createProgramClassLoader() {
-    Configuration conf = new Configuration(new YarnConfiguration());
-    conf.addResource(new Path(MRJobConfig.JOB_CONF_FILE));
-    MapReduceContextConfig contextConfig = new MapReduceContextConfig(conf);
+  public MapReduceClassLoader(ClassLoader programClassLoader) {
+    this(new Parameters(programClassLoader));
+  }
 
-    // In distributed mode, the program is created by expanding the program jar.
-    // The program jar is localized to container with the program jar name.
-    // It's ok to expand to a temp dir in local directory, as the YARN container will be gone.
-    Location programLocation = new LocalLocationFactory()
-      .create(new File(contextConfig.getProgramJarName()).getAbsoluteFile().toURI());
-    try {
-      File unpackDir = DirUtils.createTempDir(new File(System.getProperty("user.dir")));
-      LOG.info("Create ProgramClassLoader from {}, expand to {}", programLocation.toURI(), unpackDir);
+  /**
+   * Constructs a ClassLoader that load classes from the programClassLoader, then from the plugin lib ClassLoader,
+   * followed by plugin Export-Package ClassLoader and with the sytem ClassLoader last.
+   */
+  public MapReduceClassLoader(ClassLoader programClassLoader,
+                              @Nullable AdapterDefinition adapterSpec,
+                              @Nullable PluginInstantiator pluginInstantiator) {
+    this(new Parameters(programClassLoader, adapterSpec, pluginInstantiator));
+  }
 
-      BundleJarUtil.unpackProgramJar(programLocation, unpackDir);
-      return ProgramClassLoader.create(unpackDir, conf.getClassLoader(), ProgramType.MAPREDUCE);
-    } catch (IOException e) {
-      LOG.error("Failed to create ProgramClassLoader", e);
-      throw Throwables.propagate(e);
+  private MapReduceClassLoader(Parameters paramters) {
+    super(null, createDelegates(paramters));
+    this.paramters = paramters;
+  }
+
+  public ClassLoader getProgramClassLoader() {
+    return paramters.getProgramClassLoader();
+  }
+
+  @Nullable
+  public PluginInstantiator getPluginInstantiator() {
+    return paramters.getPluginInstantiator();
+  }
+
+  /**
+   * Creates the delegating list of ClassLoader.
+   */
+  private static List<ClassLoader> createDelegates(Parameters parameters) {
+    ImmutableList.Builder<ClassLoader> builder = ImmutableList.builder();
+    builder.add(parameters.getProgramClassLoader());
+    builder.addAll(parameters.getFilteredPluginClassLoaders());
+    builder.add(MapReduceClassLoader.class.getClassLoader());
+
+    return builder.build();
+  }
+
+  /**
+   * A container class for holding parameters for the construction of the MapReduceClassLoader.
+   * It is needed because we need all parameters available when calling super constructor.
+   */
+  private static final class Parameters {
+
+    private final ClassLoader programClassLoader;
+    private final PluginInstantiator pluginInstantiator;
+    private final List<ClassLoader> filteredPluginClassLoaders;
+
+    /**
+     * Creates from the Job Configuration
+     */
+    Parameters() {
+      this(createContextConfig());
+    }
+
+    /**
+     * Creates from the given ProgramClassLoader without plugin support.
+     */
+    Parameters(ClassLoader programClassLoader) {
+      this.programClassLoader = programClassLoader;
+      this.pluginInstantiator = null;
+      this.filteredPluginClassLoaders = ImmutableList.of();
+    }
+
+    Parameters(MapReduceContextConfig contextConfig) {
+      this(contextConfig, createProgramClassLoader(contextConfig));
+    }
+
+    Parameters(MapReduceContextConfig contextConfig, ClassLoader programClassLoader) {
+      this(programClassLoader, contextConfig.getAdapterSpec(),
+           createPluginInstantiator(contextConfig, programClassLoader));
+    }
+
+    /**
+     * Creates from the given ProgramClassLoader with plugin classloading support.
+     */
+    Parameters(ClassLoader programClassLoader,
+               @Nullable AdapterDefinition adapterSpec,
+               @Nullable PluginInstantiator pluginInstantiator) {
+      this.programClassLoader = programClassLoader;
+      this.pluginInstantiator = pluginInstantiator;
+      this.filteredPluginClassLoaders = createFilteredPluginClassLoaders(adapterSpec, pluginInstantiator);
+    }
+
+    public ClassLoader getProgramClassLoader() {
+      return programClassLoader;
+    }
+
+    @Nullable
+    public PluginInstantiator getPluginInstantiator() {
+      return pluginInstantiator;
+    }
+
+    public List<ClassLoader> getFilteredPluginClassLoaders() {
+      return filteredPluginClassLoaders;
+    }
+
+    private static MapReduceContextConfig createContextConfig() {
+      Configuration conf = new Configuration(new YarnConfiguration());
+      conf.addResource(new Path(MRJobConfig.JOB_CONF_FILE));
+      return new MapReduceContextConfig(conf);
+    }
+
+    /**
+     * Creates a program {@link ClassLoader} based on the MR job config.
+     */
+    private static ClassLoader createProgramClassLoader(MapReduceContextConfig contextConfig) {
+      // In distributed mode, the program is created by expanding the program jar.
+      // The program jar is localized to container with the program jar name.
+      // It's ok to expand to a temp dir in local directory, as the YARN container will be gone.
+      Location programLocation = new LocalLocationFactory()
+        .create(new File(contextConfig.getProgramJarName()).getAbsoluteFile().toURI());
+      try {
+        File unpackDir = DirUtils.createTempDir(new File(System.getProperty("user.dir")));
+        LOG.info("Create ProgramClassLoader from {}, expand to {}", programLocation.toURI(), unpackDir);
+
+        BundleJarUtil.unpackProgramJar(programLocation, unpackDir);
+        return ProgramClassLoader.create(unpackDir,
+                                         contextConfig.getConfiguration().getClassLoader(), ProgramType.MAPREDUCE);
+      } catch (IOException e) {
+        LOG.error("Failed to create ProgramClassLoader", e);
+        throw Throwables.propagate(e);
+      }
+    }
+
+    /**
+     * Returns a new {@link PluginInstantiator} or {@code null} if no plugin is supported.
+     */
+    @Nullable
+    private static PluginInstantiator createPluginInstantiator(MapReduceContextConfig contextConfig,
+                                                               ClassLoader programClassLoader) {
+      if (contextConfig.getAdapterSpec() == null) {
+        return null;
+      }
+      return new PluginInstantiator(contextConfig.getConf(), contextConfig.getAdapterSpec().getTemplate(),
+                                    programClassLoader);
+    }
+
+    /**
+     * Returns a list of {@link ClassLoader} for loading plugin classes. The ordering is:
+     *
+     * Plugin Lib ClassLoader, Plugin Export-Package ClassLoader, ...
+     *
+     * The ordering of the plugins are defined by the ordering of {@link PluginInfo}.
+     */
+    private static List<ClassLoader> createFilteredPluginClassLoaders(@Nullable AdapterDefinition adapterSpec,
+                                                                      @Nullable PluginInstantiator pluginInstantiator) {
+      if (pluginInstantiator == null || adapterSpec == null) {
+        return ImmutableList.of();
+      }
+
+      try {
+        // Gather all explicitly used plugin class names. It is needed for external plugin case,
+        Multimap<PluginInfo, String> adapterPluginClasses = getAdapterPluginClasses(adapterSpec);
+
+        // There should be just one plugin lib ClassLoader shared across all plugins
+        ClassLoader pluginLibClassLoader = null;
+        Deque<ClassLoader> pluginClassLoaders = Lists.newLinkedList();
+
+        for (PluginInfo pluginInfo : adapterSpec.getPluginInfos()) {
+          ClassLoader pluginClassLoader = pluginInstantiator.getPluginClassLoader(pluginInfo);
+          pluginLibClassLoader = pluginClassLoader.getParent();
+
+          if (pluginClassLoader instanceof PluginClassLoader) {
+            // One with filter by class name
+            Collection<String> allowedClasses = adapterPluginClasses.get(pluginInfo);
+            if (!allowedClasses.isEmpty()) {
+              pluginClassLoaders.add(createClassFilteredClassLoader(allowedClasses, pluginClassLoader));
+            }
+            // One with Export-Package
+            pluginClassLoaders.add(((PluginClassLoader) pluginClassLoader).getExportPackagesClassLoader());
+          }
+        }
+
+        if (pluginLibClassLoader != null) {
+          pluginClassLoaders.add(pluginLibClassLoader);
+        }
+        return ImmutableList.copyOf(pluginClassLoaders);
+      } catch (IOException e) {
+        throw Throwables.propagate(e);
+      }
+    }
+
+    /**
+     * Returns a {@link Multimap} from {@link PluginInfo} to set of classes used by the adapter.
+     */
+    private static Multimap<PluginInfo, String> getAdapterPluginClasses(AdapterDefinition adapterSpec) {
+      Multimap<PluginInfo, String> result = HashMultimap.create();
+      for (Map.Entry<String, AdapterPlugin> entry : adapterSpec.getPlugins().entrySet()) {
+        result.put(entry.getValue().getPluginInfo(), entry.getValue().getPluginClass().getClassName());
+      }
+      return result;
+    }
+
+    private static ClassLoader createClassFilteredClassLoader(Iterable<String> allowedClasses,
+                                                              ClassLoader parentClassLoader) {
+      Set<String> allowedResources = ImmutableSet.copyOf(Iterables.transform(allowedClasses, CLASS_TO_RESOURCE_NAME));
+      return new FilterClassLoader(Predicates.in(allowedResources), Predicates.<String>alwaysTrue(), parentClassLoader);
     }
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextConfig.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextConfig.java
@@ -86,12 +86,13 @@ public final class MapReduceContextConfig {
   }
 
   private void setArguments(Map<String, String> arguments) {
-    hConf.set(HCONF_ATTR_ARGS, new Gson().toJson(arguments));
+    hConf.set(HCONF_ATTR_ARGS, GSON.toJson(arguments));
   }
 
   public Arguments getArguments() {
-    Map<String, String> arguments = new Gson().fromJson(hConf.get(HCONF_ATTR_ARGS),
-                                                        new TypeToken<Map<String, String>>() { }.getType());
+    Map<String, String> arguments = GSON.fromJson(hConf.get(HCONF_ATTR_ARGS),
+                                                  new TypeToken<Map<String, String>>() {
+                                                  }.getType());
     return new BasicArguments(arguments);
   }
 
@@ -165,9 +166,7 @@ public final class MapReduceContextConfig {
       splitClass = SimpleSplit.class;
     }
     hConf.set(HCONF_ATTR_INPUT_SPLIT_CLASS, splitClass.getName());
-
-    // todo: re-use Gson instance?
-    hConf.set(HCONF_ATTR_INPUT_SPLITS, new Gson().toJson(splits));
+    hConf.set(HCONF_ATTR_INPUT_SPLITS, GSON.toJson(splits));
   }
 
   public List<Split> getInputSelection() {
@@ -182,7 +181,7 @@ public final class MapReduceContextConfig {
       @SuppressWarnings("unchecked")
       Class<? extends Split> splitClass =
         (Class<? extends Split>) hConf.getClassLoader().loadClass(splitClassName);
-      return new Gson().fromJson(splitsJson, new ListSplitType(splitClass));
+      return GSON.fromJson(splitsJson, new ListSplitType(splitClass));
     } catch (ClassNotFoundException e) {
       //todo
       throw Throwables.propagate(e);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextProvider.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextProvider.java
@@ -81,7 +81,7 @@ public final class MapReduceContextProvider {
                contextConfig.getInputSelection(),
                contextConfig.getOutputDataSet(),
                contextConfig.getAdapterSpec(),
-               createPluginInstantiator(cConf)
+               getPluginInstantiator(cConf)
         );
     }
     return context;
@@ -129,12 +129,16 @@ public final class MapReduceContextProvider {
   }
 
   @Nullable
-  private PluginInstantiator createPluginInstantiator(CConfiguration cConf) {
+  private PluginInstantiator getPluginInstantiator(CConfiguration cConf) {
     if (contextConfig.getAdapterSpec() == null) {
       return null;
     }
-    return new PluginInstantiator(cConf, contextConfig.getAdapterSpec().getTemplate(),
-                                  getProgramClassLoader(taskContext.getConfiguration()));
+
+    ClassLoader classLoader = cConf.getClassLoader();
+    if (!(classLoader instanceof MapReduceClassLoader)) {
+      throw new IllegalArgumentException("ClassLoader is not an MapReduceClassLoader");
+    }
+    return ((MapReduceClassLoader) classLoader).getPluginInstantiator();
   }
 
   /**
@@ -145,7 +149,7 @@ public final class MapReduceContextProvider {
   static ClassLoader getProgramClassLoader(Configuration hConf) {
     ClassLoader classLoader = hConf.getClassLoader();
     if (!(classLoader instanceof MapReduceClassLoader)) {
-      throw new IllegalArgumentException("ClassLoader is not an ApplicationClassLoader");
+      throw new IllegalArgumentException("ClassLoader is not an MapReduceClassLoader");
     }
     return ((MapReduceClassLoader) classLoader).getProgramClassLoader();
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
@@ -47,6 +47,7 @@ import co.cask.cdap.templates.AdapterDefinition;
 import co.cask.tephra.TransactionSystemClient;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
+import com.google.common.io.Closeables;
 import com.google.common.reflect.TypeToken;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.Service;
@@ -147,25 +148,68 @@ public class MapReduceProgramRunner implements ProgramRunner {
       throw Throwables.propagate(e);
     }
 
-    final DynamicMapReduceContext context =
-      new DynamicMapReduceContext(program, null, runId, null, options.getUserArguments(), spec,
-                                  logicalStartTime, workflowBatch, discoveryServiceClient, metricsCollectionService,
-                                  txSystemClient, datasetFramework, adapterSpec,
-                                  createPluginInstantiator(adapterSpec, program.getClassLoader()));
+    final PluginInstantiator pluginInstantiator = createPluginInstantiator(adapterSpec, program.getClassLoader());
+    try {
+      final DynamicMapReduceContext context =
+        new DynamicMapReduceContext(program, null, runId, null, options.getUserArguments(), spec,
+                                    logicalStartTime, workflowBatch, discoveryServiceClient, metricsCollectionService,
+                                    txSystemClient, datasetFramework, adapterSpec, pluginInstantiator);
 
 
-    Reflections.visit(mapReduce, TypeToken.of(mapReduce.getClass()),
-                      new PropertyFieldSetter(context.getSpecification().getProperties()),
-                      new MetricsFieldSetter(context.getMetrics()),
-                      new DataSetFieldSetter(context));
+      Reflections.visit(mapReduce, TypeToken.of(mapReduce.getClass()),
+                        new PropertyFieldSetter(context.getSpecification().getProperties()),
+                        new MetricsFieldSetter(context.getMetrics()),
+                        new DataSetFieldSetter(context));
 
-    // note: this sets logging context on the thread level
-    LoggingContextAccessor.setLoggingContext(context.getLoggingContext());
+      // note: this sets logging context on the thread level
+      LoggingContextAccessor.setLoggingContext(context.getLoggingContext());
 
-    final Service mapReduceRuntimeService = new MapReduceRuntimeService(cConf, hConf, mapReduce, spec, context,
-                                                                        program.getJarLocation(), locationFactory,
-                                                                        streamAdmin, txSystemClient, usageRegistry);
-    mapReduceRuntimeService.addListener(new ServiceListenerAdapter() {
+      final Service mapReduceRuntimeService = new MapReduceRuntimeService(cConf, hConf, mapReduce, spec, context,
+                                                                          program.getJarLocation(), locationFactory,
+                                                                          streamAdmin, txSystemClient, usageRegistry);
+      mapReduceRuntimeService.addListener(createRuntimeServiceListener(program, runId, adapterSpec,
+                                                                       twillRunId, pluginInstantiator),
+                                          Threads.SAME_THREAD_EXECUTOR);
+
+      final ProgramController controller = new MapReduceProgramController(mapReduceRuntimeService, context);
+
+      LOG.info("Starting MapReduce Job: {}", context.toString());
+      // if security is not enabled, start the job as the user we're using to access hdfs with.
+      // if this is not done, the mapred job will be launched as the user that runs the program
+      // runner, which is probably the yarn user. This may cause permissions issues if the program
+      // tries to access cdap data. For example, writing to a FileSet will fail, as the yarn user will
+      // be running the job, but the data directory will be owned by cdap.
+      if (!UserGroupInformation.isSecurityEnabled()) {
+        String runAs = cConf.get(Constants.CFG_HDFS_USER);
+        try {
+          UserGroupInformation.createRemoteUser(runAs)
+            .doAs(new PrivilegedExceptionAction<ListenableFuture<Service.State>>() {
+              @Override
+              public ListenableFuture<Service.State> run() throws Exception {
+                return mapReduceRuntimeService.start();
+              }
+            });
+        } catch (Exception e) {
+          LOG.error("Exception running mapreduce job as user {}.", runAs, e);
+          throw Throwables.propagate(e);
+        }
+      } else {
+        mapReduceRuntimeService.start();
+      }
+      return controller;
+    } catch (Exception e) {
+      Closeables.closeQuietly(pluginInstantiator);
+      throw Throwables.propagate(e);
+    }
+  }
+
+  /**
+   * Creates a service listener to reactor on state changes on {@link MapReduceRuntimeService}.
+   */
+  private Service.Listener createRuntimeServiceListener(final Program program, final RunId runId,
+                                                        final AdapterDefinition adapterSpec, final String twillRunId,
+                                                        final PluginInstantiator pluginInstantiator) {
+    return new ServiceListenerAdapter() {
       @Override
       public void starting() {
         //Get start time from RunId
@@ -180,6 +224,7 @@ public class MapReduceProgramRunner implements ProgramRunner {
 
       @Override
       public void terminated(Service.State from) {
+        Closeables.closeQuietly(pluginInstantiator);
         if (from == Service.State.STOPPING) {
           // Service was killed
           store.setStop(program.getId(), runId.getId(), TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()),
@@ -193,37 +238,11 @@ public class MapReduceProgramRunner implements ProgramRunner {
 
       @Override
       public void failed(Service.State from, Throwable failure) {
+        Closeables.closeQuietly(pluginInstantiator);
         store.setStop(program.getId(), runId.getId(), TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()),
                       ProgramController.State.ERROR.getRunStatus());
       }
-    }, Threads.SAME_THREAD_EXECUTOR);
-
-    final ProgramController controller = new MapReduceProgramController(mapReduceRuntimeService, context);
-
-    LOG.info("Starting MapReduce Job: {}", context.toString());
-    // if security is not enabled, start the job as the user we're using to access hdfs with.
-    // if this is not done, the mapred job will be launched as the user that runs the program
-    // runner, which is probably the yarn user. This may cause permissions issues if the program
-    // tries to access cdap data. For example, writing to a FileSet will fail, as the yarn user will
-    // be running the job, but the data directory will be owned by cdap.
-    if (!UserGroupInformation.isSecurityEnabled()) {
-      String runAs = cConf.get(Constants.CFG_HDFS_USER);
-      try {
-        UserGroupInformation.createRemoteUser(runAs)
-          .doAs(new PrivilegedExceptionAction<ListenableFuture<Service.State>>() {
-            @Override
-            public ListenableFuture<Service.State> run() throws Exception {
-              return mapReduceRuntimeService.start();
-            }
-          });
-      } catch (Exception e) {
-        LOG.error("Exception running mapreduce job as user {}.", runAs, e);
-        throw Throwables.propagate(e);
-      }
-    } else {
-      mapReduceRuntimeService.start();
-    }
-    return controller;
+    };
   }
 
   @Nullable

--- a/cdap-common/src/main/java/co/cask/cdap/common/lang/FilterClassLoader.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/lang/FilterClassLoader.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.lang;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Enumeration;
+import java.util.List;
+
+/**
+ * ClassLoader that filters out certain resources.
+ */
+public final class FilterClassLoader extends ClassLoader {
+
+  private final Predicate<String> resourceAcceptor;
+  private final Predicate<String> packageAcceptor;
+  private final ClassLoader bootstrapClassLoader;
+
+  /**
+   * @param resourceAcceptor Filter for accepting resources
+   * @param parentClassLoader Parent classloader
+   */
+  public FilterClassLoader(Predicate<String> resourceAcceptor,
+                           Predicate<String> packageAcceptor, ClassLoader parentClassLoader) {
+    super(parentClassLoader);
+    this.resourceAcceptor = resourceAcceptor;
+    this.packageAcceptor = packageAcceptor;
+    this.bootstrapClassLoader = new URLClassLoader(new URL[0], null);
+  }
+
+  @Override
+  protected synchronized Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+    // Try to load it from bootstrap class loader first
+    try {
+      return bootstrapClassLoader.loadClass(name);
+    } catch (ClassNotFoundException e) {
+      if (isValidResource(classNameToResourceName(name))) {
+        return super.loadClass(name, resolve);
+      }
+      throw e;
+    }
+  }
+
+  @Override
+  public URL findResource(String name) {
+    if (isValidResource(name)) {
+      return super.findResource(name);
+    }
+
+    return null;
+  }
+
+  @Override
+  public Enumeration<URL> findResources(String name) throws IOException {
+    if (isValidResource(name)) {
+      return super.findResources(name);
+    }
+
+    return Iterators.asEnumeration(ImmutableList.<URL>of().iterator());
+  }
+
+  @Override
+  protected Package[] getPackages() {
+    List<Package> packages = Lists.newArrayList();
+    for (Package pkg : super.getPackages()) {
+      if (packageAcceptor.apply(pkg.getName())) {
+        packages.add(pkg);
+      }
+    }
+    return packages.toArray(new Package[packages.size()]);
+  }
+
+  @Override
+  protected Package getPackage(String name) {
+    return (packageAcceptor.apply(name)) ? super.getPackage(name) : null;
+  }
+
+  @Override
+  public URL getResource(String name) {
+    return super.getResource(name);
+  }
+
+  private String classNameToResourceName(String className) {
+    return className.replace('.', '/') + ".class";
+  }
+
+  private boolean isValidResource(String resourceName) {
+    return resourceAcceptor.apply(resourceName);
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/utils/DirUtils.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/utils/DirUtils.java
@@ -16,7 +16,6 @@
 
 package co.cask.cdap.common.utils;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Queues;
@@ -50,7 +49,9 @@ public final class DirUtils {
    * @throws IOException
    */
   public static void deleteDirectoryContents(File directory) throws IOException {
-    Preconditions.checkArgument(directory.isDirectory(), "Not a directory: %s", directory);
+    if (!directory.isDirectory()) {
+      throw new IOException("Not a directory: " + directory);
+    }
     Deque<File> stack = Queues.newArrayDeque();
     stack.add(directory);
 


### PR DESCRIPTION
- Changes in the MapReduceClassLoader to support exposing Plugin classes to the MR framework
  - It is needed when a plugin set classes needed by the framework, e.g. OutputFormat
  - Currently only classes under Export-Package are exposed to provide ClassLoading isolation