### PR TITLE
Remove dependency on xerces of doxia

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1273,6 +1273,19 @@
           <groupId>org.apache.rat</groupId>
           <artifactId>apache-rat-plugin</artifactId>
           <version>0.10</version>
+          <dependencies>
+            <dependency>
+              <groupId>org.apache.maven.doxia</groupId>
+              <artifactId>doxia-core</artifactId>
+              <version>1.6</version>
+              <exclusions>
+                <exclusion>
+                  <groupId>xerces</groupId>
+                  <artifactId>xercesImpl</artifactId>
+                </exclusion>
+              </exclusions>
+            </dependency>
+          </dependencies>
           <executions>
             <execution>
               <id>rat-check</id>


### PR DESCRIPTION
The dependency of doxia-core on xerces causes lots of error messages in the maven builds:
```
Warning:  org.apache.xerces.jaxp.SAXParserImpl$JAXPSAXParser: Property 'http://www.oracle.com/xml/jaxp/properties/entityExpansionLimit' is not recognized.
Compiler warnings:
  WARNING:  'org.apache.xerces.jaxp.SAXParserImpl: Property 'http://javax.xml.XMLConstants/property/accessExternalDTD' is not recognized.'
Warning:  org.apache.xerces.parsers.SAXParser: Feature 'http://javax.xml.XMLConstants/feature/secure-processing' is not recognized.
Warning:  org.apache.xerces.parsers.SAXParser: Property 'http://javax.xml.XMLConstants/property/accessExternalDTD' is not recognized.
Warning:  org.apache.xerces.parsers.SAXParser: Property 'http://www.oracle.com/xml/jaxp/properties/entityExpansionLimit' is not recognized.
```
This addition to the ``pom.xml`` removes this dependency (it has been [merged into an unreleased version of doxia](http://svn.apache.org/viewvc?view=revision&revision=1659741) to fix https://issues.apache.org/jira/browse/DOXIA-526). It's part of a fix for https://issues.apache.org/jira/browse/RAT-158. 

Applying this makes the error message go away, resulting in readable logs...

Log from running RAT check style: 
http://builds.cask.co/download/CDAP-DRC1863-JOB1/build_logs/CDAP-DRC1863-JOB1-1.log

Compare it with this one, littered with the bogus messages:
http://builds.cask.co/download/CDAP-DRC-JOB1/build_logs/CDAP-DRC-JOB1-1219.log