### PR TITLE
CDAP-1868: Set dataset properties support for client and CLI

### DIFF
--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/DescribeDatasetInstanceCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/DescribeDatasetInstanceCommand.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.cli.command;
+
+import co.cask.cdap.cli.ArgumentName;
+import co.cask.cdap.cli.CLIConfig;
+import co.cask.cdap.cli.ElementType;
+import co.cask.cdap.cli.english.Article;
+import co.cask.cdap.cli.english.Fragment;
+import co.cask.cdap.cli.util.AbstractAuthCommand;
+import co.cask.cdap.cli.util.RowMaker;
+import co.cask.cdap.cli.util.table.Table;
+import co.cask.cdap.client.DatasetClient;
+import co.cask.cdap.proto.DatasetMeta;
+import co.cask.common.cli.Arguments;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.gson.Gson;
+import com.google.inject.Inject;
+
+import java.io.PrintStream;
+import java.util.List;
+
+/**
+ * Shows information about a dataset instance.
+ */
+public class DescribeDatasetInstanceCommand extends AbstractAuthCommand {
+
+  private static final Gson GSON = new Gson();
+  private final DatasetClient datasetClient;
+
+  @Inject
+  public DescribeDatasetInstanceCommand(DatasetClient datasetClient, CLIConfig cliConfig) {
+    super(cliConfig);
+    this.datasetClient = datasetClient;
+  }
+
+  @Override
+  public void perform(Arguments arguments, PrintStream output) throws Exception {
+    String name = arguments.get(ArgumentName.DATASET.toString());
+    DatasetMeta meta = datasetClient.get(name);
+
+    Table table = Table.builder()
+      .setHeader("hive table", "spec", "type")
+      .setRows(ImmutableList.of(meta), new RowMaker<DatasetMeta>() {
+        @Override
+        public List<?> makeRow(DatasetMeta object) {
+          return Lists.newArrayList(object.getHiveTableName(), GSON.toJson(object.getSpec()),
+                                    GSON.toJson(object.getType()));
+        }
+      }).build();
+    cliConfig.getTableRenderer().render(cliConfig, output, table);
+  }
+
+  @Override
+  public String getPattern() {
+    return String.format("describe dataset instance <%s>", ArgumentName.DATASET);
+  }
+
+  @Override
+  public String getDescription() {
+    return String.format("Shows information about %s.",
+                         Fragment.of(Article.A, ElementType.DATASET.getTitleName()));
+  }
+}

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetDatasetInstancePropertiesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetDatasetInstancePropertiesCommand.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.cli.command;
+
+import co.cask.cdap.cli.ArgumentName;
+import co.cask.cdap.cli.CLIConfig;
+import co.cask.cdap.cli.ElementType;
+import co.cask.cdap.cli.english.Article;
+import co.cask.cdap.cli.english.Fragment;
+import co.cask.cdap.cli.util.AbstractCommand;
+import co.cask.cdap.cli.util.ArgumentParser;
+import co.cask.cdap.client.DatasetClient;
+import co.cask.common.cli.Arguments;
+import com.google.gson.Gson;
+import com.google.inject.Inject;
+
+import java.io.PrintStream;
+import java.util.Map;
+
+/**
+ * Sets properties for a dataset instance.
+ */
+public class SetDatasetInstancePropertiesCommand extends AbstractCommand {
+
+  private static final Gson GSON = new Gson();
+  private final DatasetClient datasetClient;
+
+  @Inject
+  public SetDatasetInstancePropertiesCommand(DatasetClient datasetClient, CLIConfig cliConfig) {
+    super(cliConfig);
+    this.datasetClient = datasetClient;
+  }
+
+  @Override
+  public void perform(Arguments arguments, PrintStream output) throws Exception {
+    String name = arguments.get(ArgumentName.DATASET.toString());
+    Map<String, String> properties = ArgumentParser.parseMap(
+      arguments.get(ArgumentName.DATASET_PROPERTIES.toString()));
+
+    datasetClient.updateExisting(name, properties);
+    output.printf("Successfully updated properties for dataset instance '%s' to %s", name, GSON.toJson(properties));
+  }
+
+  @Override
+  public String getPattern() {
+    return String.format("set dataset instance properties <%s> <%s>",
+                         ArgumentName.DATASET, ArgumentName.DATASET_PROPERTIES);
+  }
+
+  @Override
+  public String getDescription() {
+    return String.format("Sets properties for %s.",
+                         Fragment.of(Article.A, ElementType.DATASET.getTitleName()));
+  }
+}

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/commandset/DatasetCommands.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/commandset/DatasetCommands.java
@@ -22,11 +22,13 @@ import co.cask.cdap.cli.command.CreateDatasetInstanceCommand;
 import co.cask.cdap.cli.command.DeleteDatasetInstanceCommand;
 import co.cask.cdap.cli.command.DeleteDatasetModuleCommand;
 import co.cask.cdap.cli.command.DeployDatasetModuleCommand;
+import co.cask.cdap.cli.command.DescribeDatasetInstanceCommand;
 import co.cask.cdap.cli.command.DescribeDatasetModuleCommand;
 import co.cask.cdap.cli.command.DescribeDatasetTypeCommand;
 import co.cask.cdap.cli.command.ListDatasetInstancesCommand;
 import co.cask.cdap.cli.command.ListDatasetModulesCommand;
 import co.cask.cdap.cli.command.ListDatasetTypesCommand;
+import co.cask.cdap.cli.command.SetDatasetInstancePropertiesCommand;
 import co.cask.cdap.cli.command.TruncateDatasetInstanceCommand;
 import co.cask.common.cli.Command;
 import co.cask.common.cli.CommandSet;
@@ -46,6 +48,8 @@ public class DatasetCommands extends CommandSet<Command> implements Categorized 
         .add(injector.getInstance(ListDatasetInstancesCommand.class))
         .add(injector.getInstance(ListDatasetModulesCommand.class))
         .add(injector.getInstance(ListDatasetTypesCommand.class))
+        .add(injector.getInstance(DescribeDatasetInstanceCommand.class))
+        .add(injector.getInstance(SetDatasetInstancePropertiesCommand.class))
         .add(injector.getInstance(CreateDatasetInstanceCommand.class))
         .add(injector.getInstance(DeleteDatasetInstanceCommand.class))
         .add(injector.getInstance(TruncateDatasetInstanceCommand.class))
@@ -53,7 +57,7 @@ public class DatasetCommands extends CommandSet<Command> implements Categorized 
         .add(injector.getInstance(DeployDatasetModuleCommand.class))
         .add(injector.getInstance(DeleteDatasetModuleCommand.class))
         .add(injector.getInstance(DescribeDatasetTypeCommand.class))
-      .build());
+        .build());
   }
 
   @Override

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/DatasetClientTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/DatasetClientTestRun.java
@@ -23,11 +23,13 @@ import co.cask.cdap.client.common.ClientTestBase;
 import co.cask.cdap.common.exception.AlreadyExistsException;
 import co.cask.cdap.common.exception.DatasetModuleNotFoundException;
 import co.cask.cdap.common.exception.DatasetTypeNotFoundException;
+import co.cask.cdap.proto.DatasetMeta;
 import co.cask.cdap.proto.DatasetModuleMeta;
 import co.cask.cdap.proto.DatasetTypeMeta;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.test.XSlowTests;
+import com.google.common.collect.ImmutableMap;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -130,6 +132,26 @@ public class DatasetClientTestRun extends ClientTestBase {
     datasetClient.create("testDataset", StandaloneDataset.TYPE_NAME);
     Assert.assertEquals(numBaseDataset + 1, datasetClient.list().size());
     datasetClient.truncate("testDataset");
+
+    DatasetMeta metaBefore = datasetClient.get("testDataset");
+    Assert.assertEquals(0, metaBefore.getSpec().getProperties().size());
+
+    datasetClient.update("testDataset", ImmutableMap.of("sdf", "foo", "abc", "123"));
+    DatasetMeta metaAfter = datasetClient.get("testDataset");
+    Assert.assertEquals(2, metaAfter.getSpec().getProperties().size());
+    Assert.assertTrue(metaAfter.getSpec().getProperties().containsKey("sdf"));
+    Assert.assertTrue(metaAfter.getSpec().getProperties().containsKey("abc"));
+    Assert.assertEquals("foo", metaAfter.getSpec().getProperties().get("sdf"));
+    Assert.assertEquals("123", metaAfter.getSpec().getProperties().get("abc"));
+
+    datasetClient.updateExisting("testDataset", ImmutableMap.of("sdf", "fzz"));
+    metaAfter = datasetClient.get("testDataset");
+    Assert.assertEquals(2, metaAfter.getSpec().getProperties().size());
+    Assert.assertTrue(metaAfter.getSpec().getProperties().containsKey("sdf"));
+    Assert.assertTrue(metaAfter.getSpec().getProperties().containsKey("abc"));
+    Assert.assertEquals("fzz", metaAfter.getSpec().getProperties().get("sdf"));
+    Assert.assertEquals("123", metaAfter.getSpec().getProperties().get("abc"));
+
     datasetClient.delete("testDataset");
     datasetClient.waitForDeleted("testDataset", 10, TimeUnit.SECONDS);
     Assert.assertEquals(numBaseDataset, datasetClient.list().size());

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
@@ -164,11 +164,9 @@ class DatasetServiceClient {
 
   public void updateInstance(String datasetInstanceName, DatasetProperties props)
     throws DatasetManagementException {
-    DatasetMeta meta = getInstance(datasetInstanceName);
-    DatasetInstanceConfiguration creationProperties =
-      new DatasetInstanceConfiguration(meta.getSpec().getType(), props.getProperties());
 
-    HttpResponse response = doPut("datasets/" + datasetInstanceName + "/properties", GSON.toJson(creationProperties));
+    HttpResponse response = doPut("datasets/" + datasetInstanceName + "/properties",
+                                  GSON.toJson(props.getProperties()));
 
     if (HttpResponseStatus.CONFLICT.getCode() == response.getResponseCode()) {
       throw new InstanceConflictException(String.format("Failed to add instance %s due to conflict, details: %s",

--- a/cdap-docs/reference-manual/source/http-restful-api/dataset.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/dataset.rst
@@ -12,7 +12,7 @@ Dataset HTTP RESTful API
 .. highlight:: console
 
 The Dataset API allows you to interact with Datasets through HTTP. You can list, create,
-delete, and truncate Datasets. For details, see the 
+delete, and truncate Datasets. For details, see the
 :ref:`CDAP Components, Datasets section <datasets-index>`
 
 
@@ -117,8 +117,8 @@ You can update an existing dataset's table and properties by issuing an HTTP PUT
 with JSON-formatted name of the dataset type and properties in the body::
 
   {
-     "typeName":"<type-name>",
-     "properties":{<properties>}
+     "key1":"value1",
+     "key2":"value2"
   }
 
 **Note:** The Dataset must exist, and the instance and type passed must match with the existing Dataset.
@@ -149,8 +149,6 @@ with JSON-formatted name of the dataset type and properties in the body::
      - Requested Dataset was successfully updated
    * - ``404 Not Found``
      - Requested Dataset instance was not found
-   * - ``409 Conflict``
-     - Dataset Type provided for update is different from the existing Dataset Type
 
 .. rubric:: Example
 .. list-table::
@@ -160,7 +158,7 @@ with JSON-formatted name of the dataset type and properties in the body::
    * - HTTP Request
      - ``PUT <base-url>/namespaces/default/data/datasets/mydataset/properties``
    * - Body
-     - ``{"typeName":"co.cask.cdap.api.dataset.table.Table",`` ``"properties":{"dataset.table.ttl":"7200"}}``
+     - ``{"dataset.table.ttl":"7200"}``
    * - Description
      - For the *mydataset* of type ``Table`` of the namespace *default*, update the Dataset
        and its time-to-live property to 2 hours
@@ -183,7 +181,7 @@ You can delete a Dataset by issuing an HTTP DELETE request to the URL::
      - Namespace ID
    * - ``<dataset-name>``
      - Dataset name
-     
+
 .. rubric:: HTTP Responses
 .. list-table::
    :widths: 20 80
@@ -275,7 +273,7 @@ Datasets used by an Application
 
 You can retrieve a list of Datasets used by an Application by issuing a HTTP GET request to the URL::
 
-  GET <base-url>/namespaces/<namespace>/apps/<app-id>/datasets 
+  GET <base-url>/namespaces/<namespace>/apps/<app-id>/datasets
 
 .. list-table::
    :widths: 20 80
@@ -286,7 +284,7 @@ You can retrieve a list of Datasets used by an Application by issuing a HTTP GET
    * - ``<namespace>``
      - Namespace ID
    * - ``<app-id>``
-     - Application ID 
+     - Application ID
 
 .. rubric:: HTTP Responses
 .. list-table::


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-1868
http://builds.cask.co/browse/CDAP-DUT1879

* Also removes requirement for passing in dataset type to PUT /data/datasets/{name}/properties endpoint (not backwards-compatible)