### PR TITLE
Revisions to build scripts:

### DIFF
--- a/cdap-docs/_common/common-build.sh
+++ b/cdap-docs/_common/common-build.sh
@@ -38,6 +38,7 @@ PROJECT="cdap"
 PROJECT_CAPS="CDAP"
 REFERENCE="reference-manual"
 SOURCE="source"
+SPHINX_MESSAGES="build/warnings.txt"
 
 FALSE="false"
 TRUE="true"
@@ -153,7 +154,7 @@ function build_docs() {
   clean
   cd ${SCRIPT_PATH}
   check_includes
-  sphinx-build -b html -d build/doctrees source build/html
+  sphinx-build -w ${SPHINX_MESSAGES} -b html -d build/doctrees source build/html
   display_any_messages
 }
 
@@ -161,7 +162,7 @@ function build_docs_google() {
   clean
   cd ${SCRIPT_PATH}
   check_includes
-  sphinx-build -D googleanalytics_id=$1 -D googleanalytics_enabled=1 -b html -d build/doctrees source build/html
+  sphinx-build -w ${SPHINX_MESSAGES} -D googleanalytics_id=$1 -D googleanalytics_enabled=1 -b html -d build/doctrees source build/html
   display_any_messages
 }
 
@@ -410,19 +411,32 @@ function set_message() {
 }
 
 function display_any_messages() {
-  if [ "x${MESSAGES}" != "x" ]; then
-    echo ""
-    echo_red_bold "Warning Messages for \"${MANUAL}\":"
-    echo ""
-    echo -e "${MESSAGES}"
-    echo ""
+  if [[ "x${MESSAGES}" != "x" || -s ${SPHINX_MESSAGES} ]]; then
+    local m="Warning Messages for \"${MANUAL}\":"
+    if [ "x${MESSAGES}" != "x" ]; then
+      echo ""
+      echo_red_bold "${m}"
+      echo ""
+      echo -e "${MESSAGES}"
+    fi
+    if [ -s ${SPHINX_MESSAGES} ]; then
+      m="Sphinx ${m}"
+      echo ""
+      echo_red_bold "${m}"
+      echo ${m} >> ${TMP_MESSAGES_FILE}
+      cat ${SPHINX_MESSAGES} | while read line
+      do
+        echo ${line}
+        echo ${line} >> ${TMP_MESSAGES_FILE}
+      done
+    fi
   fi
 }
 
 function display_messages_file() {
   if [[ "x${TMP_MESSAGES_FILE}" != "x" && -a ${TMP_MESSAGES_FILE} ]]; then
     echo ""
-    echo "Warning Messages:"
+    echo "Warning Messages: ${TMP_MESSAGES_FILE}"
     echo ""
     cat ${TMP_MESSAGES_FILE} | while read line
     do

--- a/cdap-docs/_common/common-build.sh
+++ b/cdap-docs/_common/common-build.sh
@@ -396,12 +396,12 @@ function clear_messages() {
 
 function set_message() {
   if [ "x${MESSAGES}" == "x" ]; then
-    MESSAGES="${1}"
+    MESSAGES=${*}
   else
-    MESSAGES="${MESSAGES}\n\n${1}"
+    MESSAGES="${MESSAGES}\n\n${*}"
   fi
   if [ "x${TMP_MESSAGES_FILE}" != "x" ]; then
-    local clean_m=`echo_clean_colors "${1}"`
+    local clean_m=`echo_clean_colors "${*}"`
     if [ -e ${TMP_MESSAGES_FILE} ]; then
       echo >> ${TMP_MESSAGES_FILE}
     fi

--- a/cdap-docs/_common/common-build.sh
+++ b/cdap-docs/_common/common-build.sh
@@ -38,7 +38,7 @@ PROJECT="cdap"
 PROJECT_CAPS="CDAP"
 REFERENCE="reference-manual"
 SOURCE="source"
-SPHINX_MESSAGES="build/warnings.txt"
+SPHINX_MESSAGES="warnings.txt"
 
 FALSE="false"
 TRUE="true"
@@ -154,7 +154,7 @@ function build_docs() {
   clean
   cd ${SCRIPT_PATH}
   check_includes
-  sphinx-build -w ${SPHINX_MESSAGES} -b html -d build/doctrees source build/html
+  sphinx-build -w ${BUILD}/${SPHINX_MESSAGES} -b html -d ${BUILD}/doctrees source ${BUILD}/html
   display_any_messages
 }
 
@@ -162,7 +162,7 @@ function build_docs_google() {
   clean
   cd ${SCRIPT_PATH}
   check_includes
-  sphinx-build -w ${SPHINX_MESSAGES} -D googleanalytics_id=$1 -D googleanalytics_enabled=1 -b html -d build/doctrees source build/html
+  sphinx-build -w ${BUILD}/${SPHINX_MESSAGES} -D googleanalytics_id=$1 -D googleanalytics_enabled=1 -b html -d ${BUILD}/doctrees source ${BUILD}/html
   display_any_messages
 }
 

--- a/cdap-docs/_common/common-build.sh
+++ b/cdap-docs/_common/common-build.sh
@@ -355,11 +355,12 @@ function version() {
   elif [ "${GIT_BRANCH:0:7}" == "release" ]; then
     GIT_BRANCH_TYPE="release"
   else
+    # We are on a feature branch: but from develop or release?
     GIT_PARENT_BRANCH=`git show-branch | grep '*' | grep -v "$(git rev-parse --abbrev-ref HEAD)" | head -n1 | sed 's/.*\[\(.*\)\].*/\1/' | sed 's/[\^~].*//'`
-    if [ "${GIT_PARENT_BRANCH}" == "develop" ]; then
-      GIT_BRANCH_TYPE="develop-feature"
-    else
+    if [ "${GIT_PARENT_BRANCH}" == "release" ]; then
       GIT_BRANCH_TYPE="release-feature"
+    else
+      GIT_BRANCH_TYPE="develop-feature"
     fi
   fi
   cd $current_directory

--- a/cdap-docs/_common/common-build.sh
+++ b/cdap-docs/_common/common-build.sh
@@ -346,6 +346,7 @@ function version() {
   PROJECT_SHORT_VERSION=`expr "${PROJECT_VERSION}" : '\([0-9]*\.[0-9]*\)'`
   local full_branch=`git rev-parse --abbrev-ref HEAD`
   IFS=/ read -a branch <<< "${full_branch}"
+  GIT_PARENT_BRANCH=""
   GIT_BRANCH="${branch[1]}"
   # Determine branch and branch type: one of develop, master, release, develop-feature, release-feature
   if [ "${full_branch}" == "develop" -o  "${full_branch}" == "master" ]; then
@@ -354,8 +355,8 @@ function version() {
   elif [ "${GIT_BRANCH:0:7}" == "release" ]; then
     GIT_BRANCH_TYPE="release"
   else
-    local parent_branch=`git show-branch | grep '*' | grep -v "$(git rev-parse --abbrev-ref HEAD)" | head -n1 | sed 's/.*\[\(.*\)\].*/\1/' | sed 's/[\^~].*//'`
-    if [ "${parent_branch}" == "develop" ]; then
+    GIT_PARENT_BRANCH=`git show-branch | grep '*' | grep -v "$(git rev-parse --abbrev-ref HEAD)" | head -n1 | sed 's/.*\[\(.*\)\].*/\1/' | sed 's/[\^~].*//'`
+    if [ "${GIT_PARENT_BRANCH}" == "develop" ]; then
       GIT_BRANCH_TYPE="develop-feature"
     else
       GIT_BRANCH_TYPE="release-feature"
@@ -374,6 +375,7 @@ function display_version() {
   echo "PROJECT_SHORT_VERSION: ${PROJECT_SHORT_VERSION}"
   echo "GIT_BRANCH: ${GIT_BRANCH}"
   echo "GIT_BRANCH_TYPE: ${GIT_BRANCH_TYPE}"
+  echo "GIT_PARENT_BRANCH: ${GIT_PARENT_BRANCH}"
 }
 
 function set_messages_file() {
@@ -384,7 +386,6 @@ function set_messages_file() {
 function cleanup_messages_file() {
   if [[ "x${TMP_MESSAGES_FILE}" != "x" && -a ${TMP_MESSAGES_FILE} ]]; then
     rm -f TMP_MESSAGES_FILE
-    echo "Deleted Message File ${TMP_MESSAGES_FILE}"
   fi
 }
 
@@ -421,7 +422,7 @@ function display_any_messages() {
 function display_messages_file() {
   if [[ "x${TMP_MESSAGES_FILE}" != "x" && -a ${TMP_MESSAGES_FILE} ]]; then
     echo ""
-    echo_red_bold "Warning Messages:"
+    echo "Warning Messages:"
     echo ""
     cat ${TMP_MESSAGES_FILE} | while read line
     do

--- a/cdap-docs/_common/common-build.sh
+++ b/cdap-docs/_common/common-build.sh
@@ -346,7 +346,6 @@ function version() {
   PROJECT_SHORT_VERSION=`expr "${PROJECT_VERSION}" : '\([0-9]*\.[0-9]*\)'`
   local full_branch=`git rev-parse --abbrev-ref HEAD`
   IFS=/ read -a branch <<< "${full_branch}"
-  GIT_PARENT_BRANCH=""
   GIT_BRANCH="${branch[1]}"
   # Determine branch and branch type: one of develop, master, release, develop-feature, release-feature
   if [ "${full_branch}" == "develop" -o  "${full_branch}" == "master" ]; then
@@ -356,8 +355,10 @@ function version() {
     GIT_BRANCH_TYPE="release"
   else
     # We are on a feature branch: but from develop or release?
-    GIT_PARENT_BRANCH=`git show-branch | grep '*' | grep -v "$(git rev-parse --abbrev-ref HEAD)" | head -n1 | sed 's/.*\[\(.*\)\].*/\1/' | sed 's/[\^~].*//'`
-    if [ "${GIT_PARENT_BRANCH}" == "release" ]; then
+    if [[ "x${GIT_BRANCH_PARENT}" == "x" ]]; then
+      GIT_BRANCH_PARENT=`git show-branch | grep '*' | grep -v "$(git rev-parse --abbrev-ref HEAD)" | head -n1 | sed 's/.*\[\(.*\)\].*/\1/' | sed 's/[\^~].*//'`  
+    fi
+    if [ "${GIT_BRANCH_PARENT}" == "release" ]; then
       GIT_BRANCH_TYPE="release-feature"
     else
       GIT_BRANCH_TYPE="develop-feature"
@@ -376,7 +377,7 @@ function display_version() {
   echo "PROJECT_SHORT_VERSION: ${PROJECT_SHORT_VERSION}"
   echo "GIT_BRANCH: ${GIT_BRANCH}"
   echo "GIT_BRANCH_TYPE: ${GIT_BRANCH_TYPE}"
-  echo "GIT_PARENT_BRANCH: ${GIT_PARENT_BRANCH}"
+  echo "GIT_BRANCH_PARENT: ${GIT_BRANCH_PARENT}"
 }
 
 function set_messages_file() {

--- a/cdap-docs/_common/common-build.sh
+++ b/cdap-docs/_common/common-build.sh
@@ -28,6 +28,7 @@ APIDOCS="apidocs"
 APIS="apis"
 BUILD="build"
 BUILD_PDF="build-pdf"
+CDAP_DOCS="cdap-docs"
 HTML="html"
 INCLUDES="_includes"
 JAVADOCS="javadocs"
@@ -140,7 +141,6 @@ function usage() {
   echo "    source         Path to $PROJECT source for javadocs, if not $PROJECT_PATH"
   echo "    test_includes  local, remote or neither (default: remote); must specify source if used"
   echo " "
-#   exit 1
 }
 
 function clean() {
@@ -386,13 +386,11 @@ function set_messages_file() {
 }
 
 function cleanup_messages_file() {
-  if [[ "x${TMP_MESSAGES_FILE}" != "x" && -a ${TMP_MESSAGES_FILE} ]]; then
-    rm -f TMP_MESSAGES_FILE
-  fi
+  rm -f ${TMP_MESSAGES_FILE}
 }
 
 function clear_messages() {
-  MESSAGES=""
+  MESSAGES=
   set_messages_file
 }
 
@@ -404,8 +402,8 @@ function set_message() {
   fi
   if [ "x${TMP_MESSAGES_FILE}" != "x" ]; then
     local clean_m=`echo_clean_colors "${1}"`
-    if [ -a ${TMP_MESSAGES_FILE} ]; then
-      echo -e "\n" >> ${TMP_MESSAGES_FILE}
+    if [ -e ${TMP_MESSAGES_FILE} ]; then
+      echo >> ${TMP_MESSAGES_FILE}
     fi
     echo -e "Warning Message for \"${MANUAL}\":\n${clean_m}" >> ${TMP_MESSAGES_FILE}
   fi

--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -38,6 +38,25 @@ function set_project_path() {
   fi
 }
 
+function check_starting_directory() {
+  E_WRONG_DIRECTORY=85
+
+  if [[ "x${MANUAL}" == "x" || "x${CDAP_DOCS}" == "x" ]]; then
+    echo "Manual or CDAP_DOCS set incorrectly: are you in the correct directory?"
+    exit ${E_WRONG_DIRECTORY}
+  fi
+  
+  if [[ " ${MANUALS[@]}" =~ "${MANUAL} " || "${MANUAL}" == "${CDAP_DOCS}" ]]; then
+    echo "Using \"${MANUAL}\""
+    return 0
+  else  
+    echo "Did not find MANUAL \"${MANUAL}\": are you in the correct directory?"
+    exit ${E_WRONG_DIRECTORY}
+  fi
+  
+  exit 1
+}
+
 function usage() {
   cd ${PROJECT_PATH}
   PROJECT_PATH=`pwd`
@@ -335,6 +354,8 @@ function clean_builds() {
     echo ""
   done
 }
+
+check_starting_directory
 
 set_project_path
 

--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -67,20 +67,20 @@ function usage() {
 
 function run_command() {
   case "${1}" in
-    all )               build_all; exit 0;;
-    clean )             clean_builds; exit 0;;
-    doc )               build_docs_outer_level; exit 0;;
-    docs )              build_docs; exit 0;;
+    all )               build_all;;
+    clean )             clean_builds;;
+    doc )               build_docs_outer_level;;
+    docs )              build_docs;;
     docs-github-part )  build_docs_github ${ARG_2} ${ARG_3};;
-    docs-github )       build_docs_github ${ARG_2} ${ARG_3}; exit 0;;
+    docs-github )       build_docs_github ${ARG_2} ${ARG_3};;
     docs-web-part )     build_docs_web ${ARG_2} ${ARG_3};;
-    docs-web )          build_docs_web ${ARG_2} ${ARG_3}; exit 0;;
-    javadocs )          build_javadocs; exit 0;;
-    licenses )          build_license_depends; exit 0;;
-    sdk )               build_sdk; exit 0;;
-    version )           print_version; exit 0;;
-    test )              test; exit 0;;
-    * )                 usage; exit 0;;
+    docs-web )          build_docs_web ${ARG_2} ${ARG_3};;
+    javadocs )          build_javadocs;;
+    licenses )          build_license_depends;;
+    sdk )               build_sdk;;
+    version )           print_version;;
+    test )              test;;
+    * )                 usage;;
   esac
 }
 
@@ -215,14 +215,17 @@ function build_docs_javadocs() {
 
 function build_docs() {
   _build_docs "docs" ${GOOGLE_ANALYTICS_WEB} ${WEB} ${TRUE}
+  return $?
 }
 
 function build_docs_github() {
   _build_docs "build-github" ${GOOGLE_ANALYTICS_GITHUB} ${GITHUB} ${FALSE}
+  return $?
 }
 
 function build_docs_web() {
   _build_docs "build-web" ${GOOGLE_ANALYTICS_WEB} ${WEB} ${TRUE}
+  return $?
 }
 
 function _build_docs() {
@@ -231,17 +234,22 @@ function _build_docs() {
   echo "========================================================"
   echo "Building target \"${1}\"..."
   echo "--------------------------------------------------------"
+  clear_message
   build_docs_inner_level ${1}
   build_docs_outer_level ${2}
   copy_docs_lower_level
   build_zip ${3}
   zip_extras ${4}
   display_version
+  display_message_file
+  local warnings="$?"
+  echo ""
   echo "--------------------------------------------------------"
   bell "Building target \"${1}\" completed."
   echo "========================================================"
   echo "========================================================"
   echo ""
+  return ${warnings}
 }
 
 function build_docs_inner_level() {

--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -234,15 +234,16 @@ function _build_docs() {
   echo "========================================================"
   echo "Building target \"${1}\"..."
   echo "--------------------------------------------------------"
-  clear_message
+  clear_messages
   build_docs_inner_level ${1}
   build_docs_outer_level ${2}
   copy_docs_lower_level
   build_zip ${3}
   zip_extras ${4}
   display_version
-  display_message_file
+  display_messages_file
   local warnings="$?"
+  cleanup_messages_file
   echo ""
   echo "--------------------------------------------------------"
   bell "Building target \"${1}\" completed."

--- a/cdap-docs/examples-manual/build.sh
+++ b/cdap-docs/examples-manual/build.sh
@@ -136,7 +136,7 @@ function download_includes() {
   test_an_include 9f963a17090976d2c15a4d092bd9e8de ../../cdap-examples/CountRandom/src/main/java/co/cask/cdap/examples/countrandom/NumberCounter.java
   
   test_an_include 8a7b4aacee88800cd82d96b07280cc64 ../../cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetExample.java
-  test_an_include a4f3a23bc33ac2c792eb2930ab832f46 ../../cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetService.java
+  test_an_include 2ad024c8093bea2b3cb9b5fa14f1224b ../../cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetService.java
   test_an_include 31c9d6fd543a48ce5e3f2b9cdc630b6d ../../cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/WordCount.java
   
   test_an_include fb66227699e66ae1e93bed905ed9efae ../../cdap-examples/HelloWorld/src/main/java/co/cask/cdap/examples/helloworld/HelloWorld.java
@@ -148,8 +148,8 @@ function download_includes() {
   test_an_include 8632b56f39c02e695f11c74729fbc456 ../../cdap-examples/SparkPageRank/src/main/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankApp.java
 
   test_an_include afe12d26b79607a846d3eaa58958ea5f ../../cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/SportResults.java
-  test_an_include f58086a5f0c86aa4e8d47ea09fa3f0f1 ../../cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/UploadService.java
-  test_an_include 53640748584c7bd98d7c58b3a51a72e9 ../../cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/ScoreCounter.java
+  test_an_include bbeed2893195fa12553e4eb28016306a ../../cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/UploadService.java
+  test_an_include 1089a092c1f0af1ecfedae646c9c6b99 ../../cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/ScoreCounter.java
   
   test_an_include 2176f426a50b2d68817cd7da7b7faffb ../../cdap-examples/StreamConversion/src/main/java/co/cask/cdap/examples/streamconversion/StreamConversionApp.java
   test_an_include b3ad7dc7ddbb5b905145dbf15a5c9b93 ../../cdap-examples/StreamConversion/src/main/java/co/cask/cdap/examples/streamconversion/StreamConversionMapReduce.java


### PR DESCRIPTION
- cleaned up exit codes on main case statements
- added a message handling facility that writes messages to a tmp file and then plays them back again, at both the end of building a manual, and at the end of the entire run.
- returns 1 if there are any warning messages to indicate a failed run.

- [Example of failed run](http://builds.cask.co/browse/CDAP-DDBD151-1/log)
- [Example of successful run, after fixing MD5 changes](http://builds.cask.co/browse/CDAP-DDBD151-8/log)

https://issues.cask.co/browse/CDAP-2552

Update: it now outputs the Sphinx warnings to a tmp file, and then appends them to the message tmp file. That way, all messages are now visible at the end of the log file...