### PR TITLE
increase polling frequency

### DIFF
--- a/cdap-ui/app/features/spark/controllers/tabs/runs/tabs/status-ctrl.js
+++ b/cdap-ui/app/features/spark/controllers/tabs/runs/tabs/status-ctrl.js
@@ -79,7 +79,8 @@ angular.module(PKG.name + '.feature.spark')
       angular.forEach(metricPaths, function (name, path) {
         dataSrc.poll({
           _cdapPath: path,
-          method: 'POST'
+          method: 'POST',
+          interval: 1000
         }, function(res) {
           $scope.data[name] = myHelpers.objectQuery(res, 'series', 0, 'data', 0, 'value') || 0;
         });

--- a/cdap-ui/app/features/spark/spark.less
+++ b/cdap-ui/app/features/spark/spark.less
@@ -2,7 +2,7 @@
 
 body.state-spark {
   .sparks-metrics {
-  
+
     .metric-row{
       margin: 0 25px 18px;
     }

--- a/cdap-ui/app/features/spark/templates/tabs/runs/tabs/status.html
+++ b/cdap-ui/app/features/spark/templates/tabs/runs/tabs/status.html
@@ -18,19 +18,19 @@
         <div class="title-stage">
           STAGES
         </div>
-          <div class="progress stage-status-line">
-            <div class="progress-bar running" data-animation="am-flip-x" bs-tooltip="runningTooltip" ng-style="{ 'width': getStagePercentage('running') + '%' }" title="">
-              {{data.schedulerRunningStages}}
-            </div>
-
-            <div class="progress-bar failed" data-animation="am-flip-x" bs-tooltip="failedTooltip" ng-style="{ 'width': getStagePercentage('failed') + '%' }" title="">
-              {{data.schedulerFailedStages}}
-            </div>
-
-            <div class="progress-bar waiting" data-animation="am-flip-x" bs-tooltip="waitingTooltip" ng-style="{ 'width': getStagePercentage('waiting') + '%' }" title="">
-              {{data.schedulerWaitingStages}}
-            </div>
+        <div class="progress stage-status-line">
+          <div class="progress-bar running" data-animation="am-flip-x" bs-tooltip="runningTooltip" ng-style="{ 'width': getStagePercentage('running') + '%' }" title="">
+            {{data.schedulerRunningStages}}
           </div>
+
+          <div class="progress-bar failed" data-animation="am-flip-x" bs-tooltip="failedTooltip" ng-style="{ 'width': getStagePercentage('failed') + '%' }" title="">
+            {{data.schedulerFailedStages}}
+          </div>
+
+          <div class="progress-bar waiting" data-animation="am-flip-x" bs-tooltip="waitingTooltip" ng-style="{ 'width': getStagePercentage('waiting') + '%' }" title="">
+            {{data.schedulerWaitingStages}}
+          </div>
+        </div>
       </div>
     </div>
 </div>


### PR DESCRIPTION
Increase polling frequency for metrics so that it will show up in the status page.
Spark program finished very quickly so the metric changed rapidly.