### PR TITLE
CDAP-2463 Using right log offset to fetch logs from Kafka

### DIFF
--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/LogHandler.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/LogHandler.java
@@ -122,6 +122,7 @@ public class LogHandler extends AuthenticatedHttpHandler {
 
       ChunkedLogReaderCallback logCallback = new ChunkedLogReaderCallback(responder, logPattern, escape);
       logReader.getLog(loggingContext, readRange.getFromMillis(), readRange.getToMillis(), filter, logCallback);
+      logCallback.close();
     } catch (SecurityException e) {
       responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);
     } catch (IllegalArgumentException e) {
@@ -178,6 +179,7 @@ public class LogHandler extends AuthenticatedHttpHandler {
       ReadRange readRange = ReadRange.createFromRange(logOffset);
       readRange = adjustReadRange(readRange, runRecord);
       logReader.getLogNext(loggingContext, readRange, maxEvents, filter, logCallback);
+      logCallback.close();
     } catch (SecurityException e) {
       responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);
     } catch (IllegalArgumentException e) {
@@ -257,6 +259,7 @@ public class LogHandler extends AuthenticatedHttpHandler {
       readRange = adjustReadRange(readRange, runRecord);
       logReader.getLogPrev(loggingContext, readRange,
                            maxEvents, filter, logCallback);
+      logCallback.close();
     } catch (SecurityException e) {
       responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);
     } catch (IllegalArgumentException e) {
@@ -286,6 +289,7 @@ public class LogHandler extends AuthenticatedHttpHandler {
                                                                              serviceId);
       ChunkedLogReaderCallback logCallback = new ChunkedLogReaderCallback(responder, logPattern, escape);
       logReader.getLog(loggingContext, timeRange.getFromMillis(), timeRange.getToMillis(), filter, logCallback);
+      logCallback.close();
     } catch (IllegalArgumentException e) {
       responder.sendString(HttpResponseStatus.BAD_REQUEST, e.getMessage());
     } catch (Throwable e) {
@@ -311,6 +315,7 @@ public class LogHandler extends AuthenticatedHttpHandler {
       ReadRange readRange = ReadRange.createFromRange(logOffset);
       logReader.getLogNext(loggingContext, readRange,
                            maxEvents, filter, logCallback);
+      logCallback.close();
     } catch (IllegalArgumentException e) {
       responder.sendString(HttpResponseStatus.BAD_REQUEST, e.getMessage());
     } catch (Throwable e) {
@@ -336,6 +341,7 @@ public class LogHandler extends AuthenticatedHttpHandler {
       ReadRange readRange = ReadRange.createToRange(logOffset);
       logReader.getLogPrev(loggingContext, readRange,
                            maxEvents, filter, logCallback);
+      logCallback.close();
     } catch (IllegalArgumentException e) {
       responder.sendString(HttpResponseStatus.BAD_REQUEST, e.getMessage());
     } catch (Throwable e) {

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/read/FileLogReader.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/read/FileLogReader.java
@@ -112,8 +112,6 @@ public class FileLogReader implements LogReader {
     } catch (Throwable e) {
       LOG.error("Got exception: ", e);
       throw  Throwables.propagate(e);
-    } finally {
-      callback.close();
     }
   }
 
@@ -158,8 +156,6 @@ public class FileLogReader implements LogReader {
     } catch (Throwable e) {
       LOG.error("Got exception: ", e);
       throw  Throwables.propagate(e);
-    } finally {
-      callback.close();
     }
   }
 
@@ -198,8 +194,6 @@ public class FileLogReader implements LogReader {
     } catch (Throwable e) {
       LOG.error("Got exception: ", e);
       throw  Throwables.propagate(e);
-    } finally {
-      callback.close();
     }
   }
 }

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/LoggingTester.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/LoggingTester.java
@@ -41,7 +41,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CountDownLatch;
 
 /**
  *
@@ -280,7 +279,6 @@ public class LoggingTester {
     private LogOffset firstOffset;
     private LogOffset lastOffset;
     private List<LogEvent> events;
-    private final CountDownLatch latch = new CountDownLatch(1);
 
     @Override
     public void init() {
@@ -303,11 +301,9 @@ public class LoggingTester {
 
     @Override
     public void close() {
-      latch.countDown();
     }
 
     public List<LogEvent> getEvents() throws Exception {
-      latch.await();
       return events;
     }
 


### PR DESCRIPTION
Also, closing log callback in handler instead of log readers since now each call to fetch logs can span multiple readers.

