### PR TITLE
Fix creating new StructuredRecord builder per conversion.

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/sources/KafkaSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/sources/KafkaSource.java
@@ -58,9 +58,11 @@ public class KafkaSource extends RealtimeSource<StructuredRecord> {
   public static final String KAFKA_BROKERS = "kafka.brokers";
   public static final String KAFKA_DEFAULT_OFFSET = "kafka.default.offset";
 
-  private KafkaSimpleApiConsumer kafkaConsumer;
+  private static final Schema SCHEMA = Schema.recordOf("Kafka Message",
+                                                       Schema.Field.of(MESSAGE, Schema.of(Schema.Type.BYTES)),
+                                                       Schema.Field.of(KEY, Schema.of(Schema.Type.STRING)));
 
-  private StructuredRecord.Builder recordBuilder;
+  private KafkaSimpleApiConsumer kafkaConsumer;
 
   private KafkaPluginConfig config;
 
@@ -78,10 +80,6 @@ public class KafkaSource extends RealtimeSource<StructuredRecord> {
 
     kafkaConsumer = new Kafka08SimpleApiConsumer(this);
     kafkaConsumer.initialize(context);
-
-    Schema.Field messageField = Schema.Field.of(MESSAGE, Schema.of(Schema.Type.BYTES));
-    Schema.Field keyField  = Schema.Field.of(KEY, Schema.of(Schema.Type.STRING));
-    recordBuilder = StructuredRecord.builder(Schema.recordOf("Kafka Message", messageField, keyField));
   }
 
   @Nullable
@@ -109,10 +107,11 @@ public class KafkaSource extends RealtimeSource<StructuredRecord> {
    * @return instance of {@link StructuredRecord} representing the message.
    */
   public StructuredRecord byteBufferToStructuredRecord(@Nullable String key, ByteBuffer payload) {
+    StructuredRecord.Builder recordBuilder = StructuredRecord.builder(SCHEMA);
     if (key != null) {
       recordBuilder.set(KEY, key);
     }
-    recordBuilder.set(MESSAGE, payload.array());
+    recordBuilder.set(MESSAGE, payload);
     return recordBuilder.build();
   }
 


### PR DESCRIPTION
The StructuredRecord builder need to be created per instance of StructuredRecord because calling the build method does not reset the internal fields.