### PR TITLE
CDAP-2612 Add Flume agent to VM

### DIFF
--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu12.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu12.json
@@ -71,7 +71,7 @@
     {
       "type": "chef-solo",
       "remote_cookbook_paths": "/var/chef/cookbooks",
-      "run_list": "recipe[maven],recipe[idea],recipe[eclipse]",
+      "run_list": "recipe[maven],recipe[hadoop::flume_agent],recipe[idea],recipe[eclipse]",
       "prevent_sudo": true,
       "skip_install": true,
       "json": {

--- a/cdap-distributions/src/packer/scripts/cookbook-setup.sh
+++ b/cdap-distributions/src/packer/scripts/cookbook-setup.sh
@@ -19,7 +19,7 @@
 #
 
 # Grab cookbooks using knife
-for cb in idea maven nodejs cdap ; do
+for cb in hadoop idea maven nodejs cdap ; do
   knife cookbook site install $cb
 done
 


### PR DESCRIPTION
Pull in the `hadoop` [cookbook](https://github.com/caskdata/hadoop_cookbook) from Chef Supermarket and install the `hadoop::flume_agent` recipe, from the default distribution.