### PR TITLE
Expose RemoteStreamManager from IntegrationTestManager. It is a capab…

### DIFF
--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestManager.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestManager.java
@@ -36,6 +36,7 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.test.remote.RemoteAdapterManager;
 import co.cask.cdap.test.remote.RemoteApplicationManager;
+import co.cask.cdap.test.remote.RemoteStreamManager;
 import com.google.common.base.Throwables;
 import com.google.common.io.Files;
 import org.apache.twill.filesystem.Location;
@@ -170,6 +171,6 @@ public class IntegrationTestManager implements TestManager {
 
   @Override
   public StreamManager getStreamManager(Id.Stream streamId) {
-    throw new UnsupportedOperationException();
+    return new RemoteStreamManager(clientConfig, streamId);
   }
 }

--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteStreamManager.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteStreamManager.java
@@ -21,6 +21,7 @@ import co.cask.cdap.api.flow.flowlet.StreamEvent;
 import co.cask.cdap.client.StreamClient;
 import co.cask.cdap.client.config.ClientConfig;
 import co.cask.cdap.common.exception.StreamNotFoundException;
+import co.cask.cdap.proto.Id;
 import co.cask.cdap.test.StreamManager;
 import com.google.common.base.Charsets;
 import com.google.common.base.Throwables;
@@ -38,9 +39,11 @@ public class RemoteStreamManager implements StreamManager {
   private final StreamClient streamClient;
   private final String streamName;
 
-  public RemoteStreamManager(ClientConfig clientConfig, String streamName) {
-    this.streamClient = new StreamClient(clientConfig);
-    this.streamName = streamName;
+  public RemoteStreamManager(ClientConfig clientConfig, Id.Stream streamId) {
+    ClientConfig namespacedClientConfig = new ClientConfig.Builder(clientConfig).build();
+    namespacedClientConfig.setNamespace(streamId.getNamespace());
+    this.streamClient = new StreamClient(namespacedClientConfig);
+    this.streamName = streamId.getId();
   }
 
   @Override

--- a/cdap-test/src/main/java/co/cask/cdap/test/ApplicationManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/ApplicationManager.java
@@ -73,7 +73,7 @@ public interface ApplicationManager {
    * @param streamName Name of the stream to write to.
    * @return A {@link StreamWriter}.
    *
-   * @deprecated use TestBase#getStreamMaanger(String streamName)
+   * @deprecated use TestBase#getStreamManager(String streamName)
    */
   @Deprecated
   StreamWriter getStreamWriter(String streamName);


### PR DESCRIPTION
…ility existing in RemoteApplicationManager#getStreamWriter, which is now deprecated.

http://builds.cask.co/browse/CDAP-DUT1827-3