### PR TITLE
CDAP-2411 tweak the filter transform so that the property must

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/transforms/ScriptFilterTransform.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/transforms/ScriptFilterTransform.java
@@ -42,10 +42,12 @@ import javax.script.ScriptException;
 @Name("ScriptFilter")
 @Description("A transform plugin that filters records using a custom javascript provided in the plugin's config.")
 public class ScriptFilterTransform extends Transform<StructuredRecord, StructuredRecord> {
-  private static final String SCRIPT_DESCRIPTION = "Script that returns true if the input record should be filtered, " +
-    "and false if not. The script has access to the input record through a variable named 'input', " +
+  private static final String SCRIPT_DESCRIPTION = "Javascript that must implement a shouldFilter function that " +
+    "returns true if the input record should be filtered and false if not. " +
+    "The script has access to the input record through a variable named 'input', " +
     "which is a Json object representation of the record. " +
-    "For example, 'return input.count > 100' will filter out any records whose count field is greater than 100.";
+    "For example, 'function shouldFilter() { return input.count > 100'; } " +
+    "will filter out any records whose count field is greater than 100.";
   private static final Gson GSON = new GsonBuilder()
     .registerTypeAdapter(StructuredRecord.class, new StructuredRecordSerializer())
     .create();
@@ -67,9 +69,8 @@ public class ScriptFilterTransform extends Transform<StructuredRecord, Structure
     String scriptStr = scriptFilterConfig.script;
     Preconditions.checkArgument(!scriptStr.isEmpty(), "Filter script must be specified.");
 
-    String script = "function shouldFilter() { " + scriptStr + " }";
     try {
-      engine.eval(script);
+      engine.eval(scriptStr);
     } catch (ScriptException e) {
       throw new IllegalArgumentException("Invalid script.", e);
     }

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/transforms/ScriptTransform.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/templates/etl/transforms/ScriptTransform.java
@@ -50,6 +50,8 @@ public class ScriptTransform extends Transform<StructuredRecord, StructuredRecor
   private static final Gson GSON = new GsonBuilder()
     .registerTypeAdapter(StructuredRecord.class, new StructuredRecordSerializer())
     .create();
+  private static final String FUNCTION_NAME = "dont_name_your_function_this";
+  private static final String VARIABLE_NAME = "dont_name_your_variable_this";
   private ScriptEngine engine;
   private Invocable invocable;
   private Schema schema;
@@ -60,9 +62,9 @@ public class ScriptTransform extends Transform<StructuredRecord, StructuredRecor
    */
   public static class Config extends PluginConfig {
     @Description("Javascript defining how to transform one record into another. The script must implement a function " +
-      "called 'transform', which must return a Json object that represents the transformed input. " +
-      "The input record will be available as a Json object named 'input'. " +
-      "For example, 'function transform() { input.count = input.count * 1024; return input; }' " +
+      "called 'transform', which take as input a Json object that represents the input record, and returns " +
+      "a Json object that respresents the transformed input. " +
+      "For example, 'function transform(input) { input.count = input.count * 1024; return input; }' " +
       "will scale the 'count' field by 1024.")
     private final String script;
 
@@ -87,7 +89,13 @@ public class ScriptTransform extends Transform<StructuredRecord, StructuredRecor
     ScriptEngineManager manager = new ScriptEngineManager();
     engine = manager.getEngineByName("JavaScript");
     try {
-      engine.eval(config.script);
+      // this is pretty ugly, but doing this so that we can pass the 'input' json into the transform function.
+      // that is, we want people to implement
+      // function transform(input) { ... }
+      // rather than function transform() { ... } and have them access a global variable in the function
+      String script = String.format("function %s() { return transform(%s); }\n%s",
+                                    FUNCTION_NAME, VARIABLE_NAME, config.script);
+      engine.eval(script);
     } catch (ScriptException e) {
       throw new IllegalArgumentException("Invalid script.", e);
     }
@@ -104,8 +112,8 @@ public class ScriptTransform extends Transform<StructuredRecord, StructuredRecor
   @Override
   public void transform(StructuredRecord input, Emitter<StructuredRecord> emitter) {
     try {
-      engine.eval("var input = " + GSON.toJson(input) + "; ");
-      Map scriptOutput = (Map) invocable.invokeFunction("transform");
+      engine.eval(String.format("var %s = %s;", VARIABLE_NAME, GSON.toJson(input)));
+      Map scriptOutput = (Map) invocable.invokeFunction(FUNCTION_NAME);
       StructuredRecord output = decodeRecord(scriptOutput, schema == null ? input.getSchema() : schema);
       emitter.emit(output);
     } catch (Exception e) {

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/templates/etl/transforms/ScriptFilterTransformTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/templates/etl/transforms/ScriptFilterTransformTest.java
@@ -43,7 +43,7 @@ public class ScriptFilterTransformTest {
   @Test(expected = IllegalArgumentException.class)
   public void testInvalidFilter() throws Exception {
     ScriptFilterTransform.ScriptFilterConfig config = new ScriptFilterTransform.ScriptFilterConfig();
-    config.script = "return 'foobar'";
+    config.script = "function shouldFilter() { return 'foobar'; }";
     Transform transform = new ScriptFilterTransform(config);
     TransformContext transformContext = new MockTransformContext(ImmutableMap.<String, String>of());
     transform.initialize(transformContext);
@@ -57,7 +57,7 @@ public class ScriptFilterTransformTest {
   @Test
   public void testSimple() throws Exception {
     ScriptFilterTransform.ScriptFilterConfig config = new ScriptFilterTransform.ScriptFilterConfig();
-    config.script = "return input.x * 1024 < 2048";
+    config.script = "function shouldFilter() { return input.x * 1024 < 2048; }";
     Schema schema = Schema.recordOf("number", Schema.Field.of("x", Schema.of(Schema.Type.INT)));
     StructuredRecord input = StructuredRecord.builder(schema).set("x", 1).build();
     Transform transform = new ScriptFilterTransform(config);
@@ -126,7 +126,11 @@ public class ScriptFilterTransformTest {
       .build();
 
     ScriptFilterTransform.ScriptFilterConfig config = new ScriptFilterTransform.ScriptFilterConfig();
-    config.script = "var pi = input.inner1.list[0].p; var e = input.inner1.list[0].e; return pi.val > e.val;";
+    config.script = "function shouldFilter() {\n" +
+      "var pi = input.inner1.list[0].p;\n" +
+      "var e = input.inner1.list[0].e;\n" +
+      "return pi.val > e.val;\n" +
+      "}";
     Transform transform = new ScriptFilterTransform(config);
     TransformContext transformContext = new MockTransformContext(ImmutableMap.<String, String>of());
     transform.initialize(transformContext);
@@ -136,7 +140,11 @@ public class ScriptFilterTransformTest {
     Assert.assertTrue(emitter.getEmitted().isEmpty());
     emitter.clear();
 
-    config.script = "var pi = input.inner1.list[0].p; var e = input.inner1.list[0].e; return pi.val > 10 * e.val;";
+    config.script = "function shouldFilter() {\n" +
+      "var pi = input.inner1.list[0].p;\n" +
+      "var e = input.inner1.list[0].e;\n" +
+      "return pi.val > 10 * e.val;\n" +
+      "}";
     transform = new ScriptFilterTransform(config);
     transformContext = new MockTransformContext(ImmutableMap.<String, String>of());
     transform.initialize(transformContext);

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/templates/etl/transforms/ScriptFilterTransformTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/templates/etl/transforms/ScriptFilterTransformTest.java
@@ -43,7 +43,7 @@ public class ScriptFilterTransformTest {
   @Test(expected = IllegalArgumentException.class)
   public void testInvalidFilter() throws Exception {
     ScriptFilterTransform.ScriptFilterConfig config = new ScriptFilterTransform.ScriptFilterConfig();
-    config.script = "function shouldFilter() { return 'foobar'; }";
+    config.script = "function shouldFilter(input) { return 'foobar'; }";
     Transform transform = new ScriptFilterTransform(config);
     TransformContext transformContext = new MockTransformContext(ImmutableMap.<String, String>of());
     transform.initialize(transformContext);
@@ -57,7 +57,7 @@ public class ScriptFilterTransformTest {
   @Test
   public void testSimple() throws Exception {
     ScriptFilterTransform.ScriptFilterConfig config = new ScriptFilterTransform.ScriptFilterConfig();
-    config.script = "function shouldFilter() { return input.x * 1024 < 2048; }";
+    config.script = "function shouldFilter(inputRecord) { return inputRecord.x * 1024 < 2048; }";
     Schema schema = Schema.recordOf("number", Schema.Field.of("x", Schema.of(Schema.Type.INT)));
     StructuredRecord input = StructuredRecord.builder(schema).set("x", 1).build();
     Transform transform = new ScriptFilterTransform(config);
@@ -126,9 +126,9 @@ public class ScriptFilterTransformTest {
       .build();
 
     ScriptFilterTransform.ScriptFilterConfig config = new ScriptFilterTransform.ScriptFilterConfig();
-    config.script = "function shouldFilter() {\n" +
-      "var pi = input.inner1.list[0].p;\n" +
-      "var e = input.inner1.list[0].e;\n" +
+    config.script = "function shouldFilter(rec) {\n" +
+      "var pi = rec.inner1.list[0].p;\n" +
+      "var e = rec.inner1.list[0].e;\n" +
       "return pi.val > e.val;\n" +
       "}";
     Transform transform = new ScriptFilterTransform(config);
@@ -140,7 +140,7 @@ public class ScriptFilterTransformTest {
     Assert.assertTrue(emitter.getEmitted().isEmpty());
     emitter.clear();
 
-    config.script = "function shouldFilter() {\n" +
+    config.script = "function shouldFilter(input) {\n" +
       "var pi = input.inner1.list[0].p;\n" +
       "var e = input.inner1.list[0].e;\n" +
       "return pi.val > 10 * e.val;\n" +

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/templates/etl/transforms/ScriptTransformTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/templates/etl/transforms/ScriptTransformTest.java
@@ -33,8 +33,6 @@ import java.util.Map;
 
 /**
  */
-// TODO: apparently NativeObject is not a Map in older versions of Java. Temporarily disabling.
-@Ignore
 public class ScriptTransformTest {
   private static final Schema SCHEMA = Schema.recordOf("record",
     Schema.Field.of("booleanField", Schema.of(Schema.Type.BOOLEAN)),
@@ -78,7 +76,7 @@ public class ScriptTransformTest {
   @Test
   public void testSimple() throws Exception {
     ScriptTransform.Config config = new ScriptTransform.Config(
-      "function transform() { input.intField = input.intField * 1024; return input; }", null);
+      "function transform(x) { x.intField = x.intField * 1024; return x; }", null);
     Transform<StructuredRecord, StructuredRecord> transform = new ScriptTransform(config);
     transform.initialize(null);
 
@@ -129,7 +127,7 @@ public class ScriptTransformTest {
       Schema.Field.of("x", Schema.of(Schema.Type.INT)),
       Schema.Field.of("y", Schema.of(Schema.Type.LONG)));
     ScriptTransform.Config config = new ScriptTransform.Config(
-      "function transform() { return { 'x':input.intField, 'y':input.longField }; }",
+      "function transform(input) { return { 'x':input.intField, 'y':input.longField }; }",
       outputSchema.toString());
     Transform<StructuredRecord, StructuredRecord> transform = new ScriptTransform(config);
     transform.initialize(null);
@@ -195,7 +193,7 @@ public class ScriptTransformTest {
 
     Schema outputSchema = Schema.recordOf("output", Schema.Field.of("x", Schema.of(Schema.Type.DOUBLE)));
     ScriptTransform.Config config = new ScriptTransform.Config(
-      "function transform() {\n" +
+      "function transform(input) {\n" +
       "  var pi = input.inner1.list[0].p;\n" +
       "  var e = input.inner1.list[0].e;\n" +
       "  var val = power(pi.val, 3) + power(e.val, 2);\n" +


### PR DESCRIPTION
supply a shouldFilter function instead of placing you inside the
shouldFilter function. This allows users to define their own
helper functions, and makes it more explicit what is going on.