### PR TITLE
Use LinkedHashSet to preserve the ordering of the classloader resourses.

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/lang/CombineClassLoader.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/lang/CombineClassLoader.java
@@ -77,7 +77,8 @@ public class CombineClassLoader extends ClassLoader {
 
   @Override
   protected Enumeration<URL> findResources(String name) throws IOException {
-    Set<URL> urls = Sets.newHashSet();
+    // Using LinkedHashSet to preserve the ordering
+    Set<URL> urls = Sets.newLinkedHashSet();
     for (ClassLoader classLoader : delegates) {
       Iterators.addAll(urls, Iterators.forEnumeration(classLoader.getResources(name)));
     }


### PR DESCRIPTION
Jira: https://issues.cask.co/browse/CDAP-2491