### PR TITLE
CDAP-2640 Remove persistent network rules on VM

### DIFF
--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu12.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu12.json
@@ -116,6 +116,7 @@
       "scripts": [
         "scripts/remove-chef.sh",
         "scripts/sdk-cleanup.sh",
+        "scripts/network-cleanup.sh",
         "scripts/apt-cleanup.sh"
       ]
     },

--- a/cdap-distributions/src/packer/scripts/network-cleanup.sh
+++ b/cdap-distributions/src/packer/scripts/network-cleanup.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# Copyright © 2015 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+# Remove UDEV persistent network rules
+rm -f /etc/udev/rules.d/70-persistent-net.rules


### PR DESCRIPTION
This removes the MAC address -> interface mapping from udev, so the first ethernet device will become `eth0` whether the MAC is reinitialized or not.