### PR TITLE
[CDAP-2633] add max-height to error popover content

### DIFF
--- a/cdap-ui/app/directives/error/error.less
+++ b/cdap-ui/app/directives/error/error.less
@@ -32,6 +32,8 @@ my-error {
       overflow-wrap: break-word;
       padding: 10px;
       margin: 10px 0 10px 10px;
+      max-height: 250px;
+      overflow-y: auto;
     }
 
     .row {


### PR DESCRIPTION
![screen shot 2015-06-02 at 3 56 33 pm](https://cloud.githubusercontent.com/assets/4398643/7949164/36b71522-0940-11e5-8140-3ab9b2ff2445.png)
