### PR TITLE
fix hoisting issue with dataset status page

### DIFF
--- a/cdap-ui/app/features/datasets/controllers/tabs/status-ctrl.js
+++ b/cdap-ui/app/features/datasets/controllers/tabs/status-ctrl.js
@@ -7,7 +7,12 @@ angular.module(PKG.name + '.feature.datasets')
       $scope.transactions = 0;
       var query = myHelpers.objectQuery;
       var dataSrc = new MyDataSource($scope),
-          currentDataset = $state.params.datasetId;
+          currentDataset = $state.params.datasetId,
+          datasetTags = {
+            namespace: $state.params.namespace,
+            dataset: currentDataset
+          };
+
 
       [
         {
@@ -20,10 +25,6 @@ angular.module(PKG.name + '.feature.datasets')
         }
       ].forEach(pollMetric);
 
-      var datasetTags = {
-        namespace: $state.params.namespace,
-        dataset: currentDataset
-      };
 
       function pollMetric(metric) {
         // A temporary way to get the rate of a metric for a dataset.


### PR DESCRIPTION
because of hoisting in JavaScript, datasetTags variable is undefined when pollMetric function is called.