### PR TITLE
(CDAP-2569) Always try to create the root ZK node on Master service startup

### DIFF
--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
@@ -60,6 +60,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.io.Closeables;
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.Service;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -80,6 +81,9 @@ import org.apache.twill.common.Threads;
 import org.apache.twill.internal.zookeeper.LeaderElection;
 import org.apache.twill.kafka.client.KafkaClientService;
 import org.apache.twill.zookeeper.ZKClientService;
+import org.apache.twill.zookeeper.ZKOperations;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -174,6 +178,10 @@ public class MasterServiceMain extends DaemonMain {
     metricsCollectionService.startAndWait();
     serviceStore.startAndWait();
     leaderElection.startAndWait();
+
+    // Tries to create the ZK root node (which can be namespaced through the zk connection string)
+    Futures.getUnchecked(ZKOperations.ignoreError(zkClient.create("/", null, CreateMode.PERSISTENT),
+                                                  KeeperException.NodeExistsException.class, null));
   }
 
   @Override


### PR DESCRIPTION
- The “root” node can be namespace by the zk connect string, hence may not exist yet.
  - E.g. host:2181/cdap
  - By creating “/“ with the given connection string, it make sure the relative root exist.