### PR TITLE
[CDAP-2385] Delete adapters on namespace delete. Also abort namespace de...

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/NamespaceHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/NamespaceHttpHandler.java
@@ -167,7 +167,7 @@ public class NamespaceHttpHandler extends AbstractAppFabricHttpHandler {
     } catch (NotFoundException e) {
       responder.sendString(HttpResponseStatus.NOT_FOUND, String.format("Namespace %s not found.", namespace));
     } catch (NamespaceCannotBeDeletedException e) {
-      responder.sendString(HttpResponseStatus.FORBIDDEN, e.getMessage());
+      responder.sendString(HttpResponseStatus.CONFLICT, e.getMessage());
     } catch (Exception e) {
       LOG.error("Internal error while deleting namespace.", e);
       responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, e.getMessage());

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdmin.java
@@ -21,6 +21,7 @@ import co.cask.cdap.api.metrics.MetricStore;
 import co.cask.cdap.app.runtime.ProgramRuntimeService;
 import co.cask.cdap.app.store.Store;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.exception.AdapterNotFoundException;
 import co.cask.cdap.common.exception.NamespaceAlreadyExistsException;
 import co.cask.cdap.common.exception.NamespaceCannotBeCreatedException;
 import co.cask.cdap.common.exception.NamespaceCannotBeDeletedException;
@@ -32,13 +33,18 @@ import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.DatasetManagementException;
 import co.cask.cdap.data2.transaction.queue.QueueAdmin;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
+import co.cask.cdap.internal.app.runtime.adapter.AdapterService;
 import co.cask.cdap.internal.app.runtime.schedule.Scheduler;
+import co.cask.cdap.internal.app.services.ApplicationLifecycleService;
+import co.cask.cdap.proto.AdapterStatus;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceConfig;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.templates.AdapterDefinition;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
+import com.google.common.base.Throwables;
 import com.google.common.collect.Maps;
 import com.google.inject.Inject;
 import org.slf4j.Logger;
@@ -53,7 +59,6 @@ import java.util.Map;
  */
 public final class DefaultNamespaceAdmin implements NamespaceAdmin {
   private static final Logger LOG = LoggerFactory.getLogger(DefaultNamespaceAdmin.class);
-  private static final String NAMESPACE_ELEMENT_TYPE = "Namespace";
 
   private final Store store;
   private final PreferencesStore preferencesStore;
@@ -64,12 +69,15 @@ public final class DefaultNamespaceAdmin implements NamespaceAdmin {
   private final StreamAdmin streamAdmin;
   private final MetricStore metricStore;
   private final Scheduler scheduler;
+  private final ApplicationLifecycleService applicationLifecycleService;
+  private final AdapterService adapterService;
 
   @Inject
   public DefaultNamespaceAdmin(Store store, PreferencesStore preferencesStore,
                                DashboardStore dashboardStore, DatasetFramework dsFramework,
                                ProgramRuntimeService runtimeService, QueueAdmin queueAdmin, StreamAdmin streamAdmin,
-                               MetricStore metricStore, Scheduler scheduler) {
+                               MetricStore metricStore, Scheduler scheduler,
+                               ApplicationLifecycleService applicationLifecycleService, AdapterService adapterService) {
     this.queueAdmin = queueAdmin;
     this.streamAdmin = streamAdmin;
     this.store = store;
@@ -79,6 +87,8 @@ public final class DefaultNamespaceAdmin implements NamespaceAdmin {
     this.runtimeService = runtimeService;
     this.scheduler = scheduler;
     this.metricStore = metricStore;
+    this.applicationLifecycleService = applicationLifecycleService;
+    this.adapterService = adapterService;
   }
 
   /**
@@ -126,7 +136,7 @@ public final class DefaultNamespaceAdmin implements NamespaceAdmin {
    * @param metadata the {@link NamespaceMeta} for the new namespace to be created
    * @throws NamespaceAlreadyExistsException if the specified namespace already exists
    */
-  public void createNamespace(NamespaceMeta metadata)
+  public synchronized void createNamespace(NamespaceMeta metadata)
     throws NamespaceCannotBeCreatedException, NamespaceAlreadyExistsException {
     // TODO: CDAP-1427 - This should be transactional, but we don't support transactions on files yet
     Preconditions.checkArgument(metadata != null, "Namespace metadata should not be null.");
@@ -151,16 +161,25 @@ public final class DefaultNamespaceAdmin implements NamespaceAdmin {
    * @throws NamespaceCannotBeDeletedException if the specified namespace cannot be deleted
    * @throws NamespaceNotFoundException if the specified namespace does not exist
    */
-  public void deleteNamespace(final Id.Namespace namespaceId)
+  public synchronized void deleteNamespace(final Id.Namespace namespaceId)
     throws NamespaceCannotBeDeletedException, NamespaceNotFoundException {
     // TODO: CDAP-870, CDAP-1427: Delete should be in a single transaction.
     if (!hasNamespace(namespaceId)) {
       throw new NamespaceNotFoundException(namespaceId);
     }
 
-    if (areProgramsRunning(namespaceId)) {
+    if (checkProgramsRunning(namespaceId)) {
       throw new NamespaceCannotBeDeletedException(namespaceId,
-                                                  "Some programs are currently running in namespace " + namespaceId);
+                                                  String.format("Some programs are currently running in namespace " +
+                                                                  "'%s', please stop them before deleting namespace",
+                                                                namespaceId));
+    }
+
+    if (checkAdaptersStarted(namespaceId)) {
+      throw new NamespaceCannotBeDeletedException(namespaceId,
+                                                  String.format("Some adapters are in started state in namespace " +
+                                                                  "'%s', please stop them before deleting namespace",
+                                                                namespaceId));
     }
 
     LOG.info("Deleting namespace '{}'.", namespaceId);
@@ -177,6 +196,10 @@ public final class DefaultNamespaceAdmin implements NamespaceAdmin {
       streamAdmin.dropAllInNamespace(namespaceId);
       // Delete all the schedules
       scheduler.deleteAllSchedules(namespaceId);
+      // Delete all applications
+      applicationLifecycleService.removeAll(namespaceId);
+      // Delete all adapters
+      adapterService.removeAdapters(namespaceId);
       // Delete all meta data
       store.removeAll(namespaceId);
 
@@ -199,6 +222,23 @@ public final class DefaultNamespaceAdmin implements NamespaceAdmin {
     LOG.info("All data for namespace '{}' deleted.", namespaceId);
   }
 
+  private boolean checkAdaptersStarted(Id.Namespace namespaceId) {
+    for (AdapterDefinition adapterDefinition : adapterService.getAdapters(namespaceId)) {
+      AdapterStatus adapterStatus;
+      try {
+        adapterStatus = adapterService.getAdapterStatus(namespaceId, adapterDefinition.getName());
+      } catch (AdapterNotFoundException e) {
+        // should never happen, since we're querying known adapters and especially since this is executed from
+        // within a synchronized method
+        throw Throwables.propagate(e);
+      }
+      if (AdapterStatus.STARTED.equals(adapterStatus)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   private void deleteMetrics(Id.Namespace namespaceId) throws Exception {
     long endTs = System.currentTimeMillis() / 1000;
     Map<String, String> tags = Maps.newHashMap();
@@ -208,14 +248,14 @@ public final class DefaultNamespaceAdmin implements NamespaceAdmin {
   }
 
   @Override
-  public void deleteDatasets(Id.Namespace namespaceId)
+  public synchronized void deleteDatasets(Id.Namespace namespaceId)
     throws NamespaceNotFoundException, NamespaceCannotBeDeletedException {
     // TODO: CDAP-870, CDAP-1427: Delete should be in a single transaction.
     if (!hasNamespace(namespaceId)) {
       throw new NamespaceNotFoundException(namespaceId);
     }
 
-    if (areProgramsRunning(namespaceId)) {
+    if (checkProgramsRunning(namespaceId)) {
       throw new NamespaceCannotBeDeletedException(namespaceId,
                                                   "Some programs are currently running in namespace " + namespaceId);
     }
@@ -233,7 +273,7 @@ public final class DefaultNamespaceAdmin implements NamespaceAdmin {
     LOG.info("Deleted data in namespace '{}'.", namespaceId);
   }
 
-  public void updateProperties(Id.Namespace namespaceId, NamespaceMeta namespaceMeta)
+  public synchronized void updateProperties(Id.Namespace namespaceId, NamespaceMeta namespaceMeta)
     throws NamespaceNotFoundException {
 
     if (store.getNamespace(namespaceId) == null) {
@@ -259,7 +299,7 @@ public final class DefaultNamespaceAdmin implements NamespaceAdmin {
     store.updateNamespace(builder.build());
   }
 
-  private boolean areProgramsRunning(final Id.Namespace namespaceId) {
+  private boolean checkProgramsRunning(final Id.Namespace namespaceId) {
     return runtimeService.checkAnyRunning(new Predicate<Id.Program>() {
       @Override
       public boolean apply(Id.Program program) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/AdapterService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/AdapterService.java
@@ -336,6 +336,13 @@ public class AdapterService extends AbstractIdleService {
     }
   }
 
+  public synchronized void removeAdapters(Id.Namespace namespaceId)
+    throws AdapterNotFoundException, CannotBeDeletedException {
+    for (AdapterDefinition adapterDefinition : getAdapters(namespaceId)) {
+      removeAdapter(namespaceId, adapterDefinition.getName());
+    }
+  }
+
   /**
    * Deletes the application (template) if there is no associated adapter using it
    * @param applicationId the {@link Id.Application} of the application (template)
@@ -645,7 +652,7 @@ public class AdapterService extends AbstractIdleService {
 
   // Reads all the jars from the adapter directory and sets up required internal structures.
   @VisibleForTesting
-  void registerTemplates() {
+  public void registerTemplates() {
     try {
       // generate a completely new map in case some templates were removed
       Map<String, ApplicationTemplateInfo> newInfoMap = Maps.newHashMap();

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/adapter/AdapterLifecycleTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/adapter/AdapterLifecycleTest.java
@@ -19,29 +19,21 @@ package co.cask.cdap.internal.app.runtime.adapter;
 import co.cask.cdap.AppWithServices;
 import co.cask.cdap.DummyBatchTemplate;
 import co.cask.cdap.DummyWorkerTemplate;
-import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
-import co.cask.cdap.common.io.Locations;
 import co.cask.cdap.internal.app.services.http.AppFabricTestBase;
-import co.cask.cdap.internal.test.AppJarHelper;
 import co.cask.cdap.proto.AdapterConfig;
 import co.cask.cdap.proto.AdapterDetail;
 import co.cask.cdap.proto.Id;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.io.Files;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
 import org.apache.http.HttpResponse;
-import org.apache.twill.filesystem.Location;
-import org.apache.twill.filesystem.LocationFactory;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.io.File;
-import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
@@ -53,15 +45,10 @@ public class AdapterLifecycleTest extends AppFabricTestBase {
   private static final Gson GSON = new Gson();
   private static final Type ADAPTER_SPEC_LIST_TYPE =
     new TypeToken<List<AdapterDetail>>() { }.getType();
-  private static LocationFactory locationFactory;
-  private static File adapterDir;
   private static AdapterService adapterService;
 
   @BeforeClass
   public static void setup() throws Exception {
-    CConfiguration conf = getInjector().getInstance(CConfiguration.class);
-    locationFactory = getInjector().getInstance(LocationFactory.class);
-    adapterDir = new File(conf.get(Constants.AppFabric.APP_TEMPLATE_DIR));
     setupAdapter(DummyBatchTemplate.class);
     setupAdapter(DummyWorkerTemplate.class);
     adapterService = getInjector().getInstance(AdapterService.class);
@@ -279,12 +266,6 @@ public class AdapterLifecycleTest extends AppFabricTestBase {
     Assert.assertEquals(200, response.getStatusLine().getStatusCode());
     list = readResponse(response, ADAPTER_SPEC_LIST_TYPE);
     Assert.assertTrue(list.isEmpty());
-  }
-
-  private static void setupAdapter(Class<?> clz) throws IOException {
-    Location adapterJar = AppJarHelper.createDeploymentJar(locationFactory, clz);
-    File destination =  new File(String.format("%s/%s", adapterDir.getAbsolutePath(), adapterJar.getName()));
-    Files.copy(Locations.newInputSupplier(adapterJar), destination);
   }
 
   private HttpResponse createAdapter(String namespaceId, String name, AdapterConfig config) throws Exception {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/NamespaceHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/NamespaceHttpHandlerTest.java
@@ -20,6 +20,7 @@ import co.cask.cdap.AppForUnrecoverableResetTest;
 import co.cask.cdap.AppWithDataset;
 import co.cask.cdap.AppWithServices;
 import co.cask.cdap.AppWithStreamSizeSchedule;
+import co.cask.cdap.DummyBatchTemplate;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.exception.NotFoundException;
@@ -28,7 +29,9 @@ import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.gateway.handlers.NamespaceHttpHandler;
+import co.cask.cdap.internal.app.runtime.adapter.AdapterService;
 import co.cask.cdap.internal.app.services.http.AppFabricTestBase;
+import co.cask.cdap.proto.AdapterConfig;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceConfig;
 import co.cask.cdap.proto.NamespaceMeta;
@@ -258,6 +261,16 @@ public class NamespaceHttpHandlerTest extends AppFabricTestBase {
     deploy(AppWithStreamSizeSchedule.class, Constants.Gateway.API_VERSION_3_TOKEN, OTHER_NAME);
     deploy(AppForUnrecoverableResetTest.class, Constants.Gateway.API_VERSION_3_TOKEN, OTHER_NAME);
 
+    // create an adapter
+    AdapterService adapterService = getInjector().getInstance(AdapterService.class);
+    setupAdapter(DummyBatchTemplate.class);
+    adapterService.registerTemplates();
+    String adapterName = "myAdapter";
+    DummyBatchTemplate.Config config = new DummyBatchTemplate.Config("somestream", "0 0 1 1 *");
+    AdapterConfig adapterConfig = new AdapterConfig("description", DummyBatchTemplate.NAME, GSON.toJsonTree(config));
+    adapterService.createAdapter(NAME_ID, adapterName, adapterConfig);
+    adapterService.startAdapter(NAME_ID, adapterName);
+
     Id.DatasetInstance myDataset = Id.DatasetInstance.from(NAME, "myds");
     Id.Stream myStream = Id.Stream.from(OTHER_NAME, "stream");
 
@@ -271,9 +284,13 @@ public class NamespaceHttpHandlerTest extends AppFabricTestBase {
     assertResponseCode(403, deleteNamespace(NAME));
     cConf.setBoolean(Constants.Dangerous.UNRECOVERABLE_RESET, resetEnabled);
     // because service is running
-    assertResponseCode(403, deleteNamespace(NAME));
+    assertResponseCode(409, deleteNamespace(NAME));
     Assert.assertTrue(nsLocation.exists());
     stopProgram(program);
+    // because adapter is started
+    assertResponseCode(409, deleteNamespace(NAME));
+    Assert.assertTrue(nsLocation.exists());
+    adapterService.stopAdapter(NAME_ID, adapterName);
     // delete should work now
     assertResponseCode(200, deleteNamespace(NAME));
     Assert.assertFalse(nsLocation.exists());
@@ -281,6 +298,7 @@ public class NamespaceHttpHandlerTest extends AppFabricTestBase {
     Assert.assertTrue(streamAdmin.exists(myStream));
     assertResponseCode(200, deleteNamespace(OTHER_NAME));
     Assert.assertFalse(streamAdmin.exists(myStream));
+    Assert.assertEquals(0, adapterService.getAdapters(NAME_ID).size());
 
     // Create the namespace again and deploy the application containing schedules.
     // Application deployment should succeed.
@@ -319,7 +337,7 @@ public class NamespaceHttpHandlerTest extends AppFabricTestBase {
     Assert.assertTrue(nsLocation.exists());
     cConf.setBoolean(Constants.Dangerous.UNRECOVERABLE_RESET, resetEnabled);
     // because service is running
-    assertResponseCode(403, deleteNamespace(NAME));
+    assertResponseCode(409, deleteNamespace(NAME));
     Assert.assertTrue(nsLocation.exists());
     stopProgram(program);
     assertResponseCode(200, deleteNamespaceData(NAME));

--- a/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionRowRecordReader.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionRowRecordReader.java
@@ -91,8 +91,8 @@ public class ReflectionRowRecordReader extends ReflectionRowReader<StructuredRec
     // if row field is given, make sure the type is a non-null simple type
     if (rowFieldName != null) {
       Schema.Field rowField = schema.getField(rowFieldName);
-      Schema.Type rowType = rowField.getSchema().getType();
       Preconditions.checkArgument(rowField != null, "Row field not found in schema");
+      Schema.Type rowType = rowField.getSchema().getType();
       Preconditions.checkArgument(rowType != Schema.Type.NULL, "Row field cannot have null type.");
       Preconditions.checkArgument(rowType.isSimpleType(),
         "Row field must be a simple type (boolean, bytes, int, long, float, double, or string).");


### PR DESCRIPTION
...lete if an adapter has been started.

[CDAP-2391] Temporarily synchronize namespace create delete and update operations until a better solution is figured out
[CDAP-1991] Part-fix - Use ApplicationLifecycleService to remove all applications on namespace delete. Complete fix needs [CDAP-2405](https://issues.cask.co/browse/CDAP-2405) (and potentially more)

Unrelated - fixed a potential NPE in ReflectionRecordReader

Jiras addressed: 
1. [CDAP-2385](https://issues.cask.co/browse/CDAP-2385)
2. [CDAP-2391](https://issues.cask.co/browse/CDAP-2391)
3. [CDAP-1991](https://issues.cask.co/browse/CDAP-1991) - Only partly addressed. 
Build: http://builds.cask.co/browse/CDAP-RBT253