### PR TITLE
Return back dependency on JMS for realtime lib bc it is breaking class logic

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/pom.xml
@@ -141,7 +141,6 @@
       <groupId>org.apache.geronimo.specs</groupId>
       <artifactId>geronimo-jms_1.1_spec</artifactId>
       <version>1.1.1</version>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.activemq</groupId>

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/realtime/source/JmsSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/realtime/source/JmsSource.java
@@ -142,18 +142,10 @@ public class JmsSource extends RealtimeSource<StructuredRecord> {
                                           "Please set the right JMSProvider");
       } else {
         LOG.trace("Using JNDI default JMS provider for destination: {}", destinationName);
-        ClassLoader oldClassLoader = null;
-        try {
-          if (driverClassLoader != null) {
-            oldClassLoader = Thread.currentThread().getContextClassLoader();
-            Thread.currentThread().setContextClassLoader(driverClassLoader);
-          }
-          jmsProvider = new JndiBasedJmsProvider(envVars, destinationName, connectionFactoryName);
-        } finally {
-          if (oldClassLoader != null) {
-            Thread.currentThread().setContextClassLoader(oldClassLoader);
-          }
+        if (driverClassLoader != null) {
+          Thread.currentThread().setContextClassLoader(driverClassLoader);
         }
+        jmsProvider = new JndiBasedJmsProvider(envVars, destinationName, connectionFactoryName);
       }
     }
     ConnectionFactory connectionFactory = jmsProvider.getConnectionFactory();


### PR DESCRIPTION
Seemed like omitting JMS dependency spec caused problem with ETLAdapter tests