### PR TITLE
Fix error message when name is missing from adapter draft.

### DIFF
--- a/cdap-ui/app/features/adapters/controllers/create-ctrl.js
+++ b/cdap-ui/app/features/adapters/controllers/create-ctrl.js
@@ -297,7 +297,7 @@ angular.module(PKG.name + '.feature.adapters')
     $scope.saveAsDraft = function() {
       if (!$scope.metadata.name.length) {
         $alert({
-          type: info,
+          type: 'info',
           content: 'Please provide a name for the Adapter to be saved as draft'
         });
         return;


### PR DESCRIPTION
The alert on adapter draft page wouldn't work.
https://s3.amazonaws.com/uploads.hipchat.com/26476/1011205/qK4lb80tLRHY4MY/Screen%20Shot%202015-05-05%20at%202.02.36%20AM.png

This resolves that.
Now it properly shows this:
https://s3.amazonaws.com/uploads.hipchat.com/26476/1011205/O7OOhNhSnQDjyAk/Screen%20Shot%202015-05-05%20at%202.04.21%20AM.png