### PR TITLE
Create new StructuredRecord.Builder instance per Tweet conversions in TwitterSource

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/realtime/source/TwitterSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/realtime/source/TwitterSource.java
@@ -70,8 +70,7 @@ public class TwitterSource extends RealtimeSource<StructuredRecord> {
   private TwitterStream twitterStream;
   private StatusListener statusListener;
   private Queue<Status> tweetQ = Queues.newConcurrentLinkedQueue();
-  private StructuredRecord.Builder recordBuilder;
-
+  private Schema schema;
 
   private final TwitterConfig twitterConfig;
 
@@ -109,6 +108,7 @@ public class TwitterSource extends RealtimeSource<StructuredRecord> {
   }
 
   private StructuredRecord convertTweet(Status tweet) {
+    StructuredRecord.Builder recordBuilder = StructuredRecord.builder(this.schema);
     recordBuilder.set(ID, tweet.getId());
     recordBuilder.set(MSG, tweet.getText());
     recordBuilder.set(LANG, tweet.getLang());
@@ -160,9 +160,8 @@ public class TwitterSource extends RealtimeSource<StructuredRecord> {
     Schema.Field geoLatField = Schema.Field.of(GLAT, Schema.of(Schema.Type.DOUBLE));
     Schema.Field geoLongField = Schema.Field.of(GLNG, Schema.of(Schema.Type.DOUBLE));
     Schema.Field reTweetField = Schema.Field.of(ISRT, Schema.of(Schema.Type.BOOLEAN));
-    recordBuilder = StructuredRecord.builder(Schema.recordOf(
-      "tweet", idField, msgField, langField, timeField, favCount, rtCount, sourceField, geoLatField, geoLongField,
-      reTweetField));
+    schema = Schema.recordOf("tweet", idField, msgField, langField, timeField, favCount, rtCount, sourceField,
+                             geoLatField, geoLongField, reTweetField);
 
     statusListener = new StatusListener() {
       @Override


### PR DESCRIPTION
Currently the TwitterSource create one instance of StructuredRecord.Builder and reuse it to convert Tweets to StructuredRecord instances.

This will cause problems because StructuredRecord.Builder#build reuse the same fields
member variable to create new StructuredRecord. All converted Tweets to StructuredRecords will have the same values when being written to Emitter.