### PR TITLE
Simple fix copy paste error log for ApplicationLifecycleService log.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ApplicationLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ApplicationLifecycleService.java
@@ -108,12 +108,12 @@ public class ApplicationLifecycleService extends AbstractIdleService {
 
   @Override
   protected void startUp() throws Exception {
-    LOG.info("Starting ProgramLifecycleService");
+    LOG.info("Starting ApplicationLifecycleService");
   }
 
   @Override
   protected void shutDown() throws Exception {
-    LOG.info("Shutting down ProgramLifecycleService");
+    LOG.info("Shutting down ApplicationLifecycleService");
   }
 
   /**


### PR DESCRIPTION
Looks like typo from ProgramLifecycleService class name when adding startup and shutdown method for ApplicationLifecycleService class.