### PR TITLE
Simplify AbstractAppFabricHttpHandler.java

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppLifecycleHttpHandler.java
@@ -162,7 +162,7 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/apps")
   public void getAllApps(HttpRequest request, HttpResponder responder,
                          @PathParam("namespace-id") String namespaceId) {
-    getAppRecords(responder, store, namespaceId, null);
+    getAppRecords(responder, store, namespaceId);
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
@@ -712,7 +712,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/flows")
   public void getAllFlows(HttpRequest request, HttpResponder responder,
                           @PathParam("namespace-id") String namespaceId) {
-    programList(responder, namespaceId, ProgramType.FLOW, null, store);
+    programList(responder, namespaceId, ProgramType.FLOW, store);
   }
 
   /**
@@ -722,7 +722,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/mapreduce")
   public void getAllMapReduce(HttpRequest request, HttpResponder responder,
                               @PathParam("namespace-id") String namespaceId) {
-    programList(responder, namespaceId, ProgramType.MAPREDUCE, null, store);
+    programList(responder, namespaceId, ProgramType.MAPREDUCE, store);
   }
 
   /**
@@ -732,7 +732,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/spark")
   public void getAllSpark(HttpRequest request, HttpResponder responder,
                           @PathParam("namespace-id") String namespaceId) {
-    programList(responder, namespaceId, ProgramType.SPARK, null, store);
+    programList(responder, namespaceId, ProgramType.SPARK, store);
   }
 
   /**
@@ -742,7 +742,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/workflows")
   public void getAllWorkflows(HttpRequest request, HttpResponder responder,
                               @PathParam("namespace-id") String namespaceId) {
-    programList(responder, namespaceId, ProgramType.WORKFLOW, null, store);
+    programList(responder, namespaceId, ProgramType.WORKFLOW, store);
   }
 
   /**
@@ -752,14 +752,14 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/services")
   public void getAllServices(HttpRequest request, HttpResponder responder,
                              @PathParam("namespace-id") String namespaceId) {
-    programList(responder, namespaceId, ProgramType.SERVICE, null, store);
+    programList(responder, namespaceId, ProgramType.SERVICE, store);
   }
 
   @GET
   @Path("/workers")
   public void getAllWorkers(HttpRequest request, HttpResponder responder,
                             @PathParam("namespace-id") String namespaceId) {
-    programList(responder, namespaceId, ProgramType.WORKER, null, store);
+    programList(responder, namespaceId, ProgramType.WORKER, store);
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/util/AbstractAppFabricHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/util/AbstractAppFabricHttpHandler.java
@@ -48,9 +48,7 @@ import org.slf4j.LoggerFactory;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.lang.reflect.Type;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -168,36 +166,15 @@ public abstract class AbstractAppFabricHttpHandler extends AbstractHttpHandler {
     }
   }
 
-  protected final void getAppRecords(HttpResponder responder, Store store, String namespaceId, String appId) {
-    if (appId != null && appId.isEmpty()) {
-      responder.sendString(HttpResponseStatus.BAD_REQUEST, "app-id is empty");
-      return;
-    }
-
+  protected final void getAppRecords(HttpResponder responder, Store store, String namespaceId) {
     try {
-      Id.Namespace accId = Id.Namespace.from(namespaceId);
+      Id.Namespace namespace = Id.Namespace.from(namespaceId);
       List<ApplicationRecord> appRecords = Lists.newArrayList();
-      List<ApplicationSpecification> specList;
-      if (appId == null) {
-        specList = new ArrayList<>(store.getAllApplications(accId));
-      } else {
-        ApplicationSpecification appSpec = store.getApplication(new Id.Application(accId, appId));
-        if (appSpec == null) {
-          responder.sendStatus(HttpResponseStatus.NOT_FOUND);
-          return;
-        }
-        specList = Collections.singletonList(store.getApplication(new Id.Application(accId, appId)));
-      }
-
-      for (ApplicationSpecification appSpec : specList) {
+      for (ApplicationSpecification appSpec : store.getAllApplications(namespace)) {
         appRecords.add(new ApplicationRecord(appSpec.getName(), appSpec.getVersion(), appSpec.getDescription()));
       }
 
-      if (appId == null) {
-        responder.sendJson(HttpResponseStatus.OK, appRecords);
-      } else {
-        responder.sendJson(HttpResponseStatus.OK, appRecords.get(0));
-      }
+      responder.sendJson(HttpResponseStatus.OK, appRecords);
     } catch (SecurityException e) {
       LOG.debug("Security Exception while retrieving app details: ", e);
       responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);
@@ -207,22 +184,10 @@ public abstract class AbstractAppFabricHttpHandler extends AbstractHttpHandler {
     }
   }
 
-  protected final void programList(HttpResponder responder, String namespaceId, ProgramType type,
-                                   @Nullable String applicationId, Store store) {
-    if (applicationId != null && applicationId.isEmpty()) {
-      responder.sendString(HttpResponseStatus.BAD_REQUEST, "Application id is empty");
-      return;
-    }
-
+  protected final void programList(HttpResponder responder, String namespaceId, ProgramType type, Store store) {
     try {
-      List<ProgramRecord> programRecords;
-      if (applicationId == null) {
-        Id.Namespace accId = Id.Namespace.from(namespaceId);
-        programRecords = listPrograms(accId, type, store);
-      } else {
-        Id.Application appId = Id.Application.from(namespaceId, applicationId);
-        programRecords = listProgramsByApp(appId, type, store);
-      }
+      Id.Namespace namespace = Id.Namespace.from(namespaceId);
+      List<ProgramRecord> programRecords = listPrograms(namespace, type, store);
 
       if (programRecords == null) {
         responder.sendStatus(HttpResponseStatus.NOT_FOUND);
@@ -246,23 +211,6 @@ public abstract class AbstractAppFabricHttpHandler extends AbstractHttpHandler {
       LOG.warn(throwable.getMessage(), throwable);
       String errorMessage = String.format("Could not retrieve application spec for namespace '%s', reason: %s",
                                            namespaceId.toString(), throwable.getMessage());
-      throw new Exception(errorMessage, throwable);
-    }
-  }
-
-  /**
-   * Return a list of {@link ProgramRecord} for a {@link ProgramType} in an Application. The return value may be
-   * null if the applicationId does not exist.
-   */
-  private List<ProgramRecord> listProgramsByApp(Id.Application appId, ProgramType type, Store store) throws Exception {
-    ApplicationSpecification appSpec;
-    try {
-      appSpec = store.getApplication(appId);
-      return appSpec == null ? null : listPrograms(Collections.singletonList(appSpec), type);
-    } catch (Throwable throwable) {
-      LOG.warn(throwable.getMessage(), throwable);
-      String errorMessage = String.format("Could not retrieve application spec for application id '%s', reason: %s",
-                                          appId.toString(), throwable.getMessage());
       throw new Exception(errorMessage, throwable);
     }
   }

--- a/cdap-docs/reference-manual/source/http-restful-api/metrics.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/metrics.rst
@@ -775,7 +775,7 @@ For example, this request will retrieve the completion percentage for the map-st
 Querying by Run-ID
 ..................
 
-Each execution of an program (Flow, MapReduce, Spark, Service, Worker) has an :ref:`associated 
+Each execution of a program (Flow, MapReduce, Spark, Service, Worker) has an :ref:`associated
 run-ID <rest-program-runs>` that uniquely identifies that program's run. We can query 
 metrics for a program by its run-ID to retrieve the metrics for a particular run. Please see 
 the :ref:`Run Records and Schedule <rest-program-runs>` on retrieving active and historical

--- a/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryBuilder.java
+++ b/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryBuilder.java
@@ -119,8 +119,7 @@ public class PurchaseHistoryBuilder extends AbstractMapReduce {
       UserProfile userProfile = null;
       try {
         URL url = new URL(userProfileServiceURL,
-                                        UserProfileServiceHandler.USER_ENDPOINT
-                                          + "/" + customer.toString());
+                          UserProfileServiceHandler.USER_ENDPOINT + "/" + customer.toString());
 
         HttpRequest request = HttpRequest.get(url).build();
         HttpResponse response = HttpRequests.execute(request);


### PR DESCRIPTION
We removed quite a few v2 handlers just prior 3.0 release, but did not simplify the helper methods in AppFabric.
This cleans it up a bit:
`programList` no longer accepts an `applicationId`, since there are no usages that pass one.
Same for the `getAppRecords` method.

http://builds.cask.co/browse/CDAP-DUT1984-4