### PR TITLE
Fix broken doc build.

### DIFF
--- a/cdap-docs/examples-manual/build.sh
+++ b/cdap-docs/examples-manual/build.sh
@@ -154,9 +154,9 @@ function download_includes() {
   test_an_include 2176f426a50b2d68817cd7da7b7faffb ../../cdap-examples/StreamConversion/src/main/java/co/cask/cdap/examples/streamconversion/StreamConversionApp.java
   test_an_include b3ad7dc7ddbb5b905145dbf15a5c9b93 ../../cdap-examples/StreamConversion/src/main/java/co/cask/cdap/examples/streamconversion/StreamConversionMapReduce.java
   
-  test_an_include dc6519d102875a83621f262c33c61894 ../../cdap-examples/UserProfiles/src/main/java/co/cask/cdap/examples/profiles/UserProfiles.java
+  test_an_include 2260781c7cef2938aa36c946f3a34341 ../../cdap-examples/UserProfiles/src/main/java/co/cask/cdap/examples/profiles/UserProfiles.java
 
-  test_an_include 71b267e35cfd92e517ef1bf4064ab338 ../../cdap-examples/WebAnalytics/src/main/java/co/cask/cdap/examples/webanalytics/UniqueVisitor.java
+  test_an_include 75aee2ce7b34eb125d41a295d5f3122d ../../cdap-examples/WebAnalytics/src/main/java/co/cask/cdap/examples/webanalytics/UniqueVisitor.java
   test_an_include 017ddf948db9cba0eebf4856c701a7e8 ../../cdap-examples/WebAnalytics/src/main/java/co/cask/cdap/examples/webanalytics/UniqueVisitCount.java
   test_an_include aa540e9300b264c928db582fb0d09f36 ../../cdap-examples/WebAnalytics/src/main/java/co/cask/cdap/examples/webanalytics/WebAnalyticsFlow.java
   

--- a/cdap-docs/examples-manual/source/examples/user-profiles.rst
+++ b/cdap-docs/examples-manual/source/examples/user-profiles.rst
@@ -40,7 +40,7 @@ of the Application are tied together by a class ``UserProfiles``:
 
 .. literalinclude:: /../../../cdap-examples/UserProfiles/src/main/java/co/cask/cdap/examples/profiles/UserProfiles.java
     :language: java
-    :lines: 34-
+    :lines: 33-
 
 This application uses a Table with conflict detection either at the row level or
 at the column level.
@@ -100,7 +100,7 @@ Before building the application, set the ``ConflictDetection`` appropriately in 
 
 .. literalinclude:: /../../../cdap-examples/UserProfiles/src/main/java/co/cask/cdap/examples/profiles/UserProfiles.java
       :language: java
-      :lines: 56-58
+      :lines: 55-57
       
 - The first time you build the application, set the ``Table.PROPERTY_CONFLICT_LEVEL`` to
   ``ConflictDetection.ROW.name()``. 

--- a/cdap-docs/examples-manual/source/examples/web-analytics.rst
+++ b/cdap-docs/examples-manual/source/examples/web-analytics.rst
@@ -70,7 +70,7 @@ Here is what the ``UniqueVisitor`` flowlet looks like:
 
 .. literalinclude:: /../../../cdap-examples/WebAnalytics/src/main/java/co/cask/cdap/examples/webanalytics/UniqueVisitor.java
    :language: java
-   :lines: 35-
+   :lines: 33-
 
 The ``UniqueVisitCount`` dataset provides an abstraction of the data logic for incrementing the visit count for a
 given IP. It exposes an ``increment`` method, implemented as:


### PR DESCRIPTION
Fixes the doc build. The break was due to changes in Java files that are included in the examples and are incorporated as part of the build. As these files are referenced by line number, any changes to the files can potentially require a change in the code that includes fragments of the Java code. In this case, that was so, as lines had been deleted from the Java code, and so the offsets needed to be adjusted in the documentation to accommodate.