### PR TITLE
CDAP-2597 Catch invalid Plugin configuration and return 400 instead of 500

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AdapterHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AdapterHttpHandler.java
@@ -27,6 +27,7 @@ import co.cask.cdap.internal.app.runtime.adapter.AdapterAlreadyExistsException;
 import co.cask.cdap.internal.app.runtime.adapter.AdapterService;
 import co.cask.cdap.internal.app.runtime.adapter.ApplicationTemplateInfo;
 import co.cask.cdap.internal.app.runtime.adapter.InvalidAdapterOperationException;
+import co.cask.cdap.internal.app.runtime.adapter.InvalidPluginConfigException;
 import co.cask.cdap.internal.app.runtime.schedule.SchedulerException;
 import co.cask.cdap.proto.AdapterConfig;
 import co.cask.cdap.proto.AdapterDetail;
@@ -329,7 +330,7 @@ public class AdapterHttpHandler extends AbstractAppFabricHttpHandler {
 
       adapterService.createAdapter(namespace, adapterName, config);
       responder.sendString(HttpResponseStatus.OK, String.format("Adapter: %s is created", adapterName));
-    } catch (IllegalArgumentException e) {
+    } catch (IllegalArgumentException | InvalidPluginConfigException e) {
       responder.sendString(HttpResponseStatus.BAD_REQUEST, e.getMessage());
     } catch (AdapterAlreadyExistsException e) {
       responder.sendString(HttpResponseStatus.CONFLICT, e.getMessage());

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/AdapterService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/AdapterService.java
@@ -614,6 +614,10 @@ public class AdapterService extends AbstractIdleService {
       if (cause instanceof IllegalArgumentException) {
         throw (IllegalArgumentException) cause;
       }
+
+      if (cause instanceof InvalidPluginConfigException) {
+        throw (InvalidPluginConfigException) cause;
+      }
       throw new RuntimeException(e);
     } catch (Exception e) {
       throw new RuntimeException(e);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/AdapterService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/AdapterService.java
@@ -58,6 +58,7 @@ import co.cask.cdap.proto.RunRecord;
 import co.cask.cdap.templates.AdapterDefinition;
 import com.clearspring.analytics.util.Preconditions;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -611,12 +612,8 @@ public class AdapterService extends AbstractIdleService {
     } catch (ExecutionException e) {
       // error handling for manager could use some work...
       Throwable cause = e.getCause();
-      if (cause instanceof IllegalArgumentException) {
-        throw (IllegalArgumentException) cause;
-      }
-
-      if (cause instanceof InvalidPluginConfigException) {
-        throw (InvalidPluginConfigException) cause;
+      if (cause instanceof RuntimeException) {
+        throw Throwables.propagate(cause);
       }
       throw new RuntimeException(e);
     } catch (Exception e) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/InvalidPluginConfigException.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/InvalidPluginConfigException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.adapter;
+
+/**
+ * Thrown when Plugin configuration is wrong.
+ */
+public class InvalidPluginConfigException extends RuntimeException {
+
+  public InvalidPluginConfigException(String message) {
+    super(message);
+  }
+
+  public InvalidPluginConfigException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/PluginInstantiator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/PluginInstantiator.java
@@ -46,6 +46,7 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.concurrent.ExecutionException;
@@ -150,9 +151,9 @@ public class PluginInstantiator implements Closeable {
       // Create the plugin instance
       return newInstance(pluginType, field, configFieldType, config);
     } catch (NoSuchFieldException e) {
-      throw new IllegalArgumentException("Config field not found in plugin class: " + pluginClass);
+      throw new InvalidPluginConfigException("Config field not found in plugin class: " + pluginClass, e);
     } catch (IllegalAccessException e) {
-      throw new IllegalArgumentException("Failed to set plugin config field: " + pluginClass);
+      throw new InvalidPluginConfigException("Failed to set plugin config field: " + pluginClass, e);
     }
   }
 
@@ -268,9 +269,16 @@ public class PluginInstantiator implements Closeable {
         rawType = Primitives.wrap(rawType);
       }
 
-      if (Primitives.isWrapperType(rawType)) {
-        Method valueOf = rawType.getMethod("valueOf", String.class);
-        return valueOf.invoke(null, value);
+      try {
+        if (Primitives.isWrapperType(rawType)) {
+          Method valueOf = rawType.getMethod("valueOf", String.class);
+          return valueOf.invoke(null, value);
+        }
+      } catch (InvocationTargetException e) {
+        if (e.getCause() instanceof NumberFormatException) {
+          // if exception is due to wrong value for integer/double conversion
+          throw new InvalidPluginConfigException(String.format("valueOf operation on %s failed", value), e.getCause());
+        }
       }
 
       throw new UnsupportedTypeException("Only primitive and String types are supported");

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/PluginInstantiator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/PluginInstantiator.java
@@ -279,6 +279,7 @@ public class PluginInstantiator implements Closeable {
           // if exception is due to wrong value for integer/double conversion
           throw new InvalidPluginConfigException(String.format("valueOf operation on %s failed", value), e.getCause());
         }
+        throw e;
       }
 
       throw new UnsupportedTypeException("Only primitive and String types are supported");

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/PluginInstantiator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/PluginInstantiator.java
@@ -269,17 +269,17 @@ public class PluginInstantiator implements Closeable {
         rawType = Primitives.wrap(rawType);
       }
 
-      try {
-        if (Primitives.isWrapperType(rawType)) {
-          Method valueOf = rawType.getMethod("valueOf", String.class);
+      if (Primitives.isWrapperType(rawType)) {
+        Method valueOf = rawType.getMethod("valueOf", String.class);
+        try {
           return valueOf.invoke(null, value);
+        } catch (InvocationTargetException e) {
+          if (e.getCause() instanceof NumberFormatException) {
+            // if exception is due to wrong value for integer/double conversion
+            throw new InvalidPluginConfigException(String.format("valueOf operation on %s failed", value), e.getCause());
+          }
+          throw e;
         }
-      } catch (InvocationTargetException e) {
-        if (e.getCause() instanceof NumberFormatException) {
-          // if exception is due to wrong value for integer/double conversion
-          throw new InvalidPluginConfigException(String.format("valueOf operation on %s failed", value), e.getCause());
-        }
-        throw e;
       }
 
       throw new UnsupportedTypeException("Only primitive and String types are supported");


### PR DESCRIPTION
Handle NumberFormatException (invalid Integer/Double values in the PluginConfiguration) which was previously propagated as RuntimeException and thus returned 500 instead of 400 Bad Request.

Build : http://builds.cask.co/browse/CDAP-RBT300