### PR TITLE
Hotfix/temp fix flow change instances

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
@@ -869,10 +869,10 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
    */
   @PUT
   @Path("/apps/{app-id}/flows/{flow-id}/flowlets/{flowlet-id}/instances")
-  public void setFlowletInstances(HttpRequest request, HttpResponder responder,
-                                  @PathParam("namespace-id") String namespaceId,
-                                  @PathParam("app-id") String appId, @PathParam("flow-id") String flowId,
-                                  @PathParam("flowlet-id") String flowletId) {
+  public synchronized void setFlowletInstances(HttpRequest request, HttpResponder responder,
+                                               @PathParam("namespace-id") String namespaceId,
+                                               @PathParam("app-id") String appId, @PathParam("flow-id") String flowId,
+                                               @PathParam("flowlet-id") String flowletId) {
     int instances;
     try {
       try {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractProgramTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractProgramTwillRunnable.java
@@ -104,6 +104,7 @@ import java.net.InetAddress;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import javax.annotation.Nullable;
 
 /**
  * A {@link TwillRunnable} for running a program through a {@link ProgramRunner}.
@@ -271,6 +272,21 @@ public abstract class AbstractProgramTwillRunnable<T extends ProgramRunner> impl
     controller = injector.getInstance(getProgramClass()).run(program, programOpts);
     final SettableFuture<ProgramController.State> state = SettableFuture.create();
     controller.addListener(new AbstractListener() {
+
+      @Override
+      public void alive() {
+        runlatch.countDown();
+      }
+
+      @Override
+      public void init(ProgramController.State currentState, @Nullable Throwable cause) {
+        if (currentState == ProgramController.State.ALIVE) {
+          alive();
+        } else {
+          super.init(currentState, cause);
+        }
+      }
+
       @Override
       public void completed() {
         state.set(ProgramController.State.COMPLETED);
@@ -288,7 +304,6 @@ public abstract class AbstractProgramTwillRunnable<T extends ProgramRunner> impl
       }
     }, MoreExecutors.sameThreadExecutor());
 
-    runlatch.countDown();
     try {
       state.get();
       LOG.info("Program stopped.");
@@ -299,6 +314,10 @@ public abstract class AbstractProgramTwillRunnable<T extends ProgramRunner> impl
       if (propagateServiceError()) {
         throw Throwables.propagate(Throwables.getRootCause(e));
       }
+    } finally {
+      // Always unblock the handleCommand method if it is not unblocked before (e.g if program failed to start).
+      // The controller state will make sure the corresponding command will be handled correctly in the correct state.
+      runlatch.countDown();
     }
   }
 

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueTest.java
@@ -260,7 +260,8 @@ public abstract class HBaseQueueTest extends QueueTest {
               HBaseConsumerState state = stateStore.getState(groupId, instanceId);
 
               if (groupId == 2L && instanceId == 0) {
-                // For group 1L, the start row shouldn't be changed. End row should be the same as the first barrier
+                // For group 2L instance 0, the start row shouldn't be changed.
+                // End row should be the same as the first barrier
                 Assert.assertEquals(0, Bytes.compareTo(state.getStartRow(),
                                                        QueueEntryRow.getQueueEntryRowKey(queueName, 10L, 0)));
                 Assert.assertEquals(0, Bytes.compareTo(state.getNextBarrier(),
@@ -366,9 +367,10 @@ public abstract class HBaseQueueTest extends QueueTest {
           } catch (Exception e) {
             // Expected
           }
-          // For group 2, there should be three barrier infos
+          // For group 2, there should be two barrier infos,
+          // since all consumers passed the first barrier (groupSize = 2). Only the size = 3 and size = 1 left
           List<QueueBarrier> queueBarriers = stateStore.getAllBarriers(2L);
-          Assert.assertEquals(3, queueBarriers.size());
+          Assert.assertEquals(2, queueBarriers.size());
 
           // Make all consumers (3 of them before reconfigure) in group 2 consumes everything
           for (int instanceId = 0; instanceId < 3; instanceId++) {
@@ -378,7 +380,7 @@ public abstract class HBaseQueueTest extends QueueTest {
           // For the remaining consumer, it should start consuming from the latest barrier
           HBaseConsumerState state = stateStore.getState(2L, 0);
           Assert.assertEquals(0, Bytes.compareTo(state.getStartRow(),
-                                                 queueBarriers.get(2).getStartRow()));
+                                                 queueBarriers.get(1).getStartRow()));
           Assert.assertNull(state.getNextBarrier());
 
           // For removed instances, they should throw exception when retrieving their states


### PR DESCRIPTION
It includes fixes for CDAP-1951 and CDAP-1996.

- CDAP-1951. It just a temp fix to make changing flowlet instances less easy to fail.
- CDAP-1996. It fixes the problem of wrongly deleting queue states when two queues share the same queue name prefix.