### PR TITLE
Change Kafka source emitter to use StructuredRecord. Convert to plugin.

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/kafka/Kafka08SimpleApiConsumer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/kafka/Kafka08SimpleApiConsumer.java
@@ -17,10 +17,13 @@
 package co.cask.cdap.templates.etl.realtime.kafka;
 
 import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.templates.etl.api.Emitter;
 import co.cask.cdap.templates.etl.api.realtime.RealtimeContext;
-
 import co.cask.cdap.templates.etl.realtime.sources.KafkaSource;
+import co.cask.cdap.templates.etl.realtime.sources.KafkaSource.KafkaPluginConfig;
+
+import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
@@ -86,22 +89,33 @@ public class Kafka08SimpleApiConsumer extends KafkaSimpleApiConsumer<String, Byt
   private BrokerService brokerService;
   private Cache<TopicPartition, SimpleConsumer> kafkaConsumers;
 
-  @Override
-  protected void configureKafka(KafkaConfigurer configurer) {
-    Map<String, String> runtimeArgs = getContext().getPluginProperties().getProperties();
-    if (runtimeArgs.containsKey(KafkaSource.KAFKA_ZOOKEEPER)) {
-      configurer.setZooKeeper(runtimeArgs.get(KafkaSource.KAFKA_ZOOKEEPER));
-    } else if (runtimeArgs.containsKey(KafkaSource.KAFKA_BROKERS)) {
-      configurer.setBrokers(runtimeArgs.get(KafkaSource.KAFKA_BROKERS));
-    }
-    setupTopicPartitions(configurer, runtimeArgs);
+  public Kafka08SimpleApiConsumer(KafkaSource kafkaSource) {
+    super(kafkaSource);
   }
 
-  private void setupTopicPartitions(KafkaConsumerConfigurer configurer, Map<String, String> runtimeArgs) {
-    int partitions = Integer.parseInt(runtimeArgs.get(KafkaSource.KAFKA_PARTITIONS));
+  @Override
+  protected void configureKafka(KafkaConfigurer configurer) {
+    KafkaPluginConfig pluginConfig = kafkaSource.getConfig();
+    Preconditions.checkNotNull(pluginConfig, "Could not have Kafka source plugin config to be null.");
+
+    String zk = pluginConfig.getZkConnect();
+    String brokers = pluginConfig.getKafkaBrokers();
+    Preconditions.checkState(zk != null || brokers != null);
+
+    if (zk != null) {
+      configurer.setZooKeeper(zk);
+    } else {
+      configurer.setBrokers(brokers);
+    }
+
+    setupTopicPartitions(configurer, pluginConfig);
+  }
+
+  private void setupTopicPartitions(KafkaConsumerConfigurer configurer, KafkaPluginConfig pluginConfig) {
+    int partitions = pluginConfig.getPartitions();
     int instanceId = getContext().getInstanceId();
     int instances = getContext().getInstanceCount();
-    String kafkaTopic = runtimeArgs.get(KafkaSource.KAFKA_TOPIC);
+    String kafkaTopic = pluginConfig.getTopic();
     for (int i = 0; i < partitions; i++) {
       if ((i % instances) == instanceId) {
         configurer.addTopicPartition(kafkaTopic, i);
@@ -180,6 +194,8 @@ public class Kafka08SimpleApiConsumer extends KafkaSimpleApiConsumer<String, Byt
       brokerService.startAndWait();
     }
 
+    String argValue = getContext().getPluginProperties().getProperties().get(KafkaSource.KAFKA_DEFAULT_OFFSET);
+
     kafkaConsumers = CacheBuilder.newBuilder()
       .concurrencyLevel(1)
       .expireAfterAccess(60, TimeUnit.SECONDS)
@@ -224,8 +240,9 @@ public class Kafka08SimpleApiConsumer extends KafkaSimpleApiConsumer<String, Byt
   }
 
   @Override
-  protected void processMessage(ByteBuffer payload , Emitter<ByteBuffer> emitter) {
-    emitter.emit(payload);
+  protected void processMessage(ByteBuffer payload , Emitter<StructuredRecord> emitter) {
+    StructuredRecord structuredRecord = byteBufferToStructuredRecord(payload);
+    emitter.emit(structuredRecord);
   }
 
   @Override
@@ -257,9 +274,9 @@ public class Kafka08SimpleApiConsumer extends KafkaSimpleApiConsumer<String, Byt
 
   @Override
   protected long getDefaultOffset(TopicPartition topicPartition) {
-    String argValue = getContext().getPluginProperties().getProperties().get(KafkaSource.KAFKA_DEFAULT_OFFSET);
+    Long argValue = kafkaSource.getConfig().getDefaultOffset();
     if (argValue != null) {
-      return Long.valueOf(argValue);
+      return argValue.longValue();
     } else {
       return kafka.api.OffsetRequest.EarliestTime();
     }
@@ -351,7 +368,7 @@ public class Kafka08SimpleApiConsumer extends KafkaSimpleApiConsumer<String, Byt
   @SuppressWarnings("unchecked")
   private <T> Class<T> loadBrokerServiceClass(ClassLoader classLoader) throws ClassNotFoundException {
     // TODO: Hacky way to construct ZKBrokerService from Twill as it's a protected class
-    // Need Twill update to resolve this hack
+    // TODO: Need Twill update to resolve this hack: https://github.com/apache/incubator-twill/pull/31
     return (Class<T>) classLoader.loadClass("org.apache.twill.internal.kafka.client.ZKBrokerService");
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/kafka/KafkaConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/kafka/KafkaConfig.java
@@ -32,7 +32,7 @@ public final class KafkaConfig {
   }
 
   /**
-   * Returns the ZooKeeper connection string as set through {@link KafkaConsumerConfigurer#setZooKeeper(String)}
+   * Returns the ZooKeeper connection string
    * or {@code null}.
    */
   @Nullable
@@ -41,7 +41,7 @@ public final class KafkaConfig {
   }
 
   /**
-   * Returns brokers information as set through {@link KafkaConsumerConfigurer#setBrokers(String)} or {@code null}.
+   * Returns brokers information
    */
   @Nullable
   public String getBrokers() {

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/templates/etl/realtime/sources/KafkaSourceTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/templates/etl/realtime/sources/KafkaSourceTest.java
@@ -16,8 +16,8 @@
 
 package co.cask.cdap.templates.etl.realtime.sources;
 
+import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.templates.etl.api.Emitter;
-import co.cask.cdap.templates.etl.api.realtime.RealtimeContext;
 import co.cask.cdap.templates.etl.api.realtime.SourceState;
 import co.cask.cdap.templates.etl.common.MockRealtimeContext;
 import com.google.common.base.Charsets;
@@ -43,7 +43,6 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -99,7 +98,7 @@ public class KafkaSourceTest {
 
   @Before
   public void beforeTest() {
-    kafkaSource = new KafkaSource();
+    kafkaSource = null;
   }
 
   @After
@@ -112,9 +111,8 @@ public class KafkaSourceTest {
   @Test
   public void testKafkaConsumerSimple() throws Exception {
     final String topic = "testKafkaConsumerSimple";
-    RealtimeContext sourceContext = new MockRealtimeContext(getRuntimeArgs(topic, PARTITIONS, false));
 
-    kafkaSource.initialize(sourceContext);
+    initializeKafkaSource(topic, PARTITIONS, false);
 
     // Publish 5 messages to Kafka, the source should consume them
     int msgCount = 5;
@@ -127,6 +125,22 @@ public class KafkaSourceTest {
     TimeUnit.SECONDS.sleep(2);
 
     verifyEmittedMessages(kafkaSource, msgCount);
+  }
+
+  private void initializeKafkaSource(String topic, int partitions, boolean preferZK)  throws Exception {
+    String zk = null;
+    String brokerList = null;
+    if (!supportBrokerList() || preferZK) {
+      zk = zkServer.getConnectionStr();
+    } else {
+      brokerList = "localhost:" + kafkaPort;
+    }
+
+    KafkaSource.KafkaPluginConfig config = new KafkaSource.KafkaPluginConfig(zk, brokerList, partitions, topic, null);
+
+    kafkaSource = new KafkaSource(config);
+
+    kafkaSource.initialize(new MockRealtimeContext());
   }
 
   // Helper method to verify
@@ -167,25 +181,6 @@ public class KafkaSourceTest {
     return true;
   }
 
-  protected Map<String, String> getRuntimeArgs(String topic, int partitions, boolean preferZK, long startOffset) {
-    Map<String, String> args = getRuntimeArgs(topic, partitions, preferZK);
-    args.put("kafka.default.offset", Long.toString(startOffset));
-    return args;
-  }
-
-  private Map<String, String> getRuntimeArgs(String topic, int partitions, boolean preferZK) {
-    Map<String, String> args = Maps.newHashMap();
-
-    args.put("kafka.topic", topic);
-    if (!supportBrokerList() || preferZK) {
-      args.put("kafka.zookeeper", zkServer.getConnectionStr());
-    } else {
-      args.put("kafka.brokers", "localhost:" + kafkaPort);
-    }
-    args.put("kafka.partitions", Integer.toString(partitions));
-    return args;
-  }
-
   private static Properties generateKafkaConfig(String zkConnectStr, int port, File logDir) {
     // Note: the log size properties below have been set so that we can have log rollovers
     // and log deletions in a minute.
@@ -213,11 +208,11 @@ public class KafkaSourceTest {
   /**
    * Helper class to emit message to next stage
    */
-  private static class MockEmitter implements Emitter<ByteBuffer> {
-    private final List<ByteBuffer> entryList = Lists.newArrayList();
+  private static class MockEmitter implements Emitter<StructuredRecord> {
+    private final List<StructuredRecord> entryList = Lists.newArrayList();
 
     @Override
-    public void emit(ByteBuffer value) {
+    public void emit(StructuredRecord value) {
       entryList.add(value);
     }
 


### PR DESCRIPTION
This PR consists changes to make Apache Kafka realtime source to be plugin mode:
-) Emit StructuredRecord instead of ByteBuffer
-) Follow plugin mode by using PluginConfig to pass properties to Kafka source.