### PR TITLE
Use Java 7 diamond operator inference.

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/data/batch/SimpleSplit.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/data/batch/SimpleSplit.java
@@ -23,7 +23,7 @@ import java.util.Map;
  * Handy implementation of the {@link Split}. Acts as a map of attributes.
  */
 public final class SimpleSplit extends Split {
-  private Map<String, String> attributes = new HashMap<String, String>();
+  private Map<String, String> attributes = new HashMap<>();
 
   /**
    * Sets an attribute.

--- a/cdap-api/src/main/java/co/cask/cdap/api/data/format/StructuredRecord.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/data/format/StructuredRecord.java
@@ -80,7 +80,7 @@ public class StructuredRecord {
 
     private Builder(Schema schema) {
       this.schema = schema;
-      this.fields = new HashMap<String, Object>();
+      this.fields = new HashMap<>();
     }
 
     /**

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/IndexedObjectStore.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/IndexedObjectStore.java
@@ -157,7 +157,7 @@ public class IndexedObjectStore<T> extends AbstractDataset {
       existingSecondaryKeys = row.getColumns().keySet();
     }
 
-    Set<byte[]> newSecondaryKeys = new TreeSet<byte[]>(new Bytes.ByteArrayComparator());
+    Set<byte[]> newSecondaryKeys = new TreeSet<>(new Bytes.ByteArrayComparator());
     newSecondaryKeys.addAll(Arrays.asList(secondaryKeys));
 
     List<byte[]> secondaryKeysDeleted = secondaryKeysToDelete(existingSecondaryKeys, newSecondaryKeys);

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/KeyValueTable.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/KeyValueTable.java
@@ -229,7 +229,7 @@ public class KeyValueTable extends AbstractDataset implements
         Preconditions.checkState(!closed);
         Row next = scanner.next();
         if (next != null) {
-          return new KeyValue<byte[], byte[]>(next.getRow(), next.get(KEY_COLUMN));
+          return new KeyValue<>(next.getRow(), next.get(KEY_COLUMN));
         }
         close();
         return null;
@@ -250,7 +250,7 @@ public class KeyValueTable extends AbstractDataset implements
   public class KeyValueRecordMaker implements Scannables.RecordMaker<byte[], byte[], KeyValue<byte[], byte[]>> {
     @Override
     public KeyValue<byte[], byte[]> makeRecord(byte[] key, byte[] value) {
-      return new KeyValue<byte[], byte[]>(key, value);
+      return new KeyValue<>(key, value);
     }
   }
 

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionFilter.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionFilter.java
@@ -108,7 +108,7 @@ public class PartitionFilter {
       if (null == lower && null == upper) { // filter is pointless if there is no bound
         return this;
       }
-      map.put(field, new Condition<T>(field, lower, upper));
+      map.put(field, new Condition<>(field, lower, upper));
       return this;
     }
 
@@ -128,7 +128,7 @@ public class PartitionFilter {
       if (map.containsKey(field)) {
         throw new IllegalArgumentException(String.format("Field '%s' already exists in partition filter.", field));
       }
-      map.put(field, new Condition<T>(field, value));
+      map.put(field, new Condition<>(field, value));
       return this;
     }
 

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/TimeseriesTable.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/TimeseriesTable.java
@@ -209,7 +209,7 @@ public class TimeseriesTable extends TimeseriesDataset
     // we don't want splits to be empty
     timeIntervalPerSplit = timeIntervalPerSplit > 0 ? timeIntervalPerSplit : 1;
 
-    List<Split> splits = new ArrayList<Split>();
+    List<Split> splits = new ArrayList<>();
     long start;
     for (start = startTime; start + timeIntervalPerSplit <= endTime; start += timeIntervalPerSplit) {
       splits.add(new InputSplit(key, start, start + timeIntervalPerSplit, tags));

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/cube/CubeDeleteQuery.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/cube/CubeDeleteQuery.java
@@ -50,7 +50,7 @@ public class CubeDeleteQuery {
     this.endTs = endTs;
     this.resolution = resolution;
     this.measureNames = measureNames;
-    this.dimensionValues = Collections.unmodifiableMap(new HashMap<String, String>(dimensionValues));
+    this.dimensionValues = Collections.unmodifiableMap(new HashMap<>(dimensionValues));
   }
 
 

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/cube/CubeExploreQuery.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/cube/CubeExploreQuery.java
@@ -47,7 +47,7 @@ public class CubeExploreQuery {
     this.endTs = endTs;
     this.resolution = resolution;
     this.limit = limit;
-    this.dimensionValues = Collections.unmodifiableList(new ArrayList<DimensionValue>(dimensionValues));
+    this.dimensionValues = Collections.unmodifiableList(new ArrayList<>(dimensionValues));
   }
 
   public long getStartTs() {
@@ -98,7 +98,7 @@ public class CubeExploreQuery {
     private long endTs;
     private int resolution;
     private int limit;
-    private List<DimensionValue> dimensionValues = new ArrayList<DimensionValue>();
+    private List<DimensionValue> dimensionValues = new ArrayList<>();
 
     /**
      * @return builder for configuring {@link CubeExploreQuery}

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/cube/CubeFact.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/cube/CubeFact.java
@@ -44,8 +44,8 @@ public class CubeFact {
    * @param timestamp timestamp (epoch in sec) of the measurements
    */
   public CubeFact(long timestamp) {
-    this.dimensionValues = new HashMap<String, String>();
-    this.measurements = new LinkedList<Measurement>();
+    this.dimensionValues = new HashMap<>();
+    this.measurements = new LinkedList<>();
     this.timestamp = timestamp;
   }
 

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/cube/CubeQuery.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/cube/CubeQuery.java
@@ -80,8 +80,8 @@ public final class CubeQuery {
     this.resolution = resolution;
     this.limit = limit;
     this.measurements = measurements;
-    this.dimensionValues = Collections.unmodifiableMap(new HashMap<String, String>(dimensionValues));
-    this.groupByDimensions = Collections.unmodifiableList(new ArrayList<String>(groupByDimensions));
+    this.dimensionValues = Collections.unmodifiableMap(new HashMap<>(dimensionValues));
+    this.groupByDimensions = Collections.unmodifiableList(new ArrayList<>(groupByDimensions));
     this.interpolator = interpolator;
   }
 
@@ -156,9 +156,9 @@ public final class CubeQuery {
     private long endTs;
     private int resolution;
     private int limit;
-    private Map<String, AggregationFunction> measurements = new HashMap<String, AggregationFunction>();
-    private Map<String, String> dimensionValues = new HashMap<String, String>();
-    private List<String> groupByDimensions = new ArrayList<String>();
+    private Map<String, AggregationFunction> measurements = new HashMap<>();
+    private Map<String, String> dimensionValues = new HashMap<>();
+    private List<String> groupByDimensions = new ArrayList<>();
     private Interpolator interpolator;
 
     /**

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/cube/TimeSeries.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/cube/TimeSeries.java
@@ -35,7 +35,7 @@ public final class TimeSeries {
 
   public TimeSeries(String measureName, Map<String, String> dimensionValues, List<TimeValue> timeValues) {
     this.measureName = measureName;
-    this.dimensionValues = Collections.unmodifiableMap(new HashMap<String, String>(dimensionValues));
+    this.dimensionValues = Collections.unmodifiableMap(new HashMap<>(dimensionValues));
     this.timeValues = Collections.unmodifiableList(timeValues);
   }
 

--- a/cdap-api/src/main/java/co/cask/cdap/api/flow/FlowletDefinition.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/flow/FlowletDefinition.java
@@ -196,7 +196,7 @@ public final class FlowletDefinition {
 
   private Map<String, Set<Schema>> generateSchema(SchemaGenerator generator, Map<String, Set<Type>> types)
                                                   throws UnsupportedTypeException {
-    Map<String, Set<Schema>> result = new HashMap<String, Set<Schema>>();
+    Map<String, Set<Schema>> result = new HashMap<>();
     for (Map.Entry<String, Set<Type>> entry : types.entrySet()) {
       ImmutableSet.Builder<Schema> schemas = ImmutableSet.builder();
       for (Type type : entry.getValue()) {
@@ -208,7 +208,7 @@ public final class FlowletDefinition {
   }
 
   private <K, V> Map<K, Set<V>> immutableCopyOf(Map<K, Set<V>> map) {
-    Map<K, Set<V>> result = new HashMap<K, Set<V>>();
+    Map<K, Set<V>> result = new HashMap<>();
     for (Map.Entry<K, Set<V>> entry : map.entrySet()) {
       result.put(entry.getKey(), ImmutableSet.copyOf(entry.getValue()));
     }

--- a/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/AbstractMapReduce.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/AbstractMapReduce.java
@@ -95,7 +95,7 @@ public abstract class AbstractMapReduce implements MapReduce {
    */
   @Deprecated
   protected final void useDatasets(String dataset, String...moreDatasets) {
-    List<String> datasets = new ArrayList<String>();
+    List<String> datasets = new ArrayList<>();
     datasets.add(dataset);
     datasets.addAll(Arrays.asList(moreDatasets));
     configurer.useDatasets(datasets);

--- a/cdap-api/src/main/java/co/cask/cdap/api/schedule/ScheduleSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/schedule/ScheduleSpecification.java
@@ -34,7 +34,7 @@ public final class ScheduleSpecification {
     this.schedule = schedule;
     this.program = program;
     this.properties = properties == null ? new HashMap<String, String>() :
-      Collections.unmodifiableMap(new HashMap<String, String>(properties));
+      Collections.unmodifiableMap(new HashMap<>(properties));
   }
 
   /**

--- a/cdap-api/src/main/java/co/cask/cdap/api/service/BasicService.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/service/BasicService.java
@@ -32,14 +32,14 @@ public class BasicService extends AbstractService {
 
   public BasicService(String name, HttpServiceHandler handler, HttpServiceHandler...handlers) {
     this.name = name;
-    this.handlers = new ArrayList<HttpServiceHandler>();
+    this.handlers = new ArrayList<>();
     this.handlers.add(handler);
     this.handlers.addAll(Arrays.asList(handlers));
   }
 
   public BasicService(String name, Iterable<? extends HttpServiceHandler> handlers) {
     this.name = name;
-    this.handlers = new ArrayList<HttpServiceHandler>();
+    this.handlers = new ArrayList<>();
     for (HttpServiceHandler handler : handlers) {
       this.handlers.add(handler);
     }

--- a/cdap-api/src/main/java/co/cask/cdap/api/service/ServiceSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/service/ServiceSpecification.java
@@ -41,7 +41,7 @@ public final class ServiceSpecification implements ProgramSpecification {
     this.className = className;
     this.name = name;
     this.description = description;
-    this.handlers = Collections.unmodifiableMap(new HashMap<String, HttpServiceHandlerSpecification>(handlers));
+    this.handlers = Collections.unmodifiableMap(new HashMap<>(handlers));
     this.resources = resources;
     this.instances = instances;
   }

--- a/cdap-api/src/main/java/co/cask/cdap/api/service/http/AbstractHttpServiceHandler.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/service/http/AbstractHttpServiceHandler.java
@@ -98,7 +98,7 @@ public abstract class AbstractHttpServiceHandler implements HttpServiceHandler {
    * @param datasets More Dataset names.
    */
   protected void useDatasets(String dataset, String...datasets) {
-    List<String> datasetList = new ArrayList<String>();
+    List<String> datasetList = new ArrayList<>();
     datasetList.add(dataset);
     datasetList.addAll(Arrays.asList(datasets));
     useDatasets(datasetList);

--- a/cdap-api/src/main/java/co/cask/cdap/api/service/http/HttpServiceHandlerSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/service/http/HttpServiceHandlerSpecification.java
@@ -49,9 +49,9 @@ public final class HttpServiceHandlerSpecification implements PropertyProvider, 
     this.className = className;
     this.name = name;
     this.description = description;
-    this.properties = Collections.unmodifiableMap(new HashMap<String, String>(properties));
-    this.datasets = Collections.unmodifiableSet(new HashSet<String>(datasets));
-    this.endpoints = Collections.unmodifiableList(new ArrayList<ServiceHttpEndpoint>(endpoints));
+    this.properties = Collections.unmodifiableMap(new HashMap<>(properties));
+    this.datasets = Collections.unmodifiableSet(new HashSet<>(datasets));
+    this.endpoints = Collections.unmodifiableList(new ArrayList<>(endpoints));
   }
 
   /**

--- a/cdap-api/src/main/java/co/cask/cdap/api/templates/plugins/PluginProperties.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/templates/plugins/PluginProperties.java
@@ -51,7 +51,7 @@ public class PluginProperties {
     private final Map<String, String> properties;
 
     private Builder() {
-      this.properties = new HashMap<String, String>();
+      this.properties = new HashMap<>();
     }
 
     /**
@@ -80,7 +80,7 @@ public class PluginProperties {
      * Creates a new instance of {@link PluginProperties} with the properties added to this builder prior to this call.
      */
     public PluginProperties build() {
-      return new PluginProperties(Collections.unmodifiableMap(new HashMap<String, String>(properties)));
+      return new PluginProperties(Collections.unmodifiableMap(new HashMap<>(properties)));
     }
   }
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/worker/AbstractWorker.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/worker/AbstractWorker.java
@@ -86,7 +86,7 @@ public abstract class AbstractWorker implements Worker {
    */
   @Deprecated
   protected void useDatasets(String dataset, String...datasets) {
-    List<String> datasetList = new ArrayList<String>();
+    List<String> datasetList = new ArrayList<>();
     datasetList.add(dataset);
     datasetList.addAll(Arrays.asList(datasets));
     useDatasets(datasetList);

--- a/cdap-api/src/main/java/co/cask/cdap/api/worker/WorkerSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/worker/WorkerSpecification.java
@@ -44,8 +44,8 @@ public final class WorkerSpecification implements ProgramSpecification, Property
     this.className = className;
     this.name = name;
     this.description = description;
-    this.properties = Collections.unmodifiableMap(new HashMap<String, String>(properties));
-    this.datasets = Collections.unmodifiableSet(new HashSet<String>(datasets));
+    this.properties = Collections.unmodifiableMap(new HashMap<>(properties));
+    this.datasets = Collections.unmodifiableSet(new HashSet<>(datasets));
     this.resources = resources;
     this.instances = instances;
   }

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowSpecification.java
@@ -43,8 +43,8 @@ public final class WorkflowSpecification implements ProgramSpecification, Proper
     this.name = name;
     this.description = description;
     this.properties = properties == null ? Collections.<String, String>emptyMap() :
-                                           Collections.unmodifiableMap(new HashMap<String, String>(properties));
-    this.nodes = Collections.unmodifiableList(new ArrayList<WorkflowNode>(nodes));
+                                           Collections.unmodifiableMap(new HashMap<>(properties));
+    this.nodes = Collections.unmodifiableList(new ArrayList<>(nodes));
   }
 
   @Override

--- a/cdap-api/src/main/java/co/cask/cdap/internal/batch/DefaultMapReduceSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/batch/DefaultMapReduceSpecification.java
@@ -109,7 +109,7 @@ public class DefaultMapReduceSpecification implements MapReduceSpecification {
   }
 
   private Set<String> getAllDatasets(Set<String> dataSets, String inputDataSet, String outputDataSet) {
-    ImmutableSet.Builder<String> builder = new ImmutableSet.Builder<String>();
+    ImmutableSet.Builder<String> builder = new ImmutableSet.Builder<>();
     builder.addAll(dataSets);
 
     if (inputDataSet != null && !inputDataSet.isEmpty()) {

--- a/cdap-api/src/main/java/co/cask/cdap/internal/builder/SimpleDescriptionSetter.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/builder/SimpleDescriptionSetter.java
@@ -27,7 +27,7 @@ public final class SimpleDescriptionSetter<T> implements DescriptionSetter<T> {
   private final T next;
 
   public static <T> DescriptionSetter<T> create(Setter<String> setter, T next) {
-    return new SimpleDescriptionSetter<T>(setter, next);
+    return new SimpleDescriptionSetter<>(setter, next);
   }
 
   private SimpleDescriptionSetter(Setter<String> setter, T next) {

--- a/cdap-api/src/main/java/co/cask/cdap/internal/builder/SimpleNameSetter.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/builder/SimpleNameSetter.java
@@ -27,7 +27,7 @@ public final class SimpleNameSetter<T> implements NameSetter<T> {
   private final T next;
 
   public static <T> NameSetter<T> create(Setter<String> setter, T next) {
-    return new SimpleNameSetter<T>(setter, next);
+    return new SimpleNameSetter<>(setter, next);
   }
 
   private SimpleNameSetter(Setter<String> setter, T next) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AbstractMonitorHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AbstractMonitorHandler.java
@@ -137,7 +137,7 @@ public class AbstractMonitorHandler extends AbstractAppFabricHttpHandler {
 
 
   public void getBootStatus(HttpRequest request, HttpResponder responder) {
-    Map<String, String> result = new HashMap<String, String>();
+    Map<String, String> result = new HashMap<>();
     for (String service : serviceManagementMap.keySet()) {
       MasterServiceManager masterServiceManager = serviceManagementMap.get(service);
       if (masterServiceManager.isServiceEnabled() && masterServiceManager.canCheckStatus()) {
@@ -174,8 +174,8 @@ public class AbstractMonitorHandler extends AbstractAppFabricHttpHandler {
 
   public void getServiceSpec(HttpRequest request, HttpResponder responder) throws Exception {
     List<SystemServiceMeta> response = Lists.newArrayList();
-    SortedSet<String> services = new TreeSet<String>(serviceManagementMap.keySet());
-    List<String> serviceList = new ArrayList<String>(services);
+    SortedSet<String> services = new TreeSet<>(serviceManagementMap.keySet());
+    List<String> serviceList = new ArrayList<>(services);
     for (String service : serviceList) {
       MasterServiceManager serviceManager = serviceManagementMap.get(service);
       if (serviceManager.isServiceEnabled()) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
@@ -1571,7 +1571,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
     if (args == null) {
       return null;
     }
-    List<BatchEndpointInstances> retVal = new ArrayList<BatchEndpointInstances>(args.size());
+    List<BatchEndpointInstances> retVal = new ArrayList<>(args.size());
     for (BatchEndpointArgs arg: args) {
       retVal.add(new BatchEndpointInstances(arg));
     }
@@ -1582,7 +1582,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
     if (args == null) {
       return null;
     }
-    List<BatchEndpointStatus> retVal = new ArrayList<BatchEndpointStatus>(args.size());
+    List<BatchEndpointStatus> retVal = new ArrayList<>(args.size());
     for (BatchEndpointArgs arg: args) {
       retVal.add(new BatchEndpointStatus(arg));
     }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/util/AbstractAppFabricHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/util/AbstractAppFabricHttpHandler.java
@@ -179,7 +179,7 @@ public abstract class AbstractAppFabricHttpHandler extends AbstractHttpHandler {
       List<ApplicationRecord> appRecords = Lists.newArrayList();
       List<ApplicationSpecification> specList;
       if (appId == null) {
-        specList = new ArrayList<ApplicationSpecification>(store.getAllApplications(accId));
+        specList = new ArrayList<>(store.getAllApplications(accId));
       } else {
         ApplicationSpecification appSpec = store.getApplication(new Id.Application(accId, appId));
         if (appSpec == null) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/SchemaFinder.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/SchemaFinder.java
@@ -58,7 +58,7 @@ public final class SchemaFinder {
     for (Schema outputSchema : output) {
       for (Schema inputSchema : input) {
         if (outputSchema.equals(inputSchema)) {
-          return new ImmutablePair<Schema, Schema>(inputSchema, outputSchema);
+          return new ImmutablePair<>(inputSchema, outputSchema);
         }
 
         if (outputSchema.isCompatible(inputSchema)) {
@@ -67,7 +67,7 @@ public final class SchemaFinder {
           if (compatibleSchema != null) {
             return null;
           }
-          compatibleSchema = new ImmutablePair<Schema, Schema>(outputSchema, inputSchema);
+          compatibleSchema = new ImmutablePair<>(outputSchema, inputSchema);
         }
       }
     }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/ApplicationVerificationStage.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/ApplicationVerificationStage.java
@@ -281,6 +281,6 @@ public class ApplicationVerificationStage extends AbstractStage<ApplicationDeplo
   }
 
   private <T extends ProgramSpecification> Verifier<T> createProgramVerifier(Class<T> clz) {
-    return new ProgramVerification<T>();
+    return new ProgramVerification<>();
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/queue/QueueReaderFactory.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/queue/QueueReaderFactory.java
@@ -32,11 +32,11 @@ public final class QueueReaderFactory {
 
   public <T> QueueReader<T> createQueueReader(Supplier<QueueConsumer> consumerSupplier,
                                               int batchSize, Function<ByteBuffer, T> decoder) {
-    return new SingleQueue2Reader<T>(consumerSupplier, batchSize, decoder);
+    return new SingleQueue2Reader<>(consumerSupplier, batchSize, decoder);
   }
 
   public <T> QueueReader<T> createStreamReader(Supplier<StreamConsumer> consumerSupplier,
                                                int batchSize, Function<StreamEvent, T> transformer) {
-    return new StreamQueueReader<T>(consumerSupplier, batchSize, transformer);
+    return new StreamQueueReader<>(consumerSupplier, batchSize, transformer);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/queue/RoundRobinQueueReader.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/queue/RoundRobinQueueReader.java
@@ -35,7 +35,7 @@ import java.util.concurrent.TimeUnit;
 
 public final class RoundRobinQueueReader<T> extends TimeTrackingQueueReader<T> {
 
-  private final InputDatum<T> nullInput = new NullInputDatum<T>();
+  private final InputDatum<T> nullInput = new NullInputDatum<>();
   private final Iterator<QueueReader<T>> readers;
 
   public RoundRobinQueueReader(Iterable<QueueReader<T>> readers) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/queue/SingleQueue2Reader.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/queue/SingleQueue2Reader.java
@@ -51,6 +51,6 @@ public final class SingleQueue2Reader<T> extends TimeTrackingQueueReader<T> {
   @Override
   public InputDatum<T> tryDequeue(long timeout, TimeUnit timeoutUnit) throws IOException {
     QueueConsumer consumer = consumerSupplier.get();
-    return new BasicInputDatum<byte[], T>(consumer.getQueueName(), consumer.dequeue(batchSize), decoder);
+    return new BasicInputDatum<>(consumer.getQueueName(), consumer.dequeue(batchSize), decoder);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/queue/StreamQueueReader.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/queue/StreamQueueReader.java
@@ -47,7 +47,7 @@ public final class StreamQueueReader<T> implements QueueReader<T> {
   @Override
   public InputDatum<T> dequeue(long timeout, TimeUnit timeoutUnit) throws IOException, InterruptedException {
     StreamConsumer consumer = consumerSupplier.get();
-    return new BasicInputDatum<StreamEvent, T>(QueueName.fromStream(consumer.getStreamId()),
+    return new BasicInputDatum<>(QueueName.fromStream(consumer.getStreamId()),
                                                consumer.poll(batchSize, timeout, timeoutUnit), eventTransform);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractProgramController.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractProgramController.java
@@ -52,7 +52,7 @@ public abstract class AbstractProgramController implements ProgramController {
   private Throwable failureCause;
 
   protected AbstractProgramController(String programName, RunId runId) {
-    this.state = new AtomicReference<State>(State.STARTING);
+    this.state = new AtomicReference<>(State.STARTING);
     this.programName = programName;
     this.runId = runId;
     this.listeners = Maps.newConcurrentMap();
@@ -341,7 +341,7 @@ public abstract class AbstractProgramController implements ProgramController {
       this.listener = listener;
       this.executor = executor;
       this.initState = initState;
-      this.tasks = new LinkedList<ListenerTask>();
+      this.tasks = new LinkedList<>();
     }
 
     @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/DataSetInputFormat.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/DataSetInputFormat.java
@@ -53,7 +53,7 @@ public final class DataSetInputFormat<KEY, VALUE> extends InputFormat<KEY, VALUE
   public List<InputSplit> getSplits(final JobContext context) throws IOException, InterruptedException {
     MapReduceContextConfig mrContextConfig = new MapReduceContextConfig(context.getConfiguration());
     List<Split> splits = mrContextConfig.getInputSelection();
-    List<InputSplit> list = new ArrayList<InputSplit>();
+    List<InputSplit> list = new ArrayList<>();
     for (Split split : splits) {
       list.add(new DataSetInputSplit(split));
     }
@@ -79,7 +79,7 @@ public final class DataSetInputFormat<KEY, VALUE> extends InputFormat<KEY, VALUE
     SplitReader<KEY, VALUE> splitReader = inputDataset.createSplitReader(inputSplit.getSplit());
 
     // the record reader now owns the context and will close it
-    return new DataSetRecordReader<KEY, VALUE>(splitReader, mrContext, dataSetName);
+    return new DataSetRecordReader<>(splitReader, mrContext, dataSetName);
   }
 
   private String getInputName(Configuration conf) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/DataSetOutputFormat.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/DataSetOutputFormat.java
@@ -59,7 +59,7 @@ public final class DataSetOutputFormat<KEY, VALUE> extends OutputFormat<KEY, VAL
     BatchWritable<KEY, VALUE> dataset = (BatchWritable<KEY, VALUE>) mrContext.getDataset(getOutputDataSet(conf));
 
     // the record writer now owns the context and will close it
-    return new DataSetRecordWriter<KEY, VALUE>(dataset, mrContext);
+    return new DataSetRecordWriter<>(dataset, mrContext);
   }
 
   private String getOutputDataSet(Configuration conf) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/ConsumerSupplier.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/ConsumerSupplier.java
@@ -60,7 +60,7 @@ final class ConsumerSupplier<T> implements Supplier<T>, Closeable {
   static <T> ConsumerSupplier<T> create(Id.Namespace namespace, List<Id> owners, UsageRegistry usageRegistry,
                                         DataFabricFacade dataFabricFacade, QueueName queueName,
                                         ConsumerConfig consumerConfig, int numGroups) {
-    return new ConsumerSupplier<T>(namespace, owners, usageRegistry, dataFabricFacade,
+    return new ConsumerSupplier<>(namespace, owners, usageRegistry, dataFabricFacade,
                                    queueName, consumerConfig, numGroups);
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowletProcessDriver.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowletProcessDriver.java
@@ -78,7 +78,7 @@ final class FlowletProcessDriver extends AbstractExecutionThreadService {
     this.txCallback = txCallback;
     this.loggingContext = flowletContext.getLoggingContext();
 
-    processQueue = new PriorityQueue<FlowletProcessEntry<?>>(processSpecifications.size());
+    processQueue = new PriorityQueue<>(processSpecifications.size());
     for (ProcessSpecification<?> spec : processSpecifications) {
       processQueue.offer(FlowletProcessEntry.create(spec));
     }
@@ -95,7 +95,7 @@ final class FlowletProcessDriver extends AbstractExecutionThreadService {
     this.dataFabricFacade = other.dataFabricFacade;
     this.txCallback = other.txCallback;
     this.loggingContext = other.loggingContext;
-    this.processQueue = new PriorityQueue<FlowletProcessEntry<?>>(other.processQueue.size());
+    this.processQueue = new PriorityQueue<>(other.processQueue.size());
     Iterables.addAll(processQueue, other.processQueue);
   }
 
@@ -370,7 +370,7 @@ final class FlowletProcessDriver extends AbstractExecutionThreadService {
           FlowletProcessEntry retryEntry = processEntry.isRetry() ?
             processEntry :
             FlowletProcessEntry.create(processEntry.getProcessSpec(),
-                                       new ProcessSpecification<T>(new SingleItemQueueReader<T>(input),
+                                       new ProcessSpecification<>(new SingleItemQueueReader<>(input),
                                                                    processEntry.getProcessSpec().getProcessMethod(),
                                                                    null));
           processQueue.offer(retryEntry);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowletProcessEntry.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowletProcessEntry.java
@@ -46,11 +46,11 @@ final class FlowletProcessEntry<T> implements Comparable<FlowletProcessEntry> {
   private long currentBackOff = BACKOFF_MIN;
 
   static <T> FlowletProcessEntry<T> create(ProcessSpecification<T> processSpec) {
-    return new FlowletProcessEntry<T>(processSpec, null, processSpec.getInitialCallDelay());
+    return new FlowletProcessEntry<>(processSpec, null, processSpec.getInitialCallDelay());
   }
 
   static <T> FlowletProcessEntry<T> create(ProcessSpecification<T> processSpec, ProcessSpecification<T> retrySpec) {
-    return new FlowletProcessEntry<T>(processSpec, retrySpec, 0);
+    return new FlowletProcessEntry<>(processSpec, retrySpec, 0);
   }
 
   private FlowletProcessEntry(ProcessSpecification<T> processSpec, ProcessSpecification<T> retrySpec, long nextDeque) {
@@ -99,7 +99,7 @@ final class FlowletProcessEntry<T> implements Comparable<FlowletProcessEntry> {
   }
 
   public FlowletProcessEntry<T> resetRetry() {
-    return retrySpec == null ? this : new FlowletProcessEntry<T>(processSpec, null, processSpec.getCallDelay());
+    return retrySpec == null ? this : new FlowletProcessEntry<>(processSpec, null, processSpec.getCallDelay());
   }
 
   public boolean isTick() {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowletProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowletProgramRunner.java
@@ -243,7 +243,7 @@ public final class FlowletProgramRunner implements ProgramRunner {
       List<ConsumerSupplier<?>> consumerSuppliers = queueConsumerSupplierBuilder.build();
 
       // Create the flowlet driver
-      AtomicReference<FlowletProgramController> controllerRef = new AtomicReference<FlowletProgramController>();
+      AtomicReference<FlowletProgramController> controllerRef = new AtomicReference<>();
       Service serviceHook = createServiceHook(flowletName, consumerSuppliers, controllerRef);
       FlowletRuntimeService driver = new FlowletRuntimeService(flowlet, flowletContext, processSpecs,
                                                              createCallback(flowlet, flowletDef.getFlowletSpec()),
@@ -482,7 +482,7 @@ public final class FlowletProgramRunner implements ProgramRunner {
             }
           });
           producerBuilder.add(producerSupplier);
-          return new DatumOutputEmitter<T>(producerSupplier, schema, datumWriterFactory.create(type, schema));
+          return new DatumOutputEmitter<>(producerSupplier, schema, datumWriterFactory.create(type, schema));
         } catch (Exception e) {
           throw Throwables.propagate(e);
         }
@@ -566,14 +566,14 @@ public final class FlowletProgramRunner implements ProgramRunner {
         if (!inputNames.isEmpty() && queueReaders.isEmpty()) {
           return null;
         }
-        return new ProcessSpecification<T>(new RoundRobinQueueReader<T>(queueReaders), method, tickAnnotation);
+        return new ProcessSpecification<>(new RoundRobinQueueReader<>(queueReaders), method, tickAnnotation);
       }
     };
   }
 
   private <T> Function<ByteBuffer, T> createInputDatumDecoder(final TypeToken<T> dataType, final Schema schema,
                                                               final SchemaCache schemaCache) {
-    final ReflectionDatumReader<T> datumReader = new ReflectionDatumReader<T>(schema, dataType);
+    final ReflectionDatumReader<T> datumReader = new ReflectionDatumReader<>(schema, dataType);
     final ByteBufferInputStream byteBufferInput = new ByteBufferInputStream(null);
     final BinaryDecoder decoder = new BinaryDecoder(byteBufferInput);
 
@@ -608,7 +608,7 @@ public final class FlowletProgramRunner implements ProgramRunner {
     final String eventsMetricsName = "process.events.in";
     final String queue = queueName.getSimpleName();
     final ImmutablePair<String, String> producerAndQueue = producerName == null ? null :
-      new ImmutablePair<String, String>(producerName, queue);
+      new ImmutablePair<>(producerName, queue);
     return new Function<S, T>() {
       @Override
       public T apply(S source) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/ReflectionProcessMethod.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/ReflectionProcessMethod.java
@@ -47,7 +47,7 @@ public final class ReflectionProcessMethod<T> implements ProcessMethod<T> {
   private final int maxRetries;
 
   public static <T> ReflectionProcessMethod<T> create(Flowlet flowlet, Method method, int maxRetries) {
-    return new ReflectionProcessMethod<T>(flowlet, method, maxRetries);
+    return new ReflectionProcessMethod<>(flowlet, method, maxRetries);
   }
 
   private ReflectionProcessMethod(Flowlet flowlet, Method method, int maxRetries) {
@@ -121,7 +121,7 @@ public final class ReflectionProcessMethod<T> implements ProcessMethod<T> {
   private ProcessResult<T> createResult(InputDatum<T> input, Throwable failureCause) {
     // If the method has param, then object for the result would be iterator or the first event (batch vs no-batch)
     T event = hasParam ? (batch ? (T) input.iterator() : input.iterator().next()) : null;
-    return new ReflectionProcessResult<T>(event, failureCause);
+    return new ReflectionProcessResult<>(event, failureCause);
   }
 
   private static final class ReflectionProcessResult<V> implements ProcessResult<V> {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/StreamSizeScheduler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/StreamSizeScheduler.java
@@ -121,7 +121,7 @@ public class StreamSizeScheduler implements Scheduler {
     this.propertiesResolver = propertiesResolver;
     this.scheduleStore = scheduleStore;
     this.streamSubscribers = Maps.newConcurrentMap();
-    this.scheduleSubscribers = new ConcurrentSkipListMap<String, StreamSubscriber>();
+    this.scheduleSubscribers = new ConcurrentSkipListMap<>();
     this.schedulerStarted = false;
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/ScalaSparkContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/ScalaSparkContext.java
@@ -110,7 +110,7 @@ class ScalaSparkContext extends AbstractSparkContext {
     Configuration hConf = setOutputDataset(datasetName);
     ClassTag<K> kClassTag = ClassTag$.MODULE$.apply(kClass);
     ClassTag<V> vClassTag = ClassTag$.MODULE$.apply(vClass);
-    PairRDDFunctions pairRDD = new PairRDDFunctions<K, V>((RDD<Tuple2<K, V>>) rdd, kClassTag, vClassTag, null);
+    PairRDDFunctions pairRDD = new PairRDDFunctions<>((RDD<Tuple2<K, V>>) rdd, kClassTag, vClassTag, null);
     pairRDD.saveAsNewAPIHadoopFile(datasetName, kClass, vClass, SparkDatasetOutputFormat.class, hConf);
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/dataset/SparkDatasetInputFormat.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/dataset/SparkDatasetInputFormat.java
@@ -53,7 +53,7 @@ public final class SparkDatasetInputFormat<KEY, VALUE> extends InputFormat<KEY, 
   public List<InputSplit> getSplits(final JobContext context) throws IOException, InterruptedException {
     SparkContextConfig sparkContextConfig = new SparkContextConfig(context.getConfiguration());
     List<Split> splits = sparkContextConfig.getInputSelection();
-    List<InputSplit> list = new ArrayList<InputSplit>();
+    List<InputSplit> list = new ArrayList<>();
     for (Split split : splits) {
       list.add(new DataSetInputSplit(split));
     }
@@ -77,7 +77,7 @@ public final class SparkDatasetInputFormat<KEY, VALUE> extends InputFormat<KEY, 
     SplitReader<KEY, VALUE> splitReader = inputDataset.createSplitReader(inputSplit.getSplit());
 
     // the record reader now owns the context and will close it
-    return new DatasetRecordReader<KEY, VALUE>(splitReader, sparkContext, dataSetName);
+    return new DatasetRecordReader<>(splitReader, sparkContext, dataSetName);
   }
 
   private String getInputName(Configuration conf) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/dataset/SparkDatasetOutputFormat.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/dataset/SparkDatasetOutputFormat.java
@@ -52,7 +52,7 @@ public final class SparkDatasetOutputFormat<KEY, VALUE> extends OutputFormat<KEY
     BatchWritable<KEY, VALUE> dataset = (BatchWritable<KEY, VALUE>) sparkContext.getDataset(getOutputDataSet(conf));
 
     // the record writer now owns the context and will close it
-    return new DatasetRecordWriter<KEY, VALUE>(dataset, sparkContext);
+    return new DatasetRecordWriter<>(dataset, sparkContext);
   }
 
   private String getOutputDataSet(Configuration conf) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowDriver.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowDriver.java
@@ -90,7 +90,7 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
   private final WorkflowSpecification workflowSpec;
   private final long logicalStartTime;
   private final ProgramWorkflowRunnerFactory workflowProgramRunnerFactory;
-  private final Map<String, WorkflowActionNode> status = new ConcurrentHashMap<String, WorkflowActionNode>();
+  private final Map<String, WorkflowActionNode> status = new ConcurrentHashMap<>();
   private final LoggingContext loggingContext;
   private NettyHttpService httpService;
   private volatile Thread runningThread;
@@ -249,7 +249,7 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
                            final WorkflowToken token) throws Exception {
     ExecutorService executorService = Executors.newFixedThreadPool(fork.getBranches().size());
     CompletionService<Map.Entry<String, WorkflowToken>> completionService =
-      new ExecutorCompletionService<Map.Entry<String, WorkflowToken>>(executorService);
+      new ExecutorCompletionService<>(executorService);
 
     try {
       for (final List<WorkflowNode> branch : fork.getBranches()) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ApplicationLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ApplicationLifecycleService.java
@@ -123,7 +123,7 @@ public class ApplicationLifecycleService extends AbstractIdleService {
    * @throws Exception
    */
   public void removeAll(Id.Namespace identifier) throws Exception {
-    List<ApplicationSpecification> allSpecs = new ArrayList<ApplicationSpecification>(
+    List<ApplicationSpecification> allSpecs = new ArrayList<>(
       store.getAllApplications(identifier));
 
     //Check if any program associated with this namespace is running

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/DefaultServiceConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/DefaultServiceConfigurer.java
@@ -141,7 +141,7 @@ public class DefaultServiceConfigurer implements ServiceConfigurer {
     HttpHandlerFactory factory = new HttpHandlerFactory("", noOpsMetricsCollector);
     @SuppressWarnings("unchecked")
     TypeToken<T> type = (TypeToken<T>) TypeToken.of(handler.getClass());
-    return factory.createHttpHandler(type, new VerificationDelegateContext<T>(handler));
+    return factory.createHttpHandler(type, new VerificationDelegateContext<>(handler));
   }
 
   private static final class VerificationDelegateContext<T extends HttpServiceHandler> implements DelegatorContext<T> {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ServiceHttpServer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ServiceHttpServer.java
@@ -123,7 +123,7 @@ public class ServiceHttpServer extends AbstractIdleService {
 
     this.contextFactory = createHttpServiceContextFactory();
     this.handlerReferences = Maps.newConcurrentMap();
-    this.handlerReferenceQueue = new ReferenceQueue<Supplier<HandlerContextPair>>();
+    this.handlerReferenceQueue = new ReferenceQueue<>();
 
     constructNettyHttpService(runId, metricsCollectionService);
   }
@@ -368,7 +368,7 @@ public class ServiceHttpServer extends AbstractIdleService {
                                     BasicHttpServiceContextFactory contextFactory) {
       this.handlerType = handlerType;
       this.instantiatorFactory = instantiatorFactory;
-      this.handlerThreadLocal = new ThreadLocal<Supplier<HandlerContextPair>>();
+      this.handlerThreadLocal = new ThreadLocal<>();
       this.spec = spec;
       this.contextFactory = contextFactory;
     }
@@ -411,7 +411,7 @@ public class ServiceHttpServer extends AbstractIdleService {
       // (in the handlerReferences map), it won't block GC of the supplier instance.
       // We can use the weak reference, which retrieved through polling the ReferenceQueue,
       // to get back the handler and call destroy() on it.
-      handlerReferences.put(new WeakReference<Supplier<HandlerContextPair>>(supplier, handlerReferenceQueue),
+      handlerReferences.put(new WeakReference<>(supplier, handlerReferenceQueue),
                             handlerContextPair);
       handlerThreadLocal.set(supplier);
       return handlerContextPair;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/workflow/DefaultWorkflowConditionConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/workflow/DefaultWorkflowConditionConfigurer.java
@@ -69,7 +69,7 @@ public class DefaultWorkflowConditionConfigurer<T extends WorkflowConditionAdder
 
   @Override
   public WorkflowForkConfigurer<? extends WorkflowConditionConfigurer<T>> fork() {
-    return new DefaultWorkflowForkConfigurer<DefaultWorkflowConditionConfigurer<T>>(this);
+    return new DefaultWorkflowForkConfigurer<>(this);
   }
 
   @Override
@@ -77,7 +77,7 @@ public class DefaultWorkflowConditionConfigurer<T extends WorkflowConditionAdder
   public WorkflowConditionConfigurer<? extends WorkflowConditionConfigurer<T>> condition(
     Predicate<WorkflowContext> predicate) {
     String predicateClassName = predicate.getClass().getName();
-    return new DefaultWorkflowConditionConfigurer<DefaultWorkflowConditionConfigurer<T>>(this, predicateClassName);
+    return new DefaultWorkflowConditionConfigurer<>(this, predicateClassName);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/workflow/DefaultWorkflowConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/workflow/DefaultWorkflowConfigurer.java
@@ -87,12 +87,12 @@ public class DefaultWorkflowConfigurer implements WorkflowConfigurer, WorkflowFo
 
   @Override
   public WorkflowForkConfigurer<? extends WorkflowConfigurer> fork() {
-    return new DefaultWorkflowForkConfigurer<DefaultWorkflowConfigurer>(this);
+    return new DefaultWorkflowForkConfigurer<>(this);
   }
 
   @Override
   public WorkflowConditionConfigurer<? extends WorkflowConfigurer> condition(Predicate<WorkflowContext> predicate) {
-    return new DefaultWorkflowConditionConfigurer<DefaultWorkflowConfigurer>(this, predicate.getClass().getName());
+    return new DefaultWorkflowConditionConfigurer<>(this, predicate.getClass().getName());
   }
 
   public WorkflowSpecification createSpecification() {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/workflow/DefaultWorkflowForkConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/workflow/DefaultWorkflowForkConfigurer.java
@@ -67,13 +67,13 @@ public class DefaultWorkflowForkConfigurer<T extends WorkflowForkJoiner & Workfl
   @Override
   @SuppressWarnings("unchecked")
   public WorkflowForkConfigurer<? extends WorkflowForkConfigurer<T>> fork() {
-    return new DefaultWorkflowForkConfigurer<DefaultWorkflowForkConfigurer<T>>(this);
+    return new DefaultWorkflowForkConfigurer<>(this);
   }
 
   @Override
   public WorkflowConditionConfigurer<? extends WorkflowForkConfigurer<T>> condition(
     Predicate<WorkflowContext> predicate) {
-    return new DefaultWorkflowConditionConfigurer<DefaultWorkflowForkConfigurer<T>>(this,
+    return new DefaultWorkflowConditionConfigurer<>(this,
                                                                                     predicate.getClass().getName());
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/pipeline/SynchronousPipelineFactory.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/pipeline/SynchronousPipelineFactory.java
@@ -29,6 +29,6 @@ public class SynchronousPipelineFactory implements PipelineFactory {
    */
   @Override
   public <T> Pipeline<T> getPipeline() {
-    return new SynchronousPipeline<T>();
+    return new SynchronousPipeline<>();
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/templates/AdapterDefinition.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/templates/AdapterDefinition.java
@@ -132,7 +132,7 @@ public final class AdapterDefinition implements AdapterSpecification {
    * Returns set of {@link PluginInfo} for the plugins in this specification.
    */
   public NavigableSet<PluginInfo> getPluginInfos() {
-    NavigableSet<PluginInfo> result = new TreeSet<PluginInfo>();
+    NavigableSet<PluginInfo> result = new TreeSet<>();
     for (AdapterPlugin plugin : plugins.values()) {
       result.add(plugin.getPluginInfo());
     }

--- a/cdap-app-fabric/src/main/java/org/apache/hadoop/mapred/LocalDistributedCacheManagerWithFix.java
+++ b/cdap-app-fabric/src/main/java/org/apache/hadoop/mapred/LocalDistributedCacheManagerWithFix.java
@@ -68,12 +68,12 @@ import java.util.concurrent.atomic.AtomicLong;
 class LocalDistributedCacheManagerWithFix {
   public static final Logger LOG = LoggerFactory.getLogger(LocalDistributedCacheManagerWithFix.class);
   
-  private List<String> localArchives = new ArrayList<String>();
-  private List<String> localFiles = new ArrayList<String>();
-  private List<String> localClasspaths = new ArrayList<String>();
-  private List<File> jarExpandDirs = new ArrayList<File>();
+  private List<String> localArchives = new ArrayList<>();
+  private List<String> localFiles = new ArrayList<>();
+  private List<String> localClasspaths = new ArrayList<>();
+  private List<File> jarExpandDirs = new ArrayList<>();
 
-  private List<File> symlinksCreated = new ArrayList<File>();
+  private List<File> symlinksCreated = new ArrayList<>();
 
   private boolean setupCalled = false;
   private JobID jobId;
@@ -95,14 +95,14 @@ class LocalDistributedCacheManagerWithFix {
     // Generate YARN local resources objects corresponding to the distributed
     // cache configuration
     Map<String, LocalResource> localResources =
-      new LinkedHashMap<String, LocalResource>();
+      new LinkedHashMap<>();
     MRApps.setupDistributedCache(conf, localResources);
     // Generating unique numbers for FSDownload.
     AtomicLong uniqueNumberGenerator =
       new AtomicLong(System.currentTimeMillis());
 
     // Find which resources are to be put on the local classpath
-    Map<String, Path> classpaths = new HashMap<String, Path>();
+    Map<String, Path> classpaths = new HashMap<>();
     Path[] archiveClassPaths = DistributedCache.getArchiveClassPaths(conf);
     if (archiveClassPaths != null) {
       for (Path p : archiveClassPaths) {

--- a/cdap-app-fabric/src/main/java/org/apache/hadoop/mapred/LocalJobRunnerWithFix.java
+++ b/cdap-app-fabric/src/main/java/org/apache/hadoop/mapred/LocalJobRunnerWithFix.java
@@ -84,7 +84,7 @@ public class LocalJobRunnerWithFix implements ClientProtocol {
     "mapreduce.local.reduce.tasks.maximum";
 
   private FileSystem fs;
-  private HashMap<JobID, Job> jobs = new HashMap<JobID, Job>();
+  private HashMap<JobID, Job> jobs = new HashMap<>();
   private JobConf conf;
   private AtomicInteger map_tasks = new AtomicInteger(0);
   private AtomicInteger reduce_tasks = new AtomicInteger(0);
@@ -267,7 +267,7 @@ public class LocalJobRunnerWithFix implements ClientProtocol {
 
       int numTasks = 0;
       ArrayList<RunnableWithThrowable> list =
-        new ArrayList<RunnableWithThrowable>();
+        new ArrayList<>();
       for (TaskSplitMetaInfo task : taskInfo) {
         list.add(new MapTaskRunnable(task, numTasks++, jobId,
                                      mapOutputFiles));
@@ -345,7 +345,7 @@ public class LocalJobRunnerWithFix implements ClientProtocol {
 
       int taskId = 0;
       ArrayList<RunnableWithThrowable> list =
-        new ArrayList<RunnableWithThrowable>();
+        new ArrayList<>();
       for (int i = 0; i < this.numReduceTasks; i++) {
         list.add(new ReduceTaskRunnable(taskId++, jobId, mapOutputFiles));
       }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/spark/SparkAppUsingObjectStore.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/spark/SparkAppUsingObjectStore.java
@@ -66,7 +66,7 @@ public class SparkAppUsingObjectStore extends AbstractApplication {
         byte[], byte[]>() {
         @Override
         public Tuple2<byte[], byte[]> call(Tuple2<byte[], String> stringTuple2) throws Exception {
-          return new Tuple2<byte[], byte[]>(stringTuple2._1(), Bytes.toBytes(stringTuple2._2().length()));
+          return new Tuple2<>(stringTuple2._1(), Bytes.toBytes(stringTuple2._2().length()));
         }
       });
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/co/cask/cdap/template/etl/batch/ETLStreamConversionTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/co/cask/cdap/template/etl/batch/ETLStreamConversionTest.java
@@ -106,7 +106,7 @@ public class ETLStreamConversionTest extends BaseETLBatchTest {
 
   private List<GenericRecord> readOutput(TimePartitionedFileSet fileSet, Schema schema) throws IOException {
     org.apache.avro.Schema avroSchema = new org.apache.avro.Schema.Parser().parse(schema.toString());
-    DatumReader<GenericRecord> datumReader = new GenericDatumReader<GenericRecord>(avroSchema);
+    DatumReader<GenericRecord> datumReader = new GenericDatumReader<>(avroSchema);
     List<GenericRecord> records = com.google.common.collect.Lists.newArrayList();
     for (Location dayLoc : fileSet.getEmbeddedFileSet().getBaseLocation().list()) {
       // this level should be the day (ex: 2015-01-19)
@@ -118,7 +118,7 @@ public class ETLStreamConversionTest extends BaseETLBatchTest {
 
           if (locName.endsWith(".avro")) {
             DataFileStream<GenericRecord> fileStream =
-              new DataFileStream<GenericRecord>(file.getInputStream(), datumReader);
+              new DataFileStream<>(file.getInputStream(), datumReader);
             while (fileStream.hasNext()) {
               records.add(fileStream.next());
             }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/common/guice/Types.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/common/guice/Types.java
@@ -144,7 +144,7 @@ final class Types {
    */
   static <D extends GenericDeclaration> TypeVariable<D> newTypeVariable(
     D declaration, String name, Type... bounds) {
-    return new TypeVariableImpl<D>(
+    return new TypeVariableImpl<>(
       declaration,
       name,
       (bounds.length == 0)

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/template/etl/common/TransformExecutorTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/template/etl/common/TransformExecutorTest.java
@@ -32,7 +32,7 @@ public class TransformExecutorTest {
   @Test
   public void testEmptyTransforms() throws Exception {
     TransformExecutor<String, String> executor =
-      new TransformExecutor<String, String>(Lists.<Transformation>newArrayList(), Lists.<StageMetrics>newArrayList());
+      new TransformExecutor<>(Lists.<Transformation>newArrayList(), Lists.<StageMetrics>newArrayList());
     List<String> results = Lists.newArrayList(executor.runOneIteration("foo"));
     Assert.assertEquals(1, results.size());
     Assert.assertEquals("foo", results.get(0));
@@ -48,7 +48,7 @@ public class TransformExecutorTest {
       new StageMetrics(mockMetrics, StageMetrics.Type.TRANSFORM, "second"),
       new StageMetrics(mockMetrics, StageMetrics.Type.SINK, "third")
     );
-    TransformExecutor<Integer, String> executor = new TransformExecutor<Integer, String>(transforms, stageMetrics);
+    TransformExecutor<Integer, String> executor = new TransformExecutor<>(transforms, stageMetrics);
 
     List<String> results = Lists.newArrayList(executor.runOneIteration(1));
     Assert.assertTrue(results.isEmpty());

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/sink/TableSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/sink/TableSink.java
@@ -105,6 +105,6 @@ public class TableSink extends BatchWritableSink<StructuredRecord, byte[], Put> 
   @Override
   public void transform(StructuredRecord input, Emitter<KeyValue<byte[], Put>> emitter) throws Exception {
     Put put = recordPutTransformer.toPut(input);
-    emitter.emit(new KeyValue<byte[], Put>(put.getRow(), put));
+    emitter.emit(new KeyValue<>(put.getRow(), put));
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/sink/TimePartitionedFileSetDatasetAvroSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/sink/TimePartitionedFileSetDatasetAvroSink.java
@@ -111,7 +111,7 @@ public class TimePartitionedFileSetDatasetAvroSink extends
   @Override
   public void transform(StructuredRecord input,
                         Emitter<KeyValue<AvroKey<GenericRecord>, NullWritable>> emitter) throws Exception {
-    emitter.emit(new KeyValue<AvroKey<GenericRecord>, NullWritable>(
-      new AvroKey<GenericRecord>(recordTransformer.transform(input)), NullWritable.get()));
+    emitter.emit(new KeyValue<>(
+      new AvroKey<>(recordTransformer.transform(input)), NullWritable.get()));
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/common/KeyValueListParser.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/common/KeyValueListParser.java
@@ -87,7 +87,7 @@ public class KeyValueListParser {
       if (keyValIter.hasNext()) {
         throw new IllegalArgumentException("Invalid syntax for key-value pair in list: " + pair);
       }
-      return new KeyValue<String, String>(key, val);
+      return new KeyValue<>(key, val);
     }
 
     @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/realtime/kafka/Kafka08SimpleApiConsumer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/realtime/kafka/Kafka08SimpleApiConsumer.java
@@ -165,7 +165,7 @@ public class Kafka08SimpleApiConsumer extends KafkaSimpleApiConsumer<String, Byt
 
           // Lets get the Kafka message based on last offset
           Message message = messageAndOffset.message();
-          return new KafkaMessage<Long>(topicPartition, messageAndOffset.nextOffset(), message.key(),
+          return new KafkaMessage<>(topicPartition, messageAndOffset.nextOffset(), message.key(),
                                         message.payload());
         }
         return endOfData();

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/realtime/kafka/KafkaSimpleApiConsumer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/realtime/kafka/KafkaSimpleApiConsumer.java
@@ -431,7 +431,7 @@ public abstract class KafkaSimpleApiConsumer<KEY, PAYLOAD, OFFSET> {
 
     for (Map.Entry<TopicPartition, Integer> entry : config.entrySet()) {
       consumers.put(entry.getKey(),
-                    new KafkaConsumerInfo<OFFSET>(entry.getKey(), entry.getValue(), getBeginOffset(entry.getKey())));
+                    new KafkaConsumerInfo<>(entry.getKey(), entry.getValue(), getBeginOffset(entry.getKey())));
     }
     return consumers.build();
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/realtime/source/JmsSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/realtime/source/JmsSource.java
@@ -115,7 +115,7 @@ public class JmsSource extends RealtimeSource<StructuredRecord> {
     messagesToReceive = configMessagesToReceive.intValue();
 
     // Get environment vars - this would be prefixed with java.naming.*
-    final Hashtable<String, String> envVars = new Hashtable<String, String>();
+    final Hashtable<String, String> envVars = new Hashtable<>();
     for (Map.Entry<String, String> entry : runtimeArguments.entrySet()) {
       envVars.put(entry.getKey(), entry.getValue());
     }

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/template/etl/common/StructuredRecordToCubeFactTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/template/etl/common/StructuredRecordToCubeFactTest.java
@@ -208,7 +208,7 @@ public class StructuredRecordToCubeFactTest {
 
   private Map<String, String> toProperties(StructuredRecordToCubeFact.MappingConfig conf) {
     if (conf == null) {
-      return new HashMap<String, String>();
+      return new HashMap<>();
     }
     return ImmutableMap.of(StructuredRecordToCubeFact.MAPPING_CONFIG_PROPERTY, new Gson().toJson(conf));
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/template/etl/transform/ProjectionTransformTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/template/etl/transform/ProjectionTransformTest.java
@@ -92,7 +92,7 @@ public class ProjectionTransformTest {
 
     Schema schema = Schema.recordOf("record", Schema.Field.of("x", Schema.of(Schema.Type.LONG)));
     StructuredRecord input = StructuredRecord.builder(schema).set("x", 5L).build();
-    MockEmitter<StructuredRecord> emitter = new MockEmitter<StructuredRecord>();
+    MockEmitter<StructuredRecord> emitter = new MockEmitter<>();
     transform.transform(input, emitter);
   }
 
@@ -113,7 +113,7 @@ public class ProjectionTransformTest {
     TransformContext transformContext = new MockTransformContext();
     transform.initialize(transformContext);
 
-    MockEmitter<StructuredRecord> emitter = new MockEmitter<StructuredRecord>();
+    MockEmitter<StructuredRecord> emitter = new MockEmitter<>();
     transform.transform(input, emitter);
     StructuredRecord output = emitter.getEmitted().get(0);
 
@@ -139,7 +139,7 @@ public class ProjectionTransformTest {
     TransformContext transformContext = new MockTransformContext();
     transform.initialize(transformContext);
 
-    MockEmitter<StructuredRecord> emitter = new MockEmitter<StructuredRecord>();
+    MockEmitter<StructuredRecord> emitter = new MockEmitter<>();
     transform.transform(input, emitter);
     StructuredRecord output = emitter.getEmitted().get(0);
 
@@ -169,7 +169,7 @@ public class ProjectionTransformTest {
     TransformContext transformContext = new MockTransformContext();
     transform.initialize(transformContext);
 
-    MockEmitter<StructuredRecord> emitter = new MockEmitter<StructuredRecord>();
+    MockEmitter<StructuredRecord> emitter = new MockEmitter<>();
     transform.transform(input, emitter);
     StructuredRecord output = emitter.getEmitted().get(0);
 
@@ -188,7 +188,7 @@ public class ProjectionTransformTest {
     TransformContext transformContext = new MockTransformContext();
     transform.initialize(transformContext);
 
-    MockEmitter<StructuredRecord> emitter = new MockEmitter<StructuredRecord>();
+    MockEmitter<StructuredRecord> emitter = new MockEmitter<>();
     transform.transform(SIMPLE_TYPES_RECORD, emitter);
     StructuredRecord output = emitter.getEmitted().get(0);
 
@@ -237,7 +237,7 @@ public class ProjectionTransformTest {
       .set("stringField", "bar")
       .build();
 
-    MockEmitter<StructuredRecord> emitter = new MockEmitter<StructuredRecord>();
+    MockEmitter<StructuredRecord> emitter = new MockEmitter<>();
     transform.transform(input, emitter);
     StructuredRecord output = emitter.getEmitted().get(0);
 
@@ -260,7 +260,7 @@ public class ProjectionTransformTest {
     TransformContext transformContext = new MockTransformContext();
     transform.initialize(transformContext);
 
-    MockEmitter<StructuredRecord> emitter = new MockEmitter<StructuredRecord>();
+    MockEmitter<StructuredRecord> emitter = new MockEmitter<>();
     transform.transform(SIMPLE_TYPES_RECORD, emitter);
     StructuredRecord output = emitter.getEmitted().get(0);
 
@@ -309,7 +309,7 @@ public class ProjectionTransformTest {
     TransformContext transformContext = new MockTransformContext();
     transform.initialize(transformContext);
 
-    MockEmitter<StructuredRecord> emitter = new MockEmitter<StructuredRecord>();
+    MockEmitter<StructuredRecord> emitter = new MockEmitter<>();
     transform.transform(input, emitter);
     StructuredRecord output = emitter.getEmitted().get(0);
 
@@ -331,7 +331,7 @@ public class ProjectionTransformTest {
     TransformContext transformContext = new MockTransformContext();
     transform.initialize(transformContext);
 
-    MockEmitter<StructuredRecord> emitter = new MockEmitter<StructuredRecord>();
+    MockEmitter<StructuredRecord> emitter = new MockEmitter<>();
     transform.transform(SIMPLE_TYPES_RECORD, emitter);
     StructuredRecord output = emitter.getEmitted().get(0);
 
@@ -362,7 +362,7 @@ public class ProjectionTransformTest {
     TransformContext transformContext = new MockTransformContext();
     transform.initialize(transformContext);
 
-    MockEmitter<StructuredRecord> emitter = new MockEmitter<StructuredRecord>();
+    MockEmitter<StructuredRecord> emitter = new MockEmitter<>();
     transform.transform(SIMPLE_TYPES_RECORD, emitter);
     StructuredRecord output = emitter.getEmitted().get(0);
 
@@ -393,7 +393,7 @@ public class ProjectionTransformTest {
     TransformContext transformContext = new MockTransformContext();
     transform.initialize(transformContext);
 
-    MockEmitter<StructuredRecord> emitter = new MockEmitter<StructuredRecord>();
+    MockEmitter<StructuredRecord> emitter = new MockEmitter<>();
     transform.transform(SIMPLE_TYPES_RECORD, emitter);
     StructuredRecord output = emitter.getEmitted().get(0);
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/template/etl/transform/ScriptFilterTransformTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/template/etl/transform/ScriptFilterTransformTest.java
@@ -50,7 +50,7 @@ public class ScriptFilterTransformTest {
 
     Schema schema = Schema.recordOf("number", Schema.Field.of("x", Schema.of(Schema.Type.INT)));
     StructuredRecord input = StructuredRecord.builder(schema).set("x", 1).build();
-    MockEmitter<StructuredRecord> emitter = new MockEmitter<StructuredRecord>();
+    MockEmitter<StructuredRecord> emitter = new MockEmitter<>();
     transform.transform(input, emitter);
   }
 
@@ -64,7 +64,7 @@ public class ScriptFilterTransformTest {
     TransformContext transformContext = new MockTransformContext(ImmutableMap.<String, String>of());
     transform.initialize(transformContext);
 
-    MockEmitter<StructuredRecord> emitter = new MockEmitter<StructuredRecord>();
+    MockEmitter<StructuredRecord> emitter = new MockEmitter<>();
     transform.transform(input, emitter);
     Assert.assertTrue(emitter.getEmitted().isEmpty());
     emitter.clear();
@@ -135,7 +135,7 @@ public class ScriptFilterTransformTest {
     TransformContext transformContext = new MockTransformContext(ImmutableMap.<String, String>of());
     transform.initialize(transformContext);
 
-    MockEmitter<StructuredRecord> emitter = new MockEmitter<StructuredRecord>();
+    MockEmitter<StructuredRecord> emitter = new MockEmitter<>();
     transform.transform(input, emitter);
     Assert.assertTrue(emitter.getEmitted().isEmpty());
     emitter.clear();

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/template/etl/transform/ScriptTransformTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/template/etl/transform/ScriptTransformTest.java
@@ -79,7 +79,7 @@ public class ScriptTransformTest {
     Transform<StructuredRecord, StructuredRecord> transform = new ScriptTransform(config);
     transform.initialize(null);
 
-    MockEmitter<StructuredRecord> emitter = new MockEmitter<StructuredRecord>();
+    MockEmitter<StructuredRecord> emitter = new MockEmitter<>();
     transform.transform(RECORD1, emitter);
     StructuredRecord output = emitter.getEmitted().get(0);
 
@@ -131,7 +131,7 @@ public class ScriptTransformTest {
     Transform<StructuredRecord, StructuredRecord> transform = new ScriptTransform(config);
     transform.initialize(null);
 
-    MockEmitter<StructuredRecord> emitter = new MockEmitter<StructuredRecord>();
+    MockEmitter<StructuredRecord> emitter = new MockEmitter<>();
     transform.transform(RECORD1, emitter);
     StructuredRecord output = emitter.getEmitted().get(0);
     Assert.assertEquals(outputSchema, output.getSchema());
@@ -210,7 +210,7 @@ public class ScriptTransformTest {
     Transform<StructuredRecord, StructuredRecord> transform = new ScriptTransform(config);
     transform.initialize(null);
 
-    MockEmitter<StructuredRecord> emitter = new MockEmitter<StructuredRecord>();
+    MockEmitter<StructuredRecord> emitter = new MockEmitter<>();
     transform.transform(input, emitter);
     StructuredRecord output = emitter.getEmitted().get(0);
     Assert.assertEquals(outputSchema, output.getSchema());

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/template/etl/transform/StructuredRecordToGenericRecordTransformTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/template/etl/transform/StructuredRecordToGenericRecordTransformTest.java
@@ -49,7 +49,7 @@ public class StructuredRecordToGenericRecordTransformTest {
 
     TransformContext transformContext = new MockTransformContext();
     transformer.initialize(transformContext);
-    MockEmitter<GenericRecord> emitter = new MockEmitter<GenericRecord>();
+    MockEmitter<GenericRecord> emitter = new MockEmitter<>();
     transformer.transform(structuredRecord, emitter);
     GenericRecord value = emitter.getEmitted().get(0);
     Assert.assertEquals("string1", value.get("field1"));

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/CLIMain.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/CLIMain.java
@@ -127,14 +127,14 @@ public class CLIMain {
 
     this.commands = ImmutableList.of(
       injector.getInstance(DefaultCommands.class),
-      new CommandSet<Command>(ImmutableList.<Command>of(
+      new CommandSet<>(ImmutableList.<Command>of(
         new HelpCommand(getCommandsSupplier(), cliConfig),
         new SearchCommandsCommand(getCommandsSupplier(), cliConfig)
       )));
     filePathResolver = injector.getInstance(FilePathResolver.class);
 
     Map<String, Completer> completers = injector.getInstance(DefaultCompleters.class).get();
-    cli = new CLI<Command>(Iterables.concat(commands), completers);
+    cli = new CLI<>(Iterables.concat(commands), completers);
     cli.setExceptionHandler(new CLIExceptionHandler<Exception>() {
       @Override
       public boolean handleException(PrintStream output, Exception e, int timesRetried) {

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/CallServiceCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/CallServiceCommand.java
@@ -138,7 +138,7 @@ public class CallServiceCommand extends AbstractCommand implements Categorized {
    */
   private String formatHeaders(HttpResponse response) {
     Multimap<String, String> headers = response.getHeaders();
-    ImmutableMap.Builder<String, String> builder = new ImmutableMap.Builder<String, String>();
+    ImmutableMap.Builder<String, String> builder = new ImmutableMap.Builder<>();
     for (String key : headers.keySet()) {
       Collection<String> value = headers.get(key);
       builder.put(key, StringUtils.arrayToString(value.toArray(new String[value.size()])));

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/completer/StringsCompleter.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/completer/StringsCompleter.java
@@ -46,7 +46,7 @@ public class StringsCompleter implements Completer {
   }
 
   public TreeSet<String> getStrings() {
-    return new TreeSet<String>(strings.get());
+    return new TreeSet<>(strings.get());
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/completer/element/NamespaceNameCompleter.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/completer/element/NamespaceNameCompleter.java
@@ -39,7 +39,7 @@ public class NamespaceNameCompleter extends StringsCompleter {
     super(new Supplier<Collection<String>>() {
       @Override
       public Collection<String> get() {
-        List<String> namespaceIds = new ArrayList<String>();
+        List<String> namespaceIds = new ArrayList<>();
         try {
           for (NamespaceMeta namespaceMeta : namespaceClient.list()) {
             namespaceIds.add(namespaceMeta.getName());

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/util/ArgumentParser.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/util/ArgumentParser.java
@@ -132,7 +132,7 @@ public class ArgumentParser {
   private static Map<String, String> parseOptional(List<String> splitInput, String pattern) {
     ImmutableMap.Builder<String, String> args = ImmutableMap.builder();
 
-    List<String> copyInput = new ArrayList<String>(splitInput);
+    List<String> copyInput = new ArrayList<>(splitInput);
     List<String> splitPattern = Parser.parsePattern(pattern);
 
     while (!splitPattern.isEmpty()) {

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/util/FilePathResolver.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/util/FilePathResolver.java
@@ -76,7 +76,7 @@ public class FilePathResolver {
 
     // resolve the "." and ".." in the path
     String[] tokens = path.split(File.separator);
-    LinkedList<String> finalTokens = new LinkedList<String>();
+    LinkedList<String> finalTokens = new LinkedList<>();
     for (String token : tokens) {
       if (token.equals("..")) {
         if (!finalTokens.isEmpty()) {

--- a/cdap-client/src/main/java/co/cask/cdap/client/ServiceClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ServiceClient.java
@@ -94,7 +94,7 @@ public class ServiceClient {
     throws IOException, UnauthorizedException, NotFoundException {
 
     ServiceSpecification specification = get(appId, serviceId);
-    ImmutableList.Builder<ServiceHttpEndpoint> builder = new ImmutableList.Builder<ServiceHttpEndpoint>();
+    ImmutableList.Builder<ServiceHttpEndpoint> builder = new ImmutableList.Builder<>();
     for (HttpServiceHandlerSpecification handlerSpecification : specification.getHandlers().values()) {
       builder.addAll(handlerSpecification.getEndpoints());
     }

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Configuration.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Configuration.java
@@ -139,7 +139,7 @@ public class Configuration implements Iterable<Map.Entry<String, String>> {
   /**
    * List of configuration resources.
    */
-  private ArrayList<Object> resources = new ArrayList<Object>();
+  private ArrayList<Object> resources = new ArrayList<>();
 
   /**
    * The value reported as the setting resource when a key is set
@@ -150,16 +150,16 @@ public class Configuration implements Iterable<Map.Entry<String, String>> {
   /**
    * List of configuration parameters marked <b>final</b>.
    */
-  private Set<String> finalParameters = new HashSet<String>();
+  private Set<String> finalParameters = new HashSet<>();
 
   /**
    * Configuration objects.
    */
   private static final WeakHashMap<Configuration, Object> REGISTRY =
-    new WeakHashMap<Configuration, Object>();
+    new WeakHashMap<>();
 
   private static final Map<ClassLoader, Map<String, Class<?>>>
-    CACHE_CLASSES = new WeakHashMap<ClassLoader, Map<String, Class<?>>>();
+    CACHE_CLASSES = new WeakHashMap<>();
 
   /**
    * Sentinel value to store negative cache results in {@link #CACHE_CLASSES}.
@@ -262,7 +262,7 @@ public class Configuration implements Iterable<Map.Entry<String, String>> {
    *         or empty {@code Map} if no deprecated properties
    */
   protected Map<String, String[]> getDeprecatedProps() {
-    Map<String, String[]> result = new HashMap<String, String[]>();
+    Map<String, String[]> result = new HashMap<>();
     for (String key : deprecatedKeyMap.keySet()) {
       result.put(key, deprecatedKeyMap.get(key).newKeys);
     }
@@ -300,7 +300,7 @@ public class Configuration implements Iterable<Map.Entry<String, String>> {
    *         the <code>name</code> or the <code>name</code> itself.
    */
   private String[] handleDeprecation(String name) {
-    ArrayList<String> names = new ArrayList<String>();
+    ArrayList<String> names = new ArrayList<>();
     if (deprecatedKeyMap.containsKey(name)) {
       DeprecatedKeyInfo keyInfo = deprecatedKeyMap.get(name);
       warnOnceIfDeprecated(name);
@@ -329,7 +329,7 @@ public class Configuration implements Iterable<Map.Entry<String, String>> {
 
   private void handleDeprecation() {
     LOG.trace("Handling deprecation for all properties in config...");
-    Set<Object> keys = new HashSet<Object>();
+    Set<Object> keys = new HashSet<>();
     keys.addAll(getProps().keySet());
     for (Object item: keys) {
       LOG.trace("Handling deprecation for " + item);
@@ -350,7 +350,7 @@ public class Configuration implements Iterable<Map.Entry<String, String>> {
 
   /** A new configuration. */
   public Configuration() {
-    updatingResource = new HashMap<String, String>();
+    updatingResource = new HashMap<>();
     synchronized (Configuration.class) {
       REGISTRY.put(this, null);
     }
@@ -373,10 +373,10 @@ public class Configuration implements Iterable<Map.Entry<String, String>> {
         this.overlay = (Properties) other.overlay.clone();
       }
 
-      this.updatingResource = new HashMap<String, String>(other.updatingResource);
+      this.updatingResource = new HashMap<>(other.updatingResource);
     }
 
-    this.finalParameters = new HashSet<String>(other.finalParameters);
+    this.finalParameters = new HashSet<>(other.finalParameters);
     synchronized (Configuration.class) {
       REGISTRY.put(this, null);
     }
@@ -1092,7 +1092,7 @@ public class Configuration implements Iterable<Map.Entry<String, String>> {
       }
     };
 
-    List<Range> ranges = new ArrayList<Range>();
+    List<Range> ranges = new ArrayList<>();
 
     public IntegerRanges() {
     }
@@ -1261,7 +1261,7 @@ public class Configuration implements Iterable<Map.Entry<String, String>> {
   public Collection<String> getTrimmedStringCollection(String name) {
     String valueString = get(name);
     if (null == valueString) {
-      Collection<String> empty = new ArrayList<String>();
+      Collection<String> empty = new ArrayList<>();
       return empty;
     }
     return StringUtils.getTrimmedStringCollection(valueString);
@@ -1463,7 +1463,7 @@ public class Configuration implements Iterable<Map.Entry<String, String>> {
    */
   @SuppressWarnings("unchecked")
   public <U> List<U> getInstances(String name, Class<U> xface) {
-    List<U> ret = new ArrayList<U>();
+    List<U> ret = new ArrayList<>();
     Class<?>[] classes = getClasses(name);
     for (Class<?> cl: classes) {
       if (!xface.isAssignableFrom(cl)) {
@@ -1930,7 +1930,7 @@ public class Configuration implements Iterable<Map.Entry<String, String>> {
   public Map<String, String> getValByRegex(String regex) {
     Pattern p = Pattern.compile(regex);
 
-    Map<String, String> result = new HashMap<String, String>();
+    Map<String, String> result = new HashMap<>();
     Matcher m;
 
     for (Map.Entry<Object, Object> item: getProps().entrySet()) {

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/ReflectionUtils.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/ReflectionUtils.java
@@ -32,7 +32,7 @@ public class ReflectionUtils {
    * can't be garbage collected until ReflectionUtils can be collected.
    */
   private static final Map<Class<?>, Constructor<?>> CONSTRUCTOR_CACHE =
-    new ConcurrentHashMap<Class<?>, Constructor<?>>();
+    new ConcurrentHashMap<>();
 
   /**
    * Check and set 'configuration' if necessary.

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/StringUtils.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/StringUtils.java
@@ -45,12 +45,12 @@ public class StringUtils {
    * @return an <code>ArrayList</code> of string values
    */
   public static Collection<String> getStringCollection(String str) {
-    List<String> values = new ArrayList<String>();
+    List<String> values = new ArrayList<>();
     if (str == null) {
       return values;
     }
     StringTokenizer tokenizer = new StringTokenizer (str, ",");
-    values = new ArrayList<String>();
+    values = new ArrayList<>();
     while (tokenizer.hasMoreTokens()) {
       values.add(tokenizer.nextToken());
     }
@@ -63,7 +63,7 @@ public class StringUtils {
    * @return a <code>Collection</code> of <code>String</code> values
    */
   public static Collection<String> getTrimmedStringCollection(String str) {
-    return new ArrayList<String>(
+    return new ArrayList<>(
                                   Arrays.asList(getTrimmedStrings(str)));
   }
 

--- a/cdap-common/src/main/java/co/cask/cdap/common/db/DBConnectionPoolManager.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/db/DBConnectionPoolManager.java
@@ -124,7 +124,7 @@ public class DBConnectionPoolManager {
     }
 
     semaphore = new Semaphore(maxConnections, true);
-    recycledConnections = new LinkedList<PooledConnection>();
+    recycledConnections = new LinkedList<>();
     poolConnectionEventListener = new PoolConnectionEventListener();
   }
 

--- a/cdap-common/src/main/java/co/cask/cdap/common/http/SecurityRequestContext.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/http/SecurityRequestContext.java
@@ -21,7 +21,7 @@ import com.google.common.base.Optional;
  * RequestContext that maintains a ThreadLocal with references to {@code AccessTokenIdentifier}.
  */
 public final class SecurityRequestContext {
-  private static final ThreadLocal<String> userId = new InheritableThreadLocal<String>();
+  private static final ThreadLocal<String> userId = new InheritableThreadLocal<>();
 
   private SecurityRequestContext() {
   }

--- a/cdap-common/src/main/java/co/cask/cdap/common/internal/guava/ClassPath.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/internal/guava/ClassPath.java
@@ -355,7 +355,7 @@ public final class ClassPath {
   @VisibleForTesting static final class Scanner {
 
     private final ImmutableSortedSet.Builder<ResourceInfo> resources =
-        new ImmutableSortedSet.Builder<ResourceInfo>(Ordering.usingToString());
+        new ImmutableSortedSet.Builder<>(Ordering.usingToString());
     private final Set<URI> scannedUris = Sets.newHashSet();
 
     ImmutableSortedSet<ResourceInfo> getResources() {

--- a/cdap-common/src/main/java/co/cask/cdap/common/kerberos/SecurityUtil.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/kerberos/SecurityUtil.java
@@ -91,7 +91,7 @@ public final class SecurityUtil {
     System.setProperty(Constants.External.Zookeeper.ENV_ALLOW_SASL_FAILED_CLIENTS, "true");
     System.setProperty(ZooKeeperSaslClient.LOGIN_CONTEXT_NAME_KEY, "Client");
 
-    final Map<String, String> properties = new HashMap<String, String>();
+    final Map<String, String> properties = new HashMap<>();
     properties.put("doNotPrompt", "true");
     properties.put("useKeyTab", "true");
     properties.put("useTicketCache", "false");

--- a/cdap-common/src/main/java/co/cask/cdap/common/lang/WeakReferenceDelegatorClassLoader.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/lang/WeakReferenceDelegatorClassLoader.java
@@ -38,7 +38,7 @@ public class WeakReferenceDelegatorClassLoader extends ClassLoader implements De
   public WeakReferenceDelegatorClassLoader(ClassLoader classLoader) {
     // Parent is null, meaning it's the bootstrap ClassLoader
     super(null);
-    this.delegate = new WeakReference<ClassLoader>(classLoader);
+    this.delegate = new WeakReference<>(classLoader);
   }
 
   @Override

--- a/cdap-common/src/main/java/co/cask/cdap/common/lang/jar/UnpackedJarDirIterator.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/lang/jar/UnpackedJarDirIterator.java
@@ -28,7 +28,7 @@ import java.util.Queue;
 public class UnpackedJarDirIterator implements Enumeration<UnpackedJarDirEntry> {
 
   private final File bundleJarDir;
-  private final Queue<File> fileQueue = new LinkedList<File>();
+  private final Queue<File> fileQueue = new LinkedList<>();
 
   private File nextFile;
 

--- a/cdap-common/src/main/java/co/cask/cdap/common/logging/LoggingContextAccessor.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/logging/LoggingContextAccessor.java
@@ -26,7 +26,7 @@ package co.cask.cdap.common.logging;
  */
 public class LoggingContextAccessor {
   private static final InheritableThreadLocal<LoggingContext> loggingContext =
-    new InheritableThreadLocal<LoggingContext>();
+    new InheritableThreadLocal<>();
 
   /**
    * Sets the logging context.

--- a/cdap-common/src/main/java/co/cask/cdap/common/options/OptionsParser.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/options/OptionsParser.java
@@ -70,7 +70,7 @@ public final class OptionsParser {
    * @return List of arguments that were not definied by annotations.
    */
   public static List<String> init(Object object, String[] args, String appName, String appVersion, PrintStream out) {
-    List<String> nonOptionArgs = new ArrayList<String>();
+    List<String> nonOptionArgs = new ArrayList<>();
     Map<String, String> parsedOptions = parseArgs(args, nonOptionArgs);
     Map<String, OptionSpec> declaredOptions = extractDeclarations(object);
 
@@ -129,7 +129,7 @@ public final class OptionsParser {
    * @return map of options to it's definitions.
    */
   private static Map<String, OptionSpec> extractDeclarations(Object object) {
-    Map<String, OptionSpec> options = new TreeMap<String, OptionSpec>();
+    Map<String, OptionSpec> options = new TreeMap<>();
 
     // Get the parent class name.
     Class<?> clazz = object.getClass();
@@ -154,7 +154,7 @@ public final class OptionsParser {
   }
 
   private static Map<String, String> parseArgs(String[] args, List<String> nonOptionArgs) {
-    Map<String, String> parsedOptions = new TreeMap<String, String>();
+    Map<String, String> parsedOptions = new TreeMap<>();
     boolean ignoreTheRest = false;
     for (String arg : args) {
       if (arg.startsWith("-") && !ignoreTheRest) {

--- a/cdap-common/src/main/java/co/cask/cdap/common/utils/ImmutablePair.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/utils/ImmutablePair.java
@@ -44,7 +44,7 @@ public final class ImmutablePair<A, B> {
   private final B second;
 
   public static <A, B> ImmutablePair<A, B> of(A first, B second) {
-    return new ImmutablePair<A, B>(first, second);
+    return new ImmutablePair<>(first, second);
   }
 
   /**

--- a/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/coordination/BalancedAssignmentStrategy.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/coordination/BalancedAssignmentStrategy.java
@@ -34,7 +34,7 @@ public class BalancedAssignmentStrategy implements AssignmentStrategy {
 
     // Compute for each handler how many partition replica is already assigned
     for (T handler : handlers) {
-      handlerQueue.add(new HandlerSize<T>(handler, assignments));
+      handlerQueue.add(new HandlerSize<>(handler, assignments));
     }
 
     // For each unassigned partition replica in the requirement, assign it to the handler

--- a/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/coordination/DefaultResourceAssigner.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/coordination/DefaultResourceAssigner.java
@@ -37,7 +37,7 @@ final class DefaultResourceAssigner<T> implements ResourceAssigner<T> {
    * @param assignments Currently set of assignments. This will get modified if any of the set methods are called.
    */
   static <T> ResourceAssigner<T> create(Multimap<T, PartitionReplica> assignments) {
-    return new DefaultResourceAssigner<T>(assignments);
+    return new DefaultResourceAssigner<>(assignments);
   }
 
   private DefaultResourceAssigner(Multimap<T, PartitionReplica> assignments) {

--- a/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/store/ZKPropertyStore.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/store/ZKPropertyStore.java
@@ -62,7 +62,7 @@ public final class ZKPropertyStore<T> extends AbstractPropertyStore<T> {
    * @param codec The codec for encode/decode property
    */
   public static <T> ZKPropertyStore<T> create(ZKClient zkClient, Codec<T> codec) {
-    return new ZKPropertyStore<T>(zkClient, codec);
+    return new ZKPropertyStore<>(zkClient, codec);
   }
 
   /**
@@ -73,7 +73,7 @@ public final class ZKPropertyStore<T> extends AbstractPropertyStore<T> {
    * @param codec The codec for encode/decode property
    */
   public static <T> ZKPropertyStore<T> create(ZKClient zkClient, String namespace, Codec<T> codec) {
-    return new ZKPropertyStore<T>(ZKClients.namespace(zkClient, namespace), codec);
+    return new ZKPropertyStore<>(ZKClients.namespace(zkClient, namespace), codec);
   }
 
   /**

--- a/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionDatumReaderFactory.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionDatumReaderFactory.java
@@ -25,6 +25,6 @@ public final class ReflectionDatumReaderFactory implements DatumReaderFactory {
 
   @Override
   public <T> DatumReader<T> create(TypeToken<T> type, Schema schema) {
-    return new ReflectionDatumReader<T>(schema, type);
+    return new ReflectionDatumReader<>(schema, type);
   }
 }

--- a/cdap-common/src/test/java/co/cask/cdap/common/collect/CollectorTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/collect/CollectorTest.java
@@ -37,7 +37,7 @@ public class CollectorTest {
 
   @Test
   public void testAllCollector() {
-    Collector<Integer> collector = new AllCollector<Integer>();
+    Collector<Integer> collector = new AllCollector<>();
     Assert.assertEquals(collect(collector, 0), ImmutableList.<Integer>of());
     Assert.assertEquals(collect(collector, 4), ImmutableList.of(0, 1, 2, 3));
     Assert.assertEquals(collect(collector, 4), ImmutableList.of(0, 1, 2, 3));
@@ -45,9 +45,9 @@ public class CollectorTest {
 
   @Test
   public void testFirstNCollector() {
-    Collector<Integer> collector1 = new FirstNCollector<Integer>(1);
-    Collector<Integer> collector4 = new FirstNCollector<Integer>(4);
-    Collector<Integer> collector10 = new FirstNCollector<Integer>(10);
+    Collector<Integer> collector1 = new FirstNCollector<>(1);
+    Collector<Integer> collector4 = new FirstNCollector<>(4);
+    Collector<Integer> collector10 = new FirstNCollector<>(10);
 
     // add 0 elements
     Assert.assertEquals(collect(collector1, 0), ImmutableList.<Integer>of());
@@ -65,9 +65,9 @@ public class CollectorTest {
 
   @Test
   public void testLastNCollector() {
-    Collector<Integer> collector1 = new LastNCollector<Integer>(1);
-    Collector<Integer> collector4 = new LastNCollector<Integer>(4);
-    Collector<Integer> collector10 = new LastNCollector<Integer>(10);
+    Collector<Integer> collector1 = new LastNCollector<>(1);
+    Collector<Integer> collector4 = new LastNCollector<>(4);
+    Collector<Integer> collector10 = new LastNCollector<>(10);
 
     // add 0 elements
     Assert.assertEquals(collect(collector1, 0), ImmutableList.<Integer>of());

--- a/cdap-common/src/test/java/co/cask/cdap/common/conf/InMemoryPropertyStoreTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/conf/InMemoryPropertyStoreTest.java
@@ -24,6 +24,6 @@ public class InMemoryPropertyStoreTest extends PropertyStoreTestBase {
 
   @Override
   protected <T> PropertyStore<T> createPropertyStore(Codec<T> codec) {
-    return new InMemoryPropertyStore<T>();
+    return new InMemoryPropertyStore<>();
   }
 }

--- a/cdap-common/src/test/java/co/cask/cdap/common/conf/PropertyStoreTestBase.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/conf/PropertyStoreTestBase.java
@@ -50,7 +50,7 @@ public abstract class PropertyStoreTestBase {
     PropertyStore<String> store = createPropertyStore(STRING_CODEC);
 
     // Add a listener before the property watch exists
-    final BlockingQueue<String> changes = new LinkedBlockingQueue<String>();
+    final BlockingQueue<String> changes = new LinkedBlockingQueue<>();
     store.addChangeListener("basic", new AbstractPropertyChangeListener<String>() {
       @Override
       public void onChange(String name, String property) {

--- a/cdap-common/src/test/java/co/cask/cdap/common/utils/ImmutablePairTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/utils/ImmutablePairTest.java
@@ -25,11 +25,11 @@ import org.junit.Test;
 public class ImmutablePairTest {
 
   static final class Fixture {
-    static ImmutablePair<Integer, Integer> a = new ImmutablePair<Integer, Integer>(1, 2);
-    static ImmutablePair<Integer, String>  b = new ImmutablePair<Integer, String>(1, "woot");
-    static ImmutablePair<String, String>   c = new ImmutablePair<String, String>("me", "you");
-    static ImmutablePair<Integer, Integer> d = new ImmutablePair<Integer, Integer>(1, 2);
-    static ImmutablePair<Integer, Integer> e = new ImmutablePair<Integer, Integer>(1, 2);
+    static ImmutablePair<Integer, Integer> a = new ImmutablePair<>(1, 2);
+    static ImmutablePair<Integer, String>  b = new ImmutablePair<>(1, "woot");
+    static ImmutablePair<String, String>   c = new ImmutablePair<>("me", "you");
+    static ImmutablePair<Integer, Integer> d = new ImmutablePair<>(1, 2);
+    static ImmutablePair<Integer, Integer> e = new ImmutablePair<>(1, 2);
   }
 
   @Test
@@ -82,8 +82,8 @@ public class ImmutablePairTest {
 
   @Test
   public void testEqualsTypeSafe() {
-    ImmutablePair<Integer, Boolean> pair1 = new ImmutablePair<Integer, Boolean>(1, true);
-    ImmutablePair<String, byte[]> pair2 = new ImmutablePair<String, byte[]>("1", "true".getBytes());
+    ImmutablePair<Integer, Boolean> pair1 = new ImmutablePair<>(1, true);
+    ImmutablePair<String, byte[]> pair2 = new ImmutablePair<>("1", "true".getBytes());
     Assert.assertFalse(pair1.equals(pair2));
     Assert.assertFalse(pair2.equals(pair1));
     Assert.assertFalse(pair1.equals(new Integer(10)));

--- a/cdap-common/src/test/java/co/cask/cdap/common/zookeeper/coordination/ResourceCoordinatorTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/zookeeper/coordination/ResourceCoordinatorTest.java
@@ -98,7 +98,7 @@ public class ResourceCoordinatorTest {
 
           // Add a change handler for this discoverable.
           final BlockingQueue<Collection<PartitionReplica>> assignmentQueue =
-            new SynchronousQueue<Collection<PartitionReplica>>();
+            new SynchronousQueue<>();
           final Semaphore finishSemaphore = new Semaphore(0);
           Cancellable cancelSubscribe1 = subscribe(client, discoverable1, assignmentQueue, finishSemaphore);
 

--- a/cdap-common/src/test/java/co/cask/cdap/io/ASMDatumCodecTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/io/ASMDatumCodecTest.java
@@ -80,7 +80,7 @@ public class ASMDatumCodecTest {
     DatumWriter<Short> writer = getWriter(type);
     writer.encode((short) 3000, new BinaryEncoder(os));
 
-    ReflectionDatumReader<Short> reader = new ReflectionDatumReader<Short>(getSchema(type), type);
+    ReflectionDatumReader<Short> reader = new ReflectionDatumReader<>(getSchema(type), type);
     short value = reader.read(new BinaryDecoder(is), getSchema(type));
 
     Assert.assertEquals((short) 3000, value);
@@ -94,7 +94,7 @@ public class ASMDatumCodecTest {
     DatumWriter<Integer> writer = getWriter(type);
     writer.encode(12234234, new BinaryEncoder(os));
 
-    ReflectionDatumReader<Integer> reader = new ReflectionDatumReader<Integer>(getSchema(type), type);
+    ReflectionDatumReader<Integer> reader = new ReflectionDatumReader<>(getSchema(type), type);
     int value = reader.read(new BinaryDecoder(is), getSchema(type));
 
     Assert.assertEquals(12234234, value);
@@ -108,7 +108,7 @@ public class ASMDatumCodecTest {
     DatumWriter<Double> writer = getWriter(type);
     writer.encode(3.14d, new BinaryEncoder(os));
 
-    ReflectionDatumReader<Double> reader = new ReflectionDatumReader<Double>(getSchema(type), type);
+    ReflectionDatumReader<Double> reader = new ReflectionDatumReader<>(getSchema(type), type);
     double value = reader.read(new BinaryDecoder(is), getSchema(type));
 
     Assert.assertEquals(3.14d, value, 0.000001d);
@@ -122,7 +122,7 @@ public class ASMDatumCodecTest {
     DatumWriter<String> writer = getWriter(type);
     writer.encode("Testing message", new BinaryEncoder(os));
 
-    ReflectionDatumReader<String> reader = new ReflectionDatumReader<String>(getSchema(type), type);
+    ReflectionDatumReader<String> reader = new ReflectionDatumReader<>(getSchema(type), type);
     String value = reader.read(new BinaryDecoder(is), getSchema(type));
 
     Assert.assertEquals("Testing message", value);
@@ -138,7 +138,7 @@ public class ASMDatumCodecTest {
     UUID uuid = UUID.randomUUID();
     writer.encode(uuid, new BinaryEncoder(os));
 
-    ReflectionDatumReader<UUID> reader = new ReflectionDatumReader<UUID>(getSchema(type), type);
+    ReflectionDatumReader<UUID> reader = new ReflectionDatumReader<>(getSchema(type), type);
     UUID value = reader.read(new BinaryDecoder(is), getSchema(type));
 
     Assert.assertEquals(uuid, value);
@@ -155,7 +155,7 @@ public class ASMDatumCodecTest {
     writer.encode(TestEnum.VALUE4, encoder);
     writer.encode(TestEnum.VALUE3, encoder);
 
-    ReflectionDatumReader<TestEnum> reader = new ReflectionDatumReader<TestEnum>(getSchema(type), type);
+    ReflectionDatumReader<TestEnum> reader = new ReflectionDatumReader<>(getSchema(type), type);
 
     TestEnum value = reader.read(new BinaryDecoder(is), getSchema(type));
     Assert.assertEquals(TestEnum.VALUE1, value);
@@ -177,7 +177,7 @@ public class ASMDatumCodecTest {
     DatumWriter<int[]> writer = getWriter(type);
     writer.encode(writeValue, new BinaryEncoder(os));
 
-    ReflectionDatumReader<int[]> reader = new ReflectionDatumReader<int[]>(getSchema(type), type);
+    ReflectionDatumReader<int[]> reader = new ReflectionDatumReader<>(getSchema(type), type);
 
     int[] value = reader.read(new BinaryDecoder(is), getSchema(type));
     Assert.assertArrayEquals(writeValue, value);
@@ -193,7 +193,7 @@ public class ASMDatumCodecTest {
     DatumWriter<String[]> writer = getWriter(type);
     writer.encode(writeValue, new BinaryEncoder(os));
 
-    ReflectionDatumReader<String[]> reader = new ReflectionDatumReader<String[]>(getSchema(type), type);
+    ReflectionDatumReader<String[]> reader = new ReflectionDatumReader<>(getSchema(type), type);
 
     String[] value = reader.read(new BinaryDecoder(is), getSchema(type));
     Assert.assertArrayEquals(writeValue, value);
@@ -209,7 +209,7 @@ public class ASMDatumCodecTest {
     DatumWriter<List<Long>> writer = getWriter(type);
     writer.encode(writeValue, new BinaryEncoder(os));
 
-    ReflectionDatumReader<List<Long>> reader = new ReflectionDatumReader<List<Long>>(getSchema(type), type);
+    ReflectionDatumReader<List<Long>> reader = new ReflectionDatumReader<>(getSchema(type), type);
 
     List<Long> value = reader.read(new BinaryDecoder(is), getSchema(type));
     Assert.assertEquals(writeValue, value);
@@ -227,7 +227,7 @@ public class ASMDatumCodecTest {
     writer.encode(map, new BinaryEncoder(os));
 
     ReflectionDatumReader<Map<String, List<String>>> reader =
-      new ReflectionDatumReader<Map<String, List<String>>>(getSchema(type), type);
+      new ReflectionDatumReader<>(getSchema(type), type);
 
     Assert.assertEquals(map, reader.read(new BinaryDecoder(is), getSchema(type)));
   }
@@ -242,7 +242,7 @@ public class ASMDatumCodecTest {
     List<URI> writeValue = ImmutableList.of(URI.create("http://www.abc.com"));
     writer.encode(writeValue, new BinaryEncoder(os));
 
-    ReflectionDatumReader<List<URI>> reader = new ReflectionDatumReader<List<URI>>(getSchema(type), type);
+    ReflectionDatumReader<List<URI>> reader = new ReflectionDatumReader<>(getSchema(type), type);
     Assert.assertEquals(writeValue, reader.read(new BinaryDecoder(is), getSchema(type)));
   }
 
@@ -289,7 +289,7 @@ public class ASMDatumCodecTest {
     Record writeValue = new Record(10, "testing", ImmutableList.of("a", "b", "c"), TestEnum.VALUE2);
     writer.encode(writeValue, new BinaryEncoder(os));
 
-    ReflectionDatumReader<Record> reader = new ReflectionDatumReader<Record>(getSchema(type), type);
+    ReflectionDatumReader<Record> reader = new ReflectionDatumReader<>(getSchema(type), type);
     Record value = reader.read(new BinaryDecoder(is), getSchema(type));
 
     Assert.assertEquals(writeValue, value);
@@ -306,7 +306,7 @@ public class ASMDatumCodecTest {
                                   new Record(10, "testing", ImmutableList.of("a", "b", "c"), TestEnum.VALUE2));
     writer.encode(writeValue, new BinaryEncoder(os));
 
-    ReflectionDatumReader<List<Record>> reader = new ReflectionDatumReader<List<Record>>(getSchema(type), type);
+    ReflectionDatumReader<List<Record>> reader = new ReflectionDatumReader<>(getSchema(type), type);
     List<Record> value = reader.read(new BinaryDecoder(is), getSchema(type));
 
     Assert.assertEquals(writeValue, value);
@@ -323,7 +323,7 @@ public class ASMDatumCodecTest {
                                                          ImmutableList.of("a", "b", "c"), TestEnum.VALUE2)}};
     writer.encode(writeValue, new BinaryEncoder(os));
 
-    ReflectionDatumReader<Record[][]> reader = new ReflectionDatumReader<Record[][]>(getSchema(type), type);
+    ReflectionDatumReader<Record[][]> reader = new ReflectionDatumReader<>(getSchema(type), type);
     Record[][] value = reader.read(new BinaryDecoder(is), getSchema(type));
 
     Assert.assertArrayEquals(writeValue, value);
@@ -375,7 +375,7 @@ public class ASMDatumCodecTest {
     Node root = new Node(1, new Node(2, null, new Node(3, null, null)), new Node(4, new Node(5, null, null), null));
     writer.encode(root, new BinaryEncoder(os));
 
-    ReflectionDatumReader<Node> reader = new ReflectionDatumReader<Node>(getSchema(type), type);
+    ReflectionDatumReader<Node> reader = new ReflectionDatumReader<>(getSchema(type), type);
     Node value = reader.read(new BinaryDecoder(is), getSchema(type));
 
     Assert.assertEquals(root, value);
@@ -392,7 +392,7 @@ public class ASMDatumCodecTest {
                                         ByteBuffer.wrap("Testing message".getBytes(Charsets.UTF_8)));
     writer.encode(event, new BinaryEncoder(os));
 
-    ReflectionDatumReader<StreamEvent> reader = new ReflectionDatumReader<StreamEvent>(getSchema(type), type);
+    ReflectionDatumReader<StreamEvent> reader = new ReflectionDatumReader<>(getSchema(type), type);
     StreamEvent value = reader.read(new BinaryDecoder(is), getSchema(type));
 
     Assert.assertEquals(event.getHeaders(), value.getHeaders());
@@ -420,7 +420,7 @@ public class ASMDatumCodecTest {
     endTime = System.nanoTime();
     System.out.println("Time spent: " + TimeUnit.MILLISECONDS.convert(endTime - startTime, TimeUnit.NANOSECONDS));
 
-    ReflectionDatumWriter<Node> datumWriter = new ReflectionDatumWriter<Node>(getSchema(type));
+    ReflectionDatumWriter<Node> datumWriter = new ReflectionDatumWriter<>(getSchema(type));
     startTime = System.nanoTime();
     for (int i = 0; i < 100000; i++) {
       os.reset();
@@ -438,7 +438,7 @@ public class ASMDatumCodecTest {
     endTime = System.nanoTime();
     System.out.println("Time spent: " + TimeUnit.MILLISECONDS.convert(endTime - startTime, TimeUnit.NANOSECONDS));
 
-    datumWriter = new ReflectionDatumWriter<Node>(getSchema(type));
+    datumWriter = new ReflectionDatumWriter<>(getSchema(type));
     startTime = System.nanoTime();
     for (int i = 0; i < 100000; i++) {
       os.reset();

--- a/cdap-common/src/test/java/co/cask/cdap/io/DatumCodecTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/io/DatumCodecTest.java
@@ -152,7 +152,7 @@ public class DatumCodecTest {
     Schema targetSchema = new ReflectionSchemaGenerator().generate(Record2.class);
 
     new ReflectionDatumWriter<Record1>(sourceSchema).encode(r1, new BinaryEncoder(output));
-    Record2 r2 = new ReflectionDatumReader<Record2>(targetSchema, TypeToken.of(Record2.class))
+    Record2 r2 = new ReflectionDatumReader<>(targetSchema, TypeToken.of(Record2.class))
                             .read(new BinaryDecoder(input), sourceSchema);
 
     Assert.assertEquals(10L, r2.i.longValue());
@@ -183,7 +183,7 @@ public class DatumCodecTest {
     PipedInputStream input = new PipedInputStream(output);
 
     new ReflectionDatumWriter<List<String>>(sourceSchema).encode(list, new BinaryEncoder(output));
-    Set<String> set = new ReflectionDatumReader<Set<String>>(targetSchema, new TypeToken<Set<String>>() { })
+    Set<String> set = new ReflectionDatumReader<>(targetSchema, new TypeToken<Set<String>>() { })
                         .read(new BinaryDecoder(input), sourceSchema);
 
     Assert.assertEquals(Sets.newHashSet("1", "2", "3"), set);
@@ -191,7 +191,7 @@ public class DatumCodecTest {
 
     targetSchema = new ReflectionSchemaGenerator().generate(String[].class);
     new ReflectionDatumWriter<List<String>>(sourceSchema).encode(list, new BinaryEncoder(output));
-    String[] array = new ReflectionDatumReader<String[]>(targetSchema, new TypeToken<String[]>() { })
+    String[] array = new ReflectionDatumReader<>(targetSchema, new TypeToken<String[]>() { })
                         .read(new BinaryDecoder(input), sourceSchema);
 
     Assert.assertArrayEquals(new String[]{"1", "2", "3"}, array);
@@ -276,7 +276,7 @@ public class DatumCodecTest {
 
     MoreFields moreFields = new MoreFields(10, 20.2, "30", ImmutableList.of("1", "2"));
     new ReflectionDatumWriter<MoreFields>(sourceSchema).encode(moreFields, new BinaryEncoder(output));
-    LessFields lessFields = new ReflectionDatumReader<LessFields>(targetSchema, TypeToken.of(LessFields.class))
+    LessFields lessFields = new ReflectionDatumReader<>(targetSchema, TypeToken.of(LessFields.class))
                                             .read(new BinaryDecoder(input), sourceSchema);
 
     Assert.assertEquals("30", lessFields.k);
@@ -296,14 +296,14 @@ public class DatumCodecTest {
     PipedInputStream input = new PipedInputStream(output);
 
     Schema schema = new ReflectionSchemaGenerator().generate(TestEnum.class);
-    ReflectionDatumWriter<TestEnum> writer = new ReflectionDatumWriter<TestEnum>(schema);
+    ReflectionDatumWriter<TestEnum> writer = new ReflectionDatumWriter<>(schema);
     BinaryEncoder encoder = new BinaryEncoder(output);
     writer.encode(TestEnum.VALUE1, encoder);
     writer.encode(TestEnum.VALUE3, encoder);
     writer.encode(TestEnum.VALUE2, encoder);
 
     BinaryDecoder decoder = new BinaryDecoder(input);
-    ReflectionDatumReader<TestEnum> reader = new ReflectionDatumReader<TestEnum>(schema, TypeToken.of(TestEnum.class));
+    ReflectionDatumReader<TestEnum> reader = new ReflectionDatumReader<>(schema, TypeToken.of(TestEnum.class));
 
     Assert.assertEquals(TestEnum.VALUE1, reader.read(decoder, schema));
     Assert.assertEquals(TestEnum.VALUE3, reader.read(decoder, schema));
@@ -315,9 +315,9 @@ public class DatumCodecTest {
   public void testEmptyValue() throws UnsupportedTypeException, IOException {
     Schema schema = new ReflectionSchemaGenerator().generate(RecordWithString.class);
     TypeRepresentation typeRep = new TypeRepresentation(RecordWithString.class);
-    DatumWriter<RecordWithString> datumWriter = new ReflectionDatumWriter<RecordWithString>(schema);
+    DatumWriter<RecordWithString> datumWriter = new ReflectionDatumWriter<>(schema);
     @SuppressWarnings("unchecked")
-    ReflectionDatumReader<RecordWithString> datumReader = new ReflectionDatumReader<RecordWithString>(
+    ReflectionDatumReader<RecordWithString> datumReader = new ReflectionDatumReader<>(
       schema, (TypeToken<RecordWithString>) TypeToken.of(typeRep.toType()));
 
     RecordWithString record = new RecordWithString();

--- a/cdap-common/src/test/java/co/cask/cdap/streamevent/StreamEventCodecTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/streamevent/StreamEventCodecTest.java
@@ -64,7 +64,7 @@ public class StreamEventCodecTest {
 
     Assert.assertEquals(schema.getSchemaHash(), schemaHash);
 
-    StreamEvent decoded = new ReflectionDatumReader<StreamEvent>(schema, TypeToken.of(StreamEvent.class))
+    StreamEvent decoded = new ReflectionDatumReader<>(schema, TypeToken.of(StreamEvent.class))
           .read(new BinaryDecoder(new ByteBufferInputStream(payload)), schema);
 
     Assert.assertEquals(event.getHeaders(), decoded.getHeaders());

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/StreamCoordinatorTestBase.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/StreamCoordinatorTestBase.java
@@ -108,8 +108,8 @@ public abstract class StreamCoordinatorTestBase {
 
 
     StreamCoordinatorClient coordinator = getStreamCoordinator();
-    final BlockingDeque<Integer> thresholds = new LinkedBlockingDeque<Integer>();
-    final BlockingDeque<Long> ttls = new LinkedBlockingDeque<Long>();
+    final BlockingDeque<Integer> thresholds = new LinkedBlockingDeque<>();
+    final BlockingDeque<Long> ttls = new LinkedBlockingDeque<>();
     coordinator.addListener(streamId, new StreamPropertyListener() {
       @Override
       public void thresholdChanged(Id.Stream streamId, int threshold) {

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/StreamInputFormatTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/StreamInputFormatTest.java
@@ -244,7 +244,7 @@ public class StreamInputFormatTest {
     StreamEvent event = new StreamEvent(headers.build(), buffer, System.currentTimeMillis());
     StreamEventDecoder<LongWritable, StreamEvent> decoder = new IdentityStreamEventDecoder();
     StreamEventDecoder.DecodeResult<LongWritable, StreamEvent> result
-      = new StreamEventDecoder.DecodeResult<LongWritable, StreamEvent>();
+      = new StreamEventDecoder.DecodeResult<>();
     result = decoder.decode(event, result);
     Assert.assertEquals(new LongWritable(event.getTimestamp()), result.getKey());
     Assert.assertEquals(event, result.getValue());
@@ -256,7 +256,7 @@ public class StreamInputFormatTest {
     StreamEvent event = new StreamEvent(ImmutableMap.<String, String>of(), Charsets.UTF_8.encode(body));
     StreamEventDecoder<LongWritable, String> decoder = new StringStreamEventDecoder();
     StreamEventDecoder.DecodeResult<LongWritable, String> result
-      = new StreamEventDecoder.DecodeResult<LongWritable, String>();
+      = new StreamEventDecoder.DecodeResult<>();
     result = decoder.decode(event, result);
 
     Assert.assertEquals(event.getTimestamp(), result.getKey().get());
@@ -308,7 +308,7 @@ public class StreamInputFormatTest {
 
     // create a record reader for the 2nd split
     StreamRecordReader<LongWritable, StreamEvent> recordReader =
-      new StreamRecordReader<LongWritable, StreamEvent>(new IdentityStreamEventDecoder());
+      new StreamRecordReader<>(new IdentityStreamEventDecoder());
     recordReader.initialize(splits.get(1), context);
 
     // check that we read the 2nd stream event

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/InMemoryStreamCoordinatorClient.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/InMemoryStreamCoordinatorClient.java
@@ -52,7 +52,7 @@ public final class InMemoryStreamCoordinatorClient extends AbstractStreamCoordin
 
   @Override
   protected <T> PropertyStore<T> createPropertyStore(Codec<T> codec) {
-    return new InMemoryPropertyStore<T>();
+    return new InMemoryPropertyStore<>();
   }
 
   @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/MultiLiveStreamFileReader.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/MultiLiveStreamFileReader.java
@@ -56,7 +56,7 @@ public final class MultiLiveStreamFileReader implements FileReader<StreamEventOf
       allSources.add(eventSource);
     }
 
-    this.eventSources = new ObjectHeapPriorityQueue<StreamEventSource>(allSources.size());
+    this.eventSources = new ObjectHeapPriorityQueue<>(allSources.size());
     this.emptySources = Sets.newHashSet(allSources);
     this.offsetsView = Iterables.transform(allSources, new Function<StreamEventSource, StreamFileOffset>() {
       @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamInputFormat.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamInputFormat.java
@@ -311,7 +311,7 @@ public class StreamInputFormat<K, V> extends InputFormat<K, V> {
   @Override
   public RecordReader<K, V> createRecordReader(InputSplit split,
                                                TaskAttemptContext context) throws IOException, InterruptedException {
-    return new StreamRecordReader<K, V>(createStreamEventDecoder(context.getConfiguration()));
+    return new StreamRecordReader<>(createStreamEventDecoder(context.getConfiguration()));
   }
 
   protected long getCurrentTime() {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamInputSplitFinder.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamInputSplitFinder.java
@@ -166,7 +166,7 @@ public class StreamInputSplitFinder<T> {
      * @return a new instance of {@link StreamInputSplitFinder}
      */
     public <T> StreamInputSplitFinder<T> build(StreamInputSplitFactory<T> splitFactory) {
-      return new StreamInputSplitFinder<T>(path, startTime, endTime, maxSplitSize, minSplitSize, splitFactory);
+      return new StreamInputSplitFinder<>(path, startTime, endTime, maxSplitSize, minSplitSize, splitFactory);
     }
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamRecordReader.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamRecordReader.java
@@ -52,7 +52,7 @@ final class StreamRecordReader<K, V> extends RecordReader<K, V> {
   StreamRecordReader(StreamEventDecoder<K, V> decoder) {
     this.decoder = decoder;
     this.events = Lists.newArrayListWithCapacity(1);
-    this.currentEntry = new StreamEventDecoder.DecodeResult<K, V>();
+    this.currentEntry = new StreamEventDecoder.DecodeResult<>();
   }
 
   @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/decoder/FormatStreamEventDecoder.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/decoder/FormatStreamEventDecoder.java
@@ -53,6 +53,6 @@ public final class FormatStreamEventDecoder<T> implements StreamEventDecoder<Lon
     key.set(event.getTimestamp());
     T body = bodyFormat.read(event);
     Map<String, String> headers = Objects.firstNonNull(event.getHeaders(), ImmutableMap.<String, String>of());
-    return result.setKey(key).setValue(new GenericStreamEventData<T>(headers, body));
+    return result.setKey(key).setValue(new GenericStreamEventData<>(headers, body));
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/ConcurrentStreamWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/ConcurrentStreamWriter.java
@@ -374,7 +374,7 @@ public final class ConcurrentStreamWriter implements Closeable {
     EventQueue(Id.Stream streamId, StreamMetricsCollectorFactory.StreamMetricsCollector metricsCollector) {
       this.streamId = streamId;
       this.streamEvent = new MutableStreamEvent();
-      this.queue = new ConcurrentLinkedQueue<WriteRequest>();
+      this.queue = new ConcurrentLinkedQueue<>();
       this.writerFlag = new AtomicBoolean(false);
       this.metrics = new WriteRequest.Metrics();
       this.metricsCollector = metricsCollector;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/upload/AsyncChannelBufferInputStream.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/upload/AsyncChannelBufferInputStream.java
@@ -31,7 +31,7 @@ import java.util.concurrent.SynchronousQueue;
  */
 public final class AsyncChannelBufferInputStream extends InputStream {
 
-  private final BlockingQueue<ChannelBuffer> buffers = new SynchronousQueue<ChannelBuffer>();
+  private final BlockingQueue<ChannelBuffer> buffers = new SynchronousQueue<>();
   private ChannelBuffer currentBuffer = ChannelBuffers.EMPTY_BUFFER;
   private boolean eof;
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/upload/AvroStreamBodyConsumer.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/upload/AvroStreamBodyConsumer.java
@@ -145,7 +145,7 @@ final class AvroStreamBodyConsumer extends BodyConsumer {
     public void run() {
       try {
         // Create an Avro reader from the given content stream.
-        try (DataFileStream<Object> reader = new DataFileStream<Object>(contentStream, new DummyDatumReader())) {
+        try (DataFileStream<Object> reader = new DataFileStream<>(contentStream, new DummyDatumReader())) {
           Schema schema = reader.getSchema();
           DecoderFactory decoderFactory = DecoderFactory.get();
           ByteBufferInputStream blockInput = new ByteBufferInputStream(ByteBuffers.EMPTY_BUFFER);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/cube/CubeDatasetDefinition.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/cube/CubeDatasetDefinition.java
@@ -168,7 +168,7 @@ public class CubeDatasetDefinition extends AbstractDatasetDefinition<CubeDataset
         if (PROPERTY_DIMENSIONS.equals(nameAndProp[1])) {
           aggDimensions.put(nameAndProp[0], Arrays.asList(dimensions));
         } else if (PROPERTY_REQUIRED_DIMENSIONS.equals(nameAndProp[1])) {
-          aggRequiredDimensions.put(nameAndProp[0], new HashSet<String>(Arrays.asList(dimensions)));
+          aggRequiredDimensions.put(nameAndProp[0], new HashSet<>(Arrays.asList(dimensions)));
         } else {
           throw new IllegalArgumentException("Invalid property: " + prop.getKey());
         }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/BufferingTable.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/BufferingTable.java
@@ -140,7 +140,7 @@ public abstract class BufferingTable extends AbstractTable implements MeteredDat
     // we want it to be of format length+value to avoid conflicts like table="ab", row="cd" vs table="abc", row="d"
     // Default uses the above scheme. Subclasses can change it by overriding the #getNameAsTxChangePrefix method
     this.nameAsTxChangePrefix = Bytes.add(new byte[]{(byte) name.length()}, Bytes.toBytes(name));
-    this.buff = new ConcurrentSkipListMap<byte[], NavigableMap<byte[], Update>>(Bytes.BYTES_COMPARATOR);
+    this.buff = new ConcurrentSkipListMap<>(Bytes.BYTES_COMPARATOR);
   }
 
   /**
@@ -263,7 +263,7 @@ public abstract class BufferingTable extends AbstractTable implements MeteredDat
 
   private Collection<byte[]> getRowChanges() {
     // we resolve conflicts on row level of individual table
-    List<byte[]> changes = new ArrayList<byte[]>(buff.size());
+    List<byte[]> changes = new ArrayList<>(buff.size());
     for (byte[] changedRow : buff.keySet()) {
       changes.add(Bytes.add(getNameAsTxChangePrefix(), changedRow));
     }
@@ -272,7 +272,7 @@ public abstract class BufferingTable extends AbstractTable implements MeteredDat
 
   private Collection<byte[]> getColumnChanges() {
     // we resolve conflicts on row level of individual table
-    List<byte[]> changes = new ArrayList<byte[]>(buff.size());
+    List<byte[]> changes = new ArrayList<>(buff.size());
     for (Map.Entry<byte[], NavigableMap<byte[], Update>> rowChange : buff.entrySet()) {
       if (rowChange.getValue() == null) {
         // NOTE: as of now we cannot detect conflict between delete whole row and row's column value change.
@@ -300,7 +300,7 @@ public abstract class BufferingTable extends AbstractTable implements MeteredDat
       // clearing up in-memory buffer by initializing new map.
       // NOTE: we want to init map here so that if no changes are made we re-use same instance of the map in next tx
       // NOTE: we could cache two maps and swap them to avoid creation of map instances, but code would be ugly
-      buff = new ConcurrentSkipListMap<byte[], NavigableMap<byte[], Update>>(Bytes.BYTES_COMPARATOR);
+      buff = new ConcurrentSkipListMap<>(Bytes.BYTES_COMPARATOR);
       // TODO: tracking of persisted items can be optimized by returning a pair {succeededOrNot, persisted} which
       //       tells if persisting succeeded and what was persisted (i.e. what we will have to undo in case of rollback)
       persist(toUndo);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/ObjectMappedTableDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/ObjectMappedTableDataset.java
@@ -73,7 +73,7 @@ public class ObjectMappedTableDataset<T> extends AbstractDataset implements Obje
     this.objectSchema = objectSchema;
     this.typeRepresentation = typeRep;
     this.typeRepresentation.setClassLoader(classLoader);
-    this.putWriter = new ReflectionPutWriter<T>(objectSchema);
+    this.putWriter = new ReflectionPutWriter<>(objectSchema);
   }
 
   @SuppressWarnings("unchecked")
@@ -82,7 +82,7 @@ public class ObjectMappedTableDataset<T> extends AbstractDataset implements Obje
       try {
         // this can throw a runtime exception from a ClassNotFoundException
         Type type = typeRepresentation.toType();
-        this.rowReader = new ReflectionRowReader<T>(objectSchema, (TypeToken<T>) TypeToken.of(type));
+        this.rowReader = new ReflectionRowReader<>(objectSchema, (TypeToken<T>) TypeToken.of(type));
       } catch (RuntimeException e) {
         String missingClass = isClassNotFoundException(e);
         if (missingClass != null) {
@@ -186,7 +186,7 @@ public class ObjectMappedTableDataset<T> extends AbstractDataset implements Obje
       Preconditions.checkState(!closed);
       Row row = scanner.next();
       if (row != null) {
-        return new KeyValue<byte[], T>(row.getRow(), readRow(row));
+        return new KeyValue<>(row.getRow(), readRow(row));
       }
       close();
       return endOfData();

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/ObjectStoreDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/ObjectStoreDataset.java
@@ -66,8 +66,8 @@ public class ObjectStoreDataset<T> extends AbstractDataset implements ObjectStor
     this.typeRep = typeRep;
     this.typeRep.setClassLoader(classLoader);
     this.schema = schema;
-    this.datumWriter = new ReflectionDatumWriter<T>(this.schema);
-    this.datumReader = new ReflectionDatumReader<T>(this.schema, getTypeToken());
+    this.datumWriter = new ReflectionDatumWriter<>(this.schema);
+    this.datumReader = new ReflectionDatumReader<>(this.schema, getTypeToken());
   }
 
   public ObjectStoreDataset(String name, KeyValueTable kvTable,
@@ -100,7 +100,7 @@ public class ObjectStoreDataset<T> extends AbstractDataset implements ObjectStor
         Preconditions.checkState(!closed);
         if (keyValueIterator.hasNext()) {
           KeyValue<byte[], byte[]> row = keyValueIterator.next();
-          return new KeyValue<byte[], T>(row.getKey(), decode(row.getValue()));
+          return new KeyValue<>(row.getKey(), decode(row.getValue()));
         }
         close();
         return null;
@@ -192,7 +192,7 @@ public class ObjectStoreDataset<T> extends AbstractDataset implements ObjectStor
   public class ObjectRecordMaker implements Scannables.RecordMaker<byte[], T, KeyValue<byte[], T>> {
     @Override
     public KeyValue<byte[], T> makeRecord(byte[] key, T value) {
-      return new KeyValue<byte[], T>(key, value);
+      return new KeyValue<>(key, value);
     }
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/Updates.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/Updates.java
@@ -48,13 +48,13 @@ public final class Updates {
     }
 
     NavigableMap<byte[], NavigableMap<Long, byte[]>> returnMap =
-      new TreeMap<byte[], NavigableMap<Long, byte[]>>(Bytes.BYTES_COMPARATOR);
+      new TreeMap<>(Bytes.BYTES_COMPARATOR);
     // TODO: make this use a wrapper to represent the existing map as <Long, byte[]> instead of copying
     for (Map.Entry<byte[], NavigableMap<Long, Update>> entry : row.entrySet()) {
       for (Map.Entry<Long, Update> cellEntry : entry.getValue().entrySet()) {
         NavigableMap<Long, byte[]> currentCell = returnMap.get(entry.getKey());
         if (currentCell == null) {
-          currentCell = new TreeMap<Long, byte[]>(InMemoryTableService.VERSIONED_VALUE_MAP_COMPARATOR);
+          currentCell = new TreeMap<>(InMemoryTableService.VERSIONED_VALUE_MAP_COMPARATOR);
           returnMap.put(entry.getKey(), currentCell);
         }
         byte[] bytes = null;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/inmemory/InMemoryScanner.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/inmemory/InMemoryScanner.java
@@ -57,7 +57,7 @@ public class InMemoryScanner implements Scanner {
 
   @Override
   public Row next() {
-    Map<byte[], byte[]> columns = new TreeMap<byte[], byte[]>(Bytes.BYTES_COMPARATOR);
+    Map<byte[], byte[]> columns = new TreeMap<>(Bytes.BYTES_COMPARATOR);
     Map.Entry<byte[], NavigableMap<byte[], byte[]>> rowEntry = null;
 
     while (columns.isEmpty() && this.rows.hasNext()) {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableCore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableCore.java
@@ -323,7 +323,7 @@ public class LevelDBTableCore {
       }
     }
     // note this will return null for the row being read if multiRow is false (because the caller knows the row)
-    return new ImmutablePair<byte[], NavigableMap<byte[], byte[]>>(rowBeingRead, map);
+    return new ImmutablePair<>(rowBeingRead, map);
   }
 
   public void deleteRows(byte[] prefix) throws IOException {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/timeseries/FactTable.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/timeseries/FactTable.java
@@ -382,7 +382,7 @@ public final class FactTable implements Closeable {
     String measureName = (scan.getMeasureNames().size() == 1) ? scan.getMeasureNames().iterator().next() : null;
     byte[] fuzzyRowMask = codec.createFuzzyRowMask(scan.getDimensionValues(), measureName);
     // note: we can use startRow, as it will contain all "fixed" parts of the key needed
-    return new FuzzyRowFilter(ImmutableList.of(new ImmutablePair<byte[], byte[]>(startRow, fuzzyRowMask)));
+    return new FuzzyRowFilter(ImmutableList.of(new ImmutablePair<>(startRow, fuzzyRowMask)));
   }
 
   // todo: shouldn't we aggregate "before" writing to FactTable? We could do it really efficient outside

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/tx/DatasetContext.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/tx/DatasetContext.java
@@ -29,7 +29,7 @@ public class DatasetContext<T> implements Iterable<T> {
   private final T dataset;
 
   public static <TYPE> DatasetContext<TYPE> of(TYPE dateset) {
-    return new DatasetContext<TYPE>(dateset);
+    return new DatasetContext<>(dateset);
   }
 
   public DatasetContext(T dataset) {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/tx/Transactional.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/tx/Transactional.java
@@ -45,7 +45,7 @@ public class Transactional<T extends Iterable<V>, V> {
 
   public static <T extends Iterable<V>, V> Transactional<T, V> of(TransactionExecutorFactory txFactory,
                                                                             Supplier<T> supplier) {
-    return new Transactional<T, V>(txFactory, supplier);
+    return new Transactional<>(txFactory, supplier);
   }
 
   /**

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/internal/pair/OrderedPairs.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/internal/pair/OrderedPairs.java
@@ -37,6 +37,6 @@ public class OrderedPairs {
     KeyMaker<FIRST> keyMaker1 = (KeyMaker<FIRST>) keyMakers.get(first);
     @SuppressWarnings("unchecked")
     KeyMaker<SECOND> keyMaker2 = (KeyMaker<SECOND>) keyMakers.get(second);
-    return new OrderedPair<FIRST, SECOND>(keyMaker1, keyMaker2, first + second);
+    return new OrderedPair<>(keyMaker1, keyMaker2, first + second);
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/TransactionManagerDebuggerMain.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/TransactionManagerDebuggerMain.java
@@ -516,7 +516,7 @@ public class TransactionManagerDebuggerMain {
     // sizes of the changesets
 
     // map of sizes with Size -> number of changesets with that size
-    Map<Integer, Integer> sizes = new HashMap<Integer, Integer>();
+    Map<Integer, Integer> sizes = new HashMap<>();
     Map.Entry<Long, Set<ChangeId>> oldest = null,
                                    biggest = null;
     for (Map.Entry<Long, Set<ChangeId>> tx : changeSets.entrySet()) {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/AbstractQueueProducer.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/AbstractQueueProducer.java
@@ -45,7 +45,7 @@ public abstract class AbstractQueueProducer implements QueueProducer, Transactio
 
   protected AbstractQueueProducer(QueueMetrics queueMetrics, QueueName queueName) {
     this.queueMetrics = queueMetrics;
-    this.queue = new LinkedBlockingQueue<QueueEntry>();
+    this.queue = new LinkedBlockingQueue<>();
     this.queueName = queueName;
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/coprocessor/ConsumerConfigCache.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/coprocessor/ConsumerConfigCache.java
@@ -58,7 +58,7 @@ public class ConsumerConfigCache {
   private static final long CONFIG_UPDATE_FREQUENCY = 300 * 1000L;
 
   private static final ConcurrentMap<byte[], ConsumerConfigCache> INSTANCES =
-    new ConcurrentSkipListMap<byte[], ConsumerConfigCache>(Bytes.BYTES_COMPARATOR);
+    new ConcurrentSkipListMap<>(Bytes.BYTES_COMPARATOR);
 
   private final byte[] queueConfigTableName;
   private final Configuration hConf;
@@ -158,7 +158,7 @@ public class ConsumerConfigCache {
           NavigableMap<byte[], byte[]> familyMap = result.getFamilyMap(QueueEntryRow.COLUMN_FAMILY);
           if (familyMap != null) {
             configCnt++;
-            Map<ConsumerInstance, byte[]> consumerInstances = new HashMap<ConsumerInstance, byte[]>();
+            Map<ConsumerInstance, byte[]> consumerInstances = new HashMap<>();
             // Gather the startRow of all instances across all consumer groups.
             int numGroups = 0;
             Long groupId = null;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/inmemory/InMemoryQueue.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/inmemory/InMemoryQueue.java
@@ -42,7 +42,7 @@ public class InMemoryQueue {
 
   private static final Logger LOG = LoggerFactory.getLogger(InMemoryQueue.class);
 
-  private final ConcurrentNavigableMap<Key, Item> entries = new ConcurrentSkipListMap<Key, Item>();
+  private final ConcurrentNavigableMap<Key, Item> entries = new ConcurrentSkipListMap<>();
 
   public void clear() {
     entries.clear();

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/leveldb/LevelDBQueueConsumer.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/leveldb/LevelDBQueueConsumer.java
@@ -153,7 +153,7 @@ public final class LevelDBQueueConsumer extends AbstractQueueConsumer {
         if (next == null) {
           return null;
         }
-        return new ImmutablePair<byte[], Map<byte[], byte[]>>(next.getRow(), next.getColumns());
+        return new ImmutablePair<>(next.getRow(), next.getColumns());
       }
 
       @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/snapshot/AbstractSnapshotCodec.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/snapshot/AbstractSnapshotCodec.java
@@ -147,7 +147,7 @@ public abstract class AbstractSnapshotCodec implements SnapshotCodec {
 
   private NavigableMap<Long, Set<ChangeId>> decodeChangeSets(BinaryDecoder decoder) throws IOException {
     int size = decoder.readInt();
-    NavigableMap<Long, Set<ChangeId>> changeSets = new TreeMap<Long, Set<ChangeId>>();
+    NavigableMap<Long, Set<ChangeId>> changeSets = new TreeMap<>();
     while (size != 0) { // zero denotes end of list as per AVRO spec
       for (int remaining = size; remaining > 0; --remaining) {
         changeSets.put(decoder.readLong(), decodeChanges(decoder));

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseTableUtil.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseTableUtil.java
@@ -253,7 +253,7 @@ public abstract class HBaseTableUtil {
     final Hasher hasher = Hashing.md5().newHasher();
     final byte[] buffer = new byte[COPY_BUFFER_SIZE];
 
-    final Map<String, URL> dependentClasses = new HashMap<String, URL>();
+    final Map<String, URL> dependentClasses = new HashMap<>();
     for (Class<? extends Coprocessor> clz : classes) {
       Dependencies.findClassDependencies(clz.getClassLoader(), new Dependencies.ClassAcceptor() {
         @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/hbase/wd/AbstractRowKeyDistributor.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/hbase/wd/AbstractRowKeyDistributor.java
@@ -62,7 +62,7 @@ public abstract class AbstractRowKeyDistributor implements Parametrizable {
 
     Pair<byte[], byte[]>[] intervals = new Pair[startKeys.length];
     for (int i = 0; i < startKeys.length; i++) {
-      intervals[i] = new Pair<byte[], byte[]>(startKeys[i], stopKeys[i]);
+      intervals[i] = new Pair<>(startKeys[i], stopKeys[i]);
     }
 
     return intervals;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/hbase/wd/DistributedScanner.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/hbase/wd/DistributedScanner.java
@@ -55,7 +55,7 @@ public class DistributedScanner implements ResultScanner {
     this.scansExecutor = scansExecutor;
     this.nextOfScanners = new List[scanners.length];
     for (int i = 0; i < this.nextOfScanners.length; i++) {
-      this.nextOfScanners[i] = new ArrayList<Result>();
+      this.nextOfScanners[i] = new ArrayList<>();
     }
   }
 
@@ -84,7 +84,7 @@ public class DistributedScanner implements ResultScanner {
   public Result[] next(int nbRows) throws IOException {
     // Identical to HTable.ClientScanner implementation
     // Collect values to be returned here
-    ArrayList<Result> resultSets = new ArrayList<Result>(nbRows);
+    ArrayList<Result> resultSets = new ArrayList<>(nbRows);
     for (int i = 0; i < nbRows; i++) {
       Result next = next();
       if (next != null) {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/hbase/wd/WdTableInputFormat.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/hbase/wd/WdTableInputFormat.java
@@ -55,7 +55,7 @@ public class WdTableInputFormat extends TableInputFormat {
 
   @Override
   public List<InputSplit> getSplits(JobContext context) throws IOException {
-    List<InputSplit> allSplits = new ArrayList<InputSplit>();
+    List<InputSplit> allSplits = new ArrayList<>();
     Scan originalScan = getScan();
 
     Scan[] scans = rowKeyDistributor.getDistributedScans(originalScan);

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/ReflectionTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/ReflectionTableTest.java
@@ -249,11 +249,11 @@ public class ReflectionTableTest {
         @Override
         public void apply() throws Exception {
           Put put = new Put(rowKey);
-          ReflectionPutWriter<User> putWriter = new ReflectionPutWriter<User>(fullSchema);
+          ReflectionPutWriter<User> putWriter = new ReflectionPutWriter<>(fullSchema);
           putWriter.write(SAMUEL, put);
           usersTable.put(put);
           Row row = usersTable.get(rowKey);
-          ReflectionRowReader<User2> rowReader = new ReflectionRowReader<User2>(projSchema, TypeToken.of(User2.class));
+          ReflectionRowReader<User2> rowReader = new ReflectionRowReader<>(projSchema, TypeToken.of(User2.class));
           User2 actual = rowReader.read(row, fullSchema);
           Assert.assertEquals(projected, actual);
         }
@@ -277,7 +277,7 @@ public class ReflectionTableTest {
         @Override
         public void apply() throws Exception {
           Put put = new Put(rowKey);
-          ReflectionPutWriter<User> putWriter = new ReflectionPutWriter<User>(schema);
+          ReflectionPutWriter<User> putWriter = new ReflectionPutWriter<>(schema);
           putWriter.write(SAMUEL, put);
           usersTable.put(put);
           Row row = usersTable.get(rowKey);
@@ -308,7 +308,7 @@ public class ReflectionTableTest {
         @Override
         public void apply() throws Exception {
           Put put = new Put(rowKey);
-          ReflectionPutWriter<User> putWriter = new ReflectionPutWriter<User>(fullSchema);
+          ReflectionPutWriter<User> putWriter = new ReflectionPutWriter<>(fullSchema);
           putWriter.write(SAMUEL, put);
           usersTable.put(put);
           Row row = usersTable.get(rowKey);
@@ -330,11 +330,11 @@ public class ReflectionTableTest {
       @Override
       public void apply() throws Exception {
         Put put = new Put(rowKey);
-        ReflectionPutWriter<User> putWriter = new ReflectionPutWriter<User>(schema);
+        ReflectionPutWriter<User> putWriter = new ReflectionPutWriter<>(schema);
         putWriter.write(obj, put);
         table.put(put);
         Row row = table.get(rowKey);
-        ReflectionRowReader<User> rowReader = new ReflectionRowReader<User>(schema, TypeToken.of(User.class));
+        ReflectionRowReader<User> rowReader = new ReflectionRowReader<>(schema, TypeToken.of(User.class));
         User actual = rowReader.read(row, schema);
         Assert.assertEquals(obj, actual);
       }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/TimeseriesTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/TimeseriesTableTest.java
@@ -234,7 +234,7 @@ public class TimeseriesTableTest {
                                      TimeseriesTable.createRow(key2, ts1, timeIntervalPerRow)));
 
     // * We can get all possible rows for a given time interval with getRowsForInterval
-    List<byte[]> rows = new ArrayList<byte[]>();
+    List<byte[]> rows = new ArrayList<>();
     long startTime = timeIntervalPerRow * 4;
     long endTime = timeIntervalPerRow * 100;
     for (long i = startTime; i <= endTime; i += timeIntervalPerRow / 10) {

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data/format/AvroRecordFormatTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data/format/AvroRecordFormatTest.java
@@ -215,7 +215,7 @@ public class AvroRecordFormatTest {
   private StreamEvent toStreamEvent(GenericRecord record, boolean writeSchema) throws IOException {
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     BinaryEncoder encoder = EncoderFactory.get().binaryEncoder(out, null);
-    DatumWriter<GenericRecord> writer = new GenericDatumWriter<GenericRecord>(record.getSchema());
+    DatumWriter<GenericRecord> writer = new GenericDatumWriter<>(record.getSchema());
     writer.write(record, encoder);
     encoder.flush();
     out.close();

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data/stream/service/upload/AvroStreamBodyConsumerTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data/stream/service/upload/AvroStreamBodyConsumerTest.java
@@ -47,7 +47,7 @@ public class AvroStreamBodyConsumerTest extends StreamBodyConsumerTestBase {
                             InputSupplier<? extends InputStream> contentSupplier) throws IOException {
         // Deserialize and verify the records
         Decoder decoder = DecoderFactory.get().binaryDecoder(contentSupplier.getInput(), null);
-        DatumReader<Record> reader = new ReflectDatumReader<Record>(Record.class);
+        DatumReader<Record> reader = new ReflectDatumReader<>(Record.class);
         reader.setSchema(new Schema.Parser().parse(headers.get("schema")));
         for (int i = 0; i < recordCount; i++) {
           Record record = reader.read(null, decoder);
@@ -76,7 +76,7 @@ public class AvroStreamBodyConsumerTest extends StreamBodyConsumerTestBase {
                                                                    Schema.create(Schema.Type.STRING))), null, null)
     ));
 
-    DataFileWriter<Record> writer = new DataFileWriter<Record>(new ReflectDatumWriter<Record>(Record.class));
+    DataFileWriter<Record> writer = new DataFileWriter<>(new ReflectDatumWriter<>(Record.class));
     try {
       writer.setCodec(CodecFactory.snappyCodec());
       writer.create(schema, file);

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data/stream/service/upload/StreamBodyConsumerTestBase.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data/stream/service/upload/StreamBodyConsumerTestBase.java
@@ -205,7 +205,7 @@ public abstract class StreamBodyConsumerTestBase {
    * A {@link HttpResponder} for testing. It only saved the first response status event sent.
    */
   private static class TestHttpResponder extends AbstractHttpResponder {
-    private final AtomicReference<HttpResponseStatus> responseStatus = new AtomicReference<HttpResponseStatus>();
+    private final AtomicReference<HttpResponseStatus> responseStatus = new AtomicReference<>();
 
     @Override
     public ChunkResponder sendChunkStart(HttpResponseStatus status, Multimap<String, String> headers) {

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/ObjectMappedTableDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/ObjectMappedTableDatasetTest.java
@@ -78,9 +78,9 @@ public class ObjectMappedTableDatasetTest {
       Record record3 = new Record(1, 0L, 3.14f, 3.14159265358979323846, "hello",
                                   Bytes.toBytes("world"), ByteBuffer.wrap(Bytes.toBytes("yo")), UUID.randomUUID());
       List<KeyValue<byte[], Record>> recordList = Lists.newArrayList();
-      recordList.add(new KeyValue<byte[], Record>(Bytes.toBytes("123"), record1));
-      recordList.add(new KeyValue<byte[], Record>(Bytes.toBytes("456"), record2));
-      recordList.add(new KeyValue<byte[], Record>(Bytes.toBytes("789"), record3));
+      recordList.add(new KeyValue<>(Bytes.toBytes("123"), record1));
+      recordList.add(new KeyValue<>(Bytes.toBytes("456"), record2));
+      recordList.add(new KeyValue<>(Bytes.toBytes("789"), record3));
 
       for (KeyValue<byte[], Record> record : recordList) {
         records.write(record.getKey(), record.getValue());

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/ObjectStoreDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/ObjectStoreDatasetTest.java
@@ -105,7 +105,7 @@ public class ObjectStoreDatasetTest {
     createObjectStoreInstance(pairs, new TypeToken<ImmutablePair<Integer, String>>() { }.getType());
 
     ObjectStoreDataset<ImmutablePair<Integer, String>> pairStore = dsFrameworkUtil.getInstance(pairs);
-    ImmutablePair<Integer, String> pair = new ImmutablePair<Integer, String>(1, "second");
+    ImmutablePair<Integer, String> pair = new ImmutablePair<>(1, "second");
     pairStore.write(a, pair);
     ImmutablePair<Integer, String> result = pairStore.read(a);
     Assert.assertEquals(pair, result);
@@ -141,7 +141,7 @@ public class ObjectStoreDatasetTest {
     createObjectStoreInstance(inners, new TypeToken<CustomWithInner.Inner<Integer>>() { }.getType());
 
     ObjectStoreDataset<CustomWithInner.Inner<Integer>> innerStore = dsFrameworkUtil.getInstance(inners);
-    CustomWithInner.Inner<Integer> inner = new CustomWithInner.Inner<Integer>(42, new Integer(99));
+    CustomWithInner.Inner<Integer> inner = new CustomWithInner.Inner<>(42, new Integer(99));
     innerStore.write(a, inner);
     CustomWithInner.Inner<Integer> result = innerStore.read(a);
     Assert.assertEquals(inner, result);
@@ -177,7 +177,7 @@ public class ObjectStoreDatasetTest {
     final ObjectStoreDataset<ImmutablePair<Integer, String>> pairStore = dsFrameworkUtil.getInstance(pairs);
     TransactionExecutor pairStoreTxnl = dsFrameworkUtil.newTransactionExecutor(store);
 
-    final ImmutablePair<Integer, String> pair = new ImmutablePair<Integer, String>(1, "second");
+    final ImmutablePair<Integer, String> pair = new ImmutablePair<>(1, "second");
     pairStoreTxnl.execute(new TransactionExecutor.Subroutine() {
       @Override
       public void apply() throws Exception {
@@ -216,7 +216,7 @@ public class ObjectStoreDatasetTest {
   public void testWithCustomClassLoader() throws Exception {
     Id.DatasetInstance kv = Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "kv");
     // create a dummy class loader that records the name of the class it loaded
-    final AtomicReference<String> lastClassLoaded = new AtomicReference<String>(null);
+    final AtomicReference<String> lastClassLoaded = new AtomicReference<>(null);
     ClassLoader loader = new ClassLoader() {
       @Override
       public Class<?> loadClass(String name) throws ClassNotFoundException {
@@ -232,7 +232,7 @@ public class ObjectStoreDatasetTest {
     TypeRepresentation typeRep = new TypeRepresentation(type);
     Schema schema = new ReflectionSchemaGenerator().generate(type);
 
-    ObjectStoreDataset<Custom> objectStore = new ObjectStoreDataset<Custom>("kv", kvTable, typeRep, schema, loader);
+    ObjectStoreDataset<Custom> objectStore = new ObjectStoreDataset<>("kv", kvTable, typeRep, schema, loader);
     objectStore.write("dummy", new Custom(382, Lists.newArrayList("blah")));
     // verify the class name was recorded (the dummy class loader was used).
     Assert.assertEquals(Custom.class.getName(), lastClassLoaded.get());

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/timeseries/FactCodecTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/timeseries/FactCodecTest.java
@@ -89,7 +89,7 @@ public class FactCodecTest {
                                  new DimensionValue("dimension3", "value3"));
     byte[] mask = codec.createFuzzyRowMask(dimensionValues, "myMetric");
     rowKey = codec.createRowKey(dimensionValues, "myMetric", ts);
-    FuzzyRowFilter filter = new FuzzyRowFilter(ImmutableList.of(new ImmutablePair<byte[], byte[]>(rowKey, mask)));
+    FuzzyRowFilter filter = new FuzzyRowFilter(ImmutableList.of(new ImmutablePair<>(rowKey, mask)));
 
     dimensionValues = ImmutableList.of(new DimensionValue("dimension1", "value1"),
                                  new DimensionValue("dimension2", "annnnnnnnnny"),
@@ -137,7 +137,7 @@ public class FactCodecTest {
     dimensionValues = ImmutableList.of(new DimensionValue("myTag", "myValue"));
     rowKey = codec.createRowKey(dimensionValues, null, ts);
     mask = codec.createFuzzyRowMask(dimensionValues, null);
-    filter = new FuzzyRowFilter(ImmutableList.of(new ImmutablePair<byte[], byte[]>(rowKey, mask)));
+    filter = new FuzzyRowFilter(ImmutableList.of(new ImmutablePair<>(rowKey, mask)));
 
     rowKey = codec.createRowKey(dimensionValues, "annyyy", ts);
     Assert.assertEquals(FuzzyRowFilter.ReturnCode.INCLUDE, filter.filterRow(rowKey));

--- a/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistory.java
+++ b/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistory.java
@@ -31,7 +31,7 @@ public class PurchaseHistory {
   public PurchaseHistory(String customer, @Nullable UserProfile userProfile) {
     this.customer = customer;
     this.userProfile = userProfile;
-    this.purchases = new ArrayList<Purchase>();
+    this.purchases = new ArrayList<>();
   }
 
   public String getCustomer() {

--- a/cdap-examples/SparkPageRank/src/main/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankProgram.java
+++ b/cdap-examples/SparkPageRank/src/main/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankProgram.java
@@ -84,7 +84,7 @@ public class SparkPageRankProgram implements JavaSparkProgram {
         @Override
         public Tuple2<String, String> call(Text s) {
           String[] parts = SPACES.split(s.toString());
-          return new Tuple2<String, String>(parts[0], parts[1]);
+          return new Tuple2<>(parts[0], parts[1]);
         }
       }).distinct().groupByKey().cache();
 
@@ -105,9 +105,9 @@ public class SparkPageRankProgram implements JavaSparkProgram {
           public Iterable<Tuple2<String, Double>> call(Tuple2<Iterable<String>, Double> s) {
             LOG.debug("Processing {} with rank {}", s._1(), s._2());
             int urlCount = Iterables.size(s._1());
-            List<Tuple2<String, Double>> results = new ArrayList<Tuple2<String, Double>>();
+            List<Tuple2<String, Double>> results = new ArrayList<>();
             for (String n : s._1()) {
-              results.add(new Tuple2<String, Double>(n, s._2() / urlCount));
+              results.add(new Tuple2<>(n, s._2() / urlCount));
             }
             return results;
           }

--- a/cdap-examples/StreamConversion/src/main/java/co/cask/cdap/examples/streamconversion/StreamConversionMapReduce.java
+++ b/cdap-examples/StreamConversion/src/main/java/co/cask/cdap/examples/streamconversion/StreamConversionMapReduce.java
@@ -93,7 +93,7 @@ public class StreamConversionMapReduce extends AbstractMapReduce {
         .set("time", streamEvent.getTimestamp())
         .set("body", Bytes.toString(streamEvent.getBody()));
       GenericRecord record = recordBuilder.build();
-      context.write(new AvroKey<GenericRecord>(record), NullWritable.get());
+      context.write(new AvroKey<>(record), NullWritable.get());
     }
   }
 }

--- a/cdap-examples/StreamConversion/src/test/java/co/cask/cdap/examples/streamconversion/StreamConversionTest.java
+++ b/cdap-examples/StreamConversion/src/test/java/co/cask/cdap/examples/streamconversion/StreamConversionTest.java
@@ -131,7 +131,7 @@ public class StreamConversionTest extends TestBase {
                         long sleepDelay, TimeUnit sleepDelayUnit)
     throws InterruptedException, ExecutionException, TimeoutException {
 
-    final AtomicMarkableReference<T> result = new AtomicMarkableReference<T>(null, false);
+    final AtomicMarkableReference<T> result = new AtomicMarkableReference<>(null, false);
     Tasks.waitFor(true, new Callable<Boolean>() {
       public Boolean call() throws Exception {
         try {

--- a/cdap-examples/WebAnalytics/src/main/java/co/cask/cdap/examples/webanalytics/UniqueVisitCount.java
+++ b/cdap-examples/WebAnalytics/src/main/java/co/cask/cdap/examples/webanalytics/UniqueVisitCount.java
@@ -102,7 +102,7 @@ public class UniqueVisitCount extends AbstractDataset implements RecordScannable
       @Override
       public KeyValue<String, Long> getCurrentRecord() throws InterruptedException {
         KeyValue<byte[], byte[]> record = scanner.getCurrentRecord();
-        return new KeyValue<String, Long>(Bytes.toString(record.getKey()), Bytes.toLong(record.getValue()));
+        return new KeyValue<>(Bytes.toString(record.getKey()), Bytes.toLong(record.getValue()));
       }
 
       @Override

--- a/cdap-examples/WordCount/src/main/java/co/cask/cdap/examples/wordcount/AssociationTable.java
+++ b/cdap-examples/WordCount/src/main/java/co/cask/cdap/examples/wordcount/AssociationTable.java
@@ -133,7 +133,7 @@ class TopKCollector {
   }
 
   final int limit;
-  TreeSet<Entry> entries = new TreeSet<Entry>();
+  TreeSet<Entry> entries = new TreeSet<>();
 
   TopKCollector(int limit) {
     this.limit = limit;
@@ -151,7 +151,7 @@ class TopKCollector {
   }
 
   Map<String, Long> getTopK() {
-    TreeMap<String, Long> topK = new TreeMap<String, Long>();
+    TreeMap<String, Long> topK = new TreeMap<>();
     for (int i = 0; i < limit; i++) {
       Entry entry = entries.pollLast();
       if (entry == null) {

--- a/cdap-examples/WordCount/src/main/java/co/cask/cdap/examples/wordcount/RetrieveCountsHandler.java
+++ b/cdap-examples/WordCount/src/main/java/co/cask/cdap/examples/wordcount/RetrieveCountsHandler.java
@@ -86,7 +86,7 @@ public class RetrieveCountsHandler extends AbstractHttpServiceHandler {
     }
 
     // Return a map as JSON
-    Map<String, Object> results = new HashMap<String, Object>();
+    Map<String, Object> results = new HashMap<>();
     results.put("totalWords", totalWords);
     results.put("uniqueWords", uniqueWords);
     results.put("averageLength", averageLength);
@@ -110,7 +110,7 @@ public class RetrieveCountsHandler extends AbstractHttpServiceHandler {
     Map<String, Long> wordsAssocs = associationTable.readWordAssocs(word, limit);
 
     // Build a map with results
-    Map<String, Object> results = new HashMap<String, Object>();
+    Map<String, Object> results = new HashMap<>();
     results.put("word", word);
     results.put("count", wordCount);
     results.put("assocs", wordsAssocs);
@@ -184,7 +184,7 @@ public class RetrieveCountsHandler extends AbstractHttpServiceHandler {
     long count = associationTable.getAssoc(word1, word2);
 
     // Return a map as JSON
-    Map<String, Object> results = new HashMap<String, Object>();
+    Map<String, Object> results = new HashMap<>();
     results.put("word1", word1);
     results.put("word2", word2);
     results.put("count", count);

--- a/cdap-examples/WordCount/src/main/java/co/cask/cdap/examples/wordcount/WordSplitter.java
+++ b/cdap-examples/WordCount/src/main/java/co/cask/cdap/examples/wordcount/WordSplitter.java
@@ -47,7 +47,7 @@ public class WordSplitter extends AbstractFlowlet {
       .decode(event.getBody()).toString();
 
     String[] words = inputString.split("\\s+");
-    List<String> wordList = new ArrayList<String>(words.length);
+    List<String> wordList = new ArrayList<>(words.length);
 
     long sumOfLengths = 0;
     long wordCount = 0;

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/guice/ExploreRuntimeModule.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/guice/ExploreRuntimeModule.java
@@ -267,7 +267,7 @@ public class ExploreRuntimeModule extends RuntimeModule {
 
     // Note the order of dependency jars is important so that HBase jars come first in the classpath order
     // LinkedHashSet maintains insertion order while removing duplicate entries.
-    Set<File> orderedDependencies = new LinkedHashSet<File>();
+    Set<File> orderedDependencies = new LinkedHashSet<>();
     orderedDependencies.addAll(hBaseTableDeps);
     orderedDependencies.addAll(ExploreServiceUtils.traceDependencies(RemoteDatasetFramework.class.getCanonicalName(),
                                                                      bootstrapClassPaths, null));

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/guice/LocalMapreduceClasspathSetter.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/guice/LocalMapreduceClasspathSetter.java
@@ -43,7 +43,7 @@ public class LocalMapreduceClasspathSetter {
   private final HiveConf hiveConf;
   private final String directory;
   private final List<String> hiveAuxJars;
-  private final Set<String> hbaseProtocolJarPaths = new LinkedHashSet<String>();
+  private final Set<String> hbaseProtocolJarPaths = new LinkedHashSet<>();
 
   public LocalMapreduceClasspathSetter(HiveConf hiveConf, String directory, List<String> hiveAuxJars) {
     this.hiveConf = hiveConf;

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/security/HiveTokenUtils.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/security/HiveTokenUtils.java
@@ -55,7 +55,7 @@ public final class HiveTokenUtils {
       Method getDelegationToken = hiveClass.getMethod("getDelegationToken", String.class, String.class);
       String tokenStr = (String) getDelegationToken.invoke(hiveObject, user, user);
 
-      Token<DelegationTokenIdentifier> delegationToken = new Token<DelegationTokenIdentifier>();
+      Token<DelegationTokenIdentifier> delegationToken = new Token<>();
       delegationToken.decodeFromUrlString(tokenStr);
       delegationToken.setService(new Text(HiveAuthFactory.HS2_CLIENT_TOKEN));
       LOG.info("Adding delegation token {} from MetaStore for service {} for user {}",

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/ExploreServiceUtils.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/ExploreServiceUtils.java
@@ -275,7 +275,7 @@ public class ExploreServiceUtils {
 
     // Note the order of dependency jars is important so that HBase jars come first in the classpath order
     // LinkedHashSet maintains insertion order while removing duplicate entries.
-    Set<File> orderedDependencies = new LinkedHashSet<File>();
+    Set<File> orderedDependencies = new LinkedHashSet<>();
     orderedDependencies.addAll(hBaseTableDeps);
     orderedDependencies.addAll(traceDependencies(DatasetService.class.getCanonicalName(),
                                                  bootstrapClassPaths, usingCL));

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/BaseHiveExploreService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/BaseHiveExploreService.java
@@ -174,9 +174,9 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
     this.hiveConf = hiveConf;
     this.schedulerQueueResolver = new SchedulerQueueResolver(cConf, store);
     this.previewsDir = previewsDir;
-    this.metastoreClientLocal = new ThreadLocal<Supplier<IMetaStoreClient>>();
+    this.metastoreClientLocal = new ThreadLocal<>();
     this.metastoreClientReferences = Maps.newConcurrentMap();
-    this.metastoreClientReferenceQueue = new ReferenceQueue<Supplier<IMetaStoreClient>>();
+    this.metastoreClientReferenceQueue = new ReferenceQueue<>();
     this.datasetFramework = datasetFramework;
     this.streamAdmin = streamAdmin;
     this.exploreTableManager = new ExploreTableManager(this, datasetFramework);
@@ -247,7 +247,7 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
         // We can use the weak reference, which is retrieved through polling the ReferenceQueue,
         // to get back the client and call close() on it.
         metastoreClientReferences.put(
-          new WeakReference<Supplier<IMetaStoreClient>>(supplier, metastoreClientReferenceQueue), client);
+          new WeakReference<>(supplier, metastoreClientReferenceQueue), client);
       } catch (MetaException e) {
         throw new ExploreException("Error initializing Hive Metastore client", e);
       }

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/objectinspector/ObjectInspectorFactory.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/objectinspector/ObjectInspectorFactory.java
@@ -53,7 +53,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public final class ObjectInspectorFactory {
 
   private static ConcurrentHashMap<Type, ObjectInspector> objectInspectorCache =
-      new ConcurrentHashMap<Type, ObjectInspector>();
+      new ConcurrentHashMap<>();
 
   public static ObjectInspector getReflectionObjectInspector(Type t) {
     ObjectInspector oi = objectInspectorCache.get(t);
@@ -139,7 +139,7 @@ public final class ObjectInspectorFactory {
     // recursive types.
     objectInspectorCache.put(t, oi);
     Field[] fields = ObjectInspectorUtils.getDeclaredNonStaticFields(c);
-    List<ObjectInspector> structFieldObjectInspectors = new ArrayList<ObjectInspector>(fields.length);
+    List<ObjectInspector> structFieldObjectInspectors = new ArrayList<>(fields.length);
     for (int i = 0; i < fields.length; i++) {
       // Exclude transient fields and synthetic fields. The latter has the effect of excluding the implicit
       // "this" pointer present in nested classes and that references the parent.
@@ -162,7 +162,7 @@ public final class ObjectInspectorFactory {
   }
 
   static ConcurrentHashMap<ObjectInspector, StandardListObjectInspector> cachedStandardListObjectInspector =
-      new ConcurrentHashMap<ObjectInspector, StandardListObjectInspector>();
+      new ConcurrentHashMap<>();
 
   public static StandardListObjectInspector getStandardListObjectInspector(ObjectInspector listElementObjectInspector) {
     StandardListObjectInspector result = cachedStandardListObjectInspector.get(listElementObjectInspector);
@@ -174,7 +174,7 @@ public final class ObjectInspectorFactory {
   }
 
   static ConcurrentHashMap<List<ObjectInspector>, StandardMapObjectInspector> cachedStandardMapObjectInspector =
-      new ConcurrentHashMap<List<ObjectInspector>, StandardMapObjectInspector>();
+      new ConcurrentHashMap<>();
 
   public static StandardMapObjectInspector getStandardMapObjectInspector(ObjectInspector mapKeyObjectInspector,
                                                                          ObjectInspector mapValueObjectInspector) {
@@ -189,7 +189,7 @@ public final class ObjectInspectorFactory {
 
   static ConcurrentHashMap<List<ObjectInspector>, StandardUnionObjectInspector>
       cachedStandardUnionObjectInspector =
-      new ConcurrentHashMap<List<ObjectInspector>, StandardUnionObjectInspector>();
+      new ConcurrentHashMap<>();
 
   public static StandardUnionObjectInspector getStandardUnionObjectInspector(
       List<ObjectInspector> unionObjectInspectors) {
@@ -203,7 +203,7 @@ public final class ObjectInspectorFactory {
   }
 
   static ConcurrentHashMap<ArrayList<List<?>>, StandardStructObjectInspector> cachedStandardStructObjectInspector =
-      new ConcurrentHashMap<ArrayList<List<?>>, StandardStructObjectInspector>();
+      new ConcurrentHashMap<>();
 
   public static StandardStructObjectInspector getStandardStructObjectInspector(
       List<String> structFieldNames,
@@ -215,7 +215,7 @@ public final class ObjectInspectorFactory {
       List<String> structFieldNames,
       List<ObjectInspector> structFieldObjectInspectors,
       List<String> structComments) {
-    ArrayList<List<?>> signature = new ArrayList<List<?>>(3);
+    ArrayList<List<?>> signature = new ArrayList<>(3);
     signature.add(structFieldNames);
     signature.add(structFieldObjectInspectors);
     if (structComments != null) {
@@ -230,7 +230,7 @@ public final class ObjectInspectorFactory {
   }
 
   static ConcurrentHashMap<List<StructObjectInspector>, UnionStructObjectInspector> cachedUnionStructObjectInspector =
-      new ConcurrentHashMap<List<StructObjectInspector>, UnionStructObjectInspector>();
+      new ConcurrentHashMap<>();
 
   public static UnionStructObjectInspector getUnionStructObjectInspector(
       List<StructObjectInspector> structObjectInspectors) {

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/objectinspector/ReflectionStructObjectInspector.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/objectinspector/ReflectionStructObjectInspector.java
@@ -124,7 +124,7 @@ public class ReflectionStructObjectInspector extends
 
     this.objectClass = objectClass;
     Field[] reflectionFields = ObjectInspectorUtils.getDeclaredNonStaticFields(objectClass);
-    fields = new ArrayList<MyField>(structFieldObjectInspectors.size());
+    fields = new ArrayList<>(structFieldObjectInspectors.size());
     int used = 0;
     for (int i = 0; i < reflectionFields.length; i++) {
       // Exclude transient fields and synthetic fields. The latter has the effect of excluding the implicit
@@ -180,7 +180,7 @@ public class ReflectionStructObjectInspector extends
       return null;
     }
     try {
-      ArrayList<Object> result = new ArrayList<Object>(fields.size());
+      ArrayList<Object> result = new ArrayList<>(fields.size());
       for (int i = 0; i < fields.size(); i++) {
         result.add(fields.get(i).field.get(data));
       }

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/objectinspector/StandardListObjectInspector.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/objectinspector/StandardListObjectInspector.java
@@ -161,7 +161,7 @@ public class StandardListObjectInspector implements SettableListObjectInspector 
   // SettableListObjectInspector
   @Override
   public Object create(int size) {
-    List<Object> a = new ArrayList<Object>(size);
+    List<Object> a = new ArrayList<>(size);
     for (int i = 0; i < size; i++) {
       a.add(null);
     }

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/objectinspector/StandardMapObjectInspector.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/objectinspector/StandardMapObjectInspector.java
@@ -98,7 +98,7 @@ public class StandardMapObjectInspector implements SettableMapObjectInspector {
   // SettableMapObjectInspector
   @Override
   public Object create() {
-    Map<Object, Object> m = new HashMap<Object, Object>();
+    Map<Object, Object> m = new HashMap<>();
     return m;
   }
 

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/objectinspector/StandardStructObjectInspector.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/objectinspector/StandardStructObjectInspector.java
@@ -118,7 +118,7 @@ public class StandardStructObjectInspector extends
     assert (structFieldComments == null ||
             (structFieldNames.size() == structFieldComments.size()));
 
-    fields = new ArrayList<MyField>(structFieldNames.size());
+    fields = new ArrayList<>(structFieldNames.size());
     for (int i = 0; i < structFieldNames.size(); i++) {
       fields.add(new MyField(i, structFieldNames.get(i),
           structFieldObjectInspectors.get(i),
@@ -131,7 +131,7 @@ public class StandardStructObjectInspector extends
   }
 
   protected void init(List<StructField> fields) {
-    this.fields = new ArrayList<MyField>(fields.size());
+    this.fields = new ArrayList<>(fields.size());
     for (int i = 0; i < fields.size(); i++) {
       this.fields.add(new MyField(i, fields.get(i).getFieldName(), fields
           .get(i).getFieldObjectInspector()));
@@ -211,7 +211,7 @@ public class StandardStructObjectInspector extends
   // SettableStructObjectInspector
   @Override
   public Object create() {
-    ArrayList<Object> a = new ArrayList<Object>(fields.size());
+    ArrayList<Object> a = new ArrayList<>(fields.size());
     for (int i = 0; i < fields.size(); i++) {
       a.add(null);
     }

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/objectinspector/UnionStructObjectInspector.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/objectinspector/UnionStructObjectInspector.java
@@ -82,7 +82,7 @@ public class UnionStructObjectInspector extends StructObjectInspector {
       totalSize += unionObjectInspectors.get(i).getAllStructFieldRefs().size();
     }
 
-    fields = new ArrayList<MyField>(totalSize);
+    fields = new ArrayList<>(totalSize);
     for (int i = 0; i < unionObjectInspectors.size(); i++) {
       StructObjectInspector oi = unionObjectInspectors.get(i);
       for (StructField sf : oi.getAllStructFieldRefs()) {
@@ -148,7 +148,7 @@ public class UnionStructObjectInspector extends StructObjectInspector {
     List<Object> list = (List<Object>) data;
     assert (list.size() == unionObjectInspectors.size());
     // Explode
-    ArrayList<Object> result = new ArrayList<Object>(fields.size());
+    ArrayList<Object> result = new ArrayList<>(fields.size());
     for (int i = 0; i < unionObjectInspectors.size(); i++) {
       result.addAll(unionObjectInspectors.get(i).getStructFieldsDataAsList(
           list.get(i)));

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/FileWriterHelper.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/FileWriterHelper.java
@@ -45,8 +45,8 @@ public class FileWriterHelper {
       new Schema.Field("key", Schema.create(Schema.Type.STRING), null, null),
       new Schema.Field("value", Schema.create(Schema.Type.STRING), null, null)));
 
-    DatumWriter<GenericRecord> datumWriter = new GenericDatumWriter<GenericRecord>(schema);
-    DataFileWriter<GenericRecord> dataFileWriter = new DataFileWriter<GenericRecord>(datumWriter);
+    DatumWriter<GenericRecord> datumWriter = new GenericDatumWriter<>(schema);
+    DataFileWriter<GenericRecord> dataFileWriter = new DataFileWriter<>(datumWriter);
     dataFileWriter.create(schema, out);
     try {
       for (int i = start; i < end; i++) {

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceStreamTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceStreamTest.java
@@ -285,7 +285,7 @@ public class HiveExploreServiceStreamTest extends BaseHiveExploreServiceTest {
     GenericRecord record = builder.build();
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     BinaryEncoder encoder = EncoderFactory.get().binaryEncoder(out, null);
-    DatumWriter<GenericRecord> writer = new GenericDatumWriter<GenericRecord>(schema);
+    DatumWriter<GenericRecord> writer = new GenericDatumWriter<>(schema);
 
     writer.write(record, encoder);
     encoder.flush();

--- a/cdap-explore/src/test/java/co/cask/cdap/hive/objectinspector/FullMapEqualComparerTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/hive/objectinspector/FullMapEqualComparerTest.java
@@ -34,7 +34,7 @@ public class FullMapEqualComparerTest {
     Map<Integer, Integer> mMap;
 
     public IntegerIntegerMapHolder() {
-      mMap = new TreeMap<Integer, Integer>();
+      mMap = new TreeMap<>();
     }
   }
 

--- a/cdap-explore/src/test/java/co/cask/cdap/hive/objectinspector/ObjectInspectorFactoryTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/hive/objectinspector/ObjectInspectorFactoryTest.java
@@ -82,7 +82,7 @@ public class ObjectInspectorFactoryTest {
     Assert.assertNull(soi.getStructFieldsDataAsList(null));
 
     // non nulls
-    ArrayList<Object> afields = new ArrayList<Object>();
+    ArrayList<Object> afields = new ArrayList<>();
     for (int i = 0; i < expectedFields.size(); i++) {
       Assert.assertEquals(expectedFields.get(i).get(data), soi.getStructFieldData(data, inspectorFields.get(i)));
       afields.add(soi.getStructFieldData(data, inspectorFields.get(i)));
@@ -119,9 +119,9 @@ public class ObjectInspectorFactoryTest {
     a.myString = "test";
     a.dummyStruct = a;
     a.myListString = Arrays.asList(new String[]{"a", "b", "c"});
-    a.myMapStringString = new HashMap<String, String>();
+    a.myMapStringString = new HashMap<>();
     a.myMapStringString.put("key", "value");
-    a.employee = new DummyEmployee<DummyAddress<String>>(new DummyAddress<String>("foo"));
+    a.employee = new DummyEmployee<>(new DummyAddress<>("foo"));
     a.ints = new int[] { 1, 2 };
 
     assertObjectInspection(DummyStruct.class, a);
@@ -129,7 +129,7 @@ public class ObjectInspectorFactoryTest {
     // NOTE: type has to come from TokenType, otherwise, if doing new DummyEmployee<...>().getClass(),
     // type will not be recognized as ParameterizedType
     assertObjectInspection(new TypeToken<DummyEmployee<DummyAddress<String>>>() { }.getType(),
-                           new DummyEmployee<DummyAddress<String>>(new DummyAddress<String>("foo")));
+                           new DummyEmployee<>(new DummyAddress<>("foo")));
   }
 
   ////////////// Dummy classes used for this class test /////////////

--- a/cdap-explore/src/test/java/co/cask/cdap/hive/objectinspector/SimpleMapEqualComparerTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/hive/objectinspector/SimpleMapEqualComparerTest.java
@@ -42,7 +42,7 @@ public class SimpleMapEqualComparerTest {
     Map<Integer, String> mMap;
 
     public IntegerStringMapHolder() {
-      mMap = new TreeMap<Integer, String>();
+      mMap = new TreeMap<>();
     }
   }
 
@@ -74,7 +74,7 @@ public class SimpleMapEqualComparerTest {
     Map<Text, String> mMap;
 
     public TextStringMapHolder() {
-      mMap = new TreeMap<Text, String>();
+      mMap = new TreeMap<>();
     }
   }
 
@@ -129,7 +129,7 @@ public class SimpleMapEqualComparerTest {
     Map<String, Text> mMap;
 
     public StringTextMapHolder() {
-      mMap = new TreeMap<String, Text>();
+      mMap = new TreeMap<>();
     }
   }
 

--- a/cdap-explore/src/test/java/co/cask/cdap/hive/objectinspector/StandardObjectInspectorsTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/hive/objectinspector/StandardObjectInspectorsTest.java
@@ -68,7 +68,7 @@ public class StandardObjectInspectorsTest {
       Assert.assertNull("loi1.getListElement(null, 100) should be null", loi1.getListElement(null, 100));
 
       // ArrayList
-      ArrayList<Integer> list = new ArrayList<Integer>();
+      ArrayList<Integer> list = new ArrayList<>();
       list.add(0);
       list.add(1);
       list.add(2);
@@ -114,7 +114,7 @@ public class StandardObjectInspectorsTest {
                           loi.getListElementObjectInspector());
 
       // Test set inspection
-      HashSet<Integer> set = new HashSet<Integer>();
+      HashSet<Integer> set = new HashSet<>();
       set.add(0);
       set.add(1);
       set.add(2);
@@ -154,7 +154,7 @@ public class StandardObjectInspectorsTest {
           loi.getListElementObjectInspector());
 
       // Test queue inspection
-      Queue<Integer> queue = new ArrayDeque<Integer>();
+      Queue<Integer> queue = new ArrayDeque<>();
       queue.add(0);
       queue.add(1);
       queue.add(2);
@@ -283,7 +283,7 @@ public class StandardObjectInspectorsTest {
     Assert.assertTrue(oi instanceof StandardListObjectInspector);
     loi = (StandardListObjectInspector) oi;
 
-    Queue<String> queue = new LinkedList<String>();
+    Queue<String> queue = new LinkedList<>();
     queue.add("foo");
     queue.add("bar");
     List<?> inspectedQueue = loi.getList(set);
@@ -319,7 +319,7 @@ public class StandardObjectInspectorsTest {
                           moi1.getTypeName());
 
       // HashMap
-      HashMap<String, Integer> map = new HashMap<String, Integer>();
+      HashMap<String, Integer> map = new HashMap<>();
       map.put("one", 1);
       map.put("two", 2);
       map.put("three", 3);
@@ -361,18 +361,18 @@ public class StandardObjectInspectorsTest {
   }
 
   private void doStandardObjectInspectorTest(boolean testComments) {
-    ArrayList<String> fieldNames = new ArrayList<String>();
+    ArrayList<String> fieldNames = new ArrayList<>();
     fieldNames.add("firstInteger");
     fieldNames.add("secondString");
     fieldNames.add("thirdBoolean");
-    ArrayList<ObjectInspector> fieldObjectInspectors = new ArrayList<ObjectInspector>();
+    ArrayList<ObjectInspector> fieldObjectInspectors = new ArrayList<>();
     fieldObjectInspectors
         .add(PrimitiveObjectInspectorFactory.javaIntObjectInspector);
     fieldObjectInspectors
         .add(PrimitiveObjectInspectorFactory.javaStringObjectInspector);
     fieldObjectInspectors
         .add(PrimitiveObjectInspectorFactory.javaBooleanObjectInspector);
-    ArrayList<String> fieldComments = new ArrayList<String>(3);
+    ArrayList<String> fieldComments = new ArrayList<>(3);
     if (testComments) {
       fieldComments.add("firstInteger comment");
       fieldComments.add("secondString comment");
@@ -433,7 +433,7 @@ public class StandardObjectInspectorsTest {
     Assert.assertNull(soi1.getStructFieldsDataAsList(null));
 
     // HashStruct
-    ArrayList<Object> struct = new ArrayList<Object>(3);
+    ArrayList<Object> struct = new ArrayList<>(3);
     struct.add(1);
     struct.add("two");
     struct.add(true);
@@ -453,7 +453,7 @@ public class StandardObjectInspectorsTest {
   @Test
   public void testStandardUnionObjectInspector() throws Throwable {
     try {
-      ArrayList<ObjectInspector> objectInspectors = new ArrayList<ObjectInspector>();
+      ArrayList<ObjectInspector> objectInspectors = new ArrayList<>();
       // add primitive types
       objectInspectors
           .add(PrimitiveObjectInspectorFactory.javaIntObjectInspector);
@@ -475,10 +475,10 @@ public class StandardObjectInspectorsTest {
           PrimitiveObjectInspectorFactory.javaStringObjectInspector));
 
       // add a struct
-      List<String> fieldNames = new ArrayList<String>();
+      List<String> fieldNames = new ArrayList<>();
       fieldNames.add("myDouble");
       fieldNames.add("myLong");
-      ArrayList<ObjectInspector> fieldObjectInspectors = new ArrayList<ObjectInspector>();
+      ArrayList<ObjectInspector> fieldObjectInspectors = new ArrayList<>();
       fieldObjectInspectors
           .add(PrimitiveObjectInspectorFactory.javaDoubleObjectInspector);
       fieldObjectInspectors
@@ -574,7 +574,7 @@ public class StandardObjectInspectorsTest {
       Assert.assertTrue(ObjectInspectorUtils.copyToStandardObject(
           union, uoi1).equals(true));
 
-      ArrayList<Integer> iList = new ArrayList<Integer>();
+      ArrayList<Integer> iList = new ArrayList<>();
       iList.add(4);
       iList.add(5);
       union = new StandardUnionObjectInspector.StandardUnion((byte) 3, iList);
@@ -586,7 +586,7 @@ public class StandardObjectInspectorsTest {
       Assert.assertTrue(ObjectInspectorUtils.copyToStandardObject(
           union, uoi1).equals(iList));
 
-      HashMap<Integer, String> map = new HashMap<Integer, String>();
+      HashMap<Integer, String> map = new HashMap<>();
       map.put(6, "six");
       map.put(7, "seven");
       map.put(8, "eight");
@@ -608,7 +608,7 @@ public class StandardObjectInspectorsTest {
           union, uoi1).equals(map));
 
 
-      ArrayList<Object> struct = new ArrayList<Object>(2);
+      ArrayList<Object> struct = new ArrayList<>(2);
       struct.add(9.0);
       struct.add(10L);
       union = new StandardUnionObjectInspector.StandardUnion((byte) 5, struct);

--- a/cdap-explore/src/test/java/co/cask/cdap/hive/objectinspector/UnionStructObjectInspectorTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/hive/objectinspector/UnionStructObjectInspectorTest.java
@@ -38,11 +38,11 @@ public class UnionStructObjectInspectorTest {
   @Test
   public void testUnionStructObjectInspector() throws Throwable {
     try {
-      ArrayList<String> fieldNames1 = new ArrayList<String>();
+      ArrayList<String> fieldNames1 = new ArrayList<>();
       fieldNames1.add("firstInteger");
       fieldNames1.add("secondString");
       fieldNames1.add("thirdBoolean");
-      ArrayList<ObjectInspector> fieldObjectInspectors1 = new ArrayList<ObjectInspector>();
+      ArrayList<ObjectInspector> fieldObjectInspectors1 = new ArrayList<>();
       fieldObjectInspectors1
           .add(PrimitiveObjectInspectorFactory.javaIntObjectInspector);
       fieldObjectInspectors1
@@ -52,10 +52,10 @@ public class UnionStructObjectInspectorTest {
       StandardStructObjectInspector soi1 =
           ObjectInspectorFactory.getStandardStructObjectInspector(fieldNames1, fieldObjectInspectors1);
 
-      ArrayList<String> fieldNames2 = new ArrayList<String>();
+      ArrayList<String> fieldNames2 = new ArrayList<>();
       fieldNames2.add("fourthDouble");
       fieldNames2.add("fifthLong");
-      ArrayList<ObjectInspector> fieldObjectInspectors2 = new ArrayList<ObjectInspector>();
+      ArrayList<ObjectInspector> fieldObjectInspectors2 = new ArrayList<>();
       fieldObjectInspectors2
           .add(PrimitiveObjectInspectorFactory.javaDoubleObjectInspector);
       fieldObjectInspectors2
@@ -96,17 +96,17 @@ public class UnionStructObjectInspectorTest {
       }
 
       // real struct
-      ArrayList<Object> struct1 = new ArrayList<Object>(3);
+      ArrayList<Object> struct1 = new ArrayList<>(3);
       struct1.add(1);
       struct1.add("two");
       struct1.add(true);
-      ArrayList<Object> struct2 = new ArrayList<Object>(2);
+      ArrayList<Object> struct2 = new ArrayList<>(2);
       struct2.add(1.0);
       struct2.add(111);
-      ArrayList<Object> struct = new ArrayList<Object>(2);
+      ArrayList<Object> struct = new ArrayList<>(2);
       struct.add(struct1);
       struct.add(struct2);
-      ArrayList<Object> all = new ArrayList<Object>(5);
+      ArrayList<Object> all = new ArrayList<>(5);
       all.addAll(struct1);
       all.addAll(struct2);
 

--- a/cdap-hbase-compat-0.94/src/main/java/co/cask/cdap/data2/increment/hbase94/IncrementHandler.java
+++ b/cdap-hbase-compat-0.94/src/main/java/co/cask/cdap/data2/increment/hbase94/IncrementHandler.java
@@ -127,14 +127,14 @@ public class IncrementHandler extends BaseRegionObserver {
 
     if (isIncrement || !transactional) {
       // incremental write
-      NavigableMap<byte[], List<KeyValue>> newFamilyMap = new TreeMap<byte[], List<KeyValue>>(Bytes.BYTES_COMPARATOR);
+      NavigableMap<byte[], List<KeyValue>> newFamilyMap = new TreeMap<>(Bytes.BYTES_COMPARATOR);
 
       long tsToAssign = 0;
       if (!transactional) {
         tsToAssign = state.getUniqueTimestamp();
       }
       for (Map.Entry<byte[], List<KeyValue>> entry : put.getFamilyMap().entrySet()) {
-        List<KeyValue> newCells = new ArrayList<KeyValue>(entry.getValue().size());
+        List<KeyValue> newCells = new ArrayList<>(entry.getValue().size());
         for (KeyValue kv : entry.getValue()) {
           // rewrite the cell value with a special prefix to identify it as a delta
           // for 0.98 we can update this to use cell tags
@@ -162,9 +162,9 @@ public class IncrementHandler extends BaseRegionObserver {
       long tsToAssign = state.getUniqueTimestamp();
       delete.setTimestamp(tsToAssign);
       // new key values
-      NavigableMap<byte[], List<KeyValue>> newFamilyMap = new TreeMap<byte[], List<KeyValue>>(Bytes.BYTES_COMPARATOR);
+      NavigableMap<byte[], List<KeyValue>> newFamilyMap = new TreeMap<>(Bytes.BYTES_COMPARATOR);
       for (Map.Entry<byte[], List<KeyValue>> entry : delete.getFamilyMap().entrySet()) {
-        List<KeyValue> newCells = new ArrayList<KeyValue>(entry.getValue().size());
+        List<KeyValue> newCells = new ArrayList<>(entry.getValue().size());
         for (KeyValue kv : entry.getValue()) {
           // replace the timestamp
           newCells.add(new KeyValue(kv.getBuffer(), kv.getRowOffset(), kv.getRowLength(),

--- a/cdap-hbase-compat-0.94/src/main/java/co/cask/cdap/data2/increment/hbase94/IncrementSummingScanner.java
+++ b/cdap-hbase-compat-0.94/src/main/java/co/cask/cdap/data2/increment/hbase94/IncrementSummingScanner.java
@@ -262,7 +262,7 @@ class IncrementSummingScanner implements RegionScanner {
   private static class WrappedScanner implements Closeable {
     private boolean hasMore;
     private byte[] currentRow;
-    private List<KeyValue> cellsToConsume = new ArrayList<KeyValue>();
+    private List<KeyValue> cellsToConsume = new ArrayList<>();
     private int currentIdx;
     private final InternalScanner scanner;
 

--- a/cdap-hbase-compat-0.94/src/test/java/co/cask/cdap/data/hbase/HBase94Test.java
+++ b/cdap-hbase-compat-0.94/src/test/java/co/cask/cdap/data/hbase/HBase94Test.java
@@ -130,7 +130,7 @@ public class HBase94Test extends HBaseTestBase {
   @Override
   public <T> Map<byte[], T> forEachRegion(byte[] tableName, Function<HRegion, T> function) {
     MiniHBaseCluster hbaseCluster = getHBaseCluster();
-    Map<byte[], T> results = new TreeMap<byte[], T>(Bytes.BYTES_COMPARATOR);
+    Map<byte[], T> results = new TreeMap<>(Bytes.BYTES_COMPARATOR);
     // make sure consumer config cache is updated
     for (JVMClusterUtil.RegionServerThread t : hbaseCluster.getRegionServerThreads()) {
       List<HRegion> serverRegions = t.getRegionServer().getOnlineRegions(tableName);

--- a/cdap-hbase-compat-0.94/src/test/java/co/cask/cdap/data2/increment/hbase94/IncrementHandlerTest.java
+++ b/cdap-hbase-compat-0.94/src/test/java/co/cask/cdap/data2/increment/hbase94/IncrementHandlerTest.java
@@ -154,7 +154,7 @@ public class IncrementHandlerTest extends AbstractIncrementHandlerTest {
      */
     @Override
     public void put(Put put) throws IOException {
-      region.batchMutate(new Pair[]{ new Pair<Mutation, Integer>(put, null) });
+      region.batchMutate(new Pair[]{ new Pair<>(put, null) });
     }
 
     @Override
@@ -172,7 +172,7 @@ public class IncrementHandlerTest extends AbstractIncrementHandlerTest {
       }
       RegionScanner rs = region.getScanner(scan);
       try {
-        List<KeyValue> tmpResults = new ArrayList<KeyValue>();
+        List<KeyValue> tmpResults = new ArrayList<>();
         boolean hasMore = rs.next(tmpResults);
         for (KeyValue cell : tmpResults) {
           results.add(convertCell(cell));

--- a/cdap-hbase-compat-0.94/src/test/java/co/cask/cdap/data2/increment/hbase94/IncrementSummingScannerTest.java
+++ b/cdap-hbase-compat-0.94/src/test/java/co/cask/cdap/data2/increment/hbase94/IncrementSummingScannerTest.java
@@ -453,6 +453,6 @@ public class IncrementSummingScannerTest {
    * Work around a bug in HRegion.internalPut(), where RegionObserver.prePut() modifications are not applied.
    */
   static void doPut(HRegion region, Put p) throws Exception {
-    region.batchMutate(new Pair[]{ new Pair<Mutation, Integer>(p, null) });
+    region.batchMutate(new Pair[]{ new Pair<>(p, null) });
   }
 }

--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/increment/hbase96/IncrementHandler.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/increment/hbase96/IncrementHandler.java
@@ -129,14 +129,14 @@ public class IncrementHandler extends BaseRegionObserver {
 
     if (isIncrement || !transactional) {
       // incremental write
-      NavigableMap<byte[], List<Cell>> newFamilyMap = new TreeMap<byte[], List<Cell>>(Bytes.BYTES_COMPARATOR);
+      NavigableMap<byte[], List<Cell>> newFamilyMap = new TreeMap<>(Bytes.BYTES_COMPARATOR);
 
       long tsToAssign = 0;
       if (!transactional) {
         tsToAssign = state.getUniqueTimestamp();
       }
       for (Map.Entry<byte[], List<Cell>> entry : put.getFamilyCellMap().entrySet()) {
-        List<Cell> newCells = new ArrayList<Cell>(entry.getValue().size());
+        List<Cell> newCells = new ArrayList<>(entry.getValue().size());
         for (Cell cell : entry.getValue()) {
           // rewrite the cell value with a special prefix to identify it as a delta
           // for 0.98 we can update this to use cell tags
@@ -163,9 +163,9 @@ public class IncrementHandler extends BaseRegionObserver {
       long tsToAssign = state.getUniqueTimestamp();
       delete.setTimestamp(tsToAssign);
       // new key values
-      NavigableMap<byte[], List<Cell>> newFamilyMap = new TreeMap<byte[], List<Cell>>(Bytes.BYTES_COMPARATOR);
+      NavigableMap<byte[], List<Cell>> newFamilyMap = new TreeMap<>(Bytes.BYTES_COMPARATOR);
       for (Map.Entry<byte[], List<Cell>> entry : delete.getFamilyCellMap().entrySet()) {
-        List<Cell> newCells = new ArrayList<Cell>(entry.getValue().size());
+        List<Cell> newCells = new ArrayList<>(entry.getValue().size());
         for (Cell kv : entry.getValue()) {
           //LOG.info("Replacing delete cell: " + kv);
           // replace the timestamp

--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/increment/hbase96/IncrementSummingScanner.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/increment/hbase96/IncrementSummingScanner.java
@@ -265,7 +265,7 @@ class IncrementSummingScanner implements RegionScanner {
   private static class WrappedScanner implements Closeable {
     private boolean hasMore;
     private byte[] currentRow;
-    private List<Cell> cellsToConsume = new ArrayList<Cell>();
+    private List<Cell> cellsToConsume = new ArrayList<>();
     private int currentIdx;
     private final InternalScanner scanner;
 

--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/util/hbase/MockRegionServerServices.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/util/hbase/MockRegionServerServices.java
@@ -52,10 +52,10 @@ import java.util.concurrent.ConcurrentSkipListMap;
 public class MockRegionServerServices implements RegionServerServices {
   private final Configuration hConf;
   private final ZooKeeperWatcher zookeeper;
-  private final Map<String, HRegion> regions = new HashMap<String, HRegion>();
+  private final Map<String, HRegion> regions = new HashMap<>();
   private boolean stopping = false;
   private final ConcurrentSkipListMap<byte[], Boolean> rit =
-    new ConcurrentSkipListMap<byte[], Boolean>(Bytes.BYTES_COMPARATOR);
+    new ConcurrentSkipListMap<>(Bytes.BYTES_COMPARATOR);
   private HFileSystem hfs = null;
   private ServerName serverName = null;
   private RpcServerInterface rpcServer = null;

--- a/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data/hbase/HBase96Test.java
+++ b/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data/hbase/HBase96Test.java
@@ -133,7 +133,7 @@ public class HBase96Test extends HBaseTestBase {
   @Override
   public <T> Map<byte[], T> forEachRegion(byte[] tableName, Function<HRegion, T> function) {
     MiniHBaseCluster hbaseCluster = getHBaseCluster();
-    Map<byte[], T> results = new TreeMap<byte[], T>(Bytes.BYTES_COMPARATOR);
+    Map<byte[], T> results = new TreeMap<>(Bytes.BYTES_COMPARATOR);
     // make sure consumer config cache is updated
     for (JVMClusterUtil.RegionServerThread t : hbaseCluster.getRegionServerThreads()) {
       List<HRegion> serverRegions = t.getRegionServer().getOnlineRegions(TableName.valueOf(tableName));

--- a/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data2/increment/hbase96/IncrementHandlerTest.java
+++ b/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data2/increment/hbase96/IncrementHandlerTest.java
@@ -171,7 +171,7 @@ public class IncrementHandlerTest extends AbstractIncrementHandlerTest {
       }
       RegionScanner rs = region.getScanner(scan);
       try {
-        List<Cell> tmpResults = new ArrayList<Cell>();
+        List<Cell> tmpResults = new ArrayList<>();
         boolean hasMore = rs.next(tmpResults);
         for (Cell cell : tmpResults) {
           results.add(convertCell(cell));

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/increment/hbase98/IncrementHandler.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/increment/hbase98/IncrementHandler.java
@@ -130,14 +130,14 @@ public class IncrementHandler extends BaseRegionObserver {
 
     if (isIncrement || !transactional) {
       // incremental write
-      NavigableMap<byte[], List<Cell>> newFamilyMap = new TreeMap<byte[], List<Cell>>(Bytes.BYTES_COMPARATOR);
+      NavigableMap<byte[], List<Cell>> newFamilyMap = new TreeMap<>(Bytes.BYTES_COMPARATOR);
 
       long tsToAssign = 0;
       if (!transactional) {
         tsToAssign = state.getUniqueTimestamp();
       }
       for (Map.Entry<byte[], List<Cell>> entry : put.getFamilyCellMap().entrySet()) {
-        List<Cell> newCells = new ArrayList<Cell>(entry.getValue().size());
+        List<Cell> newCells = new ArrayList<>(entry.getValue().size());
         for (Cell cell : entry.getValue()) {
           // rewrite the cell value with a special prefix to identify it as a delta
           // for 0.98 we can update this to use cell tags
@@ -164,9 +164,9 @@ public class IncrementHandler extends BaseRegionObserver {
       long tsToAssign = state.getUniqueTimestamp();
       delete.setTimestamp(tsToAssign);
       // new key values
-      NavigableMap<byte[], List<Cell>> newFamilyMap = new TreeMap<byte[], List<Cell>>(Bytes.BYTES_COMPARATOR);
+      NavigableMap<byte[], List<Cell>> newFamilyMap = new TreeMap<>(Bytes.BYTES_COMPARATOR);
       for (Map.Entry<byte[], List<Cell>> entry : delete.getFamilyCellMap().entrySet()) {
-        List<Cell> newCells = new ArrayList<Cell>(entry.getValue().size());
+        List<Cell> newCells = new ArrayList<>(entry.getValue().size());
         for (Cell kv : entry.getValue()) {
           // replace the timestamp
           newCells.add(CellUtil.createCell(CellUtil.cloneRow(kv),

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/increment/hbase98/IncrementSummingScanner.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/increment/hbase98/IncrementSummingScanner.java
@@ -265,7 +265,7 @@ class IncrementSummingScanner implements RegionScanner {
   private static class WrappedScanner implements Closeable {
     private boolean hasMore;
     private byte[] currentRow;
-    private List<Cell> cellsToConsume = new ArrayList<Cell>();
+    private List<Cell> cellsToConsume = new ArrayList<>();
     private int currentIdx;
     private final InternalScanner scanner;
 

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/util/hbase/MockRegionServerServices.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/util/hbase/MockRegionServerServices.java
@@ -56,10 +56,10 @@ import java.util.concurrent.ConcurrentSkipListMap;
 public class MockRegionServerServices implements RegionServerServices {
   private final Configuration hConf;
   private final ZooKeeperWatcher zookeeper;
-  private final Map<String, HRegion> regions = new HashMap<String, HRegion>();
+  private final Map<String, HRegion> regions = new HashMap<>();
   private boolean stopping = false;
   private final ConcurrentSkipListMap<byte[], Boolean> rit =
-    new ConcurrentSkipListMap<byte[], Boolean>(Bytes.BYTES_COMPARATOR);
+    new ConcurrentSkipListMap<>(Bytes.BYTES_COMPARATOR);
   private HFileSystem hfs = null;
   private ServerName serverName = null;
   private RpcServerInterface rpcServer = null;

--- a/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data/hbase/HBase98Test.java
+++ b/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data/hbase/HBase98Test.java
@@ -133,7 +133,7 @@ public class HBase98Test extends HBaseTestBase {
   @Override
   public <T> Map<byte[], T> forEachRegion(byte[] tableName, Function<HRegion, T> function) {
     MiniHBaseCluster hbaseCluster = getHBaseCluster();
-    Map<byte[], T> results = new TreeMap<byte[], T>(Bytes.BYTES_COMPARATOR);
+    Map<byte[], T> results = new TreeMap<>(Bytes.BYTES_COMPARATOR);
     // make sure consumer config cache is updated
     for (JVMClusterUtil.RegionServerThread t : hbaseCluster.getRegionServerThreads()) {
       List<HRegion> serverRegions = t.getRegionServer().getOnlineRegions(TableName.valueOf(tableName));

--- a/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data2/increment/hbase98/IncrementHandlerTest.java
+++ b/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data2/increment/hbase98/IncrementHandlerTest.java
@@ -167,7 +167,7 @@ public class IncrementHandlerTest extends AbstractIncrementHandlerTest {
       }
       RegionScanner rs = region.getScanner(scan);
       try {
-        List<Cell> tmpResults = new ArrayList<Cell>();
+        List<Cell> tmpResults = new ArrayList<>();
         boolean hasMore = rs.next(tmpResults);
         for (Cell cell : tmpResults) {
           results.add(convertCell(cell));

--- a/cdap-notifications/src/main/java/co/cask/cdap/notifications/service/AbstractNotificationService.java
+++ b/cdap-notifications/src/main/java/co/cask/cdap/notifications/service/AbstractNotificationService.java
@@ -103,7 +103,7 @@ public abstract class AbstractNotificationService extends AbstractIdleService im
     // This call will make sure that the feed exists
     feedManager.getFeed(feed);
 
-    NotificationCaller<N> caller = new NotificationCaller<N>(feed, handler, executor);
+    NotificationCaller<N> caller = new NotificationCaller<>(feed, handler, executor);
     subscribers.put(feed, caller);
     return caller;
   }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/ProgramType.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/ProgramType.java
@@ -93,7 +93,7 @@ public enum ProgramType {
   private static final Map<String, ProgramType> CATEGORY_MAP;
 
   static {
-    CATEGORY_MAP = new HashMap<String, ProgramType>();
+    CATEGORY_MAP = new HashMap<>();
     for (ProgramType type : ProgramType.values()) {
       CATEGORY_MAP.put(type.getCategoryName(), type);
     }

--- a/cdap-security/src/main/java/co/cask/cdap/security/auth/DistributedKeyManager.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/auth/DistributedKeyManager.java
@@ -84,7 +84,7 @@ public class DistributedKeyManager extends AbstractKeyManager implements Resourc
       acls = ZooDefs.Ids.OPEN_ACL_UNSAFE;
     }
     LOG.info("Zookeeper ACLs {} for keys", acls);
-    this.keyCache = new SharedResourceCache<KeyIdentifier>(zookeeper, codec, "/keys", acls);
+    this.keyCache = new SharedResourceCache<>(zookeeper, codec, "/keys", acls);
   }
 
   @Override

--- a/cdap-security/src/main/java/co/cask/cdap/security/guice/SecurityModule.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/guice/SecurityModule.java
@@ -122,7 +122,7 @@ public abstract class SecurityModule extends PrivateModule {
 
     @Inject
     public AuthenticationHandlerMapProvider(@Named("security.handlers.map") Map<String, Object> handlers) {
-      handlerMap = new HashMap<String, Object>(handlers);
+      handlerMap = new HashMap<>(handlers);
     }
 
     @Override

--- a/cdap-security/src/main/java/co/cask/cdap/security/server/JAASLoginService.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/server/JAASLoginService.java
@@ -145,7 +145,7 @@ public class JAASLoginService extends AbstractLifeCycle implements LoginService 
 
   /* ------------------------------------------------------------ */
   public void setRoleClassNames (String[] classnames) {
-    ArrayList<String> tmp = new ArrayList<String>();
+    ArrayList<String> tmp = new ArrayList<>();
 
     if (classnames != null) {
       tmp.addAll(Arrays.asList(classnames));
@@ -272,7 +272,7 @@ public class JAASLoginService extends AbstractLifeCycle implements LoginService 
   private String[] getGroups (Subject subject) {
     //get all the roles of the various types
     String[] roleClassNames = getRoleClassNames();
-    Collection<String> groups = new LinkedHashSet<String>();
+    Collection<String> groups = new LinkedHashSet<>();
     try {
       for (String roleClassName : roleClassNames) {
         Class loadClass = Thread.currentThread().getContextClassLoader().loadClass(roleClassName);

--- a/cdap-security/src/main/java/co/cask/cdap/security/server/JASPIAuthenticationHandler.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/server/JASPIAuthenticationHandler.java
@@ -77,7 +77,7 @@ public class JASPIAuthenticationHandler extends AbstractAuthenticationHandler {
     JaspiAuthenticatorFactory jaspiAuthenticatorFactory = new JaspiAuthenticatorFactory();
     jaspiAuthenticatorFactory.setLoginService(getHandlerLoginService());
 
-    HashMap<String, ServerAuthContext> serverAuthContextMap = new HashMap<String, ServerAuthContext>();
+    HashMap<String, ServerAuthContext> serverAuthContextMap = new HashMap<>();
     ServletCallbackHandler callbackHandler = new ServletCallbackHandler(getHandlerLoginService());
     ServerAuthModule authModule = new BasicAuthModule(callbackHandler, "JAASRealm");
     serverAuthContextMap.put("authContextID", new ServerAuthContextImpl(Collections.singletonList(authModule)));
@@ -108,7 +108,7 @@ public class JASPIAuthenticationHandler extends AbstractAuthenticationHandler {
     return new Configuration() {
       @Override
       public AppConfigurationEntry[] getAppConfigurationEntry(String s) {
-        HashMap<String, String> map = new HashMap<String, String>();
+        HashMap<String, String> map = new HashMap<>();
 
 
         String configRegex = Constants.Security.AUTH_HANDLER_CONFIG_BASE.replace(".", "\\.").concat(".");

--- a/cdap-security/src/test/java/co/cask/cdap/security/auth/TestFileBasedTokenManager.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/auth/TestFileBasedTokenManager.java
@@ -49,7 +49,7 @@ public class TestFileBasedTokenManager extends TestTokenManager {
     TokenManager tokenManager = injector.getInstance(TokenManager.class);
     tokenManager.startAndWait();
     Codec<AccessToken> tokenCodec = injector.getInstance(AccessTokenCodec.class);
-    return new ImmutablePair<TokenManager, Codec<AccessToken>>(tokenManager, tokenCodec);
+    return new ImmutablePair<>(tokenManager, tokenCodec);
   }
 
   /**

--- a/cdap-security/src/test/java/co/cask/cdap/security/auth/TestInMemoryTokenManager.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/auth/TestInMemoryTokenManager.java
@@ -38,6 +38,6 @@ public class TestInMemoryTokenManager extends TestTokenManager {
     TokenManager tokenManager = injector.getInstance(TokenManager.class);
     tokenManager.startAndWait();
     Codec<AccessToken> tokenCodec = injector.getInstance(AccessTokenCodec.class);
-    return new ImmutablePair<TokenManager, Codec<AccessToken>>(tokenManager, tokenCodec);
+    return new ImmutablePair<>(tokenManager, tokenCodec);
   }
 }

--- a/cdap-security/src/test/java/co/cask/cdap/security/zookeeper/SharedResourceCacheTest.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/zookeeper/SharedResourceCacheTest.java
@@ -88,7 +88,7 @@ public class SharedResourceCacheTest {
     ZKClientService zkClient1 = injector1.getInstance(ZKClientService.class);
     zkClient1.startAndWait();
     SharedResourceCache<String> cache1 =
-      new SharedResourceCache<String>(zkClient1, new StringCodec(), parentZNode, acls);
+      new SharedResourceCache<>(zkClient1, new StringCodec(), parentZNode, acls);
     cache1.init();
 
     // add items to one and wait for them to show up in the second
@@ -99,7 +99,7 @@ public class SharedResourceCacheTest {
     ZKClientService zkClient2 = injector2.getInstance(ZKClientService.class);
     zkClient2.startAndWait();
     SharedResourceCache<String> cache2 =
-      new SharedResourceCache<String>(zkClient2, new StringCodec(), parentZNode, acls);
+      new SharedResourceCache<>(zkClient2, new StringCodec(), parentZNode, acls);
     cache2.init();
 
     waitForEntry(cache2, key1, value1, 10000);

--- a/cdap-unit-test/src/test/java/co/cask/cdap/mapreduce/MapReduceStreamInputTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/mapreduce/MapReduceStreamInputTestRun.java
@@ -73,7 +73,7 @@ public class MapReduceStreamInputTestRun extends TestFrameworkTestBase {
       .build();
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     BinaryEncoder encoder = EncoderFactory.get().binaryEncoder(out, null);
-    DatumWriter<GenericRecord> writer = new GenericDatumWriter<GenericRecord>(schema);
+    DatumWriter<GenericRecord> writer = new GenericDatumWriter<>(schema);
 
     writer.write(record, encoder);
     encoder.flush();

--- a/cdap-unit-test/src/test/java/co/cask/cdap/spark/service/TestSparkServiceIntegrationApp.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/spark/service/TestSparkServiceIntegrationApp.java
@@ -89,7 +89,7 @@ public class TestSparkServiceIntegrationApp extends AbstractApplication {
           BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream()));
           String squaredVale = reader.readLine();
           Closeables.closeQuietly(reader);
-          return new Tuple2<byte[], byte[]>(Bytes.toBytes(String.valueOf(num)),
+          return new Tuple2<>(Bytes.toBytes(String.valueOf(num)),
                                             Bytes.toBytes(squaredVale));
         }
       });

--- a/cdap-unit-test/src/test/java/co/cask/cdap/spark/stream/TestSparkStreamIntegrationApp.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/spark/stream/TestSparkStreamIntegrationApp.java
@@ -58,7 +58,7 @@ public class TestSparkStreamIntegrationApp extends AbstractApplication {
         byte[], byte[]>() {
         @Override
         public Tuple2<byte[], byte[]> call(Tuple2<LongWritable, String> longWritableTextTuple2) throws Exception {
-          return new Tuple2<byte[], byte[]>(Bytes.toBytes(longWritableTextTuple2._2()),
+          return new Tuple2<>(Bytes.toBytes(longWritableTextTuple2._2()),
                                             Bytes.toBytes(longWritableTextTuple2._2()));
         }
       });

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/appender/kafka/LoggingEventSerializer.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/appender/kafka/LoggingEventSerializer.java
@@ -57,7 +57,7 @@ public final class LoggingEventSerializer {
   public byte[] toBytes(ILoggingEvent loggingEvent, LoggingContext loggingContext) {
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     BinaryEncoder encoder = EncoderFactory.get().directBinaryEncoder(out, null);
-    GenericDatumWriter<GenericRecord> writer = new GenericDatumWriter<GenericRecord>(logSchema.getAvroSchema());
+    GenericDatumWriter<GenericRecord> writer = new GenericDatumWriter<>(logSchema.getAvroSchema());
     try {
       writer.write(LoggingEvent.encode(logSchema.getAvroSchema(), loggingEvent, loggingContext), encoder);
     } catch (IOException e) {
@@ -81,7 +81,7 @@ public final class LoggingEventSerializer {
     }
 
     BinaryDecoder decoder = DecoderFactory.get().directBinaryDecoder(in, null);
-    GenericDatumReader<GenericRecord> reader = new GenericDatumReader<GenericRecord>(logSchema.getAvroSchema());
+    GenericDatumReader<GenericRecord> reader = new GenericDatumReader<>(logSchema.getAvroSchema());
     try {
       return reader.read(null, decoder);
     } catch (IOException e) {

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/appender/kafka/SimpleKafkaProducer.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/appender/kafka/SimpleKafkaProducer.java
@@ -55,12 +55,12 @@ public final class SimpleKafkaProducer {
     ProducerConfig config = new ProducerConfig(props);
 
     kafkaTopic = KafkaTopic.getTopic();
-    producer = new Producer<String, byte[]>(config);
+    producer = new Producer<>(config);
   }
 
   public void publish(String key, byte[] bytes) {
     try {
-      KeyedMessage<String, byte[]> data = new KeyedMessage<String, byte[]>(kafkaTopic, key, bytes);
+      KeyedMessage<String, byte[]> data = new KeyedMessage<>(kafkaTopic, key, bytes);
       producer.send(data);
     } catch (Throwable t) {
       LOG.error("Exception when trying to publish log message to kafka with key {} and topic {}", key, kafkaTopic, t);

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/read/AvroFileReader.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/read/AvroFileReader.java
@@ -182,7 +182,7 @@ public class AvroFileReader {
   }
 
   private DataFileReader<GenericRecord> createReader(Location location) throws IOException {
-    return new DataFileReader<GenericRecord>(new LocationSeekableInput(location),
+    return new DataFileReader<>(new LocationSeekableInput(location),
                                              new GenericDatumReader<GenericRecord>(schema));
 
   }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/KafkaLogWriterPlugin.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/KafkaLogWriterPlugin.java
@@ -210,7 +210,7 @@ public class KafkaLogWriterPlugin extends AbstractKafkaLogProcessor {
           long eventArrivalBucketKey = System.currentTimeMillis() / eventBucketIntervalMs;
           msgList = Lists.newArrayList();
           messageTable.put(key, loggingContext.getLogPathFragment(logBaseDir),
-                           new AbstractMap.SimpleEntry<Long, List<KafkaLogEvent>>(eventArrivalBucketKey, msgList));
+                           new AbstractMap.SimpleEntry<>(eventArrivalBucketKey, msgList));
         } else {
           msgList = messageTable.get(key, loggingContext.getLogPathFragment(logBaseDir)).getValue();
         }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/LogSaver.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/LogSaver.java
@@ -63,8 +63,8 @@ public final class LogSaver extends AbstractIdleService implements PartitionChan
     LOG.info(String.format("Kafka topic is %s", this.topic));
 
     this.kafkaClient = kafkaClient;
-    this.kafkaCancelMap = new HashMap<Integer, Cancellable>();
-    this.kafkaCancelCallbackLatchMap = new HashMap<Integer, CountDownLatch>();
+    this.kafkaCancelMap = new HashMap<>();
+    this.kafkaCancelCallbackLatchMap = new HashMap<>();
     this.messageProcessors = messageProcessors;
   }
 

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/serialize/CallerDataSerializer.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/serialize/CallerDataSerializer.java
@@ -30,7 +30,7 @@ public final class CallerDataSerializer {
   public static GenericArray<GenericRecord> encode(Schema schema, StackTraceElement[] stackTraceElements) {
     if (stackTraceElements != null) {
       Schema steArraySchema = schema.getTypes().get(1);
-      GenericArray<GenericRecord> steArray = new GenericData.Array<GenericRecord>(stackTraceElements.length,
+      GenericArray<GenericRecord> steArray = new GenericData.Array<>(stackTraceElements.length,
                                                                                   steArraySchema);
       for (StackTraceElement stackTraceElement : stackTraceElements) {
         steArray.add(StackTraceElementSerializer.encode(steArraySchema.getElementType(), stackTraceElement));

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/serialize/LoggingEvent.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/serialize/LoggingEvent.java
@@ -182,7 +182,7 @@ public final class LoggingEvent implements ILoggingEvent {
 
     if (loggingEvent.argumentArray != null) {
     GenericArray<String> argArray =
-      new GenericData.Array<String>(loggingEvent.argumentArray.length,
+      new GenericData.Array<>(loggingEvent.argumentArray.length,
                                     schema.getField("argumentArray").schema().getTypes().get(1));
       Collections.addAll(argArray, loggingEvent.argumentArray);
       datum.put("argumentArray", argArray);

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/serialize/StackTraceElementProxyArraySerializer.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/serialize/StackTraceElementProxyArraySerializer.java
@@ -31,7 +31,7 @@ public final class StackTraceElementProxyArraySerializer {
   public static GenericArray<GenericRecord> encode(Schema schema, StackTraceElementProxy[] stackTraceElementProxies) {
     if (stackTraceElementProxies != null) {
       Schema steArraySchema = schema.getTypes().get(1);
-      GenericArray<GenericRecord> steArray = new GenericData.Array<GenericRecord>(stackTraceElementProxies.length,
+      GenericArray<GenericRecord> steArray = new GenericData.Array<>(stackTraceElementProxies.length,
                                                                                   steArraySchema);
       for (StackTraceElementProxy ste : stackTraceElementProxies) {
         steArray.add(StackTraceElementProxySerializer.encode(steArraySchema.getElementType(), ste));

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/serialize/ThrowableProxyArraySerializer.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/serialize/ThrowableProxyArraySerializer.java
@@ -31,7 +31,7 @@ public final class ThrowableProxyArraySerializer {
   public static GenericArray<GenericRecord> encode(Schema schema, IThrowableProxy[] throwableProxies) {
     if (throwableProxies != null) {
       Schema tpArraySchema = schema.getTypes().get(1);
-      GenericArray<GenericRecord> steArray = new GenericData.Array<GenericRecord>(throwableProxies.length,
+      GenericArray<GenericRecord> steArray = new GenericData.Array<>(throwableProxies.length,
                                                                                   tpArraySchema);
       for (IThrowableProxy tp : throwableProxies) {
         steArray.add(ThrowableProxySerializer.encode(tpArraySchema.getElementType(), tp));

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/write/AvroFileWriter.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/write/AvroFileWriter.java
@@ -232,7 +232,7 @@ public final class AvroFileWriter implements Closeable, Flushable {
      */
     void open() throws IOException {
       this.outputStream = new FSDataOutputStream(location.getOutputStream(), null);
-      this.dataFileWriter = new DataFileWriter<GenericRecord>(new GenericDatumWriter<GenericRecord>(schema));
+      this.dataFileWriter = new DataFileWriter<>(new GenericDatumWriter<GenericRecord>(schema));
       this.dataFileWriter.create(schema, this.outputStream);
       this.dataFileWriter.setSyncInterval(syncIntervalBytes);
       this.lastModifiedTs = System.currentTimeMillis();

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/store/upgrade/MetricsEntityCodec.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/store/upgrade/MetricsEntityCodec.java
@@ -139,7 +139,7 @@ final class MetricsEntityCodec {
     Arrays.fill(result, entityParts.length * idSize, depth * idSize, (byte) (padding & 0xff));
     Arrays.fill(mask, entityParts.length * idSize, depth * idSize, (byte) 1);
 
-    return new ImmutablePair<byte[], byte[]>(result, mask);
+    return new ImmutablePair<>(result, mask);
   }
 
   public String decode(MetricsEntityType type, byte[] encoded) {

--- a/cdap-watchdog/src/test/java/co/cask/cdap/metrics/collect/AggregatedMetricsCollectionServiceTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/metrics/collect/AggregatedMetricsCollectionServiceTest.java
@@ -39,7 +39,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class AggregatedMetricsCollectionServiceTest {
 
-  private static final HashMap<String, String> EMPTY_TAGS = new HashMap<String, String>();
+  private static final HashMap<String, String> EMPTY_TAGS = new HashMap<>();
   private static final String NAMESPACE = "testnamespace";
   private static final String APP = "testapp";
   private static final String FLOW = "testprogram";
@@ -62,7 +62,7 @@ public class AggregatedMetricsCollectionServiceTest {
   @Category(SlowTests.class)
   @Test
   public void testPublish() throws InterruptedException {
-    final BlockingQueue<MetricValues> published = new LinkedBlockingQueue<MetricValues>();
+    final BlockingQueue<MetricValues> published = new LinkedBlockingQueue<>();
 
     AggregatedMetricsCollectionService service = new AggregatedMetricsCollectionService() {
       @Override

--- a/cdap-watchdog/src/test/java/co/cask/cdap/metrics/collect/KafkaMetricsCollectionServiceTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/metrics/collect/KafkaMetricsCollectionServiceTest.java
@@ -181,7 +181,7 @@ public class KafkaMetricsCollectionServiceTest {
     kafkaClient.getConsumer().prepare().addFromBeginning("metrics", 0)
                                        .consume(new KafkaConsumer.MessageCallback() {
 
-      ReflectionDatumReader<MetricValues> reader = new ReflectionDatumReader<MetricValues>(schema, metricRecordType);
+      ReflectionDatumReader<MetricValues> reader = new ReflectionDatumReader<>(schema, metricRecordType);
 
       @Override
       public void onReceived(Iterator<FetchedMessage> messages) {


### PR DESCRIPTION
Intellij and the docs linked below say that in Java 7, the explicit type declaration for generic classes is unnecessary as long as the compiler can infer them, so removed them.
I don't see any drawbacks to this.

http://docs.oracle.com/javase/7/docs/technotes/guides/language/type-inference-generic-instance-creation.html

https://builds.cask.co/browse/CDAP-DUT1972-1

These updates were done by IntelliJ's Run Inspection > Fix utility.