### PR TITLE
Fixes runtime args and preferences on program level to be persistent for the duration of the browser session

### DIFF
--- a/cdap-ui/app/directives/program-preferences/program-preferences.js
+++ b/cdap-ui/app/directives/program-preferences/program-preferences.js
@@ -82,7 +82,7 @@ angular.module(PKG.name+'.commons')
         })
         .then(function() {
           $scope.loadProperties();
-          $scope.$close();
+          $scope.$close(obj);
         });
     };
 
@@ -98,10 +98,17 @@ angular.module(PKG.name+'.commons')
   .service('myProgramPreferencesService', function($bootstrapModal, $rootScope){
     var modalInstance;
 
-    this.show = function(type) {
+    this.show = function(type, preferences) {
 
       var scope = $rootScope.$new();
       scope.type = type;
+      scope.preferences = [];
+      angular.forEach(preferences, function(value, key) {
+        scope.preferences.push({
+          key: key,
+          value: value
+        });
+      });
 
       modalInstance = $bootstrapModal.open({
         template: '<my-program-preferences></my-program-preferences>',

--- a/cdap-ui/app/directives/program-preferences/program-preferences.js
+++ b/cdap-ui/app/directives/program-preferences/program-preferences.js
@@ -98,17 +98,10 @@ angular.module(PKG.name+'.commons')
   .service('myProgramPreferencesService', function($bootstrapModal, $rootScope){
     var modalInstance;
 
-    this.show = function(type, preferences) {
+    this.show = function(type) {
 
       var scope = $rootScope.$new();
       scope.type = type;
-      scope.preferences = [];
-      angular.forEach(preferences, function(value, key) {
-        scope.preferences.push({
-          key: key,
-          value: value
-        });
-      });
 
       modalInstance = $bootstrapModal.open({
         template: '<my-program-preferences></my-program-preferences>',

--- a/cdap-ui/app/directives/runtime-args/runtime-args.js
+++ b/cdap-ui/app/directives/runtime-args/runtime-args.js
@@ -10,9 +10,16 @@ angular.module(PKG.name+'.commons')
   .service('myRuntimeService', function($bootstrapModal, $rootScope){
     var modalInstance;
 
-    this.show = function() {
+    this.show = function(runtimeargs) {
 
       var scope = $rootScope.$new();
+      scope.preferences = [];
+      angular.forEach(runtimeargs, function(value, key) {
+        scope.preferences.push({
+          key: key,
+          value: value
+        });
+      });
 
       modalInstance = $bootstrapModal.open({
         template: '<my-runtime-args></my-runtime-args>',
@@ -25,7 +32,7 @@ angular.module(PKG.name+'.commons')
   })
   .controller('RuntimeArgumentsController', function($scope) {
 
-    $scope.preferences = [];
+    $scope.preferences = $scope.preferences || [];
 
     $scope.addPreference = function() {
       $scope.preferences.push({

--- a/cdap-ui/app/directives/start-stop-button/start-stop-button.js
+++ b/cdap-ui/app/directives/start-stop-button/start-stop-button.js
@@ -13,7 +13,6 @@ angular.module(PKG.name + '.commons')
         $scope.isStoppable = ($scope.isStoppable === 'true');
 
         $scope.runtimeArgs = [];
-        $scope.preferences = [];
         var path = '/apps/' + $state.params.appId +
                    '/' + $scope.type + '/' + $state.params.programId;
         var dataSrc = new MyDataSource($scope);
@@ -64,11 +63,7 @@ angular.module(PKG.name + '.commons')
           if ('undefined' !== typeof fn) {
             fn();
           } else {
-            myProgramPreferencesService.show($scope.type, $scope.preferences)
-              .result
-              .then(function(res) {
-                $scope.preferences = res;
-              });
+            myProgramPreferencesService.show($scope.type);
           }
         };
       }

--- a/cdap-ui/app/directives/start-stop-button/start-stop-button.js
+++ b/cdap-ui/app/directives/start-stop-button/start-stop-button.js
@@ -5,7 +5,6 @@ angular.module(PKG.name + '.commons')
       scope: {
         type: '@',
         isStoppable: '@',
-        isPreferences: '@',
         preferencesHandler: '&',
         runtimeHandler: '&'
       },
@@ -13,12 +12,8 @@ angular.module(PKG.name + '.commons')
       controller: function($scope, $state, MyDataSource, myRuntimeService, myProgramPreferencesService) {
         $scope.isStoppable = ($scope.isStoppable === 'true');
 
-        if ( typeof $scope.isPreferences === 'undefined') {
-          $scope.isPreferences = true;
-        } else {
-          $scope.isPreferences = !!$scope.isPreferences;
-        }
         $scope.runtimeArgs = [];
+        $scope.preferences = [];
         var path = '/apps/' + $state.params.appId +
                    '/' + $scope.type + '/' + $state.params.programId;
         var dataSrc = new MyDataSource($scope);
@@ -58,7 +53,7 @@ angular.module(PKG.name + '.commons')
           if ('undefined' !== typeof fn) {
             fn();
           } else {
-            myRuntimeService.show().result.then(function(res) {
+            myRuntimeService.show($scope.runtimeArgs).result.then(function(res) {
               $scope.runtimeArgs = res;
             });
           }
@@ -69,7 +64,11 @@ angular.module(PKG.name + '.commons')
           if ('undefined' !== typeof fn) {
             fn();
           } else {
-            myProgramPreferencesService.show($scope.type);
+            myProgramPreferencesService.show($scope.type, $scope.preferences)
+              .result
+              .then(function(res) {
+                $scope.preferences = res;
+              });
           }
         };
       }


### PR DESCRIPTION
- Provides the ability to store the preferences and run time arguments for the duration of the browser session.
- Modifies my-start-stop-button directive to use the preferences & runtime arguments services (pass in runtime args and preferences to be displayed in the modal)