### PR TITLE
Add CubeService as a module to cdap-examples pom

### DIFF
--- a/cdap-examples/pom.xml
+++ b/cdap-examples/pom.xml
@@ -31,6 +31,7 @@
 
   <modules>
     <module>CountRandom</module>
+    <module>CubeService</module>
     <module>FileSetExample</module>
     <module>HelloWorld</module>
     <module>Purchase</module>


### PR DESCRIPTION
It was missing, and so the following command from `BUILD.rst` was not working (RAT check failures):
` MAVEN_OPTS="-Xmx512m -XX:MaxPermSize=128m" mvn package -DskipTests -pl cdap-examples -am -amd -P examples`

http://builds.cask.co/browse/CDAP-DUT1831-2