### PR TITLE
CDAP-2489 Fixed the invalid RunId comparison and simplified the condition. Cherry pick for release 3.0.1

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedProgramRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedProgramRuntimeService.java
@@ -238,10 +238,8 @@ public final class DistributedProgramRuntimeService extends AbstractProgramRunti
     List<RunRecord> activeRunRecords = store.getRuns(ProgramRunStatus.RUNNING, new Predicate<RunRecord>() {
       @Override
       public boolean apply(RunRecord record) {
-        if (record.getTwillRunId() == null) {
-          return false;
-        }
-        return twillRunIds.contains(record.getTwillRunId());
+        return record.getTwillRunId() != null
+          && twillRunIds.contains(org.apache.twill.internal.RunIds.fromString(record.getTwillRunId()));
       }
     });
 


### PR DESCRIPTION
This PR is for back porting the fix for Jira https://issues.cask.co/browse/CDAP-2489 to release 3.0.1