### PR TITLE
Expose Avro class in ETL lib batch jar

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/pom.xml
@@ -197,8 +197,8 @@
               <classifier>batch</classifier>
               <instructions>
                 <!-- build bundle jar for batch. excluding realtime-->
-                <Export-Package>co.cask.cdap.templates.etl.batch.*;co.cask.cdap.templates.etl.transforms.*,
-                  co.cask.cdap.templates.etl.common,org.apache.avro.mapreduce</Export-Package>
+                <Export-Package>co.cask.cdap.templates.etl.batch.*;co.cask.cdap.templates.etl.transforms.*;
+                  co.cask.cdap.templates.etl.common;org.apache.avro.mapreduce</Export-Package>
                 <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
                 <Embed-Transitive>true</Embed-Transitive>
                 <Embed-Directory>lib</Embed-Directory>
@@ -215,7 +215,7 @@
               <classifier>realtime</classifier>
               <instructions>
                 <!-- build bundle jar for realtime. excluding batch-->
-                <Export-Package>co.cask.cdap.templates.etl.realtime.*;co.cask.cdap.templates.etl.transforms.*,
+                <Export-Package>co.cask.cdap.templates.etl.realtime.*;co.cask.cdap.templates.etl.transforms.*;
                   co.cask.cdap.templates.etl.common</Export-Package>
                 <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
                 <Embed-Transitive>true</Embed-Transitive>

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/pom.xml
@@ -198,7 +198,7 @@
               <instructions>
                 <!-- build bundle jar for batch. excluding realtime-->
                 <Export-Package>co.cask.cdap.templates.etl.batch.*;co.cask.cdap.templates.etl.transforms.*,
-                  co.cask.cdap.templates.etl.common</Export-Package>
+                  co.cask.cdap.templates.etl.common,org.apache.avro.mapreduce</Export-Package>
                 <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
                 <Embed-Transitive>true</Embed-Transitive>
                 <Embed-Directory>lib</Embed-Directory>


### PR DESCRIPTION
Tested on cluster (throws ClassNotFoundException: Class org.apache.avro.mapreduce.AvroKeyOutputFormat without this fix).

Bamboo : http://builds.cask.co/browse/CDAP-RT22-1