### PR TITLE
Fix/ui widget simplification

### DIFF
--- a/cdap-ui/Gulpfile.js
+++ b/cdap-ui/Gulpfile.js
@@ -140,6 +140,15 @@ gulp.task('js:lib', function() {
     .pipe(gulp.dest('./dist/assets/bundle'));
 });
 
+gulp.task('js:aceworkers', function() {
+  gulp.src([
+    './bower_components/ace-builds/src-min-noconflict/ace.js',
+    './bower_components/ace-builds/src-min-noconflict/mode-javascript.js',
+    './bower_components/ace-builds/src-min-noconflict/worker-javascript.js'
+  ])
+    .pipe(gulp.dest('./dist/assets/bundle/ace-editor-worker-scripts/'));
+});
+
 gulp.task('js:$modal', function() {
   gulp.src([
     './bower_components/angular-bootstrap/ui-bootstrap-tpls.js',
@@ -309,9 +318,9 @@ gulp.task('rev:replace', ['html:main', 'rev:manifest'], function() {
 /*
   alias tasks
  */
-gulp.task('lib', ['js:$modal', 'js:lib', 'css:lib']);
+gulp.task('lib', ['js:$modal', 'js:lib', 'js:aceworkers', 'css:lib']);
 gulp.task('app', ['js:app', 'css:app']);
-gulp.task('js', ['js:$modal', 'js:lib', 'js:app']);
+gulp.task('js', ['js:$modal', 'js:lib', 'js:aceworkers', 'js:app']);
 gulp.task('css', ['css:lib', 'css:app']);
 gulp.task('style', ['css']);
 

--- a/cdap-ui/app/directives/widget-container/widget-container.js
+++ b/cdap-ui/app/directives/widget-container/widget-container.js
@@ -1,6 +1,5 @@
 angular.module(PKG.name + '.commons')
-  .directive('widgetContainer', function($compile) {
-
+  .directive('widgetContainer', function($compile, $window, WidgetFactory) {
     return {
       restrict: 'A',
       scope: {
@@ -11,30 +10,19 @@ angular.module(PKG.name + '.commons')
       replace: false,
       link: function (scope, element, attrs) {
         var angularElement,
-            infoElement;
-        switch(scope.myconfig.widget) {
-          case 'textbox':
-            angularElement = angular.element('<input class="form-control" ng-model="model"/>');
-            angularElement.attr('placeholder', scope.myconfig.description);
-            break;
-          case 'password':
-            angularElement = angular.element('<input class="form-control" ng-model="model"/>');
-            angularElement.attr('type', 'password');
-            angularElement.attr('placeholder', scope.myconfig.info);
-            break;
-          case 'json-editor':
-            angularElement = angular.element('<textarea style="resize: vertical;" class="form-control" cask-json-edit="model"></textarea>');
-            angularElement.attr('placeholder', scope.myconfig.info);
-            break;
-          case 'javascript-editor':
-            angularElement = angular.element('<div style="width: 400px;height: 300px;" ui-ace></div>');
-            break;
-          case 'default':
-            angularElement = angular.element('<input ng-model="model"/ >');
-            break;
+            infoElement,
+            widget;
+        if (WidgetFactory.registry[scope.myconfig.widget]) {
+          widget = WidgetFactory.registry[scope.myconfig.widget];
+        } else {
+          widget = WidgetFactory.registry['__default__'];
         }
-
+        angularElement = angular.element(widget.element);
+        angular.forEach(widget.attributes, function(value, key) {
+          angularElement.attr(key, value);
+        });
         element.append(angularElement);
+
         if (scope.myconfig.info) {
           infoElement = angular.element('<a href="#"><i class="fa fa-exclamation-circle text-info" tooltip="{{myconfig.info}}"></i></a>');
           element.append(infoElement);

--- a/cdap-ui/app/directives/widget-container/widget-container.less
+++ b/cdap-ui/app/directives/widget-container/widget-container.less
@@ -8,4 +8,7 @@
   [class*="fa-"] {
     vertical-align: middle;
   }
+  textarea {
+    resize: vertical;
+  }
 }

--- a/cdap-ui/app/directives/widget-container/widget-factory.js
+++ b/cdap-ui/app/directives/widget-container/widget-factory.js
@@ -21,7 +21,9 @@ angular.module(PKG.name + '.commons')
       'json-editor': {
         element: '<textarea></textarea>',
         attributes: {
-          'cask-json-edit': 'model'
+          'cask-json-edit': 'model',
+          'class': 'form-control',
+          placeholder: 'myconfig.description'
         }
       },
       'javascript-editor': {

--- a/cdap-ui/app/directives/widget-container/widget-factory.js
+++ b/cdap-ui/app/directives/widget-container/widget-factory.js
@@ -1,0 +1,35 @@
+angular.module(PKG.name + '.commons')
+  .service('WidgetFactory', function() {
+    this.registry = {
+      'textbox': {
+        element: '<input/>',
+        attributes: {
+          'class': 'form-control',
+          'ng-model': 'model',
+          placeholder: 'myconfig.description'
+        }
+      },
+      'password': {
+        element: '<input/>',
+        attributes: {
+          'class': 'form-control',
+          'ng-model': 'model',
+          type: 'password',
+          placeholder: 'myconfig.description'
+        }
+      },
+      'json-editor': {
+        element: '<textarea></textarea>',
+        attributes: {
+          'cask-json-edit': 'model'
+        }
+      },
+      'javascript-editor': {
+        element: '<div my-ace-editor></div>',
+        attributes: {
+          'ng-model': 'model'
+        }
+      }
+    };
+    this.registry['__default__'] = this.registry['textbox'];
+  });

--- a/cdap-ui/app/directives/widget-container/widget-js-editor/widget-js-editor.js
+++ b/cdap-ui/app/directives/widget-container/widget-js-editor/widget-js-editor.js
@@ -1,0 +1,21 @@
+angular.module(PKG.name + '.commons')
+  .directive('myAceEditor', function($window) {
+    return {
+      restrict: 'EA',
+      scope: {
+        model: '=ngModel'
+      },
+      template: '<div ui-ace="aceoptions" ng-model="model" aceEditorStyle></div>',
+      controller: function($scope) {
+        var config = $window.ace.require('ace/config');
+        config.set('modePath', '/assets/bundle/ace-editor-worker-scripts/');
+        $scope.aceoptions = {
+          maxLines: 15,
+          workerPath: '/assets/bundle/ace-editor-worker-scripts',
+          mode: 'javascript',
+          useWrapMode: false,
+          newLineMode: 'unix'
+        };
+      }
+    };
+  });

--- a/cdap-ui/app/directives/widget-container/widget-js-editor/widget-js-editor.less
+++ b/cdap-ui/app/directives/widget-container/widget-js-editor/widget-js-editor.less
@@ -1,0 +1,9 @@
+[my-ace-editor] {
+  width: 90%;
+  margin-right: 5px;
+  display: inline-block;
+  vertical-align: top;
+  [aceEditorStyle] {
+    height: 200px;
+  }
+}


### PR DESCRIPTION
- Simplifies widget-container to have a simpler way to add a new widget.
- Adds a WidgetFactory registry.
   - Any newly added widget can add itself to the registry and if need additional functionality can create its own controller. It should ideally be like creating a directive which accepts an ng-model and optional attributes it requires and render. Once there is a change in the model it should be serialized (say we show a date time picker, once the user choose a date/time we should update the model with the respective epoch time).
- Provides javascript-editor as a simple example for creating custom widgets.
