### PR TITLE
Fix routing for explore service status endpoints

### DIFF
--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterPathLookup.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterPathLookup.java
@@ -116,6 +116,8 @@ public final class RouterPathLookup extends AuthenticatedHttpHandler {
         || uriParts[5].equals("tables") || uriParts[5].equals("jdbc"))) {
       // namespaced explore operations. For example, /v3/namespaces/{namespace-id}/data/explore/streams/{stream}/enable
       return Constants.Service.EXPLORE_HTTP_USER_SERVICE;
+    } else if ((uriParts.length == 3) && uriParts[1].equals("explore") && uriParts[2].equals("status")) {
+      return Constants.Service.EXPLORE_HTTP_USER_SERVICE;
     } else if (uriParts.length == 7 && uriParts[3].equals("data") && uriParts[4].equals("datasets") &&
       (uriParts[6].equals("flows") || uriParts[6].equals("workers") || uriParts[6].equals("mapreduce"))) {
       // namespaced app fabric data operations:

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/RouterPathTest.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/RouterPathTest.java
@@ -281,6 +281,14 @@ public class RouterPathTest {
   }
 
   @Test
+  public void testRouterExploreStatusPathLookUp() throws Exception {
+    String explorePath = "/v3/explore/status";
+    HttpRequest httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("GET"), explorePath);
+    String result = pathLookup.getRoutingService(FALLBACKSERVICE, explorePath, httpRequest);
+    Assert.assertEquals(Constants.Service.EXPLORE_HTTP_USER_SERVICE, result);
+  }
+
+  @Test
   public void testRouterWebAppPathLookUp() throws Exception {
     //Calls to webapp service with appName in the first split of URI will be routed to webappService
     //But if it has v2 then use the regular router lookup logic to find the appropriate service


### PR DESCRIPTION
Explore Service Status endpoint was not working properly (which I noticed while trying to run JDBC driver against CDAP). The issue was a failure in routing.

Simply pulled in the following code from 2.8, to get it working again:
https://github.com/caskdata/cdap/blob/release/2.8/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterPathLookup.java#L91-L92

http://builds.cask.co/browse/CDAP-RBT261-1