### PR TITLE
CDAP-2254 Fixed the error message returned by handler

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/WorkflowHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/WorkflowHttpHandler.java
@@ -89,7 +89,8 @@ public class WorkflowHttpHandler extends ProgramLifecycleHttpHandler {
       Id.Program id = Id.Program.from(namespaceId, appId, ProgramType.WORKFLOW, workflowName);
       ProgramRuntimeService.RuntimeInfo runtimeInfo = runtimeService.list(id).get(RunIds.fromString(runId));
       if (runtimeInfo == null) {
-        sendInvalidResponse(responder, id);
+        responder.sendString(HttpResponseStatus.NOT_FOUND, String.format("Runtime information for run-id %s not found",
+                runId));
         return;
       }
       ProgramController controller = runtimeInfo.getController();
@@ -118,7 +119,8 @@ public class WorkflowHttpHandler extends ProgramLifecycleHttpHandler {
       Id.Program id = Id.Program.from(namespaceId, appId, ProgramType.WORKFLOW, workflowName);
       ProgramRuntimeService.RuntimeInfo runtimeInfo = runtimeService.list(id).get(RunIds.fromString(runId));
       if (runtimeInfo == null) {
-        sendInvalidResponse(responder, id);
+        responder.sendString(HttpResponseStatus.NOT_FOUND, String.format("Runtime information for run-id %s not found",
+                runId));
         return;
       }
       ProgramController controller = runtimeInfo.getController();
@@ -130,28 +132,6 @@ public class WorkflowHttpHandler extends ProgramLifecycleHttpHandler {
       controller.resume().get();
       responder.sendString(HttpResponseStatus.OK, "Program run resumed.");
     }  catch (SecurityException e) {
-      responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);
-    } catch (Throwable e) {
-      LOG.error("Got exception:", e);
-      responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
-    }
-  }
-
-  private void sendInvalidResponse(HttpResponder responder, Id.Program id) {
-    try {
-      AppFabricServiceStatus status;
-      ProgramStatus programStatus = getProgramStatus(id, ProgramType.WORKFLOW);
-      if (programStatus.getStatus().equals(HttpResponseStatus.NOT_FOUND.toString())) {
-        status = AppFabricServiceStatus.PROGRAM_NOT_FOUND;
-      } else if (ProgramController.State.COMPLETED.toString().equals(programStatus.getStatus())
-          || ProgramController.State.KILLED.toString().equals(programStatus.getStatus())
-          || ProgramController.State.ERROR.toString().equals(programStatus.getStatus())) {
-        status = AppFabricServiceStatus.PROGRAM_ALREADY_STOPPED;
-      } else {
-        status = AppFabricServiceStatus.RUNTIME_INFO_NOT_FOUND;
-      }
-      responder.sendString(status.getCode(), status.getMessage());
-    } catch (SecurityException e) {
       responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);
     } catch (Throwable e) {
       LOG.error("Got exception:", e);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowHttpHandlerTest.java
@@ -303,6 +303,11 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
     verifyProgramRuns(programId, "completed");
 
     waitState(programId, "STOPPED");
+
+    suspendWorkflow(programId, runId, 404);
+
+    resumeWorkflow(programId, runId, 404);
+
   }
 
   @Category(XSlowTests.class)


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-2254
Build: http://builds.cask.co/browse/CDAP-DUT1918-1

Fix the following bug: when one tries to suspend or resume a stopped/completed/failed workflow, he will get incorrect message "Unable to retrieve runtime information for %s (Application: %s)"

How to fix:
For the two methods suspendWorkflowRun and resumeWorkflowRun in WorkflowHttpHandler.java, once I found the run-id is stopped/completed/failed, I sent an error message at once.
Since sendInvalidResponse method is not used any more, delete it.

Test case:
1. Tested fix manually on standalone as well as on distributed mode.
2. Added a unit test case to the corresponding test file, to test I get correct code when I try to suspend/resume after a workflow is completed.