### PR TITLE
Fix .gitignore to ignore templates directory due to plugins dir restructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,7 @@ logs/
 .nux_dashboard
 
 # Singlenode and test data files.
-/plugins/
+/templates/
 /data/
 /data-fabric-tests/data/
 


### PR DESCRIPTION
Change the .gitignore to add templates and remove plugins directory.