### PR TITLE
Exclude JMS spec from ETL lib bundle to avoid duplicate dependencies.

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/pom.xml
@@ -221,9 +221,10 @@
                 <!-- build bundle jar for realtime. excluding batch-->
                 <Export-Package>co.cask.cdap.template.etl.realtime.*;co.cask.cdap.template.etl.transform.*;
                   co.cask.cdap.template.etl.common</Export-Package>
-                <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
+                <Embed-Dependency>*;inline=false;scope=compile;artifactId=!geronimo-jms_1.1_spec</Embed-Dependency>
                 <Embed-Transitive>true</Embed-Transitive>
                 <Embed-Directory>lib</Embed-Directory>
+                javax/jms
               </instructions>
             </configuration>
            <goals>


### PR DESCRIPTION
With both JSM spec jar and ActiveMQ jar in the classloader, we could get duplicate declaration of ConnectionFactory when calling:
```
connectionFactory = (ConnectionFactory) jndiContext.lookup(connectionFactoryName);
```
could generate error org.apache.activemq.ActiveMQConnectionFactory cannot be cast to javax.jms.ConnectionFactory
