### PR TITLE
Fix CubeQuery Javadoc.

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/cube/CubeQuery.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/cube/CubeQuery.java
@@ -31,13 +31,15 @@ import javax.annotation.Nullable;
  * </p>
  * Another way to think about the query is to map it to the following statement::
  * <pre>
+ * <code>
  * SELECT count('read.ops')                                           << measure name and aggregation function
  * FROM aggregation1.1min_resolution                                  << aggregation and resolution
  * GROUP BY dataset,                                                  << groupByDimensions
  * WHERE namespace='ns1' AND app='myApp' AND program='myFlow' AND     << dimensionValues
- *       ts>=1423370200 AND ts{@literal<}1423398198                             << startTs and endTs
+ *       ts>=1423370200 AND ts<1423398198                             << startTs and endTs
  * LIMIT 100                                                          << limit
  *
+ * </code>
  * </pre>
  * See also {@link Cube#query(CubeQuery)}.
  */

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/cube/CubeQuery.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/cube/CubeQuery.java
@@ -30,14 +30,13 @@ import javax.annotation.Nullable;
  * Defines a query to perform on {@link Cube} data.
  * </p>
  * Another way to think about the query is to map it to the following statement::
- * <pre>
- * <code>
- * SELECT count('read.ops')                                           << measure name and aggregation function
- * FROM aggregation1.1min_resolution                                  << aggregation and resolution
- * GROUP BY dataset,                                                  << groupByDimensions
- * WHERE namespace='ns1' AND app='myApp' AND program='myFlow' AND     << dimensionValues
- *       ts>=1423370200 AND ts<1423398198                             << startTs and endTs
- * LIMIT 100                                                          << limit
+ * <pre><code>
+ * SELECT count('read.ops')                                         {@literal <<} measure name and aggregation function
+ * FROM aggregation1.1min_resolution                                {@literal <<} aggregation and resolution
+ * GROUP BY dataset,                                                {@literal <<} groupByDimensions
+ * WHERE namespace='ns1' AND app='myApp' AND program='myFlow' AND   {@literal <<} dimensionValues
+ *       ts>=1423370200 AND ts{@literal <}1423398198                           {@literal <<} startTs and endTs
+ * LIMIT 100                                                        {@literal <<} limit
  *
  * </code>
  * </pre>


### PR DESCRIPTION
Fixes broken Javadocs by surrounding code sample in \<code> and \</code> in addition to \<pre> and \</pre>.

The problem can be seen in the currently staged javadocs: [CubeQuery](http://stg-web101.sw.joyent.continuuity.net/cdap/3.0.0-SNAPSHOT/en/reference-manual/javadocs/co/cask/cdap/api/dataset/lib/cube/CubeQuery.html)