### PR TITLE
CDAP-1583 refactored inmemory program runners - worker, service

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/AbstractInMemoryProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/AbstractInMemoryProgramRunner.java
@@ -21,12 +21,19 @@ import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.app.runtime.ProgramRunner;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.internal.app.runtime.AbstractProgramController;
+import co.cask.cdap.internal.app.runtime.BasicArguments;
 import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
 import co.cask.cdap.internal.app.runtime.ProgramRunnerFactory;
+import co.cask.cdap.internal.app.runtime.SimpleProgramOptions;
 import com.google.common.base.Function;
+import com.google.common.base.Throwables;
+import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Table;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -47,10 +54,12 @@ public abstract class AbstractInMemoryProgramRunner implements ProgramRunner {
 
   private static final Logger LOG = LoggerFactory.getLogger(AbstractInMemoryProgramRunner.class);
 
+  private final String host;
   private final ProgramRunnerFactory programRunnerFactory;
 
   @Inject
-  public AbstractInMemoryProgramRunner(ProgramRunnerFactory programRunnerFactory) {
+  public AbstractInMemoryProgramRunner(CConfiguration cConf, ProgramRunnerFactory programRunnerFactory) {
+    this.host = cConf.get(Constants.AppFabric.SERVER_ADDRESS);
     this.programRunnerFactory = programRunnerFactory;
   }
 
@@ -65,7 +74,7 @@ public abstract class AbstractInMemoryProgramRunner implements ProgramRunner {
    * @param components A Table for storing the resulting ProgramControllers
    * @param type Type of ProgramRunnerFactory
    */
-  protected void startComponent(Program program, String name, int instances, RunId runId, ProgramOptions options,
+  private void startComponent(Program program, String name, int instances, RunId runId, ProgramOptions options,
                                 Table<String, Integer, ProgramController> components, ProgramRunnerFactory.Type type) {
     for (int instanceId = 0; instanceId < instances; instanceId++) {
       ProgramOptions componentOptions = createComponentOptions(name, instanceId, instances, runId, options);
@@ -74,8 +83,42 @@ public abstract class AbstractInMemoryProgramRunner implements ProgramRunner {
     }
   }
 
-  protected abstract ProgramOptions createComponentOptions(String name, int instanceId, int instances, RunId runId,
-                                                           ProgramOptions options);
+  protected Table<String, Integer, ProgramController> startPrograms(Program program, RunId runId,
+                                                                    ProgramOptions options,
+                                                                    ProgramRunnerFactory.Type type, int numInstances) {
+    Table<String, Integer, ProgramController> components = HashBasedTable.create();
+    try {
+      startComponent(program, program.getName(), numInstances, runId, options, components, type);
+    } catch (Throwable t) {
+      LOG.error("Failed to start all program instances", t);
+      try {
+        // Need to stop all started components
+        Futures.successfulAsList(Iterables.transform(components.values(),
+                                                     new Function<ProgramController, ListenableFuture<?>>() {
+                                                       @Override
+                                                       public ListenableFuture<?> apply(ProgramController controller) {
+                                                         return controller.stop();
+                                                       }
+                                                     })).get();
+        throw Throwables.propagate(t);
+      } catch (Exception e) {
+        LOG.error("Failed to stop all program instances upon startup failure.", e);
+        throw Throwables.propagate(e);
+      }
+    }
+    return components;
+  }
+
+  private ProgramOptions createComponentOptions(String name, int instanceId, int instances, RunId runId,
+                                                           ProgramOptions options) {
+    Map<String, String> systemOptions = Maps.newHashMap();
+    systemOptions.putAll(options.getArguments().asMap());
+    systemOptions.put(ProgramOptionConstants.INSTANCE_ID, Integer.toString(instanceId));
+    systemOptions.put(ProgramOptionConstants.INSTANCES, Integer.toString(instances));
+    systemOptions.put(ProgramOptionConstants.RUN_ID, runId.getId());
+    systemOptions.put(ProgramOptionConstants.HOST, host);
+    return new SimpleProgramOptions(name, new BasicArguments(systemOptions), options.getUserArguments());
+  }
 
   /**
    * ProgramController to manage multiple in-memory instances of a Program.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/InMemoryServiceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/InMemoryServiceProgramRunner.java
@@ -23,43 +23,23 @@ import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.common.conf.CConfiguration;
-import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.internal.app.AbstractInMemoryProgramRunner;
-import co.cask.cdap.internal.app.runtime.BasicArguments;
-import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
 import co.cask.cdap.internal.app.runtime.ProgramRunnerFactory;
-import co.cask.cdap.internal.app.runtime.SimpleProgramOptions;
 import co.cask.cdap.proto.ProgramType;
-import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Throwables;
-import com.google.common.collect.HashBasedTable;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Table;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
 import com.google.inject.Inject;
 import org.apache.twill.api.RunId;
 import org.apache.twill.internal.RunIds;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.Map;
 
 /**
  * For running {@link Service}. Only used in in-memory/standalone mode.
  */
 public class InMemoryServiceProgramRunner extends AbstractInMemoryProgramRunner {
 
-  private static final Logger LOG = LoggerFactory.getLogger(InMemoryServiceProgramRunner.class);
-
-  private final String host;
-
   @Inject
   InMemoryServiceProgramRunner(CConfiguration cConf, ProgramRunnerFactory programRunnerFactory) {
-    super(programRunnerFactory);
-    this.host = cConf.get(Constants.AppFabric.SERVER_ADDRESS);
+    super(cConf, programRunnerFactory);
   }
 
   @Override
@@ -77,58 +57,10 @@ public class InMemoryServiceProgramRunner extends AbstractInMemoryProgramRunner 
 
     //RunId for the service
     RunId runId = RunIds.generate();
-    Table<String, Integer, ProgramController> components = startServiceComponent(program, runId,
-                                                                                 options,
-                                                                                 serviceSpec);
+    Table<String, Integer, ProgramController> components = startPrograms(program, runId, options,
+                                                                         ProgramRunnerFactory.Type.SERVICE_COMPONENT,
+                                                                         serviceSpec.getInstances());
     return new InMemoryProgramController(components, runId, program, serviceSpec, options,
                                          ProgramRunnerFactory.Type.SERVICE_COMPONENT);
-  }
-
-  /**
-   * Creates and starts all components of the given Service program.
-   *
-   * @return A {@link Table} with component name in the row, instance id in the column and the {@link ProgramController}
-   *         of the component runner as the cell value.
-   */
-  private Table<String, Integer, ProgramController> startServiceComponent(Program program, RunId runId,
-                                                                          ProgramOptions options,
-                                                                          ServiceSpecification spec) {
-    Table<String, Integer, ProgramController> components = HashBasedTable.create();
-
-    try {
-      // Starts the http service. The name is the same as the service name.
-      startComponent(program, program.getName(), spec.getInstances(), runId, options, components,
-                     ProgramRunnerFactory.Type.SERVICE_COMPONENT);
-    } catch (Throwable t) {
-      LOG.error("Failed to start all service components upon startup failure.", t);
-      try {
-        // Need to stop all started components
-        Futures.successfulAsList(Iterables.transform(components.values(),
-         new Function<ProgramController, ListenableFuture<?>>() {
-           @Override
-           public ListenableFuture<?> apply(ProgramController controller) {
-             return controller.stop();
-           }
-         })).get();
-        throw Throwables.propagate(t);
-      } catch (Exception e) {
-        LOG.error("Failed to stop all service components upon startup failure.", e);
-        throw Throwables.propagate(e);
-      }
-    }
-    return components;
-  }
-
-
-  @Override
-  public ProgramOptions createComponentOptions(String name, int instanceId, int instances, RunId runId,
-                                               ProgramOptions options) {
-    Map<String, String> systemOptions = Maps.newHashMap();
-    systemOptions.putAll(options.getArguments().asMap());
-    systemOptions.put(ProgramOptionConstants.INSTANCE_ID, Integer.toString(instanceId));
-    systemOptions.put(ProgramOptionConstants.INSTANCES, Integer.toString(instances));
-    systemOptions.put(ProgramOptionConstants.RUN_ID, runId.getId());
-    systemOptions.put(ProgramOptionConstants.HOST, host);
-    return new SimpleProgramOptions(name, new BasicArguments(systemOptions), options.getUserArguments());
   }
 }


### PR DESCRIPTION
Moving common functionality to parent class. Removal of ServiceWorkers logic made this easier to accomplish.

Build: http://builds.cask.co/browse/CDAP-DUT2030