### PR TITLE
Rewrite try-finally-close block using Java7 ARM construct, which is the best practice.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/deploy/SandboxJVM.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/deploy/SandboxJVM.java
@@ -154,12 +154,9 @@ public class SandboxJVM {
       // Convert the specification to JSON.
       // We write the Application specification to output file in JSON format.
       try {
-        Writer writer = Files.newWriter(outputFile, Charsets.UTF_8);
-        try {
+        try (Writer writer = Files.newWriter(outputFile, Charsets.UTF_8)) {
           // TODO: The SchemaGenerator should be injected.
           ApplicationSpecificationAdapter.create(new ReflectionSchemaGenerator()).toJson(specification, writer);
-        } finally {
-          writer.close();
         }
       } catch (IOException e) {
         LOG.error("Error writing to file {}. {}", outputFile, e.getMessage());

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/NotificationFeedHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/NotificationFeedHttpHandler.java
@@ -188,14 +188,11 @@ public class NotificationFeedHttpHandler extends AuthenticatedHttpHandler {
     if (!content.readable()) {
       return null;
     }
-    Reader reader = new InputStreamReader(new ChannelBufferInputStream(content), Charsets.UTF_8);
-    try {
+    try (Reader reader = new InputStreamReader(new ChannelBufferInputStream(content), Charsets.UTF_8)) {
       return GSON.fromJson(reader, type);
     } catch (JsonSyntaxException e) {
       LOG.debug("Failed to parse body on {} as {}", request.getUri(), type, e);
       throw e;
-    } finally {
-      reader.close();
     }
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
@@ -1439,8 +1439,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
       responder.sendString(HttpResponseStatus.BAD_REQUEST, "Cannot read request");
       return null;
     }
-    Reader reader = new InputStreamReader(new ChannelBufferInputStream(content), Charsets.UTF_8);
-    try {
+    try (Reader reader = new InputStreamReader(new ChannelBufferInputStream(content), Charsets.UTF_8)) {
       List<BatchEndpointArgs> input = GSON.fromJson(reader, new TypeToken<List<BatchEndpointArgs>>() { }.getType());
       for (BatchEndpointArgs requestedObj : input) {
         // make sure the following args exist
@@ -1468,8 +1467,6 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
     } catch (JsonSyntaxException e) {
       responder.sendJson(HttpResponseStatus.BAD_REQUEST, "Invalid Json object provided");
       return null;
-    } finally {
-      reader.close();
     }
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/TransactionHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/TransactionHttpHandler.java
@@ -68,9 +68,8 @@ public class TransactionHttpHandler extends AbstractAppFabricHttpHandler {
   public void getTxManagerSnapshot(HttpRequest request, HttpResponder responder) {
     try {
       LOG.trace("Taking transaction manager snapshot at time {}", System.currentTimeMillis());
-      InputStream in = txClient.getSnapshotInputStream();
       LOG.trace("Took and retrieved transaction manager snapshot successfully.");
-      try {
+      try (InputStream in = txClient.getSnapshotInputStream()) {
         ChunkResponder chunkResponder = responder.sendChunkStart(HttpResponseStatus.OK,
                                                                  ImmutableMultimap.<String, String>of());
         while (true) {
@@ -85,8 +84,6 @@ public class TransactionHttpHandler extends AbstractAppFabricHttpHandler {
           chunkResponder.sendChunk(ChannelBuffers.wrappedBuffer(readBytes, 0, res));
         }
         Closeables.closeQuietly(chunkResponder);
-      } finally {
-        in.close();
       }
     } catch (Exception e) {
       LOG.error("Could not take transaction manager snapshot", e);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/ApplicationSpecificationAdapter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/ApplicationSpecificationAdapter.java
@@ -130,11 +130,8 @@ public final class ApplicationSpecificationAdapter {
 
   public void toJson(ApplicationSpecification appSpec,
                      OutputSupplier<? extends Writer> outputSupplier) throws IOException {
-    Writer writer = outputSupplier.getOutput();
-    try {
+    try (Writer writer = outputSupplier.getOutput()) {
       toJson(appSpec, writer);
-    } finally {
-      Closeables.closeQuietly(writer);
     }
   }
 
@@ -151,11 +148,8 @@ public final class ApplicationSpecificationAdapter {
   }
 
   public ApplicationSpecification fromJson(InputSupplier<? extends Reader> inputSupplier) throws IOException {
-    Reader reader = inputSupplier.getInput();
-    try {
+    try (Reader reader = inputSupplier.getInput()) {
       return fromJson(reader);
-    } finally {
-      Closeables.closeQuietly(reader);
     }
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/BufferFileInputStream.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/BufferFileInputStream.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.internal.app;
 
+import java.io.Closeable;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -25,7 +26,7 @@ import java.util.Arrays;
 /**
  * File input stream that returns byte array while reading.
  */
-public final class BufferFileInputStream {
+public final class BufferFileInputStream implements Closeable {
 
   /**
    * Buffer for holding bytes read from file.
@@ -92,6 +93,7 @@ public final class BufferFileInputStream {
    *
    * @throws java.io.IOException
    */
+  @Override
   public void close() throws IOException {
     stream.close();
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/InMemoryAdapterConfigurator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/InMemoryAdapterConfigurator.java
@@ -34,7 +34,6 @@ import co.cask.cdap.templates.AdapterDefinition;
 import co.cask.cdap.templates.DefaultAdapterConfigurer;
 import com.google.common.base.Preconditions;
 import com.google.common.io.CharStreams;
-import com.google.common.io.Closeables;
 import com.google.common.io.Files;
 import com.google.common.reflect.TypeToken;
 import com.google.common.util.concurrent.Futures;
@@ -114,9 +113,8 @@ public final class InMemoryAdapterConfigurator implements Configurator {
         }
 
         ApplicationTemplate template = (ApplicationTemplate) appMain;
-        PluginInstantiator pluginInstantiator = new PluginInstantiator(cConf, adapterConfig.getTemplate(),
-                                                                       template.getClass().getClassLoader());
-        try {
+        try (PluginInstantiator pluginInstantiator = new PluginInstantiator(cConf, adapterConfig.getTemplate(),
+                                                                            template.getClass().getClassLoader())) {
           DefaultAdapterConfigurer configurer = new DefaultAdapterConfigurer(namespaceId, adapterName,
                                                                              adapterConfig, templateSpec,
                                                                              pluginRepository, pluginInstantiator);
@@ -134,8 +132,6 @@ public final class InMemoryAdapterConfigurator implements Configurator {
           template.configureAdapter(adapterName, decodeConfig(adapterConfig, configType), configurer);
           AdapterDefinition spec = configurer.createSpecification();
           result.set(new DefaultConfigResponse(0, CharStreams.newReaderSupplier(GSON.toJson(spec))));
-        } finally {
-          Closeables.closeQuietly(pluginInstantiator);
         }
       } finally {
         removeDir(unpackedJarDir);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/adapter/ConfigureAdapterStage.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/adapter/ConfigureAdapterStage.java
@@ -93,11 +93,8 @@ public class ConfigureAdapterStage extends AbstractStage<AdapterDeploymentInfo> 
     if (configResponse.getExitCode() != 0 || configSupplier == null) {
       throw new IllegalArgumentException("Failed to configure adapter: " + deploymentInfo);
     }
-    Reader reader = configSupplier.getInput();
-    try {
+    try (Reader reader = configSupplier.getInput()) {
       emit(GSON.fromJson(reader, AdapterDefinition.class));
-    } finally {
-      Closeables.closeQuietly(reader);
     }
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/AdapterService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/AdapterService.java
@@ -64,7 +64,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.hash.HashCode;
 import com.google.common.hash.Hashing;
-import com.google.common.io.Closeables;
 import com.google.common.io.Files;
 import com.google.common.io.InputSupplier;
 import com.google.common.util.concurrent.AbstractIdleService;
@@ -706,11 +705,8 @@ public class AdapterService extends AbstractIdleService {
       throw new IllegalArgumentException("Failed to get template info");
     }
     ApplicationSpecification spec;
-    Reader configReader = configSupplier.getInput();
-    try {
+    try (Reader configReader = configSupplier.getInput()) {
       spec = GSON.fromJson(configReader, ApplicationSpecification.class);
-    } finally {
-      Closeables.closeQuietly(configReader);
     }
 
     // verify that the name is ok

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractDistributedProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractDistributedProgramRunner.java
@@ -244,21 +244,15 @@ public abstract class AbstractDistributedProgramRunner implements ProgramRunner 
 
 
   private File saveHConf(Configuration conf, File file) throws IOException {
-    Writer writer = Files.newWriter(file, Charsets.UTF_8);
-    try {
+    try (Writer writer = Files.newWriter(file, Charsets.UTF_8)) {
       conf.writeXml(writer);
-    } finally {
-      writer.close();
     }
     return file;
   }
 
   private File saveCConf(CConfiguration conf, File file) throws IOException {
-    Writer writer = Files.newWriter(file, Charsets.UTF_8);
-    try {
+    try (Writer writer = Files.newWriter(file, Charsets.UTF_8)) {
       conf.writeXml(writer);
-    } finally {
-      writer.close();
     }
     return file;
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/HttpHandlerGenerator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/HttpHandlerGenerator.java
@@ -147,8 +147,9 @@ final class HttpHandlerGenerator {
     Class<?> rawType = inspectType.getRawType();
 
     // Visit the delegate class, copy and rewrite handler method, with method body just do delegation
-    InputStream sourceBytes = rawType.getClassLoader().getResourceAsStream(Type.getInternalName(rawType) + ".class");
-    try {
+    try (
+      InputStream sourceBytes = rawType.getClassLoader().getResourceAsStream(Type.getInternalName(rawType) + ".class")
+    ) {
       ClassReader classReader = new ClassReader(sourceBytes);
       classReader.accept(new ClassVisitor(Opcodes.ASM4) {
 
@@ -207,8 +208,6 @@ final class HttpHandlerGenerator {
                                           exceptions, classType, classWriter, preservedClasses);
         }
       }, ClassReader.SKIP_DEBUG);
-    } finally {
-      sourceBytes.close();
     }
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkRuntimeService.java
@@ -37,7 +37,6 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.io.ByteStreams;
-import com.google.common.io.Closeables;
 import com.google.common.util.concurrent.AbstractExecutionThreadService;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapreduce.MRConfig;
@@ -337,13 +336,10 @@ final class SparkRuntimeService extends AbstractExecutionThreadService {
                                                                    context.getRunId().getId()));
 
     LOG.debug("Creating Spark Job Jar: {}", jobJarLocation.toURI());
-    JarOutputStream jarOut = new JarOutputStream(jobJarLocation.getOutputStream());
-    try {
+    try (JarOutputStream jarOut = new JarOutputStream(jobJarLocation.getOutputStream())) {
       // All we need is the serialized hConf in the job jar
       jarOut.putNextEntry(new JarEntry(SPARK_HCONF_FILENAME));
       conf.writeXml(jarOut);
-    } finally {
-      Closeables.closeQuietly(jarOut);
     }
 
     return jobJarLocation;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/webapp/JarExploder.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/webapp/JarExploder.java
@@ -35,9 +35,8 @@ public class JarExploder {
 
   public static int explode(File jarFile, File destDir, Predicate<JarEntry> filter) throws IOException {
     int count = 0;
-    final JarFile jar = new JarFile(jarFile);
 
-    try {
+    try (JarFile jar = new JarFile(jarFile)) {
       if (!DirUtils.mkdirs(destDir)) {
         throw new IOException(String.format("Cannot create destination dir %s", destDir.getAbsolutePath()));
       }
@@ -75,9 +74,6 @@ public class JarExploder {
       }
 
       return count;
-
-    } finally {
-      jar.close();
     }
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/webapp/WebappProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/webapp/WebappProgramRunner.java
@@ -153,8 +153,7 @@ public class WebappProgramRunner implements ProgramRunner {
   private static final String DEFAULT_DIR_NAME_COLON = ServePathGenerator.DEFAULT_DIR_NAME + ":";
 
   public static Set<String> getServingHostNames(InputSupplier<? extends InputStream> inputSupplier) throws Exception {
-    JarInputStream jarInput = new JarInputStream(inputSupplier.getInput());
-    try {
+    try (JarInputStream jarInput = new JarInputStream(inputSupplier.getInput())) {
       Set<String> hostNames = Sets.newHashSet();
       JarEntry jarEntry;
       String webappDir = Constants.Webapp.WEBAPP_DIR + "/";
@@ -183,8 +182,6 @@ public class WebappProgramRunner implements ProgramRunner {
       }
 
       return registerNames;
-    } finally {
-      Closeables.closeQuietly(jarInput);
     }
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/test/internal/AppFabricClient.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/test/internal/AppFabricClient.java
@@ -297,8 +297,7 @@ public class AppFabricClient {
     BodyConsumer bodyConsumer = appLifecycleHttpHandler.deploy(request, mockResponder, namespace.getId(), archiveName);
     Preconditions.checkNotNull(bodyConsumer, "BodyConsumer from deploy call should not be null");
 
-    BufferFileInputStream is = new BufferFileInputStream(deployedJar.getInputStream(), 100 * 1024);
-    try {
+    try (BufferFileInputStream is = new BufferFileInputStream(deployedJar.getInputStream(), 100 * 1024)) {
       byte[] chunk = is.read();
       while (chunk.length > 0) {
         mockResponder = new MockResponder();
@@ -311,8 +310,6 @@ public class AppFabricClient {
       verifyResponse(HttpResponseStatus.OK, mockResponder.getStatus(), "Failed to deploy app");
     } catch (Exception e) {
       throw Throwables.propagate(e);
-    } finally {
-      is.close();
     }
     return deployedJar;
   }

--- a/cdap-app-fabric/src/main/java/org/apache/hadoop/mapred/LocalJobRunnerWithFix.java
+++ b/cdap-app-fabric/src/main/java/org/apache/hadoop/mapred/LocalJobRunnerWithFix.java
@@ -167,11 +167,8 @@ public class LocalJobRunnerWithFix implements ClientProtocol {
       // Write out configuration file.  Instead of copying it from
       // systemJobFile, we re-write it, since setup(), above, may have
       // updated it.
-      OutputStream out = localFs.create(localJobFile);
-      try {
+      try (OutputStream out = localFs.create(localJobFile)) {
         conf.writeXml(out);
-      } finally {
-        out.close();
       }
       this.job = new JobConf(localJobFile);
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/sink/DBSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/sink/DBSink.java
@@ -133,18 +133,13 @@ public class DBSink extends BatchSink<StructuredRecord, DBRecord, NullWritable> 
       connection = DriverManager.getConnection(dbSinkConfig.connectionString, dbSinkConfig.user, dbSinkConfig.password);
     }
     try {
-      Statement statement = connection.createStatement();
-      try {
-        // Using LIMIT in the following query even though its not SQL standard since DBInputFormat already depends on it
+      // Using LIMIT in the following query even though its not SQL standard since DBInputFormat already depends on it
+      try (
+        Statement statement = connection.createStatement();
         ResultSet rs = statement.executeQuery(String.format("SELECT %s from %s LIMIT 1",
-                                                            dbSinkConfig.columns, dbSinkConfig.tableName));
-        try {
-          resultSetMetadata = rs.getMetaData();
-        } finally {
-          rs.close();
-        }
-      } finally {
-        statement.close();
+                                                            dbSinkConfig.columns, dbSinkConfig.tableName))
+      ) {
+        resultSetMetadata = rs.getMetaData();
       }
     } finally {
       connection.close();

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/common/DBRecord.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/common/DBRecord.java
@@ -247,14 +247,11 @@ public class DBRecord implements Writable, DBWritable {
           StringBuffer sbf = new StringBuffer();
           Clob clob = (Clob) original;
           try {
-            BufferedReader br = new BufferedReader(clob.getCharacterStream(1, (int) clob.length()));
-            try {
+            try (BufferedReader br = new BufferedReader(clob.getCharacterStream(1, (int) clob.length()))) {
               while ((s = br.readLine()) != null) {
                 sbf.append(s);
                 sbf.append(System.getProperty("line.separator"));
               }
-            } finally {
-              br.close();
             }
           } catch (IOException e) {
             throw new SQLException(e);

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/LoadPreferencesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/LoadPreferencesCommand.java
@@ -66,9 +66,8 @@ public class LoadPreferencesCommand extends AbstractSetPreferencesCommand {
       throw new IllegalArgumentException("Not a file: " + file);
     }
 
-    FileReader reader = new FileReader(file);
     Map<String, String> args = Maps.newHashMap();
-    try {
+    try (FileReader reader = new FileReader(file)) {
       if (contentType.equals("json")) {
         args = GSON.fromJson(reader, MAP_STRING_STRING_TYPE);
       } else {
@@ -77,8 +76,6 @@ public class LoadPreferencesCommand extends AbstractSetPreferencesCommand {
     } catch (JsonSyntaxException e) {
       throw new BadRequestException(
         String.format("Json Syntax in File is invalid. Support only for string-to-string map. %s", e.getMessage()));
-    } finally {
-      reader.close();
     }
 
     if (arguments.hasArgument(type.getArgumentName().toString())) {

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetStreamPropertiesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetStreamPropertiesCommand.java
@@ -25,14 +25,12 @@ import co.cask.cdap.internal.io.SchemaTypeAdapter;
 import co.cask.cdap.proto.StreamProperties;
 import co.cask.common.cli.Arguments;
 import com.google.common.base.Charsets;
+import com.google.common.io.Files;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.inject.Inject;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileReader;
-import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.io.Reader;
 
@@ -61,14 +59,11 @@ public class SetStreamPropertiesCommand extends AbstractAuthCommand {
       throw new IllegalArgumentException("Not a file: " + file);
     }
 
-    Reader reader = new InputStreamReader(new FileInputStream(file), Charsets.UTF_8);
     StreamProperties streamProperties;
-    try {
-      streamProperties = GSON.fromJson(new FileReader(file), StreamProperties.class);
+    try (Reader reader = Files.newReader(file, Charsets.UTF_8)) {
+      streamProperties = GSON.fromJson(reader, StreamProperties.class);
     } catch (Exception e) {
       throw new IllegalArgumentException("Stream properties are malformed.", e);
-    } finally {
-      reader.close();
     }
 
     streamClient.setStreamProperties(streamId, streamProperties);

--- a/cdap-common/src/main/java/co/cask/cdap/common/lang/DirectoryClassLoader.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/lang/DirectoryClassLoader.java
@@ -20,7 +20,6 @@ import co.cask.cdap.common.utils.DirUtils;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
-import com.google.common.io.Closeables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,11 +64,10 @@ public class DirectoryClassLoader extends URLClassLoader {
     // Try to load the Manifest from the unpacked directory
     Manifest manifest = null;
     try {
-      InputStream input = new FileInputStream(new File(dir, JarFile.MANIFEST_NAME.replace('/', File.separatorChar)));
-      try {
+      try (
+        InputStream input = new FileInputStream(new File(dir, JarFile.MANIFEST_NAME.replace('/', File.separatorChar)))
+      ) {
         manifest = new Manifest(input);
-      } finally {
-        Closeables.closeQuietly(input);
       }
     } catch (IOException e) {
       // Ignore, since it's possible that there is no MANIFEST

--- a/cdap-common/src/main/java/co/cask/cdap/common/lang/jar/BundleJarUtil.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/lang/jar/BundleJarUtil.java
@@ -55,17 +55,13 @@ public class BundleJarUtil {
 
     // Small optimization if the location is local
     if ("file".equals(uri.getScheme())) {
-      JarFile jarFile = new JarFile(new File(uri));
-      try {
+      try (JarFile jarFile = new JarFile(new File(uri))) {
         return jarFile.getManifest();
-      } finally {
-        jarFile.close();
       }
     }
 
     // Otherwise, need to search it with JarInputStream
-    JarInputStream is = new JarInputStream(new BufferedInputStream(jarLocation.getInputStream()));
-    try {
+    try (JarInputStream is = new JarInputStream(new BufferedInputStream(jarLocation.getInputStream()))) {
       // This only looks at the first entry, which if is created with jar util, then it'll be there.
       Manifest manifest = is.getManifest();
       if (manifest != null) {
@@ -81,8 +77,6 @@ public class BundleJarUtil {
         jarEntry = is.getNextJarEntry();
       }
 
-    } finally {
-      is.close();
     }
 
     return null;
@@ -175,12 +169,9 @@ public class BundleJarUtil {
 
     destinationFolder.mkdirs();
     Preconditions.checkState(destinationFolder.exists());
-    ZipInputStream input = new ZipInputStream(inputSupplier.getInput());
-    try {
+    try (ZipInputStream input = new ZipInputStream(inputSupplier.getInput())) {
       unJar(input, destinationFolder);
       return destinationFolder;
-    } finally {
-      Closeables.closeQuietly(input);
     }
   }
 

--- a/cdap-common/src/main/java/co/cask/cdap/common/lang/jar/JarResources.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/lang/jar/JarResources.java
@@ -140,8 +140,7 @@ public final class JarResources {
    * initializes internal hash tables with Jar file resources.
    */
   private Manifest init(Location jarLocation) throws IOException {
-    JarInputStream jarInput = new JarInputStream(new BufferedInputStream(jarLocation.getInputStream()));
-    try {
+    try (JarInputStream jarInput = new JarInputStream(new BufferedInputStream(jarLocation.getInputStream()))) {
       Manifest manifest = jarInput.getManifest();
       JarEntry ze;
       // For each ".class" entry in the jar file, read the bytes and stores it in the classContents map.
@@ -184,8 +183,6 @@ public final class JarResources {
       }
       return manifest;
 
-    } finally {
-      jarInput.close();
     }
   }
 }

--- a/cdap-common/src/main/java/co/cask/cdap/common/logging/LogFileReader.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/logging/LogFileReader.java
@@ -104,16 +104,13 @@ public class LogFileReader implements LogReader {
 
     // open current file for reading
     byte[] bytes = new byte[(int) bytesToRead];
-    FSDataInputStream input = fileSystem.open(path);
-    try {
+    try (FSDataInputStream input = fileSystem.open(path)) {
       // seek into latest file
       if (seekPos > 0) {
         input.seek(seekPos);
       }
       // read to the end of current file
       input.readFully(bytes);
-    } finally {
-      input.close();
     }
     int pos = 0;
     if (seekPos > 0) {
@@ -144,8 +141,7 @@ public class LogFileReader implements LogReader {
 
   private long determineTrueFileSize(Path path, FileStatus status)
       throws IOException {
-    FSDataInputStream stream = fileSystem.open(path);
-    try {
+    try (FSDataInputStream stream = fileSystem.open(path)) {
       stream.seek(status.getLen());
       // we need to read repeatedly until we reach the end of the file
       byte[] buffer = new byte[1024 * 1024];
@@ -154,8 +150,6 @@ public class LogFileReader implements LogReader {
       }
       long trueSize = stream.getPos();
       return trueSize;
-    } finally {
-      stream.close();
     }
   }
 

--- a/cdap-common/src/main/java/co/cask/cdap/common/twill/TwillRunnerMain.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/twill/TwillRunnerMain.java
@@ -241,21 +241,15 @@ public abstract class TwillRunnerMain extends DaemonMain {
   }
 
   private static File saveHConf(Configuration conf, File file) throws IOException {
-    Writer writer = Files.newWriter(file, Charsets.UTF_8);
-    try {
+    try (Writer writer = Files.newWriter(file, Charsets.UTF_8)) {
       conf.writeXml(writer);
-    } finally {
-      writer.close();
     }
     return file;
   }
 
   private File saveCConf(CConfiguration conf, File file) throws IOException {
-    Writer writer = Files.newWriter(file, Charsets.UTF_8);
-    try {
+    try (Writer writer = Files.newWriter(file, Charsets.UTF_8)) {
       conf.writeXml(writer);
-    } finally {
-      writer.close();
     }
     return file;
   }

--- a/cdap-common/src/main/java/co/cask/cdap/common/utils/Networks.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/utils/Networks.java
@@ -54,11 +54,8 @@ public final class Networks {
    */
   public static int getRandomPort() {
     try {
-      ServerSocket socket = new ServerSocket(0);
-      try {
+      try (ServerSocket socket = new ServerSocket(0)) {
         return socket.getLocalPort();
-      } finally {
-        socket.close();
       }
     } catch (IOException e) {
       return -1;

--- a/cdap-common/src/main/java/co/cask/cdap/common/utils/ProjectInfo.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/utils/ProjectInfo.java
@@ -38,8 +38,7 @@ public final class ProjectInfo {
     Version version = new Version(null);
     try {
       Properties buildProp = new Properties();
-      InputStream input = ProjectInfo.class.getResourceAsStream("/build.properties");
-      try {
+      try (InputStream input = ProjectInfo.class.getResourceAsStream("/build.properties")) {
         buildProp.load(input);
 
         String versionStr = buildProp.getProperty("project.info.version");
@@ -49,8 +48,6 @@ public final class ProjectInfo {
           long buildTime = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ").parse(buildTimeStr).getTime();
           version = new Version(String.format("%s-%d", versionStr, buildTime));
         }
-      } finally {
-        input.close();
       }
     } catch (Exception e) {
       LOG.warn("No BuildInfo available: {}", e.getMessage(), e);

--- a/cdap-common/src/main/java/co/cask/cdap/internal/test/AppJarHelper.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/test/AppJarHelper.java
@@ -65,48 +65,42 @@ public final class AppJarHelper {
 
     // Create the program jar for deployment. It removes the "classes/" prefix as that's the convention taken
     // by the ApplicationBundler inside Twill.
-    JarOutputStream jarOutput = new JarOutputStream(deployJar.getOutputStream(), jarManifest);
-    try {
-      JarInputStream jarInput = new JarInputStream(jarLocation.getInputStream());
-      try {
-        JarEntry jarEntry = jarInput.getNextJarEntry();
-        while (jarEntry != null) {
-          boolean isDir = jarEntry.isDirectory();
-          String entryName = jarEntry.getName();
-          if (!entryName.equals("classes/")) {
-            if (entryName.startsWith("classes/")) {
-              jarEntry = new JarEntry(entryName.substring("classes/".length()));
-            } else {
-              jarEntry = new JarEntry(entryName);
-            }
-
-            // TODO: this is due to manifest possibly already existing in the jar, but we also
-            // create a manifest programatically so it's possible to have a duplicate entry here
-            if ("META-INF/MANIFEST.MF".equalsIgnoreCase(jarEntry.getName())) {
-              jarEntry = jarInput.getNextJarEntry();
-              continue;
-            }
-
-            jarOutput.putNextEntry(jarEntry);
-            if (!isDir) {
-              ByteStreams.copy(jarInput, jarOutput);
-            }
+    try (
+      JarOutputStream jarOutput = new JarOutputStream(deployJar.getOutputStream(), jarManifest);
+      JarInputStream jarInput = new JarInputStream(jarLocation.getInputStream())
+    ) {
+      JarEntry jarEntry = jarInput.getNextJarEntry();
+      while (jarEntry != null) {
+        boolean isDir = jarEntry.isDirectory();
+        String entryName = jarEntry.getName();
+        if (!entryName.equals("classes/")) {
+          if (entryName.startsWith("classes/")) {
+            jarEntry = new JarEntry(entryName.substring("classes/".length()));
+          } else {
+            jarEntry = new JarEntry(entryName);
           }
 
-          jarEntry = jarInput.getNextJarEntry();
+          // TODO: this is due to manifest possibly already existing in the jar, but we also
+          // create a manifest programatically so it's possible to have a duplicate entry here
+          if ("META-INF/MANIFEST.MF".equalsIgnoreCase(jarEntry.getName())) {
+            jarEntry = jarInput.getNextJarEntry();
+            continue;
+          }
+
+          jarOutput.putNextEntry(jarEntry);
+          if (!isDir) {
+            ByteStreams.copy(jarInput, jarOutput);
+          }
         }
-      } finally {
-        jarInput.close();
+
+        jarEntry = jarInput.getNextJarEntry();
       }
 
       for (File embeddedJar : bundleEmbeddedJars) {
-        JarEntry jarEntry = new JarEntry("lib/" + embeddedJar.getName());
+        jarEntry = new JarEntry("lib/" + embeddedJar.getName());
         jarOutput.putNextEntry(jarEntry);
         Files.copy(embeddedJar, jarOutput);
       }
-
-    } finally {
-      jarOutput.close();
     }
 
     return deployJar;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamDataFileIndex.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamDataFileIndex.java
@@ -19,7 +19,6 @@ import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.common.io.BinaryDecoder;
 import com.google.common.collect.Maps;
 import com.google.common.io.ByteStreams;
-import com.google.common.io.Closeables;
 import com.google.common.io.InputSupplier;
 import com.google.common.primitives.Longs;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
@@ -60,11 +59,8 @@ final class StreamDataFileIndex {
     // Load the whole index into memory.
     try {
       Map.Entry<LongList, LongList> index;
-      InputStream indexInput = indexInputSupplier.getInput();
-      try {
+      try (InputStream indexInput = indexInputSupplier.getInput()) {
         index = loadIndex(indexInput);
-      } finally {
-        Closeables.closeQuietly(indexInput);
       }
       timestamps = LongLists.unmodifiable(index.getKey());
       positions = LongLists.unmodifiable(index.getValue());

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamFetchHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamFetchHandler.java
@@ -122,8 +122,7 @@ public final class StreamFetchHandler extends AuthenticatedHttpHandler {
     endTime = Math.min(endTime, now);
 
     // Create the stream event reader
-    FileReader<StreamEventOffset, Iterable<StreamFileOffset>> reader = createReader(streamConfig, startTime);
-    try {
+    try (FileReader<StreamEventOffset, Iterable<StreamFileOffset>> reader = createReader(streamConfig, startTime)) {
       TimeRangeReadFilter readFilter = new TimeRangeReadFilter(startTime, endTime);
       List<StreamEvent> events = Lists.newArrayListWithCapacity(100);
 
@@ -177,8 +176,6 @@ public final class StreamFetchHandler extends AuthenticatedHttpHandler {
         chunkResponder.sendChunk(buffer);
       }
       Closeables.closeQuietly(chunkResponder);
-    } finally {
-      reader.close();
     }
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/upload/AvroStreamBodyConsumer.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/upload/AvroStreamBodyConsumer.java
@@ -145,8 +145,7 @@ final class AvroStreamBodyConsumer extends BodyConsumer {
     public void run() {
       try {
         // Create an Avro reader from the given content stream.
-        DataFileStream<Object> reader = new DataFileStream<Object>(contentStream, new DummyDatumReader());
-        try {
+        try (DataFileStream<Object> reader = new DataFileStream<Object>(contentStream, new DummyDatumReader())) {
           Schema schema = reader.getSchema();
           DecoderFactory decoderFactory = DecoderFactory.get();
           ByteBufferInputStream blockInput = new ByteBufferInputStream(ByteBuffers.EMPTY_BUFFER);
@@ -193,8 +192,6 @@ final class AvroStreamBodyConsumer extends BodyConsumer {
             contentWriter.cancel();
             throw t;
           }
-        } finally {
-          Closeables.closeQuietly(reader);
         }
       } catch (Throwable t) {
         failure = t;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/type/DistributedDatasetTypeClassLoaderFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/type/DistributedDatasetTypeClassLoaderFactory.java
@@ -101,11 +101,8 @@ public class DistributedDatasetTypeClassLoaderFactory implements DatasetTypeClas
     File tmpJar = File.createTempFile(jarLocation.getName(), null);
     try {
       MessageDigest messageDigest = MESSAGE_DIGEST.get();
-      DigestOutputStream digestOutput = new DigestOutputStream(new FileOutputStream(tmpJar), messageDigest);
-      try {
+      try (DigestOutputStream digestOutput = new DigestOutputStream(new FileOutputStream(tmpJar), messageDigest)) {
         ByteStreams.copy(Locations.newInputSupplier(jarLocation), digestOutput);
-      } finally {
-        digestOutput.close();
       }
 
       // The folder name to expand to is formed by the module name and the checksum.

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableCore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableCore.java
@@ -223,12 +223,9 @@ public class LevelDBTableCore {
 
     byte[] startKey = createStartKey(row, columns == null ? startCol : columns[0]);
     byte[] endKey = createEndKey(row, columns == null ? stopCol : upperBound(columns[columns.length - 1]));
-    DBIterator iterator = getDB().iterator();
-    try {
+    try (DBIterator iterator = getDB().iterator()) {
       iterator.seek(startKey);
       return getRow(iterator, endKey, tx, false, columns, limit).getSecond();
-    } finally {
-      iterator.close();
     }
   }
 
@@ -333,8 +330,7 @@ public class LevelDBTableCore {
     Preconditions.checkNotNull(prefix, "prefix must not be null");
     DB db = getDB();
     WriteBatch batch = db.createWriteBatch();
-    DBIterator iterator = db.iterator();
-    try {
+    try (DBIterator iterator = db.iterator()) {
       iterator.seek(createStartKey(prefix));
       while (iterator.hasNext()) {
         Map.Entry<byte[], byte[]> entry = iterator.next();
@@ -345,8 +341,6 @@ public class LevelDBTableCore {
         batch.delete(entry.getKey());
       }
       db.write(batch);
-    } finally {
-      iterator.close();
     }
   }
 
@@ -363,9 +357,8 @@ public class LevelDBTableCore {
     byte[] currentRow = rows.next();
     byte[] startKey = createStartKey(currentRow);
     DB db = getDB();
-    DBIterator iterator = db.iterator();
     WriteBatch batch = db.createWriteBatch();
-    try {
+    try (DBIterator iterator = db.iterator()) {
       iterator.seek(startKey);
       if (!iterator.hasNext()) {
         return; // nothing in the db to delete
@@ -389,8 +382,6 @@ public class LevelDBTableCore {
           entry = iterator.hasNext() ? iterator.next() : null;
         }
       }
-    } finally {
-      iterator.close();
     }
     // delete all the entries that were found
     db.write(batch, getWriteOptions());
@@ -450,12 +441,9 @@ public class LevelDBTableCore {
   public void deleteColumn(byte[] row, byte[] column) throws IOException {
     DB db = getDB();
     WriteBatch batch = db.createWriteBatch();
-    DBIterator iterator = db.iterator();
-    try {
+    try (DBIterator iterator = db.iterator()) {
       addToDeleteBatch(batch, iterator, row, column);
       db.write(batch);
-    } finally {
-      iterator.close();
     }
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/TransactionManagerDebuggerMain.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/TransactionManagerDebuggerMain.java
@@ -388,13 +388,10 @@ public class TransactionManagerDebuggerMain {
     try {
       System.out.println("Retrieving snapshot from file " + existingFilename);
       File snapshotFile = new File(existingFilename);
-      FileInputStream fis = new FileInputStream(snapshotFile);
-      try {
+      try (FileInputStream fis = new FileInputStream(snapshotFile)) {
         TransactionSnapshot snapshot = codecProvider.decode(fis);
         System.out.println("Snapshot retrieved, timestamp is " + snapshot.getTimestamp() + " ms.");
         return snapshot;
-      } finally {
-        fis.close();
       }
     } catch (IOException e) {
       System.out.println("File " + existingFilename + " could not be read.");
@@ -422,12 +419,9 @@ public class TransactionManagerDebuggerMain {
       int responseCode = connection.getResponseCode();
       if (responseCode == 200) {
         // Retrieve and deserialize the snapshot
-        InputStream input = connection.getInputStream();
         TransactionSnapshot snapshot;
-        try {
+        try (InputStream input = connection.getInputStream()) {
           snapshot = codecProvider.decode(input);
-        } finally {
-          input.close();
         }
         System.out.println("Snapshot taken and retrieved properly, snapshot timestamp is " +
                            snapshot.getTimestamp() + " ms");
@@ -435,12 +429,9 @@ public class TransactionManagerDebuggerMain {
         if (persistingFilename != null) {
           // Persist the snapshot on disk for future queries and debugging
           File outputFile = new File(persistingFilename);
-          OutputStream out = new FileOutputStream(outputFile);
-          try {
+          try (OutputStream out = new FileOutputStream(outputFile)) {
             // todo use pipes here to avoid having everyhting in memory twice
             codecProvider.encode(out, snapshot);
-          } finally {
-            out.close();
           }
           System.out.println("Snapshot persisted on your disk as " + outputFile.getAbsolutePath() +
                              " for future queries.");

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueAdmin.java
@@ -160,11 +160,8 @@ public class HBaseQueueAdmin extends AbstractQueueAdmin {
     createStateStoreDataset(queueName.getFirstComponent());
 
     TableId tableId = getDataTableId(queueName);
-    DatasetAdmin dsAdmin = new DatasetAdmin(tableId, hConf, tableUtil, properties);
-    try {
+    try (DatasetAdmin dsAdmin = new DatasetAdmin(tableId, hConf, tableUtil, properties)) {
       dsAdmin.create();
-    } finally {
-      dsAdmin.close();
     }
   }
 
@@ -370,11 +367,8 @@ public class HBaseQueueAdmin extends AbstractQueueAdmin {
   }
 
   private void upgrade(TableId tableId, Properties properties) throws Exception {
-    AbstractHBaseDataSetAdmin dsAdmin = new DatasetAdmin(tableId, hConf, tableUtil, properties);
-    try {
+    try (AbstractHBaseDataSetAdmin dsAdmin = new DatasetAdmin(tableId, hConf, tableUtil, properties)) {
       dsAdmin.upgrade();
-    } finally {
-      dsAdmin.close();
     }
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueClientFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueClientFactory.java
@@ -126,8 +126,7 @@ public class HBaseQueueClientFactory implements QueueClientFactory {
         @Override
         public List<HBaseQueueConsumer> call() throws Exception {
           List<HBaseConsumerState> states;
-          final HBaseConsumerStateStore stateStore = admin.getConsumerStateStore(queueName);
-          try {
+          try (HBaseConsumerStateStore stateStore = admin.getConsumerStateStore(queueName)) {
             TransactionExecutor txExecutor = Transactions.createTransactionExecutor(txExecutorFactory, stateStore);
 
             // Find all consumer states for consumers that need to be created based on current state
@@ -155,7 +154,7 @@ public class HBaseQueueClientFactory implements QueueClientFactory {
                   @Override
                   public boolean apply(QueueBarrier barrier) {
                     return barrier.getGroupConfig().getGroupSize() > consumerConfig.getInstanceId()
-                            && stateStore.isAllConsumed(consumerConfig, barrier.getStartRow());
+                      && stateStore.isAllConsumed(consumerConfig, barrier.getStartRow());
                   }
                 }, queueBarriers.get(0));
 
@@ -166,9 +165,6 @@ public class HBaseQueueClientFactory implements QueueClientFactory {
                 return consumerStates;
               }
             });
-
-          } finally {
-            Closeables.closeQuietly(stateStore);
           }
 
           List<HBaseQueueConsumer> consumers = Lists.newArrayList();

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/FileStreamAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/FileStreamAdmin.java
@@ -131,8 +131,7 @@ public class FileStreamAdmin implements StreamAdmin {
     LOG.info("Configure instances: {} {}", groupId, instances);
 
     StreamConfig config = StreamUtils.ensureExists(this, streamId);
-    StreamConsumerStateStore stateStore = stateStoreFactory.create(config);
-    try {
+    try (StreamConsumerStateStore stateStore = stateStoreFactory.create(config)) {
       Set<StreamConsumerState> states = Sets.newHashSet();
       stateStore.getByGroup(groupId, states);
 
@@ -149,9 +148,6 @@ public class FileStreamAdmin implements StreamAdmin {
         stateStore.remove(removeStates);
         LOG.info("Configure instances remove states: {} {} {}", groupId, instances, removeStates);
       }
-
-    } finally {
-      stateStore.close();
     }
   }
 
@@ -162,8 +158,7 @@ public class FileStreamAdmin implements StreamAdmin {
     LOG.info("Configure groups for {}: {}", streamId, groupInfo);
 
     StreamConfig config = StreamUtils.ensureExists(this, streamId);
-    StreamConsumerStateStore stateStore = stateStoreFactory.create(config);
-    try {
+    try (StreamConsumerStateStore stateStore = stateStoreFactory.create(config)) {
       Set<StreamConsumerState> states = Sets.newHashSet();
       stateStore.getAll(states);
 
@@ -198,9 +193,6 @@ public class FileStreamAdmin implements StreamAdmin {
         stateStore.remove(removeStates);
         LOG.info("Configure groups remove states: {} {}", groupInfo, removeStates);
       }
-
-    } finally {
-      stateStore.close();
     }
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseStreamConsumerStateStoreFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseStreamConsumerStateStoreFactory.java
@@ -52,9 +52,9 @@ public final class HBaseStreamConsumerStateStoreFactory implements StreamConsume
   public synchronized StreamConsumerStateStore create(StreamConfig streamConfig) throws IOException {
     Id.Namespace namespace = streamConfig.getStreamId().getNamespace();
     TableId streamStateStoreTableId = StreamUtils.getStateStoreTableId(namespace);
-    HBaseAdmin admin = new HBaseAdmin(hConf);
-    if (!tableUtil.tableExists(admin, streamStateStoreTableId)) {
-      try {
+    try (HBaseAdmin admin = new HBaseAdmin(hConf)) {
+      if (!tableUtil.tableExists(admin, streamStateStoreTableId)) {
+
         HTableDescriptor htd = tableUtil.createHTableDescriptor(streamStateStoreTableId);
 
         HColumnDescriptor hcd = new HColumnDescriptor(QueueEntryRow.COLUMN_FAMILY);
@@ -63,8 +63,6 @@ public final class HBaseStreamConsumerStateStoreFactory implements StreamConsume
 
         tableUtil.createTableIfNotExists(admin, streamStateStoreTableId, htd, null,
                                          QueueConstants.MAX_CREATE_TABLE_WAIT, TimeUnit.MILLISECONDS);
-      } finally {
-        admin.close();
       }
     }
 
@@ -76,14 +74,11 @@ public final class HBaseStreamConsumerStateStoreFactory implements StreamConsume
 
   @Override
   public synchronized void dropAllInNamespace(Id.Namespace namespace) throws IOException {
-    HBaseAdmin admin = new HBaseAdmin(hConf);
-    try {
+    try (HBaseAdmin admin = new HBaseAdmin(hConf)) {
       TableId tableId = StreamUtils.getStateStoreTableId(namespace);
       if (tableUtil.tableExists(admin, tableId)) {
         tableUtil.dropTable(admin, tableId);
       }
-    } finally {
-      admin.close();
     }
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseTableUtil.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseTableUtil.java
@@ -276,32 +276,23 @@ public abstract class HBaseTableUtil {
       LOG.debug("Adding " + dependentClasses.size() + " classes to jar");
       File jarFile = File.createTempFile(filePrefix, ".jar");
       try {
-        JarOutputStream jarOutput = null;
-        try {
-          jarOutput = new JarOutputStream(new FileOutputStream(jarFile));
+        try (JarOutputStream jarOutput = new JarOutputStream(new FileOutputStream(jarFile))) {
           for (Map.Entry<String, URL> entry : dependentClasses.entrySet()) {
             try {
               jarOutput.putNextEntry(new JarEntry(entry.getKey().replace('.', File.separatorChar) + ".class"));
-              InputStream inputStream = entry.getValue().openStream();
 
-              try {
+              try (InputStream inputStream = entry.getValue().openStream()) {
                 int len = inputStream.read(buffer);
                 while (len >= 0) {
                   hasher.putBytes(buffer, 0, len);
                   jarOutput.write(buffer, 0, len);
                   len = inputStream.read(buffer);
                 }
-              } finally {
-                inputStream.close();
               }
             } catch (IOException e) {
               LOG.info("Error writing to jar", e);
               throw Throwables.propagate(e);
             }
-          }
-        } finally {
-          if (jarOutput != null) {
-            jarOutput.close();
           }
         }
 

--- a/cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetService.java
+++ b/cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetService.java
@@ -101,11 +101,8 @@ public class FileSetService extends AbstractService {
       Location location = fileSet.getLocation(filePath);
 
       try {
-        WritableByteChannel channel = Channels.newChannel(location.getOutputStream());
-        try {
+        try (WritableByteChannel channel = Channels.newChannel(location.getOutputStream())) {
           channel.write(request.getContent());
-        } finally {
-          channel.close();
         }
       } catch (IOException e) {
         responder.sendError(400, String.format("Unable to write path '%s' in file set '%s'", filePath, set));

--- a/cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/UploadService.java
+++ b/cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/UploadService.java
@@ -103,11 +103,8 @@ public class UploadService extends AbstractService {
       PartitionOutput output = results.getPartitionOutput(key);
       try {
         Location location = output.getLocation().append("file");
-        WritableByteChannel channel = Channels.newChannel(location.getOutputStream());
-        try {
+        try (WritableByteChannel channel = Channels.newChannel(location.getOutputStream())) {
           channel.write(request.getContent());
-        } finally {
-          channel.close();
         }
       } catch (IOException e) {
         responder.sendError(400, String.format("Unable to write path '%s'", output.getRelativePath()));

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/executor/AbstractExploreMetadataHttpHandler.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/executor/AbstractExploreMetadataHttpHandler.java
@@ -80,15 +80,12 @@ public class AbstractExploreMetadataHttpHandler extends AbstractHttpHandler {
     if (!content.readable()) {
       return defaultValue;
     }
-    Reader reader = new InputStreamReader(new ChannelBufferInputStream(content), Charsets.UTF_8);
-    try {
+    try (Reader reader = new InputStreamReader(new ChannelBufferInputStream(content), Charsets.UTF_8)) {
       T args = GSON.fromJson(reader, argsType);
       return (args == null) ? defaultValue : args;
     } catch (JsonSyntaxException e) {
       LOG.info("Failed to parse runtime arguments on {}", request.getUri(), e);
       throw e;
-    } finally {
-      reader.close();
     }
   }
 

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/executor/AbstractQueryExecutorHttpHandler.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/executor/AbstractQueryExecutorHttpHandler.java
@@ -92,15 +92,12 @@ public class AbstractQueryExecutorHttpHandler extends AbstractHttpHandler {
     if (!content.readable()) {
       return ImmutableMap.of();
     }
-    Reader reader = new InputStreamReader(new ChannelBufferInputStream(content), Charsets.UTF_8);
-    try {
+    try (Reader reader = new InputStreamReader(new ChannelBufferInputStream(content), Charsets.UTF_8)) {
       Map<String, String> args = GSON.fromJson(reader, STRING_MAP_TYPE);
       return args == null ? ImmutableMap.<String, String>of() : args;
     } catch (JsonSyntaxException e) {
       LOG.info("Failed to parse runtime arguments on {}", request.getUri(), e);
       throw e;
-    } finally {
-      reader.close();
     }
   }
 

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/BaseHiveExploreService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/BaseHiveExploreService.java
@@ -861,14 +861,11 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
       try {
         // Create preview results for query
         previewFile = new File(previewsDir, handle.getHandle());
-        FileWriter fileWriter = new FileWriter(previewFile);
-        try {
+        try (FileWriter fileWriter = new FileWriter(previewFile)) {
           List<QueryResult> results = fetchNextResults(handle, PREVIEW_COUNT);
           GSON.toJson(results, fileWriter);
           operationInfo.setPreviewFile(previewFile);
           return results;
-        } finally {
-          Closeables.closeQuietly(fileWriter);
         }
       } catch (IOException e) {
         LOG.error("Could not write preview results into file", e);

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/datasets/DatasetAccessor.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/datasets/DatasetAccessor.java
@@ -128,8 +128,7 @@ public class DatasetAccessor {
    * @throws IOException in case the conf does not contain a valid RecordScannable.
    */
   private static Type getRecordType(Configuration conf, Id.DatasetInstance id) throws IOException {
-    Dataset dataset = instantiate(conf, id);
-    try {
+    try (Dataset dataset = instantiate(conf, id)) {
       if (dataset instanceof RecordWritable) {
         return ((RecordWritable) dataset).getRecordType();
       } else if (dataset instanceof RecordScannable) {
@@ -138,8 +137,6 @@ public class DatasetAccessor {
       throw new IOException(
         String.format("Dataset %s does not implement neither RecordScannable nor RecordWritable.",
                       getDatasetInstanceId(conf)));
-    } finally {
-      dataset.close();
     }
   }
 

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
@@ -618,21 +618,15 @@ public class MasterServiceMain extends DaemonMain {
   }
 
   private static File saveHConf(Configuration conf, File file) throws IOException {
-    Writer writer = Files.newWriter(file, Charsets.UTF_8);
-    try {
+    try (Writer writer = Files.newWriter(file, Charsets.UTF_8)) {
       conf.writeXml(writer);
-    } finally {
-      writer.close();
     }
     return file;
   }
 
   private File saveCConf(CConfiguration conf, File file) throws IOException {
-    Writer writer = Files.newWriter(file, Charsets.UTF_8);
-    try {
+    try (Writer writer = Files.newWriter(file, Charsets.UTF_8)) {
       conf.writeXml(writer);
-    } finally {
-      writer.close();
     }
     return file;
   }

--- a/cdap-security/src/main/java/co/cask/cdap/security/tools/SSLHandlerFactory.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/tools/SSLHandlerFactory.java
@@ -49,11 +49,8 @@ public class SSLHandlerFactory {
 
     try {
       KeyStore ks = KeyStore.getInstance(keyStoreType);
-      InputStream inputStream = new FileInputStream(keyStore);
-      try {
+      try (InputStream inputStream = new FileInputStream(keyStore)) {
         ks.load(inputStream, keyStorePassword.toCharArray());
-      } finally {
-        inputStream.close();
       }
       // Set up key manager factory to use our key store
       KeyManagerFactory kmf = KeyManagerFactory.getInstance(algorithm);

--- a/cdap-standalone/src/main/java/co/cask/cdap/UserInterfaceService.java
+++ b/cdap-standalone/src/main/java/co/cask/cdap/UserInterfaceService.java
@@ -105,11 +105,8 @@ final class UserInterfaceService extends AbstractExecutionThreadService {
   }
 
   private void generateConfigFile(File path, Configuration config) throws Exception {
-    Writer configWriter = Files.newWriter(path, Charsets.UTF_8);
-    try {
+    try (Writer configWriter = Files.newWriter(path, Charsets.UTF_8)) {
       ConfigurationJsonTool.exportToJson(config, configWriter);
-    } finally {
-      configWriter.close();
     }
   }
 

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/UnitTestManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/UnitTestManager.java
@@ -201,11 +201,8 @@ public class UnitTestManager implements TestManager {
       json.add("properties", GSON.toJsonTree(properties));
     }
     File configFile = new File(templateDir, fileName);
-    Writer writer = Files.newWriter(configFile, Charsets.UTF_8);
-    try {
+    try (Writer writer = Files.newWriter(configFile, Charsets.UTF_8)) {
       GSON.toJson(Lists.newArrayList(json), writer);
-    } finally {
-      writer.close();
     }
   }
 

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
@@ -49,7 +49,6 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.google.common.io.Closeables;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import org.junit.Assert;
@@ -849,12 +848,11 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
 
   private String callServiceGet(URL serviceURL, String path) throws IOException {
     HttpURLConnection connection = (HttpURLConnection) new URL(serviceURL.toString() + path).openConnection();
-    BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream(), Charsets.UTF_8));
-    try {
+    try (
+      BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream(), Charsets.UTF_8))
+    ) {
       Assert.assertEquals(200, connection.getResponseCode());
       return reader.readLine();
-    } finally {
-      Closeables.closeQuietly(reader);
     }
   }
 
@@ -865,12 +863,11 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     OutputStreamWriter out = new OutputStreamWriter(connection.getOutputStream());
     out.write(body);
     out.close();
-    BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream(), Charsets.UTF_8));
-    try {
+    try (
+      BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream(), Charsets.UTF_8))
+    ) {
       Assert.assertEquals(200, connection.getResponseCode());
       return reader.readLine();
-    } finally {
-      Closeables.closeQuietly(reader);
     }
   }
 }

--- a/cdap-unit-test/src/test/java/net/fake/test/app/TestBundleJarApp.java
+++ b/cdap-unit-test/src/test/java/net/fake/test/app/TestBundleJarApp.java
@@ -26,7 +26,6 @@ import co.cask.cdap.test.StreamManager;
 import co.cask.cdap.test.TestBase;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.io.Closeables;
 import com.google.gson.Gson;
 import org.junit.Assert;
 import org.junit.Test;
@@ -84,11 +83,10 @@ public class TestBundleJarApp extends TestBase {
 
   private String callServiceGet(URL serviceURL, String path) throws IOException {
     URLConnection connection = new URL(serviceURL.toString() + path).openConnection();
-    BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream(), Charsets.UTF_8));
-    try {
+    try (
+      BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream(), Charsets.UTF_8))
+    ) {
       return reader.readLine();
-    } finally {
-      Closeables.closeQuietly(reader);
     }
   }
 }


### PR DESCRIPTION
- Better error handling
  - Exception from Closeable.close() won’t shadow the actual IOException
- Not using Closelables.closeQuietly so that error on close is still
  available in the stacktrace (record as suppressed exception)

Mainly main classes are done. Most test classes are not changed