### PR TITLE
Improved log messages.

### DIFF
--- a/cdap-client/src/main/java/co/cask/cdap/client/AdapterClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/AdapterClient.java
@@ -129,7 +129,7 @@ public class AdapterClient {
     if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
       throw new ApplicationTemplateNotFoundException(Id.ApplicationTemplate.from(adapterSpec.getTemplate()));
     } else if (response.getResponseCode() == HttpURLConnection.HTTP_BAD_REQUEST) {
-      throw new BadRequestException(response.getResponseMessage());
+      throw new BadRequestException(response.getResponseBodyAsString());
     }
   }
 

--- a/cdap-common/src/main/java/co/cask/cdap/common/http/AuthenticationChannelHandler.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/http/AuthenticationChannelHandler.java
@@ -61,7 +61,7 @@ public class AuthenticationChannelHandler extends SimpleChannelUpstreamHandler {
 
   @Override
   public void exceptionCaught(ChannelHandlerContext ctx, ExceptionEvent e) {
-    LOG.error("Got exception: ", e);
+    LOG.error("Got exception: ", e.getCause());
     ChannelFuture future = Channels.future(ctx.getChannel());
     future.addListener(ChannelFutureListener.CLOSE);
     // TODO: add WWW-Authenticate header for 401 response -  REACTOR-900


### PR DESCRIPTION
Some http logging wasn't logging the exception, [like so](https://s3.amazonaws.com/uploads.hipchat.com/26476/1011205/2CLgnrdnyuubUgp/Screen%20Shot%202015-05-01%20at%2011.20.00%20AM.png). Now it's [like this](https://s3.amazonaws.com/uploads.hipchat.com/26476/1011205/72a05GKCmB0JPLB/Screen%20Shot%202015-05-01%20at%2011.56.20%20AM.png).
Also, adapter create error message was not informative, [like so](https://s3.amazonaws.com/uploads.hipchat.com/26476/1011205/3NekgQzWEdzIsib/Screen%20Shot%202015-05-01%20at%2011.37.17%20AM.png). Now it's [like this](https://s3.amazonaws.com/uploads.hipchat.com/26476/1011205/gM1rGFOP0tG5kYe/Screen%20Shot%202015-05-01%20at%2011.38.01%20AM.png).

http://builds.cask.co/browse/CDAP-RBT254-1