### PR TITLE
CDAP-2422: Remove redundant catch blocks in AdapterHttpHandler

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/AdapterAlreadyExistsException.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/AdapterAlreadyExistsException.java
@@ -16,10 +16,12 @@
 
 package co.cask.cdap.internal.app.runtime.adapter;
 
+import co.cask.cdap.common.exception.ConflictException;
+
 /**
  * Thrown when Adapter creation is requested, but an adapter already exists.
  */
-public class AdapterAlreadyExistsException extends Exception {
+public class AdapterAlreadyExistsException extends ConflictException {
   public AdapterAlreadyExistsException(String adapterName) {
     super(String.format("Adapter %s already exists.", adapterName));
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/InvalidAdapterOperationException.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/InvalidAdapterOperationException.java
@@ -16,11 +16,13 @@
 
 package co.cask.cdap.internal.app.runtime.adapter;
 
+import co.cask.cdap.common.exception.ConflictException;
+
 /**
  * Thrown when an invalid adapter action occurs. For instance, if an adapter 'stop' is requested, but the adapter is
  * already stopped.
  */
-public class InvalidAdapterOperationException extends Exception {
+public class InvalidAdapterOperationException extends ConflictException {
   public InvalidAdapterOperationException(String message) {
     super(message);
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/test/internal/AppFabricClient.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/test/internal/AppFabricClient.java
@@ -318,8 +318,13 @@ public class AppFabricClient {
     DefaultHttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.PUT,
       String.format("%s/templates/%s", getNamespacePath(namespace.getId()), templateId.getId()));
     MockResponder responder = new MockResponder();
-    adapterHttpHandler.deployTemplate(request, responder, namespace.getId(), templateId.getId());
-    verifyResponse(HttpResponseStatus.valueOf(200), responder.getStatus(), "Failed to deploy template.");
+
+    try {
+      adapterHttpHandler.deployTemplate(request, responder, namespace.getId(), templateId.getId());
+      verifyResponse(HttpResponseStatus.valueOf(200), responder.getStatus(), "Failed to deploy template.");
+    } catch (Exception e) {
+      LOG.error("Error deploying template", e);
+    }
   }
 
   public void createAdapter(Id.Adapter id, AdapterConfig config) {
@@ -327,41 +332,68 @@ public class AppFabricClient {
       String.format("%s/adapters/%s", getNamespacePath(id.getNamespaceId()), id.getId()));
     request.setContent(ChannelBuffers.wrappedBuffer(GSON.toJson(config).getBytes(Charsets.UTF_8)));
     MockResponder responder = new MockResponder();
-    adapterHttpHandler.createAdapter(request, responder, id.getNamespaceId(), id.getId());
-    verifyResponse(HttpResponseStatus.valueOf(200), responder.getStatus(), "Failed to create adapter.");
+
+    try {
+      adapterHttpHandler.createAdapter(request, responder, id.getNamespaceId(), id.getId());
+      verifyResponse(HttpResponseStatus.valueOf(200), responder.getStatus(), "Failed to create adapter.");
+    } catch (Exception e) {
+      LOG.error("Error creating adapter", e);
+    }
   }
 
   public void startAdapter(Id.Adapter id) {
     DefaultHttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST,
       String.format("%s/adapters/%s/start", getNamespacePath(id.getNamespaceId()), id.getId()));
     MockResponder responder = new MockResponder();
-    adapterHttpHandler.startStopAdapter(request, responder, id.getNamespaceId(), id.getId(), "start");
-    verifyResponse(HttpResponseStatus.valueOf(200), responder.getStatus(), "Failed to start adapter.");
+
+    try {
+      adapterHttpHandler.startStopAdapter(request, responder, id.getNamespaceId(), id.getId(), "start");
+      verifyResponse(HttpResponseStatus.valueOf(200), responder.getStatus(), "Failed to start adapter.");
+    } catch (Exception e) {
+      LOG.error("Error starting adapter", e);
+    }
   }
 
   public void stopAdapter(Id.Adapter id) {
     DefaultHttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST,
       String.format("%s/adapters/%s/stop", getNamespacePath(id.getNamespaceId()), id.getId()));
     MockResponder responder = new MockResponder();
-    adapterHttpHandler.startStopAdapter(request, responder, id.getNamespaceId(), id.getId(), "stop");
-    verifyResponse(HttpResponseStatus.valueOf(200), responder.getStatus(), "Failed to stop adapter.");
+
+    try {
+      adapterHttpHandler.startStopAdapter(request, responder, id.getNamespaceId(), id.getId(), "stop");
+      verifyResponse(HttpResponseStatus.valueOf(200), responder.getStatus(), "Failed to stop adapter.");
+    } catch (Exception e) {
+      LOG.error("Error stopping adapter", e);
+    }
   }
 
   public List<RunRecord> getAdapterRuns(Id.Adapter id) {
     DefaultHttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET,
       String.format("%s/adapters/%s/runs", getNamespacePath(id.getNamespaceId()), id.getId()));
     MockResponder responder = new MockResponder();
-    adapterHttpHandler.getAdapterRuns(request, responder, id.getNamespaceId(), id.getId(), null, null, null, 100);
-    verifyResponse(HttpResponseStatus.valueOf(200), responder.getStatus(), "Failed to get runs for adapter.");
-    return responder.decodeResponseContent(RUN_RECORDS_TYPE);
+
+    try {
+      adapterHttpHandler.getAdapterRuns(request, responder, id.getNamespaceId(), id.getId(), null, null, null, 100);
+      verifyResponse(HttpResponseStatus.valueOf(200), responder.getStatus(), "Failed to get runs for adapter.");
+      return responder.decodeResponseContent(RUN_RECORDS_TYPE);
+    } catch (Exception e) {
+      LOG.error("Error getting adapter runs", e);
+      throw Throwables.propagate(e);
+    }
   }
 
   public RunRecord getAdapterRun(Id.Adapter adapterId, String runId) {
     DefaultHttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET,
       String.format("%s/adapters/%s/runs/%s", getNamespacePath(adapterId.getNamespaceId()), adapterId.getId(), runId));
     MockResponder responder = new MockResponder();
-    adapterHttpHandler.getAdapterRun(request, responder, adapterId.getNamespaceId(), adapterId.getId(), runId);
-    verifyResponse(HttpResponseStatus.valueOf(200), responder.getStatus(), "Failed to get run for adapter.");
-    return responder.decodeResponseContent(RunRecord.class);
+
+    try {
+      adapterHttpHandler.getAdapterRun(request, responder, adapterId.getNamespaceId(), adapterId.getId(), runId);
+      verifyResponse(HttpResponseStatus.valueOf(200), responder.getStatus(), "Failed to get run for adapter.");
+      return responder.decodeResponseContent(RunRecord.class);
+    } catch (Exception e) {
+      LOG.error("Error getting adapter run", e);
+      throw Throwables.propagate(e);
+    }
   }
 }

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/BadRequestException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/BadRequestException.java
@@ -24,4 +24,8 @@ public class BadRequestException extends Exception {
   public BadRequestException(String message) {
     super(message);
   }
+
+  public BadRequestException(Throwable cause) {
+    super(cause);
+  }
 }

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/CannotBeDeletedException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/CannotBeDeletedException.java
@@ -21,7 +21,7 @@ import co.cask.cdap.proto.Id;
 /**
  * Thrown when an element cannot be deleted.
  */
-public class CannotBeDeletedException extends Exception {
+public class CannotBeDeletedException extends ConflictException {
 
   private final Id objectId;
 


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-2422
http://builds.cask.co/browse/CDAP-DUT1812

Preview before making changes to the rest of the HTTP handlers.