### PR TITLE
Feature/allow main class from elsewhere

### DIFF
--- a/cdap-common/bin/common-env.sh
+++ b/cdap-common/bin/common-env.sh
@@ -53,6 +53,8 @@ export LOCAL_DIR=/var/tmp/cdap
 # Specifies the JAVA_HEAPMAX
 export JAVA_HEAPMAX=${JAVA_HEAPMAX:--Xmx128m}
 
+# The options below can be set in the sourced component-specific conf/[component]-env.sh scripts
+
 # Main class to be invoked.
 #MAIN_CLASS=
 

--- a/cdap-common/bin/common-env.sh
+++ b/cdap-common/bin/common-env.sh
@@ -54,7 +54,7 @@ export LOCAL_DIR=/var/tmp/cdap
 export JAVA_HEAPMAX=${JAVA_HEAPMAX:--Xmx128m}
 
 # Main class to be invoked.
-MAIN_CLASS=
+#MAIN_CLASS=
 
 # Arguments for main class.
 #MAIN_CLASS_ARGS=""


### PR DESCRIPTION
Our common-env.sh was forcing ``$MAIN_CLASS`` to empty, making it impossible to wrap these scripts.  The Cloudera CSD also sources these scripts, and should be able to set ``$MAIN_CLASS`` for the upgrade tool