### PR TITLE
Fixes overflow-x in adapters to show list of drafts + plugins count fix in panel header

### DIFF
--- a/cdap-ui/app/features/adapters/etlapps.less
+++ b/cdap-ui/app/features/adapters/etlapps.less
@@ -21,7 +21,9 @@ body.theme-cdap.state-adapters-detail,
 body.theme-cdap.state-adapters-create {
 
   .ui-select-container.ui-select-bootstrap {
-    overflow-x: auto;
+    .ui-select-toggle {
+      overflow-x: auto;
+    }
   }
 
   .etlflowcontainer {

--- a/cdap-ui/app/features/adapters/services/etl-create-factory.js
+++ b/cdap-ui/app/features/adapters/services/etl-create-factory.js
@@ -3,6 +3,9 @@ angular.module(PKG.name + '.feature.adapters')
     var filterFilter = $filter('filter');
     function AdapterApiFactory(scope) {
       this.scope = scope;
+      this.scope.defaultSources = [];
+      this.scope.defaultSinks = [];
+      this.scope.defaultTransforms = [];
       this.dataSrc = new MyDataSource(scope);
     }
 

--- a/cdap-ui/app/features/adapters/templates/create.html
+++ b/cdap-ui/app/features/adapters/templates/create.html
@@ -34,7 +34,7 @@
                reset-search-input="false"
                title="Create New or Select draft">
               <ui-select-match placeholder="Create New or Select draft" > {{selectedAdapterDraft}}</ui-select-match>
-              <ui-select-choices repeat="adapter in adapterDraftList| filter: $select.search">
+              <ui-select-choices repeat="adapter in adaptersDraftList| filter: $select.search">
                 <div ng-bind-html="adapter | highlight: $select.search"></div>
               </ui-select-choices>
             </ui-select>


### PR DESCRIPTION
- Fixes overflow-x to show the dropdown menu of list of stored adapters.
- Fixes plugins count to show '0' when no plugins are there.