### PR TITLE
CDAP-2493 Change the name of parameters for JMS source from ConnectionFactory to jms.jndi.connectionfactory.name in JSON file for UI.

### DIFF
--- a/cdap-ui/templates/etlRealtime/Jms.json
+++ b/cdap-ui/templates/etlRealtime/Jms.json
@@ -32,9 +32,9 @@
 
     "group2": {
        "display" : "JMS Connection Factory",
-       "position" : [ "ConnectionFactory", "jms.factory.initial", "jms.provider.url" ],
+       "position" : [ "jms.jndi.connectionfactory.name", "jms.factory.initial", "jms.provider.url" ],
        "fields" : {
-          "ConnectionFactory" : {
+          "jms.jndi.connectionfactory.name" : {
              "widget": "textbox",
              "label": "Connection Factory Name"
           },


### PR DESCRIPTION
From JIRA:

After the fix for CDAP-2474 for ConnectionFactory in JMS source, we need to update name of the ConnectionFactory in the json file to reflect in UI