### PR TITLE
CDAP-2617 start and end times for logging now working.

### DIFF
--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramLogsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramLogsCommand.java
@@ -24,6 +24,7 @@ import co.cask.cdap.cli.english.Fragment;
 import co.cask.cdap.cli.exception.CommandInputError;
 import co.cask.cdap.cli.util.AbstractAuthCommand;
 import co.cask.cdap.client.ProgramClient;
+import co.cask.cdap.common.utils.TimeMathParser;
 import co.cask.common.cli.Arguments;
 
 import java.io.PrintStream;
@@ -46,8 +47,10 @@ public class GetProgramLogsCommand extends AbstractAuthCommand {
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     String[] programIdParts = arguments.get(elementType.getArgumentName().toString()).split("\\.");
     String appId = programIdParts[0];
-    long start = arguments.getLong(ArgumentName.START_TIME.toString(), 0);
-    long stop = arguments.getLong(ArgumentName.START_TIME.toString(), Long.MAX_VALUE);
+    String startString = arguments.get(ArgumentName.START_TIME.toString(), "0");
+    long start = TimeMathParser.parseTime(startString);
+    String stopString = arguments.get(ArgumentName.END_TIME.toString(), Long.toString(Integer.MAX_VALUE));
+    long stop = TimeMathParser.parseTime(stopString);
 
     String logs;
     if (elementType.getProgramType() != null) {


### PR DESCRIPTION
This means that you can provide a time range for retrieving logs from the CLI. Earlier, if start and end times were provided, an error would pop up saying that the end time should be greater than the start time provided. This was because the start and end times were being defaulted to 0. Also, "now" works if given as input to the start and end times in CLI. So the current time can be obtained easily. 