### PR TITLE
(CDAP-2369) Scan all package resources to find plugin classes

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/PluginRepository.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/PluginRepository.java
@@ -67,11 +67,11 @@ import java.io.Reader;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Type;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -321,21 +321,23 @@ public class PluginRepository {
               }
               currentPackage = packageIterator.next();
 
-              URL packageResource = pluginClassLoader.getResource(currentPackage.replace('.', File.separatorChar));
-              if (packageResource == null) {
-                // Cannot happen since we know the class loader expand the jar into directory, the class loader
-                // should have the package URL pointing to the package directory.
-                continue;
-              }
-
               try {
-                // Only inspect classes in the top level jar file for Plugins.
-                // The jar manifest may have packages in Export-Package that are loadable from the bundled jar files,
-                // which is for classloading purpose. Those classes won't be inspected for plugin classes.
-                if (packageResource.getProtocol().equals("file")) {
-                  classIterator = DirUtils.list(new File(packageResource.toURI()), "class").iterator();
+                // Gets all package resource URL for the given package
+                String resourceName = currentPackage.replace('.', File.separatorChar);
+                Enumeration<URL> resources = pluginClassLoader.getResources(resourceName);
+                while (resources.hasMoreElements()) {
+                  URL packageResource = resources.nextElement();
+
+                  // Only inspect classes in the top level jar file for Plugins.
+                  // The jar manifest may have packages in Export-Package that are loadable from the bundled jar files,
+                  // which is for classloading purpose. Those classes won't be inspected for plugin classes.
+                  // There should be exactly one of resource that match, because it maps to a directory on the FS.
+                  if (packageResource.getProtocol().equals("file")) {
+                    classIterator = DirUtils.list(new File(packageResource.toURI()), "class").iterator();
+                    break;
+                  }
                 }
-              } catch (URISyntaxException e) {
+              } catch (Exception e) {
                 // Cannot happen
                 throw Throwables.propagate(e);
               }


### PR DESCRIPTION
- When the plugin jar has jar inside, it’s possible that there is more than one URL that matches with the package resource. We should search for the one that is in local directory (vs in JAR) and pickup Plugin classes form there.