### PR TITLE
Ui/fix c3 memory leak

### DIFF
--- a/cdap-ui/app/directives/c3/charts.js
+++ b/cdap-ui/app/directives/c3/charts.js
@@ -15,10 +15,9 @@ ngC3.factory('c3', function ($window) {
   return $window.c3;
 });
 
-ngC3.controller('c3Controller', function ($scope, caskWindowManager, c3, myHelpers, $filter) {
+ngC3.controller('c3Controller', function ($scope, c3, myHelpers, $filter) {
   // We need to bind because the init function is called directly from the directives below
   // and so the function arguments would not otherwise be available to the initC3 and render functions.
-  var caskWindowManager = caskWindowManager;
   var c3 = c3;
   var myHelpers = myHelpers;
   var $filter = $filter;
@@ -101,8 +100,6 @@ ngC3.controller('c3Controller', function ($scope, caskWindowManager, c3, myHelpe
                     }
     $scope.me = c3.generate(chartConfig);
   }
-
-  $scope.$on(caskWindowManager.event.resize, render);
 
 });
 

--- a/cdap-ui/app/directives/c3/charts.js
+++ b/cdap-ui/app/directives/c3/charts.js
@@ -22,8 +22,14 @@ ngC3.controller('c3Controller', function ($scope, c3, myHelpers, $filter) {
   var myHelpers = myHelpers;
   var $filter = $filter;
 
+  $scope.$on('$destroy', function() {
+      if ($scope.chart) {
+        $scope.chart = $scope.chart.destroy();
+      }
+  });
+
   $scope.initC3 = function (elem, type, attr, forcedOpts) {
-    if($scope.me) {
+    if($scope.chart) {
       return;
     }
 
@@ -58,9 +64,9 @@ ngC3.controller('c3Controller', function ($scope, c3, myHelpers, $filter) {
           // Save the data for when it gets resized.
           $scope.options.data = myData;
 
-          render()
+          render();
           // WARN: using load() API has funny animation (when inserting new data points to the right)
-//            $scope.me.load(myData);  // Alternative to render()
+//            $scope.chart.load(myData);  // Alternative to render()
         }
       });
     }
@@ -78,7 +84,7 @@ ngC3.controller('c3Controller', function ($scope, c3, myHelpers, $filter) {
     chartConfig.size = $scope.options.size;
 
     var xTick = {};
-    xTick.count = $scope.options.xtickcount
+    xTick.count = $scope.options.xtickcount;
     if ($scope.options.formatAsTimestamp) {
       var timestampFormat = function(timestampSeconds) {
         return $filter('amDateFormat')(timestampSeconds * 1000, 'h:mm:ss a');
@@ -94,11 +100,9 @@ ngC3.controller('c3Controller', function ($scope, c3, myHelpers, $filter) {
     if($scope.options.subchart) {
       chartConfig.subchart = $scope.options.subchart;
     }
-    chartConfig.zoom = { enabled: true};
-    chartConfig.transition = {
-                        duration: 1000
-                    }
-    $scope.me = c3.generate(chartConfig);
+    chartConfig.zoom = { enabled: true };
+    chartConfig.transition = { duration: 1000 };
+    $scope.chart = c3.generate(chartConfig);
   }
 
 });

--- a/cdap-ui/app/features/operations/ops-ctrl.js
+++ b/cdap-ui/app/features/operations/ops-ctrl.js
@@ -20,7 +20,6 @@ angular.module(PKG.name+'.feature.dashboard')
       ['Bytes Store',   'namespace.*', ['system.dataset.store.bytes'],      'c3-line'],
       ['Dataset Read/Writes',     'namespace.*', ['system.dataset.store.writes' ,'system.dataset.store.reads'], 'c3-area-spline'],
       ['Containers Used', 'namespace.*', ['system.resources.used.containers', 'system.process.instance'], 'c3-area-step']
-    
     ];
 
     $scope.currentBoard = opshelper.createBoardFromPanels(panels);

--- a/cdap-ui/server/aggregator.js
+++ b/cdap-ui/server/aggregator.js
@@ -8,12 +8,12 @@ var log = log4js.getLogger('default');
 
 /**
  * Default Poll Interval used by the backend.
- * We set the default poll interval to high, so 
+ * We set the default poll interval to high, so
  * if any of the frontend needs faster than this
  * time, then would have to pass in the 'interval'
  * in their request.
  */
-var POLL_INTERVAL = 10*1000; 
+var POLL_INTERVAL = 10*1000;
 
 /**
  * Aggregator
@@ -106,9 +106,9 @@ Aggregator.prototype.stopPollingAll = function() {
 }
 
 /**
- * Pushes the adapter configuration for templates and plugins to the 
+ * Pushes the adapter configuration for templates and plugins to the
  * FE. These configurations are UI specific and hences need to be supported
- * here. 
+ * here.
  */
 Aggregator.prototype.pushConfiguration = function(resource) {
   var templateid = resource.templateid;
@@ -123,12 +123,12 @@ Aggregator.prototype.pushConfiguration = function(resource) {
   } catch(e1) {
    try {
      // Some times there might a plugin that is common across multiple templates
-     // in which case, this is stored within the common directory. So, if the 
+     // in which case, this is stored within the common directory. So, if the
      // template specific plugin check fails, then attempt to get it from common.
      var file = __dirname + '/../templates/common/' + pluginid + '.json';
      config = JSON.parse(fs.readFileSync(file, 'utf8'));
      statusCode = 200;
-   } catch (e2) { 
+   } catch (e2) {
      log.debug("Unable to find template %s, plugin %s", templateid, pluginid);
    }
   }
@@ -186,10 +186,10 @@ function emitResponse (resource, error, response, body) {
   resource.timerId = undefined;
   resource.stop = undefined;
   resource.startTs = undefined;
-  
-  if(error) { 
+
+  if(error) {
     log.debug('[' + timeDiff + 'ms] Error (' + resource.id + ',' + resource.url + ')');
-    log.trace('[' + timeDiff + 'ms] Error (' + resource.id + ',' 
+    log.trace('[' + timeDiff + 'ms] Error (' + resource.id + ','
        + resource.url + ') body : (' + error.toString() + ')');
     this.connection.write(JSON.stringify({
       resource: resource,
@@ -199,7 +199,7 @@ function emitResponse (resource, error, response, body) {
 
   } else {
     log.debug('[' + timeDiff + 'ms] Success (' + resource.id + ',' + resource.url + ')');
-    log.trace('[' + timeDiff + 'ms] Success (' + resource.id + ',' 
+    log.trace('[' + timeDiff + 'ms] Success (' + resource.id + ','
        + resource.url + ') body : (' + JSON.stringify(body) + ')');
     this.connection.write(JSON.stringify({
       resource: resource,


### PR DESCRIPTION
1) Remove resize event handling from c3 charts because c3 has its own onResize event handling.
2) Destroy c3 chart when scope is destroyed (helps reduce memory leakage by a lot).