### PR TITLE
Use IntegrationTestBase#getRestClient for all clients utilized in Int…

### DIFF
--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestBase.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestBase.java
@@ -21,10 +21,12 @@ import co.cask.cdap.cli.util.InstanceURIParser;
 import co.cask.cdap.client.ApplicationClient;
 import co.cask.cdap.client.DatasetClient;
 import co.cask.cdap.client.MetaClient;
+import co.cask.cdap.client.MetricsClient;
 import co.cask.cdap.client.NamespaceClient;
 import co.cask.cdap.client.ProgramClient;
 import co.cask.cdap.client.StreamClient;
 import co.cask.cdap.client.config.ClientConfig;
+import co.cask.cdap.client.util.RESTClient;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.exception.NotFoundException;
@@ -88,7 +90,7 @@ public class IntegrationTestBase {
 
   protected TestManager createTestManager(Id.Namespace namespace) {
     try {
-      return new IntegrationTestManager(createNamespacedClientConfig(getClientConfig(), namespace),
+      return new IntegrationTestManager(createNamespacedClientConfig(getClientConfig(), namespace), getRestClient(),
                                         new LocalLocationFactory(TEMP_FOLDER.newFolder()));
     } catch (IOException e) {
       throw Throwables.propagate(e);
@@ -117,7 +119,7 @@ public class IntegrationTestBase {
 
   private void assertIsClear() throws Exception {
     // only namespace existing should be 'default'
-    NamespaceClient namespaceClient = new NamespaceClient(getClientConfig());
+    NamespaceClient namespaceClient = getNamespaceClient();
     List<NamespaceMeta> list = namespaceClient.list();
     Assert.assertEquals(1, list.size());
     Assert.assertEquals(Constants.DEFAULT_NAMESPACE_META, list.get(0));
@@ -145,24 +147,36 @@ public class IntegrationTestBase {
     return builder.build();
   }
 
+  protected RESTClient getRestClient() {
+    return new RESTClient(getClientConfig());
+  }
+
   protected MetaClient getMetaClient() {
-    return new MetaClient(getClientConfig());
+    return new MetaClient(getClientConfig(), getRestClient());
+  }
+
+  protected NamespaceClient getNamespaceClient() {
+    return new NamespaceClient(getClientConfig(), getRestClient());
+  }
+
+  protected MetricsClient getMetricsClient() {
+    return new MetricsClient(getClientConfig(), getRestClient());
   }
 
   protected ApplicationClient getApplicationClient() {
-    return new ApplicationClient(getClientConfig());
+    return new ApplicationClient(getClientConfig(), getRestClient());
   }
 
   protected ProgramClient getProgramClient() {
-    return new ProgramClient(getClientConfig());
+    return new ProgramClient(getClientConfig(), getRestClient());
   }
 
   protected StreamClient getStreamClient() {
-    return new StreamClient(getClientConfig());
+    return new StreamClient(getClientConfig(), getRestClient());
   }
 
   protected DatasetClient getDatasetClient() {
-    return new DatasetClient(getClientConfig());
+    return new DatasetClient(getClientConfig(), getRestClient());
   }
 
   protected Id.Namespace createNamespace(String name) throws Exception {

--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestManager.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestManager.java
@@ -29,6 +29,7 @@ import co.cask.cdap.client.ApplicationClient;
 import co.cask.cdap.client.NamespaceClient;
 import co.cask.cdap.client.ProgramClient;
 import co.cask.cdap.client.config.ClientConfig;
+import co.cask.cdap.client.util.RESTClient;
 import co.cask.cdap.common.io.Locations;
 import co.cask.cdap.internal.test.AppJarHelper;
 import co.cask.cdap.proto.AdapterConfig;
@@ -61,18 +62,20 @@ public class IntegrationTestManager implements TestManager {
 
   private final ApplicationClient applicationClient;
   private final ClientConfig clientConfig;
+  private final RESTClient restClient;
   private final LocationFactory locationFactory;
   private final ProgramClient programClient;
   private final NamespaceClient namespaceClient;
   private final AdapterClient adapterClient;
 
-  public IntegrationTestManager(ClientConfig clientConfig, LocationFactory locationFactory) {
+  public IntegrationTestManager(ClientConfig clientConfig, RESTClient restClient, LocationFactory locationFactory) {
     this.clientConfig = clientConfig;
+    this.restClient = restClient;
     this.locationFactory = locationFactory;
-    this.applicationClient = new ApplicationClient(clientConfig);
-    this.programClient = new ProgramClient(clientConfig);
-    this.namespaceClient = new NamespaceClient(clientConfig);
-    this.adapterClient = new AdapterClient(clientConfig);
+    this.applicationClient = new ApplicationClient(clientConfig, restClient);
+    this.programClient = new ProgramClient(clientConfig, restClient);
+    this.namespaceClient = new NamespaceClient(clientConfig, restClient);
+    this.adapterClient = new AdapterClient(clientConfig, restClient);
   }
 
   @Override
@@ -108,7 +111,7 @@ public class IntegrationTestManager implements TestManager {
       DefaultAppConfigurer configurer = new DefaultAppConfigurer(application);
       application.configure(configurer, new ApplicationContext());
       String applicationId = configurer.createSpecification().getName();
-      return new RemoteApplicationManager(Id.Application.from(namespace, applicationId), clientConfig);
+      return new RemoteApplicationManager(Id.Application.from(namespace, applicationId), clientConfig, restClient);
     } catch (Exception e) {
       throw Throwables.propagate(e);
     }
@@ -188,7 +191,7 @@ public class IntegrationTestManager implements TestManager {
 
   @Override
   public StreamManager getStreamManager(Id.Stream streamId) {
-    return new RemoteStreamManager(clientConfig, streamId);
+    return new RemoteStreamManager(clientConfig, restClient, streamId);
   }
 
   /**

--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteApplicationManager.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteApplicationManager.java
@@ -19,6 +19,7 @@ package co.cask.cdap.test.remote;
 import co.cask.cdap.client.ApplicationClient;
 import co.cask.cdap.client.ProgramClient;
 import co.cask.cdap.client.config.ClientConfig;
+import co.cask.cdap.client.util.RESTClient;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramRecord;
 import co.cask.cdap.proto.ProgramType;
@@ -45,21 +46,23 @@ public class RemoteApplicationManager extends AbstractApplicationManager {
   private final ClientConfig clientConfig;
   private final ProgramClient programClient;
   private final ApplicationClient applicationClient;
+  private final RESTClient restClient;
 
-  public RemoteApplicationManager(Id.Application application, ClientConfig clientConfig) {
+  public RemoteApplicationManager(Id.Application application, ClientConfig clientConfig, RESTClient restClient) {
     super(application);
 
     ClientConfig namespacedClientConfig = new ClientConfig.Builder(clientConfig).build();
     namespacedClientConfig.setNamespace(application.getNamespace());
     this.clientConfig = namespacedClientConfig;
-    this.programClient = new ProgramClient(clientConfig);
-    this.applicationClient = new ApplicationClient(clientConfig);
+    this.restClient = restClient;
+    this.programClient = new ProgramClient(clientConfig, restClient);
+    this.applicationClient = new ApplicationClient(clientConfig, restClient);
   }
 
   @Override
   public FlowManager getFlowManager(String flowName) {
     Id.Program flowId = Id.Program.from(application, ProgramType.FLOW, flowName);
-    return new RemoteFlowManager(flowId, clientConfig, this);
+    return new RemoteFlowManager(flowId, clientConfig, restClient, this);
   }
 
   @Override
@@ -77,25 +80,25 @@ public class RemoteApplicationManager extends AbstractApplicationManager {
   @Override
   public WorkflowManager getWorkflowManager(String workflowName) {
     Id.Program programId = Id.Program.from(application, ProgramType.WORKFLOW, workflowName);
-    return new RemoteWorkflowManager(programId, clientConfig, this);
+    return new RemoteWorkflowManager(programId, clientConfig, restClient, this);
   }
 
   @Override
   public ServiceManager getServiceManager(String serviceName) {
     Id.Program programId = Id.Program.from(application, ProgramType.SERVICE, serviceName);
-    return new RemoteServiceManager(programId, clientConfig, this);
+    return new RemoteServiceManager(programId, clientConfig, restClient, this);
   }
 
   @Override
   public WorkerManager getWorkerManager(String workerName) {
     Id.Program programId = Id.Program.from(application, ProgramType.WORKER, workerName);
-    return new RemoteWorkerManager(programId, clientConfig, this);
+    return new RemoteWorkerManager(programId, clientConfig, restClient, this);
   }
 
   @Override
   @Deprecated
   public StreamWriter getStreamWriter(String streamName) {
-    return new RemoteStreamWriter(new RemoteStreamManager(clientConfig,
+    return new RemoteStreamWriter(new RemoteStreamManager(clientConfig, restClient,
                                                           Id.Stream.from(application.getNamespaceId(), streamName)));
   }
 

--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteFlowManager.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteFlowManager.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.metrics.RuntimeMetrics;
 import co.cask.cdap.client.MetricsClient;
 import co.cask.cdap.client.ProgramClient;
 import co.cask.cdap.client.config.ClientConfig;
+import co.cask.cdap.client.util.RESTClient;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.test.AbstractProgramManager;
 import co.cask.cdap.test.FlowManager;
@@ -33,13 +34,13 @@ public class RemoteFlowManager extends AbstractProgramManager<FlowManager> imple
   private final ProgramClient programClient;
   private final MetricsClient metricsClient;
 
-  public RemoteFlowManager(Id.Program programId, ClientConfig clientConfig,
+  public RemoteFlowManager(Id.Program programId, ClientConfig clientConfig, RESTClient restClient,
                            RemoteApplicationManager applicationManager) {
     super(programId, applicationManager);
     ClientConfig namespacedClientConfig = new ClientConfig.Builder(clientConfig).build();
     namespacedClientConfig.setNamespace(programId.getNamespace());
-    this.programClient = new ProgramClient(namespacedClientConfig);
-    this.metricsClient = new MetricsClient(namespacedClientConfig);
+    this.programClient = new ProgramClient(namespacedClientConfig, restClient);
+    this.metricsClient = new MetricsClient(namespacedClientConfig, restClient);
   }
 
   @Override

--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteServiceManager.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteServiceManager.java
@@ -21,6 +21,7 @@ import co.cask.cdap.client.MetricsClient;
 import co.cask.cdap.client.ProgramClient;
 import co.cask.cdap.client.ServiceClient;
 import co.cask.cdap.client.config.ClientConfig;
+import co.cask.cdap.client.util.RESTClient;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.test.AbstractProgramManager;
 import co.cask.cdap.test.ServiceManager;
@@ -37,14 +38,14 @@ public class RemoteServiceManager extends AbstractProgramManager<ServiceManager>
   private final ProgramClient programClient;
   private final ServiceClient serviceClient;
 
-  public RemoteServiceManager(Id.Program programId, ClientConfig clientConfig,
+  public RemoteServiceManager(Id.Program programId, ClientConfig clientConfig, RESTClient restClient,
                               RemoteApplicationManager remoteApplicationManager) {
     super(programId, remoteApplicationManager);
     ClientConfig namespacedClientConfig = new ClientConfig.Builder(clientConfig).build();
     namespacedClientConfig.setNamespace(programId.getNamespace());
-    this.metricsClient = new MetricsClient(namespacedClientConfig);
-    this.programClient = new ProgramClient(namespacedClientConfig);
-    this.serviceClient = new ServiceClient(namespacedClientConfig);
+    this.metricsClient = new MetricsClient(namespacedClientConfig, restClient);
+    this.programClient = new ProgramClient(namespacedClientConfig, restClient);
+    this.serviceClient = new ServiceClient(namespacedClientConfig, restClient);
   }
 
   @Override

--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteStreamManager.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteStreamManager.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.flow.flowlet.StreamEvent;
 import co.cask.cdap.client.StreamClient;
 import co.cask.cdap.client.config.ClientConfig;
+import co.cask.cdap.client.util.RESTClient;
 import co.cask.cdap.common.exception.StreamNotFoundException;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.test.StreamManager;
@@ -39,10 +40,10 @@ public class RemoteStreamManager implements StreamManager {
   private final StreamClient streamClient;
   private final String streamName;
 
-  public RemoteStreamManager(ClientConfig clientConfig, Id.Stream streamId) {
+  public RemoteStreamManager(ClientConfig clientConfig, RESTClient restClient, Id.Stream streamId) {
     ClientConfig namespacedClientConfig = new ClientConfig.Builder(clientConfig).build();
     namespacedClientConfig.setNamespace(streamId.getNamespace());
-    this.streamClient = new StreamClient(namespacedClientConfig);
+    this.streamClient = new StreamClient(namespacedClientConfig, restClient);
     this.streamName = streamId.getId();
   }
 

--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteWorkerManager.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteWorkerManager.java
@@ -18,6 +18,7 @@ package co.cask.cdap.test.remote;
 
 import co.cask.cdap.client.ProgramClient;
 import co.cask.cdap.client.config.ClientConfig;
+import co.cask.cdap.client.util.RESTClient;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.test.AbstractProgramManager;
 import co.cask.cdap.test.WorkerManager;
@@ -30,12 +31,12 @@ import com.google.common.base.Throwables;
 public class RemoteWorkerManager extends AbstractProgramManager<WorkerManager> implements WorkerManager {
   private final ProgramClient programClient;
 
-  public RemoteWorkerManager(Id.Program programId, ClientConfig clientConfig,
+  public RemoteWorkerManager(Id.Program programId, ClientConfig clientConfig, RESTClient restClient,
                              RemoteApplicationManager applicationManager) {
     super(programId, applicationManager);
     ClientConfig namespacedClientConfig = new ClientConfig.Builder(clientConfig).build();
     namespacedClientConfig.setNamespace(programId.getNamespace());
-    this.programClient = new ProgramClient(namespacedClientConfig);
+    this.programClient = new ProgramClient(namespacedClientConfig, restClient);
   }
 
   @Override

--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteWorkflowManager.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteWorkflowManager.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.schedule.ScheduleSpecification;
 import co.cask.cdap.client.ProgramClient;
 import co.cask.cdap.client.ScheduleClient;
 import co.cask.cdap.client.config.ClientConfig;
+import co.cask.cdap.client.util.RESTClient;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.RunRecord;
@@ -37,13 +38,13 @@ public class RemoteWorkflowManager extends AbstractProgramManager<WorkflowManage
   private final ScheduleClient scheduleClient;
   private final ProgramClient programClient;
 
-  public RemoteWorkflowManager(Id.Program programId, ClientConfig clientConfig,
+  public RemoteWorkflowManager(Id.Program programId, ClientConfig clientConfig, RESTClient restClient,
                                RemoteApplicationManager applicationManager) {
     super(programId, applicationManager);
     ClientConfig namespacedClientConfig = new ClientConfig.Builder(clientConfig).build();
     namespacedClientConfig.setNamespace(programId.getNamespace());
-    this.programClient = new ProgramClient(namespacedClientConfig);
-    this.scheduleClient = new ScheduleClient(namespacedClientConfig);
+    this.programClient = new ProgramClient(namespacedClientConfig, restClient);
+    this.scheduleClient = new ScheduleClient(namespacedClientConfig, restClient);
   }
 
   @Override


### PR DESCRIPTION
Use `IntegrationTestBase#getRestClient` for all clients utilized in Integration testing framework

This makes it so that `getRestClient` can be overridden to return a custom `RESTClient` object, that is always used for all clients in the integration testing framework.
One example [use case](https://github.com/caskdata/cdap-integration-tests/blob/develop/integration-test-remote/src/test/java/co/cask/cdap/apps/AudiTestBase.java#L125) for why a user would want to do this is to create a `RESTClient` with a `RestClient.Listener`, for custom logging of all http requests made via the clients.

http://builds.cask.co/browse/CDAP-DUT1985-1