### PR TITLE
Fix the build log message.

### DIFF
--- a/cdap-docs/_common/common-build.sh
+++ b/cdap-docs/_common/common-build.sh
@@ -438,6 +438,7 @@ function display_messages_file() {
     echo ""
     echo "Warning Messages: ${TMP_MESSAGES_FILE}"
     echo ""
+    echo >> ${TMP_MESSAGES_FILE}
     cat ${TMP_MESSAGES_FILE} | while read line
     do
       echo -e "${line}"


### PR DESCRIPTION
The doc log was truncating the last line of any collected messages. This fixes that by adding an extra line at the end.