### PR TITLE
Make the key to become optional for schema definition in Kafka source.

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/sources/KafkaSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/realtime/sources/KafkaSource.java
@@ -60,7 +60,8 @@ public class KafkaSource extends RealtimeSource<StructuredRecord> {
 
   private static final Schema SCHEMA = Schema.recordOf("Kafka Message",
                                                        Schema.Field.of(MESSAGE, Schema.of(Schema.Type.BYTES)),
-                                                       Schema.Field.of(KEY, Schema.of(Schema.Type.STRING)));
+                                                       Schema.Field.of(KEY, Schema.nullableOf(
+                                                         Schema.of(Schema.Type.STRING))));
 
   private KafkaSimpleApiConsumer kafkaConsumer;
 


### PR DESCRIPTION
Since key could be null, need to make the StructuredRecord's schema to be nullable for Kafka realtime source plugin.