### PR TITLE
WorkflowManager extend ProgramManager for common program functionalities

### DIFF
--- a/cdap-test/src/main/java/co/cask/cdap/test/WorkflowManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/WorkflowManager.java
@@ -24,7 +24,7 @@ import java.util.List;
 /**
  * Workflow manager interface for managing the workflow and its schedules
  */
-public interface WorkflowManager {
+public interface WorkflowManager extends ProgramManager {
 
   /**
    * Get the list of schedules of the workflow


### PR DESCRIPTION
WorkflowManager extend ProgramManager for common program functionalities.
This change was missed from the following PR: https://github.com/caskdata/cdap/pull/2705; putting it in now.

http://builds.cask.co/browse/CDAP-DUT1900-1