### PR TITLE
Propagate NaN values from JobClient to responder#sendJson, because ot…

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
@@ -241,7 +241,9 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
         mrJobInfo.setStopTime(TimeUnit.SECONDS.toMillis(stopTs));
       }
 
-      responder.sendJson(HttpResponseStatus.OK, mrJobInfo);
+      // JobClient (in DistributedMRJobInfoFetcher) can return NaN as some of the values, and GSON otherwise fails
+      Gson gson = new GsonBuilder().serializeSpecialFloatingPointValues().create();
+      responder.sendJson(HttpResponseStatus.OK, mrJobInfo, mrJobInfo.getClass(), gson);
     } catch (NotFoundException e) {
       LOG.warn("NotFoundException while getting MapReduce Run info.", e);
       responder.sendString(HttpResponseStatus.NOT_FOUND, e.getMessage());


### PR DESCRIPTION
Propagate NaN values from JobClient to responder#sendJson, because otherwise GSON fails during serialization of NaN values.

Build: http://builds.cask.co/browse/CDAP-DUT1999-1
Related JIRA: https://issues.cask.co/browse/CDAP-2433