### PR TITLE
Fixes viewing access token in user profile page when security is on

### DIFF
--- a/cdap-ui/app/features/userprofile/controllers/profile-ctrl.js
+++ b/cdap-ui/app/features/userprofile/controllers/profile-ctrl.js
@@ -1,6 +1,7 @@
 angular.module(PKG.name + '.feature.userprofile')
-  .controller('UserProfileController', function($scope, $http, myAlert, myAuth) {
+  .controller('UserProfileController', function($scope, $http, myAlert, myAuth, MY_CONFIG) {
     $scope.reAuthenticated = false;
+    $scope.isAuthenticated = MY_CONFIG.securityEnabled;
     $scope.credentials = {
       username: myAuth.currentUser.username
     };


### PR DESCRIPTION
-This was missed because when security is not enabled we don't show the login view and skip directly to the overview page.
- But when it is enabled and if the current user is not authenticated we show the login form.
- This login form is being reused(only the template) in the profile page which wanted the security to be enabled (which needed to be set in the current scope)