### PR TITLE
Make DiscoveryServiceClient non-static

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -67,6 +67,7 @@ import co.cask.cdap.internal.app.runtime.schedule.LocalSchedulerService;
 import co.cask.cdap.internal.app.runtime.schedule.Scheduler;
 import co.cask.cdap.internal.app.runtime.schedule.SchedulerService;
 import co.cask.cdap.internal.app.runtime.schedule.store.DatasetBasedTimeScheduleStore;
+import co.cask.cdap.internal.app.runtime.spark.serialization.SparkRuntimeModule;
 import co.cask.cdap.internal.app.services.AppFabricServer;
 import co.cask.cdap.internal.app.services.ProgramLifecycleService;
 import co.cask.cdap.internal.app.services.StandaloneAppFabricServer;
@@ -125,6 +126,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
   public Module getInMemoryModules() {
     return Modules.combine(new AppFabricServiceModule(StreamHandler.class, StreamFetchHandler.class),
                            new ConfigStoreModule().getInMemoryModule(),
+                           new SparkRuntimeModule().getInMemoryModules(),
                            new AbstractModule() {
                              @Override
                              protected void configure() {
@@ -171,6 +173,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
 
     return Modules.combine(new AppFabricServiceModule(StreamHandler.class, StreamFetchHandler.class),
                            new ConfigStoreModule().getStandaloneModule(),
+                           new SparkRuntimeModule().getStandaloneModules(),
                            new AbstractModule() {
                              @Override
                              protected void configure() {
@@ -218,6 +221,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
 
     return Modules.combine(new AppFabricServiceModule(),
                            new ConfigStoreModule().getDistributedModule(),
+                           new SparkRuntimeModule().getDistributedModules(),
                            new AbstractModule() {
                              @Override
                              protected void configure() {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/services/AbstractServiceDiscoverer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/services/AbstractServiceDiscoverer.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.ServiceDiscoverer;
 import co.cask.cdap.app.program.Program;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.discovery.RandomEndpointStrategy;
+import co.cask.cdap.proto.Id;
 import org.apache.twill.discovery.Discoverable;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.apache.twill.discovery.ServiceDiscovered;
@@ -47,9 +48,9 @@ public abstract class AbstractServiceDiscoverer implements ServiceDiscoverer {
   protected AbstractServiceDiscoverer() {
   }
 
-  public AbstractServiceDiscoverer(Program program) {
-    this.namespaceId = program.getNamespaceId();
-    this.applicationId = program.getApplicationId();
+  public AbstractServiceDiscoverer(Id.Application application) {
+    this.namespaceId = application.getNamespaceId();
+    this.applicationId = application.getId();
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractContext.java
@@ -91,7 +91,7 @@ public abstract class AbstractContext extends AbstractServiceDiscoverer
                             DatasetFramework dsFramework, DiscoveryServiceClient discoveryServiceClient,
                             @Nullable AdapterDefinition adapterSpec,
                             @Nullable PluginInstantiator pluginInstantiator) {
-    super(program);
+    super(program.getId().getApplication());
     this.program = program;
     this.runId = runId;
     this.runtimeArguments = ImmutableMap.copyOf(arguments.asMap());

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/AbstractSparkContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/AbstractSparkContext.java
@@ -74,7 +74,7 @@ abstract class AbstractSparkContext implements SparkContext {
   private final SparkConf sparkConf;
 
   public AbstractSparkContext(BasicSparkContext basicSparkContext) {
-    hConf = loadHConf();
+    this.hConf = loadHConf();
     this.basicSparkContext = basicSparkContext;
     this.logicalStartTime = basicSparkContext.getLogicalStartTime();
     this.spec = basicSparkContext.getSpecification();

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/AbstractSparkContextBuilder.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/AbstractSparkContextBuilder.java
@@ -26,6 +26,7 @@ import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.internal.app.runtime.batch.BasicMapReduceContext;
 import co.cask.cdap.internal.app.runtime.spark.inmemory.InMemorySparkContextBuilder;
+import co.cask.cdap.internal.app.runtime.spark.serialization.SerializableServiceDiscoverer;
 import co.cask.tephra.Transaction;
 import co.cask.tephra.TransactionAware;
 import com.google.common.base.Throwables;
@@ -86,12 +87,15 @@ public abstract class AbstractSparkContextBuilder {
     DiscoveryServiceClient discoveryServiceClient = injector.getInstance(DiscoveryServiceClient.class);
     StreamAdmin streamAdmin = injector.getInstance(StreamAdmin.class);
 
+    SerializableServiceDiscoverer serializableServiceDiscoverer =
+      injector.getInstance(SerializableServiceDiscoverer.class);
+
     // Creating Spark job context
     SparkSpecification sparkSpec = program.getApplicationSpecification().getSpark().get(program.getName());
     BasicSparkContext context =
       new BasicSparkContext(program, RunIds.fromString(runId), runtimeArguments, appSpec.getDatasets().keySet(),
                             sparkSpec, logicalStartTime, workflowBatch, metricsCollectionService,
-                            datasetFramework, discoveryServiceClient, streamAdmin);
+                            datasetFramework, discoveryServiceClient, streamAdmin, serializableServiceDiscoverer);
 
     // propagating tx to all txAware guys
     // The tx is committed or aborted depending upon the job success by the ProgramRunner and DatasetRecordWriter

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/BasicSparkContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/BasicSparkContext.java
@@ -26,13 +26,13 @@ import co.cask.cdap.api.spark.SparkSpecification;
 import co.cask.cdap.api.stream.StreamEventDecoder;
 import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.runtime.Arguments;
-import co.cask.cdap.app.services.SerializableServiceDiscoverer;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.logging.LoggingContext;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.internal.app.runtime.AbstractContext;
 import co.cask.cdap.internal.app.runtime.spark.metrics.SparkUserMetrics;
+import co.cask.cdap.internal.app.runtime.spark.serialization.SerializableServiceDiscoverer;
 import co.cask.cdap.logging.context.SparkLoggingContext;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.tephra.TransactionAware;
@@ -85,15 +85,16 @@ public class BasicSparkContext extends AbstractContext implements SparkContext {
                            SparkSpecification sparkSpec, long logicalStartTime, String workflowBatch,
                            MetricsCollectionService metricsCollectionService,
                            DatasetFramework dsFramework,
-                           DiscoveryServiceClient discoveryServiceClient, StreamAdmin streamAdmin) {
+                           DiscoveryServiceClient discoveryServiceClient, StreamAdmin streamAdmin,
+                           SerializableServiceDiscoverer serializableServiceDiscoverer) {
     super(program, runId, runtimeArguments, datasets,
           getMetricCollector(metricsCollectionService, program, runId.getId()),
           dsFramework, discoveryServiceClient);
     this.logicalStartTime = logicalStartTime;
     this.workflowBatch = workflowBatch;
     this.streamAdmin = streamAdmin;
-    SerializableServiceDiscoverer.setDiscoveryServiceClient(getDiscoveryServiceClient());
-    this.serializableServiceDiscoverer = new SerializableServiceDiscoverer(getProgram());
+    this.serializableServiceDiscoverer = serializableServiceDiscoverer;
+    serializableServiceDiscoverer.setAppId(program.getId().getApplication());
     SparkUserMetrics.setMetricsCollector(getProgramMetrics());
     this.userMetrics = new SparkUserMetrics();
     this.loggingContext = new SparkLoggingContext(getNamespaceId(), getApplicationId(), getProgramName(),

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkProgramRunner.java
@@ -33,6 +33,7 @@ import co.cask.cdap.common.logging.LoggingContextAccessor;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
+import co.cask.cdap.internal.app.runtime.spark.serialization.SerializableServiceDiscoverer;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.tephra.TransactionSystemClient;
 import com.google.common.base.Preconditions;
@@ -67,12 +68,14 @@ public class SparkProgramRunner implements ProgramRunner {
   private final DiscoveryServiceClient discoveryServiceClient;
   private final StreamAdmin streamAdmin;
   private final Store store;
+  private final SerializableServiceDiscoverer serializableServiceDiscoverer;
 
   @Inject
   public SparkProgramRunner(DatasetFramework datasetFramework, CConfiguration cConf,
                             MetricsCollectionService metricsCollectionService, Configuration hConf,
                             TransactionSystemClient txSystemClient, LocationFactory locationFactory,
-                            DiscoveryServiceClient discoveryServiceClient, StreamAdmin streamAdmin, Store store) {
+                            DiscoveryServiceClient discoveryServiceClient, StreamAdmin streamAdmin, Store store,
+                            SerializableServiceDiscoverer serializableServiceDiscoverer) {
     this.hConf = hConf;
     this.datasetFramework = datasetFramework;
     this.cConf = cConf;
@@ -82,6 +85,7 @@ public class SparkProgramRunner implements ProgramRunner {
     this.discoveryServiceClient = discoveryServiceClient;
     this.streamAdmin = streamAdmin;
     this.store = store;
+    this.serializableServiceDiscoverer = serializableServiceDiscoverer;
   }
 
   @Override
@@ -118,7 +122,8 @@ public class SparkProgramRunner implements ProgramRunner {
                                                             appSpec.getDatasets().keySet(), spec,
                                                             logicalStartTime, workflowBatch,
                                                             metricsCollectionService, datasetFramework,
-                                                            discoveryServiceClient, streamAdmin);
+                                                            discoveryServiceClient, streamAdmin,
+                                                            serializableServiceDiscoverer);
 
     LoggingContextAccessor.setLoggingContext(context.getLoggingContext());
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/inmemory/InMemorySparkContextBuilder.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/inmemory/InMemorySparkContextBuilder.java
@@ -28,6 +28,7 @@ import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data.stream.StreamAdminModules;
 import co.cask.cdap.internal.app.runtime.spark.AbstractSparkContextBuilder;
 import co.cask.cdap.internal.app.runtime.spark.BasicSparkContext;
+import co.cask.cdap.internal.app.runtime.spark.serialization.SparkRuntimeModule;
 import co.cask.cdap.logging.guice.LoggingModules;
 import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
 import co.cask.cdap.notifications.feeds.guice.NotificationFeedServiceRuntimeModule;
@@ -77,7 +78,8 @@ public class InMemorySparkContextBuilder extends AbstractSparkContextBuilder {
       new MetricsClientRuntimeModule().getInMemoryModules(),
       new LoggingModules().getInMemoryModules(),
       new StreamAdminModules().getInMemoryModules(),
-      new NotificationFeedServiceRuntimeModule().getInMemoryModules()
+      new NotificationFeedServiceRuntimeModule().getInMemoryModules(),
+      new SparkRuntimeModule().getInMemoryModules()
     );
 
     return Guice.createInjector(inMemoryModules);
@@ -95,7 +97,8 @@ public class InMemorySparkContextBuilder extends AbstractSparkContextBuilder {
       new MetricsClientRuntimeModule().getStandaloneModules(),
       new LoggingModules().getStandaloneModules(),
       new StreamAdminModules().getStandaloneModules(),
-      new NotificationFeedServiceRuntimeModule().getInMemoryModules()
+      new NotificationFeedServiceRuntimeModule().getInMemoryModules(),
+      new SparkRuntimeModule().getStandaloneModules()
     );
     return Guice.createInjector(standaloneModules);
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/serialization/InMemorySerializableServiceDiscoverer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/serialization/InMemorySerializableServiceDiscoverer.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.spark.serialization;
+
+import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
+import co.cask.cdap.proto.Id;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.apache.twill.discovery.DiscoveryServiceClient;
+
+/**
+ *
+ */
+public class InMemorySerializableServiceDiscoverer extends SerializableServiceDiscoverer {
+  private static final long serialVersionUID = 6547316362453719580L;
+  private static final Injector injector = Guice.createInjector(new DiscoveryRuntimeModule().getInMemoryModules());
+
+  private final transient DiscoveryServiceClient discoveryServiceClient;
+
+  // no-arg constructor required for serialization/deserialization to work
+  @SuppressWarnings("unused")
+  public InMemorySerializableServiceDiscoverer() {
+    this.discoveryServiceClient = injector.getInstance(DiscoveryServiceClient.class);
+  }
+
+  public InMemorySerializableServiceDiscoverer(Id.Application application,
+                                               DiscoveryServiceClient discoveryServiceClient) {
+    super(application);
+    this.discoveryServiceClient = discoveryServiceClient;
+  }
+
+  @Override
+  public DiscoveryServiceClient getDiscoveryServiceClient() {
+    return discoveryServiceClient;
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/serialization/SparkRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/serialization/SparkRuntimeModule.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.spark.serialization;
+
+import co.cask.cdap.common.runtime.RuntimeModule;
+import com.google.inject.AbstractModule;
+import com.google.inject.Module;
+
+/**
+ *
+ */
+public final class SparkRuntimeModule extends RuntimeModule {
+  @Override
+  public Module getInMemoryModules() {
+    return new SparkModule();
+  }
+
+  @Override
+  public Module getStandaloneModules() {
+    return new SparkModule();
+  }
+
+  @Override
+  public Module getDistributedModules() {
+    return new SparkModule();
+  }
+
+  private static final class SparkModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+      bind(SerializableServiceDiscoverer.class).to(InMemorySerializableServiceDiscoverer.class);
+    }
+  }
+}

--- a/cdap-unit-test/src/test/java/co/cask/cdap/spark/service/TestSparkServiceIntegrationApp.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/spark/service/TestSparkServiceIntegrationApp.java
@@ -89,8 +89,7 @@ public class TestSparkServiceIntegrationApp extends AbstractApplication {
           BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream()));
           String squaredVale = reader.readLine();
           Closeables.closeQuietly(reader);
-          return new Tuple2<>(Bytes.toBytes(String.valueOf(num)),
-                                            Bytes.toBytes(squaredVale));
+          return new Tuple2<>(Bytes.toBytes(String.valueOf(num)), Bytes.toBytes(squaredVale));
         }
       });
       context.writeToDataset(resultRDD, "result", byte[].class, byte[].class);


### PR DESCRIPTION
1. Made ``DiscoveryServiceClient`` non-static in ``SerializableServiceDiscoverer``
2. Added an ``InMemorySerializableServiceDiscoverer`` for use in in-memory mode
3. Changed the constructor in ``AbstractServiceDiscoverer`` to accept just an ``Id.Application`` instead of the entire ``Program`` object which is not needed.


Only works in in-memory mode. Testing on a cluster with more changes. Will create a separate PR for distributed once that works.

Build: https://builds.cask.co/browse/CDAP-DUT2032/
