### PR TITLE
Fixes margin top for all modal in cdap

### DIFF
--- a/cdap-ui/app/styles/themes/cdap/theme.less
+++ b/cdap-ui/app/styles/themes/cdap/theme.less
@@ -377,9 +377,7 @@ body.theme-cdap {
       }
     }
     .modal-dialog {
-      -ms-transform: translateX(0%) translateY(60px);
-      -webkit-transform: translateX(0%) translateY(60px);
-      transform: translateX(0%) translateY(60px);
+      margin-top: 100px;
       .modal-header {
         .btn {
           .cask-btn(@color: @cdap-header, @background: white, @border: 0, @border-radius: 16px, @padding: 5px 7px);


### PR DESCRIPTION
Fixes modal's margin-top to be a constant instead of using translate css property. (Doesn't play well with both angular-strap's modal and angular-bootstrap modal)