### PR TITLE
CDAP-2656 fix the time field for tweets to just use the timestamp

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/realtime/source/TwitterSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/realtime/source/TwitterSource.java
@@ -115,7 +115,10 @@ public class TwitterSource extends RealtimeSource<StructuredRecord> {
     recordBuilder.set(ID, tweet.getId());
     recordBuilder.set(MSG, tweet.getText());
     recordBuilder.set(LANG, tweet.getLang());
-    recordBuilder.set(TIME, convertDataToTimeStamp(tweet.getCreatedAt()));
+    Date tweetDate = tweet.getCreatedAt();
+    if (tweetDate != null) {
+      recordBuilder.set(TIME, tweetDate.getTime());
+    }
     recordBuilder.set(FAVC, tweet.getFavoriteCount());
     recordBuilder.set(RTC, tweet.getRetweetCount());
     recordBuilder.set(SRC, tweet.getSource());
@@ -125,14 +128,6 @@ public class TwitterSource extends RealtimeSource<StructuredRecord> {
     }
     recordBuilder.set(ISRT, tweet.isRetweet());
     return recordBuilder.build();
-  }
-
-  private Long convertDataToTimeStamp(Date date) {
-    if (date == null) {
-      return null;
-    }
-    long startTime = date.getTime() * 1000000;
-    return System.nanoTime() - startTime;
   }
 
   @Nullable


### PR DESCRIPTION
of the tweet instead of calculating difference in ingest time
versus tweet time.