### PR TITLE
[CDAP-2330] Disallow hyphens in namespace names

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/NamespaceHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/NamespaceHttpHandler.java
@@ -105,6 +105,15 @@ public class NamespaceHttpHandler extends AbstractAppFabricHttpHandler {
   @PUT
   @Path("/namespaces/{namespace-id}")
   public void create(HttpRequest request, HttpResponder responder, @PathParam("namespace-id") String namespaceId) {
+    Id.Namespace namespace;
+    try {
+      namespace = Id.Namespace.from(namespaceId);
+    } catch (IllegalArgumentException e) {
+      responder.sendString(HttpResponseStatus.BAD_REQUEST,
+                           "Namespace id can contain only alphanumeric characters or '_'.");
+      return;
+    }
+
     NamespaceMeta metadata;
     try {
       metadata = parseBody(request, NamespaceMeta.class);
@@ -117,12 +126,6 @@ public class NamespaceHttpHandler extends AbstractAppFabricHttpHandler {
       return;
     }
 
-    if (!isValid(namespaceId)) {
-      responder.sendString(HttpResponseStatus.BAD_REQUEST,
-                           "Namespace id can contain only alphanumeric characters, '-' or '_'.");
-      return;
-    }
-
     if (isReserved(namespaceId)) {
       responder.sendString(HttpResponseStatus.BAD_REQUEST,
                            String.format("Cannot create the namespace '%s'. '%s' is a reserved namespace.",
@@ -130,7 +133,7 @@ public class NamespaceHttpHandler extends AbstractAppFabricHttpHandler {
       return;
     }
 
-    NamespaceMeta.Builder builder = new NamespaceMeta.Builder().setName(namespaceId);
+    NamespaceMeta.Builder builder = new NamespaceMeta.Builder().setName(namespace);
 
     // Handle optional params
     if (metadata != null && metadata.getDescription() != null) {
@@ -197,15 +200,6 @@ public class NamespaceHttpHandler extends AbstractAppFabricHttpHandler {
       LOG.error("Internal error while deleting namespace.", e);
       responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, e.getMessage());
     }
-  }
-
-  private boolean isValid(String namespaceId) {
-    // TODO: Re-use from proto.Id
-    return CharMatcher.inRange('A', 'Z')
-      .or(CharMatcher.inRange('a', 'z'))
-      .or(CharMatcher.is('-'))
-      .or(CharMatcher.is('_'))
-      .or(CharMatcher.inRange('0', '9')).matchesAllOf(namespaceId);
   }
 
   private boolean isReserved(String namespaceId) {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/NamespaceHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/NamespaceHttpHandlerTest.java
@@ -167,6 +167,9 @@ public class NamespaceHttpHandlerTest extends AppFabricTestBase {
   public void testInvalidReservedId() throws Exception {
     HttpResponse response = createNamespace(METADATA_VALID, INVALID_NAME);
     assertResponseCode(400, response);
+    // '-' is not allowed anymore
+    response = createNamespace(METADATA_VALID, "my-namespace");
+    assertResponseCode(400, response);
     // 'default' and 'system' are reserved namespaces
     response = createNamespace(METADATA_VALID, Constants.DEFAULT_NAMESPACE);
     assertResponseCode(400, response);

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data/stream/service/upload/StreamBodyConsumerTestBase.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data/stream/service/upload/StreamBodyConsumerTestBase.java
@@ -69,7 +69,7 @@ public abstract class StreamBodyConsumerTestBase {
     BodyConsumer bodyConsumer = createBodyConsumer(new ContentWriterFactory() {
       @Override
       public Id.Stream getStream() {
-        return Id.Stream.from("test-namespace", "test-stream");
+        return Id.Stream.from("test_namespace", "test-stream");
       }
 
       @Override

--- a/cdap-docs/developers-manual/source/building-blocks/namespaces.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/namespaces.rst
@@ -35,7 +35,7 @@ Namespace Components
 A Namespace has a namespace identifier (the namespace 'name') and a description.
 
 Namespace IDs are composed from a limited set of characters; they are restricted to
-letters (a-z, A-Z), digits (0-9), hyphens (-), and underscores (_). There is no size limit
+letters (a-z, A-Z), digits (0-9), and underscores (_). There is no size limit
 on the length of a namespace ID nor on the number of namespaces.
 
 The namespace IDs ``cdap``, ``default``, and ``system`` are reserved. The ``default``

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/Id.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/Id.java
@@ -34,25 +34,26 @@ public abstract class Id {
     return type.getSimpleName().toLowerCase();
   }
 
-  private static boolean isId(String name) {
-    return CharMatcher.inRange('A', 'Z')
-      .or(CharMatcher.inRange('a', 'z'))
-      .or(CharMatcher.is('-'))
-      .or(CharMatcher.is('_'))
-      .or(CharMatcher.inRange('0', '9')).matchesAllOf(name);
+  private static final CharMatcher namespaceMatcher =
+    CharMatcher.inRange('A', 'Z')
+    .or(CharMatcher.inRange('a', 'z'))
+    .or(CharMatcher.inRange('0', '9'))
+    .or(CharMatcher.is('_'));
+  // Allow hyphens for other ids.
+  private static final CharMatcher idMatcher = namespaceMatcher.or(CharMatcher.is('-'));
+  // Allow '.' and '$' for dataset ids since they can be fully qualified class names
+  private static final CharMatcher datasetIdCharMatcher = idMatcher.or(CharMatcher.is('.')).or(CharMatcher.is('$'));
+
+  private static boolean isValidNamespaceId(String name) {
+    return namespaceMatcher.matchesAllOf(name);
   }
 
-  /**
-   * Allow '.' and '$' for dataset ids since they can be fully qualified class names
-   */
+  private static boolean isValidId(String name) {
+    return idMatcher.matchesAllOf(name);
+  }
+
   private static boolean isValidDatasetId(String datasetId) {
-    return CharMatcher.inRange('A', 'Z')
-      .or(CharMatcher.inRange('a', 'z'))
-      .or(CharMatcher.is('-'))
-      .or(CharMatcher.is('_'))
-      .or(CharMatcher.inRange('0', '9'))
-      .or(CharMatcher.is('.'))
-      .or(CharMatcher.is('$')).matchesAllOf(datasetId);
+    return datasetIdCharMatcher.matchesAllOf(datasetId);
   }
 
   public String getIdType() {
@@ -153,7 +154,7 @@ public abstract class Id {
 
     public Namespace(String id) {
       Preconditions.checkNotNull(id, "Namespace '" + id + "' cannot be null.");
-      Preconditions.checkArgument(isId(id), "Namespace '" + id + "' has an incorrect format.");
+      Preconditions.checkArgument(isValidNamespaceId(id), "Namespace '" + id + "' has an incorrect format.");
       this.id = id;
     }
 
@@ -310,7 +311,7 @@ public abstract class Id {
     public Application(final Namespace namespace, final String applicationId) {
       Preconditions.checkNotNull(namespace, "Namespace cannot be null.");
       Preconditions.checkNotNull(applicationId, "Application cannot be null.");
-      Preconditions.checkArgument(isId(applicationId), "Invalid Application ID.");
+      Preconditions.checkArgument(isValidId(applicationId), "Invalid Application ID.");
       this.namespace = namespace;
       this.applicationId = applicationId;
     }
@@ -764,7 +765,7 @@ public abstract class Id {
       Preconditions.checkArgument(category != null && !category.isEmpty(),
                                   "Category value cannot be null or empty.");
       Preconditions.checkArgument(name != null && !name.isEmpty(), "Name value cannot be null or empty.");
-      Preconditions.checkArgument(isId(namespace) && isId(category) && isId(name),
+      Preconditions.checkArgument(isValidId(namespace) && isValidId(category) && isValidId(name),
                                   "Namespace, category or name has a wrong format.");
 
       this.namespace = Namespace.from(namespace);
@@ -904,7 +905,7 @@ public abstract class Id {
       Preconditions.checkNotNull(namespace, "Namespace cannot be null.");
       Preconditions.checkNotNull(streamName, "Stream name cannot be null.");
 
-      Preconditions.checkArgument(isId(streamName), "Stream name can only contain alphanumeric, " +
+      Preconditions.checkArgument(isValidId(streamName), "Stream name can only contain alphanumeric, " +
                                     "'-' and '_' characters: %s", streamName);
 
       this.namespace = namespace;


### PR DESCRIPTION
Disallows hyphens in namespace names only for now. Retains current behavior for other ids. 
This is needed because hive complains if the database name has a hyphen in it.

Jira: [CDAP-2330](https://issues.cask.co/browse/CDAP-2330)
Build: http://builds.cask.co/browse/CDAP-RBT242