### PR TITLE
Decrease donut radius, so that text overflow is not an issue.

### DIFF
--- a/cdap-ui/app/directives/c3/charts.js
+++ b/cdap-ui/app/directives/c3/charts.js
@@ -103,6 +103,7 @@ ngC3.controller('c3Controller', function ($scope, c3, myHelpers, $filter) {
     }
     chartConfig.zoom = { enabled: false };
     chartConfig.transition = { duration: 1000 };
+    chartConfig.donut = { width: 45 };
     $scope.chart = c3.generate(chartConfig);
   }
 


### PR DESCRIPTION
Looks like this now:
![image](https://s3.amazonaws.com/uploads.hipchat.com/26476/1011205/5suFjsLiEzgLZGj/Screen%20Shot%202015-05-12%20at%2012.46.09%20PM.png)