### PR TITLE
[CDAP-2385] Delete adapters on namespace delete. Also abort namespace de...

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/AdapterService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/AdapterService.java
@@ -336,6 +336,13 @@ public class AdapterService extends AbstractIdleService {
     }
   }
 
+  public synchronized void removeAdapters(Id.Namespace namespaceId)
+    throws AdapterNotFoundException, CannotBeDeletedException {
+    for (AdapterDefinition adapterDefinition : getAdapters(namespaceId)) {
+      removeAdapter(namespaceId, adapterDefinition.getName());
+    }
+  }
+
   /**
    * Deletes the application (template) if there is no associated adapter using it
    * @param applicationId the {@link Id.Application} of the application (template)
@@ -645,7 +652,7 @@ public class AdapterService extends AbstractIdleService {
 
   // Reads all the jars from the adapter directory and sets up required internal structures.
   @VisibleForTesting
-  void registerTemplates() {
+  public void registerTemplates() {
     try {
       // generate a completely new map in case some templates were removed
       Map<String, ApplicationTemplateInfo> newInfoMap = Maps.newHashMap();

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/NamespaceHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/NamespaceHttpHandlerTest.java
@@ -20,6 +20,7 @@ import co.cask.cdap.AppForUnrecoverableResetTest;
 import co.cask.cdap.AppWithDataset;
 import co.cask.cdap.AppWithServices;
 import co.cask.cdap.AppWithStreamSizeSchedule;
+import co.cask.cdap.DummyBatchTemplate;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.exception.NotFoundException;
@@ -28,7 +29,9 @@ import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.gateway.handlers.NamespaceHttpHandler;
+import co.cask.cdap.internal.app.runtime.adapter.AdapterService;
 import co.cask.cdap.internal.app.services.http.AppFabricTestBase;
+import co.cask.cdap.proto.AdapterConfig;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceConfig;
 import co.cask.cdap.proto.NamespaceMeta;
@@ -258,6 +261,16 @@ public class NamespaceHttpHandlerTest extends AppFabricTestBase {
     deploy(AppWithStreamSizeSchedule.class, Constants.Gateway.API_VERSION_3_TOKEN, OTHER_NAME);
     deploy(AppForUnrecoverableResetTest.class, Constants.Gateway.API_VERSION_3_TOKEN, OTHER_NAME);
 
+    // create an adapter
+    AdapterService adapterService = getInjector().getInstance(AdapterService.class);
+    setupAdapter(DummyBatchTemplate.class);
+    adapterService.registerTemplates();
+    String adapterName = "myAdapter";
+    DummyBatchTemplate.Config config = new DummyBatchTemplate.Config("somestream", "0 0 1 1 *");
+    AdapterConfig adapterConfig = new AdapterConfig("description", DummyBatchTemplate.NAME, GSON.toJsonTree(config));
+    adapterService.createAdapter(NAME_ID, adapterName, adapterConfig);
+    adapterService.startAdapter(NAME_ID, adapterName);
+
     Id.DatasetInstance myDataset = Id.DatasetInstance.from(NAME, "myds");
     Id.Stream myStream = Id.Stream.from(OTHER_NAME, "stream");
 
@@ -274,6 +287,10 @@ public class NamespaceHttpHandlerTest extends AppFabricTestBase {
     assertResponseCode(403, deleteNamespace(NAME));
     Assert.assertTrue(nsLocation.exists());
     stopProgram(program);
+    // because adapter is started
+    assertResponseCode(403, deleteNamespace(NAME));
+    Assert.assertTrue(nsLocation.exists());
+    adapterService.stopAdapter(NAME_ID, adapterName);
     // delete should work now
     assertResponseCode(200, deleteNamespace(NAME));
     Assert.assertFalse(nsLocation.exists());
@@ -281,6 +298,7 @@ public class NamespaceHttpHandlerTest extends AppFabricTestBase {
     Assert.assertTrue(streamAdmin.exists(myStream));
     assertResponseCode(200, deleteNamespace(OTHER_NAME));
     Assert.assertFalse(streamAdmin.exists(myStream));
+    Assert.assertEquals(0, adapterService.getAdapters(NAME_ID).size());
 
     // Create the namespace again and deploy the application containing schedules.
     // Application deployment should succeed.

--- a/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionRowRecordReader.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionRowRecordReader.java
@@ -91,8 +91,8 @@ public class ReflectionRowRecordReader extends ReflectionRowReader<StructuredRec
     // if row field is given, make sure the type is a non-null simple type
     if (rowFieldName != null) {
       Schema.Field rowField = schema.getField(rowFieldName);
-      Schema.Type rowType = rowField.getSchema().getType();
       Preconditions.checkArgument(rowField != null, "Row field not found in schema");
+      Schema.Type rowType = rowField.getSchema().getType();
       Preconditions.checkArgument(rowType != Schema.Type.NULL, "Row field cannot have null type.");
       Preconditions.checkArgument(rowType.isSimpleType(),
         "Row field must be a simple type (boolean, bytes, int, long, float, double, or string).");


### PR DESCRIPTION
...lete if an adapter has been started.

[CDAP-2391] Temporarily synchronize namespace create delete and update operations until a better solution is figured out
[CDAP-1991] Part-fix - Use ApplicationLifecycleService to remove all applications on namespace delete. Complete fix needs [CDAP-2405](https://issues.cask.co/browse/CDAP-2405) (and potentially more)

Unrelated - fixed a potential NPE in ReflectionRecordReader


Jiras addressed: 
1. [CDAP-2385](https://issues.cask.co/browse/CDAP-2385)
2. [CDAP-2391](https://issues.cask.co/browse/CDAP-2391)
3. [CDAP-1991](https://issues.cask.co/browse/CDAP-1991) - Only partly addressed. 
Build: http://builds.cask.co/browse/CDAP-RBT253