### PR TITLE
CDAP-2208 fixing dataset and explore classloading issues.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceClassLoader.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceClassLoader.java
@@ -279,7 +279,8 @@ public class MapReduceClassLoader extends CombineClassLoader {
     private static ClassLoader createClassFilteredClassLoader(Iterable<String> allowedClasses,
                                                               ClassLoader parentClassLoader) {
       Set<String> allowedResources = ImmutableSet.copyOf(Iterables.transform(allowedClasses, CLASS_TO_RESOURCE_NAME));
-      return new FilterClassLoader(Predicates.in(allowedResources), Predicates.<String>alwaysTrue(), parentClassLoader);
+      return FilterClassLoader.create(Predicates.in(allowedResources),
+        Predicates.<String>alwaysTrue(), parentClassLoader);
     }
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/co/cask/cdap/template/etl/batch/BaseETLBatchTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/co/cask/cdap/template/etl/batch/BaseETLBatchTest.java
@@ -34,6 +34,7 @@ import co.cask.cdap.template.etl.batch.source.StreamBatchSource;
 import co.cask.cdap.template.etl.batch.source.TableSource;
 import co.cask.cdap.template.etl.batch.source.TimePartitionedFileSetDatasetAvroSource;
 import co.cask.cdap.template.etl.common.DBRecord;
+import co.cask.cdap.template.etl.common.ETLConfig;
 import co.cask.cdap.template.etl.transform.ProjectionTransform;
 import co.cask.cdap.template.etl.transform.ScriptFilterTransform;
 import co.cask.cdap.template.etl.transform.StructuredRecordToGenericRecordTransform;
@@ -84,7 +85,8 @@ public class BaseETLBatchTest extends TestBase {
       JDBCDriver.class.getName());
     deployTemplate(NAMESPACE, TEMPLATE_ID, ETLBatchTemplate.class,
       PipelineConfigurable.class.getPackage().getName(),
-      BatchSource.class.getPackage().getName());
+      BatchSource.class.getPackage().getName(),
+      ETLConfig.class.getPackage().getName());
   }
 
   protected List<GenericRecord> readOutput(TimePartitionedFileSet fileSet, Schema schema) throws IOException {

--- a/cdap-common/src/main/java/co/cask/cdap/common/lang/FilterClassLoader.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/lang/FilterClassLoader.java
@@ -16,16 +16,20 @@
 
 package co.cask.cdap.common.lang;
 
+import co.cask.cdap.proto.ProgramType;
 import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterators;
+import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.Set;
 
 /**
  * ClassLoader that filters out certain resources.
@@ -36,11 +40,36 @@ public final class FilterClassLoader extends ClassLoader {
   private final Predicate<String> packageAcceptor;
   private final ClassLoader bootstrapClassLoader;
 
+  public static FilterClassLoader create(ClassLoader parentClassLoader) {
+    return create(null, parentClassLoader);
+  }
+
+  public static FilterClassLoader create(ProgramType programType, ClassLoader parentClassLoader) {
+    Set<String> visibleResources = ProgramResources.getVisibleResources(programType);
+    ImmutableSet.Builder<String> visiblePackages = ImmutableSet.builder();
+    for (String resource : visibleResources) {
+      if (resource.endsWith(".class")) {
+        int idx = resource.lastIndexOf('/');
+        // Ignore empty package
+        if (idx > 0) {
+          visiblePackages.add(resource.substring(0, idx));
+        }
+      }
+    }
+    return new FilterClassLoader(Predicates.in(visibleResources),
+      Predicates.in(visiblePackages.build()), parentClassLoader);
+  }
+
+  public static FilterClassLoader create(Predicate<String> resourceAcceptor,
+                                         Predicate<String> packageAcceptor, ClassLoader parentClassLoader) {
+    return new FilterClassLoader(resourceAcceptor, packageAcceptor, parentClassLoader);
+  }
+
   /**
    * @param resourceAcceptor Filter for accepting resources
    * @param parentClassLoader Parent classloader
    */
-  public FilterClassLoader(Predicate<String> resourceAcceptor,
+  private FilterClassLoader(Predicate<String> resourceAcceptor,
                            Predicate<String> packageAcceptor, ClassLoader parentClassLoader) {
     super(parentClassLoader);
     this.resourceAcceptor = resourceAcceptor;
@@ -62,24 +91,6 @@ public final class FilterClassLoader extends ClassLoader {
   }
 
   @Override
-  public URL findResource(String name) {
-    if (isValidResource(name)) {
-      return super.findResource(name);
-    }
-
-    return null;
-  }
-
-  @Override
-  public Enumeration<URL> findResources(String name) throws IOException {
-    if (isValidResource(name)) {
-      return super.findResources(name);
-    }
-
-    return Iterators.asEnumeration(ImmutableList.<URL>of().iterator());
-  }
-
-  @Override
   protected Package[] getPackages() {
     List<Package> packages = Lists.newArrayList();
     for (Package pkg : super.getPackages()) {
@@ -97,7 +108,17 @@ public final class FilterClassLoader extends ClassLoader {
 
   @Override
   public URL getResource(String name) {
-    return super.getResource(name);
+    return resourceAcceptor.apply(name) ? super.getResource(name) : null;
+  }
+
+  @Override
+  public Enumeration<URL> getResources(String name) throws IOException {
+    return resourceAcceptor.apply(name) ? super.getResources(name) : Collections.<URL>emptyEnumeration();
+  }
+
+  @Override
+  public InputStream getResourceAsStream(String name) {
+    return resourceAcceptor.apply(name) ? super.getResourceAsStream(name) : null;
   }
 
   private String classNameToResourceName(String className) {

--- a/cdap-common/src/main/java/co/cask/cdap/common/lang/ProgramClassLoader.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/lang/ProgramClassLoader.java
@@ -17,12 +17,9 @@
 package co.cask.cdap.common.lang;
 
 import co.cask.cdap.proto.ProgramType;
-import com.google.common.base.Predicates;
-import com.google.common.collect.ImmutableSet;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
@@ -53,21 +50,7 @@ public class ProgramClassLoader extends DirectoryClassLoader {
    */
   public static ProgramClassLoader create(File unpackedJarDir, ClassLoader parentClassLoader,
                                           @Nullable ProgramType programType) throws IOException {
-    Set<String> visibleResources = ProgramResources.getVisibleResources(programType);
-    ImmutableSet.Builder<String> visiblePackages = ImmutableSet.builder();
-    for (String resource : visibleResources) {
-      if (resource.endsWith(".class")) {
-        int idx = resource.lastIndexOf('/');
-        // Ignore empty package
-        if (idx > 0) {
-          visiblePackages.add(resource.substring(0, idx));
-        }
-      }
-    }
-
-    ClassLoader filteredParent = new FilterClassLoader(Predicates.in(visibleResources),
-                                                       Predicates.in(visiblePackages.build()),
-                                                       parentClassLoader);
+    ClassLoader filteredParent = FilterClassLoader.create(programType, parentClassLoader);
     return new ProgramClassLoader(unpackedJarDir, filteredParent);
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/dataset/SystemDatasetInstantiatorFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/dataset/SystemDatasetInstantiatorFactory.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.data.dataset;
 
 import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.lang.FilterClassLoader;
 import co.cask.cdap.data2.datafabric.dataset.type.DirectoryClassLoaderProvider;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import com.google.inject.Inject;
@@ -44,10 +45,23 @@ public class SystemDatasetInstantiatorFactory {
     this.cConf = cConf;
   }
 
+  /**
+   * Create a {@link SystemDatasetInstantiator} using the system classloader as the parent classloader.
+   *
+   * @return a {@link SystemDatasetInstantiator} using the system classloader as the parent classloader
+   */
   public SystemDatasetInstantiator create() {
     return create(null);
   }
 
+  /**
+   * Create a {@link SystemDatasetInstantiator} that uses the given classloader as the parent when instantiating
+   * datasets. 
+   *
+   * @param parentClassLoader the parent classloader to use when instantiating datasets. If null, the system
+   *                          classloader will be used
+   * @return a {@link SystemDatasetInstantiator} using the given classloader as the parent classloader
+   */
   public SystemDatasetInstantiator create(@Nullable ClassLoader parentClassLoader) {
     return new SystemDatasetInstantiator(datasetFramework, parentClassLoader,
       new DirectoryClassLoaderProvider(cConf, locationFactory),

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/type/DirectoryClassLoaderProvider.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/type/DirectoryClassLoaderProvider.java
@@ -136,7 +136,7 @@ public class DirectoryClassLoaderProvider implements DatasetClassLoaderProvider 
       BundleJarUtil.unpackProgramJar(jarLocation, unpackedDir);
       LOG.trace("unpacking dataset jar from {} to {}.", key.uri.toString(), unpackedDir.getAbsolutePath());
 
-      return new DirectoryClassLoader(unpackedDir, key.parentClassLoader);
+      return new DirectoryClassLoader(unpackedDir, key.parentClassLoader, "lib");
     }
   }
 }

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/datasets/ExtensiveSchemaTableDefinition.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/datasets/ExtensiveSchemaTableDefinition.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.explore.service.datasets;
 
+import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.data.batch.RecordScannable;
 import co.cask.cdap.api.data.batch.RecordScanner;
 import co.cask.cdap.api.data.batch.Scannables;
@@ -32,7 +33,6 @@ import co.cask.cdap.api.dataset.module.DatasetModule;
 import co.cask.cdap.api.dataset.table.Row;
 import co.cask.cdap.api.dataset.table.Table;
 import com.google.gson.Gson;
-import org.apache.hadoop.hbase.util.Bytes;
 
 import java.io.IOException;
 import java.lang.reflect.Type;

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/datasets/KeyExtendedStructValueTableDefinition.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/datasets/KeyExtendedStructValueTableDefinition.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.explore.service.datasets;
 
+import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.data.batch.RecordScannable;
 import co.cask.cdap.api.data.batch.RecordScanner;
 import co.cask.cdap.api.data.batch.RecordWritable;
@@ -34,7 +35,6 @@ import co.cask.cdap.api.dataset.table.Row;
 import co.cask.cdap.api.dataset.table.Table;
 import com.google.common.base.Objects;
 import com.google.gson.Gson;
-import org.apache.hadoop.hbase.util.Bytes;
 
 import java.io.IOException;
 import java.lang.reflect.Type;

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/datasets/KeyStructValueTableDefinition.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/datasets/KeyStructValueTableDefinition.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.explore.service.datasets;
 
+import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.data.batch.RecordScannable;
 import co.cask.cdap.api.data.batch.RecordScanner;
 import co.cask.cdap.api.data.batch.RecordWritable;
@@ -34,7 +35,6 @@ import co.cask.cdap.api.dataset.table.Row;
 import co.cask.cdap.api.dataset.table.Table;
 import com.google.common.base.Objects;
 import com.google.gson.Gson;
-import org.apache.hadoop.hbase.util.Bytes;
 
 import java.io.IOException;
 import java.lang.reflect.Type;

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/datasets/KeyValueTableDefinition.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/datasets/KeyValueTableDefinition.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.explore.service.datasets;
 
+import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.data.batch.RecordScannable;
 import co.cask.cdap.api.data.batch.RecordScanner;
 import co.cask.cdap.api.data.batch.RecordWritable;
@@ -34,7 +35,6 @@ import co.cask.cdap.api.dataset.table.Row;
 import co.cask.cdap.api.dataset.table.Table;
 import com.google.common.base.Objects;
 import com.google.gson.Gson;
-import org.apache.hadoop.hbase.util.Bytes;
 
 import java.io.IOException;
 import java.lang.reflect.Type;

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/datasets/WritableKeyStructValueTableDefinition.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/datasets/WritableKeyStructValueTableDefinition.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.explore.service.datasets;
 
+import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.data.batch.RecordWritable;
 import co.cask.cdap.api.dataset.DatasetAdmin;
 import co.cask.cdap.api.dataset.DatasetContext;
@@ -29,7 +30,6 @@ import co.cask.cdap.api.dataset.module.DatasetModule;
 import co.cask.cdap.api.dataset.table.Table;
 import com.google.common.base.Objects;
 import com.google.gson.Gson;
-import org.apache.hadoop.hbase.util.Bytes;
 
 import java.io.IOException;
 import java.lang.reflect.Type;


### PR DESCRIPTION
The first issue is that the FilterClassLoader does not filter
when getResource is called. When a dataset jar is built, this
can result in system jars getting leaked into the dataset jar.
The second issue is that in standalone mode, the classloader used
to instantiate DatasetType is a URLClassLoader, which means the
bundled lib jars are not visible. Finally, in explore, the
classloader a dataset is the same as the classloader for that
dataset's type, with the system classloader as a parent. This means
that system classes are leaked. Instead, the parent classloader
must be a FilterClassLoader. To support this, adding a couple
new ways to create a FilterClassLoader.