### PR TITLE
Remove alpha from the directory structure for UI

### DIFF
--- a/cdap-standalone/bin/cdap.bat
+++ b/cdap-standalone/bin/cdap.bat
@@ -24,7 +24,7 @@ SET CDAP_HOME=%CDAP_HOME:~0,-5%
 SET JAVACMD=%JAVA_HOME%\bin\java.exe
 
 REM Specifies Web App Path
-SET UI_PATH=%CDAP_HOME%\ui\alpha\server.js
+SET UI_PATH=%CDAP_HOME%\ui\server.js
 
 REM %CDAP_HOME%
 SET CLASSPATH=%CDAP_HOME%\lib\*;%CDAP_HOME%\conf\

--- a/cdap-standalone/bin/cdap.sh
+++ b/cdap-standalone/bin/cdap.sh
@@ -29,7 +29,7 @@ fi
 CDAP_OPTS="-XX:+UseConcMarkSweepGC -Djava.security.krb5.realm= -Djava.security.krb5.kdc= -Djava.awt.headless=true"
 
 # Specifies Web App Path
-UI_PATH=${UI_PATH:-"ui/alpha/server.js"}
+UI_PATH=${UI_PATH:-"ui/server.js"}
 
 APP_NAME="cask-cdap"
 APP_BASE_NAME=`basename "$0"`

--- a/cdap-standalone/pom.xml
+++ b/cdap-standalone/pom.xml
@@ -267,23 +267,23 @@
                     <!-- Copy cdap-ui -->
                     <resource>
                       <directory>${project.parent.basedir}/cdap-ui/server</directory>
-                      <targetPath>ui/alpha/server</targetPath>
+                      <targetPath>ui/server</targetPath>
                     </resource>
                     <resource>
                       <directory>${project.parent.basedir}/cdap-ui/dist</directory>
-                      <targetPath>ui/alpha/dist</targetPath>
+                      <targetPath>ui/dist</targetPath>
                     </resource>
                     <resource>
                       <directory>${project.parent.basedir}/cdap-ui/node_modules</directory>
-                      <targetPath>ui/alpha/node_modules</targetPath>
+                      <targetPath>ui/node_modules</targetPath>
                     </resource>
                     <resource>
                       <directory>${project.parent.basedir}/cdap-ui/templates</directory>
-                      <targetPath>ui/alpha/templates</targetPath>
+                      <targetPath>ui/templates</targetPath>
                     </resource>
                     <resource>
                       <directory>${project.parent.basedir}/cdap-ui/</directory>
-                      <targetPath>ui/alpha/</targetPath>
+                      <targetPath>ui/</targetPath>
                       <includes>
                         <include>server.js</include>
                         <include>package.json</include>

--- a/cdap-standalone/src/main/java/co/cask/cdap/UserInterfaceService.java
+++ b/cdap-standalone/src/main/java/co/cask/cdap/UserInterfaceService.java
@@ -48,7 +48,6 @@ final class UserInterfaceService extends AbstractExecutionThreadService {
 
   private static final Logger LOG = LoggerFactory.getLogger(UserInterfaceService.class);
   private static final String NODE_JS_EXECUTABLE = "node";
-  private static final String UI_VERSION = "alpha";
 
   static final String UI;
   static {
@@ -57,8 +56,6 @@ final class UserInterfaceService extends AbstractExecutionThreadService {
     File base = new File("ui");
     if (!base.isDirectory()) {
       base = new File("cdap-ui");
-    } else {
-      base = new File(base, UI_VERSION);
     }
     UI = new File(base, "server.js").getAbsolutePath();
   }

--- a/cdap-ui/conf/ui-env.sh
+++ b/cdap-ui/conf/ui-env.sh
@@ -8,4 +8,4 @@ MAIN_CMD=node
 export NODE_ENV=production
 
 # Arguments for MAIN_CMD
-MAIN_CMD_ARGS="$CDAP_HOME/ui/alpha/server.js"
+MAIN_CMD_ARGS="$CDAP_HOME/ui/server.js"

--- a/cdap-ui/pom.xml
+++ b/cdap-ui/pom.xml
@@ -236,24 +236,24 @@
                 </goals>
                 <configuration>
                   <target>
-                    <copy todir = "${stage.opt.dir}/alpha/server">
+                    <copy todir = "${stage.opt.dir}/server">
                       <fileset dir = "server"/>
                     </copy>
-                    <copy todir = "${stage.opt.dir}/alpha/dist">
+                    <copy todir = "${stage.opt.dir}/dist">
                       <fileset dir = "dist"/>
                     </copy>
-                    <copy todir = "${stage.opt.dir}/alpha/node_modules">
+                    <copy todir = "${stage.opt.dir}/node_modules">
                       <fileset dir = "node_modules"/>
                     </copy>
-                    <copy todir = "${stage.opt.dir}/alpha/templates">
+                    <copy todir = "${stage.opt.dir}/templates">
                       <fileset dir = "templates"/>
                     </copy>
-                    <copy todir = "${stage.opt.dir}/alpha/">
+                    <copy todir = "${stage.opt.dir}/">
                       <fileset dir = "./">
                         <include name="package.json" />
                       </fileset>
                     </copy>
-                    <copy todir = "${stage.opt.dir}/alpha/">
+                    <copy todir = "${stage.opt.dir}/">
                       <fileset dir = "./">
                         <include name="server.js" />
                       </fileset>


### PR DESCRIPTION
- [x] Changed Service file for running in distributed mode. 
- [x] Cleaned up Singlenode UserInterface source to remove any references to alpha
- [x] Changed the pom.xml in cdap-ui and cdap-standalone to not reference 'alpha'