### PR TITLE
Sort lists in alphabetical order, as opposed to reverse alphabetical ord...

### DIFF
--- a/cdap-ui/app/directives/program-preferences/program-preferences.html
+++ b/cdap-ui/app/directives/program-preferences/program-preferences.html
@@ -53,8 +53,8 @@
       <table class="table table-curved" cask-sortable>
         <thead>
           <tr ng-class="{'sort-enabled': systemPreferences.length>0}">
-            <th data-predicate="key" data-predicate-default="reverse">Name</th>
-            <th data-predicate="value" data-predicate-default="reverse">Value</th>
+            <th data-predicate="key">Name</th>
+            <th data-predicate="value">Value</th>
           </tr>
         </thead>
         <tbody>

--- a/cdap-ui/app/features/admin/templates/namespace/apps.html
+++ b/cdap-ui/app/features/admin/templates/namespace/apps.html
@@ -14,7 +14,7 @@
         <table class="table table-curved" cask-sortable>
             <thead>
               <tr ng-class="{'sort-enabled': apps.length>0}">
-                <th data-predicate="name" data-predicate-default="reverse">Name</th>
+                <th data-predicate="name">Name</th>
                 <th data-predicate="version">Version</th>
                 <th data-predicate="type">Type</th>
                 <th data-predicate="description">Description</th>

--- a/cdap-ui/app/features/admin/templates/namespace/datatypes.html
+++ b/cdap-ui/app/features/admin/templates/namespace/datatypes.html
@@ -4,7 +4,7 @@
     <table class="table table-curved" cask-sortable>
         <thead>
             <tr ng-class="{'sort-enabled': datatypes.length>0}">
-                <th data-predicate="name" data-predicate-default="reverse"></th>
+                <th data-predicate="name"></th>
                 <th data-predicate="className">Class</th>
                 <th data-predicate="description">Description</th>
                 <th data-predicate="instances">Instances</th>

--- a/cdap-ui/app/features/admin/templates/overview.html
+++ b/cdap-ui/app/features/admin/templates/overview.html
@@ -26,7 +26,7 @@
     <table class="table table-curved" cask-sortable>
         <thead>
           <tr ng-class="{'sort-enabled': nsList.length>0}">
-            <th data-predicate="name" data-predicate-default="reverse">Name</th>
+            <th data-predicate="name">Name</th>
             <th data-predicate="appsCount">Apps</th>
             <th>Datasets</th>
             <th>Streams</th>

--- a/cdap-ui/app/features/admin/templates/preferences.html
+++ b/cdap-ui/app/features/admin/templates/preferences.html
@@ -56,8 +56,8 @@
         <table class="table table-curved" cask-sortable>
           <thead>
             <tr ng-class="{'sort-enabled': parentPreferences.length>0}">
-              <th data-predicate="key" data-predicate-default="reverse">Name</th>
-              <th data-predicate="value" data-predicate-default="reverse">Value</th>
+              <th data-predicate="key">Name</th>
+              <th data-predicate="value">Value</th>
             </tr>
           </thead>
           <tbody>

--- a/cdap-ui/app/features/admin/templates/system/services.html
+++ b/cdap-ui/app/features/admin/templates/system/services.html
@@ -4,7 +4,7 @@
   <table class="table table-curved" cask-sortable>
     <thead>
       <tr ng-class="{'sort-enabled': services.length>0}">
-        <th data-predicate="name" data-predicate-default="reverse">Name</th>
+        <th data-predicate="name">Name</th>
         <th data-predicate="status">Status</th>
         <th data-predicate="provisioned">Provisioned</th>
         <th data-predicate="requested">Requested</th>

--- a/cdap-ui/app/features/apps/templates/list.html
+++ b/cdap-ui/app/features/apps/templates/list.html
@@ -24,7 +24,7 @@
   <table class="table table-curved" cask-sortable>
     <thead>
       <tr ng-class="{'sort-enabled': apps.length>0}">
-        <th data-predicate="name" data-predicate-default="reverse"> Name </th>
+        <th data-predicate="name"> Name </th>
         <th data-predicate="version"> Version </th>
         <th data-predicate="description"> Description </th>
       </tr>

--- a/cdap-ui/app/features/apps/templates/tabs/status.html
+++ b/cdap-ui/app/features/apps/templates/tabs/status.html
@@ -12,7 +12,7 @@
         <table class="table table-curved" cask-sortable>
           <thead>
             <tr ng-class="{'sort-enabled': programs.length>0}">
-              <th data-predicate="name" data-predicate-default="reverse"> Name </th>
+              <th data-predicate="name"> Name </th>
               <th data-predicate="status"> Status </th>
               <th data-predicate="description"> Description </th>
               <th data-predicate="type"> Type </th>

--- a/cdap-ui/app/features/data/list.html
+++ b/cdap-ui/app/features/data/list.html
@@ -4,7 +4,7 @@
   <table class="table table-curved" cask-sortable>
     <thead>
       <tr ng-class="{'sort-enabled': dataList.length>0}">
-        <th data-predicate="name" data-predicate-default="reverse"> Name </th>
+        <th data-predicate="name"> Name </th>
         <th data-predicate="dataType"> Type </th>
       </tr>
     </thead>

--- a/cdap-ui/app/features/datasets/templates/list.html
+++ b/cdap-ui/app/features/datasets/templates/list.html
@@ -3,7 +3,7 @@
   <table class="table table-curved" cask-sortable>
     <thead>
       <tr ng-class="{'sort-enabled': datasets.length>0}">
-        <th data-predicate="name" data-predicate-default="reverse"> Name </th>
+        <th data-predicate="name"> Name </th>
         <th data-predicate="type"> Type </th>
         <th data-predicate="description"> Description </th>
         <th data-predicate="storage"> Storage </th>

--- a/cdap-ui/app/features/datasets/templates/tabs/status.html
+++ b/cdap-ui/app/features/datasets/templates/tabs/status.html
@@ -33,7 +33,7 @@
         <table class="table table-curved" cask-sortable ng-show="schema.length > 0">
           <thead>
             <tr ng-class="{'sort-enabled': schema.length > 1}">
-              <th data-predicate="name" data-predicate-default="reverse"> Name </th>
+              <th data-predicate="name"> Name </th>
               <th data-predicate="type"> Type </th>
             </tr>
           </thead>

--- a/cdap-ui/app/features/flows/templates/list.html
+++ b/cdap-ui/app/features/flows/templates/list.html
@@ -2,7 +2,7 @@
 <table class="table table-responsive" cask-sortable>
   <thead>
     <tr ng-class="{'sort-enabled': flows.length>0}">
-      <th data-predicate="name" data-predicate-default="reverse"> Name </th>
+      <th data-predicate="name"> Name </th>
       <th data-predicate="description"> Description </th>
       <th data-predicate="app"> App </th>
       <th data-predicate="status"> Status </th>

--- a/cdap-ui/app/features/mapreduce/templates/list.html
+++ b/cdap-ui/app/features/mapreduce/templates/list.html
@@ -2,7 +2,7 @@
 <table class="table table-responsive" cask-sortable>
   <thead>
     <tr ng-class="{'sort-enabled': mapreduceList.length>0}">
-      <th data-predicate="name" data-predicate-default="reverse"> Name </th>
+      <th data-predicate="name"> Name </th>
       <th data-predicate="description"> Description </th>
       <th data-predicate="app"> App </th>
       <th data-predicate="status"> Status </th>

--- a/cdap-ui/app/features/services/templates/list.html
+++ b/cdap-ui/app/features/services/templates/list.html
@@ -2,7 +2,7 @@
 <table class="table table-responsive" cask-sortable>
   <thead>
     <tr ng-class="{'sort-enabled': services.length>0}">
-      <th data-predicate="name" data-predicate-default="reverse"> Name </th>
+      <th data-predicate="name"> Name </th>
       <th data-predicate="description"> Description </th>
       <th data-predicate="app"> App </th>
       <th data-predicate="status"> Status </th>

--- a/cdap-ui/app/features/streams/templates/list.html
+++ b/cdap-ui/app/features/streams/templates/list.html
@@ -4,7 +4,7 @@
   <table class="table table-curved" cask-sortable>
     <thead>
       <tr ng-class="{'sort-enabled': streams.length>0}">
-        <th data-predicate="name" data-predicate-default="reverse"> Name </th>
+        <th data-predicate="name"> Name </th>
         <th data-predicate="type"> Type </th>
       </tr>
     </thead>

--- a/cdap-ui/app/features/streams/templates/tabs/status.html
+++ b/cdap-ui/app/features/streams/templates/tabs/status.html
@@ -24,7 +24,7 @@
       <table class="table table-curved" cask-sortable ng-show="schema.length > 0">
         <thead>
           <tr ng-class="{'sort-enabled': schema.length > 1}">
-            <th data-predicate="name" data-predicate-default="reverse"> Name </th>
+            <th data-predicate="name"> Name </th>
             <th data-predicate="type"> Type </th>
           </tr>
         </thead>


### PR DESCRIPTION
...er.

I have removed 'reverse' as being the default order, because that seems unusual.
Natural alphabetical order seems more appropriate.

It remains only in one place - `program-history.html` - because that's how it is showing most recent runs first.