### PR TITLE
CDAP-2734 Partition-level metadata support for PartitionedFileSet and…

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/Partition.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/Partition.java
@@ -37,9 +37,4 @@ public interface Partition {
    * @return the partition key
    */
   PartitionKey getPartitionKey();
-
-  /**
-   * Gets the metadata for the partition
-   */
-  PartitionMetadata getMetadata();
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/Partition.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/Partition.java
@@ -37,4 +37,9 @@ public interface Partition {
    * @return the partition key
    */
   PartitionKey getPartitionKey();
+
+  /**
+   * Gets the metadata for the partition
+   */
+  PartitionMetadata getMetadata();
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionDetail.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionDetail.java
@@ -17,7 +17,12 @@
 package co.cask.cdap.api.dataset.lib;
 
 /**
- * Represents a partition of a partitioned file set for writing.
+ * Represents a partition of a partitioned file set, having metadata associated with it.
  */
-public interface TimePartitionOutput extends TimePartition, PartitionOutput {
+public interface PartitionDetail extends Partition {
+
+  /**
+   * Gets the metadata for the partition
+   */
+  PartitionMetadata getMetadata();
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionMetadata.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionMetadata.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.api.dataset.lib;
+
+import com.google.common.base.Objects;
+
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * Contains metadata associated with a particular {@link Partition} of a {@link @PartitionedFileSet}
+ */
+public class PartitionMetadata implements Iterable<Map.Entry<String, String>> {
+  private final Map<String, String> metadata;
+
+  public PartitionMetadata(Map<String, String> metadata) {
+    this.metadata = metadata;
+  }
+
+  public String get(String key) {
+    return metadata.get(key);
+  }
+
+  public Map<String, String> getAsMap() {
+    return metadata;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    PartitionMetadata that = (PartitionMetadata) o;
+
+    return Objects.equal(this.metadata, that.metadata);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(metadata);
+  }
+
+  @Override
+  public Iterator<Map.Entry<String, String>> iterator() {
+    return metadata.entrySet().iterator();
+  }
+}

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionMetadata.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionMetadata.java
@@ -18,6 +18,8 @@ package co.cask.cdap.api.dataset.lib;
 
 import com.google.common.base.Objects;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
@@ -28,14 +30,14 @@ public class PartitionMetadata implements Iterable<Map.Entry<String, String>> {
   private final Map<String, String> metadata;
 
   public PartitionMetadata(Map<String, String> metadata) {
-    this.metadata = metadata;
+    this.metadata = Collections.unmodifiableMap(new HashMap<>(metadata));
   }
 
   public String get(String key) {
     return metadata.get(key);
   }
 
-  public Map<String, String> getAsMap() {
+  public Map<String, String> asMap() {
     return metadata;
   }
 

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionMetadata.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionMetadata.java
@@ -16,12 +16,11 @@
 
 package co.cask.cdap.api.dataset.lib;
 
-import com.google.common.base.Objects;
-
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Contains metadata associated with a particular {@link Partition} of a {@link @PartitionedFileSet}
@@ -33,10 +32,19 @@ public class PartitionMetadata implements Iterable<Map.Entry<String, String>> {
     this.metadata = Collections.unmodifiableMap(new HashMap<>(metadata));
   }
 
+  /**
+   * Perform a get on the underlying map of user-defined metadata.
+   * @param key the key to use in the lookup on the underlying map.
+   * @return the value returned by the underlying map.
+   */
+  @Nullable
   public String get(String key) {
     return metadata.get(key);
   }
 
+  /**
+   * @return the underlying map of user-defined metadata.
+   */
   public Map<String, String> asMap() {
     return metadata;
   }
@@ -52,12 +60,12 @@ public class PartitionMetadata implements Iterable<Map.Entry<String, String>> {
 
     PartitionMetadata that = (PartitionMetadata) o;
 
-    return Objects.equal(this.metadata, that.metadata);
+    return this.metadata.equals(that.metadata);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(metadata);
+    return metadata.hashCode();
   }
 
   @Override

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionOutput.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionOutput.java
@@ -16,6 +16,8 @@
 
 package co.cask.cdap.api.dataset.lib;
 
+import java.util.Map;
+
 /**
  * Represents a partition of a partitioned file set for writing.
  */
@@ -29,5 +31,5 @@ public interface PartitionOutput extends Partition {
   /**
    * Sets the metadata of a partition, when creating a new partition.
    */
-  void setMetadata(PartitionMetadata metadata);
+  void setMetadata(Map<String, String> metadata);
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionOutput.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionOutput.java
@@ -27,7 +27,7 @@ public interface PartitionOutput extends Partition {
   void addPartition();
 
   /**
-   * Sets the metadata of a partition.
+   * Sets the metadata of a partition, when creating a new partition.
    */
   void setMetadata(PartitionMetadata metadata);
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionOutput.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionOutput.java
@@ -25,4 +25,9 @@ public interface PartitionOutput extends Partition {
    * Add the partition to the partitioned file set.
    */
   void addPartition();
+
+  /**
+   * Sets the metadata of a partition.
+   */
+  void setMetadata(PartitionMetadata metadata);
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionedFileSet.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionedFileSet.java
@@ -52,12 +52,19 @@ public interface PartitionedFileSet extends Dataset, InputFormatProvider, Output
    * Add a partition for a given partition key, stored at a given path (relative to the file set's base path),
    * with the given metadata.
    */
-  void addPartition(PartitionKey key, String path, PartitionMetadata metadata);
+  void addPartition(PartitionKey key, String path, Map<String, String> metadata);
 
   /**
-   * Updates the metadata for a particular partition.
+   * Adds a new metadata entry for a particular partition.
+   * Note that existing entries can not be updated; {@link IllegalArgumentException} will be thrown in that case.
    */
-  void updateMetadata(PartitionKey key, PartitionMetadata metadata);
+  void addMetadata(PartitionKey key, String metadataKey, String metadataValue);
+
+  /**
+   * Adds a set of new metadata entries for a particular partition
+   * Note that existing entries can not be updated; {@link IllegalArgumentException} will be thrown in that case.
+   */
+  void addMetadata(PartitionKey key, Map<String, String> metadata);
 
   /**
    * Remove a partition for a given partition key.
@@ -68,14 +75,14 @@ public interface PartitionedFileSet extends Dataset, InputFormatProvider, Output
    * Return the partition for a specific partition key.
    */
   @Nullable
-  Partition getPartition(PartitionKey key);
+  PartitionDetail getPartition(PartitionKey key);
 
   /**
    * Return all partitions matching the partition filter.
    * @param filter If non null, only partitions that match this filter are returned. If null,
    *               all partitions are returned.
    */
-  Set<Partition> getPartitions(@Nullable PartitionFilter filter);
+  Set<PartitionDetail> getPartitions(@Nullable PartitionFilter filter);
 
   /**
    * Return a partition output for a specific partition key, in preparation for creating a new partition.

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionedFileSet.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionedFileSet.java
@@ -56,13 +56,15 @@ public interface PartitionedFileSet extends Dataset, InputFormatProvider, Output
 
   /**
    * Adds a new metadata entry for a particular partition.
-   * Note that existing entries can not be updated; {@link IllegalArgumentException} will be thrown in that case.
+   * Note that existing entries can not be updated.
+   * @throws IllegalArgumentException in case an attempt is made to update existing entries.
    */
   void addMetadata(PartitionKey key, String metadataKey, String metadataValue);
 
   /**
    * Adds a set of new metadata entries for a particular partition
-   * Note that existing entries can not be updated; {@link IllegalArgumentException} will be thrown in that case.
+   * Note that existing entries can not be updated.
+   * @throws IllegalArgumentException in case an attempt is made to update existing entries.
    */
   void addMetadata(PartitionKey key, Map<String, String> metadata);
 

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionedFileSet.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionedFileSet.java
@@ -49,6 +49,17 @@ public interface PartitionedFileSet extends Dataset, InputFormatProvider, Output
   void addPartition(PartitionKey key, String path);
 
   /**
+   * Add a partition for a given partition key, stored at a given path (relative to the file set's base path),
+   * with the given metadata.
+   */
+  void addPartition(PartitionKey key, String path, PartitionMetadata metadata);
+
+  /**
+   * Updates the metadata for a particular partition.
+   */
+  void updateMetadata(PartitionKey key, PartitionMetadata metadata);
+
+  /**
    * Remove a partition for a given partition key.
    */
   void dropPartition(PartitionKey key);

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionedFileSet.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionedFileSet.java
@@ -19,6 +19,7 @@ package co.cask.cdap.api.dataset.lib;
 import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.data.batch.InputFormatProvider;
 import co.cask.cdap.api.data.batch.OutputFormatProvider;
+import co.cask.cdap.api.dataset.DataSetException;
 import co.cask.cdap.api.dataset.Dataset;
 
 import java.util.Map;
@@ -57,14 +58,14 @@ public interface PartitionedFileSet extends Dataset, InputFormatProvider, Output
   /**
    * Adds a new metadata entry for a particular partition.
    * Note that existing entries can not be updated.
-   * @throws IllegalArgumentException in case an attempt is made to update existing entries.
+   * @throws DataSetException in case an attempt is made to update existing entries.
    */
   void addMetadata(PartitionKey key, String metadataKey, String metadataValue);
 
   /**
    * Adds a set of new metadata entries for a particular partition
    * Note that existing entries can not be updated.
-   * @throws IllegalArgumentException in case an attempt is made to update existing entries.
+   * @throws DataSetException in case an attempt is made to update existing entries.
    */
   void addMetadata(PartitionKey key, Map<String, String> metadata);
 

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/TimePartitionDetail.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/TimePartitionDetail.java
@@ -17,7 +17,7 @@
 package co.cask.cdap.api.dataset.lib;
 
 /**
- * Represents a partition of a partitioned file set for writing.
+ * Represents a partition of a time partitioned file set.
  */
-public interface TimePartitionOutput extends TimePartition, PartitionOutput {
+public interface TimePartitionDetail extends TimePartition, PartitionDetail {
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/TimePartitionedFileSet.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/TimePartitionedFileSet.java
@@ -59,12 +59,14 @@ public interface TimePartitionedFileSet extends PartitionedFileSet {
   /**
    * Adds a new metadata entry for a particular partition.
    * Note that existing entries can not be updated.
+   * @throws IllegalArgumentException in case an attempt is made to update existing entries.
    */
   void addMetadata(long time, String metadataKey, String metadataValue);
 
   /**
    * Adds a set of new metadata entries for a particular partition
    * Note that existing entries can not be updated.
+   * * @throws IllegalArgumentException in case an attempt is made to update existing entries.
    */
   void addMetadata(long time, Map<String, String> metadata);
 

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/TimePartitionedFileSet.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/TimePartitionedFileSet.java
@@ -50,6 +50,19 @@ public interface TimePartitionedFileSet extends PartitionedFileSet {
    */
   void addPartition(long time, String path);
 
+  // Why are some of these methods methodNameByTime, while others are just methodName?
+  // (why are some suffixed by 'ByTime')
+  /**
+   * Add a partition for a given time, stored at a given path (relative to the file set's base path),
+   * with given metadata.
+   */
+  void addPartition(long time, String path, PartitionMetadata metadata);
+
+  /**
+   * Updates the metadata for a particular partition.
+   */
+  void updateMetadata(long time, PartitionMetadata metadata);
+
   /**
    * Remove a partition for a given time.
    */

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/TimePartitionedFileSet.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/TimePartitionedFileSet.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.api.dataset.lib;
 
 import co.cask.cdap.api.annotation.Beta;
+import co.cask.cdap.api.dataset.DataSetException;
 
 import java.util.Collection;
 import java.util.Map;
@@ -59,14 +60,14 @@ public interface TimePartitionedFileSet extends PartitionedFileSet {
   /**
    * Adds a new metadata entry for a particular partition.
    * Note that existing entries can not be updated.
-   * @throws IllegalArgumentException in case an attempt is made to update existing entries.
+   * @throws DataSetException in case an attempt is made to update existing entries.
    */
   void addMetadata(long time, String metadataKey, String metadataValue);
 
   /**
    * Adds a set of new metadata entries for a particular partition
    * Note that existing entries can not be updated.
-   * * @throws IllegalArgumentException in case an attempt is made to update existing entries.
+   * * @throws DataSetException in case an attempt is made to update existing entries.
    */
   void addMetadata(long time, Map<String, String> metadata);
 

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/TimePartitionedFileSet.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/TimePartitionedFileSet.java
@@ -50,18 +50,23 @@ public interface TimePartitionedFileSet extends PartitionedFileSet {
    */
   void addPartition(long time, String path);
 
-  // Why are some of these methods methodNameByTime, while others are just methodName?
-  // (why are some suffixed by 'ByTime')
   /**
    * Add a partition for a given time, stored at a given path (relative to the file set's base path),
    * with given metadata.
    */
-  void addPartition(long time, String path, PartitionMetadata metadata);
+  void addPartition(long time, String path, Map<String, String> metadata);
 
   /**
-   * Updates the metadata for a particular partition.
+   * Adds a new metadata entry for a particular partition.
+   * Note that existing entries can not be updated.
    */
-  void updateMetadata(long time, PartitionMetadata metadata);
+  void addMetadata(long time, String metadataKey, String metadataValue);
+
+  /**
+   * Adds a set of new metadata entries for a particular partition
+   * Note that existing entries can not be updated.
+   */
+  void addMetadata(long time, Map<String, String> metadata);
 
   /**
    * Remove a partition for a given time.
@@ -73,13 +78,13 @@ public interface TimePartitionedFileSet extends PartitionedFileSet {
    * or null if no such partition exists.
    */
   @Nullable
-  TimePartition getPartitionByTime(long time);
+  TimePartitionDetail getPartitionByTime(long time);
 
   /**
    * Return all partitions within the time range given by startTime (inclusive) and endTime (exclusive),
    * both rounded to the full minute.
    */
-  Set<TimePartition> getPartitionsByTime(long startTime, long endTime);
+  Set<TimePartitionDetail> getPartitionsByTime(long startTime, long endTime);
 
   /**
    * Return a partition output for a specific time, rounded to the minute, in preparation for creating a new partition.

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceWithPartitionedTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceWithPartitionedTest.java
@@ -19,7 +19,7 @@ package co.cask.cdap.internal.app.runtime.batch;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.common.RuntimeArguments;
 import co.cask.cdap.api.common.Scope;
-import co.cask.cdap.api.dataset.lib.PartitionDetail;
+import co.cask.cdap.api.dataset.lib.Partition;
 import co.cask.cdap.api.dataset.lib.PartitionFilter;
 import co.cask.cdap.api.dataset.lib.PartitionKey;
 import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
@@ -169,9 +169,9 @@ public class MapReduceWithPartitionedTest {
       new TransactionExecutor.Subroutine() {
         @Override
         public void apply() {
-          PartitionDetail partitionDetail = tpfs.getPartitionByTime(time);
-          Assert.assertNotNull(partitionDetail);
-          String path = partitionDetail.getRelativePath();
+          Partition partition = tpfs.getPartitionByTime(time);
+          Assert.assertNotNull(partition);
+          String path = partition.getRelativePath();
           Assert.assertNotNull(path);
           Assert.assertTrue(path.contains("2015-01-15/11-15"));
         }
@@ -199,9 +199,9 @@ public class MapReduceWithPartitionedTest {
       new TransactionExecutor.Subroutine() {
         @Override
         public void apply() {
-          PartitionDetail partitionDetail = tpfs.getPartitionByTime(time5);
-          Assert.assertNotNull(partitionDetail);
-          String path = partitionDetail.getRelativePath();
+          Partition partition = tpfs.getPartitionByTime(time5);
+          Assert.assertNotNull(partition);
+          String path = partition.getRelativePath();
           Assert.assertNotNull(path);
           Assert.assertTrue(path.contains("2015-01-15/11-20"));
         }
@@ -282,9 +282,9 @@ public class MapReduceWithPartitionedTest {
       new TransactionExecutor.Subroutine() {
         @Override
         public void apply() {
-          PartitionDetail partitionDetail = dataset.getPartition(keyX);
-          Assert.assertNotNull(partitionDetail);
-          String path = partitionDetail.getRelativePath();
+          Partition partition = dataset.getPartition(keyX);
+          Assert.assertNotNull(partition);
+          String path = partition.getRelativePath();
           Assert.assertTrue(path.contains("x"));
           Assert.assertTrue(path.contains("150000"));
         }
@@ -316,9 +316,9 @@ public class MapReduceWithPartitionedTest {
       new TransactionExecutor.Subroutine() {
         @Override
         public void apply() {
-          PartitionDetail partitionDetail = dataset.getPartition(keyY);
-          Assert.assertNotNull(partitionDetail);
-          String path = partitionDetail.getRelativePath();
+          Partition partition = dataset.getPartition(keyY);
+          Assert.assertNotNull(partition);
+          String path = partition.getRelativePath();
           Assert.assertNotNull(path);
           Assert.assertTrue(path.contains("y"));
           Assert.assertTrue(path.contains("200000"));

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceWithPartitionedTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceWithPartitionedTest.java
@@ -19,7 +19,7 @@ package co.cask.cdap.internal.app.runtime.batch;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.common.RuntimeArguments;
 import co.cask.cdap.api.common.Scope;
-import co.cask.cdap.api.dataset.lib.Partition;
+import co.cask.cdap.api.dataset.lib.PartitionDetail;
 import co.cask.cdap.api.dataset.lib.PartitionFilter;
 import co.cask.cdap.api.dataset.lib.PartitionKey;
 import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
@@ -169,9 +169,9 @@ public class MapReduceWithPartitionedTest {
       new TransactionExecutor.Subroutine() {
         @Override
         public void apply() {
-          Partition partition = tpfs.getPartitionByTime(time);
-          Assert.assertNotNull(partition);
-          String path = partition.getRelativePath();
+          PartitionDetail partitionDetail = tpfs.getPartitionByTime(time);
+          Assert.assertNotNull(partitionDetail);
+          String path = partitionDetail.getRelativePath();
           Assert.assertNotNull(path);
           Assert.assertTrue(path.contains("2015-01-15/11-15"));
         }
@@ -199,9 +199,9 @@ public class MapReduceWithPartitionedTest {
       new TransactionExecutor.Subroutine() {
         @Override
         public void apply() {
-          Partition partition = tpfs.getPartitionByTime(time5);
-          Assert.assertNotNull(partition);
-          String path = partition.getRelativePath();
+          PartitionDetail partitionDetail = tpfs.getPartitionByTime(time5);
+          Assert.assertNotNull(partitionDetail);
+          String path = partitionDetail.getRelativePath();
           Assert.assertNotNull(path);
           Assert.assertTrue(path.contains("2015-01-15/11-20"));
         }
@@ -282,9 +282,9 @@ public class MapReduceWithPartitionedTest {
       new TransactionExecutor.Subroutine() {
         @Override
         public void apply() {
-          Partition partition = dataset.getPartition(keyX);
-          Assert.assertNotNull(partition);
-          String path = partition.getRelativePath();
+          PartitionDetail partitionDetail = dataset.getPartition(keyX);
+          Assert.assertNotNull(partitionDetail);
+          String path = partitionDetail.getRelativePath();
           Assert.assertTrue(path.contains("x"));
           Assert.assertTrue(path.contains("150000"));
         }
@@ -316,9 +316,9 @@ public class MapReduceWithPartitionedTest {
       new TransactionExecutor.Subroutine() {
         @Override
         public void apply() {
-          Partition partition = dataset.getPartition(keyY);
-          Assert.assertNotNull(partition);
-          String path = partition.getRelativePath();
+          PartitionDetail partitionDetail = dataset.getPartition(keyY);
+          Assert.assertNotNull(partitionDetail);
+          String path = partitionDetail.getRelativePath();
           Assert.assertNotNull(path);
           Assert.assertTrue(path.contains("y"));
           Assert.assertTrue(path.contains("200000"));

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/BasicPartition.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/BasicPartition.java
@@ -26,7 +26,7 @@ import org.apache.twill.filesystem.Location;
  */
 class BasicPartition implements Partition {
 
-  private final transient PartitionedFileSetDataset partitionedFileSetDataset;
+  protected final transient PartitionedFileSetDataset partitionedFileSetDataset;
   protected final String relativePath;
   protected final PartitionKey key;
 
@@ -38,7 +38,7 @@ class BasicPartition implements Partition {
 
   @Override
   public Location getLocation() {
-    return partitionedFileSetDataset.getFiles().getLocation(relativePath);
+    return partitionedFileSetDataset.getEmbeddedFileSet().getLocation(relativePath);
   }
 
   @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/BasicPartition.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/BasicPartition.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.dataset2.lib.partitioned;
+
+import co.cask.cdap.api.dataset.lib.Partition;
+import co.cask.cdap.api.dataset.lib.PartitionKey;
+import com.google.common.base.Objects;
+import org.apache.twill.filesystem.Location;
+
+/**
+ * Simple Implementation of Partition.
+ */
+class BasicPartition implements Partition {
+
+  private final transient PartitionedFileSetDataset partitionedFileSetDataset;
+  protected final String relativePath;
+  protected final PartitionKey key;
+
+  protected BasicPartition(PartitionedFileSetDataset partitionedFileSetDataset, String relativePath, PartitionKey key) {
+    this.partitionedFileSetDataset = partitionedFileSetDataset;
+    this.relativePath = relativePath;
+    this.key = key;
+  }
+
+  @Override
+  public Location getLocation() {
+    return partitionedFileSetDataset.getFiles().getLocation(relativePath);
+  }
+
+  @Override
+  public String getRelativePath() {
+    return relativePath;
+  }
+
+  @Override
+  public PartitionKey getPartitionKey() {
+    return key;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || !(o instanceof BasicPartition)) {
+      return false;
+    }
+    BasicPartition that = (BasicPartition) o;
+    return key.equals(that.key) && relativePath.equals(that.relativePath);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(key, relativePath);
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/BasicPartitionDetail.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/BasicPartitionDetail.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.dataset2.lib.partitioned;
+
+import co.cask.cdap.api.dataset.lib.PartitionDetail;
+import co.cask.cdap.api.dataset.lib.PartitionKey;
+import co.cask.cdap.api.dataset.lib.PartitionMetadata;
+import com.google.common.base.Objects;
+
+/**
+ * Implementation of Partition, with associated metadata.
+ */
+class BasicPartitionDetail extends BasicPartition implements PartitionDetail {
+  protected final PartitionMetadata metadata;
+
+  protected BasicPartitionDetail(PartitionedFileSetDataset partitionedFileSetDataset,
+                                 String relativePath, PartitionKey key, PartitionMetadata metadata) {
+    super(partitionedFileSetDataset, relativePath, key);
+    this.metadata = metadata;
+  }
+
+  @Override
+  public PartitionMetadata getMetadata() {
+    return metadata;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || !(o instanceof BasicPartitionDetail)) {
+      return false;
+    }
+    BasicPartitionDetail that = (BasicPartitionDetail) o;
+    return key.equals(that.key) && relativePath.equals(that.relativePath) && metadata.equals(that.metadata);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(key, relativePath, metadata);
+  }
+
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetDataset.java
@@ -174,7 +174,7 @@ public class PartitionedFileSetDataset extends AbstractDataset implements Partit
   public void addMetadata(PartitionKey key, Map<String, String> metadata) {
     final byte[] rowKey = generateRowKey(key, partitioning);
     Row row = partitionsTable.get(rowKey);
-    if (row == null) {
+    if (row.isEmpty()) {
       throw new DataSetException(String.format("Dataset '%s' does not have a partition for key: %s", getName(), key));
     }
 
@@ -244,7 +244,7 @@ public class PartitionedFileSetDataset extends AbstractDataset implements Partit
   public PartitionDetail getPartition(PartitionKey key) {
     byte[] rowKey = generateRowKey(key, partitioning);
     Row row = partitionsTable.get(rowKey);
-    if (row == null) {
+    if (row.isEmpty()) {
       return null;
     }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetDataset.java
@@ -25,7 +25,7 @@ import co.cask.cdap.api.dataset.lib.AbstractDataset;
 import co.cask.cdap.api.dataset.lib.FileSet;
 import co.cask.cdap.api.dataset.lib.FileSetArguments;
 import co.cask.cdap.api.dataset.lib.FileSetProperties;
-import co.cask.cdap.api.dataset.lib.Partition;
+import co.cask.cdap.api.dataset.lib.PartitionDetail;
 import co.cask.cdap.api.dataset.lib.PartitionFilter;
 import co.cask.cdap.api.dataset.lib.PartitionKey;
 import co.cask.cdap.api.dataset.lib.PartitionMetadata;
@@ -34,7 +34,6 @@ import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
 import co.cask.cdap.api.dataset.lib.PartitionedFileSetArguments;
 import co.cask.cdap.api.dataset.lib.Partitioning;
 import co.cask.cdap.api.dataset.lib.Partitioning.FieldType;
-import co.cask.cdap.api.dataset.table.Delete;
 import co.cask.cdap.api.dataset.table.Put;
 import co.cask.cdap.api.dataset.table.Row;
 import co.cask.cdap.api.dataset.table.Scanner;
@@ -43,7 +42,6 @@ import co.cask.cdap.explore.client.ExploreFacade;
 import co.cask.cdap.proto.Id;
 import co.cask.tephra.Transaction;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
@@ -118,46 +116,24 @@ public class PartitionedFileSetDataset extends AbstractDataset implements Partit
 
   @Override
   public void addPartition(PartitionKey key, String path) {
-    addPartition(key, path, new PartitionMetadata(ImmutableMap.<String, String>of()));
+    addPartition(key, path, ImmutableMap.<String, String>of());
   }
 
   @Override
-  public void addPartition(PartitionKey key, String path, PartitionMetadata metadata) {
+  public void addPartition(PartitionKey key, String path, Map<String, String> metadata) {
     addPartition(key, path, true, metadata);
   }
 
-  @Override
-  public void updateMetadata(PartitionKey key, PartitionMetadata metadata) {
-    final byte[] rowKey = generateRowKey(key, partitioning);
-    Row row = partitionsTable.get(rowKey);
-    if (row == null) {
-      throw new DataSetException(String.format("Dataset '%s' does not have a partition for key: %s", getName(), key));
-    }
-
-    // delete all the old metadata and then write the new metadata
-    Delete delete = new Delete(rowKey);
-    addMetadataToDelete(row, metadata, delete);
-    partitionsTable.delete(delete);
-
-    Put put = new Put(rowKey);
-    addMetadataToPut(metadata, put);
-    partitionsTable.put(put);
-  }
-
-  // removes all metadata columns, except those that have keys also in the new metadata.
-  private void addMetadataToDelete(Row oldRow, PartitionMetadata newMetadata, Delete delete) {
-    for (Map.Entry<byte[], byte[]> entry : oldRow.getColumns().entrySet()) {
-      if (Bytes.startsWith(entry.getKey(), METADATA_PREFIX)) {
-        // we only need to delete the keys that are not in the new metadata entries
-        String metadataKey = metadataKeyFromColumnKey(entry.getKey());
-        if (!newMetadata.asMap().containsKey(metadataKey)) {
-          delete.add(entry.getKey());
-        }
-      }
-    }
-  }
-
-  protected void addPartition(PartitionKey key, String path, boolean addToExplore, PartitionMetadata metadata) {
+  /**
+   * Add a partition for a given partition key, stored at a given path (relative to the file set's base path),
+   * with the given metadata.
+   *
+   * @param key the partitionKey for the partition.
+   * @param path the path for the partition.
+   * @param explorable whether to add the partition to explore
+   * @param metadata the metadata associated with the partition.
+   */
+  protected void addPartition(PartitionKey key, String path, boolean explorable, Map<String, String> metadata) {
     byte[] rowKey = generateRowKey(key, partitioning);
     Row row = partitionsTable.get(rowKey);
     if (row != null && !row.isEmpty()) {
@@ -183,15 +159,40 @@ public class PartitionedFileSetDataset extends AbstractDataset implements Partit
     partitionsTable.put(put);
     partitionsAddedInSameTx.put(path, key);
 
-    if (addToExplore) {
+    if (explorable) {
       addPartitionToExplore(key, path);
       // TODO: make DDL operations transactional [CDAP-1393]
     }
   }
 
-  private void addMetadataToPut(PartitionMetadata metadata, Put put) {
-    for (Map.Entry<String, String> entry : metadata) {
-      byte[] columnKey = Bytes.add(METADATA_PREFIX, Bytes.toBytes(entry.getKey()));
+  @Override
+  public void addMetadata(PartitionKey key, String metadataKey, String metadataValue) {
+    addMetadata(key, ImmutableMap.of(metadataKey, metadataValue));
+  }
+
+  @Override
+  public void addMetadata(PartitionKey key, Map<String, String> metadata) {
+    final byte[] rowKey = generateRowKey(key, partitioning);
+    Row row = partitionsTable.get(rowKey);
+    if (row == null) {
+      throw new DataSetException(String.format("Dataset '%s' does not have a partition for key: %s", getName(), key));
+    }
+
+    // ensure that none of the entries already exist in the metadata
+    for (Map.Entry<String, String> metadataEntry : metadata.entrySet()) {
+      String metadataKey = metadataEntry.getKey();
+      byte[] columnKey = columnKeyFromMetadataKey(metadataKey);
+      Preconditions.checkArgument(row.get(columnKey) == null, "Entry already exists for metadata key: {}", metadataKey);
+    }
+
+    Put put = new Put(rowKey);
+    addMetadataToPut(metadata, put);
+    partitionsTable.put(put);
+  }
+
+  private void addMetadataToPut(Map<String, String> metadata, Put put) {
+    for (Map.Entry<String, String> entry : metadata.entrySet()) {
+      byte[] columnKey = columnKeyFromMetadataKey(entry.getKey());
       put.add(columnKey, Bytes.toBytes(entry.getValue()));
     }
   }
@@ -238,7 +239,7 @@ public class PartitionedFileSetDataset extends AbstractDataset implements Partit
   }
 
   @Override
-  public Partition getPartition(PartitionKey key) {
+  public PartitionDetail getPartition(PartitionKey key) {
     byte[] rowKey = generateRowKey(key, partitioning);
     Row row = partitionsTable.get(rowKey);
     if (row == null) {
@@ -246,21 +247,22 @@ public class PartitionedFileSetDataset extends AbstractDataset implements Partit
     }
 
     byte[] pathBytes = row.get(RELATIVE_PATH);
-    Preconditions.checkNotNull(pathBytes,
-                               "pathBytes is null for partitionKey: {}, with rowKey: {}", key, row.getRow());
-    return new BasicPartition(Bytes.toString(pathBytes), key, metadataFromRow(row));
+    if (pathBytes == null) {
+      return null;
+    }
+    return new BasicPartitionDetail(this, Bytes.toString(pathBytes), key, metadataFromRow(row));
   }
 
   @Override
-  public Set<Partition> getPartitions(@Nullable PartitionFilter filter) {
-    final Set<Partition> partitions = Sets.newHashSet();
+  public Set<PartitionDetail> getPartitions(@Nullable PartitionFilter filter) {
+    final Set<PartitionDetail> partitionDetails = Sets.newHashSet();
     getPartitions(filter, new PartitionConsumer() {
       @Override
       public void consume(PartitionKey key, String path, @Nullable PartitionMetadata metadata) {
-        partitions.add(new BasicPartition(path, key, metadata));
+        partitionDetails.add(new BasicPartitionDetail(PartitionedFileSetDataset.this, path, key, metadata));
       }
     });
-    return partitions;
+    return partitionDetails;
   }
 
   @VisibleForTesting
@@ -281,9 +283,9 @@ public class PartitionedFileSetDataset extends AbstractDataset implements Partit
     getPartitions(filter, consumer, true);
   }
 
-  // if parseMetadata is false, null is passed as the PartitionMetadata to the PartitionConsumer,
+  // if decodeMetadata is false, null is passed as the PartitionMetadata to the PartitionConsumer,
   // for efficiency reasons, since the metadata is not always needed
-  protected void getPartitions(@Nullable PartitionFilter filter, PartitionConsumer consumer, boolean parseMetadata) {
+  protected void getPartitions(@Nullable PartitionFilter filter, PartitionConsumer consumer, boolean decodeMetadata) {
     byte[] startKey = generateStartKey(filter);
     byte[] endKey = generateStopKey(filter);
     Scanner scanner = partitionsTable.scan(startKey, endKey);
@@ -307,9 +309,9 @@ public class PartitionedFileSetDataset extends AbstractDataset implements Partit
           continue;
         }
         byte[] pathBytes = row.get(RELATIVE_PATH);
-        Preconditions.checkNotNull(pathBytes,
-                                   "pathBytes is null for partitionKey: {}, with rowKey: {}", key, row.getRow());
-        consumer.consume(key, Bytes.toString(pathBytes), parseMetadata ? metadataFromRow(row) : null);
+        if (pathBytes != null) {
+          consumer.consume(key, Bytes.toString(pathBytes), decodeMetadata ? metadataFromRow(row) : null);
+        }
       }
     } finally {
       scanner.close();
@@ -317,18 +319,22 @@ public class PartitionedFileSetDataset extends AbstractDataset implements Partit
   }
 
   private PartitionMetadata metadataFromRow(Row row) {
-    Map<String, String> metadataEntries = Maps.newHashMap();
+    Map<String, String> metadata = Maps.newHashMap();
     for (Map.Entry<byte[], byte[]> entry : row.getColumns().entrySet()) {
       if (Bytes.startsWith(entry.getKey(), METADATA_PREFIX)) {
         String metadataKey = metadataKeyFromColumnKey(entry.getKey());
-        metadataEntries.put(metadataKey, Bytes.toString(entry.getValue()));
+        metadata.put(metadataKey, Bytes.toString(entry.getValue()));
       }
     }
-    return new PartitionMetadata(metadataEntries);
+    return new PartitionMetadata(metadata);
   }
 
   private String metadataKeyFromColumnKey(byte[] columnKey) {
-    return Bytes.toString(columnKey, METADATA_PREFIX.length, columnKey.length);
+    return Bytes.toString(columnKey, METADATA_PREFIX.length, columnKey.length - METADATA_PREFIX.length);
+  }
+
+  private byte[] columnKeyFromMetadataKey(String metadataKey) {
+    return Bytes.add(METADATA_PREFIX, Bytes.toBytes(metadataKey));
   }
 
   /**
@@ -343,6 +349,10 @@ public class PartitionedFileSetDataset extends AbstractDataset implements Partit
       sep = "/";
     }
     return builder.toString();
+  }
+
+  FileSet getFiles() {
+    return files;
   }
 
   /**
@@ -414,7 +424,7 @@ public class PartitionedFileSetDataset extends AbstractDataset implements Partit
     }
     // we know for sure there is an output partition key (checked in getOutputFormatConfig())
     PartitionKey outputKey = PartitionedFileSetArguments.getOutputPartitionKey(runtimeArguments, getPartitioning());
-    // TODO: how will, from mapreduce, write metadata to the partition?
+    // TODO: Add support to write to metadata from MapReduce - https://issues.cask.co/browse/CDAP-2784
     addPartition(outputKey, outputPath);
   }
 
@@ -602,64 +612,14 @@ public class PartitionedFileSetDataset extends AbstractDataset implements Partit
   }
 
   /**
-   * Simple Implementation of Partition.
-   */
-  protected class BasicPartition implements Partition {
-    protected final String relativePath;
-    protected final PartitionKey key;
-    protected PartitionMetadata metadata;
-
-    protected BasicPartition(String relativePath, PartitionKey key, PartitionMetadata metadata) {
-      this.relativePath = relativePath;
-      this.key = key;
-      this.metadata = metadata;
-    }
-
-    @Override
-    public Location getLocation() {
-      return files.getLocation(relativePath);
-    }
-
-    @Override
-    public String getRelativePath() {
-      return relativePath;
-    }
-
-    @Override
-    public PartitionKey getPartitionKey() {
-      return key;
-    }
-
-    @Override
-    public PartitionMetadata getMetadata() {
-      return metadata;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || !(o instanceof BasicPartition)) {
-        return false;
-      }
-      BasicPartition that = (BasicPartition) o;
-      return key.equals(that.key) && relativePath.equals(that.relativePath) && metadata.equals(that.metadata);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hashCode(key, relativePath, metadata);
-    }
-  }
-
-  /**
    * Simple Implementation of PartitionOutput.
    */
   protected class BasicPartitionOutput extends BasicPartition implements PartitionOutput {
+    private Map<String, String> metadata;
 
     protected BasicPartitionOutput(String relativePath, PartitionKey key) {
-      super(relativePath, key, new PartitionMetadata(ImmutableMap.<String, String>of()));
+      super(PartitionedFileSetDataset.this, relativePath, key);
+      this.metadata = Maps.newHashMap();
     }
 
     @Override
@@ -668,7 +628,7 @@ public class PartitionedFileSetDataset extends AbstractDataset implements Partit
     }
 
     @Override
-    public void setMetadata(PartitionMetadata metadata) {
+    public void setMetadata(Map<String, String> metadata) {
       this.metadata = metadata;
     }
   }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetTest.java
@@ -182,6 +182,18 @@ public class PartitionedFileSetTest {
           Assert.fail("Expected not to be able to update an existing metadata entry");
         } catch (DataSetException expected) {
         }
+
+        PartitionKey nonexistentPartitionKey = PartitionKey.builder()
+          .addIntField("i", 42)
+          .addLongField("l", 17L)
+          .addStringField("s", "nonexistent")
+          .build();
+
+        try {
+          dataset.addMetadata(nonexistentPartitionKey, "key2", "value3");
+          Assert.fail("Expected not to be able to add metadata for a nonexistent partition");
+        } catch (DataSetException expected) {
+        }
       }
     });
   }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetTest.java
@@ -43,6 +43,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
@@ -203,7 +204,7 @@ public class PartitionedFileSetTest {
                 p.addPartition();
                 return new BasicPartitionDetail((PartitionedFileSetDataset) dataset,
                                                  p.getRelativePath(), p.getPartitionKey(),
-                                                 new PartitionMetadata(ImmutableMap.<String, String>of()));
+                                                 new PartitionMetadata(Collections.<String, String>emptyMap()));
               }
             });
           keys[s][i][l] = key;

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetTest.java
@@ -16,7 +16,7 @@
 
 package co.cask.cdap.data2.dataset2.lib.partitioned;
 
-import co.cask.cdap.api.dataset.lib.Partition;
+import co.cask.cdap.api.dataset.lib.PartitionDetail;
 import co.cask.cdap.api.dataset.lib.PartitionFilter;
 import co.cask.cdap.api.dataset.lib.PartitionKey;
 import co.cask.cdap.api.dataset.lib.PartitionMetadata;
@@ -33,6 +33,7 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.junit.After;
 import org.junit.Assert;
@@ -42,6 +43,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -127,17 +129,17 @@ public class PartitionedFileSetTest {
       .addStringField("s", "x")
       .build();
 
-    PartitionMetadata metadata = new PartitionMetadata(ImmutableMap.of("key1", "value",
-                                                                       "key2", "value2",
-                                                                       "key3", "value2"));
+    ImmutableMap<String, String> metadata = ImmutableMap.of("key1", "value",
+                                                            "key2", "value2",
+                                                            "key3", "value2");
 
     PartitionOutput partitionOutput = dataset.getPartitionOutput(partitionKey);
     partitionOutput.setMetadata(metadata);
     partitionOutput.addPartition();
 
-    Partition partition = dataset.getPartition(partitionKey);
-    Assert.assertNotNull(partition);
-    Assert.assertEquals(metadata, partition.getMetadata());
+    PartitionDetail partitionDetail = dataset.getPartition(partitionKey);
+    Assert.assertNotNull(partitionDetail);
+    Assert.assertEquals(metadata, partitionDetail.getMetadata().asMap());
   }
 
   @Test
@@ -151,15 +153,27 @@ public class PartitionedFileSetTest {
       .build();
 
     PartitionOutput partitionOutput = dataset.getPartitionOutput(partitionKey);
-    partitionOutput.setMetadata(new PartitionMetadata(ImmutableMap.of("key1", "value1")));
+    ImmutableMap<String, String> originalEntries = ImmutableMap.of("key1", "value1");
+    partitionOutput.setMetadata(originalEntries);
     partitionOutput.addPartition();
 
-    PartitionMetadata updatedMetadata = new PartitionMetadata(ImmutableMap.of("key2", "value2"));
-    dataset.updateMetadata(partitionKey, updatedMetadata);
+    ImmutableMap<String, String> updatedMetadata = ImmutableMap.of("key2", "value2");
+    dataset.addMetadata(partitionKey, updatedMetadata);
 
-    Partition partition = dataset.getPartition(partitionKey);
-    Assert.assertNotNull(partition);
-    Assert.assertEquals(updatedMetadata, partition.getMetadata());
+    PartitionDetail partitionDetail = dataset.getPartition(partitionKey);
+    Assert.assertNotNull(partitionDetail);
+
+    HashMap<String, String> combinedEntries = Maps.newHashMap();
+    combinedEntries.putAll(originalEntries);
+    combinedEntries.putAll(updatedMetadata);
+    Assert.assertEquals(combinedEntries, partitionDetail.getMetadata().asMap());
+
+    // adding an entry, for a key that already exists will throw an Exception
+    try {
+      dataset.addMetadata(partitionKey, "key2", "value3");
+      Assert.fail("Expected not to be able to update an existing metadata entry");
+    } catch (IllegalArgumentException expected) {
+    }
   }
 
   @Test
@@ -170,7 +184,7 @@ public class PartitionedFileSetTest {
 
     final PartitionKey[][][] keys = new PartitionKey[4][4][4];
     final String[][][] paths = new String[4][4][4];
-    final Set<Partition> allPartitions = Sets.newHashSet();
+    final Set<PartitionDetail> allPartitionDetails = Sets.newHashSet();
 
     // add a bunch of partitions
     for (int s = 0; s < 4; s++) {
@@ -181,18 +195,20 @@ public class PartitionedFileSetTest {
             .addField("i", i * 100)
             .addField("l", 15L - 10 * l)
             .build();
-          Partition partition = dsFrameworkUtil.newTransactionExecutor((TransactionAware) dataset)
-            .execute(new Callable<PartitionOutput>() {
+          PartitionDetail partitionDetail = dsFrameworkUtil.newTransactionExecutor((TransactionAware) dataset)
+            .execute(new Callable<PartitionDetail>() {
               @Override
-              public PartitionOutput call() throws Exception {
+              public PartitionDetail call() throws Exception {
                 PartitionOutput p = dataset.getPartitionOutput(key);
                 p.addPartition();
-                return p;
+                return new BasicPartitionDetail((PartitionedFileSetDataset) dataset,
+                                                 p.getRelativePath(), p.getPartitionKey(),
+                                                 new PartitionMetadata(ImmutableMap.<String, String>of()));
               }
             });
           keys[s][i][l] = key;
-          paths[s][i][l] = partition.getRelativePath();
-          allPartitions.add(partition);
+          paths[s][i][l] = partitionDetail.getRelativePath();
+          allPartitionDetails.add(partitionDetail);
         }
       }
     }
@@ -207,14 +223,14 @@ public class PartitionedFileSetTest {
             new TransactionExecutor.Subroutine() {
               @Override
               public void apply() throws Exception {
-                Partition partition = dataset.getPartition(key);
-                Assert.assertNotNull(partition);
-                Assert.assertEquals(path, partition.getRelativePath());
+                PartitionDetail partitionDetail = dataset.getPartition(key);
+                Assert.assertNotNull(partitionDetail);
+                Assert.assertEquals(path, partitionDetail.getRelativePath());
               }
           });
           // also test getPartitionPaths() and getPartitions() for the filter matching this
           @SuppressWarnings({"unchecked", "unused"})
-          boolean success = testFilter(dataset, allPartitions,
+          boolean success = testFilter(dataset, allPartitionDetails,
                                        PartitionFilter.builder()
                                          .addValueCondition("l", key.getField("l"))
                                          .addValueCondition("s", key.getField("s"))
@@ -225,13 +241,13 @@ public class PartitionedFileSetTest {
     }
 
     // test whether query works without filter
-    testFilter(dataset, allPartitions, null);
+    testFilter(dataset, allPartitionDetails, null);
 
     // generate an list of partition filters with exhaustive coverage
     List<PartitionFilter> filters = generateFilters();
 
     // test all kinds of filters
-    testAllFilters(dataset, allPartitions, filters);
+    testAllFilters(dataset, allPartitionDetails, filters);
 
     // remove a few of the partitions and test again, repeatedly
     PartitionKey[] keysToRemove = { keys[1][2][3], keys[0][1][0], keys[2][3][2], keys[3][1][2] };
@@ -247,24 +263,24 @@ public class PartitionedFileSetTest {
       }, key);
 
       // test all filters
-      Partition toRemove = Iterables.tryFind(allPartitions, new Predicate<Partition>() {
+      PartitionDetail toRemove = Iterables.tryFind(allPartitionDetails, new Predicate<PartitionDetail>() {
         @Override
-        public boolean apply(Partition partition) {
+        public boolean apply(PartitionDetail partition) {
           return key.equals(partition.getPartitionKey());
         }
       }).get();
-      allPartitions.remove(toRemove);
-      testAllFilters(dataset, allPartitions, filters);
+      allPartitionDetails.remove(toRemove);
+      testAllFilters(dataset, allPartitionDetails, filters);
     }
 
   }
 
   private void testAllFilters(PartitionedFileSet dataset,
-                              Set<Partition> allPartitions,
+                              Set<PartitionDetail> allPartitionDetails,
                               List<PartitionFilter> filters) throws Exception {
     for (PartitionFilter filter : filters) {
       try {
-        testFilter(dataset, allPartitions, filter);
+        testFilter(dataset, allPartitionDetails, filter);
       } catch (Throwable e) {
         throw new Exception("testFilter() failed for filter: " + filter, e);
       }
@@ -272,14 +288,14 @@ public class PartitionedFileSetTest {
   }
 
   private boolean testFilter(final PartitionedFileSet dataset,
-                             Set<Partition> allPartitions,
+                             Set<PartitionDetail> allPartitionDetails,
                              final PartitionFilter filter) throws Exception {
 
     // determine the keys and paths that match the filter
-    final Set<Partition> matching = filter == null ? allPartitions :
-      Sets.filter(allPartitions, new Predicate<Partition>() {
+    final Set<PartitionDetail> matching = filter == null ? allPartitionDetails :
+      Sets.filter(allPartitionDetails, new Predicate<PartitionDetail>() {
         @Override
-        public boolean apply(Partition partition) {
+        public boolean apply(PartitionDetail partition) {
           return filter.match(partition.getPartitionKey());
         }
       });

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetTest.java
@@ -80,20 +80,25 @@ public class TimePartitionedFileSetTest {
 
   @Test
   public void testPartitionMetadata() throws Exception {
-    // make sure the dataset has no partitions
     final TimePartitionedFileSet tpfs = dsFrameworkUtil.getInstance(TPFS_INSTANCE);
-    validateTimePartitions(tpfs, 0L, MAX, Collections.<Long, String>emptyMap());
+    dsFrameworkUtil.newTransactionExecutor((TransactionAware) tpfs).execute(new TransactionExecutor.Subroutine() {
+      @Override
+      public void apply() throws Exception {
+        // make sure the dataset has no partitions
+        validateTimePartitions(tpfs, 0L, MAX, Collections.<Long, String>emptyMap());
 
-    Date date = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT).parse("6/4/12 10:00 am");
-    final long time = date.getTime();
+        Date date = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT).parse("6/4/12 10:00 am");
+        final long time = date.getTime();
 
-    final ImmutableMap<String, String> metadata = ImmutableMap.of("key1", "value1",
-                                                                  "key2", "value3",
-                                                                  "key100", "value4");
-    tpfs.addPartition(time, "file", metadata);
-    TimePartitionDetail partitionByTime = tpfs.getPartitionByTime(time);
-    Assert.assertNotNull(partitionByTime);
-    Assert.assertEquals(metadata, partitionByTime.getMetadata().asMap());
+        final ImmutableMap<String, String> metadata = ImmutableMap.of("key1", "value1",
+                                                                      "key2", "value3",
+                                                                      "key100", "value4");
+        tpfs.addPartition(time, "file", metadata);
+        TimePartitionDetail partitionByTime = tpfs.getPartitionByTime(time);
+        Assert.assertNotNull(partitionByTime);
+        Assert.assertEquals(metadata, partitionByTime.getMetadata().asMap());
+      }
+    });
   }
 
   @Test
@@ -223,7 +228,6 @@ public class TimePartitionedFileSetTest {
 
     Date date = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT).parse("6/4/12 10:00 am");
     final long time = date.getTime();
-
     dsFrameworkUtil.newTransactionExecutor((TransactionAware) tpfs).execute(new TransactionExecutor.Subroutine() {
       @Override
       public void apply() throws Exception {

--- a/cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/ScoreCounter.java
+++ b/cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/ScoreCounter.java
@@ -47,7 +47,6 @@ import java.util.Map;
 public class ScoreCounter extends AbstractMapReduce {
 
   private static final Logger LOG = LoggerFactory.getLogger(ScoreCounter.class);
-  private static final Gson GSON = new Gson();
 
   @Override
   public void configure() {

--- a/cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/UploadService.java
+++ b/cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/UploadService.java
@@ -17,7 +17,7 @@
 package co.cask.cdap.examples.sportresults;
 
 import co.cask.cdap.api.annotation.UseDataSet;
-import co.cask.cdap.api.dataset.lib.Partition;
+import co.cask.cdap.api.dataset.lib.PartitionDetail;
 import co.cask.cdap.api.dataset.lib.PartitionKey;
 import co.cask.cdap.api.dataset.lib.PartitionOutput;
 import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
@@ -66,20 +66,20 @@ public class UploadService extends AbstractService {
                      @PathParam("league") String league, @PathParam("season") int season) {
 
 
-      Partition partition = results.getPartition(PartitionKey.builder()
+      PartitionDetail partitionDetail = results.getPartition(PartitionKey.builder()
                                                    .addStringField("league", league)
                                                    .addIntField("season", season)
                                                    .build());
-      if (partition == null) {
+      if (partitionDetail == null) {
         responder.sendString(404, "Partition not found.", Charsets.UTF_8);
         return;
       }
       ByteBuffer content;
       try {
-        Location location = partition.getLocation().append("file");
+        Location location = partitionDetail.getLocation().append("file");
         content = ByteBuffer.wrap(ByteStreams.toByteArray(location.getInputStream()));
       } catch (IOException e) {
-        responder.sendError(400, String.format("Unable to read path '%s'", partition.getRelativePath()));
+        responder.sendError(400, String.format("Unable to read path '%s'", partitionDetail.getRelativePath()));
         return;
       }
       responder.send(200, content, "text/plain", ImmutableMultimap.<String, String>of());

--- a/cdap-examples/SportResults/src/test/java/co/cask/cdap/examples/sportresults/SportResultsTest.java
+++ b/cdap-examples/SportResults/src/test/java/co/cask/cdap/examples/sportresults/SportResultsTest.java
@@ -16,7 +16,7 @@
 
 package co.cask.cdap.examples.sportresults;
 
-import co.cask.cdap.api.dataset.lib.Partition;
+import co.cask.cdap.api.dataset.lib.PartitionDetail;
 import co.cask.cdap.api.dataset.lib.PartitionKey;
 import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
 import co.cask.cdap.test.ApplicationManager;
@@ -76,9 +76,10 @@ public class SportResultsTest extends TestBase {
     // validate the output by reading directly from the file set
     DataSetManager<PartitionedFileSet> dataSetManager = getDataset("totals");
     PartitionedFileSet totals = dataSetManager.get();
-    Partition partition = totals.getPartition(PartitionKey.builder().addStringField("league", "fantasy").build());
-    Assert.assertNotNull(partition);
-    Location location = partition.getLocation();
+    PartitionDetail partitionDetail =
+      totals.getPartition(PartitionKey.builder().addStringField("league", "fantasy").build());
+    Assert.assertNotNull(partitionDetail);
+    Location location = partitionDetail.getLocation();
 
     // find the part file that has the actual results
     Assert.assertTrue(location.isDirectory());
@@ -121,6 +122,7 @@ public class SportResultsTest extends TestBase {
     Assert.assertFalse(results.next());
   }
 
+  // write a file to the file set using the service
   private void uploadResults(URL url, String league, int season, String content) throws Exception {
     HttpURLConnection connection = (HttpURLConnection)
       new URL(url, String.format("leagues/%s/seasons/%d", league, season)).openConnection();
@@ -133,9 +135,4 @@ public class SportResultsTest extends TestBase {
       connection.disconnect();
     }
   }
-
-  // write a file to the file set using the service
-
-
-
 }

--- a/cdap-examples/StreamConversion/src/test/java/co/cask/cdap/examples/streamconversion/StreamConversionTest.java
+++ b/cdap-examples/StreamConversion/src/test/java/co/cask/cdap/examples/streamconversion/StreamConversionTest.java
@@ -17,7 +17,7 @@
 package co.cask.cdap.examples.streamconversion;
 
 import co.cask.cdap.api.common.RuntimeArguments;
-import co.cask.cdap.api.dataset.lib.TimePartition;
+import co.cask.cdap.api.dataset.lib.TimePartitionDetail;
 import co.cask.cdap.api.dataset.lib.TimePartitionedFileSet;
 import co.cask.cdap.common.utils.Tasks;
 import co.cask.cdap.test.ApplicationManager;
@@ -70,7 +70,7 @@ public class StreamConversionTest extends TestBase {
       public Long call() throws Exception {
         DataSetManager<TimePartitionedFileSet> fileSetManager = getDataset("converted");
         TimePartitionedFileSet converted = fileSetManager.get();
-        Set<TimePartition> partitions = converted.getPartitionsByTime(startTime, System.currentTimeMillis());
+        Set<TimePartitionDetail> partitions = converted.getPartitionsByTime(startTime, System.currentTimeMillis());
         Assert.assertEquals(1, partitions.size());
         return partitions.iterator().next().getTime();
       }

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/ExploreTableManager.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/ExploreTableManager.java
@@ -25,7 +25,7 @@ import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.dataset.lib.FileSet;
 import co.cask.cdap.api.dataset.lib.FileSetProperties;
-import co.cask.cdap.api.dataset.lib.Partition;
+import co.cask.cdap.api.dataset.lib.PartitionDetail;
 import co.cask.cdap.api.dataset.lib.PartitionKey;
 import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
 import co.cask.cdap.api.dataset.lib.Partitioning;
@@ -291,25 +291,25 @@ public class ExploreTableManager {
    * Adds multiple partitions to the Hive table for the given dataset.
    *
    * @param datasetID the ID of the dataset to add partitions to
-   * @param partitions a map of partition key to partition path
+   * @param partitionDetails a map of partition key to partition path
    * @return the query handle for adding partitions to the dataset
    * @throws ExploreException if there was an exception adding the partition
    * @throws SQLException if there was a problem with the add partition statement
    */
   public QueryHandle addPartitions(Id.DatasetInstance datasetID,
-                                   Set<Partition> partitions) throws ExploreException, SQLException {
-    if (partitions.isEmpty()) {
+                                   Set<PartitionDetail> partitionDetails) throws ExploreException, SQLException {
+    if (partitionDetails.isEmpty()) {
       return QueryHandle.NO_OP;
     }
     StringBuilder statement = new StringBuilder()
       .append("ALTER TABLE ")
       .append(getDatasetTableName(datasetID))
       .append(" ADD");
-    for (Partition partition : partitions) {
+    for (PartitionDetail partitionDetail : partitionDetails) {
       statement.append(" PARTITION")
-        .append(generateHivePartitionKey(partition.getPartitionKey()))
+        .append(generateHivePartitionKey(partitionDetail.getPartitionKey()))
         .append(" LOCATION '")
-        .append(partition.getRelativePath())
+        .append(partitionDetail.getRelativePath())
         .append("'");
     }
 

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/BaseHiveExploreService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/BaseHiveExploreService.java
@@ -18,7 +18,7 @@ package co.cask.cdap.explore.service.hive;
 
 import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.dataset.DatasetSpecification;
-import co.cask.cdap.api.dataset.lib.Partition;
+import co.cask.cdap.api.dataset.lib.PartitionDetail;
 import co.cask.cdap.api.dataset.lib.TimePartitionedFileSet;
 import co.cask.cdap.app.runtime.scheduler.SchedulerQueueResolver;
 import co.cask.cdap.app.store.Store;
@@ -1049,9 +1049,9 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
     // if this is a time partitioned file set, we need to add all partitions
     if (dataset instanceof TimePartitionedFileSet) {
       TimePartitionedFileSet tpfs = (TimePartitionedFileSet) dataset;
-      Set<Partition> partitions = tpfs.getPartitions(null);
-      if (!partitions.isEmpty()) {
-        QueryHandle handle = exploreTableManager.addPartitions(datasetID, partitions);
+      Set<PartitionDetail> partitionDetails = tpfs.getPartitions(null);
+      if (!partitionDetails.isEmpty()) {
+        QueryHandle handle = exploreTableManager.addPartitions(datasetID, partitionDetails);
         QueryStatus status = waitForCompletion(handle);
         // if add partitions failed, stop
         if (status.getStatus() != QueryStatus.OpStatus.FINISHED) {

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreUpgradeTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreUpgradeTest.java
@@ -20,7 +20,7 @@ import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.lib.FileSetProperties;
 import co.cask.cdap.api.dataset.lib.KeyValueTable;
-import co.cask.cdap.api.dataset.lib.Partition;
+import co.cask.cdap.api.dataset.lib.PartitionDetail;
 import co.cask.cdap.api.dataset.lib.PartitionKey;
 import co.cask.cdap.api.dataset.lib.TimePartitionedFileSet;
 import co.cask.cdap.common.conf.CConfiguration;
@@ -99,7 +99,7 @@ public class ExploreUpgradeTest extends BaseHiveExploreServiceTest {
       TransactionAware txTpfs = (TransactionAware) tpfs;
       txTpfs.startTx(tx1);
       tpfs.addPartition(0L, "epoch");
-      Set<Partition> partitions = tpfs.getPartitions(null);
+      Set<PartitionDetail> partitionDetails = tpfs.getPartitions(null);
       txTpfs.commitTx();
       transactionManager.canCommit(tx1, txTpfs.getTxChanges());
       transactionManager.commit(tx1);
@@ -157,7 +157,7 @@ public class ExploreUpgradeTest extends BaseHiveExploreServiceTest {
       Assert.assertFalse(tableInfo.getParameters().containsKey(Constants.Explore.CDAP_VERSION));
 
       // check partition was added to tpfs dataset
-      Iterator<Partition> partitionIter = partitions.iterator();
+      Iterator<PartitionDetail> partitionIter = partitionDetails.iterator();
       String expected = stringify(partitionIter.next().getPartitionKey());
       runCommand(Constants.DEFAULT_NAMESPACE_ID, "show partitions dataset_myfiles", true,
                  Lists.newArrayList(new ColumnDesc("partition", "STRING", 1, "from deserializer")),


### PR DESCRIPTION
CDAP-2734 Partition-level metadata support for PartitionedFileSet and TimePartitionedFileSet.

https://issues.cask.co/browse/CDAP-2734
http://builds.cask.co/browse/CDAP-DUT2017-19

A couple of comments by Andreas on a previous commit:
https://github.com/caskdata/cdap/commit/df1476486a0cd5e6d42703fff4ffef49d7299bb5#commitcomment-11645773 - resolved.
https://github.com/caskdata/cdap/commit/df1476486a0cd5e6d42703fff4ffef49d7299bb5#commitcomment-11645814 - resolved.
https://github.com/caskdata/cdap/commit/df1476486a0cd5e6d42703fff4ffef49d7299bb5#commitcomment-11645825 - resolved.
https://github.com/caskdata/cdap/commit/df1476486a0cd5e6d42703fff4ffef49d7299bb5#commitcomment-11645838 - resolved.
https://github.com/caskdata/cdap/commit/df1476486a0cd5e6d42703fff4ffef49d7299bb5#commitcomment-11645848 - opened JIRA https://issues.cask.co/browse/CDAP-2784