### PR TITLE
Miscellanous UI changes

### DIFF
--- a/cdap-ui/app/directives/flow-graph/flow.js
+++ b/cdap-ui/app/directives/flow-graph/flow.js
@@ -132,7 +132,7 @@ module.directive('myFlowGraph', function ($filter, $state, $alert, myStreamServi
             diagramWidth: leafDiagramWidth
           };
           drawLeafShape(parent, leafOptions);
-          
+
           parent.insert('text')
             .attr('x', calculateLeafBuffer(parent, leafOptions))
             .attr('y', metricCountPadding)
@@ -164,14 +164,14 @@ module.directive('myFlowGraph', function ($filter, $state, $alert, myStreamServi
           // Elements are positioned with respect to shapeSvg.
           var width = shapeSvg.node().getBBox().width+10;
           var circleXPos = -1 * width/2;
-          
+
           var leafOptions = {
             classNames: ['stream-events'],
             circleRadius: flowletCircleRadius,
             diagramWidth: leafDiagramWidth
           };
           drawLeafShape(parent, leafOptions);
-          
+
           parent.append('text')
             .attr('x', calculateLeafBuffer(parent, leafOptions))
             .attr('y', metricCountPadding)
@@ -238,7 +238,7 @@ module.directive('myFlowGraph', function ($filter, $state, $alert, myStreamServi
         var xFactor = leafXFactor;
         var circleRadius = flowletCircleRadius;
         var classNamesStr = 'flow-shapes leaf-shape';
-        
+
         if (properties && Object.prototype.toString.call(properties) === '[object Object]') {
           diagramWidth = properties.diagramWidth || diagramWidth;
           yFactor = properties.yFactor || yFactor;
@@ -268,7 +268,7 @@ module.directive('myFlowGraph', function ($filter, $state, $alert, myStreamServi
           .attr("d", line(pathinfo))
           .attr('class', classNamesStr)
           .attr("transform", function(d) {
-            return "translate(" 
+            return "translate("
               + (- circleRadius + leafBuffer) + ", 0) rotate(-180)";
           });
       }
@@ -416,7 +416,7 @@ module.directive('myWorkflowGraph', function ($filter, $state) {
   }, baseDirective);
 });
 
-function genericRender(scope, $filter) {
+function genericRender(scope) {
   var nodes = scope.model.nodes;
   var edges = scope.model.edges;
 

--- a/cdap-ui/app/features/admin/templates/overview.html
+++ b/cdap-ui/app/features/admin/templates/overview.html
@@ -5,12 +5,9 @@
         Welcome CDAP Admin!
       </h3>
     </div>
-    <div class="panel-body" ng-show="isEnterprise">
-      <p>This is the control console for CDAP (Enterprise mode). Here, you can view and manage your system configuration and define and manage namespaces, entities and access permissions to keep your team's work organized and secure.</p>
-      <p>Begin by configuring your default namespace.</p>
-    </div>
-    <div class="panel-body" ng-hide="isEnterprise">
-      <p>This is the control console for CDAP (Standalone mode).</p>
+    <div class="panel-body">
+      <p>This is the control console for CDAP. Here, you can view and manage your system configuration and define and manage namespaces and entities.
+         Begin by configuring your default namespace.</p>
     </div>
   </div>
 </div>

--- a/cdap-ui/app/features/flows/controllers/tabs/runs/tabs/status-ctrl.js
+++ b/cdap-ui/app/features/flows/controllers/tabs/runs/tabs/status-ctrl.js
@@ -1,5 +1,5 @@
 angular.module(PKG.name + '.feature.flows')
-  .controller('FlowsRunDetailStatusControler', function($state, $scope, MyDataSource, myHelpers, FlowDiagramData, $timeout, $filter) {
+  .controller('FlowsRunDetailStatusController', function($state, $scope, MyDataSource, myHelpers, FlowDiagramData, $timeout, $filter) {
     var filterFilter = $filter('filter');
     var dataSrc = new MyDataSource($scope),
         basePath = '/apps/' + $state.params.appId + '/flows/' + $state.params.programId;
@@ -27,12 +27,12 @@ angular.module(PKG.name + '.feature.flows')
     }
 
     function pollMetrics() {
-      if (!$scope.runs.length) {
-        return;
-      }
       var nodes = $scope.data.nodes;
       // Requesting Metrics data
       angular.forEach(nodes, function (node) {
+        if (node.type !== 'STREAM' && !$scope.runs.length) {
+          return;
+        }
         dataSrc.poll({
           _cdapPath: (node.type === 'STREAM' ? metricStreamPath: metricFlowletPath) + node.name + '&aggregate=true',
           method: 'POST'

--- a/cdap-ui/app/features/flows/templates/tabs/runs/run-detail.html
+++ b/cdap-ui/app/features/flows/templates/tabs/runs/run-detail.html
@@ -17,7 +17,7 @@
           <tr>
             <th>Status</th>
             <th>Started</th>
-            <th>Running</th>
+            <th>Duration</th>
           </tr>
         </thead>
         <tbody>

--- a/cdap-ui/app/features/flows/templates/tabs/runs/tabs/status.html
+++ b/cdap-ui/app/features/flows/templates/tabs/runs/tabs/status.html
@@ -1,3 +1,3 @@
-<div ng-controller="FlowsRunDetailStatusControler">
+<div ng-controller="FlowsRunDetailStatusController">
 <my-flow-graph data-model="data" data-click="flowletClick" parent="#c{{$state.params.runid}}" id="c{{$state.params.runid}}"></my-flow-graph>
 </div>

--- a/cdap-ui/app/features/overview/controllers/overview-ctrl.js
+++ b/cdap-ui/app/features/overview/controllers/overview-ctrl.js
@@ -34,7 +34,7 @@ function ($scope, MyDataSource, $state, myLocalStorage, MY_CONFIG, Widget, MyOrd
   };
 
   $scope.isEnterprise = MY_CONFIG.isEnterprise;
-  $scope.systemStatus = 'red';
+  $scope.systemStatus = '#C9C9D1';
   dataSrc.poll({
     _cdapPath: '/system/services/status',
     interval: 10000

--- a/cdap-ui/app/features/spark/controllers/tabs/runs/tabs/status-ctrl.js
+++ b/cdap-ui/app/features/spark/controllers/tabs/runs/tabs/status-ctrl.js
@@ -1,5 +1,5 @@
 angular.module(PKG.name + '.feature.spark')
-  .controller('SparkRunsDetailStatusControler', function($state, $scope, MyDataSource, myHelpers, $timeout, $filter) {
+  .controller('SparkRunsDetailStatusController', function($state, $scope, MyDataSource, myHelpers, $timeout, $filter) {
     var filterFilter = $filter('filter');
     var dataSrc = new MyDataSource($scope),
         basePath = '/apps/' + $state.params.appId + '/spark/' + $state.params.programId;

--- a/cdap-ui/app/features/spark/templates/tabs/runs/run-detail.html
+++ b/cdap-ui/app/features/spark/templates/tabs/runs/run-detail.html
@@ -8,7 +8,7 @@
   </button>
 </div>
 
-<div class="spark-components" ng-controller="SparkRunsDetailStatusControler">
+<div class="spark-components" ng-controller="SparkRunsDetailStatusController">
   <div class="row run-status">
     <div class="col-xs-6">
       <table class="table table-curved table-status">
@@ -16,7 +16,7 @@
           <tr>
             <th>Status</th>
             <th>Started</th>
-            <th>Running</th>
+            <th>Duration</th>
           </tr>
         </thead>
         <tbody>

--- a/cdap-ui/app/features/spark/templates/tabs/runs/tabs/status.html
+++ b/cdap-ui/app/features/spark/templates/tabs/runs/tabs/status.html
@@ -1,4 +1,4 @@
-<div ng-controller="SparkRunsDetailStatusControler" class="container">
+<div ng-controller="SparkRunsDetailStatusController" class="container">
     <div class="sparks-metrics row clearfix">
       <div class="spark-metrics-storage col-sm-3">
         <div class="title-storage">

--- a/cdap-ui/app/index.html
+++ b/cdap-ui/app/index.html
@@ -34,7 +34,7 @@
           <div class="col-xs-12 col-md-6 text-uppercase">
             <p>
               <img src="/assets/img/cask.png" alt="" />
-              <span>Copyright &copy; 2014-2015 Cask Data, Inc. All Rights Reserved.</span>
+              <span>Copyright &copy; 2015 Cask Data, Inc. All Rights Reserved.</span>
             </p>
           </div>
           <div class="col-xs-12 col-md-6">

--- a/cdap-ui/app/services/data/datasource.js
+++ b/cdap-ui/app/services/data/datasource.js
@@ -3,7 +3,7 @@ angular.module(PKG.name+'.services')
   /**
     Example Usage:
 
-    MyDataSource // usage in a controler:
+    MyDataSource // usage in a controller:
 
     var dataSrc = new MyDataSource($scope);
 
@@ -168,12 +168,12 @@ angular.module(PKG.name+'.services')
     };
 
     /**
-     * Fetch a template configuration on-demand. Send the action 
-     * 'template-config' to the node backend. 
+     * Fetch a template configuration on-demand. Send the action
+     * 'template-config' to the node backend.
      */
     DataSource.prototype.config = function (resource, cb) {
       var deferred = $q.defer();
-   
+
       var id = generateUUID();
       resource.id = id;
       this.bindings.push({

--- a/cdap-ui/app/services/my-orderings.js
+++ b/cdap-ui/app/services/my-orderings.js
@@ -18,12 +18,15 @@ angular.module(PKG.name+'.services')
     }.bind(this));
 
     function typeClicked(arr, id, key) {
-      var idx = arr.indexOf(id);
-      if (idx !== -1) {
-        arr.splice(idx, 1);
-      }
-      arr.unshift(id);
-      myLocalStorage.set(key, arr);
+      // delay by 1000ms so that the order does not change on the same visit to the page.
+      setTimeout(function() {
+        var idx = arr.indexOf(id);
+        if (idx !== -1) {
+          arr.splice(idx, 1);
+        }
+        arr.unshift(id);
+        myLocalStorage.set(key, arr);
+      }, 1000);
     }
 
     this.appClicked = function (appName) {

--- a/cdap-ui/app/styles/themes/cdap.less
+++ b/cdap-ui/app/styles/themes/cdap.less
@@ -66,6 +66,12 @@ body.theme-cdap {
     }
   } // end main.container
 
+  #loading-bar {
+    .bar {
+      height: 5px;
+    }
+  }
+
   footer {
     background-color: white;
     font-weight: 600;

--- a/cdap-ui/app/styles/themes/cdap/header.less
+++ b/cdap-ui/app/styles/themes/cdap/header.less
@@ -58,21 +58,6 @@ body {
           background-size: 100px auto;
           position: relative;
           top: -5px;
-          &:after {
-            position: absolute;
-            content: 'BETA';
-            width: 76px;
-            text-align: center;
-            background-color: @cdap-bluegray;
-            color: @cdap-white;
-            font-size: 8px;
-            line-height: 12px;
-            .border-radius(2px);
-            bottom: -5px;
-            left: 24px;
-            letter-spacing: 2px;
-            padding: 1px 0;
-          }
           > strong {
             display: inline-block;
             visibility: hidden;


### PR DESCRIPTION
1) debounce of 1000ms after clicking on a data/app before registering it in the ordering service.
2) hover on stream/flowlets on a flow page with out runs.
3) show stream metrics on a flow page with out runs (previously wasn't retrieving stream metrics on the flow page, if there are no runs).
4) remove BETA
5) Update Management page to look like [this](https://s3.amazonaws.com/uploads.hipchat.com/26476/1011205/RdNQt0sMSBqb6xx/Screen%20Shot%202015-04-30%20at%206.39.00%20PM.png) regardless of enterprise or standalone.
6) remove 2014 from footers
7) Changed 'RUNNING' to 'DURATION' on flow/spark run-detail page.
8) 'controler' -> 'controller'
9) Make loading bar thicker (upon app deploy): [like so](https://s3.amazonaws.com/uploads.hipchat.com/26476/1011205/PL7ctSTCJnY6Dmv/Screen%20Shot%202015-04-30%20at%208.04.32%20PM.png)
10) System Services circle on overview page is now grey instead of red, until the request is received.