### PR TITLE
Allow polling on metrics dashboard to stop polling.

### DIFF
--- a/cdap-ui/app/features/dashboard/controllers/dashboard-ctrl.js
+++ b/cdap-ui/app/features/dashboard/controllers/dashboard-ctrl.js
@@ -9,7 +9,7 @@ function ($scope, $state, $dropdown, rDashboardsModel, MY_CONFIG, $alert) {
   $scope.unknownBoard = false;
   $scope.isEnterprise = MY_CONFIG.isEnterprise;
   $scope.dashboards = rDashboardsModel.data || [];
-  $scope.liveDashboard = null;
+  $scope.liveDashboard = false;
 
   // Available refresh rates.
   $scope.refreshIntervals = [
@@ -146,6 +146,7 @@ function ($scope, $state, $dropdown, rDashboardsModel, MY_CONFIG, $alert) {
       });
       return;
     }
+    $scope.liveDashboard = false;
     applyOnWidgets(rDashboardsModel, function (widget) {
       widget.metric.startTime = Math.floor($scope.timeOptions.startMs / 1000);
       widget.metric.endTime = Math.floor($scope.timeOptions.endMs / 1000);
@@ -156,6 +157,7 @@ function ($scope, $state, $dropdown, rDashboardsModel, MY_CONFIG, $alert) {
   };
 
   $scope.updateWithFrequency = function() {
+    $scope.liveDashboard = true;
     applyOnWidgets(rDashboardsModel, function (widget) {
       widget.metric.startTime = $scope.timeOptions.durationMs;
       widget.metric.endTime = 'now';
@@ -163,6 +165,14 @@ function ($scope, $state, $dropdown, rDashboardsModel, MY_CONFIG, $alert) {
       widget.isLive = true;
       widget.interval = $scope.timeOptions.refreshInterval.value * 1000;
       widget.reconfigure();
+    });
+  };
+
+  $scope.stopPolling = function() {
+    $scope.liveDashboard = false;
+    applyOnWidgets(rDashboardsModel, function (widget) {
+      widget.isLive = false;
+      widget.stopPolling();
     });
   };
 });

--- a/cdap-ui/app/features/dashboard/templates/userdashboard.html
+++ b/cdap-ui/app/features/dashboard/templates/userdashboard.html
@@ -35,7 +35,7 @@
           </div>
           <button class="btn btn-success"
                   ng-click="updateWithTimeRange()">
-            Apply!
+            Make Request!
           </button>
         </div>
       </div>
@@ -72,8 +72,11 @@
               <li ng-repeat="tab in tabs" ng-click="activateTab($index)"><a>{{tab}}</a></li>
             </ul>
           </div>
-          <button class="btn btn-success" ng-click="updateWithFrequency()">
-            Apply!
+          <button ng-if="!liveDashboard" class="btn btn-success" ng-click="updateWithFrequency()">
+            Start Polling!
+          </button>
+          <button ng-if="liveDashboard" class="btn btn-danger" ng-click="stopPolling()">
+            Stop Polling!
           </button>
         </div>
       </div>


### PR DESCRIPTION
Previously, you could not suspend the polling frequency except by navigating to a different page or applying a Time Range.
This allows you to stop the polling.