### PR TITLE
CDAP-2371 Added the verification that the program name should not be emp...

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/verification/AbstractVerifier.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/verification/AbstractVerifier.java
@@ -26,7 +26,7 @@ import com.google.common.base.CharMatcher;
 public abstract class AbstractVerifier<T> implements Verifier<T> {
 
   protected boolean isId(final String name) {
-    return CharMatcher.inRange('A', 'Z')
+    return !name.isEmpty() && CharMatcher.inRange('A', 'Z')
              .or(CharMatcher.inRange('a', 'z'))
              .or(CharMatcher.is('-'))
              .or(CharMatcher.is('_'))

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/error/Err.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/error/Err.java
@@ -33,7 +33,8 @@ public final class Err {
   /**
    * Common Error messages that can be used in different contexts.
    */
-  public static final Errors NOT_AN_ID = new Errors("%s name is not an ID. ID can contain only characters A-Za-z0-9_-");
+  public static final Errors NOT_AN_ID = new Errors("'%s' name is not an ID. ID should be non empty and can contain" +
+                                                      " only characters A-Za-z0-9_-");
 
   /**
    * Defines Schema related error messages.

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/AppWithAnonymousWorkflow.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/AppWithAnonymousWorkflow.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap;
+
+import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.api.workflow.AbstractWorkflow;
+
+/**
+ * App with anonymous Workflow
+ */
+public class AppWithAnonymousWorkflow extends AbstractApplication {
+  @Override
+  public void configure() {
+    setName("AppWithAnonymousWorkflow");
+    setDescription("Application with anonymous Workflow.");
+    addWorkflow(new AbstractWorkflow() {
+      @Override
+      protected void configure() {
+        // no name for the workflow set here. this should fail
+      }
+    });
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/runtime/WorkflowTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/runtime/WorkflowTest.java
@@ -15,6 +15,7 @@
  */
 package co.cask.cdap.runtime;
 
+import co.cask.cdap.AppWithAnonymousWorkflow;
 import co.cask.cdap.MissingMapReduceWorkflowApp;
 import co.cask.cdap.MissingSparkWorkflowApp;
 import co.cask.cdap.OneActionWorkflowApp;
@@ -161,6 +162,16 @@ public class WorkflowTest {
     } catch (Exception ex) {
       Assert.assertEquals(ex.getCause().getMessage(),
                           "Workflow 'NonExistentWorkflow' is not configured with the Application.");
+    }
+
+    // try deploying app containing anonymous workflow
+    try {
+      final ApplicationWithPrograms app = AppFabricTestHelper.deployApplicationWithManager(
+        AppWithAnonymousWorkflow.class, TEMP_FOLDER_SUPPLIER);
+      Assert.fail("Should have thrown Exception because Workflow does not have name.");
+    } catch (Exception ex) {
+      Assert.assertEquals(ex.getCause().getMessage(),
+                          "'' name is not an ID. ID should be non empty and can contain only characters A-Za-z0-9_-");
     }
   }
 


### PR DESCRIPTION
...ty

Jira: https://issues.cask.co/browse/CDAP-2371

If the programs are added in the application as `anonymous inner classes`, there name is always empty. Added verification to throw an exception if the name is not empty. 

This means the flow, flowlets, datasets, mapreduce, workflows should always have name otherwise app deployment would fail.