### PR TITLE
[CDAP-2474] Change the ConnectionFactory JNDI name to be consistent with other properties in JMS source.

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/realtime/source/JmsSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/realtime/source/JmsSource.java
@@ -66,7 +66,7 @@ public class JmsSource extends RealtimeSource<StructuredRecord> {
   public static final String JMS_PROVIDER_URL = "jms.provider.url";
   public static final String JMS_CONNECTION_FACTORY_NAME = "jms.jndi.connectionfactory.name";
 
-  public static final String CONNECTION_FACTORY = "ConnectionFactory";
+  public static final String DEFAULT_CONNECTION_FACTORY = "ConnectionFactory";
 
   private static final long JMS_CONSUMER_TIMEOUT_MS = 2000;
 
@@ -330,7 +330,7 @@ public class JmsSource extends RealtimeSource<StructuredRecord> {
 
     public JmsPluginConfig() {
       messagesToReceive = 50;
-      connectionFactoryName = CONNECTION_FACTORY;
+      connectionFactoryName = DEFAULT_CONNECTION_FACTORY;
     }
 
     public JmsPluginConfig(String destinationName, @Nullable Integer messagesToReceive, String initialContextFactory,
@@ -346,7 +346,7 @@ public class JmsSource extends RealtimeSource<StructuredRecord> {
       if (connectionFactoryName != null) {
         this.connectionFactoryName = connectionFactoryName;
       } else {
-        this.connectionFactoryName = CONNECTION_FACTORY;
+        this.connectionFactoryName = DEFAULT_CONNECTION_FACTORY;
       }
     }
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/realtime/source/JmsSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/realtime/source/JmsSource.java
@@ -66,6 +66,8 @@ public class JmsSource extends RealtimeSource<StructuredRecord> {
   public static final String JMS_PROVIDER_URL = "jms.provider.url";
   public static final String JMS_CONNECTION_FACTORY_NAME = "jms.jndi.connectionfactory.name";
 
+  public static final String CONNECTION_FACTORY = "ConnectionFactory";
+
   private static final long JMS_CONSUMER_TIMEOUT_MS = 2000;
 
   public static final String MESSAGE = "message";
@@ -328,7 +330,7 @@ public class JmsSource extends RealtimeSource<StructuredRecord> {
 
     public JmsPluginConfig() {
       messagesToReceive = 50;
-      connectionFactoryName = "ConnectionFactory";
+      connectionFactoryName = CONNECTION_FACTORY;
     }
 
     public JmsPluginConfig(String destinationName, @Nullable Integer messagesToReceive, String initialContextFactory,
@@ -344,7 +346,7 @@ public class JmsSource extends RealtimeSource<StructuredRecord> {
       if (connectionFactoryName != null) {
         this.connectionFactoryName = connectionFactoryName;
       } else {
-        this.connectionFactoryName = "ConnectionFactory";
+        this.connectionFactoryName = CONNECTION_FACTORY;
       }
     }
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/realtime/source/JmsSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/realtime/source/JmsSource.java
@@ -64,7 +64,7 @@ public class JmsSource extends RealtimeSource<StructuredRecord> {
   public static final String JMS_MESSAGES_TO_RECEIVE = "jms.messages.receive";
   public static final String JMS_NAMING_FACTORY_INITIAL = "jms.factory.initial";
   public static final String JMS_PROVIDER_URL = "jms.provider.url";
-  public static final String JMS_CONNECTION_FACTORY_NAME = "ConnectionFactory";
+  public static final String JMS_CONNECTION_FACTORY_NAME = "jms.jndi.connectionfactory.name";
 
   private static final long JMS_CONSUMER_TIMEOUT_MS = 2000;
 
@@ -344,7 +344,7 @@ public class JmsSource extends RealtimeSource<StructuredRecord> {
       if (connectionFactoryName != null) {
         this.connectionFactoryName = connectionFactoryName;
       } else {
-        this.connectionFactoryName = JMS_CONNECTION_FACTORY_NAME;
+        this.connectionFactoryName = "ConnectionFactory";
       }
     }
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/template/etl/realtime/source/JmsSourceTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/template/etl/realtime/source/JmsSourceTest.java
@@ -202,7 +202,7 @@ public class JmsSourceTest {
   private void initializeJmsSource(String destination, int messageReceive, String initialContextFactory,
                                    String providerUrl) {
     jmsSource = new JmsSource(new JmsPluginConfig(destination, messageReceive, initialContextFactory, providerUrl,
-                                                  JmsSource.CONNECTION_FACTORY));
+                                                  JmsSource.DEFAULT_CONNECTION_FACTORY));
   }
 
   /**

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/template/etl/realtime/source/JmsSourceTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/template/etl/realtime/source/JmsSourceTest.java
@@ -202,7 +202,7 @@ public class JmsSourceTest {
   private void initializeJmsSource(String destination, int messageReceive, String initialContextFactory,
                                    String providerUrl) {
     jmsSource = new JmsSource(new JmsPluginConfig(destination, messageReceive, initialContextFactory, providerUrl,
-                                                  "ConnectionFactory"));
+                                                  JmsSource.CONNECTION_FACTORY));
   }
 
   /**

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/template/etl/realtime/source/JmsSourceTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/template/etl/realtime/source/JmsSourceTest.java
@@ -202,7 +202,7 @@ public class JmsSourceTest {
   private void initializeJmsSource(String destination, int messageReceive, String initialContextFactory,
                                    String providerUrl) {
     jmsSource = new JmsSource(new JmsPluginConfig(destination, messageReceive, initialContextFactory, providerUrl,
-                                                  JmsSource.JMS_CONNECTION_FACTORY_NAME));
+                                                  "ConnectionFactory"));
   }
 
   /**


### PR DESCRIPTION
Currently the name of the ConnectionFactory property for JMS source is called "ConnectionFactory".

Need to change it something to follow the rest of JMS source property names, for example: jms.destination.name