### PR TITLE
CDAP-2162: CLI show error status when query finishes with non-FINISHED status

### DIFF
--- a/cdap-client/src/main/java/co/cask/cdap/client/QueryClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/QueryClient.java
@@ -76,4 +76,5 @@ public class QueryClient {
   public ListenableFuture<ExploreExecutionResult> execute(String query) {
     return exploreClient.submit(config.getConnectionConfig().getNamespace(), query);
   }
+
 }

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/AbstractExploreClient.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/AbstractExploreClient.java
@@ -319,7 +319,7 @@ public abstract class AbstractExploreClient extends ExploreHttpClient implements
               close(handle);
             }
             if (!resultFuture.set(new ClientExploreExecutionResult(AbstractExploreClient.this,
-                                                                   handle, status.hasResults()))) {
+                                                                   handle, status))) {
               close(handle);
             }
           }
@@ -357,20 +357,22 @@ public abstract class AbstractExploreClient extends ExploreHttpClient implements
 
     private final ExploreHttpClient exploreClient;
     private final QueryHandle handle;
-    private final boolean canContainResults;
-    private final boolean hasResults;
+    private final QueryStatus status;
 
-    public ClientExploreExecutionResult(ExploreHttpClient exploreClient, QueryHandle handle,
-                                        boolean canContainResults) {
+    public ClientExploreExecutionResult(ExploreHttpClient exploreClient, QueryHandle handle, QueryStatus status) {
       this.exploreClient = exploreClient;
       this.handle = handle;
-      this.canContainResults = canContainResults;
-      this.hasResults = canContainResults;
+      this.status = status;
+    }
+
+    @Override
+    public QueryStatus getStatus() {
+      return status;
     }
 
     @Override
     protected QueryResult computeNext() {
-      if (!hasResults) {
+      if (!status.hasResults()) {
         return endOfData();
       }
 
@@ -496,7 +498,7 @@ public abstract class AbstractExploreClient extends ExploreHttpClient implements
 
     @Override
     public boolean canContainResults() {
-      return canContainResults;
+      return status.hasResults();
     }
   }
 

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/ExploreExecutionResult.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/ExploreExecutionResult.java
@@ -19,6 +19,7 @@ package co.cask.cdap.explore.client;
 import co.cask.cdap.explore.service.ExploreException;
 import co.cask.cdap.proto.ColumnDesc;
 import co.cask.cdap.proto.QueryResult;
+import co.cask.cdap.proto.QueryStatus;
 
 import java.io.Closeable;
 import java.util.Iterator;
@@ -58,4 +59,9 @@ public interface ExploreExecutionResult extends Iterator<QueryResult>, Closeable
    * @return true if this {@link ExploreExecutionResult} may contain results.
    */
   boolean canContainResults();
+
+  /**
+   * @return the {@link QueryStatus} of the execution.
+   */
+  QueryStatus getStatus();
 }

--- a/cdap-explore-jdbc/src/test/java/co/cask/cdap/explore/jdbc/MockExploreClient.java
+++ b/cdap-explore-jdbc/src/test/java/co/cask/cdap/explore/jdbc/MockExploreClient.java
@@ -24,6 +24,7 @@ import co.cask.cdap.explore.service.MetaDataInfo;
 import co.cask.cdap.proto.ColumnDesc;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.QueryResult;
+import co.cask.cdap.proto.QueryStatus;
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.AbstractIdleService;
 import com.google.common.util.concurrent.ForwardingListenableFuture;
@@ -235,6 +236,11 @@ public class MockExploreClient extends AbstractIdleService implements ExploreCli
     @Override
     public boolean canContainResults() {
       return true;
+    }
+
+    @Override
+    public QueryStatus getStatus() {
+      return QueryStatus.NO_OP;
     }
   }
 


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-2162
http://builds.cask.co/browse/CDAP-RBT267

```
cdap (http://localhost:10000/default)> execute "select count(*) from stream_purchasestream"
Error: Query 'select count(*) from stream_purchasestream' execution did not finish successfully. Got final state - ERROR
```