### PR TITLE
CDAP-2475 Make the JMS source to accept type and name of the JMS provider plugin.

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/realtime/source/JmsSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/realtime/source/JmsSource.java
@@ -343,15 +343,12 @@ public class JmsSource extends RealtimeSource<StructuredRecord> {
     public String jmsPluginType;
 
     public JmsPluginConfig() {
-      messagesToReceive = 50;
-      connectionFactoryName = DEFAULT_CONNECTION_FACTORY;
-      jmsPluginName = Context.INITIAL_CONTEXT_FACTORY;
-      jmsPluginType = JMS_PROVIDER;
+      this(null, null, null, 50, DEFAULT_CONNECTION_FACTORY, Context.INITIAL_CONTEXT_FACTORY, JMS_PROVIDER);
     }
 
-    public JmsPluginConfig(String destinationName, @Nullable Integer messagesToReceive, String initialContextFactory,
-                           String providerUrl, @Nullable String connectionFactoryName, @Nullable String jmsPluginName,
-                           @Nullable String jmsPluginType) {
+    public JmsPluginConfig(String destinationName, String initialContextFactory, String providerUrl,
+                           @Nullable Integer messagesToReceive, @Nullable String connectionFactoryName,
+                           @Nullable String jmsPluginName, @Nullable String jmsPluginType) {
       this.destinationName = destinationName;
       if (messagesToReceive != null) {
         this.messagesToReceive = messagesToReceive;
@@ -366,7 +363,7 @@ public class JmsSource extends RealtimeSource<StructuredRecord> {
         this.connectionFactoryName = DEFAULT_CONNECTION_FACTORY;
       }
       this.jmsPluginName = jmsPluginName;
-      if (jmsPluginName == null) {
+      if (this.jmsPluginName == null) {
         this.jmsPluginName = Context.INITIAL_CONTEXT_FACTORY;
       }
       this.jmsPluginType = jmsPluginType;

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/template/etl/realtime/source/JmsSourceTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/template/etl/realtime/source/JmsSourceTest.java
@@ -201,7 +201,7 @@ public class JmsSourceTest {
 
   private void initializeJmsSource(String destination, int messageReceive, String initialContextFactory,
                                    String providerUrl) {
-    jmsSource = new JmsSource(new JmsPluginConfig(destination, messageReceive, initialContextFactory, providerUrl,
+    jmsSource = new JmsSource(new JmsPluginConfig(destination, initialContextFactory, providerUrl, messageReceive,
                                                   JmsSource.DEFAULT_CONNECTION_FACTORY, null, null));
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/template/etl/realtime/source/JmsSourceTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/template/etl/realtime/source/JmsSourceTest.java
@@ -202,7 +202,7 @@ public class JmsSourceTest {
   private void initializeJmsSource(String destination, int messageReceive, String initialContextFactory,
                                    String providerUrl) {
     jmsSource = new JmsSource(new JmsPluginConfig(destination, messageReceive, initialContextFactory, providerUrl,
-                                                  JmsSource.DEFAULT_CONNECTION_FACTORY));
+                                                  JmsSource.DEFAULT_CONNECTION_FACTORY, null, null));
   }
 
   /**

--- a/cdap-ui/templates/etlRealtime/Jms.json
+++ b/cdap-ui/templates/etlRealtime/Jms.json
@@ -47,7 +47,17 @@
           "jms.provider.url" : {
              "widget" : "textbox",
              "label" : "Provider URL"
-          }
+          },
+
+         "jms.plugin.name" : {
+           "widget": "textbox",
+           "label": "JMS Provider Plugin Name"
+         },
+
+         "jms.plugin.type": {
+           "widget": "textbox",
+           "label": "JMS Provider Plugin Type"
+         }
        }
     }
 


### PR DESCRIPTION
Add 2 new JMS source configuration properties to set the dependent 3rd party plugin for JMS Connection initial context factory.

This will allow different JMS Source plugin to have different JMS provider implementation plugin definition, eg: ActiveMQ or RabbitMQ, or ZeroQ