### PR TITLE
Fixes tables default header color + datasets non-explorable view + add in apps list view

### DIFF
--- a/cdap-ui/app/features/apps/templates/list.html
+++ b/cdap-ui/app/features/apps/templates/list.html
@@ -10,10 +10,11 @@
       </button>
       <ul class="dropdown-menu dropdown-menu-right" role="menu">
         <li role="presentation">
-          <my-file-select on-file-select="onFileSelected($files)"
-            data-button-label="Add App"
-            data-button-icon="fa-plus"
-            data-dropdown="true"> </my-file-select>
+          <a role="menuitem" ui-sref="admin.namespace.detail.apps({nsadmin: $state.params.namespace})"
+             class="text-center clearfix">
+            <span class="pull-left"> Add App </span>
+            <span class="fa fa-plus pull-right"></span>
+          </a>
         </li>
       </ul>
     </div>
@@ -42,4 +43,3 @@
     <tbody>
   </table>
 </div>
-

--- a/cdap-ui/app/features/datasets/templates/detail.html
+++ b/cdap-ui/app/features/datasets/templates/detail.html
@@ -44,5 +44,5 @@
 <my-tabs
   data-tabs-list="['Programs']"
   data-tabs-partial-path="/assets/features/datasets/templates/tabs/"
-  ng-if="!explorable">
+  ng-if="explorable === false">
 </my-tabs>

--- a/cdap-ui/app/styles/themes/cdap/theme.less
+++ b/cdap-ui/app/styles/themes/cdap/theme.less
@@ -72,8 +72,8 @@ body.theme-cdap {
     margin-top: 10px;
     &[cask-sortable] {
       thead {
-        background-color: @cdap-header;
-        th { color: white; }
+
+        
         .empty { cursor: default; }
       }
     }


### PR DESCRIPTION
- Fixes add app in apps list view.
- Fixes Dataset detailed view of explorable datasets.
- Fixes global table header view (reverses the background color with text color)