### PR TITLE
Update the requirement for Java to 1.7 for CDAP.

### DIFF
--- a/cdap-docs/admin-manual/source/installation/installation.rst
+++ b/cdap-docs/admin-manual/source/installation/installation.rst
@@ -110,7 +110,7 @@ You'll need this software installed:
 
 Java Runtime
 ++++++++++++
-The latest `JDK or JRE version 1.6.xx or 1.7.xx <http://www.java.com/en/download/manual.jsp>`__
+The latest `JDK or JRE version 1.7.xx <http://www.java.com/en/download/manual.jsp>`__
 for Linux and Solaris must be installed in your environment; we recommend the Oracle JDK.
 
 To check the Java version installed, run the command::

--- a/cdap-docs/admin-manual/source/installation/quick-start.rst
+++ b/cdap-docs/admin-manual/source/installation/quick-start.rst
@@ -24,7 +24,7 @@ Software Prerequisites
 
 Install:
 
-- Java runtime (`JDK 1.7.xx <http://www.java.com/en/download/manual.jsp>`__)
+- Java runtime (`JDK or JRE version 1.7.xx <http://www.java.com/en/download/manual.jsp>`__)
   on CDAP and Hadoop nodes; we recommend the Oracle JDK. 
 - Set the JAVA_HOME environment variable (:ref:`details <install-java-runtime>`).
 - `Node.js <http://nodejs.org>`__ on CDAP nodes (:ref:`details <install-node.js>`).

--- a/cdap-docs/admin-manual/source/installation/quick-start.rst
+++ b/cdap-docs/admin-manual/source/installation/quick-start.rst
@@ -24,7 +24,7 @@ Software Prerequisites
 
 Install:
 
-- Java runtime (`JDK or JRE version 1.6.xx or 1.7.xx <http://www.java.com/en/download/manual.jsp>`__)
+- Java runtime (`JDK 1.7.xx <http://www.java.com/en/download/manual.jsp>`__)
   on CDAP and Hadoop nodes; we recommend the Oracle JDK. 
 - Set the JAVA_HOME environment variable (:ref:`details <install-java-runtime>`).
 - `Node.js <http://nodejs.org>`__ on CDAP nodes (:ref:`details <install-node.js>`).

--- a/cdap-docs/admin-manual/source/operations/troubleshooting.rst
+++ b/cdap-docs/admin-manual/source/operations/troubleshooting.rst
@@ -30,7 +30,7 @@ Things to check as possible solutions:
 
     java -version
 
-#. Check if the CDAP user is using a correct version of the JDK::
+#. Check if the CDAP user is using a :ref:`correct version of the JDK <install-java-runtime>`::
 
     sudo su - <cdap-user> 
     java -version

--- a/cdap-docs/developers-manual/source/getting-started/standalone/index.rst
+++ b/cdap-docs/developers-manual/source/getting-started/standalone/index.rst
@@ -25,9 +25,9 @@ CDAP Software Development Kit (SDK)
 
 The CDAP SDK runs on Linux, MacOS and Windows, and has three requirements:
 
-- `JDK 6 or JDK 7 <http://www.oracle.com/technetwork/java/javase/downloads/index.html>`__ 
+- `JDK 7 <http://www.oracle.com/technetwork/java/javase/downloads/index.html>`__ 
   (required to run CDAP; note that $JAVA_HOME should be set)
-- `Node.js 0.8.16 through 0.10.37 <http://nodejs.org/dist/>`__ (required to run the CDAP Console UI)
+- `Node.js 0.8.16 through 0.10.37 <http://nodejs.org/dist/>`__ (required to run the CDAP UI)
 - `Apache Maven 3.0+ <http://maven.apache.org>`__ (required to build CDAP applications)
 
 We recommend using an IDE when building CDAP applications, such as either `IntelliJ

--- a/cdap-docs/reference-manual/source/faq.rst
+++ b/cdap-docs/reference-manual/source/faq.rst
@@ -79,7 +79,7 @@ CDAP currently supports Java for developing applications.
 
 .. rubric:: What Version of Java SDK is Required by CDAP?
 
-The latest version of the JDK or JRE version 6 or 7 (JDK/JRE 1.6 or 1.7) must be installed
+The latest version of the JDK or JRE version 7 (JDK/JRE 1.7) must be installed
 in your environment; we recommend the Oracle JDK.
 
 .. rubric:: What Version of Node.JS is Required by CDAP?


### PR DESCRIPTION
Note that READMEs are being handled in another PR: https://github.com/caskdata/cdap/pull/2382