### PR TITLE
(CDP-2311) Fix MapReduce memory leak issue in local mode

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
@@ -178,7 +178,7 @@ public class MapReduceProgramRunner implements ProgramRunner {
       // runner, which is probably the yarn user. This may cause permissions issues if the program
       // tries to access cdap data. For example, writing to a FileSet will fail, as the yarn user will
       // be running the job, but the data directory will be owned by cdap.
-      if (!UserGroupInformation.isSecurityEnabled()) {
+      if (!MapReduceContextProvider.isLocal(hConf) && !UserGroupInformation.isSecurityEnabled()) {
         String runAs = cConf.get(Constants.CFG_HDFS_USER);
         try {
           UserGroupInformation.createRemoteUser(runAs)

--- a/cdap-app-fabric/src/main/java/org/apache/hadoop/mapred/LocalJobRunnerWithFix.java
+++ b/cdap-app-fabric/src/main/java/org/apache/hadoop/mapred/LocalJobRunnerWithFix.java
@@ -35,7 +35,6 @@ import org.apache.hadoop.mapreduce.TaskCompletionEvent;
 import org.apache.hadoop.mapreduce.TaskTrackerInfo;
 import org.apache.hadoop.mapreduce.TaskType;
 import org.apache.hadoop.mapreduce.filecache.ClientDistributedCacheManager;
-import org.apache.hadoop.mapreduce.filecache.DistributedCache;
 import org.apache.hadoop.mapreduce.protocol.ClientProtocol;
 import org.apache.hadoop.mapreduce.security.token.delegation.DelegationTokenIdentifier;
 import org.apache.hadoop.mapreduce.server.jobtracker.JTConfig;
@@ -158,10 +157,6 @@ public class LocalJobRunnerWithFix implements ClientProtocol {
         new Path(conf.getLocalPath(jobDir), user), jobid.toString()));
       this.localJobFile = new Path(this.localJobDir, id + ".xml");
 
-      // This is another fix for LocalJobRunner bug: job jar is not added to classpath.
-      // Alternatively to doing it here, we could use job.addFileToClassPath(jobJar) before submitting job in client
-      // code, but we don't want to mess with "correct" distributed execution (which adds job jar in classpath).
-      DistributedCache.addFileToClassPath(new Path(conf.getJar()), conf, FileSystem.get(conf));
       ClientDistributedCacheManager.determineTimestampsAndCacheVisibilities(conf);
 
       // Manage the distributed cache.  If there are files to be copied,

--- a/cdap-common/src/main/java/co/cask/cdap/common/lang/Delegator.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/lang/Delegator.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.lang;
+
+import javax.annotation.Nullable;
+
+/**
+ * Represents class that performs operation by delegating to another object.
+ *
+ * @param <T> Type of the object that delegates to.
+ */
+public interface Delegator<T> {
+
+  /**
+   * Returns the delegating object or {@code null} if there is no delegating object.
+   */
+  @Nullable
+  T getDelegate();
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/lang/Delegators.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/lang/Delegators.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.lang;
+
+/**
+ * Helper class to deal with {@link Delegator}.
+ */
+public final class Delegators {
+
+  /**
+   * Returns the root delegate object that is not a {@link Delegator} in the delegation chain
+   * that is assignable to the given type.
+   */
+  @SuppressWarnings("unchecked")
+  public static <T, V> T getDelegate(T object, Class<V> type) {
+    T result = object;
+
+    // Keep searching while the result is still instance of Delegator
+    while (result != null && result instanceof Delegator) {
+      result = ((Delegator<T>) result).getDelegate();
+
+      // Terminate the search if result is not a Delegator and assignable to the given type
+      if (result != null && !(result instanceof Delegator) && type.isAssignableFrom(result.getClass())) {
+        break;
+      }
+    }
+
+    if (result == null || !type.isAssignableFrom(result.getClass())) {
+      throw new IllegalArgumentException("No object in the delegation chain is of type " + type);
+    }
+    return result;
+  }
+
+  private Delegators() {
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/lang/WeakReferenceDelegatorClassLoader.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/lang/WeakReferenceDelegatorClassLoader.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.lang;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.ref.WeakReference;
+import java.net.URL;
+import java.util.Enumeration;
+
+/**
+ * A ClassLoader that do class loading by delegating to another ClassLoader. It holds the delegating ClassLoader
+ * with a {@link WeakReference} so that garbage collection of the delegating ClassLoader is possible.
+ */
+public class WeakReferenceDelegatorClassLoader extends ClassLoader implements Delegator<ClassLoader> {
+
+  private final WeakReference<ClassLoader> delegate;
+
+  public WeakReferenceDelegatorClassLoader(ClassLoader classLoader) {
+    // Parent is null, meaning it's the bootstrap ClassLoader
+    super(null);
+    this.delegate = new WeakReference<ClassLoader>(classLoader);
+  }
+
+  @Override
+  protected Class<?> findClass(String name) throws ClassNotFoundException {
+    return ensureDelegateExists().loadClass(name);
+  }
+
+  @Override
+  public URL getResource(String name) {
+    return ensureDelegateExists().getResource(name);
+  }
+
+  @Override
+  public InputStream getResourceAsStream(String name) {
+    return ensureDelegateExists().getResourceAsStream(name);
+  }
+
+  @Override
+  public Enumeration<URL> getResources(String name) throws IOException {
+    return ensureDelegateExists().getResources(name);
+  }
+
+  @Override
+  public ClassLoader getDelegate() {
+    return delegate.get();
+  }
+
+  private ClassLoader ensureDelegateExists() {
+    ClassLoader classLoader = delegate.get();
+    if (classLoader == null) {
+      throw new IllegalStateException("Delegating ClassLoader is already Garbage Collected.");
+    }
+    return classLoader;
+  }
+}


### PR DESCRIPTION
- Introduce a WeakReferenceDelegatorClassLoader to hold a weak reference to the actual MapReduceClassLoader. The MR Framework will keep a reference to the WeakReferenceDelegatorClassLoader in a static variable, but it won’t prevent the GC of the actual MR ClassLoader
- Fix the MR ProgramRunner so that in local mode it won’t create new UGI for each run. It is needed to avoid the cache inside the Hadoop FileSystem object keep building up.
- Fix the LocalJobRunnerWithFix to not creating a new ClassLoader, but always use the one set in the Configuration object.