### PR TITLE
(CDAP-2423) Skip synthetic methods when inspecting flowlet methods.

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/internal/lang/Reflections.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/lang/Reflections.java
@@ -65,6 +65,9 @@ public final class Reflections {
         }
 
         for (Field field : type.getRawType().getDeclaredFields()) {
+          if (field.isSynthetic()) {
+            continue;
+          }
           if (!field.isAccessible()) {
             field.setAccessible(true);
           }
@@ -74,6 +77,9 @@ public final class Reflections {
         }
 
         for (Method method : type.getRawType().getDeclaredMethods()) {
+          if (method.isSynthetic() || method.isBridge()) {
+            continue;
+          }
           if (!method.isAccessible()) {
             method.setAccessible(true);
           }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowletProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowletProgramRunner.java
@@ -296,6 +296,9 @@ public final class FlowletProgramRunner implements ProgramRunner {
 
       // Extracts all process and tick methods
       for (Method method : type.getRawType().getDeclaredMethods()) {
+        if (method.isSynthetic() || method.isBridge()) {
+          continue;
+        }
         if (!seenMethods.add(new FlowletMethod(method, flowletType))) {
           // The method is already seen. It can only happen if a children class override a parent class method and
           // is visting the parent method, since the method visiting order is always from the leaf class walking


### PR DESCRIPTION
Without this, unit test "TestFrameworkTestRun.testGenerator()" fails.