### PR TITLE
update sockjs client to version 1.0.0

### DIFF
--- a/cdap-ui/bower.json
+++ b/cdap-ui/bower.json
@@ -22,7 +22,7 @@
     "cask-angular-confirmable": "https://github.com/caskdata/ng-capsules/raw/develop/zip/cask-angular-confirmable.zip",
     "cask-angular-promptable": "https://github.com/caskdata/ng-capsules/raw/develop/zip/cask-angular-promptable.zip",
     "cask-angular-json-edit": "https://github.com/caskdata/ng-capsules/raw/develop/zip/cask-angular-json-edit.zip",
-    "sockjs-client": "~0.3.4",
+    "sockjs-client": "1.0.0",
     "d3": "~3.5.5",
     "epoch": "~0.6.0",
     "ng-sortable": "~1.1.9",


### PR DESCRIPTION
Updated SockJS Client to version 1.0.0 from 0.3.4. 

Have to remove bower_components, and do bower install.

This PR should be merged after #2749 