### PR TITLE
Fixes source/sink & tranforms edit properites to popover default descriptions if not provided by nodejs config

### DIFF
--- a/cdap-ui/app/features/adapters/templates/create/tabs/sinkPropertyEdit.html
+++ b/cdap-ui/app/features/adapters/templates/create/tabs/sinkPropertyEdit.html
@@ -8,7 +8,17 @@
           <div ng-repeat="(name, value) in plugin.properties track by $index" class="row">
             <div class="row-padding">
               <div class="form-group">
-                <label class="control-label col-xs-12">{{name}}</label>
+                <label
+                      ng-init="title='info';description=plugin._backendProperties[name].description"
+                      class="control-label col-xs-12">
+                  <span  data-placement="right"
+                         data-trigger="hover"
+                         data-auto-close="1"
+                         data-template="/assets/features/adapters/templates/create/popover.html"
+                         bs-popover>
+                         {{name}}
+                  </span>
+                </label>
                 <div class="col-xs-12">
                   <input type="text"
                           class="form-control"
@@ -32,7 +42,7 @@
                     <div class="form-group">
                       <label class="control-label col-xs-12"
                           ng-init="title=groups[group].fields[field].info;description=groups[group].fields[field].description">
-                        <span data-placement="bottom"
+                        <span data-placement="right"
                               data-trigger="hover"
                               data-auto-close="1"
                               data-template="/assets/features/adapters/templates/create/popover.html"

--- a/cdap-ui/app/features/adapters/templates/create/tabs/sourcePropertyEdit.html
+++ b/cdap-ui/app/features/adapters/templates/create/tabs/sourcePropertyEdit.html
@@ -8,7 +8,17 @@
           <div ng-repeat="(name, value) in plugin.properties track by $index" class="row">
             <div class="row-padding">
               <div class="form-group">
-                <label class="control-label col-xs-12">{{name}}</label>
+                <label
+                      ng-init="title='info';description=plugin._backendProperties[name].description"
+                      class="control-label col-xs-12">
+                  <span  data-placement="right"
+                         data-trigger="hover"
+                         data-auto-close="1"
+                         data-template="/assets/features/adapters/templates/create/popover.html"
+                         bs-popover>
+                         {{name}}
+                  </span>
+                </label>
                 <div class="col-xs-12">
                   <input type="text"
                           class="form-control"

--- a/cdap-ui/app/features/adapters/templates/create/tabs/transformPropertyEdit.html
+++ b/cdap-ui/app/features/adapters/templates/create/tabs/transformPropertyEdit.html
@@ -9,7 +9,17 @@
           <div ng-repeat="(name, value) in plugin.properties track by $index" class="row">
             <div class="row-padding">
               <div class="form-group">
-                <label class="control-label col-xs-12">{{name}}</label>
+                <label
+                      ng-init="title='info';description=plugin._backendProperties[name].description"
+                      class="control-label col-xs-12">
+                  <span  data-placement="right"
+                         data-trigger="hover"
+                         data-auto-close="1"
+                         data-template="/assets/features/adapters/templates/create/popover.html"
+                         bs-popover>
+                         {{name}}
+                  </span>
+                </label>
                 <div class="col-xs-12">
                   <input type="text"
                           class="form-control"
@@ -33,7 +43,7 @@
                   <div class="form-group">
                     <label class="control-label col-xs-12"
                         ng-init="title=groups[group].fields[field].info;description=groups[group].fields[field].description">
-                      <span data-placement="bottom"
+                      <span data-placement="right"
                             data-trigger="hover"
                             data-auto-close="1"
                             data-template="/assets/features/adapters/templates/create/popover.html"


### PR DESCRIPTION
Fixes plugin property label in adapter create view provides a valid popover with default description if the backend doesn't provide one.