### PR TITLE
Ordering the Data and Apps on Overview page

### DIFF
--- a/cdap-ui/app/features/apps/controllers/list-ctrl.js
+++ b/cdap-ui/app/features/apps/controllers/list-ctrl.js
@@ -1,5 +1,6 @@
 angular.module(PKG.name + '.feature.apps')
-  .controller('CdapAppListController', function CdapAppList( $timeout, $scope, MyDataSource, myAppUploader, $alert, $state) {
+  .controller('CdapAppListController', function CdapAppList( $timeout, $scope, MyDataSource, myAppUploader, $alert, $state, MyOrderings) {
+    $scope.MyOrderings = MyOrderings;
     var data = new MyDataSource($scope);
 
     data.request({

--- a/cdap-ui/app/features/apps/templates/list.html
+++ b/cdap-ui/app/features/apps/templates/list.html
@@ -23,7 +23,7 @@
     <tbody>
       <tr ng-repeat="app in apps | orderBy:sortable.predicate:sortable.reverse">
         <td >
-          <a ui-sref="apps.detail.overview({ appId: app.id })">
+          <a ui-sref="apps.detail.overview({ appId: app.id })" ng-click="MyOrderings.appClicked(app.id)">
             <strong> {{ ::app.name }} </strong>
           </a>
         </td>

--- a/cdap-ui/app/features/data/list-ctrl.js
+++ b/cdap-ui/app/features/data/list-ctrl.js
@@ -1,5 +1,6 @@
 angular.module(PKG.name + '.feature.data')
-  .controller('CdapDataListController', function($state, $scope, MyDataSource) {
+  .controller('CdapDataListController', function($state, $scope, MyDataSource, MyOrderings) {
+    $scope.MyOrderings = MyOrderings;
     var dataSrc = new MyDataSource($scope);
     $scope.dataList = [];
     dataSrc.request({
@@ -36,6 +37,7 @@ angular.module(PKG.name + '.feature.data')
           streamId: data.name
         });
       }
+      MyOrderings.dataClicked(data.name);
     };
 
     $scope.goToList = function(data) {

--- a/cdap-ui/app/features/overview/controllers/overview-ctrl.js
+++ b/cdap-ui/app/features/overview/controllers/overview-ctrl.js
@@ -3,7 +3,8 @@
  */
 
 angular.module(PKG.name+'.feature.overview').controller('OverviewCtrl',
-function ($scope, MyDataSource, $state, myLocalStorage, MY_CONFIG, Widget) {
+function ($scope, MyDataSource, $state, myLocalStorage, MY_CONFIG, Widget, MyOrderings) {
+  $scope.MyOrderings = MyOrderings;
 
   if(!$state.params.namespace) {
     // the controller for "ns" state should handle the case of

--- a/cdap-ui/app/features/overview/templates/data-apps.html
+++ b/cdap-ui/app/features/overview/templates/data-apps.html
@@ -26,15 +26,15 @@
       </div>
 
       <ul class="list-group" >
-        <li class="list-group-item" ng-repeat="data in dataList | orderBy:'name' | limitTo: 5 track by $index ">
-          <a ng-if="data.type === 'Stream'" ui-sref="streams.detail.overview({streamId: data.name})">
+        <li class="list-group-item" ng-repeat="data in dataList | orderBy:MyOrderings.dataOrdering | limitTo: 5 track by $index ">
+          <a ng-if="data.type === 'Stream'" ui-sref="streams.detail.overview({streamId: data.name})" ng-click="MyOrderings.dataClicked(data.name)">
             <p ng-bind="data.name"> </p>
             <div class="title-type-image">
               <img class="type-icon" src="assets/img/ico_stream.png" alt="" />
               <span> Stream </span>
             </div>
           </a>
-          <a ng-if="data.type !== 'Stream'" ui-sref="datasets.detail.overview({datasetId: data.name})">
+          <a ng-if="data.type !== 'Stream'" ui-sref="datasets.detail.overview({datasetId: data.name})" ng-click="MyOrderings.dataClicked(data.name)">
             <p ng-bind="data.name"> </p>
             <div class="title-type-image">
               <img class="type-icon" src="assets/img/ico_datasets.png" alt="" />
@@ -98,8 +98,8 @@
       </div>
 
       <ul class="list-group">
-        <li class="list-group-item" ng-repeat="app in apps | orderBy:'name' | limitTo:5">
-          <a ui-sref="apps.detail.overview({appId: app.id})">
+        <li class="list-group-item" ng-repeat="app in apps | orderBy:MyOrderings.appOrdering | limitTo:5">
+          <a ui-sref="apps.detail.overview({appId: app.id})"  ng-click="MyOrderings.appClicked(app.id)">
             <p ng-bind="app.name"> </p>
             <div class="title-type-image">
               <img class="type-icon" src="assets/img/ico_cdap.png" alt="" />

--- a/cdap-ui/app/services/my-orderings.js
+++ b/cdap-ui/app/services/my-orderings.js
@@ -1,0 +1,52 @@
+angular.module(PKG.name+'.services')
+  .service('MyOrderings', function(myLocalStorage) {
+    var APP_KEY = 'appOrdering';
+    var DATA_KEY = 'dataOrdering';
+    myLocalStorage.get(APP_KEY).then(function(value) {
+      if (typeof value === 'undefined') {
+        this.appList = [];
+      } else {
+        this.appList = value;
+      }
+    }.bind(this));
+    myLocalStorage.get(DATA_KEY).then(function(value) {
+      if (typeof value === 'undefined') {
+        this.dataList = [];
+      } else {
+        this.dataList = value;
+      }
+    }.bind(this));
+
+    function typeClicked(arr, id, key) {
+      var idx = arr.indexOf(id);
+      if (idx !== -1) {
+        arr.splice(idx, 1);
+      }
+      arr.unshift(id);
+      myLocalStorage.set(key, arr);
+    }
+
+    this.appClicked = function (appName) {
+      typeClicked(this.appList, appName, APP_KEY);
+    };
+
+    this.dataClicked = function (dataName) {
+      typeClicked(this.dataList, dataName, DATA_KEY);
+    };
+
+    function typeOrdering(arr, el) {
+      var idx = arr.indexOf(el.name);
+      if (idx == -1) {
+        return arr.length;
+      }
+      return idx;
+    }
+
+    this.appOrdering = function(app) {
+      return typeOrdering(this.appList, app);
+    }.bind(this);
+
+    this.dataOrdering = function(data) {
+      return typeOrdering(this.dataList, data);
+    }.bind(this);
+  });


### PR DESCRIPTION
Ordering the Data and Apps on Overview page by most recently clicked first.
This is useful especially because we limit the number of elements shown.

Whenever someone clicks on an app or data element on the overview page, 'All apps' page, or 'App Datasets' page, it gets marked as most recently used. This information is then used to order the limited-length lists on the Overview page.

Click the gif for a larger view.
![](http://g.recordit.co/eeYV5xaa4p.gif)