### PR TITLE
(CDAP-2698) Cleanup Program jar properly

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractDistributedProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractDistributedProgramRunner.java
@@ -126,7 +126,7 @@ public abstract class AbstractDistributedProgramRunner implements ProgramRunner 
       localizeFiles.put("hConf.xml", saveHConf(hConf, File.createTempFile("hConf", ".xml", tempDir)));
       localizeFiles.put("cConf.xml", saveCConf(cConf, File.createTempFile("cConf", ".xml", tempDir)));
       programDir = DirUtils.createTempDir(tempDir);
-      copiedProgram = copyProgramJar(program, programDir);
+      copiedProgram = copyProgramJar(program, tempDir, programDir);
 
       final URI logbackURI = getLogBackURI(copiedProgram, programDir, tempDir);
       final String programOptions = GSON.toJson(options);
@@ -267,8 +267,8 @@ public abstract class AbstractDistributedProgramRunner implements ProgramRunner 
    * Copies the program jar to a local temp file and return a {@link Program} instance
    * with {@link Program#getJarLocation()} points to the local temp file.
    */
-  private Program copyProgramJar(final Program program, File programDir) throws IOException {
-    File tempJar = File.createTempFile(program.getName(), ".jar");
+  private Program copyProgramJar(final Program program, File tempDir, File programDir) throws IOException {
+    File tempJar = File.createTempFile(program.getName(), ".jar", tempDir);
     Files.copy(new InputSupplier<InputStream>() {
       @Override
       public InputStream getInput() throws IOException {


### PR DESCRIPTION
- The bug was introduced to 3.0.0 in CDAP-1917, PR https://github.com/caskdata/cdap/pull/2147
  - The attempt was to have all temporary files created under a single temp directory to simplify cleanup process, but missed the usage of File.createTempFile.