### PR TITLE
Update build instructions, doc build script, and a file cleanup.

### DIFF
--- a/BUILD.rst
+++ b/BUILD.rst
@@ -50,7 +50,7 @@ Standalone and Distributed CDAP
 
 - Build Standalone distribution ZIP::
 
-    MAVEN_OPTS="-Xmx512m" mvn clean package -DskipTests -P examples,templates -pl cdap-examples,cdap-app-templates/cdap-etl -am -amd && MAVEN_OPTS="-Xmx512m" mvn package -pl cdap-standalone -am -DskipTests -P dist,release
+    MAVEN_OPTS="-Xmx1024m" mvn clean package -DskipTests -P examples,templates -pl cdap-examples,cdap-app-templates/cdap-etl -am -amd && MAVEN_OPTS="-Xmx1024m" mvn package -pl cdap-standalone -am -DskipTests -P dist,release
     
 - Build the limited set of Javadocs used in distribution ZIP::
 

--- a/cdap-docs/_common/common-build.sh
+++ b/cdap-docs/_common/common-build.sh
@@ -296,7 +296,7 @@ function test_an_include() {
 function build_standalone() {
   cd ${PROJECT_PATH}
   set_mvn_environment
-  MAVEN_OPTS="-Xmx512m" mvn clean package -DskipTests -P examples,templates -pl cdap-examples,cdap-app-templates -am -amd && MAVEN_OPTS="-Xmx512m" mvn package -pl cdap-standalone -am -DskipTests -P dist,release
+  MAVEN_OPTS="-Xmx1024m" mvn clean package -DskipTests -P examples,templates -pl cdap-examples,cdap-app-templates/cdap-etl -am -amd && MAVEN_OPTS="-Xmx1024m" mvn package -pl cdap-standalone -am -DskipTests -P dist,release
 }
 
 function build_sdk() {


### PR DESCRIPTION
Delete a zero-length file. 
Update the Docs SDK build command to the latest target. 
Update the BUILD.rst to 1024 for building SDK.