### PR TITLE
Fix the dependency on cdap-api for the ETL app.

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-api/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/pom.xml
@@ -34,6 +34,7 @@
     <dependency>
       <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-api</artifactId>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/pom.xml
@@ -37,6 +37,12 @@
   <dependencies>
     <dependency>
       <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-api</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-etl-api</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/pom.xml
@@ -33,6 +33,12 @@
   <dependencies>
     <dependency>
       <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-api</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-etl-api</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>

--- a/cdap-app-templates/cdap-etl/cdap-etl-realtime/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-realtime/pom.xml
@@ -37,6 +37,12 @@
   <dependencies>
     <dependency>
       <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-api</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-etl-api</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/cdap-app-templates/cdap-etl/pom.xml
+++ b/cdap-app-templates/cdap-etl/pom.xml
@@ -48,12 +48,6 @@
 
   <dependencyManagement>
     <dependencies>
-      <dependency>
-        <groupId>co.cask.cdap</groupId>
-        <artifactId>cdap-api</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-
       <!-- Hadoop Dependencies -->
       <dependency>
         <groupId>org.apache.hadoop</groupId>
@@ -162,13 +156,6 @@
             <artifactId>servlet-api</artifactId>
           </exclusion>
         </exclusions>
-      </dependency>
-
-      <dependency>
-        <groupId>co.cask.cdap</groupId>
-        <artifactId>cdap-unit-test</artifactId>
-        <version>${project.version}</version>
-        <scope>test</scope>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
- For modules that build bundle jar, we should explicitly declare dependency on cdap-api and have it as provided scope.
- For inter-module dependency, shouldn’t use dependency management.