### PR TITLE
update angular and fix breakage in services within admin

### DIFF
--- a/cdap-ui/app/features/admin/controllers/ServiceDetailController.js
+++ b/cdap-ui/app/features/admin/controllers/ServiceDetailController.js
@@ -17,11 +17,10 @@ function ($scope, $state, MyDataSource) {
       $scope.tabs.activeTab = ($state.is('admin.system.services.detail.metadata')? 0: 1);
     }
     $scope.$watch('tabs.activeTab', function(newValue) {
-      var toState = ($state.includes('admin.system.services.detail.*') ? '^': '');
       if(newValue === 0) {
-        $state.go(toState + '.metadata');
+        $state.go('admin.system.services.detail.metadata');
       } else if(newValue === 1) {
-        $state.go(toState + '.logs');
+        $state.go('admin.system.services.detail.logs');
       }
     });
 });

--- a/cdap-ui/bower.json
+++ b/cdap-ui/bower.json
@@ -2,16 +2,16 @@
   "name": "cdap-ui",
   "private": true,
   "dependencies": {
-    "angular": "1.3.14",
-    "angular-animate": "1.3.14",
-    "angular-sanitize": "1.3.14",
-    "angular-resource": "1.3.14",
-    "angular-mocks": "1.3.14",
+    "angular": "1.3.15",
+    "angular-animate": "1.3.15",
+    "angular-sanitize": "1.3.15",
+    "angular-resource": "1.3.15",
+    "angular-mocks": "1.3.15",
     "bootstrap": "3.3.2",
     "font-awesome": "4.3.0",
     "angular-strap": "2.2.0",
     "angular-motion": "0.3.4",
-    "angular-ui-router": "0.2.13",
+    "angular-ui-router": "0.2.14",
     "angular-loading-bar": "0.7.1",
     "ngstorage": "0.3.0",
     "cask-angular-capitalize": "https://github.com/caskdata/ng-capsules/raw/develop/zip/cask-angular-capitalize.zip",
@@ -29,17 +29,17 @@
     "angular-breadcrumb": "~0.3.3",
     "dagre-d3": "~0.4.2",
     "d3-tip": "~0.6.6",
-    "angular-moment": "~0.9.0",
+    "angular-moment": "0.10.1",
     "angular-bootstrap": "~0.12.1",
     "node-uuid": "~1.4.3",
     "angular-ui-select": "~0.11.2",
-    "angular-cookies": "~1.3.15",
+    "angular-cookies": "1.3.15",
     "c3": "~0.4.10",
     "angular-ui-ace": "bower",
     "jsPlumb": "~1.7.5"
   },
   "resolutions": {
-    "angular": "1.3.14",
+    "angular": "1.3.15",
     "d3": "~3.5.5"
   }
 }


### PR DESCRIPTION
Update Angular and angular components to 1.3.15 (1.4 is not a stable release yet). There are some performance improvement especially in regards to memory leakage.

You need to remove bower_components and clean up bower cache (**bower cache clean**). Then do **bower install**