### PR TITLE
CLI capitalization

### DIFF
--- a/cdap-cli/src/main/java/co/cask/cdap/cli/CLIConfig.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/CLIConfig.java
@@ -149,7 +149,7 @@ public class CLIConfig implements TableRendererConfig {
       }
       checkConnection(clientConfig, connectionConfig, accessToken);
       setConnectionConfig(connectionConfig);
-      output.printf("Successfully connected CDAP instance at %s", connectionConfig.getURI().toString());
+      output.printf("Successfully connected to CDAP instance at %s", connectionConfig.getURI().toString());
       output.println();
     } catch (IOException e) {
       throw new IOException(String.format("CDAP instance at '%s' could not be reached: %s",

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/AbstractGetPreferencesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/AbstractGetPreferencesCommand.java
@@ -78,7 +78,7 @@ public abstract class AbstractGetPreferencesCommand extends AbstractCommand {
       case SPARK:
         return client.getProgramPreferences(parseProgramId(programIdParts, type.getProgramType()), resolved);
       default:
-        throw new IllegalArgumentException("Unrecognized Element Type for Preferences "  + type.getTitleName());
+        throw new IllegalArgumentException("Unrecognized element type for preferences "  + type.getTitleName());
     }
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/AbstractSetPreferencesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/AbstractSetPreferencesCommand.java
@@ -70,7 +70,7 @@ public abstract class AbstractSetPreferencesCommand extends AbstractCommand {
         break;
 
       default:
-        throw new IllegalArgumentException("Unrecognized Element Type for Preferences " + type.getTitleName());
+        throw new IllegalArgumentException("Unrecognized element type for preferences " + type.getTitleName());
     }
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeleteNamespaceCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeleteNamespaceCommand.java
@@ -49,12 +49,11 @@ public class DeleteNamespaceCommand extends AbstractCommand {
 
   @Override
   public void perform(Arguments arguments, PrintStream out) throws Exception {
-    out.println("WARNING: Deleting namespace is an unrecoverable operation");
-
     Id.Namespace namespaceId = Id.Namespace.from(arguments.get(ArgumentName.NAMESPACE_NAME.toString()));
 
     ConsoleReader consoleReader = new ConsoleReader();
     if (Constants.DEFAULT_NAMESPACE_ID.equals(namespaceId)) {
+      out.println("WARNING: Deleting contents of a namespace is an unrecoverable operation");
       String prompt = String.format("Are you sure you want to delete contents of namespace '%s' [y/N]? ",
                                     namespaceId.getId());
       String userConfirm = consoleReader.readLine(prompt);
@@ -64,6 +63,7 @@ public class DeleteNamespaceCommand extends AbstractCommand {
         out.println();
       }
     } else {
+      out.println("WARNING: Deleting a namespace is an unrecoverable operation");
       String prompt = String.format("Are you sure you want to delete namespace '%s' [y/N]? ",
                                     namespaceId.getId());
       String userConfirm = consoleReader.readLine(prompt);

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeletePreferencesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeletePreferencesCommand.java
@@ -30,7 +30,7 @@ import java.io.PrintStream;
  * Deletes preferences for instance, namespace, application, program.
  */
 public class DeletePreferencesCommand extends AbstractCommand {
-  private static final String SUCCESS = "Deleted Preferences successfully for the '%s'";
+  private static final String SUCCESS = "Deleted preferences successfully for the '%s'";
 
   private final PreferencesClient client;
   private final ElementType type;
@@ -82,7 +82,7 @@ public class DeletePreferencesCommand extends AbstractCommand {
         break;
 
       default:
-        throw new IllegalArgumentException("Unrecognized Element Type for Preferences " + type.getTitleName());
+        throw new IllegalArgumentException("Unrecognized element type for preferences " + type.getTitleName());
     }
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetServiceEndpointsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetServiceEndpointsCommand.java
@@ -79,7 +79,7 @@ public class GetServiceEndpointsCommand extends AbstractAuthCommand implements C
 
   @Override
   public String getDescription() {
-    return String.format("List the endpoints that %s exposes.",
+    return String.format("Lists the endpoints that %s exposes.",
                          Fragment.of(Article.A, ElementType.SERVICE.getTitleName()));
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetWorkflowCurrentRunCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetWorkflowCurrentRunCommand.java
@@ -81,6 +81,6 @@ public class GetWorkflowCurrentRunCommand extends AbstractCommand {
 
   @Override
   public String getDescription() {
-    return "Gets the currently running nodes of a Workflow for a given run id.";
+    return "Gets the currently running nodes of a workflow for a given run id.";
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/LoadPreferencesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/LoadPreferencesCommand.java
@@ -75,7 +75,7 @@ public class LoadPreferencesCommand extends AbstractSetPreferencesCommand {
       }
     } catch (JsonSyntaxException e) {
       throw new BadRequestException(
-        String.format("JSON Syntax in File is invalid. Support only for string-to-string map. %s", e.getMessage()));
+        String.format("JSON syntax in file is invalid. Support only for string-to-string map. %s", e.getMessage()));
     }
 
     if (arguments.hasArgument(type.getArgumentName().toString())) {
@@ -92,7 +92,7 @@ public class LoadPreferencesCommand extends AbstractSetPreferencesCommand {
 
   @Override
   public String getDescription() {
-    return String.format("Set preferences of %s from a local Config File (supported formats = JSON).",
+    return String.format("Sets preferences of %s from a local config file (supported formats = JSON).",
                          Fragment.of(Article.A, type.getTitleName()));
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/LoadPreferencesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/LoadPreferencesCommand.java
@@ -71,11 +71,11 @@ public class LoadPreferencesCommand extends AbstractSetPreferencesCommand {
       if (contentType.equals("json")) {
         args = GSON.fromJson(reader, MAP_STRING_STRING_TYPE);
       } else {
-        throw new IllegalArgumentException("Unsupported file format. Only json format is supported");
+        throw new IllegalArgumentException("Unsupported file format. Only JSON format is supported");
       }
     } catch (JsonSyntaxException e) {
       throw new BadRequestException(
-        String.format("Json Syntax in File is invalid. Support only for string-to-string map. %s", e.getMessage()));
+        String.format("JSON Syntax in File is invalid. Support only for string-to-string map. %s", e.getMessage()));
     }
 
     if (arguments.hasArgument(type.getArgumentName().toString())) {
@@ -92,7 +92,7 @@ public class LoadPreferencesCommand extends AbstractSetPreferencesCommand {
 
   @Override
   public String getDescription() {
-    return String.format("Set Preferences of %s from a local Config File (supported formats = JSON).",
+    return String.format("Set preferences of %s from a local Config File (supported formats = JSON).",
                          Fragment.of(Article.A, type.getTitleName()));
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetPreferencesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetPreferencesCommand.java
@@ -32,7 +32,7 @@ import java.util.Map;
  * Sets preferences for instance, namespace, application, program.
  */
 public class SetPreferencesCommand extends AbstractSetPreferencesCommand {
-  protected static final String SUCCESS = "Set Preferences successfully for the '%s'";
+  protected static final String SUCCESS = "Set preferences successfully for the '%s'";
 
   private final ElementType type;
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetStreamFormatCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetStreamFormatCommand.java
@@ -102,7 +102,7 @@ public class SetStreamFormatCommand extends AbstractAuthCommand {
       .append(Fragment.of(Article.A, ElementType.STREAM.getTitleName()))
       .append(". <")
       .append(ArgumentName.SCHEMA)
-      .append("> is a sql-like schema \"column_name data_type, ...\" or avro-like json schema and <")
+      .append("> is a sql-like schema \"column_name data_type, ...\" or Avro-like JSON schema and <")
       .append(ArgumentName.SETTINGS)
       .append("> is specified in the format \"key1=v1 key2=v2\".")
       .toString();

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetStreamNotificationThresholdCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetStreamNotificationThresholdCommand.java
@@ -60,7 +60,7 @@ public class SetStreamNotificationThresholdCommand extends AbstractAuthCommand {
 
   @Override
   public String getDescription() {
-    return String.format("Sets the Notification Threshold of %s.",
+    return String.format("Sets the notification threshold of %s.",
                          Fragment.of(Article.A, ElementType.STREAM.getTitleName()));
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetStreamPropertiesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetStreamPropertiesCommand.java
@@ -77,6 +77,6 @@ public class SetStreamPropertiesCommand extends AbstractAuthCommand {
 
   @Override
   public String getDescription() {
-    return "Sets the properties of a Stream, such as TTL, format, and notification threshold.";
+    return "Sets the properties of a stream, such as TTL, format, and notification threshold.";
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetStreamTTLCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetStreamTTLCommand.java
@@ -56,7 +56,7 @@ public class SetStreamTTLCommand extends AbstractAuthCommand {
 
   @Override
   public String getDescription() {
-    return String.format("Sets the Time-to-Live (TTL) of %s.",
+    return String.format("Sets the time-to-live (TTL) of %s.",
                          Fragment.of(Article.A, ElementType.STREAM.getTitleName()));
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/system/HelpCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/system/HelpCommand.java
@@ -148,7 +148,7 @@ public class HelpCommand implements Command {
 
   @Override
   public String getDescription() {
-    return String.format("Prints this helper text. Optionally, provide <%s> to get help with a specific category.",
+    return String.format("Prints this helper text. Optionally, provide <%s> for help for a specific category.",
                          ArgumentName.COMMAND_CATEGORY);
   }
 


### PR DESCRIPTION
- Standardizes the capitalization for the CLI help and messages
- Corrects grammer in  a couple of messages
- Adds an additional "warning" message when deleting a namespace or its contents