### PR TITLE
CDAP-2613 Cache dependencies to build CDAP examples

### DIFF
--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu12.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu12.json
@@ -107,6 +107,7 @@
         "scripts/fluxbox.sh",
         "scripts/slim.sh",
         "scripts/firefox.sh",
+        "scripts/fill-maven-cache.sh",
         "scripts/vbox-guest-additions.sh"
       ],
       "only": ["cdap-sdk-vm"]

--- a/cdap-distributions/src/packer/scripts/fill-maven-cache.sh
+++ b/cdap-distributions/src/packer/scripts/fill-maven-cache.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# Copyright © 2015 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+__tmpdir=/tmp/cdap-examples.$$
+mkdir -p ${__tmpdir}
+cd ${__tmpdir}
+git clone https://github.com/caskdata/cdap.git
+chown -R cdap cdap
+su - cdap -c "cd ${__tmpdir}/cdap && MAVEN_OPTS='-Xmx512m -XX:MaxPermSize=128m' mvn package -DskipTests -pl cdap-examples -am -amd -P examples"
+rm -rf ${__tmpdir}


### PR DESCRIPTION
This populates `/home/cdap/.m2/repository` with a bunch of dependency JARs for building CDAP examples.