### PR TITLE
CDAP-2587 During namespace create, delete the namespace directory on the filesystem if it already exists

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdmin.java
@@ -210,10 +210,10 @@ public final class DefaultNamespaceAdmin implements NamespaceAdmin {
       // Another reason for not deleting the default namespace is that we do not want to call a delete on the default
       // namespace in the storage provider (Hive, HBase, etc), since we re-use their default namespace.
       if (!Constants.DEFAULT_NAMESPACE_ID.equals(namespaceId)) {
-        // Delete namespace in storage providers
-        dsFramework.deleteNamespace(namespaceId);
         // Finally delete namespace from MDS
         store.deleteNamespace(namespaceId);
+        // Delete namespace in storage providers
+        dsFramework.deleteNamespace(namespaceId);
       }
     } catch (Exception e) {
       LOG.warn("Error while deleting namespace {}", namespaceId, e);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataSetServiceModules.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataSetServiceModules.java
@@ -23,9 +23,9 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.runtime.RuntimeModule;
 import co.cask.cdap.data2.datafabric.dataset.DatasetMetaTableUtil;
 import co.cask.cdap.data2.datafabric.dataset.service.DatasetService;
-import co.cask.cdap.data2.datafabric.dataset.service.DistributedUnderlyingSystemNamespaceAdmin;
-import co.cask.cdap.data2.datafabric.dataset.service.LocalUnderlyingSystemNamespaceAdmin;
-import co.cask.cdap.data2.datafabric.dataset.service.UnderlyingSystemNamespaceAdmin;
+import co.cask.cdap.data2.datafabric.dataset.service.DistributedStorageProviderNamespaceAdmin;
+import co.cask.cdap.data2.datafabric.dataset.service.LocalStorageProviderNamespaceAdmin;
+import co.cask.cdap.data2.datafabric.dataset.service.StorageProviderNamespaceAdmin;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetAdminOpHTTPHandler;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetOpExecutor;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetOpExecutorService;
@@ -88,8 +88,8 @@ public class DataSetServiceModules extends RuntimeModule {
         bind(DatasetOpExecutor.class).to(LocalDatasetOpExecutor.class);
         expose(DatasetOpExecutor.class);
 
-        bind(UnderlyingSystemNamespaceAdmin.class).to(LocalUnderlyingSystemNamespaceAdmin.class);
-        expose(UnderlyingSystemNamespaceAdmin.class);
+        bind(StorageProviderNamespaceAdmin.class).to(LocalStorageProviderNamespaceAdmin.class);
+        expose(StorageProviderNamespaceAdmin.class);
       }
     };
 
@@ -125,8 +125,8 @@ public class DataSetServiceModules extends RuntimeModule {
         bind(DatasetOpExecutor.class).to(LocalDatasetOpExecutor.class);
         expose(DatasetOpExecutor.class);
 
-        bind(UnderlyingSystemNamespaceAdmin.class).to(LocalUnderlyingSystemNamespaceAdmin.class);
-        expose(UnderlyingSystemNamespaceAdmin.class);
+        bind(StorageProviderNamespaceAdmin.class).to(LocalStorageProviderNamespaceAdmin.class);
+        expose(StorageProviderNamespaceAdmin.class);
       }
     };
 
@@ -164,8 +164,8 @@ public class DataSetServiceModules extends RuntimeModule {
         bind(DatasetOpExecutor.class).to(YarnDatasetOpExecutor.class);
         expose(DatasetOpExecutor.class);
 
-        bind(UnderlyingSystemNamespaceAdmin.class).to(DistributedUnderlyingSystemNamespaceAdmin.class);
-        expose(UnderlyingSystemNamespaceAdmin.class);
+        bind(StorageProviderNamespaceAdmin.class).to(DistributedStorageProviderNamespaceAdmin.class);
+        expose(StorageProviderNamespaceAdmin.class);
       }
     };
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetService.java
@@ -84,7 +84,7 @@ public class DatasetService extends AbstractExecutionThreadService {
                         MDSDatasetsRegistry mdsDatasets,
                         ExploreFacade exploreFacade,
                         Set<DatasetMetricsReporter> metricReporters,
-                        UnderlyingSystemNamespaceAdmin underlyingSystemNamespaceAdmin,
+                        StorageProviderNamespaceAdmin storageProviderNamespaceAdmin,
                         UsageRegistry usageRegistry) throws Exception {
 
     this.typeManager = typeManager;
@@ -93,7 +93,7 @@ public class DatasetService extends AbstractExecutionThreadService {
                                                                                opExecutorClient, exploreFacade, cConf,
                                                                                usageRegistry);
     UnderlyingSystemNamespaceHandler underlyingSystemNamespaceHandler =
-      new UnderlyingSystemNamespaceHandler(underlyingSystemNamespaceAdmin);
+      new UnderlyingSystemNamespaceHandler(storageProviderNamespaceAdmin);
     NettyHttpService.Builder builder = new CommonNettyHttpServiceBuilder(cConf);
     builder.addHttpHandlers(ImmutableList.of(datasetTypeHandler,
                                              datasetInstanceHandler,

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DistributedStorageProviderNamespaceAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DistributedStorageProviderNamespaceAdmin.java
@@ -26,7 +26,6 @@ import com.google.inject.Inject;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.client.HBaseAdmin;
-import org.apache.twill.filesystem.LocationFactory;
 
 import java.io.IOException;
 import java.sql.SQLException;
@@ -34,16 +33,16 @@ import java.sql.SQLException;
 /**
  * Manages namespaces on underlying systems - HDFS, HBase, Hive, etc.
  */
-public final class DistributedUnderlyingSystemNamespaceAdmin extends UnderlyingSystemNamespaceAdmin {
+public final class DistributedStorageProviderNamespaceAdmin extends StorageProviderNamespaceAdmin {
 
   private final Configuration hConf;
   private final HBaseTableUtil tableUtil;
   private HBaseAdmin hBaseAdmin;
 
   @Inject
-  public DistributedUnderlyingSystemNamespaceAdmin(CConfiguration cConf,
-                                                   NamespacedLocationFactory namespacedLocationFactory,
-                                                   ExploreFacade exploreFacade, HBaseTableUtil tableUtil) {
+  public DistributedStorageProviderNamespaceAdmin(CConfiguration cConf,
+                                                  NamespacedLocationFactory namespacedLocationFactory,
+                                                  ExploreFacade exploreFacade, HBaseTableUtil tableUtil) {
     super(cConf, namespacedLocationFactory, exploreFacade);
     this.hConf = HBaseConfiguration.create();
     this.tableUtil = tableUtil;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/LocalStorageProviderNamespaceAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/LocalStorageProviderNamespaceAdmin.java
@@ -20,16 +20,15 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.explore.client.ExploreFacade;
 import com.google.inject.Inject;
-import org.apache.twill.filesystem.LocationFactory;
 
 /**
  * Manages namespaces on local underlying systems.
  */
-public final class LocalUnderlyingSystemNamespaceAdmin extends UnderlyingSystemNamespaceAdmin {
+public final class LocalStorageProviderNamespaceAdmin extends StorageProviderNamespaceAdmin {
 
   @Inject
-  public LocalUnderlyingSystemNamespaceAdmin(CConfiguration cConf, NamespacedLocationFactory namespacedLocationFactory,
-                                             ExploreFacade exploreFacade) {
+  public LocalStorageProviderNamespaceAdmin(CConfiguration cConf, NamespacedLocationFactory namespacedLocationFactory,
+                                            ExploreFacade exploreFacade) {
     super(cConf, namespacedLocationFactory, exploreFacade);
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/UnderlyingSystemNamespaceHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/UnderlyingSystemNamespaceHandler.java
@@ -39,11 +39,11 @@ import javax.ws.rs.PathParam;
 @Path(Constants.Gateway.API_VERSION_3 + "/namespaces/{namespace-id}")
 public class UnderlyingSystemNamespaceHandler extends AbstractHttpHandler {
 
-  private final UnderlyingSystemNamespaceAdmin underlyingSystemNamespaceAdmin;
+  private final StorageProviderNamespaceAdmin storageProviderNamespaceAdmin;
 
   @Inject
-  public UnderlyingSystemNamespaceHandler(UnderlyingSystemNamespaceAdmin underlyingSystemNamespaceAdmin) {
-    this.underlyingSystemNamespaceAdmin = underlyingSystemNamespaceAdmin;
+  public UnderlyingSystemNamespaceHandler(StorageProviderNamespaceAdmin storageProviderNamespaceAdmin) {
+    this.storageProviderNamespaceAdmin = storageProviderNamespaceAdmin;
   }
 
   @PUT
@@ -51,7 +51,7 @@ public class UnderlyingSystemNamespaceHandler extends AbstractHttpHandler {
   public void createNamespace(HttpRequest request, HttpResponder responder,
                               @PathParam("namespace-id") String namespaceId) {
     try {
-      underlyingSystemNamespaceAdmin.create(Id.Namespace.from(namespaceId));
+      storageProviderNamespaceAdmin.create(Id.Namespace.from(namespaceId));
     } catch (IOException e) {
       responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR,
                            "Error while creating namespace - " + e.getMessage());
@@ -74,7 +74,7 @@ public class UnderlyingSystemNamespaceHandler extends AbstractHttpHandler {
   public void deleteNamespace(HttpRequest request, HttpResponder responder,
                               @PathParam("namespace-id") String namespaceId) {
     try {
-      underlyingSystemNamespaceAdmin.delete(Id.Namespace.from(namespaceId));
+      storageProviderNamespaceAdmin.delete(Id.Namespace.from(namespaceId));
     } catch (IOException e) {
       responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR,
                            "Error while deleting namespace - " + e.getMessage());

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
@@ -26,7 +26,7 @@ import co.cask.cdap.common.namespace.DefaultNamespacedLocationFactory;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.data2.datafabric.dataset.instance.DatasetInstanceManager;
 import co.cask.cdap.data2.datafabric.dataset.service.DatasetService;
-import co.cask.cdap.data2.datafabric.dataset.service.LocalUnderlyingSystemNamespaceAdmin;
+import co.cask.cdap.data2.datafabric.dataset.service.LocalStorageProviderNamespaceAdmin;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetAdminOpHTTPHandler;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetOpExecutorService;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.InMemoryDatasetOpExecutor;
@@ -80,7 +80,6 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
   private DatasetOpExecutorService opExecutorService;
   private DatasetService service;
   private RemoteDatasetFramework framework;
-  private LocalLocationFactory locationFactory;
 
   @ClassRule
   public static TemporaryFolder tmpFolder = new TemporaryFolder();
@@ -103,7 +102,7 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
     txManager.startAndWait();
     InMemoryTxSystemClient txSystemClient = new InMemoryTxSystemClient(txManager);
 
-    locationFactory = new LocalLocationFactory(new File(cConf.get(Constants.CFG_LOCAL_DATA_DIR)));
+    LocalLocationFactory locationFactory = new LocalLocationFactory(new File(cConf.get(Constants.CFG_LOCAL_DATA_DIR)));
     NamespacedLocationFactory namespacedLocationFactory = new DefaultNamespacedLocationFactory(cConf, locationFactory);
     framework = new RemoteDatasetFramework(discoveryService, registryFactory,
                                            new LocalDatasetTypeClassLoaderFactory());
@@ -135,8 +134,8 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
                                  mdsDatasetsRegistry,
                                  exploreFacade,
                                  new HashSet<DatasetMetricsReporter>(),
-                                 new LocalUnderlyingSystemNamespaceAdmin(cConf, namespacedLocationFactory,
-                                                                         exploreFacade),
+                                 new LocalStorageProviderNamespaceAdmin(cConf, namespacedLocationFactory,
+                                                                        exploreFacade),
                                  new UsageRegistry(txExecutorFactory, framework));
     // Start dataset service, wait for it to be discoverable
     service.start();

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
@@ -52,8 +52,6 @@ import co.cask.common.http.HttpRequest;
 import co.cask.common.http.HttpRequests;
 import co.cask.common.http.ObjectResponse;
 import co.cask.http.HttpHandler;
-import co.cask.tephra.TransactionAware;
-import co.cask.tephra.TransactionExecutor;
 import co.cask.tephra.TransactionExecutorFactory;
 import co.cask.tephra.TransactionManager;
 import co.cask.tephra.inmemory.InMemoryTxSystemClient;
@@ -184,8 +182,8 @@ public abstract class DatasetServiceTestBase {
                                  mdsDatasetsRegistry,
                                  exploreFacade,
                                  new HashSet<DatasetMetricsReporter>(),
-                                 new LocalUnderlyingSystemNamespaceAdmin(cConf, namespacedLocationFactory,
-                                                                         exploreFacade),
+                                 new LocalStorageProviderNamespaceAdmin(cConf, namespacedLocationFactory,
+                                                                        exploreFacade),
                                  new UsageRegistry(txExecutorFactory, dsFramework));
 
     // Start dataset service, wait for it to be discoverable

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/UnderlyingSystemNamespaceHandlerTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/UnderlyingSystemNamespaceHandlerTest.java
@@ -32,7 +32,8 @@ public class UnderlyingSystemNamespaceHandlerTest extends DatasetServiceTestBase
   @Test
   public void test() throws IOException {
     Assert.assertEquals(200, createNamespace("myspace").getResponseCode());
-    Assert.assertEquals(500, createNamespace("myspace").getResponseCode());
+    // creation is idempotent, now that we delete the namespace directory if it exists
+    Assert.assertEquals(200, createNamespace("myspace").getResponseCode());
     Assert.assertEquals(200, deleteNamespace("myspace").getResponseCode());
   }
 

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/AbstractDatasetFrameworkTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/AbstractDatasetFrameworkTest.java
@@ -323,12 +323,6 @@ public abstract class AbstractDatasetFrameworkTest {
 
     Id.Namespace namespace = Id.Namespace.from("yourspace");
     framework.createNamespace(namespace);
-    try {
-      framework.createNamespace(namespace);
-      Assert.fail("Should not be able to create a duplicate namespace");
-    } catch (DatasetManagementException e) {
-      // expected
-    }
     framework.deleteNamespace(namespace);
   }
 


### PR DESCRIPTION
1st commit deletes the namespace directory if it exists during namespace creation. It also switches the order of deletion during namespace delete - Removes from MDS first, then from the storage providers. This ordering will help us make this process more fool-proof in future.

2nd commit is a mere rename of all ``Underlying**`` classes to ``StorageProvider**``.

Jira: [CDAP-2587](https://issues.cask.co/browse/CDAP-2587)
Build: http://builds.cask.co/browse/CDAP-RBT301