### PR TITLE
Add PermGen size in app.program.jvm.opts

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -642,7 +642,7 @@
 
     <property>
         <name>app.program.jvm.opts</name>
-        <value>${twill.jvm.gc.opts}</value>
+        <value>-XX:MaxPermSize=128M -verbose:gc -Xloggc:&lt;LOG_DIR&gt;/gc.log -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=1M</value>
         <description>Java options for all program containers</description>
     </property>
 

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -642,7 +642,7 @@
 
     <property>
         <name>app.program.jvm.opts</name>
-        <value>-XX:MaxPermSize=128M -verbose:gc -Xloggc:&lt;LOG_DIR&gt;/gc.log -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=1M</value>
+        <value>-XX:MaxPermSize=128M ${twill.jvm.gc.opts}</value>
         <description>Java options for all program containers</description>
     </property>
 


### PR DESCRIPTION
Adding perm gen size to twill runnables.

Tested on a cluster and the service spun up with MaxPermSize set
`/usr/lib/jvm/java/bin/java -Djava.io.tmpdir=tmp -Dyarn.container=container_1434045650548_0001_01_000006 -Dtwill.runnable=master.services.explore.service -cp launcher.jar:/etc/hadoop/conf -Xmx774m -XX:MaxPermSize=128M -verbose:gc -Xloggc:/data/logs/hadoop-yarn/userlogs/application_1434045650548_0001/container_1434045650548_0001_01_000006/gc.log -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=1M org.apache.twill.launcher.TwillLauncher container.jar org.apache.twill.internal.container.TwillContainerMain true`