### PR TITLE
Check for null keys when pulling messages for Kafka topic.

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/kafka/Kafka08SimpleApiConsumer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/kafka/Kafka08SimpleApiConsumer.java
@@ -194,8 +194,6 @@ public class Kafka08SimpleApiConsumer extends KafkaSimpleApiConsumer<String, Byt
       brokerService.startAndWait();
     }
 
-    String argValue = getContext().getPluginProperties().getProperties().get(KafkaSource.KAFKA_DEFAULT_OFFSET);
-
     kafkaConsumers = CacheBuilder.newBuilder()
       .concurrencyLevel(1)
       .expireAfterAccess(60, TimeUnit.SECONDS)
@@ -240,8 +238,14 @@ public class Kafka08SimpleApiConsumer extends KafkaSimpleApiConsumer<String, Byt
   }
 
   @Override
+  protected void processMessage(String key, ByteBuffer payload, Emitter<StructuredRecord> emitter) {
+    StructuredRecord structuredRecord = byteBufferToStructuredRecord(key, payload);
+    emitter.emit(structuredRecord);
+  }
+
+  @Override
   protected void processMessage(ByteBuffer payload , Emitter<StructuredRecord> emitter) {
-    StructuredRecord structuredRecord = byteBufferToStructuredRecord(payload);
+    StructuredRecord structuredRecord = byteBufferToStructuredRecord(null, payload);
     emitter.emit(structuredRecord);
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/kafka/KafkaSimpleApiConsumer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/kafka/KafkaSimpleApiConsumer.java
@@ -21,9 +21,8 @@ import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.templates.etl.api.Emitter;
 import co.cask.cdap.templates.etl.api.realtime.RealtimeContext;
 import co.cask.cdap.templates.etl.api.realtime.SourceState;
-
 import co.cask.cdap.templates.etl.realtime.sources.KafkaSource;
-import co.cask.cdap.templates.etl.realtime.sources.KafkaSource.KafkaPluginConfig;
+
 import com.google.common.base.Charsets;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
@@ -230,7 +229,11 @@ public abstract class KafkaSimpleApiConsumer<KEY, PAYLOAD, OFFSET> {
     Preconditions.checkArgument((partition % getContext().getInstanceCount()) == getContext().getInstanceId(),
                                 "Received unexpected partition " + partition);
 
-    processMessage(decodeKey(message.getKey()), decodePayload(message.getPayload()), emitter);
+    if (message.getKey() == null) {
+      processMessage(decodePayload(message.getPayload()), emitter);
+    } else {
+      processMessage(decodeKey(message.getKey()), decodePayload(message.getPayload()), emitter);
+    }
   }
 
   /**
@@ -304,8 +307,8 @@ public abstract class KafkaSimpleApiConsumer<KEY, PAYLOAD, OFFSET> {
     return offsetStore;
   }
 
-  protected StructuredRecord byteBufferToStructuredRecord(ByteBuffer payload) {
-    return kafkaSource.byteBufferToStructuredRecord(payload);
+  protected StructuredRecord byteBufferToStructuredRecord(@Nullable String key, ByteBuffer payload) {
+    return kafkaSource.byteBufferToStructuredRecord(key, payload);
   }
 
   /**

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/sources/KafkaSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/sources/KafkaSource.java
@@ -23,26 +23,16 @@ import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.templates.plugins.PluginConfig;
 import co.cask.cdap.templates.etl.api.Emitter;
-import co.cask.cdap.templates.etl.api.PipelineConfigurer;
-import co.cask.cdap.templates.etl.api.Property;
-import co.cask.cdap.templates.etl.api.StageConfigurer;
-import co.cask.cdap.templates.etl.api.config.ETLStage;
 import co.cask.cdap.templates.etl.api.realtime.RealtimeContext;
 import co.cask.cdap.templates.etl.api.realtime.RealtimeSource;
 import co.cask.cdap.templates.etl.api.realtime.SourceState;
 import co.cask.cdap.templates.etl.realtime.kafka.Kafka08SimpleApiConsumer;
-import co.cask.cdap.templates.etl.realtime.kafka.KafkaConfigurer;
-import co.cask.cdap.templates.etl.realtime.kafka.KafkaConsumerConfigurer;
 import co.cask.cdap.templates.etl.realtime.kafka.KafkaSimpleApiConsumer;
 
-import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.ByteBuffer;
-import java.util.Map;
-
 import javax.annotation.Nullable;
 
 /**
@@ -60,6 +50,7 @@ public class KafkaSource extends RealtimeSource<StructuredRecord> {
   private static final Logger LOG = LoggerFactory.getLogger(KafkaSource.class);
 
   public static final String MESSAGE = "message";
+  public static final String KEY = "key";
 
   public static final String KAFKA_PARTITIONS = "kafka.partitions";
   public static final String KAFKA_TOPIC = "kafka.topic";
@@ -89,17 +80,23 @@ public class KafkaSource extends RealtimeSource<StructuredRecord> {
     kafkaConsumer.initialize(context);
 
     Schema.Field messageField = Schema.Field.of(MESSAGE, Schema.of(Schema.Type.BYTES));
-    recordBuilder = StructuredRecord.builder(Schema.recordOf("Kafka Message", messageField));
+    Schema.Field keyField  = Schema.Field.of(KEY, Schema.of(Schema.Type.STRING));
+    recordBuilder = StructuredRecord.builder(Schema.recordOf("Kafka Message", messageField, keyField));
   }
 
   @Nullable
   @Override
   @SuppressWarnings("unchecked")
   public SourceState poll(Emitter<StructuredRecord> writer, SourceState currentState) {
-    // Lets set the internal offset store
-    kafkaConsumer.saveState(currentState);
+    try {
+      // Lets set the internal offset store
+      kafkaConsumer.saveState(currentState);
 
-    kafkaConsumer.pollMessages(writer);
+      kafkaConsumer.pollMessages(writer);
+    } catch (Throwable t) {
+      LOG.error("Error encountered during poll to get message for Kafka source.", t);
+      return currentState;
+    }
 
     // Update current state
     return new SourceState(kafkaConsumer.getSavedState());
@@ -107,10 +104,14 @@ public class KafkaSource extends RealtimeSource<StructuredRecord> {
 
   /**
    * Convert {@code Apache Kafka} ByetBuffer from message into CDAP {@link StructuredRecord} instance.
+   * @param key the String key of the Kafka message
    * @param payload the ByteBuffer of the Kafka message.
    * @return instance of {@link StructuredRecord} representing the message.
    */
-  public StructuredRecord byteBufferToStructuredRecord(ByteBuffer payload) {
+  public StructuredRecord byteBufferToStructuredRecord(@Nullable String key, ByteBuffer payload) {
+    if (key != null) {
+      recordBuilder.set(KEY, key);
+    }
     recordBuilder.set(MESSAGE, payload.array());
     return recordBuilder.build();
   }


### PR DESCRIPTION
Kafka messages could have null keys, so we need to check before calling KafkaSimpleApiConsumer#decodeKey method when processing the messages.

Also removed some unused imports.