### PR TITLE
Feature/r3.0 remove console

### DIFF
--- a/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/package-info.java
+++ b/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -29,7 +29,7 @@
  *     When scheduled by the PurchaseHistoryWorkflow, the PurchaseHistoryBuilder MapReduce program
  *     reads the purchases DataSet, creates a purchase history,
  *     and stores the purchase history in the history DataSet every morning at 4:00 A.M.
- *     Or you can manually (in the Process screen in the CDAP Console) or programmatically execute 
+ *     Or, you can manually (in the Process screen in the CDAP UI) or programmatically execute 
  *     the PurchaseHistoryBuilder MapReduce to store customers' purchase history in the history DataSet.
  *   </li><li>
  *     Request the PurchaseHistoryService retrieve from the history Dataset the purchase history of a user.

--- a/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/package-info.java
+++ b/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/package-info.java
@@ -26,11 +26,10 @@
  *     The PurchaseFlow reads the purchaseStream and converts every input String into a Purchase object and stores
  *     the object in the purchases DataSet.
  *   </li><li>
- *     When scheduled by the PurchaseHistoryWorkflow, the PurchaseHistoryBuilder MapReduce program
- *     reads the purchases DataSet, creates a purchase history,
- *     and stores the purchase history in the history DataSet every morning at 4:00 A.M.
- *     Or, you can manually (in the Process screen in the CDAP UI) or programmatically execute 
- *     the PurchaseHistoryBuilder MapReduce to store customers' purchase history in the history DataSet.
+ *     As scheduled by the PurchaseHistoryWorkflow, the PurchaseHistoryBuilder MapReduce program
+ *     reads the purchases DataSet, creates a purchase history, and stores the purchase history in the
+ *     history DataSet every morning at 4:00 A.M. To avoid waiting, you can manually start the  
+ *     PurchaseHistoryBuilder MapReduce either from within the CDAP UI or programmatically by using the CDAP CLI.
  *   </li><li>
  *     Request the PurchaseHistoryService retrieve from the history Dataset the purchase history of a user.
  *     <p>

--- a/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
+++ b/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
@@ -268,11 +268,6 @@ public class StandaloneMain {
         usage(false);
         return;
       } else {
-        PrintStream out = System.err;
-        out.println("Args:");
-        for (int i = 0; i <= args.length - 1; i++) {
-          out.println("Parameter #" + i + ": " + args[i]);
-        }
         usage(true);
       }
     }

--- a/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
+++ b/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
@@ -183,7 +183,7 @@ public class StandaloneMain {
       configuration.getInt(Constants.Dashboard.SSL_BIND_PORT) :
       configuration.getInt(Constants.Dashboard.BIND_PORT);
     System.out.println("Standalone CDAP started successfully.");
-    System.out.printf("Connect to the Console at %s://%s:%d\n", protocol, "localhost", dashboardPort);
+    System.out.printf("Connect to the CDAP UI at %s://%s:%d\n", protocol, "localhost", dashboardPort);
   }
 
   /**
@@ -240,7 +240,7 @@ public class StandaloneMain {
 
     // And our requirements and usage
     out.println("Requirements: ");
-    out.println("  Java:    JDK 1.6+ must be installed and JAVA_HOME environment variable set to the java executable");
+    out.println("  Java:    JDK 1.7 must be installed and JAVA_HOME environment variable set to the java executable");
     out.println("  Node.js: Node.js must be installed (obtain from http://nodejs.org/#download).  ");
     out.println("           The \"node\" executable must be in the system $PATH environment variable");
     out.println("");
@@ -268,6 +268,11 @@ public class StandaloneMain {
         usage(false);
         return;
       } else {
+        PrintStream out = System.err;
+        out.println("Args:");
+        for (int i = 0; i <= args.length - 1; i++) {
+          out.println("Parameter #" + i + ": " + args[i]);
+        }
         usage(true);
       }
     }


### PR DESCRIPTION
Removes remaining usage of the word "Console" (in the context of "CDAP Console"; there are other instances in different contexts that remain).

Updates the usage in the StandaloneMain to include JDK 1.7.

Fixes https://issues.cask.co/browse/CDAP-2235