### PR TITLE
CDAP-2400 adding ability to add a list of classes to include in

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/co/cask/cdap/templates/etl/batch/BaseETLBatchTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/co/cask/cdap/templates/etl/batch/BaseETLBatchTest.java
@@ -28,12 +28,20 @@ import co.cask.cdap.templates.etl.batch.sources.DBSource;
 import co.cask.cdap.templates.etl.batch.sources.KVTableSource;
 import co.cask.cdap.templates.etl.batch.sources.StreamBatchSource;
 import co.cask.cdap.templates.etl.batch.sources.TableSource;
+import co.cask.cdap.templates.etl.common.DBRecord;
+import co.cask.cdap.templates.etl.common.ETLStage;
 import co.cask.cdap.templates.etl.transforms.IdentityTransform;
 import co.cask.cdap.templates.etl.transforms.ProjectionTransform;
 import co.cask.cdap.templates.etl.transforms.ScriptFilterTransform;
 import co.cask.cdap.templates.etl.transforms.StructuredRecordToGenericRecordTransform;
 import co.cask.cdap.test.TestBase;
+import com.google.common.collect.Lists;
 import com.google.gson.Gson;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.mapred.AvroKey;
+import org.apache.avro.mapreduce.AvroKeyOutputFormat;
+import org.hsqldb.jdbc.JDBCDriver;
 import org.junit.BeforeClass;
 
 import java.io.IOException;
@@ -55,8 +63,16 @@ public class BaseETLBatchTest extends TestBase {
       TableSink.class, TimePartitionedFileSetDatasetAvroSink.class);
     addTemplatePlugins(TEMPLATE_ID, "transforms-1.0.0.jar", IdentityTransform.class,
       ProjectionTransform.class, ScriptFilterTransform.class, StructuredRecordToGenericRecordTransform.class);
+    addTemplatePlugins(TEMPLATE_ID, "hsql-jdbc-1.0.0.jar", JDBCDriver.class);
+    addTemplatePluginJson(TEMPLATE_ID, "hsql-jdbc-1.0.0.json", "jdbc", "hypersql", "hypersql jdbc driver",
+      JDBCDriver.class.getName());
     deployTemplate(NAMESPACE, TEMPLATE_ID, ETLBatchTemplate.class,
+      Lists.newArrayList(AvroKeyOutputFormat.class, DBRecord.class),
       EndPointStage.class.getPackage().getName(),
-      BatchSource.class.getPackage().getName());
+      ETLStage.class.getPackage().getName(),
+      BatchSource.class.getPackage().getName(),
+      Schema.class.getPackage().getName(),
+      GenericRecord.class.getPackage().getName(),
+      AvroKey.class.getPackage().getName());
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/co/cask/cdap/templates/etl/batch/ETLStreamConversionTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/co/cask/cdap/templates/etl/batch/ETLStreamConversionTest.java
@@ -50,10 +50,10 @@ import org.apache.avro.file.DataFileStream;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.DatumReader;
+import org.apache.avro.mapreduce.AvroKeyOutputFormat;
 import org.apache.twill.filesystem.Location;
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -64,8 +64,6 @@ import java.util.concurrent.TimeUnit;
  * Tests for {@link ETLBatchTemplate} for Stream conversion from stream to avro format for writing to
  * {@link TimePartitionedFileSet}
  */
-// TODO: re-enable after mapred classloading fix
-@Ignore
 public class ETLStreamConversionTest extends BaseETLBatchTest {
   private static final Gson GSON = new Gson();
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/common/DBConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/common/DBConfig.java
@@ -46,12 +46,15 @@ public class DBConfig extends PluginConfig {
   public String password;
 
   @Description("Name of the JDBC plugin to use. This is the value of the 'name' key defined in the json file " +
-    "for the JDBC plugin. Defaults to 'jdbc'.")
-  @Nullable
-  public String jdbcPluginName = "jdbc";
+    "for the JDBC plugin.")
+  public String jdbcPluginName;
 
   @Description("Type of the JDBC plugin to use. This is the value of the 'type' key defined in the json file " +
     "for the JDBC plugin. Defaults to 'jdbc'.")
   @Nullable
   public String jdbcPluginType = "jdbc";
+
+  public DBConfig() {
+    jdbcPluginType = "jdbc";
+  }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/common/Properties.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/common/Properties.java
@@ -25,14 +25,16 @@ public final class Properties {
    * Class to hold properties for DBSource and DBSink
    */
   public static class DB {
-    public static final String DRIVER_CLASS = "dbDriverClass";
-    public static final String CONNECTION_STRING = "dbConnectionString";
-    public static final String TABLE_NAME = "dbTableName";
-    public static final String USER = "dbUser";
-    public static final String PASSWORD = "dbPassword";
-    public static final String COLUMNS = "dbColumns";
-    public static final String IMPORT_QUERY = "dbImportQuery";
-    public static final String COUNT_QUERY = "dbCountQuery";
+    public static final String DRIVER_CLASS = "driverClass";
+    public static final String CONNECTION_STRING = "connectionString";
+    public static final String TABLE_NAME = "tableName";
+    public static final String USER = "user";
+    public static final String PASSWORD = "password";
+    public static final String COLUMNS = "columns";
+    public static final String JDBC_PLUGIN_NAME = "jdbcPluginName";
+    public static final String JDBC_PLUGIN_TYPE = "jdbcPluginType";
+    public static final String IMPORT_QUERY = "importQuery";
+    public static final String COUNT_QUERY = "countQuery";
   }
 
   /**

--- a/cdap-common/src/main/java/co/cask/cdap/internal/test/AppJarHelper.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/test/AppJarHelper.java
@@ -19,6 +19,7 @@ package co.cask.cdap.internal.test;
 import co.cask.cdap.common.lang.ClassLoaders;
 import co.cask.cdap.common.utils.ApplicationBundler;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.Files;
 import org.apache.twill.filesystem.Location;
@@ -26,6 +27,7 @@ import org.apache.twill.filesystem.LocationFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 import java.util.jar.Attributes;
 import java.util.jar.JarEntry;
 import java.util.jar.JarInputStream;
@@ -41,18 +43,19 @@ public final class AppJarHelper {
     // No-op
   }
 
-  public static Location createDeploymentJar(LocationFactory locationFactory, Class<?> clz, Manifest manifest,
-                                             File... bundleEmbeddedJars) throws IOException {
+  public static Location createDeploymentJar(LocationFactory locationFactory, List<Class<?>> classes,
+                                             Manifest manifest, File... bundleEmbeddedJars) throws IOException {
 
     ApplicationBundler bundler = new ApplicationBundler(ImmutableList.of("co.cask.cdap.api",
                                                                          "org.apache.hadoop",
                                                                          "org.apache.hive",
                                                                          "org.apache.spark"),
                                                         ImmutableList.of("org.apache.hadoop.hbase"));
+    Class<?> clz = classes.get(0);
     Location jarLocation = locationFactory.create(clz.getName()).getTempFile(".jar");
     ClassLoader oldClassLoader = ClassLoaders.setContextClassLoader(clz.getClassLoader());
     try {
-      bundler.createBundle(jarLocation, clz);
+      bundler.createBundle(jarLocation, classes);
     } finally {
       ClassLoaders.setContextClassLoader(oldClassLoader);
     }
@@ -110,6 +113,11 @@ public final class AppJarHelper {
     }
 
     return deployJar;
+  }
+
+  public static Location createDeploymentJar(LocationFactory locationFactory, Class<?> clz, Manifest manifest,
+                                             File... bundleEmbeddedJars) throws IOException {
+    return createDeploymentJar(locationFactory, Lists.<Class<?>>newArrayList(clz), manifest, bundleEmbeddedJars);
   }
 
   public static Location createDeploymentJar(LocationFactory locationFactory,

--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestManager.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestManager.java
@@ -22,10 +22,10 @@ import co.cask.cdap.api.dataset.DatasetAdmin;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.module.DatasetModule;
 import co.cask.cdap.api.templates.ApplicationTemplate;
+import co.cask.cdap.api.templates.plugins.PluginPropertyField;
 import co.cask.cdap.app.DefaultAppConfigurer;
 import co.cask.cdap.client.AdapterClient;
 import co.cask.cdap.client.ApplicationClient;
-import co.cask.cdap.client.MetaClient;
 import co.cask.cdap.client.NamespaceClient;
 import co.cask.cdap.client.ProgramClient;
 import co.cask.cdap.client.config.ClientConfig;
@@ -46,6 +46,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.sql.Connection;
+import java.util.List;
 
 /**
  *
@@ -54,7 +55,6 @@ public class IntegrationTestManager implements TestManager {
 
   private static final Logger LOG = LoggerFactory.getLogger(IntegrationTestManager.class);
 
-  private final MetaClient metaClient;
   private final ApplicationClient applicationClient;
   private final ClientConfig clientConfig;
   private final LocationFactory locationFactory;
@@ -65,7 +65,6 @@ public class IntegrationTestManager implements TestManager {
   public IntegrationTestManager(ClientConfig clientConfig, LocationFactory locationFactory) {
     this.clientConfig = clientConfig;
     this.locationFactory = locationFactory;
-    this.metaClient = new MetaClient(clientConfig);
     this.applicationClient = new ApplicationClient(clientConfig);
     this.programClient = new ProgramClient(clientConfig);
     this.namespaceClient = new NamespaceClient(clientConfig);
@@ -106,8 +105,22 @@ public class IntegrationTestManager implements TestManager {
   }
 
   @Override
+  public void deployTemplate(Id.Namespace namespace, Id.ApplicationTemplate templateId,
+                             Class<? extends ApplicationTemplate> templateClz, List<Class<?>> libraries,
+                             String... exportPackages) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public void addTemplatePlugins(Id.ApplicationTemplate templateId, String jarName,
                                  Class<?> pluginClz, Class<?>... classes) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void addTemplatePluginJson(Id.ApplicationTemplate templateId, String fileName, String type, String name,
+                                    String description, String className,
+                                    PluginPropertyField... fields) throws IOException {
     throw new UnsupportedOperationException();
   }
 

--- a/cdap-test/src/main/java/co/cask/cdap/test/TestManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/TestManager.java
@@ -24,6 +24,7 @@ import co.cask.cdap.api.dataset.DatasetAdmin;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.module.DatasetModule;
 import co.cask.cdap.api.templates.ApplicationTemplate;
+import co.cask.cdap.api.templates.plugins.PluginPropertyField;
 import co.cask.cdap.proto.AdapterConfig;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
@@ -31,6 +32,7 @@ import co.cask.cdap.proto.NamespaceMeta;
 import java.io.File;
 import java.io.IOException;
 import java.sql.Connection;
+import java.util.List;
 
 /**
  *
@@ -63,6 +65,23 @@ public interface TestManager {
   void deployTemplate(Id.Namespace namespace, Id.ApplicationTemplate templateId,
                       Class<? extends ApplicationTemplate> templateClz,
                       String... exportPackages) throws IOException;
+  /**
+   * Deploys an {@link ApplicationTemplate}. Only supported in unit tests.
+   *
+   * @param namespace The namespace to deploy to
+   * @param templateId The id of the template. Must match the name set in
+   *                   {@link ApplicationTemplate#configure(ApplicationConfigurer, ApplicationContext)}
+   * @param templateClz The template class
+   * @param libraries Additional libraries to bundle in the template jar. Used to simulate jars that you would normally
+   *                  place in the lib directory for the template.
+   * @param exportPackages The list of packages that should be visible to template plugins. For example,
+   *                       if your plugins implement an interface com.company.api.myinterface that is in your template,
+   *                       you will want to include 'com.company.api' in the list of export pacakges.
+   */
+  void deployTemplate(Id.Namespace namespace, Id.ApplicationTemplate templateId,
+                      Class<? extends ApplicationTemplate> templateClz,
+                      List<Class<?>> libraries,
+                      String... exportPackages) throws IOException;
 
   /**
    * Adds a plugins jar usable by the given template. Only supported in unit tests. Plugins added will not be visible
@@ -84,6 +103,23 @@ public interface TestManager {
    */
   void addTemplatePlugins(Id.ApplicationTemplate templateId, String jarName, Class<?> pluginClz,
                           Class<?>... classes) throws IOException;
+
+  /**
+   * Add a template plugin configuration file.
+   *
+   * @param templateId the id of the template to add the plugin config for
+   * @param fileName the name of the config file. The name should match the plugin jar file that it is for. For example,
+   *                 if you added a plugin named hsql-jdbc-1.0.0.jar, the config file must be named hsql-jdbc-1.0.0.json
+   * @param type the type of plugin
+   * @param name the name of the plugin
+   * @param description the description for the plugin
+   * @param className the class name of the plugin
+   * @param fields the fields the plugin uses
+   * @throws IOException
+   */
+  void addTemplatePluginJson(Id.ApplicationTemplate templateId, String fileName, String type, String name,
+                             String description, String className,
+                             PluginPropertyField... fields) throws IOException;
 
   /**
    * Creates an adapter.

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/ConfigurableTestBase.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/ConfigurableTestBase.java
@@ -25,6 +25,7 @@ import co.cask.cdap.api.dataset.module.DatasetModule;
 import co.cask.cdap.api.metrics.MetricStore;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.api.templates.ApplicationTemplate;
+import co.cask.cdap.api.templates.plugins.PluginPropertyField;
 import co.cask.cdap.app.guice.AppFabricServiceRuntimeModule;
 import co.cask.cdap.app.guice.InMemoryProgramRunnerModule;
 import co.cask.cdap.app.guice.ServiceStoreModules;
@@ -406,6 +407,26 @@ public class ConfigurableTestBase {
   }
 
   /**
+   * Deploys an {@link ApplicationTemplate}.
+   *
+   * @param namespace The namespace to deploy to
+   * @param templateId The id of the template. Must match the name set in
+   *                   {@link ApplicationTemplate#configure(ApplicationConfigurer, ApplicationContext)}
+   * @param templateClz The template class
+   * @param libraries Additional libraries to bundle in the template jar. Used to simulate jars that you would normally
+   *                  place in the lib directory for the template.
+   * @param exportPackages The list of packages that should be visible to template plugins. For example,
+   *                       if your plugins implement an interface com.company.api.myinterface that is in your template,
+   *                       you will want to include 'com.company.api' in the list of export pacakges.
+   */
+  protected static void deployTemplate(Id.Namespace namespace, Id.ApplicationTemplate templateId,
+                                       Class<? extends ApplicationTemplate> templateClz,
+                                       List<Class<?>> libraries,
+                                       String... exportPackages) throws IOException {
+    getTestManager().deployTemplate(namespace, templateId, templateClz, libraries, exportPackages);
+  }
+
+  /**
    * Adds a plugins jar usable by the given template. Only supported in unit tests. Plugins added will not be visible
    * until a call to {@link #deployTemplate(Id.Namespace, Id.ApplicationTemplate, Class, String...)} is made. The
    * jar created will include all classes in the same package as the given plugin class, plus any dependencies of the
@@ -429,6 +450,26 @@ public class ConfigurableTestBase {
   protected static void addTemplatePlugins(Id.ApplicationTemplate templateId, String jarName,
                                            Class<?> pluginClz, Class<?>... classes) throws IOException {
     getTestManager().addTemplatePlugins(templateId, jarName, pluginClz, classes);
+  }
+
+  /**
+   * Add a template plugin configuration file.
+   *
+   * @param templateId the id of the template to add the plugin config for
+   * @param fileName the name of the config file. The name should match the plugin jar file that it is for. For example,
+   *                 if you added a plugin named hsql-jdbc-1.0.0.jar, the config file must be named hsql-jdbc-1.0.0.json
+   * @param type the type of plugin
+   * @param name the name of the plugin
+   * @param description the description for the plugin
+   * @param className the class name of the plugin
+   * @param fields the fields the plugin uses
+   * @throws IOException
+   */
+  protected static void addTemplatePluginJson(Id.ApplicationTemplate templateId, String fileName,
+                                              String type, String name,
+                                              String description, String className,
+                                              PluginPropertyField... fields) throws IOException {
+    getTestManager().addTemplatePluginJson(templateId, fileName, type, name, description, className, fields);
   }
 
   /**


### PR DESCRIPTION
the bundled template jar to simulate the plugins lib directory.
Also adding a method to add a plugin config json file in the
test framework. Lastly, updating etl test cases that needed this
functionality in order to pass.