### PR TITLE
Fix log output for the auto build of docs

### DIFF
--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -182,12 +182,18 @@ function build_all() {
   echo "--------------------------------------------------------"
   echo ""
   run_command docs-web-part ${ARG_2} ${ARG_3}
+  echo ""
+  echo "========================================================"
   echo "Replacing GitHub Docs."
+  echo "--------------------------------------------------------"
+  echo ""
   mv ${SCRIPT_PATH}/${BUILD_TEMP}/*.zip ${SCRIPT_PATH}/${BUILD}
   rm -rf ${SCRIPT_PATH}/${BUILD_TEMP}
-  if [ "${BELL}" == 'yes' ]; then
-    bell
-  fi
+  echo ""
+  echo "========================================================"
+  bell "Completed \"build_all\""
+  echo "--------------------------------------------------------"
+  echo ""
   exit 0
 }
 
@@ -284,7 +290,11 @@ function print_version() {
 
 function bell() {
   # Pass a message as ${1}
-  echo -e "\a${1}"
+  if [ "x${BELL}" == 'xyes' -o "x${BELL}" == 'x${TRUE}' ]; then
+    echo -e "\a${1}"
+  else
+    echo -e "${1}"
+  fi
 }
 
 function test() {

--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -191,7 +191,7 @@ function build_all() {
   rm -rf ${SCRIPT_PATH}/${BUILD_TEMP}
   echo ""
   echo "========================================================"
-  bell "Completed \"build_all\""
+  bell "Completed \"build_all\"."
   echo "--------------------------------------------------------"
   echo ""
   exit 0

--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -21,7 +21,7 @@
 # _common directory holds common files and scripts.
 
 # Optional Parameter (passed via Bamboo env variable or exported in shell)
-# BELL (set it to yes, if you want the bell commands to work in their script)
+# BELL (set it to either 'yes' or 'TRUE', if you want the bell function to make a sound when called)
 
 source ./vars
 source _common/common-build.sh

--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -142,7 +142,7 @@ function build_docs_outer_level() {
 function copy_docs_lower_level() {
   echo ""
   echo "========================================================"
-  echo "Copying lower-level docs..."
+  echo "Copying lower-level documenation..."
   echo "--------------------------------------------------------"
   echo ""
 
@@ -238,7 +238,7 @@ function build_docs_inner_level() {
 function build_specific_doc() {
   echo ""
   echo "========================================================"
-  echo "Building ${1}, target ${2}..."
+  echo "Building \"${1}\", target \"${2}\"..."
   echo "--------------------------------------------------------"
   echo ""
   cd $SCRIPT_PATH/${1}

--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -83,7 +83,6 @@ function run_command() {
     * )                 usage; exit 0;;
   esac
 }
-################################################## new
 
 function clean() {
   cd ${SCRIPT_PATH}
@@ -114,7 +113,7 @@ function build_docs_outer_level() {
   echo ""
   echo "========================================================"
   echo "Building outer-level docs..."
-  echo "========================================================"
+  echo "--------------------------------------------------------"
   echo ""
   clean
   version
@@ -144,7 +143,7 @@ function copy_docs_lower_level() {
   echo ""
   echo "========================================================"
   echo "Copying lower-level docs..."
-  echo "========================================================"
+  echo "--------------------------------------------------------"
   echo ""
 
   for i in ${MANUALS}; do
@@ -167,17 +166,21 @@ function copy_docs_lower_level() {
 ################################################## current
 
 function build_all() {
-  echo "========================================================================="
+  echo ""
+  echo "========================================================"
   echo "Building GitHub Docs."
-  echo "========================================================================="
+  echo "--------------------------------------------------------"
+  echo ""
   run_command docs-github-part ${ARG_2} ${ARG_3}
   echo "Stashing GitHub Docs."
   cd ${SCRIPT_PATH}
   mkdir -p ${SCRIPT_PATH}/${BUILD_TEMP}
   mv ${SCRIPT_PATH}/${BUILD}/*.zip ${SCRIPT_PATH}/${BUILD_TEMP}
-  echo "========================================================================="
+  echo ""
+  echo "========================================================"
   echo "Building Web Docs."
-  echo "========================================================================="
+  echo "--------------------------------------------------------"
+  echo ""
   run_command docs-web-part ${ARG_2} ${ARG_3}
   echo "Replacing GitHub Docs."
   mv ${SCRIPT_PATH}/${BUILD_TEMP}/*.zip ${SCRIPT_PATH}/${BUILD}
@@ -210,13 +213,20 @@ function build_docs_web() {
 }
 
 function _build_docs() {
+  echo ""
+  echo "========================================================"
+  echo "Building \"${1}\"..."
+  echo "--------------------------------------------------------"
   build_docs_inner_level ${1}
   build_docs_outer_level ${2}
   copy_docs_lower_level
   build_zip ${3}
   zip_extras ${4}
   display_version
-  bell "Building ${1} completed."
+  echo "========================================================"
+  bell "Building \"${1}\" completed."
+  echo "--------------------------------------------------------"
+  echo ""
 }
 
 function build_docs_inner_level() {
@@ -229,7 +239,7 @@ function build_specific_doc() {
   echo ""
   echo "========================================================"
   echo "Building ${1}, target ${2}..."
-  echo "========================================================"
+  echo "--------------------------------------------------------"
   echo ""
   cd $SCRIPT_PATH/${1}
   ./build.sh ${2} ${ARG_2} ${ARG_3}

--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -215,7 +215,7 @@ function build_docs_web() {
 function _build_docs() {
   echo ""
   echo "========================================================"
-  echo "Building \"${1}\"..."
+  echo "Building target \"${1}\"..."
   echo "--------------------------------------------------------"
   build_docs_inner_level ${1}
   build_docs_outer_level ${2}
@@ -224,7 +224,7 @@ function _build_docs() {
   zip_extras ${4}
   display_version
   echo "========================================================"
-  bell "Building \"${1}\" completed."
+  bell "Building target \"${1}\" completed."
   echo "--------------------------------------------------------"
   echo ""
 }

--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -142,7 +142,7 @@ function build_docs_outer_level() {
 function copy_docs_lower_level() {
   echo ""
   echo "========================================================"
-  echo "Copying lower-level documenation..."
+  echo "Copying lower-level documentation..."
   echo "--------------------------------------------------------"
   echo ""
 

--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -21,7 +21,7 @@
 # _common directory holds common files and scripts.
 
 # Optional Parameter (passed via Bamboo env variable or exported in shell)
-# BELL (set it to either 'yes' or 'TRUE', if you want the bell function to make a sound when called)
+# BELL (set it to either 'yes' or 'true', if you want the bell function to make a sound when called)
 
 source ./vars
 source _common/common-build.sh
@@ -290,7 +290,7 @@ function print_version() {
 
 function bell() {
   # Pass a message as ${1}
-  if [ "x${BELL}" == 'xyes' -o "x${BELL}" == 'x${TRUE}' ]; then
+  if [[ "x${BELL}" == "xyes" || "x${BELL}" == "x${TRUE}" ]]; then
     echo -e "\a${1}"
   else
     echo -e "${1}"
@@ -299,7 +299,7 @@ function bell() {
 
 function test() {
   echo "Test..."
-  build_json
+  bell "A test message"
   echo "Test completed."
 }
 


### PR DESCRIPTION
These changes improve the output of the logs for the building of documentation.

There is now a clear start and finish header, and all headers follow the same pattern: a string of "=" followed by a string of "-". That way you can search for either pattern, and "hop" from header to header.

Additional quote marks have been added to make it clear which targets are being built.