### PR TITLE
Bugfix/cdap 2202 update invalid runrecords running

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -68,6 +68,7 @@ import co.cask.cdap.internal.app.runtime.schedule.Scheduler;
 import co.cask.cdap.internal.app.runtime.schedule.SchedulerService;
 import co.cask.cdap.internal.app.runtime.schedule.store.DatasetBasedTimeScheduleStore;
 import co.cask.cdap.internal.app.services.AppFabricServer;
+import co.cask.cdap.internal.app.services.ProgramLifecycleService;
 import co.cask.cdap.internal.app.services.StandaloneAppFabricServer;
 import co.cask.cdap.internal.app.store.DefaultStore;
 import co.cask.cdap.internal.pipeline.SynchronousPipelineFactory;
@@ -294,6 +295,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
 
       bind(Store.class).to(DefaultStore.class);
       bind(AdapterService.class).in(Scopes.SINGLETON);
+      bind(ProgramLifecycleService.class).in(Scopes.SINGLETON);
       bind(PluginRepository.class).in(Scopes.SINGLETON);
       bind(NamespaceAdmin.class).to(DefaultNamespaceAdmin.class).in(Scopes.SINGLETON);
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/Store.java
@@ -47,6 +47,17 @@ import javax.annotation.Nullable;
 public interface Store {
 
   /**
+   * Compare and set operation that allow to compare and set expected and update status.
+   * Implementation of this method should guarantee that the operation is atomic or in transaction.
+   *
+   * @param id              Info about program
+   * @param pid             The run id
+   * @param expectedStatus  The expected value
+   * @param updateStatus    The new value
+   */
+  void compareAndSetStatus(Id.Program id, String pid, ProgramRunStatus expectedStatus, ProgramRunStatus updateStatus);
+
+  /**
    * Loads a given program.
    *
    * @param program id of the program

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AppFabricServer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AppFabricServer.java
@@ -75,6 +75,7 @@ public class AppFabricServer extends AbstractIdleService {
   private final Set<String> handlerHookNames;
   private final NamespaceAdmin namespaceAdmin;
   private final StreamCoordinatorClient streamCoordinatorClient;
+  private final ProgramLifecycleService programLifecycleService;
 
   private NettyHttpService httpService;
   private Set<HttpHandler> handlers;
@@ -92,6 +93,7 @@ public class AppFabricServer extends AbstractIdleService {
                          @Nullable MetricsCollectionService metricsCollectionService,
                          ProgramRuntimeService programRuntimeService, AdapterService adapterService,
                          ApplicationLifecycleService applicationLifecycleService,
+                         ProgramLifecycleService programLifecycleService,
                          StreamCoordinatorClient streamCoordinatorClient,
                          @Named("appfabric.services.names") Set<String> servicesNames,
                          @Named("appfabric.handler.hooks") Set<String> handlerHookNames,
@@ -110,6 +112,7 @@ public class AppFabricServer extends AbstractIdleService {
     this.namespaceAdmin = namespaceAdmin;
     this.applicationLifecycleService = applicationLifecycleService;
     this.streamCoordinatorClient = streamCoordinatorClient;
+    this.programLifecycleService = programLifecycleService;
   }
 
   /**
@@ -131,6 +134,7 @@ public class AppFabricServer extends AbstractIdleService {
     adapterService.start();
     programRuntimeService.start();
     streamCoordinatorClient.start();
+    programLifecycleService.start();
 
     // Create handler hooks
     ImmutableList.Builder<HandlerHook> builder = ImmutableList.builder();

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AppFabricServer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AppFabricServer.java
@@ -220,5 +220,6 @@ public class AppFabricServer extends AbstractIdleService {
     applicationLifecycleService.stopAndWait();
     adapterService.stopAndWait();
     notificationService.stopAndWait();
+    programLifecycleService.stopAndWait();
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramLifecycleService.java
@@ -70,8 +70,8 @@ public class ProgramLifecycleService extends AbstractIdleService {
   protected void startUp() throws Exception {
     LOG.info("Starting ProgramLifecycleService");
 
-    scheduledExecutorService.scheduleAtFixedRate(new RunRecordsCorrectorRunnable(this, store, runtimeService),
-                                                 2L, 600L, TimeUnit.SECONDS);
+    scheduledExecutorService.scheduleWithFixedDelay(new RunRecordsCorrectorRunnable(this, store, runtimeService),
+                                                    2L, 600L, TimeUnit.SECONDS);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramLifecycleService.java
@@ -19,6 +19,7 @@ package co.cask.cdap.internal.app.services;
 import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.app.runtime.ProgramRuntimeService;
+import co.cask.cdap.app.runtime.ProgramRuntimeService.RuntimeInfo;
 import co.cask.cdap.app.store.Store;
 import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.common.exception.ProgramNotFoundException;
@@ -27,7 +28,10 @@ import co.cask.cdap.internal.app.runtime.BasicArguments;
 import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
 import co.cask.cdap.internal.app.runtime.SimpleProgramOptions;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.RunRecord;
+import com.google.common.base.Predicate;
 import com.google.common.util.concurrent.AbstractIdleService;
 import com.google.inject.Inject;
 import org.apache.twill.api.RunId;
@@ -37,8 +41,11 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
@@ -48,6 +55,7 @@ import javax.annotation.Nullable;
 public class ProgramLifecycleService extends AbstractIdleService {
   private static final Logger LOG = LoggerFactory.getLogger(ProgramLifecycleService.class);
 
+  private final ScheduledExecutorService scheduledExecutorService;
   private final Store store;
   private final ProgramRuntimeService runtimeService;
 
@@ -55,16 +63,29 @@ public class ProgramLifecycleService extends AbstractIdleService {
   public ProgramLifecycleService(Store store, ProgramRuntimeService runtimeService) {
     this.store = store;
     this.runtimeService = runtimeService;
+    this.scheduledExecutorService = Executors.newScheduledThreadPool(1);
   }
 
   @Override
   protected void startUp() throws Exception {
     LOG.info("Starting ProgramLifecycleService");
+
+    scheduledExecutorService.scheduleAtFixedRate(new RunRecordsCorrectorRunnable(this, store, runtimeService),
+                                                 2L, 600L, TimeUnit.SECONDS);
   }
 
   @Override
   protected void shutDown() throws Exception {
     LOG.info("Shutting down ProgramLifecycleService");
+
+    scheduledExecutorService.shutdown();
+    try {
+      if (!scheduledExecutorService.awaitTermination(5, TimeUnit.SECONDS)) {
+        scheduledExecutorService.shutdownNow();
+      }
+    } catch (InterruptedException ie) {
+      Thread.currentThread().interrupt();
+    }
   }
 
   private Program getProgram(Id.Program id, ProgramType programType) throws IOException, ProgramNotFoundException {
@@ -191,4 +212,67 @@ public class ProgramLifecycleService extends AbstractIdleService {
     }
     return null;
   }
+
+  /**
+   * Fix all the possible inconsistent states for RunRecords that shows it is in RUNNING state but actually not
+   * via check to {@link ProgramRuntimeService}.
+   *
+   * @param programType The type of programs the run records nee to validate and update.
+   * @param store The data store that manages run records instances for all programs.
+   * @param runtimeService The {@link ProgramRuntimeService} instance to check the actual state of the program.
+   */
+  private  void validateAndCorrectRunningRunRecords(ProgramType programType, Store store,
+                                                  ProgramRuntimeService runtimeService) {
+      final Map<RunId, RuntimeInfo> runIdToRuntimeInfo = runtimeService.list(programType);
+
+    List<RunRecord> invalidRunRecords = store.getRuns(ProgramRunStatus.RUNNING, new Predicate<RunRecord>() {
+      @Override
+      public boolean apply(@Nullable RunRecord input) {
+        if (input == null) {
+          return false;
+        }
+        // Check if it is actually running
+        String runId = input.getPid();
+        return !runIdToRuntimeInfo.containsKey(RunIds.fromString(runId));
+      }
+    });
+
+    if (!invalidRunRecords.isEmpty()) {
+      LOG.debug("Found {} RunRecords with RUNNING status but the program not actually running.",
+                invalidRunRecords.size());
+    }
+
+    // Now lets correct the invalid RunRecords
+    for (RunRecord rr : invalidRunRecords) {
+      String runId = rr.getPid();
+      RuntimeInfo runtimeInfo = runIdToRuntimeInfo.get(RunIds.fromString(runId));
+      store.compareAndSetStatus(runtimeInfo.getProgramId(), runId, ProgramController.State.ALIVE.getRunStatus(),
+                                ProgramController.State.ERROR.getRunStatus());
+    }
+  }
+
+  /**
+   * Helper class to run in separate thread to validate t
+   */
+  public static class RunRecordsCorrectorRunnable implements Runnable {
+    private final ProgramLifecycleService programLifecycleService;
+    private final Store store;
+    private final ProgramRuntimeService runtimeService;
+
+    public RunRecordsCorrectorRunnable(ProgramLifecycleService programLifecycleService, Store store,
+                                       ProgramRuntimeService runtimeService) {
+      this.programLifecycleService = programLifecycleService;
+      this.store = store;
+      this.runtimeService = runtimeService;
+    }
+
+    @Override
+    public void run() {
+      // Lets update the running programs run records
+      for (ProgramType programType : ProgramType.values()) {
+        programLifecycleService.validateAndCorrectRunningRunRecords(programType, store, runtimeService);
+      }
+    }
+  }
+
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/StandaloneAppFabricServer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/StandaloneAppFabricServer.java
@@ -57,6 +57,7 @@ public class StandaloneAppFabricServer extends AppFabricServer {
                                    ProgramRuntimeService programRuntimeService,
                                    AdapterService adapterService,
                                    ApplicationLifecycleService applicationLifecycleService,
+                                   ProgramLifecycleService programLifecycleService,
                                    StreamCoordinatorClient streamCoordinatorClient,
                                    @Named("appfabric.services.names") Set<String> servicesNames,
                                    @Named("appfabric.handler.hooks") Set<String> handlerHookNames,
@@ -64,7 +65,7 @@ public class StandaloneAppFabricServer extends AppFabricServer {
                                    MetricStore metricStore) {
     super(configuration, discoveryService, schedulerService, notificationService, hostname, handlers,
           metricsCollectionService, programRuntimeService, adapterService, applicationLifecycleService,
-          streamCoordinatorClient, servicesNames, handlerHookNames, namespaceAdmin);
+          programLifecycleService, streamCoordinatorClient, servicesNames, handlerHookNames, namespaceAdmin);
     this.metricStore = metricStore;
   }
 


### PR DESCRIPTION
Proposed fix for CDAP-2202 to update invalid RunRecords with RUNNING state 

Currently the calls to check run status of a program is run against run records' store.
In case of abrupt shutdown, there is no chance to update the state of the run record of the programs.
For example if a Flow program is running in standalone then the programs dies, then the run record
for that program will indicate still running when the CDAP is restarted.

So, the call for
```
http://localhost:10000/v3/namespaces/default/apps/CountRandom/flows/CountRandom/runs?status=running
```
and
```
http://localhost:10000/v3/namespaces/default/apps/CountRandom/flows/CountRandom/status
could return different results.
```

Adding schedule thread in ProgramLifecycleService to manage the Store updating the RunRecords with invalid state.

Makes ProgramLifecycleService to be Singleton to make sure only one instance of such thread exists.
At start of the service, it will check immediately for all invalid RunRecords.

Add CAS like method in the app Store to do the compare and set operation to make the update to be
atomic.

For Adapter we also need to check runtime status for the programs bc the program may not actually running.