### PR TITLE
[CDAP-1926] streams endpoint accepts now-xs format

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/test/java/co/cask/cdap/template/etl/realtime/ETLWorkerTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/test/java/co/cask/cdap/template/etl/realtime/ETLWorkerTest.java
@@ -118,7 +118,8 @@ public class ETLWorkerTest extends TestBase {
     adapterManager.stop();
 
     StreamManager streamManager = getStreamManager(NAMESPACE, "testStream");
-    List<StreamEvent> streamEvents = streamManager.getEvents(startTime, System.currentTimeMillis(), Integer.MAX_VALUE);
+    long currentDiff = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis() - startTime) + 1;
+    List<StreamEvent> streamEvents = streamManager.getEvents("now-" + Long.toString(currentDiff) + "s", "now", Integer.MAX_VALUE);
     // verify that some events were sent to the stream
     Assert.assertTrue(streamEvents.size() > 0);
     // since we sent all identical events, verify the contents of just one of them

--- a/cdap-test/src/main/java/co/cask/cdap/test/StreamManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/StreamManager.java
@@ -108,10 +108,10 @@ public interface StreamManager {
   /**
    * Get events from the specified stream in the specified interval
    *
-   * @param startTime the start time
-   * @param endTime the end time
+   * @param startTime the start time in seconds or "now-xs" format
+   * @param endTime the end time in seconds or "now-xs" format
    * @param limit the maximum number of events to return
    * @return a list of stream events in the given time range
    */
-  List<StreamEvent> getEvents(long startTime, long endTime, int limit) throws IOException;
+  List<StreamEvent> getEvents(String startTime, String endTime, int limit) throws IOException;
 }

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultStreamManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultStreamManager.java
@@ -19,6 +19,7 @@ package co.cask.cdap.test.internal;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.flow.flowlet.StreamEvent;
 import co.cask.cdap.common.stream.StreamEventTypeAdapter;
+import co.cask.cdap.common.utils.TimeMathParser;
 import co.cask.cdap.data.stream.service.StreamFetchHandler;
 import co.cask.cdap.data.stream.service.StreamHandler;
 import co.cask.cdap.internal.io.SchemaTypeAdapter;
@@ -46,6 +47,7 @@ import java.lang.reflect.Type;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Default implementation of {@link StreamManager} for use in tests
@@ -149,11 +151,14 @@ public class DefaultStreamManager implements StreamManager {
   }
 
   @Override
-  public List<StreamEvent> getEvents(long startTime, long endTime, int limit) throws IOException {
+  public List<StreamEvent> getEvents(String startTime, String endTime, int limit) throws IOException {
     return getEvents(streamId, startTime, endTime, limit);
   }
 
-  private List<StreamEvent> getEvents(Id.Stream streamId, long startTime, long endTime, int limit) throws IOException {
+  private List<StreamEvent> getEvents(Id.Stream streamId, String start, String end, int limit) throws IOException {
+    long startTime = TimeUnit.SECONDS.toMillis(TimeMathParser.parseTime(start));
+    long endTime = TimeUnit.SECONDS.toMillis(TimeMathParser.parseTime(end));
+
     String path = String.format("/v3/namespaces/%s/streams/%s/events?start=%d&end=%d&limit=%d",
                                 streamId.getNamespaceId(), streamId.getId(), startTime, endTime, limit);
     HttpRequest httpRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, path);


### PR DESCRIPTION
Build - http://builds.cask.co/browse/CDAP-DUT1878-1

JIRA - https://issues.cask.co/browse/CDAP-1926

Streams endpoint now accepts times formatted as "now-xs".