### PR TITLE
[CDAP-1926] streams endpoint accepts now-xs format

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/test/java/co/cask/cdap/template/etl/realtime/ETLWorkerTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/test/java/co/cask/cdap/template/etl/realtime/ETLWorkerTest.java
@@ -88,7 +88,8 @@ public class ETLWorkerTest extends TestBase {
     ETLStage sink = new ETLStage("Stream", ImmutableMap.of(Properties.Stream.NAME, "testS"));
     ETLRealtimeConfig etlConfig = new ETLRealtimeConfig(source, sink, Lists.<ETLStage>newArrayList());
 
-    AdapterConfig adapterConfig = new AdapterConfig("null properties", TEMPLATE_ID.getId(), GSON.toJsonTree(etlConfig));
+    AdapterConfig adapterConfig = new AdapterConfig("null properties", TEMPLATE_ID.getId(),
+                                                    GSON.toJsonTree(etlConfig));
     Id.Adapter adapterId = Id.Adapter.from(NAMESPACE, "testAdap");
     AdapterManager adapterManager = createAdapter(adapterId, adapterConfig);
     Assert.assertNotNull(adapterManager);
@@ -119,7 +120,8 @@ public class ETLWorkerTest extends TestBase {
 
     StreamManager streamManager = getStreamManager(NAMESPACE, "testStream");
     long currentDiff = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis() - startTime);
-    List<StreamEvent> streamEvents = streamManager.getEvents("now-" + Long.toString(currentDiff) + "s", "now", Integer.MAX_VALUE);
+    List<StreamEvent> streamEvents = streamManager.getEvents("now-" + Long.toString(currentDiff) + "s", "now",
+                                                             Integer.MAX_VALUE);
     // verify that some events were sent to the stream
     Assert.assertTrue(streamEvents.size() > 0);
     // since we sent all identical events, verify the contents of just one of them

--- a/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/test/java/co/cask/cdap/template/etl/realtime/ETLWorkerTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/test/java/co/cask/cdap/template/etl/realtime/ETLWorkerTest.java
@@ -119,8 +119,8 @@ public class ETLWorkerTest extends TestBase {
     adapterManager.stop();
 
     StreamManager streamManager = getStreamManager(NAMESPACE, "testStream");
-    long currentDiff = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis() - startTime);
-    List<StreamEvent> streamEvents = streamManager.getEvents("now-" + Long.toString(currentDiff) + "s", "now",
+    long currentDiff = System.currentTimeMillis() - startTime;
+    List<StreamEvent> streamEvents = streamManager.getEvents("now-" + Long.toString(currentDiff) + "ms", "now",
                                                              Integer.MAX_VALUE);
     // verify that some events were sent to the stream
     Assert.assertTrue(streamEvents.size() > 0);

--- a/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/test/java/co/cask/cdap/template/etl/realtime/ETLWorkerTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/test/java/co/cask/cdap/template/etl/realtime/ETLWorkerTest.java
@@ -118,7 +118,8 @@ public class ETLWorkerTest extends TestBase {
     adapterManager.stop();
 
     StreamManager streamManager = getStreamManager(NAMESPACE, "testStream");
-    List<StreamEvent> streamEvents = streamManager.getEvents(startTime, System.currentTimeMillis(), Integer.MAX_VALUE);
+    long currentDiff = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis() - startTime);
+    List<StreamEvent> streamEvents = streamManager.getEvents("now-" + Long.toString(currentDiff) + "s", "now", Integer.MAX_VALUE);
     // verify that some events were sent to the stream
     Assert.assertTrue(streamEvents.size() > 0);
     // since we sent all identical events, verify the contents of just one of them

--- a/cdap-client/src/main/java/co/cask/cdap/client/StreamClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/StreamClient.java
@@ -87,7 +87,7 @@ public class StreamClient {
    * Gets the configuration of a stream.
    *
    * @param streamId ID of the stream
-   * @throws IOException if a network error occurred
+   * @throws IOException             if a network error occurred
    * @throws StreamNotFoundException if the stream was not found
    */
   public StreamProperties getConfig(String streamId)
@@ -106,11 +106,11 @@ public class StreamClient {
   /**
    * Sets properties of a stream.
    *
-   * @param streamId ID of the stream
+   * @param streamId   ID of the stream
    * @param properties properties to set
-   * @throws IOException if a network error occurred
-   * @throws UnauthorizedException if the client is unauthorized
-   * @throws BadRequestException if the request is bad
+   * @throws IOException             if a network error occurred
+   * @throws UnauthorizedException   if the client is unauthorized
+   * @throws BadRequestException     if the request is bad
    * @throws StreamNotFoundException if the stream was not found
    */
   public void setStreamProperties(String streamId, StreamProperties properties)
@@ -135,7 +135,7 @@ public class StreamClient {
    * Creates a stream.
    *
    * @param newStreamId ID of the new stream to create
-   * @throws IOException if a network error occurred
+   * @throws IOException         if a network error occurred
    * @throws BadRequestException if the provided stream ID was invalid
    */
   public void create(String newStreamId) throws IOException, BadRequestException, UnauthorizedException {
@@ -151,12 +151,12 @@ public class StreamClient {
    * Sends an event to a stream.
    *
    * @param streamId ID of the stream
-   * @param event event to send to the stream
-   * @throws IOException if a network error occurred
+   * @param event    event to send to the stream
+   * @throws IOException             if a network error occurred
    * @throws StreamNotFoundException if the stream with the specified ID was not found
    */
   public void sendEvent(String streamId, String event) throws IOException,
-                                                              StreamNotFoundException, UnauthorizedException {
+    StreamNotFoundException, UnauthorizedException {
     writeEvent(config.resolveNamespacedURLV3(String.format("streams/%s", streamId)), streamId, event);
   }
 
@@ -165,22 +165,22 @@ public class StreamClient {
    * the event has been received by the server, but may not get persisted.
    *
    * @param streamId ID of the stream
-   * @param event event to send to the stream
-   * @throws IOException if a network error occurred
+   * @param event    event to send to the stream
+   * @throws IOException             if a network error occurred
    * @throws StreamNotFoundException if the stream with the specified ID was not found
    */
   public void asyncSendEvent(String streamId, String event) throws IOException,
-                                                                   StreamNotFoundException, UnauthorizedException {
+    StreamNotFoundException, UnauthorizedException {
     writeEvent(config.resolveNamespacedURLV3(String.format("streams/%s/async", streamId)), streamId, event);
   }
 
   /**
    * Sends a file of the given content type to a stream batch endpoint.
    *
-   * @param streamId ID of the stream
+   * @param streamId    ID of the stream
    * @param contentType content type of the file
-   * @param file the file to upload
-   * @throws IOException if a network error occurred
+   * @param file        the file to upload
+   * @throws IOException             if a network error occurred
    * @throws StreamNotFoundException if the stream with the specified ID was not found
    */
   public void sendFile(String streamId, String contentType,
@@ -191,10 +191,10 @@ public class StreamClient {
   /**
    * Sends a batch request to a stream batch endpoint.
    *
-   * @param streamId ID of the stream
-   * @param contentType content type of the data
+   * @param streamId      ID of the stream
+   * @param contentType   content type of the data
    * @param inputSupplier provides content for the batch request
-   * @throws IOException if a network error occurred
+   * @throws IOException             if a network error occurred
    * @throws StreamNotFoundException if the stream with the specified ID was not found
    */
   public void sendBatch(String streamId, String contentType,
@@ -216,7 +216,7 @@ public class StreamClient {
    * Truncates a stream, deleting all stream events belonging to the stream.
    *
    * @param streamId ID of the stream to truncate
-   * @throws IOException if a network error occurred
+   * @throws IOException             if a network error occurred
    * @throws StreamNotFoundException if the stream with the specified name was not found
    */
   public void truncate(String streamId) throws IOException, StreamNotFoundException, UnauthorizedException {
@@ -233,7 +233,7 @@ public class StreamClient {
    * Deletes a stream.
    *
    * @param streamId ID of the stream to truncate
-   * @throws IOException if a network error occurred
+   * @throws IOException             if a network error occurred
    * @throws StreamNotFoundException if the stream with the specified name was not found
    */
   public void delete(String streamId) throws IOException, StreamNotFoundException, UnauthorizedException {
@@ -249,9 +249,9 @@ public class StreamClient {
   /**
    * Sets the Time-to-Live (TTL) of a stream. TTL governs how long stream events are readable.
    *
-   * @param streamId ID of the stream
+   * @param streamId     ID of the stream
    * @param ttlInSeconds desired TTL, in seconds
-   * @throws IOException if a network error occurred
+   * @throws IOException             if a network error occurred
    * @throws StreamNotFoundException if the stream with the specified name was not found
    */
   public void setTTL(String streamId, long ttlInSeconds)
@@ -276,20 +276,21 @@ public class StreamClient {
   public List<StreamDetail> list() throws IOException, UnauthorizedException {
     URL url = config.resolveNamespacedURLV3("streams");
     HttpResponse response = restClient.execute(HttpMethod.GET, url, config.getAccessToken());
-    return ObjectResponse.fromJsonBody(response, new TypeToken<List<StreamDetail>>() { }).getResponseObject();
+    return ObjectResponse.fromJsonBody(response, new TypeToken<List<StreamDetail>>() {
+    }).getResponseObject();
   }
 
   /**
    * Reads events from a stream
    *
-   * @param streamId ID of the stream
+   * @param streamId  ID of the stream
    * @param startTime Timestamp in milliseconds to start reading event from (inclusive)
-   * @param endTime Timestamp in milliseconds for the last event to read (exclusive)
-   * @param limit Maximum number of events to read
-   * @param results Collection for storing the resulting stream events
-   * @param <T> Type of the collection for storing results
+   * @param endTime   Timestamp in milliseconds for the last event to read (exclusive)
+   * @param limit     Maximum number of events to read
+   * @param results   Collection for storing the resulting stream events
+   * @param <T>       Type of the collection for storing results
    * @return The same collection object as passed in the {@code results} parameter
-   * @throws IOException If fails to read from stream
+   * @throws IOException             If fails to read from stream
    * @throws StreamNotFoundException If the given stream does not exists
    */
   public <T extends Collection<? super StreamEvent>> T getEvents(String streamId, String startTime,
@@ -308,40 +309,33 @@ public class StreamClient {
   /**
    * Reads events from a stream
    *
-   * @param streamId ID of the stream
+   * @param streamId  ID of the stream
    * @param startTime Timestamp in milliseconds to start reading event from (inclusive)
-   * @param endTime Timestamp in milliseconds for the last event to read (exclusive)
-   * @param limit Maximum number of events to read
-   * @param results Collection for storing the resulting stream events
-   * @param <T> Type of the collection for storing results
+   * @param endTime   Timestamp in milliseconds for the last event to read (exclusive)
+   * @param limit     Maximum number of events to read
+   * @param results   Collection for storing the resulting stream events
+   * @param <T>       Type of the collection for storing results
    * @return The same collection object as passed in the {@code results} parameter
-   * @throws IOException If fails to read from stream
+   * @throws IOException             If fails to read from stream
    * @throws StreamNotFoundException If the given stream does not exists
    */
   @Deprecated
   public <T extends Collection<? super StreamEvent>> T getEvents(String streamId, long startTime,
                                                                  long endTime, int limit, final T results)
     throws IOException, StreamNotFoundException, UnauthorizedException {
-    getEvents(streamId, startTime, endTime, limit, new Function<StreamEvent, Boolean>() {
-      @Override
-      public Boolean apply(StreamEvent input) {
-        results.add(input);
-        return true;
-      }
-    });
-    return results;
+    return getEvents(streamId, String.valueOf(startTime), String.valueOf(endTime), limit, results);
   }
 
   /**
    * Reads events from a stream
    *
    * @param streamId ID of the stream
-   * @param start Timestamp in milliseconds or now-xs format to start reading event from (inclusive)
-   * @param end Timestamp in milliseconds or now-xs format for the last event to read (exclusive)
-   * @param limit Maximum number of events to read
+   * @param start    Timestamp in milliseconds or now-xs format to start reading event from (inclusive)
+   * @param end      Timestamp in milliseconds or now-xs format for the last event to read (exclusive)
+   * @param limit    Maximum number of events to read
    * @param callback Callback to invoke for each stream event read. If the callback function returns {@code false}
    *                 upon invocation, it will stops the reading
-   * @throws IOException If fails to read from stream
+   * @throws IOException             If fails to read from stream
    * @throws StreamNotFoundException If the given stream does not exists
    */
   public void getEvents(String streamId, String start, String end, int limit,
@@ -399,13 +393,13 @@ public class StreamClient {
   /**
    * Reads events from a stream
    *
-   * @param streamId ID of the stream
+   * @param streamId  ID of the stream
    * @param startTime Timestamp in milliseconds to start reading event from (inclusive)
-   * @param endTime Timestamp in milliseconds for the last event to read (exclusive)
-   * @param limit Maximum number of events to read
-   * @param callback Callback to invoke for each stream event read. If the callback function returns {@code false}
-   *                 upon invocation, it will stops the reading
-   * @throws IOException If fails to read from stream
+   * @param endTime   Timestamp in milliseconds for the last event to read (exclusive)
+   * @param limit     Maximum number of events to read
+   * @param callback  Callback to invoke for each stream event read. If the callback function returns {@code false}
+   *                  upon invocation, it will stops the reading
+   * @throws IOException             If fails to read from stream
    * @throws StreamNotFoundException If the given stream does not exists
    */
   @Deprecated

--- a/cdap-client/src/main/java/co/cask/cdap/client/StreamClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/StreamClient.java
@@ -24,6 +24,7 @@ import co.cask.cdap.common.exception.BadRequestException;
 import co.cask.cdap.common.exception.StreamNotFoundException;
 import co.cask.cdap.common.exception.UnauthorizedException;
 import co.cask.cdap.common.stream.StreamEventTypeAdapter;
+import co.cask.cdap.common.utils.TimeMathParser;
 import co.cask.cdap.internal.io.SchemaTypeAdapter;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.StreamDetail;
@@ -55,6 +56,7 @@ import java.net.URL;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 import javax.net.ssl.HttpsURLConnection;
 import javax.ws.rs.core.HttpHeaders;
@@ -290,8 +292,8 @@ public class StreamClient {
    * @throws IOException If fails to read from stream
    * @throws StreamNotFoundException If the given stream does not exists
    */
-  public <T extends Collection<? super StreamEvent>> T getEvents(String streamId, long startTime,
-                                                                 long endTime, int limit, final T results)
+  public <T extends Collection<? super StreamEvent>> T getEvents(String streamId, String startTime,
+                                                                 String endTime, int limit, final T results)
     throws IOException, StreamNotFoundException, UnauthorizedException {
     getEvents(streamId, startTime, endTime, limit, new Function<StreamEvent, Boolean>() {
       @Override
@@ -310,14 +312,44 @@ public class StreamClient {
    * @param startTime Timestamp in milliseconds to start reading event from (inclusive)
    * @param endTime Timestamp in milliseconds for the last event to read (exclusive)
    * @param limit Maximum number of events to read
+   * @param results Collection for storing the resulting stream events
+   * @param <T> Type of the collection for storing results
+   * @return The same collection object as passed in the {@code results} parameter
+   * @throws IOException If fails to read from stream
+   * @throws StreamNotFoundException If the given stream does not exists
+   */
+  @Deprecated
+  public <T extends Collection<? super StreamEvent>> T getEvents(String streamId, long startTime,
+                                                                 long endTime, int limit, final T results)
+    throws IOException, StreamNotFoundException, UnauthorizedException {
+    getEvents(streamId, startTime, endTime, limit, new Function<StreamEvent, Boolean>() {
+      @Override
+      public Boolean apply(StreamEvent input) {
+        results.add(input);
+        return true;
+      }
+    });
+    return results;
+  }
+
+  /**
+   * Reads events from a stream
+   *
+   * @param streamId ID of the stream
+   * @param start Timestamp in milliseconds or now-xs format to start reading event from (inclusive)
+   * @param end Timestamp in milliseconds or now-xs format for the last event to read (exclusive)
+   * @param limit Maximum number of events to read
    * @param callback Callback to invoke for each stream event read. If the callback function returns {@code false}
    *                 upon invocation, it will stops the reading
    * @throws IOException If fails to read from stream
    * @throws StreamNotFoundException If the given stream does not exists
    */
-  public void getEvents(String streamId, long startTime, long endTime, int limit,
+  public void getEvents(String streamId, String start, String end, int limit,
                         Function<? super StreamEvent, Boolean> callback)
     throws IOException, StreamNotFoundException, UnauthorizedException {
+
+    long startTime = TimeMathParser.parseTime(start, TimeUnit.MILLISECONDS);
+    long endTime = TimeMathParser.parseTime(end, TimeUnit.MILLISECONDS);
 
     Id.Stream stream = Id.Stream.from(config.getNamespace(), streamId);
     URL url = config.resolveNamespacedURLV3(String.format("streams/%s/events?start=%d&end=%d&limit=%d",
@@ -362,6 +394,26 @@ public class StreamClient {
     } finally {
       urlConn.disconnect();
     }
+  }
+
+  /**
+   * Reads events from a stream
+   *
+   * @param streamId ID of the stream
+   * @param startTime Timestamp in milliseconds to start reading event from (inclusive)
+   * @param endTime Timestamp in milliseconds for the last event to read (exclusive)
+   * @param limit Maximum number of events to read
+   * @param callback Callback to invoke for each stream event read. If the callback function returns {@code false}
+   *                 upon invocation, it will stops the reading
+   * @throws IOException If fails to read from stream
+   * @throws StreamNotFoundException If the given stream does not exists
+   */
+  @Deprecated
+  public void getEvents(String streamId, long startTime, long endTime, int limit,
+                        Function<? super StreamEvent, Boolean> callback)
+    throws IOException, StreamNotFoundException, UnauthorizedException {
+
+    getEvents(streamId, String.valueOf(startTime), String.valueOf(endTime), limit, callback);
   }
 
   /**

--- a/cdap-client/src/main/java/co/cask/cdap/client/StreamClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/StreamClient.java
@@ -319,7 +319,6 @@ public class StreamClient {
    * @throws IOException             If fails to read from stream
    * @throws StreamNotFoundException If the given stream does not exists
    */
-  @Deprecated
   public <T extends Collection<? super StreamEvent>> T getEvents(String streamId, long startTime,
                                                                  long endTime, int limit, final T results)
     throws IOException, StreamNotFoundException, UnauthorizedException {
@@ -402,7 +401,6 @@ public class StreamClient {
    * @throws IOException             If fails to read from stream
    * @throws StreamNotFoundException If the given stream does not exists
    */
-  @Deprecated
   public void getEvents(String streamId, long startTime, long endTime, int limit,
                         Function<? super StreamEvent, Boolean> callback)
     throws IOException, StreamNotFoundException, UnauthorizedException {

--- a/cdap-client/src/main/java/co/cask/cdap/client/StreamClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/StreamClient.java
@@ -87,7 +87,7 @@ public class StreamClient {
    * Gets the configuration of a stream.
    *
    * @param streamId ID of the stream
-   * @throws IOException             if a network error occurred
+   * @throws IOException if a network error occurred
    * @throws StreamNotFoundException if the stream was not found
    */
   public StreamProperties getConfig(String streamId)
@@ -106,11 +106,11 @@ public class StreamClient {
   /**
    * Sets properties of a stream.
    *
-   * @param streamId   ID of the stream
+   * @param streamId ID of the stream
    * @param properties properties to set
-   * @throws IOException             if a network error occurred
-   * @throws UnauthorizedException   if the client is unauthorized
-   * @throws BadRequestException     if the request is bad
+   * @throws IOException if a network error occurred
+   * @throws UnauthorizedException if the client is unauthorized
+   * @throws BadRequestException if the request is bad
    * @throws StreamNotFoundException if the stream was not found
    */
   public void setStreamProperties(String streamId, StreamProperties properties)
@@ -135,7 +135,7 @@ public class StreamClient {
    * Creates a stream.
    *
    * @param newStreamId ID of the new stream to create
-   * @throws IOException         if a network error occurred
+   * @throws IOException if a network error occurred
    * @throws BadRequestException if the provided stream ID was invalid
    */
   public void create(String newStreamId) throws IOException, BadRequestException, UnauthorizedException {
@@ -151,12 +151,12 @@ public class StreamClient {
    * Sends an event to a stream.
    *
    * @param streamId ID of the stream
-   * @param event    event to send to the stream
-   * @throws IOException             if a network error occurred
+   * @param event event to send to the stream
+   * @throws IOException if a network error occurred
    * @throws StreamNotFoundException if the stream with the specified ID was not found
    */
   public void sendEvent(String streamId, String event) throws IOException,
-    StreamNotFoundException, UnauthorizedException {
+                                                              StreamNotFoundException, UnauthorizedException {
     writeEvent(config.resolveNamespacedURLV3(String.format("streams/%s", streamId)), streamId, event);
   }
 
@@ -165,8 +165,8 @@ public class StreamClient {
    * the event has been received by the server, but may not get persisted.
    *
    * @param streamId ID of the stream
-   * @param event    event to send to the stream
-   * @throws IOException             if a network error occurred
+   * @param event event to send to the stream
+   * @throws IOException if a network error occurred
    * @throws StreamNotFoundException if the stream with the specified ID was not found
    */
   public void asyncSendEvent(String streamId, String event) throws IOException,
@@ -177,10 +177,10 @@ public class StreamClient {
   /**
    * Sends a file of the given content type to a stream batch endpoint.
    *
-   * @param streamId    ID of the stream
+   * @param streamId ID of the stream
    * @param contentType content type of the file
-   * @param file        the file to upload
-   * @throws IOException             if a network error occurred
+   * @param file the file to upload
+   * @throws IOException if a network error occurred
    * @throws StreamNotFoundException if the stream with the specified ID was not found
    */
   public void sendFile(String streamId, String contentType,
@@ -191,10 +191,10 @@ public class StreamClient {
   /**
    * Sends a batch request to a stream batch endpoint.
    *
-   * @param streamId      ID of the stream
-   * @param contentType   content type of the data
+   * @param streamId ID of the stream
+   * @param contentType content type of the data
    * @param inputSupplier provides content for the batch request
-   * @throws IOException             if a network error occurred
+   * @throws IOException if a network error occurred
    * @throws StreamNotFoundException if the stream with the specified ID was not found
    */
   public void sendBatch(String streamId, String contentType,
@@ -216,7 +216,7 @@ public class StreamClient {
    * Truncates a stream, deleting all stream events belonging to the stream.
    *
    * @param streamId ID of the stream to truncate
-   * @throws IOException             if a network error occurred
+   * @throws IOException if a network error occurred
    * @throws StreamNotFoundException if the stream with the specified name was not found
    */
   public void truncate(String streamId) throws IOException, StreamNotFoundException, UnauthorizedException {
@@ -233,7 +233,7 @@ public class StreamClient {
    * Deletes a stream.
    *
    * @param streamId ID of the stream to truncate
-   * @throws IOException             if a network error occurred
+   * @throws IOException if a network error occurred
    * @throws StreamNotFoundException if the stream with the specified name was not found
    */
   public void delete(String streamId) throws IOException, StreamNotFoundException, UnauthorizedException {
@@ -249,9 +249,9 @@ public class StreamClient {
   /**
    * Sets the Time-to-Live (TTL) of a stream. TTL governs how long stream events are readable.
    *
-   * @param streamId     ID of the stream
+   * @param streamId ID of the stream
    * @param ttlInSeconds desired TTL, in seconds
-   * @throws IOException             if a network error occurred
+   * @throws IOException if a network error occurred
    * @throws StreamNotFoundException if the stream with the specified name was not found
    */
   public void setTTL(String streamId, long ttlInSeconds)
@@ -283,14 +283,14 @@ public class StreamClient {
   /**
    * Reads events from a stream
    *
-   * @param streamId  ID of the stream
+   * @param streamId ID of the stream
    * @param startTime Timestamp in milliseconds to start reading event from (inclusive)
-   * @param endTime   Timestamp in milliseconds for the last event to read (exclusive)
-   * @param limit     Maximum number of events to read
-   * @param results   Collection for storing the resulting stream events
-   * @param <T>       Type of the collection for storing results
+   * @param endTime Timestamp in milliseconds for the last event to read (exclusive)
+   * @param limit Maximum number of events to read
+   * @param results Collection for storing the resulting stream events
+   * @param <T> Type of the collection for storing results
    * @return The same collection object as passed in the {@code results} parameter
-   * @throws IOException             If fails to read from stream
+   * @throws IOException If fails to read from stream
    * @throws StreamNotFoundException If the given stream does not exists
    */
   public <T extends Collection<? super StreamEvent>> T getEvents(String streamId, String startTime,
@@ -309,14 +309,14 @@ public class StreamClient {
   /**
    * Reads events from a stream
    *
-   * @param streamId  ID of the stream
+   * @param streamId ID of the stream
    * @param startTime Timestamp in milliseconds to start reading event from (inclusive)
-   * @param endTime   Timestamp in milliseconds for the last event to read (exclusive)
-   * @param limit     Maximum number of events to read
-   * @param results   Collection for storing the resulting stream events
-   * @param <T>       Type of the collection for storing results
+   * @param endTime Timestamp in milliseconds for the last event to read (exclusive)
+   * @param limit Maximum number of events to read
+   * @param results Collection for storing the resulting stream events
+   * @param <T> Type of the collection for storing results
    * @return The same collection object as passed in the {@code results} parameter
-   * @throws IOException             If fails to read from stream
+   * @throws IOException If fails to read from stream
    * @throws StreamNotFoundException If the given stream does not exists
    */
   public <T extends Collection<? super StreamEvent>> T getEvents(String streamId, long startTime,
@@ -329,12 +329,12 @@ public class StreamClient {
    * Reads events from a stream
    *
    * @param streamId ID of the stream
-   * @param start    Timestamp in milliseconds or now-xs format to start reading event from (inclusive)
-   * @param end      Timestamp in milliseconds or now-xs format for the last event to read (exclusive)
-   * @param limit    Maximum number of events to read
+   * @param start Timestamp in milliseconds or now-xs format to start reading event from (inclusive)
+   * @param end Timestamp in milliseconds or now-xs format for the last event to read (exclusive)
+   * @param limit Maximum number of events to read
    * @param callback Callback to invoke for each stream event read. If the callback function returns {@code false}
    *                 upon invocation, it will stops the reading
-   * @throws IOException             If fails to read from stream
+   * @throws IOException If fails to read from stream
    * @throws StreamNotFoundException If the given stream does not exists
    */
   public void getEvents(String streamId, String start, String end, int limit,
@@ -392,13 +392,13 @@ public class StreamClient {
   /**
    * Reads events from a stream
    *
-   * @param streamId  ID of the stream
+   * @param streamId ID of the stream
    * @param startTime Timestamp in milliseconds to start reading event from (inclusive)
-   * @param endTime   Timestamp in milliseconds for the last event to read (exclusive)
-   * @param limit     Maximum number of events to read
-   * @param callback  Callback to invoke for each stream event read. If the callback function returns {@code false}
+   * @param endTime Timestamp in milliseconds for the last event to read (exclusive)
+   * @param limit Maximum number of events to read
+   * @param callback Callback to invoke for each stream event read. If the callback function returns {@code false}
    *                  upon invocation, it will stops the reading
-   * @throws IOException             If fails to read from stream
+   * @throws IOException If fails to read from stream
    * @throws StreamNotFoundException If the given stream does not exists
    */
   public void getEvents(String streamId, long startTime, long endTime, int limit,

--- a/cdap-client/src/main/java/co/cask/cdap/client/StreamClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/StreamClient.java
@@ -170,7 +170,7 @@ public class StreamClient {
    * @throws StreamNotFoundException if the stream with the specified ID was not found
    */
   public void asyncSendEvent(String streamId, String event) throws IOException,
-    StreamNotFoundException, UnauthorizedException {
+                                                                   StreamNotFoundException, UnauthorizedException {
     writeEvent(config.resolveNamespacedURLV3(String.format("streams/%s/async", streamId)), streamId, event);
   }
 

--- a/cdap-common/src/main/java/co/cask/cdap/common/utils/TimeMathParser.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/utils/TimeMathParser.java
@@ -21,6 +21,7 @@ import com.google.common.base.Preconditions;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import javax.ws.rs.DefaultValue;
 
 /**
  * Utility class for parsing time strings into timestamps, with support for some basic time math.
@@ -66,6 +67,9 @@ public class TimeMathParser {
     return convertToSeconds("+", num, unitStr);
   }
 
+  /**
+   * @return the current time in seconds
+   */
   public static long nowInSeconds() {
     return TimeUnit.SECONDS.convert(System.currentTimeMillis(), TimeUnit.MILLISECONDS);
   }
@@ -79,20 +83,53 @@ public class TimeMathParser {
     return output;
   }
 
+  /** parses a time in String format into a long value, assuming the input is in seconds if numeric
+   *
+   * @param timeStr the string to parse
+   * @return the parsed time in seconds
+   */
   public static long parseTime(String timeStr) {
-    return parseTime(nowInSeconds(), timeStr);
+    return parseTime(timeStr, TimeUnit.SECONDS);
   }
 
+  /** parses a time in String format into a long value
+   *
+   * @param timeStr the string to parse
+   * @param timeUnit the unit of time to return, if timeStr is numeric then it is assumed to be in the unit timeUnit
+   * @return the parsed time
+   */
+  public static long parseTime(String timeStr, TimeUnit timeUnit) {
+    return parseTime(nowInSeconds(), timeStr, timeUnit);
+  }
+
+  /** parses a time in String format into a long value, assuming the input is in seconds if numeric
+   *
+   * @param now the present time in seconds
+   * @param timeStr the string to parse
+   * @return the parsed time in seconds
+   */
   public static long parseTime(long now, String timeStr) {
+    return parseTime(now, timeStr, TimeUnit.SECONDS);
+  }
+
+  /** parses a time in String format into a long value
+   *
+   * @param now the present time in seconds
+   * @param timeStr the string to parse
+   * @param timeUnit the unit of time to return, if timeStr is numeric then it is assumed to be in the unit timeUnit
+   * @return the parsed time
+   * @throws IllegalArgumentException if the format of timeStr is bad
+   */
+  public static long parseTime(long now, String timeStr, TimeUnit timeUnit) {
     Preconditions.checkNotNull(timeStr);
 
     if (NOW.equals(timeStr.toUpperCase())) {
       return now;
     }
-    // if its a timestamp in seconds
+    // if its a numeric timestamp, assume units are correct
     Matcher matcher = TIMESTAMP_PATTERN.matcher(timeStr);
     if (matcher.matches()) {
-      return Integer.parseInt(timeStr);
+      return Long.parseLong(timeStr);
     }
 
     // if its some time math pattern like now-1d-6h
@@ -117,6 +154,6 @@ public class TimeMathParser {
     } else {
       throw new IllegalArgumentException("invalid time format " + timeStr);
     }
-    return output;
+    return timeUnit.convert(output, TimeUnit.SECONDS);
   }
 }

--- a/cdap-common/src/main/java/co/cask/cdap/common/utils/TimeMathParser.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/utils/TimeMathParser.java
@@ -21,7 +21,6 @@ import com.google.common.base.Preconditions;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import javax.ws.rs.DefaultValue;
 
 /**
  * Utility class for parsing time strings into timestamps, with support for some basic time math.
@@ -83,7 +82,8 @@ public class TimeMathParser {
     return output;
   }
 
-  /** parses a time in String format into a long value, assuming the input is in seconds if numeric
+  /**
+   * Parses a time in String format into a long value. If the input is numeric we assume the input is in seconds.
    *
    * @param timeStr the string to parse
    * @return the parsed time in seconds
@@ -92,7 +92,8 @@ public class TimeMathParser {
     return parseTime(timeStr, TimeUnit.SECONDS);
   }
 
-  /** parses a time in String format into a long value
+  /**
+   * Parses a time in String format into a long value
    *
    * @param timeStr the string to parse
    * @param timeUnit the unit of time to return, if timeStr is numeric then it is assumed to be in the unit timeUnit
@@ -102,7 +103,8 @@ public class TimeMathParser {
     return parseTime(nowInSeconds(), timeStr, timeUnit);
   }
 
-  /** parses a time in String format into a long value, assuming the input is in seconds if numeric
+  /**
+   * Parses a time in String format into a long value. If the input is numeric we assume the input is in seconds.
    *
    * @param now the present time in seconds
    * @param timeStr the string to parse
@@ -112,7 +114,8 @@ public class TimeMathParser {
     return parseTime(now, timeStr, TimeUnit.SECONDS);
   }
 
-  /** parses a time in String format into a long value
+  /**
+   * Parses a time in String format into a long value
    *
    * @param now the present time in seconds
    * @param timeStr the string to parse

--- a/cdap-common/src/main/java/co/cask/cdap/common/utils/TimeMathParser.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/utils/TimeMathParser.java
@@ -34,7 +34,7 @@ import java.util.regex.Pattern;
 public class TimeMathParser {
 
   private static final String NOW = "now";
-  private static final String VALID_UNITS = "s|m|h|d";
+  private static final String VALID_UNITS = "ms|s|m|h|d";
   private static final Pattern OP_PATTERN = Pattern.compile("(\\-|\\+)(\\d+)(" + VALID_UNITS + ")");
   private static final Pattern RESOLUTION_PATTERN = Pattern.compile("(\\d+)(" + VALID_UNITS + ")");
   private static final Pattern TIMESTAMP_PATTERN = Pattern.compile("^(\\d+)$");
@@ -49,8 +49,11 @@ public class TimeMathParser {
       seconds = TimeUnit.HOURS.toSeconds(num);
     } else if ("d".equals(unitStr)) {
       seconds = TimeUnit.DAYS.toSeconds(num);
+    } else if ("ms".equals(unitStr)) {
+      seconds = TimeUnit.MILLISECONDS.toSeconds(num);
     } else {
-      throw new IllegalArgumentException("invalid time unit " + unitStr + ", should be one of 's', 'm', 'h', 'd'");
+      throw new IllegalArgumentException("invalid time unit " + unitStr +
+                                           ", should be one of 'ms', 's', 'm', 'h', 'd'");
     }
 
     if ("+".equals(op)) {

--- a/cdap-common/src/main/java/co/cask/cdap/common/utils/TimeMathParser.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/utils/TimeMathParser.java
@@ -92,7 +92,7 @@ public class TimeMathParser {
    * @param timeStr the string to parse
    * @return the parsed time in seconds
    */
-  public static long parseTime(String timeStr) {
+  public static long parseTimeInSeconds(String timeStr) {
     return parseTime(timeStr, TimeUnit.SECONDS);
   }
 
@@ -114,7 +114,7 @@ public class TimeMathParser {
    * @param timeStr the string to parse
    * @return the parsed time in seconds
    */
-  public static long parseTime(long now, String timeStr) {
+  public static long parseTimeInSeconds(long now, String timeStr) {
     return parseTime(TimeUnit.MILLISECONDS.convert(now, TimeUnit.SECONDS), timeStr, TimeUnit.SECONDS);
   }
 

--- a/cdap-common/src/test/java/co/cask/cdap/common/utils/TimeMathParserTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/utils/TimeMathParserTest.java
@@ -33,30 +33,30 @@ public class TimeMathParserTest {
 
   @Test
   public void testParseTimestamp() {
-    Assert.assertEquals(1234567890, TimeMathParser.parseTime("1234567890"));
-    Assert.assertEquals(1234567890, TimeMathParser.parseTime(0, "1234567890"));
+    Assert.assertEquals(1234567890, TimeMathParser.parseTimeInSeconds("1234567890"));
+    Assert.assertEquals(1234567890, TimeMathParser.parseTimeInSeconds(0, "1234567890"));
   }
 
   @Test
   public void testParseNow() {
     long now = TimeMathParser.nowInSeconds();
-    long result = TimeMathParser.parseTime("now");
+    long result = TimeMathParser.parseTimeInSeconds("now");
     // in case we're on the border between seconds
     Assert.assertTrue((result - now) == 1 || (result == now));
-    Assert.assertEquals(1234567890, TimeMathParser.parseTime(1234567890, "now"));
+    Assert.assertEquals(1234567890, TimeMathParser.parseTimeInSeconds(1234567890, "now"));
   }
 
   @Test
   public void testOneOperation() {
     long now = TimeMathParser.nowInSeconds();
-    Assert.assertEquals(now - 7, TimeMathParser.parseTime(now, "now-7s"));
-    Assert.assertEquals(now - 7 * 60, TimeMathParser.parseTime(now, "now-7m"));
-    Assert.assertEquals(now - 7 * 3600, TimeMathParser.parseTime(now, "now-7h"));
-    Assert.assertEquals(now - 7 * 86400, TimeMathParser.parseTime(now, "now-7d"));
-    Assert.assertEquals(now + 7, TimeMathParser.parseTime(now, "now+7s"));
-    Assert.assertEquals(now + 7 * 60, TimeMathParser.parseTime(now, "now+7m"));
-    Assert.assertEquals(now + 7 * 3600, TimeMathParser.parseTime(now, "now+7h"));
-    Assert.assertEquals(now + 7 * 86400, TimeMathParser.parseTime(now, "now+7d"));
+    Assert.assertEquals(now - 7, TimeMathParser.parseTimeInSeconds(now, "now-7s"));
+    Assert.assertEquals(now - 7 * 60, TimeMathParser.parseTimeInSeconds(now, "now-7m"));
+    Assert.assertEquals(now - 7 * 3600, TimeMathParser.parseTimeInSeconds(now, "now-7h"));
+    Assert.assertEquals(now - 7 * 86400, TimeMathParser.parseTimeInSeconds(now, "now-7d"));
+    Assert.assertEquals(now + 7, TimeMathParser.parseTimeInSeconds(now, "now+7s"));
+    Assert.assertEquals(now + 7 * 60, TimeMathParser.parseTimeInSeconds(now, "now+7m"));
+    Assert.assertEquals(now + 7 * 3600, TimeMathParser.parseTimeInSeconds(now, "now+7h"));
+    Assert.assertEquals(now + 7 * 86400, TimeMathParser.parseTimeInSeconds(now, "now+7d"));
     Assert.assertEquals(System.currentTimeMillis() - 10, TimeMathParser.parseTime("now-10ms",
                                                                                   TimeUnit.MILLISECONDS), 1);
     Assert.assertEquals(System.currentTimeMillis() + 50, TimeMathParser.parseTime("now+50ms",
@@ -81,31 +81,31 @@ public class TimeMathParserTest {
   public void testMultipleOperations() {
     long now = TimeMathParser.nowInSeconds();
     Assert.assertEquals(now - 7 * 86400 + 3 * 3600 - 13 * 60 + 11,
-                        TimeMathParser.parseTime(now, "now-7d+3h-13m+11s"));
+                        TimeMathParser.parseTimeInSeconds(now, "now-7d+3h-13m+11s"));
   }
 
   // happens if input is supposed to be url encoded but is not
   @Test(expected = IllegalArgumentException.class)
   public void testSpaceInsteadOfPlusThrowsException() {
     long now = TimeMathParser.nowInSeconds();
-    TimeMathParser.parseTime(now, "now 6h");
+    TimeMathParser.parseTimeInSeconds(now, "now 6h");
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testGibberishInMiddleThrowsException() {
     long now = TimeMathParser.nowInSeconds();
-    TimeMathParser.parseTime(now, "now-3d+23lnkfasd-6h");
+    TimeMathParser.parseTimeInSeconds(now, "now-3d+23lnkfasd-6h");
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testInvalidOperationThrowsException() {
     long now = TimeMathParser.nowInSeconds();
-    TimeMathParser.parseTime(now, "now/1d");
+    TimeMathParser.parseTimeInSeconds(now, "now/1d");
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testInvalidUnitThrowsException() {
     long now = TimeMathParser.nowInSeconds();
-    TimeMathParser.parseTime(now, "now-1w");
+    TimeMathParser.parseTimeInSeconds(now, "now-1w");
   }
 }

--- a/cdap-common/src/test/java/co/cask/cdap/common/utils/TimeMathParserTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/utils/TimeMathParserTest.java
@@ -57,6 +57,10 @@ public class TimeMathParserTest {
     Assert.assertEquals(now + 7 * 60, TimeMathParser.parseTime(now, "now+7m"));
     Assert.assertEquals(now + 7 * 3600, TimeMathParser.parseTime(now, "now+7h"));
     Assert.assertEquals(now + 7 * 86400, TimeMathParser.parseTime(now, "now+7d"));
+    Assert.assertEquals(System.currentTimeMillis() - 10, TimeMathParser.parseTime("now-10ms",
+                                                                                  TimeUnit.MILLISECONDS), 1);
+    Assert.assertEquals(System.currentTimeMillis() + 50, TimeMathParser.parseTime("now+50ms",
+                                                                                  TimeUnit.MILLISECONDS), 1);
   }
 
   @Test

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamFetchHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamFetchHandler.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.flow.flowlet.StreamEvent;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.stream.StreamEventTypeAdapter;
+import co.cask.cdap.common.utils.TimeMathParser;
 import co.cask.cdap.data.file.FileReader;
 import co.cask.cdap.data.file.ReadFilter;
 import co.cask.cdap.data.stream.MultiLiveStreamFileReader;
@@ -107,9 +108,11 @@ public final class StreamFetchHandler extends AuthenticatedHttpHandler {
   public void fetch(HttpRequest request, HttpResponder responder,
                     @PathParam("namespace-id") String namespaceId,
                     @PathParam("stream") String stream,
-                    @QueryParam("start") long startTime,
-                    @QueryParam("end") @DefaultValue("9223372036854775807") long endTime,
+                    @QueryParam("start") String start,
+                    @QueryParam("end") @DefaultValue("9223372036854775807") String end,
                     @QueryParam("limit") @DefaultValue("2147483647") int limit) throws Exception {
+    long startTime = TimeMathParser.parseTime(start, TimeUnit.MILLISECONDS);
+    long endTime = TimeMathParser.parseTime(end, TimeUnit.MILLISECONDS);
 
     Id.Stream streamId = Id.Stream.from(namespaceId, stream);
     if (!verifyGetEventsRequest(streamId, startTime, endTime, limit, responder)) {

--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteStreamManager.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteStreamManager.java
@@ -122,10 +122,15 @@ public class RemoteStreamManager implements StreamManager {
   }
 
   @Override
-  public <T> List<StreamEvent> getEvents(T startTime, T endTime, int limit) throws IOException {
+  public List<StreamEvent> getEvents(long startTime, long endTime, int limit) throws IOException {
+    return getEvents(String.valueOf(startTime), String.valueOf(endTime), limit);
+  }
+
+  @Override
+  public List<StreamEvent> getEvents(String startTime, String endTime, int limit) throws IOException {
     List<StreamEvent> results = Lists.newArrayList();
     try {
-      streamClient.getEvents(streamName, startTime.toString(), endTime.toString(), limit, results);
+      streamClient.getEvents(streamName, startTime, endTime, limit, results);
     } catch (StreamNotFoundException e) {
       throw new IOException(e);
     } catch (Exception e) {

--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteStreamManager.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteStreamManager.java
@@ -122,6 +122,20 @@ public class RemoteStreamManager implements StreamManager {
   }
 
   @Override
+  public List<StreamEvent> getEvents(String startTime, String endTime, int limit) throws IOException {
+    List<StreamEvent> results = Lists.newArrayList();
+    try {
+      streamClient.getEvents(streamName, startTime, endTime, limit, results);
+    } catch (StreamNotFoundException e) {
+      throw new IOException(e);
+    } catch (Exception e) {
+      throw Throwables.propagate(e);
+    }
+    return results;
+  }
+
+  @Override
+  @Deprecated
   public List<StreamEvent> getEvents(long startTime, long endTime, int limit) throws IOException {
     List<StreamEvent> results = Lists.newArrayList();
     try {

--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteStreamManager.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteStreamManager.java
@@ -122,24 +122,10 @@ public class RemoteStreamManager implements StreamManager {
   }
 
   @Override
-  public List<StreamEvent> getEvents(String startTime, String endTime, int limit) throws IOException {
+  public <T> List<StreamEvent> getEvents(T startTime, T endTime, int limit) throws IOException {
     List<StreamEvent> results = Lists.newArrayList();
     try {
-      streamClient.getEvents(streamName, startTime, endTime, limit, results);
-    } catch (StreamNotFoundException e) {
-      throw new IOException(e);
-    } catch (Exception e) {
-      throw Throwables.propagate(e);
-    }
-    return results;
-  }
-
-  @Override
-  @Deprecated
-  public List<StreamEvent> getEvents(long startTime, long endTime, int limit) throws IOException {
-    List<StreamEvent> results = Lists.newArrayList();
-    try {
-      streamClient.getEvents(streamName, startTime, endTime, limit, results);
+      streamClient.getEvents(streamName, startTime.toString(), endTime.toString(), limit, results);
     } catch (StreamNotFoundException e) {
       throw new IOException(e);
     } catch (Exception e) {

--- a/cdap-test/src/main/java/co/cask/cdap/test/StreamManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/StreamManager.java
@@ -113,16 +113,5 @@ public interface StreamManager {
    * @param limit the maximum number of events to return
    * @return a list of stream events in the given time range
    */
-  List<StreamEvent> getEvents(String startTime, String endTime, int limit) throws IOException;
-
-  /**
-   * Get events from the specified stream in the specified interval
-   *
-   * @param startTime the start time
-   * @param endTime the end time
-   * @param limit the maximum number of events to return
-   * @return a list of stream events in the given time range
-   */
-  @Deprecated
-  List<StreamEvent> getEvents(long startTime, long endTime, int limit) throws IOException;
+  <T> List<StreamEvent> getEvents(T startTime, T endTime, int limit) throws IOException;
 }

--- a/cdap-test/src/main/java/co/cask/cdap/test/StreamManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/StreamManager.java
@@ -108,10 +108,20 @@ public interface StreamManager {
   /**
    * Get events from the specified stream in the specified interval
    *
-   * @param startTime the start time in seconds or "now-xs" format
-   * @param endTime the end time in seconds or "now-xs" format
+   * @param startTime the start time in milliseconds or "now-xs" format
+   * @param endTime the end time in milliseconds or "now-xs" format
    * @param limit the maximum number of events to return
    * @return a list of stream events in the given time range
    */
-  <T> List<StreamEvent> getEvents(T startTime, T endTime, int limit) throws IOException;
+   List<StreamEvent> getEvents(String startTime, String endTime, int limit) throws IOException;
+
+  /**
+   * Get events from the specified stream in the specified interval
+   *
+   * @param startTime the start time in milliseconds
+   * @param endTime the end time in milliseconds
+   * @param limit the maximum number of events to return
+   * @return a list of stream events in the given time range
+   */
+  List<StreamEvent> getEvents(long startTime, long endTime, int limit) throws IOException;
 }

--- a/cdap-test/src/main/java/co/cask/cdap/test/StreamManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/StreamManager.java
@@ -108,10 +108,21 @@ public interface StreamManager {
   /**
    * Get events from the specified stream in the specified interval
    *
+   * @param startTime the start time in seconds or "now-xs" format
+   * @param endTime the end time in seconds or "now-xs" format
+   * @param limit the maximum number of events to return
+   * @return a list of stream events in the given time range
+   */
+  List<StreamEvent> getEvents(String startTime, String endTime, int limit) throws IOException;
+
+  /**
+   * Get events from the specified stream in the specified interval
+   *
    * @param startTime the start time
    * @param endTime the end time
    * @param limit the maximum number of events to return
    * @return a list of stream events in the given time range
    */
+  @Deprecated
   List<StreamEvent> getEvents(long startTime, long endTime, int limit) throws IOException;
 }

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultStreamManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultStreamManager.java
@@ -152,14 +152,8 @@ public class DefaultStreamManager implements StreamManager {
   }
 
   @Override
-  public List<StreamEvent> getEvents(String startTime, String endTime, int limit) throws IOException {
-    return getEvents(streamId, startTime, endTime, limit);
-  }
-
-  @Override
-  @Deprecated
-  public List<StreamEvent> getEvents(long startTime, long endTime, int limit) throws IOException {
-    return getEvents(String.valueOf(startTime), String.valueOf(endTime), limit);
+  public <T> List<StreamEvent> getEvents(T startTime, T endTime, int limit) throws IOException {
+    return getEvents(streamId, startTime.toString(), endTime.toString(), limit);
   }
 
   private List<StreamEvent> getEvents(Id.Stream streamId, String startTime, String endTime,

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultStreamManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultStreamManager.java
@@ -152,8 +152,13 @@ public class DefaultStreamManager implements StreamManager {
   }
 
   @Override
-  public <T> List<StreamEvent> getEvents(T startTime, T endTime, int limit) throws IOException {
-    return getEvents(streamId, startTime.toString(), endTime.toString(), limit);
+  public List<StreamEvent> getEvents(String startTime, String endTime, int limit) throws IOException {
+    return getEvents(streamId, startTime, endTime, limit);
+  }
+
+  @Override
+  public List<StreamEvent> getEvents(long startTime, long endTime, int limit) throws IOException {
+    return getEvents(streamId, String.valueOf(startTime), String.valueOf(endTime), limit);
   }
 
   private List<StreamEvent> getEvents(Id.Stream streamId, String startTime, String endTime,

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultStreamManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultStreamManager.java
@@ -19,6 +19,7 @@ package co.cask.cdap.test.internal;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.flow.flowlet.StreamEvent;
 import co.cask.cdap.common.stream.StreamEventTypeAdapter;
+import co.cask.cdap.common.utils.TimeMathParser;
 import co.cask.cdap.data.stream.service.StreamFetchHandler;
 import co.cask.cdap.data.stream.service.StreamHandler;
 import co.cask.cdap.internal.MockResponder;
@@ -47,6 +48,7 @@ import java.lang.reflect.Type;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Default implementation of {@link StreamManager} for use in tests
@@ -150,13 +152,23 @@ public class DefaultStreamManager implements StreamManager {
   }
 
   @Override
-  public List<StreamEvent> getEvents(long startTime, long endTime, int limit) throws IOException {
+  public List<StreamEvent> getEvents(String startTime, String endTime, int limit) throws IOException {
     return getEvents(streamId, startTime, endTime, limit);
   }
 
-  private List<StreamEvent> getEvents(Id.Stream streamId, long startTime, long endTime, int limit) throws IOException {
+  @Override
+  @Deprecated
+  public List<StreamEvent> getEvents(long startTime, long endTime, int limit) throws IOException {
+    return getEvents(String.valueOf(startTime), String.valueOf(endTime), limit);
+  }
+
+  private List<StreamEvent> getEvents(Id.Stream streamId, String startTime, String endTime,
+                                      int limit) throws IOException {
+    long start = TimeMathParser.parseTime(startTime, TimeUnit.MILLISECONDS);
+    long end = TimeMathParser.parseTime(endTime, TimeUnit.MILLISECONDS);
+
     String path = String.format("/v3/namespaces/%s/streams/%s/events?start=%d&end=%d&limit=%d",
-                                streamId.getNamespaceId(), streamId.getId(), startTime, endTime, limit);
+                                streamId.getNamespaceId(), streamId.getId(), start, end, limit);
     HttpRequest httpRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, path);
 
     MockResponder responder = new MockResponder();

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/MetricQueryParser.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/MetricQueryParser.java
@@ -458,8 +458,8 @@ final class MetricQueryParser {
     }
 
     if (queryParams.containsKey(START_TIME) && queryParams.containsKey(END_TIME)) {
-      startTime = TimeMathParser.parseTime(now, queryParams.get(START_TIME).get(0));
-      endTime = TimeMathParser.parseTime(now, queryParams.get(END_TIME).get(0));
+      startTime = TimeMathParser.parseTimeInSeconds(now, queryParams.get(START_TIME).get(0));
+      endTime = TimeMathParser.parseTimeInSeconds(now, queryParams.get(END_TIME).get(0));
       if (queryParams.containsKey(RESOLUTION)) {
         if (isAutoResolution(queryParams)) {
           // auto determine resolution, based on time difference.
@@ -478,10 +478,10 @@ final class MetricQueryParser {
       count = Integer.parseInt(queryParams.get(COUNT).get(0));
       // both start and end times are inclusive, which is the reason for the +-1.
       if (queryParams.containsKey(START_TIME)) {
-        startTime = TimeMathParser.parseTime(now, queryParams.get(START_TIME).get(0));
+        startTime = TimeMathParser.parseTimeInSeconds(now, queryParams.get(START_TIME).get(0));
         endTime = startTime + (count * resolution) - resolution;
       } else if (queryParams.containsKey(END_TIME)) {
-        endTime = TimeMathParser.parseTime(now, queryParams.get(END_TIME).get(0));
+        endTime = TimeMathParser.parseTimeInSeconds(now, queryParams.get(END_TIME).get(0));
         startTime = endTime - (count * resolution) + resolution;
       } else {
         // if only count is specified, assume the current time is desired as the end.

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/MetricsHandler.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/MetricsHandler.java
@@ -305,10 +305,10 @@ public class MetricsHandler extends AuthenticatedHttpHandler {
   private void setTimeRangeInQueryRequest(MetricQueryRequest request, Map<String, List<String>> queryTimeParams) {
     Long start =
       queryTimeParams.containsKey(PARAM_START_TIME) ?
-        TimeMathParser.parseTime(queryTimeParams.get(PARAM_START_TIME).get(0)) : null;
+        TimeMathParser.parseTimeInSeconds(queryTimeParams.get(PARAM_START_TIME).get(0)) : null;
     Long end =
       queryTimeParams.containsKey(PARAM_END_TIME) ?
-        TimeMathParser.parseTime(queryTimeParams.get(PARAM_END_TIME).get(0)) : null;
+        TimeMathParser.parseTimeInSeconds(queryTimeParams.get(PARAM_END_TIME).get(0)) : null;
     Integer count = null;
 
     boolean aggregate =


### PR DESCRIPTION
Build -http://builds.cask.co/browse/CDAP-DUT1934-2

JIRA - https://issues.cask.co/browse/CDAP-1926

Streams endpoint now accepts times formatted as "now-xs".