### PR TITLE
CDAP-2448 Add new test ProgramLifecycleServiceTest to test RunRecord instances with RUNNING state but no actual program running

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramLifecycleService.java
@@ -223,7 +223,7 @@ public class ProgramLifecycleService extends AbstractIdleService {
    *
    * @param programType The type of programs the run records nee to validate and update.
    */
-  private void validateAndCorrectRunningRunRecords(ProgramType programType) {
+  void validateAndCorrectRunningRunRecords(ProgramType programType) {
     final Map<RunId, RuntimeInfo> runIdToRuntimeInfo = runtimeService.list(programType);
 
     List<RunRecord> invalidRunRecords = store.getRuns(ProgramRunStatus.RUNNING, new Predicate<RunRecord>() {
@@ -239,8 +239,8 @@ public class ProgramLifecycleService extends AbstractIdleService {
     });
 
     if (!invalidRunRecords.isEmpty()) {
-      LOG.warn("Found {} RunRecords with RUNNING status but the program not actually running for type {}",
-                invalidRunRecords.size(), programType.getPrettyName());
+      LOG.warn("Found {} RunRecords with RUNNING status but the program not actually running",
+               invalidRunRecords.size());
     }
 
     // Now lets correct the invalid RunRecords
@@ -255,6 +255,9 @@ public class ProgramLifecycleService extends AbstractIdleService {
 
       // Check if such program exist for the RunRecord
       if (targetProgramId != null) {
+        LOG.warn("Fixing RunRecord {} in program {} of type {} with RUNNING status but the program is not running",
+                 runId, targetProgramId, programType.getPrettyName());
+
         store.compareAndSetStatus(targetProgramId, runId, ProgramController.State.ALIVE.getRunStatus(),
                                   ProgramController.State.ERROR.getRunStatus());
       }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/ProgramLifecycleServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/ProgramLifecycleServiceTest.java
@@ -42,8 +42,6 @@ import java.util.concurrent.TimeUnit;
  * Unit test for {@link ProgramLifecycleService}
  */
 public class ProgramLifecycleServiceTest extends AppFabricTestBase {
-  private static final String WORDCOUNT_APP_NAME = "WordCountApp";
-  private static final String WORDCOUNT_FLOW_NAME = "WordCountFlow";
 
   private static ProgramLifecycleService programLifecycleService;
   private static Store store;
@@ -63,7 +61,7 @@ public class ProgramLifecycleServiceTest extends AppFabricTestBase {
     Assert.assertEquals(200, response.getStatusLine().getStatusCode());
 
     Id.Program wordcountFlow1 =
-      Id.Program.from(TEST_NAMESPACE1, WORDCOUNT_APP_NAME, ProgramType.FLOW, WORDCOUNT_FLOW_NAME);
+      Id.Program.from(TEST_NAMESPACE1, "WordCountApp", ProgramType.FLOW, "WordCountFlow");
 
     // flow is stopped initially
     Assert.assertEquals("STOPPED", getProgramStatus(wordcountFlow1));

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/ProgramLifecycleServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/ProgramLifecycleServiceTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.internal.app.services;
+
+import co.cask.cdap.WordCountApp;
+import co.cask.cdap.app.runtime.ProgramController;
+import co.cask.cdap.app.runtime.ProgramRuntimeService;
+import co.cask.cdap.app.runtime.ProgramRuntimeService.RuntimeInfo;
+import co.cask.cdap.app.store.Store;
+import co.cask.cdap.common.app.RunIds;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.internal.app.services.http.AppFabricTestBase;
+import co.cask.cdap.internal.app.store.DefaultStore;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.ProgramRunStatus;
+import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.RunRecord;
+
+import org.apache.http.HttpResponse;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+
+/**
+ * Unit test for {@link ProgramLifecycleService}
+ */
+public class ProgramLifecycleServiceTest extends AppFabricTestBase {
+  private static final String WORDCOUNT_APP_NAME = "WordCountApp";
+  private static final String WORDCOUNT_FLOW_NAME = "WordCountFlow";
+
+  private static ProgramLifecycleService programLifecycleService;
+  private static Store store;
+  private static ProgramRuntimeService runtimeService;
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    programLifecycleService = getInjector().getInstance(ProgramLifecycleService.class);
+    store = getInjector().getInstance(DefaultStore.class);
+    runtimeService = getInjector().getInstance(ProgramRuntimeService.class);
+  }
+
+  @Test
+  public void testInvalidFlowRunRecord() throws Exception {
+    // Create App with Flow and the deploy
+    HttpResponse response = deploy(WordCountApp.class, Constants.Gateway.API_VERSION_3_TOKEN, TEST_NAMESPACE1);
+    Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+
+    Id.Program wordcountFlow1 =
+      Id.Program.from(TEST_NAMESPACE1, WORDCOUNT_APP_NAME, ProgramType.FLOW, WORDCOUNT_FLOW_NAME);
+
+    // flow is stopped initially
+    Assert.assertEquals("STOPPED", getProgramStatus(wordcountFlow1));
+
+    // start a flow and check the status
+    startProgram(wordcountFlow1);
+    waitState(wordcountFlow1, ProgramRunStatus.RUNNING.toString());
+
+    // Get the RunRecord
+    List<RunRecord> runRecords = getProgramRuns(wordcountFlow1, ProgramRunStatus.RUNNING.toString());
+    Assert.assertEquals(1, runRecords.size());
+    RunRecord rr = runRecords.get(0);
+
+    // Check the RunRecords status
+    Assert.assertEquals(ProgramRunStatus.RUNNING, rr.getStatus());
+
+    // Lets set the runtime info to off
+    RuntimeInfo runtimeInfo = runtimeService.lookup(wordcountFlow1, RunIds.fromString(rr.getPid()));
+    ProgramController programController = runtimeInfo.getController();
+    programController.stop();
+
+    Thread.sleep(2000);
+
+    // Verify that the status of that run is KILLED
+    rr = store.getRun(wordcountFlow1, rr.getPid());
+    Assert.assertEquals(ProgramRunStatus.KILLED, rr.getStatus());
+
+    // Use the store manipulate state to be RUNNING
+    long now = System.currentTimeMillis();
+    long nowSecs = TimeUnit.MILLISECONDS.toSeconds(now);
+    store.setStart(wordcountFlow1, rr.getPid(), nowSecs);
+
+    // Now check again via Store to assume data store is wrong.
+    rr = store.getRun(wordcountFlow1, rr.getPid());
+    Assert.assertEquals(ProgramRunStatus.RUNNING, rr.getStatus());
+
+    // Verify there is NO FAILED run record for the application
+    runRecords = getProgramRuns(wordcountFlow1, ProgramRunStatus.FAILED.toString());
+    Assert.assertEquals(0, runRecords.size());
+
+    // Lets fix it
+    programLifecycleService.validateAndCorrectRunningRunRecords(ProgramType.FLOW);
+
+    // Verify there is one FAILED run record for the application
+    runRecords = getProgramRuns(wordcountFlow1, ProgramRunStatus.FAILED.toString());
+    Assert.assertEquals(1, runRecords.size());
+    rr = runRecords.get(0);
+    Assert.assertEquals(ProgramRunStatus.FAILED, rr.getStatus());
+  }
+}


### PR DESCRIPTION
The PR add new test for ProgramLifecycleService#validateAndCorrectRunningRunRecords to validate the RunRecords with RUNNING state but no actual program running when checking the ProgramRuntimeService.

Make the validateAndCorrectRunningRunRecords method to be packaged private for easy testing.