### PR TITLE
Fix the log class name for MasterTwillApplication from MasterServiceMain to MasterTwillApplication.

### DIFF
--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterTwillApplication.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterTwillApplication.java
@@ -39,7 +39,7 @@ import java.util.Set;
  * TwillApplication wrapper for Master Services running in YARN.
  */
 public class MasterTwillApplication implements TwillApplication {
-  private static final Logger LOG = LoggerFactory.getLogger(MasterServiceMain.class);
+  private static final Logger LOG = LoggerFactory.getLogger(MasterTwillApplication.class);
   private static final String NAME = Constants.Service.MASTER_SERVICES;
 
   private final CConfiguration cConf;


### PR DESCRIPTION
Looks like the log class for MasterTwillApplication has it sets to use MasterServiceMain class.