### PR TITLE
[CDAP-2393] emit process.events.processed tagged with the simple queue name 

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowletProcessDriver.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowletProcessDriver.java
@@ -397,7 +397,7 @@ final class FlowletProcessDriver extends AbstractExecutionThreadService {
         } else if (inputQueueName == null) {
           flowletContext.getProgramMetrics().increment("process.events.processed", processedCount);
         } else {
-          queueMetricsCollectors.getUnchecked("input." + inputQueueName.toString())
+          queueMetricsCollectors.getUnchecked(inputQueueName.getSimpleName())
             .increment("process.events.processed", processedCount);
         }
       }


### PR DESCRIPTION
... instead of the full queue name