### PR TITLE
[CDAP-2537] Fixed exists() condition in FileStreamAdmin to also make …

### DIFF
--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/StreamAdminTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/StreamAdminTest.java
@@ -65,6 +65,12 @@ public abstract class StreamAdminTest {
 
     streamAdmin.create(otherStreamId);
     Assert.assertTrue(streamAdmin.exists(otherStreamId));
+
+    streamAdmin.drop(streamId);
+    Assert.assertFalse(streamAdmin.exists(streamId));
+
+    streamAdmin.drop(otherStreamId);
+    Assert.assertFalse(streamAdmin.exists(otherStreamId));
   }
 
   @Test

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/FileStreamAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/FileStreamAdmin.java
@@ -266,7 +266,7 @@ public class FileStreamAdmin implements StreamAdmin {
   @Override
   public boolean exists(Id.Stream streamId) throws Exception {
     try {
-      return getConfigLocation(streamId).exists();
+      return streamMetaStore.streamExists(streamId) && getConfigLocation(streamId).exists();
     } catch (IOException e) {
       LOG.error("Exception when check for stream exist.", e);
       return false;

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/StreamHandlerTest.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/StreamHandlerTest.java
@@ -81,8 +81,7 @@ public abstract class StreamHandlerTest extends GatewayTestBase {
   @Test
   public void testStreamCreate() throws Exception {
     // Try to get info on a non-existent stream
-    HttpURLConnection urlConn = openURL(createStreamInfoURL("test_stream1"),
-                                        HttpMethod.GET);
+    HttpURLConnection urlConn = openURL(createStreamInfoURL("test_stream1"), HttpMethod.GET);
 
     Assert.assertEquals(HttpResponseStatus.NOT_FOUND.getCode(), urlConn.getResponseCode());
     urlConn.disconnect();
@@ -106,8 +105,7 @@ public abstract class StreamHandlerTest extends GatewayTestBase {
   @Test
   public void testSimpleStreamEnqueue() throws Exception {
     // Create new stream.
-    HttpURLConnection urlConn = openURL(createURL("streams/test_stream_enqueue"),
-                                        HttpMethod.PUT);
+    HttpURLConnection urlConn = openURL(createURL("streams/test_stream_enqueue"), HttpMethod.PUT);
     Assert.assertEquals(HttpResponseStatus.OK.getCode(), urlConn.getResponseCode());
     urlConn.disconnect();
 
@@ -122,8 +120,7 @@ public abstract class StreamHandlerTest extends GatewayTestBase {
     }
 
     // Fetch 10 entries
-    urlConn = openURL(createURL("streams/test_stream_enqueue/events?limit=10"),
-                      HttpMethod.GET);
+    urlConn = openURL(createURL("streams/test_stream_enqueue/events?limit=10"), HttpMethod.GET);
     List<StreamEvent> events = GSON.fromJson(new String(ByteStreams.toByteArray(urlConn.getInputStream()),
                                                         Charsets.UTF_8),
                                              new TypeToken<List<StreamEvent>>() { }.getType());
@@ -157,8 +154,7 @@ public abstract class StreamHandlerTest extends GatewayTestBase {
     urlConn.disconnect();
 
     // test the config ttl by calling info
-    urlConn = openURL(createStreamInfoURL("stream_info"),
-                      HttpMethod.GET);
+    urlConn = openURL(createStreamInfoURL("stream_info"), HttpMethod.GET);
     Assert.assertEquals(HttpResponseStatus.OK.getCode(), urlConn.getResponseCode());
     StreamProperties actual = GSON.fromJson(new String(ByteStreams.toByteArray(urlConn.getInputStream()),
                                                         Charsets.UTF_8), StreamProperties.class);
@@ -184,8 +180,7 @@ public abstract class StreamHandlerTest extends GatewayTestBase {
     urlConn.disconnect();
 
     // test the config ttl by calling info
-    urlConn = openURL(createStreamInfoURL("stream_defaults"),
-                      HttpMethod.GET);
+    urlConn = openURL(createStreamInfoURL("stream_defaults"), HttpMethod.GET);
     Assert.assertEquals(HttpResponseStatus.OK.getCode(), urlConn.getResponseCode());
     StreamProperties actual = GSON.fromJson(new String(ByteStreams.toByteArray(urlConn.getInputStream()),
                                                        Charsets.UTF_8), StreamProperties.class);

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
@@ -813,7 +813,6 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     }
   }
 
-
   @Category(XSlowTests.class)
   @Test
   public void testByteCodeClassLoader() throws Exception {


### PR DESCRIPTION
…sure that the stream exists in the metastore along with checking that the stream config exists on the filesystem



Issue: [CDAP-2537](https://issues.cask.co/browse/CDAP-2537)
Analysis:
- ``streamAdmin.dropAllInNamespace()`` leaves behind the ``config.json`` file on the filesystem
- ``FileStreamAdmin.exists()`` however, only checks that ``config.json`` exists and doesn't make sure that the stream exists in the metastore as well. This PR adds that check, along with some minor test cleanup.
- This has been fixed via #2266 on develop already

Build: http://builds.cask.co/browse/CDAP-RBT297