### PR TITLE
go to the most current runs when a program start is clicked

### DIFF
--- a/cdap-ui/app/directives/start-stop-button/start-stop-button.js
+++ b/cdap-ui/app/directives/start-stop-button/start-stop-button.js
@@ -44,7 +44,12 @@ angular.module(PKG.name + '.commons')
           }
           dataSrc.request(requestObj)
             .then(function() {
-              $state.go($state.current, $state.params, {reload: true});
+              if ($state.params.runid && action === 'start') {
+                // go to the most current run, /runs
+                $state.go('^', $state.params, {reload: true});
+              } else {
+                $state.go($state.current, $state.params, {reload: true});
+              }
             });
         };
 

--- a/cdap-ui/app/directives/start-stop-button/start-stop-button.js
+++ b/cdap-ui/app/directives/start-stop-button/start-stop-button.js
@@ -44,7 +44,7 @@ angular.module(PKG.name + '.commons')
           }
           dataSrc.request(requestObj)
             .then(function() {
-              if ($state.params.runid && action === 'start') {
+              if ($state.includes('**.run')) {
                 // go to the most current run, /runs
                 $state.go('^', $state.params, {reload: true});
               } else {


### PR DESCRIPTION
Fixing a problem where when a user is at /runs/:runid and they click start a new run button, it does not go to the most recent runs.