### PR TITLE
Batch Source/Sink initialize method takes in Context

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/templates/etl/api/batch/BatchSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/templates/etl/api/batch/BatchSink.java
@@ -17,7 +17,6 @@
 package co.cask.cdap.templates.etl.api.batch;
 
 import co.cask.cdap.api.dataset.lib.KeyValue;
-import co.cask.cdap.api.templates.plugins.PluginProperties;
 import co.cask.cdap.templates.etl.api.Destroyable;
 import co.cask.cdap.templates.etl.api.Emitter;
 import co.cask.cdap.templates.etl.api.EndPointStage;
@@ -52,9 +51,9 @@ public abstract class BatchSink<IN, KEY_OUT, VAL_OUT>
    * Initialize the sink. This is called once each time the Hadoop Job runs, before any
    * calls to {@link #transform(Object, Emitter)} are made.
    *
-   * @param properties plugin properties
+   * @param context {@link BatchSinkContext}
    */
-  public void initialize(PluginProperties properties) throws Exception {
+  public void initialize(BatchSinkContext context) throws Exception {
     // no-op
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/templates/etl/api/batch/BatchSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/templates/etl/api/batch/BatchSource.java
@@ -17,7 +17,6 @@
 package co.cask.cdap.templates.etl.api.batch;
 
 import co.cask.cdap.api.dataset.lib.KeyValue;
-import co.cask.cdap.api.templates.plugins.PluginProperties;
 import co.cask.cdap.templates.etl.api.Destroyable;
 import co.cask.cdap.templates.etl.api.Emitter;
 import co.cask.cdap.templates.etl.api.EndPointStage;
@@ -52,9 +51,9 @@ public abstract class BatchSource<KEY_IN, VAL_IN, OUT>
    * Initialize the source. This is called once each time the Hadoop Job runs, before any
    * calls to {@link #transform(KeyValue, Emitter)} are made.
    *
-   * @param properties plugin properties
+   * @param context {@link BatchSourceContext}
    */
-  public void initialize(PluginProperties properties) throws Exception {
+  public void initialize(BatchSourceContext context) throws Exception {
     // no-op
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/batch/sinks/BatchCubeSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/batch/sinks/BatchCubeSink.java
@@ -26,6 +26,7 @@ import co.cask.cdap.api.dataset.lib.cube.CubeFact;
 import co.cask.cdap.api.templates.plugins.PluginConfig;
 import co.cask.cdap.api.templates.plugins.PluginProperties;
 import co.cask.cdap.templates.etl.api.Emitter;
+import co.cask.cdap.templates.etl.api.batch.BatchSinkContext;
 import co.cask.cdap.templates.etl.api.config.ETLStage;
 import co.cask.cdap.templates.etl.common.Properties;
 import co.cask.cdap.templates.etl.common.StructuredRecordToCubeFact;
@@ -89,9 +90,9 @@ public class BatchCubeSink extends BatchWritableSink<StructuredRecord, byte[], C
   private StructuredRecordToCubeFact transform;
 
   @Override
-  public void initialize(PluginProperties properties) throws Exception {
-    super.initialize(properties);
-    transform = new StructuredRecordToCubeFact(properties.getProperties());
+  public void initialize(BatchSinkContext context) throws Exception {
+    super.initialize(context);
+    transform = new StructuredRecordToCubeFact(context.getPluginProperties().getProperties());
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/batch/sinks/DBSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/batch/sinks/DBSink.java
@@ -112,8 +112,8 @@ public class DBSink extends BatchSink<StructuredRecord, DBRecord, NullWritable> 
   }
 
   @Override
-  public void initialize(PluginProperties properties) throws Exception {
-    super.initialize(properties);
+  public void initialize(BatchSinkContext context) throws Exception {
+    super.initialize(context);
     setResultSetMetadata();
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/batch/sinks/TableSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/batch/sinks/TableSink.java
@@ -24,9 +24,9 @@ import co.cask.cdap.api.dataset.lib.KeyValue;
 import co.cask.cdap.api.dataset.table.Put;
 import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.api.templates.plugins.PluginConfig;
-import co.cask.cdap.api.templates.plugins.PluginProperties;
 import co.cask.cdap.templates.etl.api.Emitter;
 import co.cask.cdap.templates.etl.api.PipelineConfigurer;
+import co.cask.cdap.templates.etl.api.batch.BatchSinkContext;
 import co.cask.cdap.templates.etl.common.Properties;
 import co.cask.cdap.templates.etl.common.RecordPutTransformer;
 import com.google.common.base.Preconditions;
@@ -89,8 +89,8 @@ public class TableSink extends BatchWritableSink<StructuredRecord, byte[], Put> 
   }
 
   @Override
-  public void initialize(PluginProperties properties) throws Exception {
-    super.initialize(properties);
+  public void initialize(BatchSinkContext context) throws Exception {
+    super.initialize(context);
     recordPutTransformer = new RecordPutTransformer(tableConfig.rowField);
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/batch/sources/TableSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/batch/sources/TableSource.java
@@ -25,7 +25,6 @@ import co.cask.cdap.api.dataset.lib.KeyValue;
 import co.cask.cdap.api.dataset.table.Row;
 import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.api.templates.plugins.PluginConfig;
-import co.cask.cdap.api.templates.plugins.PluginProperties;
 import co.cask.cdap.templates.etl.api.Emitter;
 import co.cask.cdap.templates.etl.api.PipelineConfigurer;
 import co.cask.cdap.templates.etl.api.batch.BatchSourceContext;
@@ -106,8 +105,8 @@ public class TableSource extends BatchReadableSource<byte[], Row, StructuredReco
   }
 
   @Override
-  public void initialize(PluginProperties properties) throws Exception {
-    super.initialize(properties);
+  public void initialize(BatchSourceContext context) throws Exception {
+    super.initialize(context);
     Schema schema = Schema.parseJson(tableConfig.schemaStr);
     rowRecordTransformer = new RowRecordTransformer(schema, tableConfig.rowField);
   }


### PR DESCRIPTION
Batch Source and Batch Sink should have access to their Contexts in the initialize method instead of just PluginProperties. 

JIRA : https://issues.cask.co/browse/CDAP-2368

Build : http://builds.cask.co/browse/CDAP-RT18