### PR TITLE
CDAP-2173 increase metric-picker limit

### DIFF
--- a/cdap-ui/app/directives/metric-picker/metric-picker.html
+++ b/cdap-ui/app/directives/metric-picker/metric-picker.html
@@ -17,7 +17,7 @@
         bs-options="c.value as c.display for c in available.contexts"
         data-watch-options="1"
         data-min-length="0"
-        data-limit="20"
+        data-limit="100"
         data-container="body"
         bs-typeahead />
     </div>
@@ -36,7 +36,7 @@
       bs-options="m for m in available.names"
       data-watch-options="1"
       data-min-length="0"
-      data-limit="20"
+      data-limit="100"
       data-container="body"
       bs-typeahead />
     <div class="input-group-addon" ng-click="deleteMetric($index)">


### PR DESCRIPTION
100 is a larger limit, while still being performant.

Helps with: https://issues.cask.co/browse/CDAP-2173