### PR TITLE
Utilize the config in the json of the metadata upon namespacece create

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/NamespaceHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/NamespaceHttpHandler.java
@@ -25,9 +25,11 @@ import co.cask.cdap.gateway.auth.Authenticator;
 import co.cask.cdap.gateway.handlers.util.AbstractAppFabricHttpHandler;
 import co.cask.cdap.internal.app.namespace.NamespaceAdmin;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.NamespaceConfig;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.http.HttpHandler;
 import co.cask.http.HttpResponder;
+import com.google.common.base.Strings;
 import com.google.gson.JsonSyntaxException;
 import com.google.inject.Inject;
 import org.jboss.netty.handler.codec.http.HttpRequest;
@@ -135,8 +137,15 @@ public class NamespaceHttpHandler extends AbstractAppFabricHttpHandler {
     NamespaceMeta.Builder builder = new NamespaceMeta.Builder().setName(namespace);
 
     // Handle optional params
-    if (metadata != null && metadata.getDescription() != null) {
+    if (metadata != null) {
+      if (metadata.getDescription() != null) {
         builder.setDescription(metadata.getDescription());
+      }
+
+      NamespaceConfig config = metadata.getConfig();
+      if (config != null && !Strings.isNullOrEmpty(config.getSchedulerQueueName())) {
+        builder.setSchedulerQueueName(config.getSchedulerQueueName());
+      }
     }
 
     try {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdmin.java
@@ -44,6 +44,7 @@ import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.templates.AdapterDefinition;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
+import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Maps;
 import com.google.inject.Inject;
@@ -286,13 +287,8 @@ public final class DefaultNamespaceAdmin implements NamespaceAdmin {
       builder.setDescription(namespaceMeta.getDescription());
     }
 
-    if (namespaceMeta.getName() != null) {
-      builder.setName(namespaceMeta.getName());
-    }
-
     NamespaceConfig config = namespaceMeta.getConfig();
-
-    if (config != null && config.getSchedulerQueueName() != null && !config.getSchedulerQueueName().isEmpty()) {
+    if (config != null && !Strings.isNullOrEmpty(config.getSchedulerQueueName())) {
       builder.setSchedulerQueueName(config.getSchedulerQueueName());
     }
 


### PR DESCRIPTION
Utilize the config in the json of the metadata upon namespace create.
Also, ignore the `name` field of the metadata upon namespace properties update.

https://issues.cask.co/browse/CDAP-2635
http://builds.cask.co/browse/CDAP-DUT1948-6