### PR TITLE
CDAP-2415 improving etl worker performance 

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/templates/etl/api/realtime/RealtimeSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/templates/etl/api/realtime/RealtimeSource.java
@@ -49,10 +49,12 @@ public abstract class RealtimeSource<T> implements EndPointStage, Destroyable {
    *
    * @param writer {@link Emitter}
    * @param currentState {@link SourceState} current state of the source
+   * @throws Exception if there's an error during this method invocation
+   *
    * @return {@link SourceState} state of the source after poll, will be persisted when all data from poll are processed
    */
   @Nullable
-  public abstract SourceState poll(Emitter<T> writer, SourceState currentState);
+  public abstract SourceState poll(Emitter<T> writer, SourceState currentState) throws Exception;
 
   /**
    * Destroy the Source.

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/templates/etl/api/realtime/SourceState.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/templates/etl/api/realtime/SourceState.java
@@ -19,11 +19,11 @@ package co.cask.cdap.templates.etl.api.realtime;
 import com.google.common.collect.Maps;
 
 import java.util.Map;
+import java.util.Objects;
 
 /**
- * State of Source maintained.
+ * State of Source.
  */
-// TODO: Improve the API as use case evolves
 public class SourceState {
 
   private final Map<String, byte[]> stateMap;
@@ -42,6 +42,15 @@ public class SourceState {
    */
   public SourceState() {
     this.stateMap = Maps.newHashMap();
+  }
+
+  /**
+   * Construct a SourceState by making a copy of another SourceState.
+   *
+   * @param state {@link SourceState}
+   */
+  public SourceState(SourceState state) {
+    this(state.getState());
   }
 
   /**
@@ -80,5 +89,41 @@ public class SourceState {
    */
   public void setState(Map<String, byte[]> map) {
     stateMap.putAll(map);
+  }
+
+  /**
+   * Clear the internal state and set it to values from provided State.
+   *
+   * @param state state to be copied
+   */
+  public void setState(SourceState state) {
+    clearState();
+    setState(state.getState());
+  }
+
+  /**
+   * Clear the internal state.
+   */
+  public void clearState() {
+    stateMap.clear();
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    SourceState that = (SourceState) o;
+    return Objects.equals(stateMap, that.stateMap);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(stateMap);
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/main/java/co/cask/cdap/templates/etl/realtime/ETLWorker.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/main/java/co/cask/cdap/templates/etl/realtime/ETLWorker.java
@@ -222,13 +222,13 @@ public class ETLWorker extends AbstractWorker {
 
       // Start a Transaction if there is data to persist or if the Source state has changed.
       try {
-        if ((dataToSink.size() != 0) || (!nextState.equals(currentState))) {
+        if ((!dataToSink.isEmpty()) || (!nextState.equals(currentState))) {
           getContext().execute(new TxRunnable() {
             @Override
             public void run(DatasetContext context) throws Exception {
 
               // Invoke the sink's write method if there is any object to be written.
-              if (dataToSink.size() != 0) {
+              if (!dataToSink.isEmpty()) {
                 DefaultDataWriter defaultDataWriter = new DefaultDataWriter(getContext(), context);
                 sink.write(dataToSink, defaultDataWriter);
               }

--- a/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/test/java/co/cask/cdap/templates/etl/realtime/ETLWorkerTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/test/java/co/cask/cdap/templates/etl/realtime/ETLWorkerTest.java
@@ -105,8 +105,14 @@ public class ETLWorkerTest extends TestBase {
     AdapterManager adapterManager = createAdapter(adapterId, adapterConfig);
 
     adapterManager.start();
-    // Let the worker run for 5 seconds
-    TimeUnit.SECONDS.sleep(5);
+    // Let the worker run for 3 seconds
+    TimeUnit.SECONDS.sleep(3);
+    adapterManager.stop();
+
+    // Start again to see if the state is maintained
+    adapterManager.start();
+    // Let the worker run for 2 seconds
+    TimeUnit.SECONDS.sleep(2);
     adapterManager.stop();
 
     StreamManager streamManager = getStreamManager(NAMESPACE, "testStream");


### PR DESCRIPTION
Mainly by reducing dataset access.

i) Fetch the source state only once in the beginning.
ii) Update that state only if there is a change in state.
iii) Invoke the sink's write method only if there is data to be persisted
iv) Start a Transaction only if there is sink data to be persisted or state has to be persisted
v) Accumulate all data from TransformExecutor before invoking sink's write

Other functional changes:
i) If there is an exception thrown when polling source, then continue without processing data

JIRA: https://issues.cask.co/browse/CDAP-2415
Build : http://builds.cask.co/browse/CDAP-RT27-1

- [x] Test on Cluster