### PR TITLE
Feature/cdap 2535 fix deploy integration test manager

### DIFF
--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestBase.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestBase.java
@@ -80,12 +80,23 @@ public class IntegrationTestBase {
     assertIsClear();
   }
 
-  protected TestManager getTestManager() {
+  protected ClientConfig createNamespacedClientConfig(ClientConfig initialClientConfig, Id.Namespace namespace) {
+    ClientConfig newClientConfig = new ClientConfig.Builder(initialClientConfig).build();
+    newClientConfig.setNamespace(namespace);
+    return newClientConfig;
+  }
+
+  protected TestManager createTestManager(Id.Namespace namespace) {
     try {
-      return new IntegrationTestManager(getClientConfig(), new LocalLocationFactory(TEMP_FOLDER.newFolder()));
+      return new IntegrationTestManager(createNamespacedClientConfig(getClientConfig(), namespace),
+                                        new LocalLocationFactory(TEMP_FOLDER.newFolder()));
     } catch (IOException e) {
       throw Throwables.propagate(e);
     }
+  }
+
+  protected TestManager getTestManager() {
+    return createTestManager(Id.Namespace.DEFAULT);
   }
 
   /**
@@ -154,10 +165,17 @@ public class IntegrationTestBase {
     return new DatasetClient(getClientConfig());
   }
 
+  protected Id.Namespace createNamespace(String name) throws Exception {
+    Id.Namespace namespace = new Id.Namespace(name);
+    NamespaceMeta namespaceMeta = new NamespaceMeta.Builder().setName(namespace).build();
+    getTestManager().createNamespace(namespaceMeta);
+    return namespace;
+  }
+
   protected ApplicationManager deployApplication(Id.Namespace namespace,
                                                  Class<? extends Application> applicationClz,
                                                  File...bundleEmbeddedJars) throws IOException {
-    return getTestManager().deployApplication(namespace, applicationClz, bundleEmbeddedJars);
+    return createTestManager(namespace).deployApplication(namespace, applicationClz, bundleEmbeddedJars);
   }
 
   protected ApplicationManager deployApplication(Class<? extends Application> applicationClz,

--- a/cdap-integration-test/src/test/java/co/cask/cdap/test/IntegrationTestBaseTest.java
+++ b/cdap-integration-test/src/test/java/co/cask/cdap/test/IntegrationTestBaseTest.java
@@ -17,6 +17,10 @@
 package co.cask.cdap.test;
 
 import co.cask.cdap.StandaloneTester;
+import co.cask.cdap.client.ApplicationClient;
+import co.cask.cdap.client.config.ClientConfig;
+import co.cask.cdap.proto.Id;
+import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -40,4 +44,21 @@ public class IntegrationTestBaseTest extends IntegrationTestBase {
     flowManager.stop();
   }
 
+  @Test
+  public void testDeployApplicationInNamespace() throws Exception {
+    Id.Namespace namespace = createNamespace("Test1");
+    ClientConfig clientConfig = new ClientConfig.Builder(getClientConfig()).build();
+    clientConfig.setNamespace(namespace);
+    ApplicationManager applicationManager = deployApplication(namespace, TestApplication.class);
+
+    // Check the default namespaces applications to see whether the application wasnt made in the default namespace
+    ClientConfig defaultClientConfig = new ClientConfig.Builder(getClientConfig()).build();
+    Assert.assertEquals(0, new ApplicationClient(defaultClientConfig).list().size());
+
+    ApplicationClient applicationClient = new ApplicationClient(clientConfig);
+    Assert.assertEquals("TestApplication", applicationClient.list().get(0).getName());
+    applicationClient.delete("TestApplication");
+    Assert.assertEquals(0, new ApplicationClient(clientConfig).list().size());
+
+  }
 }


### PR DESCRIPTION
Feature makes sure that deploy application is now making use of namespace that is passed as function parameter
Build : http://builds.cask.co/browse/CDAP-DUT1944-2
JIRA : https://issues.cask.co/browse/CDAP-2535