### PR TITLE
Give bar charts tick culling, to avoid crowded timestamps.

### DIFF
--- a/cdap-ui/app/directives/c3/charts.js
+++ b/cdap-ui/app/directives/c3/charts.js
@@ -85,6 +85,7 @@ ngC3.controller('c3Controller', function ($scope, c3, myHelpers, $filter) {
 
     var xTick = {};
     xTick.count = $scope.options.xtickcount;
+    xTick.culling = $scope.options.xTickCulling;
     if ($scope.options.formatAsTimestamp) {
       var timestampFormat = function(timestampSeconds) {
         return $filter('amDateFormat')(timestampSeconds * 1000, 'h:mm:ss a');
@@ -118,7 +119,8 @@ ngC3.directive('c3Line', function () {
 ngC3.directive('c3Bar', function () {
   return angular.extend({
     link: function (scope, elem, attr) {
-      scope.initC3(elem, 'bar', attr, {stack: true});
+      // xtickcount option does not work for bar charts, so have to use culling
+      scope.initC3(elem, 'bar', attr, {stack: true, xTickCulling: {max: 5}});
     }
   }, baseDirective);
 });


### PR DESCRIPTION
Before
![image](https://s3.amazonaws.com/uploads.hipchat.com/26476/1011205/qVhlNlQ1OYKaEHH/Screen%20Shot%202015-05-04%20at%201.19.15%20PM.png)
---------
After
![image](https://s3.amazonaws.com/uploads.hipchat.com/26476/1011205/KHvEOpmTsdnfmBU/Screen%20Shot%202015-05-04%20at%201.16.56%20PM.png)