### PR TITLE
CDAP-2529: CLI print error on failed autoconnect

### DIFF
--- a/cdap-cli/src/main/java/co/cask/cdap/cli/CLIMain.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/CLIMain.java
@@ -178,6 +178,8 @@ public class CLIMain {
       } catch (Exception e) {
         if (options.isDebug()) {
           e.printStackTrace(cliConfig.getOutput());
+        } else {
+          cliConfig.getOutput().print(e.getMessage());
         }
       }
     }


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-2529

Now when you try to execute a command in the CLI but the provided connection cannot be used, you see the following:

```
CDAP instance at 'http://localhost:10000' could not be reached: Connection refused
```

instead of

```
```