### PR TITLE
Refactor and fix start-debug command of CDAP CLI.

### DIFF
--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/StartDebugProgramCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/StartDebugProgramCommand.java
@@ -21,57 +21,16 @@ import co.cask.cdap.cli.CLIConfig;
 import co.cask.cdap.cli.ElementType;
 import co.cask.cdap.cli.english.Article;
 import co.cask.cdap.cli.english.Fragment;
-import co.cask.cdap.cli.exception.CommandInputError;
-import co.cask.cdap.cli.util.AbstractAuthCommand;
-import co.cask.cdap.cli.util.ArgumentParser;
 import co.cask.cdap.client.ProgramClient;
-import co.cask.common.cli.Arguments;
-import com.google.gson.Gson;
-
-import java.io.PrintStream;
-import java.util.Map;
 
 /**
  * Starts a program in debug mode.
  */
-public class StartDebugProgramCommand extends AbstractAuthCommand {
-
-  private static final Gson GSON = new Gson();
-
-  private final ProgramClient programClient;
-  private final ElementType elementType;
+public class StartDebugProgramCommand extends StartProgramCommand {
 
   public StartDebugProgramCommand(ElementType elementType, ProgramClient programClient, CLIConfig cliConfig) {
-    super(cliConfig);
-    this.elementType = elementType;
-    this.programClient = programClient;
-  }
-
-  @Override
-  public void perform(Arguments arguments, PrintStream output) throws Exception {
-    String[] programIdParts = arguments.get(elementType.getArgumentName().toString()).split("\\.");
-    if (programIdParts.length < 2) {
-      throw new CommandInputError(this);
-    }
-
-    String appId = programIdParts[0];
-    String programId = programIdParts[1];
-
-    String runtimeArgsString = arguments.get(ArgumentName.RUNTIME_ARGS.toString(), "");
-    if (runtimeArgsString == null || runtimeArgsString.isEmpty()) {
-      // run with stored runtime args
-      programClient.start(appId, elementType.getProgramType(), programId, true);
-      runtimeArgsString = GSON.toJson(programClient.getRuntimeArgs(appId, elementType.getProgramType(), programId));
-      output.printf("Successfully started %s '%s' of application '%s' with stored runtime arguments '%s'\n",
-                    elementType.getTitleName(), programId, appId, runtimeArgsString);
-    } else {
-      // run with user-provided runtime args
-      Map<String, String> runtimeArgs = ArgumentParser.parseMap(runtimeArgsString);
-      programClient.start(appId, elementType.getProgramType(), programId, true, runtimeArgs);
-      output.printf("Successfully started %s '%s' of application '%s' with provided runtime arguments '%s'\n",
-                    elementType.getTitleName(), programId, appId, runtimeArgsString);
-    }
-
+    super(elementType, programClient, cliConfig);
+    this.isDebug = true;
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/StartProgramCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/StartProgramCommand.java
@@ -35,11 +35,12 @@ import java.util.Map;
  * Starts a program.
  */
 public class StartProgramCommand extends AbstractAuthCommand {
-
   private static final Gson GSON = new Gson();
 
+  protected final ElementType elementType;
   private final ProgramClient programClient;
-  private final ElementType elementType;
+
+  protected boolean isDebug = false;
 
   public StartProgramCommand(ElementType elementType, ProgramClient programClient, CLIConfig cliConfig) {
     super(cliConfig);
@@ -60,14 +61,14 @@ public class StartProgramCommand extends AbstractAuthCommand {
     String runtimeArgsString = arguments.get(ArgumentName.RUNTIME_ARGS.toString(), "");
     if (runtimeArgsString == null || runtimeArgsString.isEmpty()) {
       // run with stored runtime args
-      programClient.start(appId, elementType.getProgramType(), programId, false);
+      programClient.start(appId, elementType.getProgramType(), programId, isDebug);
       runtimeArgsString = GSON.toJson(programClient.getRuntimeArgs(appId, elementType.getProgramType(), programId));
       output.printf("Successfully started %s '%s' of application '%s' with stored runtime arguments '%s'\n",
                     elementType.getTitleName(), programId, appId, runtimeArgsString);
     } else {
       // run with user-provided runtime args
       Map<String, String> runtimeArgs = ArgumentParser.parseMap(runtimeArgsString);
-      programClient.start(appId, elementType.getProgramType(), programId, false, runtimeArgs);
+      programClient.start(appId, elementType.getProgramType(), programId, isDebug, runtimeArgs);
       output.printf("Successfully started %s '%s' of application '%s' with provided runtime arguments '%s'\n",
                     elementType.getTitleName(), programId, appId, runtimeArgsString);
     }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/StartProgramCommandSet.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/StartProgramCommandSet.java
@@ -41,6 +41,7 @@ public class StartProgramCommandSet extends CommandSet<Command> {
     for (ElementType elementType : ElementType.values()) {
       if (elementType.canStart()) {
         commands.add(new StartProgramCommand(elementType, programClient, cliConfig));
+        commands.add(new StartDebugProgramCommand(elementType, programClient, cliConfig));
       }
     }
     return commands;

--- a/cdap-client/src/main/java/co/cask/cdap/client/ProgramClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ProgramClient.java
@@ -550,7 +550,7 @@ public class ProgramClient {
   /**
    * Gets the runtime args of a program.
    *
-   * @param appId ID of the application tat the program belongs to
+   * @param appId ID of the application that the program belongs to
    * @param programType type of the program
    * @param programId ID of the program
    * @return runtime args of the program
@@ -577,7 +577,7 @@ public class ProgramClient {
   /**
    * Sets the runtime args of a program.
    *
-   * @param appId ID of the application tat the program belongs to
+   * @param appId ID of the application that the program belongs to
    * @param programType type of the program
    * @param programId ID of the program
    * @param runtimeArgs args of the program


### PR DESCRIPTION
The `StartDebugProgramCommand` seemed to be nearly identical to `StartProgramCommand`, with only minor differences, so refactored it.

Also, the `StartDebugProgramCommand` was not being added to the `StartProgramCommandSet`, which is fixed in this PR.

Build: http://builds.cask.co/browse/CDAP-DUT2028-1