### PR TITLE
Fix the 'stop-polling' websocket event. The timerId of the resource was ...

### DIFF
--- a/cdap-ui/server/aggregator.js
+++ b/cdap-ui/server/aggregator.js
@@ -171,6 +171,18 @@ function doPoll (resource) {
 }
 
 /**
+ * Helps avoid sending certain properties to the browser (meta attributes used only in the node server)
+ */
+function stripResource(key, value) {
+  // note that 'stop' is not the stop timestamp, but rather a stop flag/signal (unlike the startTs)
+  if (key==="timerId" || key==='startTs' || key==='stop') {
+    return undefined;
+  }
+  return value;
+}
+
+
+/**
  * @private emitResponse
  *
  * sends data back to the client through socket
@@ -183,10 +195,6 @@ function doPoll (resource) {
 function emitResponse (resource, error, response, body) {
   var timeDiff = Date.now()  - resource.startTs;
 
-  resource.timerId = undefined;
-  resource.stop = undefined;
-  resource.startTs = undefined;
-
   if(error) {
     log.debug('[' + timeDiff + 'ms] Error (' + resource.id + ',' + resource.url + ')');
     log.trace('[' + timeDiff + 'ms] Error (' + resource.id + ','
@@ -195,7 +203,7 @@ function emitResponse (resource, error, response, body) {
       resource: resource,
       error: error,
       warning: error.toString()
-    }));
+    }, stripResource));
 
   } else {
     log.debug('[' + timeDiff + 'ms] Success (' + resource.id + ',' + resource.url + ')');
@@ -205,7 +213,7 @@ function emitResponse (resource, error, response, body) {
       resource: resource,
       statusCode: response.statusCode,
       response: body
-    }));
+    }, stripResource));
   }
 }
 


### PR DESCRIPTION
...being cleared (in order to avoid sending it to browser), and as a side effect, we lost a handle the timer id.

To avoid that, just avoid pushing these fields in the JSON, but leave them on the resource object.