### PR TITLE
Fix SDK build and javadocs

### DIFF
--- a/BUILD.rst
+++ b/BUILD.rst
@@ -58,11 +58,11 @@ Standalone and Distributed CDAP
     
 - Build the limited set of Javadocs, including the App Templates, used in documentation::
 
-    MAVEN_OPTS="-Xmx512m" mvn clean install -P examples,templates,release -DskipTests -Dgpg.skip=true && mvn clean site -DskipTests -P templates -DisOffline=false
+    MAVEN_OPTS="-Xmx1024m" mvn clean install -P examples,templates,release -DskipTests -Dgpg.skip=true && mvn clean site -DskipTests -P templates -DisOffline=false
 
-- Build the complete set of Javadocs, for all modules::
+- Build the complete set of Javadocs, for all modules (currently incomplete)::
 
-    MAVEN_OPTS="-Xmx512m" mvn clean site -Dmaxmemory=1024m -DskipTests
+    MAVEN_OPTS="-Xmx1024m" mvn clean site -Dmaxmemory=1024m -DskipTests
     
 - Build distributions (rpm, deb, tgz)::
 

--- a/cdap-standalone/pom.xml
+++ b/cdap-standalone/pom.xml
@@ -289,12 +289,7 @@
                         <include>package.json</include>
                       </includes>
                     </resource>
-                    <!-- Copy api javadocs -->
-                    <resource>
-                      <directory>${project.parent.basedir}/cdap-api/target/apidocs</directory>
-                      <targetPath>javadocs</targetPath>
-                    </resource>
-                    <!-- Copy examples. The assume the example is already built -->
+                    <!-- Copy examples. This assumes the examples are already built -->
                     <resource>
                       <directory>${project.parent.basedir}/cdap-examples</directory>
                       <targetPath>examples</targetPath>

--- a/cdap-standalone/pom.xml
+++ b/cdap-standalone/pom.xml
@@ -257,13 +257,6 @@
                         <include>*.dll</include>
                       </includes>
                     </resource>
-                    <!-- Copy api jars -->
-                    <resource>
-                      <directory>${project.parent.basedir}/cdap-api/target</directory>
-                      <includes>
-                        <include>cdap-api-${project.version}*.jar</include>
-                      </includes>
-                    </resource>
                     <!-- Copy cdap-ui -->
                     <resource>
                       <directory>${project.parent.basedir}/cdap-ui/server</directory>

--- a/pom.xml
+++ b/pom.xml
@@ -1516,9 +1516,6 @@
                   <![CDATA[Copyright &#169; {currentYear} <a href="http://cask.co" target="_blank">Cask Data, Inc.</a> Licensed under the <a href="http://www.apache.org/licenses/LICENSE-2.0" target="_blank">Apache License, Version 2.0</a>.]]>
                 </bottom>
                 <doctitle>${project.name} ${project.version}</doctitle>
-                <!-- Missing links:
-                kafka.api
-                -->
                 <links>
                   <link>http://avro.apache.org/docs/current/api/java/</link>
                   <link>http://docs.oracle.com/javaee/${jee.version}/api/</link>


### PR DESCRIPTION
Removes the HTML Javadocs included in the SDK zip file, and cdap-api files no longer required as offline compilation is no longer supported.

Built and tested locally.

Fix for https://issues.cask.co/browse/CDAP-2730