### PR TITLE
Show N/A instead of 0 or empty string, if the information from backend i...

### DIFF
--- a/cdap-ui/app/features/mapreduce/controllers/tabs/runs/runs-detail-ctrl.js
+++ b/cdap-ui/app/features/mapreduce/controllers/tabs/runs/runs-detail-ctrl.js
@@ -1,6 +1,7 @@
 angular.module(PKG.name + '.feature.mapreduce')
-  .controller('MapreduceRunsDetailController', function($scope, MyDataSource, $state) {
+  .controller('MapreduceRunsDetailController', function($scope, MyDataSource, $state, $filter) {
     var dataSrc = new MyDataSource($scope);
+    var myNumber = $filter('myNumber');
 
     $scope.tabs = [{
       title: 'Status',
@@ -38,8 +39,13 @@ angular.module(PKG.name + '.feature.mapreduce')
         $scope.mapProgress = Math.floor(res.mapProgress * 100);
         $scope.reduceProgress = Math.floor(res.reduceProgress * 100);
 
-        $scope.mapperStats = getStats($scope.info.mapTasks);
-        $scope.reducerStats = getStats($scope.info.reduceTasks);
+        $scope.mapperStats = getStats($scope.info.mapTasks, $scope.info.complete);
+        $scope.mapperStats.inputRecords = myNumber($scope.info.counters.MAP_INPUT_RECORDS);
+        $scope.mapperStats.outputRecords = myNumber($scope.info.counters.MAP_OUTPUT_RECORDS);
+
+        $scope.reducerStats = getStats($scope.info.reduceTasks, $scope.info.complete);
+        $scope.reducerStats.inputRecords = myNumber($scope.info.counters.REDUCE_INPUT_RECORDS);
+        $scope.reducerStats.outputRecords = myNumber($scope.info.counters.REDUCE_OUTPUT_RECORDS);
       });
     }
 
@@ -54,15 +60,13 @@ angular.module(PKG.name + '.feature.mapreduce')
     };
 
 
-    function getStats(tasks) {
+    function getStats(tasks, completeInfo) {
       var stats = {
         completed: 0,
         running: 0,
         pending: 0,
         killed: 0,
         failed: 0,
-        recordsIn: 0,
-        bytesIn: 0,
         total: 0
       };
 
@@ -88,6 +92,21 @@ angular.module(PKG.name + '.feature.mapreduce')
         stats.total++;
       });
 
+      if (completeInfo === false) {
+        var NA = 'NA';
+        return {
+          completed: NA,
+          running: NA,
+          pending: NA,
+          killed: NA,
+          failed: NA,
+          total: stats.total
+        };
+      }
+
+      angular.forEach(Object.keys(stats), function(key) {
+        stats[key] = myNumber(stats[key]);
+      });
       return stats;
 
     }

--- a/cdap-ui/app/features/mapreduce/templates/tabs/runs/tabs/mappers.html
+++ b/cdap-ui/app/features/mapreduce/templates/tabs/runs/tabs/mappers.html
@@ -16,14 +16,15 @@
       <tbody>
         <tr ng-repeat="map in info.mapTasks | orderBy:sortable.predicate:sortable.reverse">
           <td>{{ ::map.taskId }}</td>
-          <td>{{ map.state }}</td>
+          <td ng-if="map.state">{{ map.state }}</td>
+          <td ng-if="!map.state">NA</td>
           <td>{{ map.progress * 100 }}%</td>
           <td>
             <span ng-show="map.finishTime !== 0">{{ (map.finishTime - map.startTime)/1000 | amDurationFormat}}</span>
             <span ng-show="map.finishTime === 0"> &mdash; </span>
           </td>
-          <td>{{ map.counters.MAP_INPUT_RECORDS }}</td>
-          <td>{{ map.counters.MAP_OUTPUT_RECORDS }}</td>
+          <td>{{ map.counters.MAP_INPUT_RECORDS | myNumber: 0}}</td>
+          <td>{{ map.counters.MAP_OUTPUT_RECORDS | myNumber: 0 }}</td>
           <td>{{ map.counters.MAP_OUTPUT_BYTES | bytes: 2 }}</td>
         </tr>
         <tr class="text-center" ng-if="!info.mapTasks.length">

--- a/cdap-ui/app/features/mapreduce/templates/tabs/runs/tabs/reducers.html
+++ b/cdap-ui/app/features/mapreduce/templates/tabs/runs/tabs/reducers.html
@@ -15,14 +15,15 @@
       <tbody>
         <tr ng-repeat="reduce in info.reduceTasks | orderBy:sortable.predicate:sortable.reverse">
           <td>{{ ::reduce.taskId }}</td>
-          <td>{{ reduce.state }}</td>
+          <td ng-if="reduce.state">{{ reduce.state }}</td>
+          <td ng-if="!reduce.state">NA</td>
           <td>{{ reduce.progress * 100 }}%</td>
           <td>
             <span ng-show="reduce.finishTime !== 0">{{ (reduce.finishTime - reduce.startTime)/1000 | amDurationFormat}}</span>
             <span ng-show="reduce.finishTime === 0"> &mdash; </span>
           </td>
-          <td>{{ reduce.counters.REDUCE_INPUT_RECORDS }}</td>
-          <td>{{ reduce.counters.REDUCE_OUTPUT_RECORDS }}</td>
+          <td>{{ reduce.counters.REDUCE_INPUT_RECORDS | myNumber: 0}}</td>
+          <td>{{ reduce.counters.REDUCE_OUTPUT_RECORDS | myNumber: 0}}</td>
         </tr>
 
         <tr class="text-center" ng-if="!info.reduceTasks.length">

--- a/cdap-ui/app/features/mapreduce/templates/tabs/runs/tabs/status.html
+++ b/cdap-ui/app/features/mapreduce/templates/tabs/runs/tabs/status.html
@@ -10,35 +10,35 @@
     <div class="row component-box">
       <div class="task-item">
         <div class="title">Completed</div>
-        <div class="entry">{{mapperStats.completed | myNumber: 0}}</div>
+        <div class="entry">{{mapperStats.completed}}</div>
       </div>
       <div class="task-item">
         <div class="title">Running</div>
-        <div class="entry">{{mapperStats.running | myNumber: 0}}</div>
+        <div class="entry">{{mapperStats.running}}</div>
       </div>
       <div class="task-item">
         <div class="title">Pending</div>
-        <div class="entry">{{mapperStats.pending | myNumber: 0}}</div>
+        <div class="entry">{{mapperStats.pending}}</div>
       </div>
       <div class="task-item">
         <div class="title">Killed</div>
-        <div class="entry">{{mapperStats.killed | myNumber: 0}}</div>
+        <div class="entry">{{mapperStats.killed}}</div>
       </div>
       <div class="task-item">
         <div class="title">Failed</div>
-        <div class="entry">{{mapperStats.failed | myNumber: 0}}</div>
+        <div class="entry">{{mapperStats.failed}}</div>
       </div>
       <div class="task-item">
         <div class="title">Records in</div>
-        <div class="entry">{{info.counters.MAP_INPUT_RECORDS | myNumber: 0}}</div>
+        <div class="entry">{{mapperStats.inputRecords}}</div>
       </div>
       <div class="task-item">
         <div class="title">Records out</div>
-        <div class="entry">{{info.counters.MAP_OUTPUT_RECORDS | myNumber: 0}}</div>
+        <div class="entry">{{mapperStats.outputRecords}}</div>
       </div>
       <div class="task-item">
         <div class="title">Total</div>
-        <div class="entry">{{mapperStats.total | myNumber: 0}}</div>
+        <div class="entry">{{mapperStats.total}}</div>
       </div>
     </div>
   </div>
@@ -53,35 +53,35 @@
     <div class="row component-box">
       <div class="task-item">
         <div class="title">Completed</div>
-        <div class="entry">{{reducerStats.completed | myNumber: 0}}</div>
+        <div class="entry">{{reducerStats.completed}}</div>
       </div>
       <div class="task-item">
         <div class="title">Running</div>
-        <div class="entry">{{reducerStats.running | myNumber: 0}}</div>
+        <div class="entry">{{reducerStats.running}}</div>
       </div>
       <div class="task-item">
         <div class="title">Pending</div>
-        <div class="entry">{{reducerStats.pending | myNumber: 0}}</div>
+        <div class="entry">{{reducerStats.pending}}</div>
       </div>
       <div class="task-item">
         <div class="title">Killed</div>
-        <div class="entry">{{reducerStats.killed | myNumber: 0}}</div>
+        <div class="entry">{{reducerStats.killed}}</div>
       </div>
       <div class="task-item">
         <div class="title">Failed</div>
-        <div class="entry">{{reducerStats.failed | myNumber: 0}}</div>
+        <div class="entry">{{reducerStats.failed}}</div>
       </div>
       <div class="task-item">
         <div class="title">Records in</div>
-        <div class="entry">{{info.counters.REDUCE_INPUT_RECORDS | myNumber: 0}}</div>
+        <div class="entry">{{reducerStats.inputRecords}}</div>
       </div>
       <div class="task-item">
         <div class="title">Records out</div>
-        <div class="entry">{{info.counters.REDUCE_OUTPUT_RECORDS | myNumber: 0}}</div>
+        <div class="entry">{{reducerStats.outputRecords}}</div>
       </div>
       <div class="task-item">
         <div class="title">Total</div>
-        <div class="entry">{{reducerStats.total | myNumber: 0}}</div>
+        <div class="entry">{{reducerStats.total}}</div>
       </div>
 
     </div>


### PR DESCRIPTION
...s not available

Two main things:
1) Before the /info endpoint returns (while UI is waiting for initial response), the UI was showing 0 for the input and output records (and nothing for the other fields, because of the myNumbers filter being activated before any response even arrived.
2) Mapper and Reducer states were empty in the table in the case that they are not available. Now, it properly shows 'N/A' as [shown here](https://s3.amazonaws.com/uploads.hipchat.com/26476/1011205/i801XCBDbwIghEZ/Screen%20Shot%202015-04-30%20at%205.28.57%20PM.png).
Also, since task states are not reported when JobHistoryServer is not available (when using metrics system as fallback), now shows 'N/A' instead of 0 for the following fields:
Number of tasks that are: completed, running, pending, killed, failed
as [shown here](https://s3.amazonaws.com/uploads.hipchat.com/26476/1011205/6XW2rQ08DL8HedJ/Screen%20Shot%202015-04-30%20at%205.28.34%20PM.png).