### PR TITLE
Setting snappy dependency to 1.1.1.7 since 1.0.5 causes problems with Kafka RealtimeSource

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/pom.xml
@@ -179,6 +179,10 @@
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka_2.10</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.xerial.snappy</groupId>
+      <artifactId>snappy-java</artifactId>
+    </dependency>
     <!-- End for Kafka Source -->
   </dependencies>
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/pom.xml
@@ -178,6 +178,12 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka_2.10</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.xerial.snappy</groupId>
+          <artifactId>snappy-java</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.xerial.snappy</groupId>

--- a/cdap-app-templates/cdap-etl/pom.xml
+++ b/cdap-app-templates/cdap-etl/pom.xml
@@ -43,6 +43,7 @@
     <twitter4j.version>4.0.1</twitter4j.version>
     <etl.avro.version>1.7.7</etl.avro.version>
     <hsqldb.version>2.3.1</hsqldb.version>
+    <snappy.version>1.1.1.7</snappy.version>
   </properties>
 
   <dependencyManagement>
@@ -186,6 +187,12 @@
         <artifactId>hsqldb</artifactId>
         <version>${hsqldb.version}</version>
         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.xerial.snappy</groupId>
+        <artifactId>snappy-java</artifactId>
+        <version>${snappy.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Bamboo : http://builds.cask.co/browse/CDAP-RT23-1