### PR TITLE
CDAP-2202 Validate RunRecord for running program agains ProgramRuntimeService as source of truth

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
@@ -62,7 +62,10 @@ import co.cask.cdap.proto.codec.ScheduleSpecificationCodec;
 import co.cask.http.HttpResponder;
 import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Predicate;
 import com.google.common.base.Throwables;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -232,6 +235,9 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
       if (runRecord == null) {
         throw new NotFoundException(run);
       }
+
+      // Try to validate the run record with runtime service
+      runRecord = lifecycleService.validateRunRecord(runRecord, programId, ProgramType.MAPREDUCE);
 
       MRJobInfo mrJobInfo = mrJobInfoFetcher.getMRJobInfo(run);
 
@@ -434,7 +440,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
     }
     long start = (startTs == null || startTs.isEmpty()) ? 0 : Long.parseLong(startTs);
     long end = (endTs == null || endTs.isEmpty()) ? Long.MAX_VALUE : Long.parseLong(endTs);
-    getRuns(responder, Id.Program.from(namespaceId, appId, type, programId), status, start, end, resultLimit);
+    getRuns(responder, Id.Program.from(namespaceId, appId, type, programId), status, start, end, resultLimit, type);
   }
 
   /**
@@ -457,6 +463,11 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
     try {
       RunRecord runRecord = store.getRun(Id.Program.from(namespaceId, appId, type, programId), runid);
       if (runRecord != null) {
+
+        // Try to validate the run record with runtime service
+        Id.Program program  = Id.Program.from(namespaceId, appId, type, programId);
+        runRecord = lifecycleService.validateRunRecord(runRecord, program, type);
+
         responder.sendJson(HttpResponseStatus.OK, runRecord);
         return;
       }
@@ -1402,12 +1413,26 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   }
 
   private void getRuns(HttpResponder responder, Id.Program programId, String status,
-                       long start, long end, int limit) {
+                       long start, long end, int limit, final ProgramType programType) {
     try {
       try {
-        ProgramRunStatus runStatus = (status == null) ? ProgramRunStatus.ALL :
+        final ProgramRunStatus runStatus = (status == null) ? ProgramRunStatus.ALL :
           ProgramRunStatus.valueOf(status.toUpperCase());
-        responder.sendJson(HttpResponseStatus.OK, store.getRuns(programId, runStatus, start, end, limit));
+
+        // Need to validate whether the run records are reflecting the actual running state of the program.
+        List<RunRecord> runRecords = lifecycleService.validateRunRecords(
+          store.getRuns(programId, runStatus, start, end, limit), programId, programType);
+
+        // Filter all the validated run records based onf run status
+        List<RunRecord> filteredRunRecords = ImmutableList.copyOf(
+          Collections2.filter(runRecords, new Predicate<RunRecord>() {
+            @Override
+            public boolean apply(RunRecord record) {
+              return (record.getStatus() == runStatus);
+            }
+          }));
+
+        responder.sendJson(HttpResponseStatus.OK, filteredRunRecords);
       } catch (IllegalArgumentException e) {
         responder.sendString(HttpResponseStatus.BAD_REQUEST,
                              "Supported options for status of runs are running/completed/failed");


### PR DESCRIPTION
Currently the calls to check run status of a program is run against run records' store.
In case of abrupt shutdown, there is no chance to update the state of the run record of the programs.
For example if a Flow program is running in standalone then the programs dies, then the run record
for that program will indicate still running when the CDAP is restarted.

So, the call for
  http://localhost:10000/v3/namespaces/default/apps/CountRandom/flows/CountRandom/runs?status=running
and
  http://localhost:10000/v3/namespaces/default/apps/CountRandom/flows/CountRandom/status
could return different results.

The proposed fix to change the Adapter and Program lifecycle to check against the runtime service
when querying for run records of a program.

For Adapter we just need to check for worker one because the workflow is done via scheduler so
when cdap start the workflow adapter should start the scheduled programs accordingly.