### PR TITLE
CDAP-2264: FlowQueuePendingCorrector tool for correcting the queue.pending metric

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/queue/QueueName.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/queue/QueueName.java
@@ -71,6 +71,10 @@ public final class QueueName {
     return new QueueName(URI.create(new String(bytes, Charsets.US_ASCII)));
   }
 
+  public static QueueName fromFlowlet(Id.Flow flow, String flowlet, String output) {
+    return fromFlowlet(flow.getNamespaceId(), flow.getApplicationId(), flow.getId(), flowlet, output);
+  }
+
   public static QueueName fromFlowlet(String namespace, String app, String flow, String flowlet, String output) {
     URI uri = URI.create(String.format("queue:///%s/%s/%s/%s/%s", namespace, app, flow, flowlet, output));
     return new QueueName(uri);

--- a/cdap-master/pom.xml
+++ b/cdap-master/pom.xml
@@ -122,6 +122,11 @@
       <groupId>org.apache.twill</groupId>
       <artifactId>twill-core</artifactId>
     </dependency>
+    <!-- for tools -->
+    <dependency>
+      <groupId>commons-cli</groupId>
+      <artifactId>commons-cli</artifactId>
+    </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/HBaseQueueDebugger.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/HBaseQueueDebugger.java
@@ -106,7 +106,7 @@ public class HBaseQueueDebugger extends AbstractIdleService {
   /**
    * Only works for {@link co.cask.cdap.data2.transaction.queue.hbase.ShardedHBaseQueueStrategy}.
    */
-  private QueueStatistics scanQueue(final QueueName queueName, @Nullable Long consumerGroupId) throws Exception {
+  public QueueStatistics scanQueue(final QueueName queueName, @Nullable Long consumerGroupId) throws Exception {
     HBaseConsumerStateStore stateStore = queueAdmin.getConsumerStateStore(queueName);
 
     TransactionExecutor txExecutor = Transactions.createTransactionExecutor(txExecutorFactory, stateStore);
@@ -236,7 +236,7 @@ public class HBaseQueueDebugger extends AbstractIdleService {
   /**
    *
    */
-  private static final class QueueStatistics {
+  public static final class QueueStatistics {
 
     private long unprocessed;
     private long processedAndVisible;

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
@@ -15,50 +15,45 @@
  */
 package co.cask.cdap.data.tools;
 
-import co.cask.cdap.api.dataset.module.DatasetDefinitionRegistry;
-import co.cask.cdap.api.dataset.module.DatasetModule;
-import co.cask.cdap.api.metrics.MetricStore;
-import co.cask.cdap.api.metrics.MetricsCollectionService;
+import co.cask.cdap.api.flow.FlowSpecification;
 import co.cask.cdap.api.schedule.SchedulableProgramType;
+import co.cask.cdap.app.ApplicationSpecification;
 import co.cask.cdap.app.guice.AppFabricServiceRuntimeModule;
 import co.cask.cdap.app.guice.ProgramRunnerRuntimeModule;
-import co.cask.cdap.app.store.ServiceStore;
+import co.cask.cdap.app.guice.ServiceStoreModules;
 import co.cask.cdap.app.store.Store;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
+import co.cask.cdap.common.guice.IOModule;
 import co.cask.cdap.common.guice.KafkaClientModule;
 import co.cask.cdap.common.guice.LocationRuntimeModule;
 import co.cask.cdap.common.guice.TwillModule;
 import co.cask.cdap.common.guice.ZKClientModule;
-import co.cask.cdap.common.metrics.NoOpMetricsCollectionService;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.common.utils.ProjectInfo;
-import co.cask.cdap.config.DefaultConfigStore;
 import co.cask.cdap.data.runtime.DataFabricDistributedModule;
+import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;
 import co.cask.cdap.data.stream.StreamAdminModules;
-import co.cask.cdap.data2.datafabric.dataset.DatasetMetaTableUtil;
-import co.cask.cdap.data2.dataset2.DatasetDefinitionRegistryFactory;
+import co.cask.cdap.data.tools.flow.FlowQueuePendingCorrector;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.DatasetManagementException;
-import co.cask.cdap.data2.dataset2.DefaultDatasetDefinitionRegistry;
-import co.cask.cdap.data2.dataset2.InMemoryDatasetFramework;
-import co.cask.cdap.data2.dataset2.lib.kv.HBaseKVTableDefinition;
+import co.cask.cdap.data2.queue.QueueClientFactory;
+import co.cask.cdap.data2.transaction.queue.QueueAdmin;
+import co.cask.cdap.data2.transaction.queue.hbase.HBaseQueueAdmin;
+import co.cask.cdap.data2.transaction.queue.hbase.HBaseQueueClientFactory;
+import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
+import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
 import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.gateway.auth.AuthModule;
-import co.cask.cdap.gateway.handlers.DatasetServiceStore;
 import co.cask.cdap.internal.app.namespace.NamespaceAdmin;
 import co.cask.cdap.internal.app.runtime.adapter.AdapterService;
 import co.cask.cdap.internal.app.runtime.schedule.AbstractSchedulerService;
 import co.cask.cdap.internal.app.runtime.schedule.ExecutorThreadPool;
 import co.cask.cdap.internal.app.runtime.schedule.store.DatasetBasedTimeScheduleStore;
-import co.cask.cdap.internal.app.runtime.schedule.store.ScheduleStoreTableUtil;
 import co.cask.cdap.internal.app.store.DefaultStore;
-import co.cask.cdap.logging.save.LogSaverTableUtil;
-import co.cask.cdap.metrics.store.DefaultMetricDatasetFactory;
-import co.cask.cdap.metrics.store.DefaultMetricStore;
-import co.cask.cdap.metrics.store.MetricDatasetFactory;
+import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
 import co.cask.cdap.notifications.feeds.client.NotificationFeedClientModule;
 import co.cask.cdap.notifications.guice.NotificationServiceRuntimeModule;
 import co.cask.cdap.proto.Id;
@@ -72,10 +67,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.Provides;
-import com.google.inject.Scopes;
 import com.google.inject.Singleton;
-import com.google.inject.TypeLiteral;
-import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.name.Named;
 import com.google.inject.name.Names;
 import org.apache.hadoop.conf.Configuration;
@@ -114,6 +106,7 @@ public class UpgradeTool {
   private final ZKClientService zkClientService;
   private final Injector injector;
   private final NamespacedLocationFactory namespacedLocationFactory;
+  private final FlowQueuePendingCorrector flowQueuePendingCorrector;
 
   private Store store;
   QuartzScheduler qs;
@@ -130,6 +123,7 @@ public class UpgradeTool {
               "  1. User Datasets (Upgrades only the coprocessor jars)\n" +
               "  2. System Datasets\n" +
               "  3. StreamConversionAdapter\n" +
+              "  4. queue.pending metrics for flowlets\n" +
               "  Note: Once you run the upgrade tool you cannot rollback to the previous version."),
     HELP("Show this help.");
 
@@ -153,6 +147,7 @@ public class UpgradeTool {
     this.namespacedLocationFactory = injector.getInstance(NamespacedLocationFactory.class);
     this.dsFramework = injector.getInstance(DatasetFramework.class);
     this.adapterService = injector.getInstance(AdapterService.class);
+    this.flowQueuePendingCorrector = injector.getInstance(FlowQueuePendingCorrector.class);
 
     Runtime.getRuntime().addShutdownHook(new Thread() {
       @Override
@@ -168,38 +163,31 @@ public class UpgradeTool {
 
   private Injector init() throws Exception {
     return Guice.createInjector(
+      new IOModule(),
       new ConfigModule(cConf, hConf),
-      new LocationRuntimeModule().getDistributedModules(),
       new ZKClientModule(),
+      new LocationRuntimeModule().getDistributedModules(),
       new DiscoveryRuntimeModule().getDistributedModules(),
       new StreamAdminModules().getDistributedModules(),
       new NotificationFeedClientModule(),
       new TwillModule(),
       new AuthModule(),
       new ExploreClientModule(),
+      new DataFabricDistributedModule(),
+      new ServiceStoreModules().getDistributedModule(),
+      new DataSetsModules().getDistributedModules(),
       new AppFabricServiceRuntimeModule().getDistributedModules(),
       new ProgramRunnerRuntimeModule().getDistributedModules(),
       new SystemDatasetRuntimeModule().getDistributedModules(),
       new NotificationServiceRuntimeModule().getDistributedModules(),
+      new MetricsClientRuntimeModule().getDistributedModules(),
       new KafkaClientModule(),
       new AbstractModule() {
         @Override
         protected void configure() {
-          install(new DataFabricDistributedModule());
-          // the DataFabricDistributedModule needs MetricsCollectionService binding and since Upgrade tool does not do
-          // anything with Metrics we just bind it to NoOpMetricsCollectionService
-          bind(MetricsCollectionService.class).to(NoOpMetricsCollectionService.class).in(Scopes.SINGLETON);
-          install(new FactoryModuleBuilder()
-                    .implement(DatasetDefinitionRegistry.class, DefaultDatasetDefinitionRegistry.class)
-                    .build(DatasetDefinitionRegistryFactory.class));
-          bind(new TypeLiteral<DatasetModule>() {
-          }).annotatedWith(Names.named("serviceModule"))
-            .toInstance(new HBaseKVTableDefinition.Module());
-          bind(ServiceStore.class).to(DatasetServiceStore.class).in(Scopes.SINGLETON);
-
-          bind(MetricDatasetFactory.class).to(DefaultMetricDatasetFactory.class).in(Scopes.SINGLETON);
-          bind(MetricStore.class).to(DefaultMetricStore.class);
-          bind(DatasetFramework.class).to(InMemoryDatasetFramework.class).in(Scopes.SINGLETON);
+          bind(QueueClientFactory.class).to(HBaseQueueClientFactory.class).in(Singleton.class);
+          bind(QueueAdmin.class).to(HBaseQueueAdmin.class).in(Singleton.class);
+          bind(HBaseTableUtil.class).toProvider(HBaseTableUtilFactory.class);
         }
 
         @Provides
@@ -219,7 +207,6 @@ public class UpgradeTool {
         public DatasetFramework getInDsFramework(DatasetFramework dsFramework) {
           return dsFramework;
         }
-
       });
   }
 
@@ -230,7 +217,7 @@ public class UpgradeTool {
     // Start all the services.
     zkClientService.startAndWait();
     txService.startAndWait();
-    initializeDSFramework(cConf, dsFramework);
+    flowQueuePendingCorrector.startAndWait();
   }
 
   /**
@@ -243,6 +230,7 @@ public class UpgradeTool {
       if (qs != null) {
         qs.shutdown();
       }
+      flowQueuePendingCorrector.stopAndWait();
     } catch (Throwable e) {
       LOG.error("Exception while trying to stop upgrade process", e);
       Runtime.getRuntime().halt(1);
@@ -339,6 +327,23 @@ public class UpgradeTool {
     dsUpgrade.upgrade();
 
     upgradeAdapters();
+    populateFlowQueuePendingMetrics();
+  }
+
+  private void populateFlowQueuePendingMetrics() throws Exception {
+    NamespaceAdmin namespaceAdmin = injector.getInstance(NamespaceAdmin.class);
+    List<NamespaceMeta> namespaceMetas = namespaceAdmin.listNamespaces();
+    for (NamespaceMeta namespaceMeta : namespaceMetas) {
+      Id.Namespace namespaceId = Id.Namespace.from(namespaceMeta.getName());
+      Collection<ApplicationSpecification> apps = getStore()
+        .getAllApplications(namespaceId);
+      for (ApplicationSpecification app : apps) {
+        Id.Application appId = Id.Application.from(namespaceId, app.getName());
+        for (FlowSpecification flow : app.getFlows().values()) {
+          flowQueuePendingCorrector.run(Id.Flow.from(appId, flow.getName()));
+        }
+      }
+    }
   }
 
   /**
@@ -369,36 +374,6 @@ public class UpgradeTool {
       datasetBasedTimeScheduleStore.removeJob(new JobKey(AbstractSchedulerService
                                                            .programIdFor(program, SchedulableProgramType.WORKFLOW)));
     }
-  }
-
-  public static void main(String[] args) {
-    try {
-      UpgradeTool upgradeTool = new UpgradeTool();
-      upgradeTool.doMain(args);
-    } catch (Throwable t) {
-      LOG.error("Failed to upgrade ...", t);
-    }
-  }
-
-  /**
-   * Sets up a {@link DatasetFramework} instance for standalone usage.  NOTE: should NOT be used by applications!!!
-   */
-  private void initializeDSFramework(CConfiguration cConf, DatasetFramework datasetFramework) throws IOException,
-    DatasetManagementException {
-    // dataset service
-    DatasetMetaTableUtil.setupDatasets(datasetFramework);
-    // app metadata
-    DefaultStore.setupDatasets(datasetFramework);
-    // config store
-    DefaultConfigStore.setupDatasets(datasetFramework);
-    // logs metadata
-    LogSaverTableUtil.setupDatasets(datasetFramework);
-    // scheduler metadata
-    ScheduleStoreTableUtil.setupDatasets(datasetFramework);
-
-    // metrics data
-    DefaultMetricDatasetFactory factory = new DefaultMetricDatasetFactory(cConf, datasetFramework);
-    DefaultMetricDatasetFactory.setupDatasets(factory);
   }
 
   /**
@@ -445,5 +420,14 @@ public class UpgradeTool {
       datasetBasedTimeScheduleStore.initialize(cch, qs.getSchedulerSignaler());
     }
     return datasetBasedTimeScheduleStore;
+  }
+
+  public static void main(String[] args) {
+    try {
+      UpgradeTool upgradeTool = new UpgradeTool();
+      upgradeTool.doMain(args);
+    } catch (Throwable t) {
+      LOG.error("Failed to upgrade ...", t);
+    }
   }
 }

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/flow/FlowQueuePendingCorrector.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/flow/FlowQueuePendingCorrector.java
@@ -1,0 +1,322 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.data.tools.flow;
+
+import co.cask.cdap.api.dataset.lib.cube.AggregationFunction;
+import co.cask.cdap.api.dataset.lib.cube.TimeValue;
+import co.cask.cdap.api.flow.FlowSpecification;
+import co.cask.cdap.api.flow.FlowletConnection;
+import co.cask.cdap.api.metrics.MetricDataQuery;
+import co.cask.cdap.api.metrics.MetricStore;
+import co.cask.cdap.api.metrics.MetricTimeSeries;
+import co.cask.cdap.api.metrics.MetricsCollectionService;
+import co.cask.cdap.api.metrics.MetricsCollector;
+import co.cask.cdap.app.ApplicationSpecification;
+import co.cask.cdap.app.guice.ProgramRunnerRuntimeModule;
+import co.cask.cdap.app.queue.QueueSpecification;
+import co.cask.cdap.app.queue.QueueSpecificationGenerator;
+import co.cask.cdap.app.runtime.ProgramRuntimeService;
+import co.cask.cdap.app.store.Store;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.guice.ConfigModule;
+import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
+import co.cask.cdap.common.guice.IOModule;
+import co.cask.cdap.common.guice.KafkaClientModule;
+import co.cask.cdap.common.guice.LocationRuntimeModule;
+import co.cask.cdap.common.guice.TwillModule;
+import co.cask.cdap.common.guice.ZKClientModule;
+import co.cask.cdap.common.queue.QueueName;
+import co.cask.cdap.data.runtime.DataFabricDistributedModule;
+import co.cask.cdap.data.runtime.DataSetsModules;
+import co.cask.cdap.data.stream.StreamAdminModules;
+import co.cask.cdap.data.tools.HBaseQueueDebugger;
+import co.cask.cdap.data2.queue.QueueClientFactory;
+import co.cask.cdap.data2.transaction.queue.QueueAdmin;
+import co.cask.cdap.data2.transaction.queue.hbase.HBaseQueueAdmin;
+import co.cask.cdap.data2.transaction.queue.hbase.HBaseQueueClientFactory;
+import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
+import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
+import co.cask.cdap.internal.app.queue.SimpleQueueSpecificationGenerator;
+import co.cask.cdap.internal.app.runtime.flow.FlowUtils;
+import co.cask.cdap.internal.app.store.DefaultStore;
+import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
+import co.cask.cdap.notifications.feeds.client.NotificationFeedClientModule;
+import co.cask.cdap.proto.Id;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Table;
+import com.google.common.util.concurrent.AbstractIdleService;
+import com.google.gson.Gson;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Singleton;
+import org.apache.commons.cli.BasicParser;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.twill.api.RunId;
+import org.apache.twill.api.TwillRunnerService;
+import org.apache.twill.kafka.client.KafkaClientService;
+import org.apache.twill.zookeeper.ZKClientService;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Corrects the "queue.pending" metric emitted in {@link co.cask.cdap.internal.app.runtime.flow.FlowletProgramRunner}.
+ */
+public class FlowQueuePendingCorrector extends AbstractIdleService {
+
+  private static final Gson GSON = new Gson();
+
+  private final MetricsCollectionService metricsCollectionService;
+  private final MetricStore metricStore;
+  private final KafkaClientService kafkaClientService;
+  private final HBaseQueueDebugger queueDebugger;
+  private final ZKClientService zkClientService;
+  private final Store store;
+  private final ProgramRuntimeService programRuntimeService;
+  private final TwillRunnerService twillRunnerService;
+
+  @Inject
+  public FlowQueuePendingCorrector(HBaseQueueDebugger queueDebugger, ZKClientService zkClientService,
+                                   MetricsCollectionService metricsCollectionService, MetricStore metricStore,
+                                   KafkaClientService kafkaClientService, Store store,
+                                   ProgramRuntimeService programRuntimeService,
+                                   TwillRunnerService twillRunnerService) {
+    this.queueDebugger = queueDebugger;
+    this.zkClientService = zkClientService;
+    this.metricsCollectionService = metricsCollectionService;
+    this.metricStore = metricStore;
+    this.kafkaClientService = kafkaClientService;
+    this.store = store;
+    this.programRuntimeService = programRuntimeService;
+    this.twillRunnerService = twillRunnerService;
+  }
+
+  public void run(Id.Flow flowId) throws Exception {
+    System.out.println("Running queue.pending correction on flow " + flowId);
+
+    SimpleQueueSpecificationGenerator queueSpecGenerator =
+      new SimpleQueueSpecificationGenerator(flowId.getApplication());
+
+    ApplicationSpecification app = store.getApplication(flowId.getApplication());
+    Preconditions.checkArgument(app != null);
+    for (FlowSpecification flow : app.getFlows().values()) {
+      Table<QueueSpecificationGenerator.Node, String, Set<QueueSpecification>> table = queueSpecGenerator.create(flow);
+      for (Table.Cell<QueueSpecificationGenerator.Node, String, Set<QueueSpecification>> cell : table.cellSet()) {
+        if (cell.getRowKey().getType() == FlowletConnection.Type.FLOWLET) {
+          String producerFlowlet = cell.getRowKey().getName();
+          String consumerFlowlet = cell.getColumnKey();
+          for (QueueSpecification queue : cell.getValue()) {
+            run(flowId, producerFlowlet, consumerFlowlet, queue.getQueueName().getSimpleName());
+          }
+        }
+      }
+    }
+  }
+
+  public void run(Id.Flow flowId, String producerFlowlet, String consumerFlowlet,
+                  String flowletQueue) throws Exception {
+
+    System.out.println("Running queue.pending correction on flow '" + flowId + "' producerFlowlet '" + producerFlowlet
+                         + "' consumerFlowlet '" + consumerFlowlet + "' flowletQueue '" + flowletQueue + "'");
+    Map<RunId, ProgramRuntimeService.RuntimeInfo> runtimeInfos = programRuntimeService.list(flowId);
+    Preconditions.checkState(runtimeInfos.isEmpty(), "Cannot run tool when flow " + flowId + " is still running");
+
+    ApplicationSpecification app = store.getApplication(flowId.getApplication());
+    Preconditions.checkArgument(app != null, flowId.getApplication() + " not found");
+    Preconditions.checkArgument(app.getFlows().containsKey(flowId.getId()), flowId + " not found");
+
+    FlowSpecification flow = app.getFlows().get(flowId.getId());
+    SimpleQueueSpecificationGenerator queueSpecGenerator =
+      new SimpleQueueSpecificationGenerator(flowId.getApplication());
+    Table<QueueSpecificationGenerator.Node, String, Set<QueueSpecification>> table = queueSpecGenerator.create(flow);
+
+    Preconditions.checkArgument(
+      table.contains(QueueSpecificationGenerator.Node.flowlet(producerFlowlet), consumerFlowlet),
+      "Flowlet " + producerFlowlet + " is not emitting to " + consumerFlowlet);
+    Set<QueueSpecification> queueSpecs =
+      table.get(QueueSpecificationGenerator.Node.flowlet(producerFlowlet), consumerFlowlet);
+    boolean validQueue = false;
+    for (QueueSpecification queueSpec : queueSpecs) {
+      if (queueSpec.getQueueName().getSimpleName().equals(flowletQueue)) {
+        validQueue = true;
+        break;
+      }
+    }
+    Preconditions.checkArgument(validQueue, "Queue " + flowletQueue + " does not exist for the given flowlets");
+
+    QueueName queueName = QueueName.fromFlowlet(flowId, producerFlowlet, flowletQueue);
+    long consumerGroupId = FlowUtils.generateConsumerGroupId(flowId, consumerFlowlet);
+    HBaseQueueDebugger.QueueStatistics stats = queueDebugger.scanQueue(queueName, consumerGroupId);
+    long correctQueuePendingValue = stats.getUnprocessed() + stats.getProcessedAndNotVisible();
+
+    Map<String, String> tags = ImmutableMap.<String, String>builder()
+      .put(Constants.Metrics.Tag.NAMESPACE, flowId.getNamespaceId())
+      .put(Constants.Metrics.Tag.APP, flowId.getApplicationId())
+      .put(Constants.Metrics.Tag.FLOW, flowId.getId())
+      .put(Constants.Metrics.Tag.CONSUMER, consumerFlowlet)
+      .put(Constants.Metrics.Tag.PRODUCER, producerFlowlet)
+      .put(Constants.Metrics.Tag.FLOWLET_QUEUE, flowletQueue)
+      .build();
+
+    MetricDataQuery query = new MetricDataQuery(
+      0, 0, Integer.MAX_VALUE, 1, ImmutableMap.of("system.queue.pending", AggregationFunction.SUM),
+      tags, ImmutableList.<String>of(), null);
+
+    Collection<MetricTimeSeries> results = metricStore.query(query);
+    long queuePending;
+    if (results.isEmpty()) {
+      queuePending = 0;
+    } else {
+      System.out.println("Got results: " + GSON.toJson(results));
+      Preconditions.checkState(results.size() == 1);
+      List<TimeValue> timeValues = results.iterator().next().getTimeValues();
+      Preconditions.checkState(timeValues.size() == 1);
+      TimeValue timeValue = timeValues.get(0);
+      queuePending = timeValue.getValue();
+    }
+
+    MetricsCollector collector = metricsCollectionService.getCollector(tags);
+    collector.gauge("queue.pending", correctQueuePendingValue);
+    System.out.printf("Adjusted system.queue.pending metric from %d to %d (tags %s)\n",
+                      queuePending, correctQueuePendingValue, GSON.toJson(tags));
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    kafkaClientService.startAndWait();
+    zkClientService.startAndWait();
+    metricsCollectionService.startAndWait();
+    twillRunnerService.startAndWait();
+    programRuntimeService.startAndWait();
+    queueDebugger.startAndWait();
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    queueDebugger.stopAndWait();
+    programRuntimeService.startAndWait();
+    twillRunnerService.startAndWait();
+    // stop will flush the metrics
+    metricsCollectionService.stopAndWait();
+    zkClientService.stopAndWait();
+    kafkaClientService.stopAndWait();
+  }
+
+  public static FlowQueuePendingCorrector createCorrector() {
+    Injector injector = Guice.createInjector(
+      new IOModule(),
+      new ConfigModule(CConfiguration.create(), HBaseConfiguration.create()),
+      new ZKClientModule(),
+      new TwillModule(),
+      new KafkaClientModule(),
+      new DataFabricDistributedModule(),
+      new NotificationFeedClientModule(),
+      new ProgramRunnerRuntimeModule().getDistributedModules(),
+      new StreamAdminModules().getDistributedModules(),
+      new LocationRuntimeModule().getDistributedModules(),
+      new DiscoveryRuntimeModule().getDistributedModules(),
+      new DataSetsModules().getDistributedModules(),
+      new MetricsClientRuntimeModule().getDistributedModules(),
+      new AbstractModule() {
+        @Override
+        protected void configure() {
+          bind(Store.class).to(DefaultStore.class);
+          bind(QueueClientFactory.class).to(HBaseQueueClientFactory.class).in(Singleton.class);
+          bind(QueueAdmin.class).to(HBaseQueueAdmin.class).in(Singleton.class);
+          bind(HBaseTableUtil.class).toProvider(HBaseTableUtilFactory.class);
+        }
+      }
+    );
+
+    return injector.getInstance(FlowQueuePendingCorrector.class);
+  }
+
+  public static void main(String[] args) throws Exception {
+    CommandLine cmd = parseArgs(args);
+    FlowQueuePendingCorrector corrector = createCorrector();
+    corrector.startAndWait();
+
+    try {
+      String namespace = cmd.getOptionValue("namespace");
+      String app = cmd.getOptionValue("app");
+      String flow = cmd.getOptionValue("flow");
+
+      if (cmd.hasOption("producer-flowlet")) {
+        Preconditions.checkArgument(cmd.hasOption("consumer-flowlet"), "Missing consumer-flowlet option");
+        String producerFlowlet = cmd.getOptionValue("producer-flowlet");
+        String consumerFlowlet = cmd.getOptionValue("consumer-flowlet");
+        String queue = cmd.getOptionValue("queue", "queue");
+        corrector.run(Id.Flow.from(namespace, app, flow), producerFlowlet, consumerFlowlet, queue);
+      } else {
+        corrector.run(Id.Flow.from(namespace, app, flow));
+      }
+    } finally {
+      corrector.stopAndWait();
+    }
+  }
+
+  private static CommandLine parseArgs(String[] args) {
+    Options options = new Options();
+    options.addOption(createOption("n", "namespace", true, "namespace", true));
+    options.addOption(createOption("a", "app", true, "app", true));
+    options.addOption(createOption("f", "flow", true, "flow", true));
+    options.addOption(createOption("p", "producer-flowlet", true,
+                                   "producer flowlet (optional, leave empty to correct entire flow)", false));
+    options.addOption(createOption("c", "consumer-flowlet", true,
+                                   "consumer flowlet (optional, leave empty to correct entire flow)", false));
+    options.addOption(createOption("q", "queue", true, "flowlet queue (optional, defaults to \"queue\")", false));
+
+    CommandLineParser parser = new BasicParser();
+    try {
+      return parser.parse(options, args);
+    } catch (ParseException e) {
+      System.out.println(e.getMessage());
+      HelpFormatter formatter = new HelpFormatter();
+      String argsFormat =
+        "--namespace <namespace> " +
+          "--app <app> " +
+          "--flow <flow> " +
+          "[--producer-flowlet <flowlet> " +
+          "--consumer-flowlet <flowlet> " +
+          "[--queue <queue>]]";
+      formatter.printHelp(argsFormat, options);
+      System.exit(0);
+      return null;
+    }
+  }
+
+  private static Option createOption(String opt, String longOpt, boolean hasOpt,
+                                     String desc, boolean required) {
+    Option option = new Option(opt, longOpt, hasOpt, desc);
+    if (required) {
+      option.setRequired(true);
+    }
+    return option;
+  }
+}

--- a/cdap-master/src/test/java/co/cask/cdap/data/tools/flow/FlowQueuePendingCorrectorTest.java
+++ b/cdap-master/src/test/java/co/cask/cdap/data/tools/flow/FlowQueuePendingCorrectorTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data.tools.flow;
+
+import org.junit.Test;
+
+/**
+ *
+ */
+public class FlowQueuePendingCorrectorTest {
+  @Test
+  public void testInjector() throws Exception {
+    FlowQueuePendingCorrector corrector = FlowQueuePendingCorrector.createCorrector();
+    // should not throw exception
+  }
+}

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/Id.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/Id.java
@@ -646,6 +646,10 @@ public abstract class Id {
       return new Flow(Id.Application.from(Namespace.DEFAULT, appId), flowId);
     }
 
+    public static Flow from(String namespaceId, String appId, String flowId) {
+      return new Flow(Id.Application.from(namespaceId, appId), flowId);
+    }
+
     /**
      * Uniquely identifies a Flowlet.
      */

--- a/cdap-watchdog-api/src/main/java/co/cask/cdap/api/metrics/MetricDataQuery.java
+++ b/cdap-watchdog-api/src/main/java/co/cask/cdap/api/metrics/MetricDataQuery.java
@@ -41,8 +41,20 @@ import javax.annotation.Nullable;
  * </pre>
  */
 public final class MetricDataQuery {
+
+  /**
+   * Start timestamp, in seconds.
+   */
   private final long startTs;
+
+  /**
+   * End timestamp, in seconds.
+   */
   private final long endTs;
+
+  /**
+   * Resolution in seconds.
+   */
   private final int resolution;
   private final int limit;
   private final Map<String, AggregationFunction> metrics;
@@ -51,18 +63,33 @@ public final class MetricDataQuery {
 
   private final Interpolator interpolator;
 
+  /**
+   * @param startTs Start timestamp, in seconds.
+   * @param endTs End timestamp, in seconds.
+   * @param resolution Resolution in seconds.
+   */
   public MetricDataQuery(long startTs, long endTs, int resolution,
                          String metricName, AggregationFunction func,
                          Map<String, String> sliceByTagValues, List<String> groupByTags) {
     this(startTs, endTs, resolution, -1, ImmutableMap.of(metricName, func), sliceByTagValues, groupByTags, null);
   }
 
+  /**
+   * @param startTs Start timestamp, in seconds.
+   * @param endTs End timestamp, in seconds.
+   * @param resolution Resolution in seconds.
+   */
   public MetricDataQuery(long startTs, long endTs, int resolution,
                          Map<String, AggregationFunction> metrics,
                          Map<String, String> sliceByTagValues, List<String> groupByTags) {
     this(startTs, endTs, resolution, -1, metrics, sliceByTagValues, groupByTags, null);
   }
 
+  /**
+   * @param startTs Start timestamp, in seconds.
+   * @param endTs End timestamp, in seconds.
+   * @param resolution Resolution in seconds.
+   */
   public MetricDataQuery(long startTs, long endTs, int resolution, int limit,
                          Map<String, AggregationFunction> metrics,
                          Map<String, String> sliceByTagValues, List<String> groupByTags,


### PR DESCRIPTION
http://builds.cask.co/browse/CDAP-RBT264

```
/opt/cdap/master/bin/svc-master run co.cask.cdap.data.tools.FlowQueuePendingCorrector -n default -a PurchaseHistory -f PurchaseFlow
```

Help message for the new tool:

```
usage: --namespace <namespace> --app <app> --flow <flow>
                   [--producer-flowlet <flowlet> --consumer-flowlet
                   <flowlet> [--queue <queue>]]
 -a,--app <arg>                app
 -c,--consumer-flowlet <arg>   consumer flowlet (optional, leave empty to
                               correct entire flow)
 -f,--flow <arg>               flow
 -n,--namespace <arg>          namespace
 -p,--producer-flowlet <arg>   producer flowlet (optional, leave empty to
                               correct entire flow)
 -q,--queue <arg>              flowlet queue (optional, defaults to
                               "queue")
```

* Tested UpgradeTool changes in a cluster
* Tested FlowQueuePendingCorrector in a cluster