### PR TITLE
hide loading icon when there is an error in delete function

### DIFF
--- a/cdap-ui/app/features/admin/controllers/NamespaceDatasetMetadataController.js
+++ b/cdap-ui/app/features/admin/controllers/NamespaceDatasetMetadataController.js
@@ -37,17 +37,17 @@ function ($scope, $state, $alert, $filter, myDatasetApi, myExploreApi, EventPipe
       datasetId: $state.params.datasetId,
       scope: $scope
     };
-    myDatasetApi.delete(params)
-      .$promise
-      .then(function () {
-        EventPipe.emit('hideLoadingIcon.immediate');
+    myDatasetApi.delete(params, {}, function success() {
+      EventPipe.emit('hideLoadingIcon.immediate');
 
-        $state.go('admin.namespace.detail.data', {}, {reload: true});
-        $alert({
-          type: 'success',
-          content: 'Successfully deleted dataset'
-        });
+      $state.go('admin.namespace.detail.data', {}, {reload: true});
+      $alert({
+        type: 'success',
+        content: 'Successfully deleted dataset'
       });
+    }, function error() {
+      EventPipe.emit('hideLoadingIcon.immediate');
+    });
   };
 
 });

--- a/cdap-ui/app/features/admin/controllers/NamespaceSettingsController.js
+++ b/cdap-ui/app/features/admin/controllers/NamespaceSettingsController.js
@@ -51,6 +51,8 @@ angular.module(PKG.name + '.feature.admin')
             content: 'You have successfully deleted a namespace.'
           });
         }, 500);
+      }, function error() {
+        EventPipe.emit('hideLoadingIcon.immediate');
       });
     };
 

--- a/cdap-ui/app/features/admin/controllers/StreamPropertiesController.js
+++ b/cdap-ui/app/features/admin/controllers/StreamPropertiesController.js
@@ -179,6 +179,8 @@ angular.module(PKG.name + '.feature.admin')
           type: 'success',
           content: 'Successfully deleted stream'
         });
+      }, function error() {
+        EventPipe.emit('hideLoadingIcon.immediate');
       });
 
     };


### PR DESCRIPTION
hiding loading icon when an error occurs during delete operation of dataset, stream, or namespace