### PR TITLE
CDAP-2761: separate MetricsCollector from the MetricsContext to allow…

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/metrics/ProgramUserMetrics.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/metrics/ProgramUserMetrics.java
@@ -18,7 +18,7 @@ package co.cask.cdap.app.metrics;
 
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
-import co.cask.cdap.api.metrics.MetricsCollector;
+import co.cask.cdap.api.metrics.MetricsContext;
 import co.cask.cdap.common.conf.Constants;
 
 import java.io.Externalizable;
@@ -34,25 +34,25 @@ import java.io.ObjectOutput;
 public class ProgramUserMetrics implements Metrics, Externalizable {
   private static final long serialVersionUID = -5913108632034346101L;
 
-  private final MetricsCollector metricsCollector;
+  private final MetricsContext metricsContext;
 
   /** For serde purposes only */
   public ProgramUserMetrics() {
-    metricsCollector = null;
+    metricsContext = null;
   }
 
-  public ProgramUserMetrics(MetricsCollector metricsCollector) {
-    this.metricsCollector = metricsCollector.childCollector(Constants.Metrics.Tag.SCOPE, "user");
+  public ProgramUserMetrics(MetricsContext metricsContext) {
+    this.metricsContext = metricsContext.childContext(Constants.Metrics.Tag.SCOPE, "user");
   }
 
   @Override
   public void count(String metricName, int delta) {
-    metricsCollector.increment(metricName, delta);
+    metricsContext.increment(metricName, delta);
   }
 
   @Override
   public void gauge(String metricName, long value) {
-    metricsCollector.gauge(metricName, value);
+    metricsContext.gauge(metricName, value);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractContext.java
@@ -22,7 +22,7 @@ import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.data.DatasetInstantiationException;
 import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.metrics.Metrics;
-import co.cask.cdap.api.metrics.MetricsCollector;
+import co.cask.cdap.api.metrics.MetricsContext;
 import co.cask.cdap.api.templates.AdapterContext;
 import co.cask.cdap.api.templates.plugins.PluginProperties;
 import co.cask.cdap.app.program.Program;
@@ -65,7 +65,7 @@ public abstract class AbstractContext extends AbstractServiceDiscoverer
   private final Map<String, String> runtimeArguments;
   private final Map<String, Dataset> datasets;
 
-  private final MetricsCollector programMetrics;
+  private final MetricsContext programMetrics;
 
   private final DatasetInstantiator dsInstantiator;
   private final DiscoveryServiceClient discoveryServiceClient;
@@ -77,9 +77,9 @@ public abstract class AbstractContext extends AbstractServiceDiscoverer
    * Constructs a context without application template adapter support.
    */
   protected AbstractContext(Program program, RunId runId, Arguments arguments,
-                            Set<String> datasets, MetricsCollector metricsCollector,
+                            Set<String> datasets, MetricsContext metricsContext,
                             DatasetFramework dsFramework, DiscoveryServiceClient discoveryServiceClient) {
-    this(program, runId, arguments, datasets, metricsCollector, dsFramework, discoveryServiceClient, null, null);
+    this(program, runId, arguments, datasets, metricsContext, dsFramework, discoveryServiceClient, null, null);
   }
 
   /**
@@ -87,7 +87,7 @@ public abstract class AbstractContext extends AbstractServiceDiscoverer
    * both the {@code adapterSpec} and {@code pluginInstantiator} must not be null.
    */
   protected AbstractContext(Program program, RunId runId, Arguments arguments,
-                            Set<String> datasets, MetricsCollector metricsCollector,
+                            Set<String> datasets, MetricsContext metricsContext,
                             DatasetFramework dsFramework, DiscoveryServiceClient discoveryServiceClient,
                             @Nullable AdapterDefinition adapterSpec,
                             @Nullable PluginInstantiator pluginInstantiator) {
@@ -97,7 +97,7 @@ public abstract class AbstractContext extends AbstractServiceDiscoverer
     this.runtimeArguments = ImmutableMap.copyOf(arguments.asMap());
     this.discoveryServiceClient = discoveryServiceClient;
 
-    this.programMetrics = metricsCollector;
+    this.programMetrics = metricsContext;
     this.dsInstantiator = new DatasetInstantiator(program.getId().getNamespace(), dsFramework,
                                                   program.getClassLoader(), getOwners(), programMetrics);
 
@@ -138,7 +138,7 @@ public abstract class AbstractContext extends AbstractServiceDiscoverer
                          getNamespaceId(), getApplicationId(), getProgramName(), runId);
   }
 
-  public MetricsCollector getProgramMetrics() {
+  public MetricsContext getProgramMetrics() {
     return programMetrics;
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractResourceReporter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractResourceReporter.java
@@ -16,7 +16,7 @@
 
 package co.cask.cdap.internal.app.runtime;
 
-import co.cask.cdap.api.metrics.MetricsCollector;
+import co.cask.cdap.api.metrics.MetricsContext;
 import co.cask.cdap.app.runtime.ProgramResourceReporter;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -43,27 +43,27 @@ public abstract class AbstractResourceReporter extends AbstractScheduledService 
   protected static final String METRIC_MEMORY_USAGE = "resources.used.memory";
   protected static final String METRIC_VIRTUAL_CORE_USAGE = "resources.used.vcores";
 
-  protected final MetricsCollector metricsCollector;
+  protected final MetricsContext metricsContext;
 
-  private final LoadingCache<Map<String, String>, MetricsCollector> programMetricsCollectors;
+  private final LoadingCache<Map<String, String>, MetricsContext> programMetricsCollectors;
 
   private final int reportInterval;
 
   private volatile ScheduledExecutorService executor;
 
-  protected AbstractResourceReporter(MetricsCollector metricsCollector) {
-    this(metricsCollector, DEFAULT_REPORT_INTERVAL);
+  protected AbstractResourceReporter(MetricsContext metricsContext) {
+    this(metricsContext, DEFAULT_REPORT_INTERVAL);
   }
 
-  protected AbstractResourceReporter(final MetricsCollector metricsCollector, int interval) {
-    this.metricsCollector = metricsCollector;
+  protected AbstractResourceReporter(final MetricsContext metricsContext, int interval) {
+    this.metricsContext = metricsContext;
     this.reportInterval = interval;
     this.programMetricsCollectors = CacheBuilder.newBuilder()
       .expireAfterAccess(1, TimeUnit.HOURS)
-      .build(new CacheLoader<Map<String, String>, MetricsCollector>() {
+      .build(new CacheLoader<Map<String, String>, MetricsContext>() {
         @Override
-        public MetricsCollector load(Map<String, String> key) throws Exception {
-          return metricsCollector.childCollector(key);
+        public MetricsContext load(Map<String, String> key) throws Exception {
+          return metricsContext.childContext(key);
         }
       });
   }
@@ -91,13 +91,13 @@ public abstract class AbstractResourceReporter extends AbstractScheduledService 
 
   protected void sendMetrics(Map<String, String> context, int containers, int memory, int vcores) {
     LOG.trace("Reporting resources: (containers, memory, vcores) = ({}, {}, {})", containers, memory, vcores);
-    MetricsCollector metricsCollector = programMetricsCollectors.getUnchecked(context);
-    metricsCollector.gauge(METRIC_CONTAINERS, containers);
-    metricsCollector.gauge(METRIC_MEMORY_USAGE, memory);
-    metricsCollector.gauge(METRIC_VIRTUAL_CORE_USAGE, vcores);
+    MetricsContext metricsContext = programMetricsCollectors.getUnchecked(context);
+    metricsContext.gauge(METRIC_CONTAINERS, containers);
+    metricsContext.gauge(METRIC_MEMORY_USAGE, memory);
+    metricsContext.gauge(METRIC_VIRTUAL_CORE_USAGE, vcores);
   }
 
-  protected MetricsCollector getCollector() {
-    return metricsCollector;
+  protected MetricsContext getCollector() {
+    return metricsContext;
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
@@ -27,7 +27,7 @@ import co.cask.cdap.api.mapreduce.MapReduceContext;
 import co.cask.cdap.api.mapreduce.MapReduceSpecification;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
-import co.cask.cdap.api.metrics.MetricsCollector;
+import co.cask.cdap.api.metrics.MetricsContext;
 import co.cask.cdap.app.metrics.MapReduceMetrics;
 import co.cask.cdap.app.metrics.ProgramUserMetrics;
 import co.cask.cdap.app.program.Program;
@@ -248,7 +248,7 @@ public class BasicMapReduceContext extends AbstractContext implements MapReduceC
   }
 
   @Nullable
-  private static MetricsCollector getMetricCollector(Program program, String runId, String taskId,
+  private static MetricsContext getMetricCollector(Program program, String runId, String taskId,
                                                      @Nullable MetricsCollectionService service,
                                                      @Nullable MapReduceMetrics.TaskType type,
                                                      @Nullable AdapterDefinition adapterSpec) {
@@ -272,7 +272,7 @@ public class BasicMapReduceContext extends AbstractContext implements MapReduceC
       tags.put(Constants.Metrics.Tag.ADAPTER, adapterSpec.getName());
     }
 
-    return service.getCollector(tags);
+    return service.getContext(tags);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/DataSetRecordReader.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/DataSetRecordReader.java
@@ -17,7 +17,7 @@
 package co.cask.cdap.internal.app.runtime.batch.dataset;
 
 import co.cask.cdap.api.data.batch.SplitReader;
-import co.cask.cdap.api.metrics.MetricsCollector;
+import co.cask.cdap.api.metrics.MetricsContext;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.logging.LoggingContextAccessor;
 import co.cask.cdap.internal.app.runtime.batch.BasicMapReduceContext;
@@ -35,13 +35,13 @@ final class DataSetRecordReader<KEY, VALUE> extends RecordReader<KEY, VALUE> {
   private static final Logger LOG = LoggerFactory.getLogger(DataSetRecordReader.class);
   private final SplitReader<KEY, VALUE> splitReader;
   private final BasicMapReduceContext context;
-  private final MetricsCollector dataSetMetrics;
+  private final MetricsContext dataSetMetrics;
 
   public DataSetRecordReader(final SplitReader<KEY, VALUE> splitReader,
                              BasicMapReduceContext context, String dataSetName) {
     this.splitReader = splitReader;
     this.context = context;
-    this.dataSetMetrics = context.getMetricsCollectionService().getCollector(
+    this.dataSetMetrics = context.getMetricsCollectionService().getContext(
       ImmutableMap.of(Constants.Metrics.Tag.DATASET, dataSetName,
                       Constants.Metrics.Tag.RUN_ID, context.getRunId().getId()));
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedProgramRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedProgramRuntimeService.java
@@ -18,7 +18,7 @@ package co.cask.cdap.internal.app.runtime.distributed;
 import co.cask.cdap.api.flow.FlowSpecification;
 import co.cask.cdap.api.flow.FlowletDefinition;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
-import co.cask.cdap.api.metrics.MetricsCollector;
+import co.cask.cdap.api.metrics.MetricsContext;
 import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.queue.QueueSpecification;
 import co.cask.cdap.app.queue.QueueSpecificationGenerator;
@@ -399,7 +399,7 @@ public final class DistributedProgramRuntimeService extends AbstractProgramRunti
 
     public ClusterResourceReporter(MetricsCollectionService metricsCollectionService, Configuration hConf,
                                    CConfiguration cConf) {
-      super(metricsCollectionService.getCollector(
+      super(metricsCollectionService.getContext(
         ImmutableMap.<String, String>of()));
       try {
         this.hdfs = FileSystem.get(hConf);
@@ -529,7 +529,7 @@ public final class DistributedProgramRuntimeService extends AbstractProgramRunti
           JsonObject clusterMetrics = response.getAsJsonObject("clusterMetrics");
           long totalMemory = clusterMetrics.get("totalMB").getAsLong();
           long availableMemory = clusterMetrics.get("availableMB").getAsLong();
-          MetricsCollector collector = getCollector();
+          MetricsContext collector = getCollector();
           LOG.trace("resource manager, total memory = " + totalMemory + " available = " + availableMemory);
           collector.gauge("resources.total.memory", totalMemory);
           collector.gauge("resources.available.memory", availableMemory);
@@ -572,7 +572,7 @@ public final class DistributedProgramRuntimeService extends AbstractProgramRunti
         long storageCapacity = hdfsStatus.getCapacity();
         long storageAvailable = hdfsStatus.getRemaining();
 
-        MetricsCollector collector = getCollector();
+        MetricsContext collector = getCollector();
         LOG.trace("total cluster storage = " + storageCapacity + " total used = " + totalUsed);
         collector.gauge("resources.total.storage", (storageCapacity / 1024 / 1024));
         collector.gauge("resources.available.storage", (storageAvailable / 1024 / 1024));

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/ProgramRunnableResourceReporter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/ProgramRunnableResourceReporter.java
@@ -36,7 +36,7 @@ public class ProgramRunnableResourceReporter extends AbstractResourceReporter {
 
   public ProgramRunnableResourceReporter(Program program, MetricsCollectionService collectionService,
                                          TwillContext context) {
-    super(collectionService.getCollector(getMetricContext(program, context)));
+    super(collectionService.getContext(getMetricContext(program, context)));
     this.runContext = context;
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowletProcessDriver.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowletProcessDriver.java
@@ -21,7 +21,7 @@ import co.cask.cdap.api.flow.flowlet.FailurePolicy;
 import co.cask.cdap.api.flow.flowlet.FailureReason;
 import co.cask.cdap.api.flow.flowlet.Flowlet;
 import co.cask.cdap.api.flow.flowlet.InputContext;
-import co.cask.cdap.api.metrics.MetricsCollector;
+import co.cask.cdap.api.metrics.MetricsContext;
 import co.cask.cdap.app.queue.InputDatum;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.logging.LoggingContext;
@@ -322,12 +322,12 @@ final class FlowletProcessDriver extends AbstractExecutionThreadService {
     final int processedCount = processEntry.getProcessSpec().getProcessMethod().needsInput() ? input.size() : 1;
 
     return new ProcessMethodCallback() {
-      private final LoadingCache<String, MetricsCollector> queueMetricsCollectors = CacheBuilder.newBuilder()
+      private final LoadingCache<String, MetricsContext> queueMetricsCollectors = CacheBuilder.newBuilder()
         .expireAfterAccess(1, TimeUnit.HOURS)
-        .build(new CacheLoader<String, MetricsCollector>() {
+        .build(new CacheLoader<String, MetricsContext>() {
           @Override
-          public MetricsCollector load(String key) throws Exception {
-            return flowletContext.getProgramMetrics().childCollector(Constants.Metrics.Tag.FLOWLET_QUEUE, key);
+          public MetricsContext load(String key) throws Exception {
+            return flowletContext.getProgramMetrics().childContext(Constants.Metrics.Tag.FLOWLET_QUEUE, key);
           }
         });
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowletProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowletProgramRunner.java
@@ -33,7 +33,7 @@ import co.cask.cdap.api.flow.flowlet.InputContext;
 import co.cask.cdap.api.flow.flowlet.OutputEmitter;
 import co.cask.cdap.api.flow.flowlet.StreamEvent;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
-import co.cask.cdap.api.metrics.MetricsCollector;
+import co.cask.cdap.api.metrics.MetricsContext;
 import co.cask.cdap.api.stream.StreamEventData;
 import co.cask.cdap.app.ApplicationSpecification;
 import co.cask.cdap.app.program.Program;
@@ -455,15 +455,15 @@ public final class FlowletProgramRunner implements ProgramRunner {
           }
 
           // create a metric collector for this queue, and also one for each consumer flowlet
-          final MetricsCollector metrics = flowletContext.getProgramMetrics()
-            .childCollector(Constants.Metrics.Tag.FLOWLET_QUEUE, outputName);
-          final MetricsCollector producerMetrics = metrics.childCollector(
+          final MetricsContext metrics = flowletContext.getProgramMetrics()
+            .childContext(Constants.Metrics.Tag.FLOWLET_QUEUE, outputName);
+          final MetricsContext producerMetrics = metrics.childContext(
             Constants.Metrics.Tag.PRODUCER, flowletContext.getFlowletId());
-          final Iterable<MetricsCollector> consumerMetrics =
-            Iterables.transform(consumerFlowlets, new Function<String, MetricsCollector>() {
+          final Iterable<MetricsContext> consumerMetrics =
+            Iterables.transform(consumerFlowlets, new Function<String, MetricsContext>() {
               @Override
-              public MetricsCollector apply(String consumer) {
-                return producerMetrics.childCollector(
+              public MetricsContext apply(String consumer) {
+                return producerMetrics.childContext(
                   Constants.Metrics.Tag.CONSUMER, consumer);
               }});
 
@@ -472,7 +472,7 @@ public final class FlowletProgramRunner implements ProgramRunner {
             @Override
             public void emitEnqueue(int count) {
               metrics.increment("process.events.out", count);
-              for (MetricsCollector collector : consumerMetrics) {
+              for (MetricsContext collector : consumerMetrics) {
                 collector.increment("queue.pending", count);
               }
             }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/AbstractHttpHandlerDelegator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/AbstractHttpHandlerDelegator.java
@@ -16,7 +16,7 @@
 
 package co.cask.cdap.internal.app.runtime.service.http;
 
-import co.cask.cdap.api.metrics.MetricsCollector;
+import co.cask.cdap.api.metrics.MetricsContext;
 import co.cask.cdap.api.service.http.HttpServiceContext;
 import co.cask.cdap.api.service.http.HttpServiceHandler;
 import co.cask.cdap.api.service.http.HttpServiceRequest;
@@ -37,11 +37,11 @@ public abstract class AbstractHttpHandlerDelegator<T extends HttpServiceHandler>
                                                                                             DelegatorContext<T> {
 
   private final DelegatorContext<T> context;
-  private MetricsCollector metricsCollector;
+  private MetricsContext metricsContext;
 
-  protected AbstractHttpHandlerDelegator(DelegatorContext<T> context, MetricsCollector metricsCollector) {
+  protected AbstractHttpHandlerDelegator(DelegatorContext<T> context, MetricsContext metricsContext) {
     this.context = context;
-    this.metricsCollector = metricsCollector;
+    this.metricsContext = metricsContext;
   }
 
   @Override
@@ -73,10 +73,10 @@ public abstract class AbstractHttpHandlerDelegator<T extends HttpServiceHandler>
   }
 
   protected final DelayedHttpServiceResponder wrapResponder(HttpResponder responder) {
-    MetricsCollector collector = this.metricsCollector;
+    MetricsContext collector = this.metricsContext;
     if (context.getServiceContext() != null && context.getServiceContext().getSpecification() != null) {
-      collector = metricsCollector.childCollector(Constants.Metrics.Tag.HANDLER,
-                                                  context.getServiceContext().getSpecification().getName());
+      collector = metricsContext.childContext(Constants.Metrics.Tag.HANDLER,
+                                              context.getServiceContext().getSpecification().getName());
     }
     return new DelayedHttpServiceResponder(responder, collector);
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/BasicHttpServiceContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/BasicHttpServiceContext.java
@@ -18,7 +18,7 @@ package co.cask.cdap.internal.app.runtime.service.http;
 
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
-import co.cask.cdap.api.metrics.MetricsCollector;
+import co.cask.cdap.api.metrics.MetricsContext;
 import co.cask.cdap.api.service.http.HttpServiceHandlerSpecification;
 import co.cask.cdap.app.metrics.ProgramUserMetrics;
 import co.cask.cdap.app.program.Program;
@@ -105,7 +105,7 @@ public class BasicHttpServiceContext extends AbstractContext implements Transact
     return txContext;
   }
 
-  private static MetricsCollector getMetricCollector(MetricsCollectionService service,
+  private static MetricsContext getMetricCollector(MetricsCollectionService service,
                                                      Program program, String handlerName,
                                                      String runId, int instanceId) {
     if (service == null) {
@@ -114,6 +114,6 @@ public class BasicHttpServiceContext extends AbstractContext implements Transact
     Map<String, String> tags = Maps.newHashMap(getMetricsContext(program, runId));
     tags.put(Constants.Metrics.Tag.HANDLER, handlerName);
     tags.put(Constants.Metrics.Tag.INSTANCE_ID, String.valueOf(instanceId));
-    return service.getCollector(tags);
+    return service.getContext(tags);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/DelayedHttpServiceResponder.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/DelayedHttpServiceResponder.java
@@ -16,7 +16,7 @@
 
 package co.cask.cdap.internal.app.runtime.service.http;
 
-import co.cask.cdap.api.metrics.MetricsCollector;
+import co.cask.cdap.api.metrics.MetricsContext;
 import co.cask.cdap.api.service.http.HttpServiceResponder;
 import co.cask.http.HttpResponder;
 import com.google.common.base.Charsets;
@@ -44,7 +44,7 @@ public final class DelayedHttpServiceResponder implements HttpServiceResponder {
   private static final Logger LOG = LoggerFactory.getLogger(DelayedHttpServiceResponder.class);
   private static final Gson GSON = new Gson();
   private final HttpResponder responder;
-  private final MetricsCollector metricsCollector;
+  private final MetricsContext metricsContext;
   private BufferedResponse bufferedResponse;
 
   /**
@@ -52,9 +52,9 @@ public final class DelayedHttpServiceResponder implements HttpServiceResponder {
    *
    * @param responder the responder which will be bound to
    */
-  public DelayedHttpServiceResponder(HttpResponder responder, MetricsCollector metricsCollector) {
+  public DelayedHttpServiceResponder(HttpResponder responder, MetricsContext metricsContext) {
     this.responder = responder;
-    this.metricsCollector = metricsCollector;
+    this.metricsContext = metricsContext;
   }
 
   /**
@@ -215,8 +215,8 @@ public final class DelayedHttpServiceResponder implements HttpServiceResponder {
     }
     builder.append(".count");
 
-    metricsCollector.increment(builder.toString(), 1);
-    metricsCollector.increment("requests.count", 1);
+    metricsContext.increment(builder.toString(), 1);
+    metricsContext.increment("requests.count", 1);
   }
 
   private static final class BufferedResponse {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/HttpHandlerFactory.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/HttpHandlerFactory.java
@@ -16,7 +16,7 @@
 
 package co.cask.cdap.internal.app.runtime.service.http;
 
-import co.cask.cdap.api.metrics.MetricsCollector;
+import co.cask.cdap.api.metrics.MetricsContext;
 import co.cask.cdap.api.service.http.HttpServiceHandler;
 import co.cask.cdap.internal.asm.ByteCodeClassLoader;
 import co.cask.cdap.internal.asm.ClassDefinition;
@@ -41,14 +41,14 @@ public final class HttpHandlerFactory {
   private static final Logger LOG = LoggerFactory.getLogger(HttpHandlerFactory.class);
 
   private final LoadingCache<TypeToken<? extends HttpServiceHandler>, Class<?>> handlerClasses;
-  private final MetricsCollector metricsCollector;
+  private final MetricsContext metricsContext;
 
   /**
    * Creates an instance that could generate {@link HttpHandler} that always binds to service Path that starts with
    * the given prefix.
    */
-  public HttpHandlerFactory(final String pathPrefix, final MetricsCollector metricsCollector) {
-    this.metricsCollector = metricsCollector;
+  public HttpHandlerFactory(final String pathPrefix, final MetricsContext metricsContext) {
+    this.metricsContext = metricsContext;
     handlerClasses = CacheBuilder.newBuilder().build(
       new CacheLoader<TypeToken<? extends HttpServiceHandler>, Class<?>>() {
       @Override
@@ -80,8 +80,8 @@ public final class HttpHandlerFactory {
 
     try {
       Constructor<? extends HttpHandler> constuctor = handlerClass.getConstructor(DelegatorContext.class,
-                                                                                  MetricsCollector.class);
-      return constuctor.newInstance(context, metricsCollector);
+                                                                                  MetricsContext.class);
+      return constuctor.newInstance(context, metricsContext);
     } catch (Exception e) {
       LOG.error("Failed to instantiate generated HttpHandler {}", handlerClass, e);
       throw Throwables.propagate(e);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/HttpHandlerGenerator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/HttpHandlerGenerator.java
@@ -16,7 +16,7 @@
 
 package co.cask.cdap.internal.app.runtime.service.http;
 
-import co.cask.cdap.api.metrics.MetricsCollector;
+import co.cask.cdap.api.metrics.MetricsContext;
 import co.cask.cdap.api.service.http.HttpServiceHandler;
 import co.cask.cdap.api.service.http.HttpServiceRequest;
 import co.cask.cdap.api.service.http.HttpServiceResponder;
@@ -215,19 +215,19 @@ final class HttpHandlerGenerator {
    * Generates the constructor. The constructor generated has signature {@code (DelegatorContext)}.
    */
   private void generateConstructor(TypeToken<? extends HttpServiceHandler> delegateType, ClassWriter classWriter) {
-    Method constructor = Methods.getMethod(void.class, "<init>", DelegatorContext.class, MetricsCollector.class);
+    Method constructor = Methods.getMethod(void.class, "<init>", DelegatorContext.class, MetricsContext.class);
     String signature = Signatures.getMethodSignature(constructor, getContextType(delegateType),
-                                                     TypeToken.of(MetricsCollector.class));
+                                                     TypeToken.of(MetricsContext.class));
 
-    // Constructor(DelegatorContext, MetricsCollector)
+    // Constructor(DelegatorContext, MetricsContext)
     GeneratorAdapter mg = new GeneratorAdapter(Opcodes.ACC_PUBLIC, constructor, signature, null, classWriter);
 
-    // super(context, metricsCollector);
+    // super(context, metricsContext);
     mg.loadThis();
     mg.loadArg(0);
     mg.loadArg(1);
     mg.invokeConstructor(Type.getType(AbstractHttpHandlerDelegator.class),
-                         Methods.getMethod(void.class, "<init>", DelegatorContext.class, MetricsCollector.class));
+                         Methods.getMethod(void.class, "<init>", DelegatorContext.class, MetricsContext.class));
     mg.returnValue();
     mg.endMethod();
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/BasicSparkContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/BasicSparkContext.java
@@ -20,7 +20,7 @@ import co.cask.cdap.api.ServiceDiscoverer;
 import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
-import co.cask.cdap.api.metrics.MetricsCollector;
+import co.cask.cdap.api.metrics.MetricsContext;
 import co.cask.cdap.api.spark.SparkContext;
 import co.cask.cdap.api.spark.SparkSpecification;
 import co.cask.cdap.api.stream.StreamEventDecoder;
@@ -94,7 +94,7 @@ public class BasicSparkContext extends AbstractContext implements SparkContext {
     this.streamAdmin = streamAdmin;
     SerializableServiceDiscoverer.setDiscoveryServiceClient(getDiscoveryServiceClient());
     this.serializableServiceDiscoverer = new SerializableServiceDiscoverer(getProgram());
-    SparkUserMetrics.setMetricsCollector(getProgramMetrics());
+    SparkUserMetrics.setMetricsContext(getProgramMetrics());
     this.userMetrics = new SparkUserMetrics();
     this.loggingContext = new SparkLoggingContext(getNamespaceId(), getApplicationId(), getProgramName(),
                                                   getRunId().getId());
@@ -153,7 +153,7 @@ public class BasicSparkContext extends AbstractContext implements SparkContext {
     throw new IllegalStateException("Reading stream is not supported here");
   }
 
-  private static MetricsCollector getMetricCollector(MetricsCollectionService service, Program program, String runId) {
+  private static MetricsContext getMetricCollector(MetricsCollectionService service, Program program, String runId) {
     if (service == null) {
       return null;
     }
@@ -161,7 +161,7 @@ public class BasicSparkContext extends AbstractContext implements SparkContext {
     // todo: use proper spark instance id. For now we have to emit smth for test framework's waitFor metric to work
     tags.put(Constants.Metrics.Tag.INSTANCE_ID, "0");
 
-    return service.getCollector(tags);
+    return service.getContext(tags);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/metrics/SparkMetricsReporter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/metrics/SparkMetricsReporter.java
@@ -16,7 +16,7 @@
 
 package co.cask.cdap.internal.app.runtime.spark.metrics;
 
-import co.cask.cdap.api.metrics.MetricsCollector;
+import co.cask.cdap.api.metrics.MetricsContext;
 import co.cask.cdap.internal.app.runtime.spark.SparkProgramWrapper;
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
@@ -33,7 +33,7 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * A {@link ScheduledReporter} reports which reports Metrics collected by the {@link SparkMetricsSink} to
- * {@link MetricsCollector}.
+ * {@link MetricsContext}.
  */
 class SparkMetricsReporter extends ScheduledReporter {
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/metrics/SparkMetricsSink.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/metrics/SparkMetricsSink.java
@@ -17,7 +17,7 @@
 
 package co.cask.cdap.internal.app.runtime.spark.metrics;
 
-import co.cask.cdap.api.metrics.MetricsCollector;
+import co.cask.cdap.api.metrics.MetricsContext;
 import co.cask.cdap.api.spark.Spark;
 import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistry;
@@ -38,7 +38,7 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * A {@link Sink} which collects Metrics from {@link Spark} program and used {@link SparkMetricsReporter} to report it
- * to {@link MetricsCollector}
+ * to {@link MetricsContext}
  * <p/>
  * This full qualified name of this class is given to spark through the metrics configuration file.
  */

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/metrics/SparkUserMetrics.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/metrics/SparkUserMetrics.java
@@ -17,7 +17,7 @@
 package co.cask.cdap.internal.app.runtime.spark.metrics;
 
 import co.cask.cdap.api.metrics.Metrics;
-import co.cask.cdap.api.metrics.MetricsCollector;
+import co.cask.cdap.api.metrics.MetricsContext;
 import co.cask.cdap.api.spark.Spark;
 import co.cask.cdap.common.conf.Constants;
 
@@ -32,28 +32,28 @@ import java.io.ObjectOutput;
 public final class SparkUserMetrics implements Metrics, Externalizable {
   private static final long serialVersionUID = -5913108632034346101L;
 
-  private static MetricsCollector metricsCollector;
+  private static MetricsContext metricsContext;
 
   /** For serde purposes only */
   public SparkUserMetrics() {
   }
 
-  public static void setMetricsCollector(MetricsCollector collector) {
-    SparkUserMetrics.metricsCollector = collector.childCollector(Constants.Metrics.Tag.SCOPE, "user");
+  public static void setMetricsContext(MetricsContext collector) {
+    SparkUserMetrics.metricsContext = collector.childContext(Constants.Metrics.Tag.SCOPE, "user");
   }
 
   @Override
   public void count(String metricName, int delta) {
-    metricsCollector.increment(metricName, delta);
+    metricsContext.increment(metricName, delta);
   }
 
   @Override
   public void gauge(String metricName, long value) {
-    metricsCollector.gauge(metricName, value);
+    metricsContext.gauge(metricName, value);
   }
 
   /**
-   * Since MetricsCollector (only member) is a static member there is nothing to serialize.
+   * Since MetricsContext (only member) is a static member there is nothing to serialize.
    * For supporting Spark in Distributed mode, this needs to be revisited.
    */
   @Override
@@ -62,7 +62,7 @@ public final class SparkUserMetrics implements Metrics, Externalizable {
   }
 
   /**
-   * Since MetricsCollector (only member) is a static field there is nothing to serialize.
+   * Since MetricsContext (only member) is a static field there is nothing to serialize.
    * For supporting Spark in Distributed mode, this needs to be revisited.
    */
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/BasicWorkerContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/BasicWorkerContext.java
@@ -22,7 +22,7 @@ import co.cask.cdap.api.data.stream.StreamWriter;
 import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
-import co.cask.cdap.api.metrics.MetricsCollector;
+import co.cask.cdap.api.metrics.MetricsContext;
 import co.cask.cdap.api.stream.StreamEventData;
 import co.cask.cdap.api.templates.AdapterSpecification;
 import co.cask.cdap.api.worker.WorkerContext;
@@ -162,7 +162,7 @@ public class BasicWorkerContext extends AbstractContext implements WorkerContext
   }
 
   @Nullable
-  private static MetricsCollector getMetricCollector(Program program, String runId, int instanceId,
+  private static MetricsContext getMetricCollector(Program program, String runId, int instanceId,
                                                      @Nullable MetricsCollectionService service,
                                                      @Nullable AdapterSpecification adapterSpec) {
     if (service == null) {
@@ -175,7 +175,7 @@ public class BasicWorkerContext extends AbstractContext implements WorkerContext
       tags.put(Constants.Metrics.Tag.ADAPTER, adapterSpec.getName());
     }
 
-    return service.getCollector(tags);
+    return service.getContext(tags);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/DefaultServiceConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/DefaultServiceConfigurer.java
@@ -17,7 +17,7 @@
 package co.cask.cdap.internal.app.services;
 
 import co.cask.cdap.api.Resources;
-import co.cask.cdap.api.metrics.MetricsCollector;
+import co.cask.cdap.api.metrics.MetricsContext;
 import co.cask.cdap.api.service.Service;
 import co.cask.cdap.api.service.ServiceConfigurer;
 import co.cask.cdap.api.service.ServiceSpecification;
@@ -136,9 +136,9 @@ public class DefaultServiceConfigurer implements ServiceConfigurer {
   }
 
   private <T extends HttpServiceHandler> HttpHandler createHttpHandler(T handler) {
-    MetricsCollector noOpsMetricsCollector =
-      new NoOpMetricsCollectionService().getCollector(new HashMap<String, String>());
-    HttpHandlerFactory factory = new HttpHandlerFactory("", noOpsMetricsCollector);
+    MetricsContext noOpsMetricsContext =
+      new NoOpMetricsCollectionService().getContext(new HashMap<String, String>());
+    HttpHandlerFactory factory = new HttpHandlerFactory("", noOpsMetricsContext);
     @SuppressWarnings("unchecked")
     TypeToken<T> type = (TypeToken<T>) TypeToken.of(handler.getClass());
     return factory.createHttpHandler(type, new VerificationDelegateContext<>(handler));

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ServiceHttpServer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ServiceHttpServer.java
@@ -17,7 +17,7 @@
 package co.cask.cdap.internal.app.services;
 
 import co.cask.cdap.api.metrics.MetricsCollectionService;
-import co.cask.cdap.api.metrics.MetricsCollector;
+import co.cask.cdap.api.metrics.MetricsContext;
 import co.cask.cdap.api.service.ServiceSpecification;
 import co.cask.cdap.api.service.http.HttpServiceHandler;
 import co.cask.cdap.api.service.http.HttpServiceHandlerSpecification;
@@ -297,7 +297,7 @@ public class ServiceHttpServer extends AbstractIdleService {
                                                   Iterable<HandlerDelegatorContext> delegatorContexts,
                                                   MetricsCollectionService metricsCollectionService) {
     // Create HttpHandlers which delegate to the HttpServiceHandlers
-    MetricsCollector collector =
+    MetricsContext collector =
       getMetricCollector(metricsCollectionService, program, runId.getId());
     HttpHandlerFactory factory = new HttpHandlerFactory(pathPrefix, collector);
     List<HttpHandler> nettyHttpHandlers = Lists.newArrayList();
@@ -312,7 +312,7 @@ public class ServiceHttpServer extends AbstractIdleService {
       .build();
   }
 
-  private static MetricsCollector getMetricCollector(MetricsCollectionService service, Program program, String runId) {
+  private static MetricsContext getMetricCollector(MetricsCollectionService service, Program program, String runId) {
     if (service == null) {
       return null;
     }
@@ -320,7 +320,7 @@ public class ServiceHttpServer extends AbstractIdleService {
     // todo: use proper service instance id. For now we have to emit smth for test framework's waitFor metric to work
     tags.put(Constants.Metrics.Tag.INSTANCE_ID, "0");
 
-    return service.getCollector(tags);
+    return service.getContext(tags);
   }
 
   /**

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/service/http/HttpHandlerGeneratorTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/service/http/HttpHandlerGeneratorTest.java
@@ -18,7 +18,7 @@ package co.cask.cdap.internal.app.runtime.service.http;
 
 import co.cask.cdap.api.data.DatasetInstantiationException;
 import co.cask.cdap.api.dataset.Dataset;
-import co.cask.cdap.api.metrics.MetricsCollector;
+import co.cask.cdap.api.metrics.MetricsContext;
 import co.cask.cdap.api.service.http.AbstractHttpServiceHandler;
 import co.cask.cdap.api.service.http.HttpServiceContext;
 import co.cask.cdap.api.service.http.HttpServiceHandler;
@@ -91,9 +91,9 @@ public class HttpHandlerGeneratorTest {
 
   @Test
   public void testHttpHandlerGenerator() throws Exception {
-    MetricsCollector noOpsMetricsCollector =
-      new NoOpMetricsCollectionService().getCollector(new HashMap<String, String>());
-    HttpHandlerFactory factory = new HttpHandlerFactory("/prefix", noOpsMetricsCollector);
+    MetricsContext noOpsMetricsContext =
+      new NoOpMetricsCollectionService().getContext(new HashMap<String, String>());
+    HttpHandlerFactory factory = new HttpHandlerFactory("/prefix", noOpsMetricsContext);
 
     HttpHandler httpHandler = factory.createHttpHandler(
       TypeToken.of(MyHttpHandler.class), new AbstractDelegatorContext<MyHttpHandler>() {

--- a/cdap-common/src/main/java/co/cask/cdap/common/metrics/NoOpMetricsCollectionService.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/metrics/NoOpMetricsCollectionService.java
@@ -17,7 +17,7 @@
 package co.cask.cdap.common.metrics;
 
 import co.cask.cdap.api.metrics.MetricsCollectionService;
-import co.cask.cdap.api.metrics.MetricsCollector;
+import co.cask.cdap.api.metrics.MetricsContext;
 import com.google.common.util.concurrent.AbstractIdleService;
 
 import java.util.Map;
@@ -38,8 +38,8 @@ public class NoOpMetricsCollectionService extends AbstractIdleService implements
   }
 
   @Override
-  public MetricsCollector getCollector(Map<String, String> tags) {
-    return new MetricsCollector() {
+  public MetricsContext getContext(Map<String, String> tags) {
+    return new MetricsContext() {
       @Override
       public void increment(String metricName, long value) {
         // no-op
@@ -51,12 +51,12 @@ public class NoOpMetricsCollectionService extends AbstractIdleService implements
       }
 
       @Override
-      public MetricsCollector childCollector(Map<String, String> tags) {
+      public MetricsContext childContext(Map<String, String> tags) {
         return this;
       }
 
       @Override
-      public MetricsCollector childCollector(String tagName, String tagValue) {
+      public MetricsContext childContext(String tagName, String tagValue) {
         return this;
       }
     };

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metrics/HBaseDatasetMetricsReporter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metrics/HBaseDatasetMetricsReporter.java
@@ -18,7 +18,7 @@ package co.cask.cdap.data2.metrics;
 
 import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
-import co.cask.cdap.api.metrics.MetricsCollector;
+import co.cask.cdap.api.metrics.MetricsContext;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
@@ -123,9 +123,9 @@ public class HBaseDatasetMetricsReporter extends AbstractScheduledService implem
           DatasetSpecification specification = dsFramework.getDatasetSpec(Id.DatasetInstance.from(namespace,
                                                                                                   spec.getName()));
           if (specification.isParent(tableName)) {
-            MetricsCollector collector =
-              metricsService.getCollector(ImmutableMap.of(Constants.Metrics.Tag.NAMESPACE, namespace,
-                                                          Constants.Metrics.Tag.DATASET, spec.getName()));
+            MetricsContext collector =
+              metricsService.getContext(ImmutableMap.of(Constants.Metrics.Tag.NAMESPACE, namespace,
+                                                        Constants.Metrics.Tag.DATASET, spec.getName()));
             collector.gauge("dataset.size.mb", statEntry.getValue().getTotalSizeMB());
             break;
           }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metrics/LevelDBDatasetMetricsReporter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metrics/LevelDBDatasetMetricsReporter.java
@@ -18,7 +18,7 @@ package co.cask.cdap.data2.metrics;
 
 import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
-import co.cask.cdap.api.metrics.MetricsCollector;
+import co.cask.cdap.api.metrics.MetricsContext;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
@@ -112,9 +112,9 @@ public class LevelDBDatasetMetricsReporter extends AbstractScheduledService impl
         DatasetSpecification specification = dsFramework.getDatasetSpec(Id.DatasetInstance.from(namespace,
                                                                                                 spec.getName()));
         if (specification.isParent(tableName)) {
-          MetricsCollector collector =
-            metricsService.getCollector(ImmutableMap.of(Constants.Metrics.Tag.NAMESPACE, namespace,
-                                                        Constants.Metrics.Tag.DATASET, spec.getName()));
+          MetricsContext collector =
+            metricsService.getContext(ImmutableMap.of(Constants.Metrics.Tag.NAMESPACE, namespace,
+                                                      Constants.Metrics.Tag.DATASET, spec.getName()));
           int sizeInMb = (int) (statEntry.getValue().getDiskSizeBytes() / BYTES_IN_MB);
           collector.gauge("dataset.size.mb", sizeInMb);
           break;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/metrics/TransactionManagerMetricsCollector.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/metrics/TransactionManagerMetricsCollector.java
@@ -17,21 +17,21 @@
 package co.cask.cdap.data2.transaction.metrics;
 
 import co.cask.cdap.api.metrics.MetricsCollectionService;
-import co.cask.cdap.api.metrics.MetricsCollector;
+import co.cask.cdap.api.metrics.MetricsContext;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.tephra.metrics.TxMetricsCollector;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 
 /**
- * Implementation for TxMetricsCollector that delegate the the underlying {@link MetricsCollector}.
+ * Implementation for TxMetricsCollector that delegate the the underlying {@link MetricsContext}.
  */
 public class TransactionManagerMetricsCollector extends TxMetricsCollector {
-  private final MetricsCollector metricsCollector;
+  private final MetricsContext metricsContext;
 
   @Inject
   public TransactionManagerMetricsCollector(MetricsCollectionService service) {
-    this.metricsCollector = service.getCollector(
+    this.metricsContext = service.getContext(
       ImmutableMap.of(Constants.Metrics.Tag.NAMESPACE, Constants.SYSTEM_NAMESPACE,
                       Constants.Metrics.Tag.COMPONENT, "transactions"));
   }
@@ -39,7 +39,7 @@ public class TransactionManagerMetricsCollector extends TxMetricsCollector {
   // todo: change TxMetricsCollector in Tephra
   @Override
   public void gauge(String metricName, int value, String...tags) {
-    metricsCollector.increment(metricName, value);
+    metricsContext.increment(metricName, value);
   }
 
 }

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/metrics/MetricsHandlerTestRun.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/metrics/MetricsHandlerTestRun.java
@@ -20,7 +20,7 @@ import co.cask.cdap.api.metrics.MetricDeleteQuery;
 import co.cask.cdap.api.metrics.MetricType;
 import co.cask.cdap.api.metrics.MetricValues;
 import co.cask.cdap.api.metrics.Metrics;
-import co.cask.cdap.api.metrics.MetricsCollector;
+import co.cask.cdap.api.metrics.MetricsContext;
 import co.cask.cdap.app.metrics.MapReduceMetrics;
 import co.cask.cdap.app.metrics.ProgramUserMetrics;
 import co.cask.cdap.proto.MetricQueryResult;
@@ -60,15 +60,15 @@ public class MetricsHandlerTestRun extends MetricsSuiteTestBase {
 
   private static void setupMetrics() throws Exception {
     // Adding metrics for app "WordCount1" in namespace "myspace", "WCount1" in "yourspace"
-    MetricsCollector collector =
-      collectionService.getCollector(getFlowletContext("myspace", "WordCount1", "WordCounter", "run1", "splitter"));
+    MetricsContext collector =
+      collectionService.getContext(getFlowletContext("myspace", "WordCount1", "WordCounter", "run1", "splitter"));
     collector.increment("reads", 1);
     collector.increment("writes", 1);
-    collector = collectionService.getCollector(getFlowletContext("yourspace", "WCount1", "WordCounter",
-                                                                 "run1", "splitter"));
+    collector = collectionService.getContext(getFlowletContext("yourspace", "WCount1", "WordCounter",
+                                                               "run1", "splitter"));
     collector.increment("reads", 1);
-    collector = collectionService.getCollector(getFlowletContext("yourspace", "WCount1", "WCounter",
-                                                                 "run1", "splitter"));
+    collector = collectionService.getContext(getFlowletContext("yourspace", "WCount1", "WCounter",
+                                                               "run1", "splitter"));
     emitTs = System.currentTimeMillis();
     // we want to emit in two different seconds
     // todo : figure out why we need this
@@ -77,60 +77,60 @@ public class MetricsHandlerTestRun extends MetricsSuiteTestBase {
     TimeUnit.MILLISECONDS.sleep(2000);
     collector.increment("reads", 2);
 
-    collector = collectionService.getCollector(getFlowletContext("yourspace", "WCount1", "WCounter",
-                                                                 "run1", "counter"));
+    collector = collectionService.getContext(getFlowletContext("yourspace", "WCount1", "WCounter",
+                                                               "run1", "counter"));
     collector.increment("reads", 1);
-    collector = collectionService.getCollector(getMapReduceTaskContext("yourspace", "WCount1", "ClassicWordCount",
-                                                                       MapReduceMetrics.TaskType.Mapper,
-                                                                       "run1", "task1"));
+    collector = collectionService.getContext(getMapReduceTaskContext("yourspace", "WCount1", "ClassicWordCount",
+                                                                     MapReduceMetrics.TaskType.Mapper,
+                                                                     "run1", "task1"));
     collector.increment("reads", 1);
-    collector = collectionService.getCollector(
+    collector = collectionService.getContext(
       getMapReduceTaskContext("yourspace", "WCount1", "ClassicWordCount",
                               MapReduceMetrics.TaskType.Reducer, "run1", "task2"));
     collector.increment("reads", 1);
-    collector = collectionService.getCollector(getFlowletContext("myspace", "WordCount1", "WordCounter",
-                                                                 "run1", "splitter"));
+    collector = collectionService.getContext(getFlowletContext("myspace", "WordCount1", "WordCounter",
+                                                               "run1", "splitter"));
     collector.increment("reads", 1);
     collector.increment("writes", 1);
 
-    collector = collectionService.getCollector(getFlowletContext("myspace", "WordCount1", "WordCounter",
-                                                                 "run1", "collector"));
+    collector = collectionService.getContext(getFlowletContext("myspace", "WordCount1", "WordCounter",
+                                                               "run1", "collector"));
     collector.increment("aa", 1);
     collector.increment("zz", 1);
     collector.increment("ab", 1);
 
-    collector = collectionService.getCollector(getAdapterContext("yourspace", "WCount1", "ClassicWordCount",
-                                                                 MapReduceMetrics.TaskType.Mapper,
-                                                                 "run1", "task1", "adapter1"));
+    collector = collectionService.getContext(getAdapterContext("yourspace", "WCount1", "ClassicWordCount",
+                                                               MapReduceMetrics.TaskType.Mapper,
+                                                               "run1", "task1", "adapter1"));
     collector.increment("areads", 3);
     collector.increment("awrites", 4);
 
-    collector = collectionService.getCollector(getAdapterContext("yourspace", "WCount1", "ClassicWordCount",
-                                                                 MapReduceMetrics.TaskType.Mapper,
-                                                                 "run2", "task1", "adapter1"));
+    collector = collectionService.getContext(getAdapterContext("yourspace", "WCount1", "ClassicWordCount",
+                                                               MapReduceMetrics.TaskType.Mapper,
+                                                               "run2", "task1", "adapter1"));
     collector.increment("areads", 3);
     collector.increment("awrites", 4);
 
-    collector = collectionService.getCollector(getWorkerAdapterContext("yourspace", "WCount1", "WorkerWordCount",
-                                                                       "run1", "task1", "adapter2"));
+    collector = collectionService.getContext(getWorkerAdapterContext("yourspace", "WCount1", "WorkerWordCount",
+                                                                     "run1", "task1", "adapter2"));
 
     collector.increment("workerreads", 5);
     collector.increment("workerwrites", 6);
 
-    collector = collectionService.getCollector(getWorkerAdapterContext("yourspace", "WCount1", "WorkerWordCount",
-                                                                       "run2", "task1", "adapter2"));
+    collector = collectionService.getContext(getWorkerAdapterContext("yourspace", "WCount1", "WorkerWordCount",
+                                                                     "run2", "task1", "adapter2"));
 
     collector.increment("workerreads", 5);
     collector.increment("workerwrites", 6);
 
     // also: user metrics
     Metrics userMetrics = new ProgramUserMetrics(
-      collectionService.getCollector(getFlowletContext("myspace", "WordCount1", "WordCounter",
-                                                       "run1", "splitter")));
+      collectionService.getContext(getFlowletContext("myspace", "WordCount1", "WordCounter",
+                                                     "run1", "splitter")));
     userMetrics.count("reads", 1);
     userMetrics.count("writes", 2);
 
-    collector = collectionService.getCollector(new HashMap<String, String>());
+    collector = collectionService.getContext(new HashMap<String, String>());
     collector.increment("resources.total.storage", 10);
 
     // need a better way to do this

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/flow/FlowQueuePendingCorrector.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/flow/FlowQueuePendingCorrector.java
@@ -23,7 +23,7 @@ import co.cask.cdap.api.metrics.MetricDataQuery;
 import co.cask.cdap.api.metrics.MetricStore;
 import co.cask.cdap.api.metrics.MetricTimeSeries;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
-import co.cask.cdap.api.metrics.MetricsCollector;
+import co.cask.cdap.api.metrics.MetricsContext;
 import co.cask.cdap.app.ApplicationSpecification;
 import co.cask.cdap.app.guice.AppFabricServiceRuntimeModule;
 import co.cask.cdap.app.guice.ProgramRunnerRuntimeModule;
@@ -294,7 +294,7 @@ public class FlowQueuePendingCorrector extends AbstractIdleService {
 
     metricsCollectionService.startAndWait();
 
-    MetricsCollector collector = metricsCollectionService.getCollector(tags);
+    MetricsContext collector = metricsCollectionService.getContext(tags);
     collector.gauge("queue.pending", correctQueuePendingValue);
     System.out.printf("Adjusted system.queue.pending metric from %d to %d (tags %s)\n",
                       queuePending, correctQueuePendingValue, GSON.toJson(tags));

--- a/cdap-watchdog-api/src/main/java/co/cask/cdap/api/metrics/MetricsCollectionService.java
+++ b/cdap-watchdog-api/src/main/java/co/cask/cdap/api/metrics/MetricsCollectionService.java
@@ -28,7 +28,7 @@ public interface MetricsCollectionService extends Service {
    * Returns the metric collector for the given context.
    *
    * @param context The tags that define the metrics context.
-   * @return A {@link MetricsCollector} for emitting metrics.
+   * @return A {@link MetricsContext} for emitting metrics.
    */
-  MetricsCollector getCollector(Map<String, String> context);
+  MetricsContext getContext(Map<String, String> context);
 }

--- a/cdap-watchdog-api/src/main/java/co/cask/cdap/api/metrics/MetricsContext.java
+++ b/cdap-watchdog-api/src/main/java/co/cask/cdap/api/metrics/MetricsContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Cask Data, Inc.
+ * Copyright © 2014 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -13,24 +13,24 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package co.cask.cdap.api.metrics;
 
+import java.util.Map;
+
 /**
- * Collects metrics.
+ * A context of metrics collection.
  */
-public interface MetricsCollector {
+public interface MetricsContext extends MetricsCollector {
   /**
-   * Increment a metric value at the current time.
-   * @param metricName Name of the metric.
-   * @param value value of the metric.
+   * Creates child {@link MetricsContext} that inherits the metrics context from this one and adds extra context
+   * information.
+   * @param tags tags to add to the child metrics context
+   * @return child {@link MetricsContext}
    */
-  void increment(String metricName, long value);
+  MetricsContext childContext(Map<String, String> tags);
 
   /**
-   * Gauge a metric value at the current time.
-   * @param metricName Name of the metric.
-   * @param value value of the metric.
+   * Convenience method that acts as {@link #childContext(java.util.Map)} by supplying single tag.
    */
-  void gauge(String metricName, long value);
+  MetricsContext childContext(String tagName, String tagValue);
 }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/LogMetricsPlugin.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/LogMetricsPlugin.java
@@ -17,7 +17,7 @@
 package co.cask.cdap.logging.save;
 
 import co.cask.cdap.api.metrics.MetricsCollectionService;
-import co.cask.cdap.api.metrics.MetricsCollector;
+import co.cask.cdap.api.metrics.MetricsContext;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.logging.LoggingContext;
 import co.cask.cdap.logging.appender.kafka.KafkaTopic;
@@ -88,7 +88,7 @@ public class LogMetricsPlugin extends AbstractKafkaLogProcessor {
 
     LoggingContext context = event.getLoggingContext();
     Map<String, String> tags = LoggingContextHelper.getMetricsTags(context);
-    MetricsCollector collector = metricsCollectionService.getCollector(tags);
+    MetricsContext collector = metricsCollectionService.getContext(tags);
 
     String metricName = getMetricName(tags.get(Constants.Metrics.Tag.NAMESPACE),
                                       event.getLogEvent().getLevel().toString().toLowerCase());

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/collect/AggregatedMetricsCollectionService.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/collect/AggregatedMetricsCollectionService.java
@@ -19,7 +19,7 @@ import co.cask.cdap.api.metrics.MetricType;
 import co.cask.cdap.api.metrics.MetricValue;
 import co.cask.cdap.api.metrics.MetricValues;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
-import co.cask.cdap.api.metrics.MetricsCollector;
+import co.cask.cdap.api.metrics.MetricsContext;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.metrics.iterator.MetricsCollectorIterator;
 import com.google.common.cache.CacheBuilder;
@@ -51,7 +51,7 @@ public abstract class AggregatedMetricsCollectionService extends AbstractSchedul
   private static final Logger LOG = LoggerFactory.getLogger(AggregatedMetricsCollectionService.class);
   private static final long CACHE_EXPIRE_MINUTES = 1;
 
-  private final LoadingCache<Map<String, String>, MetricsCollector> collectors;
+  private final LoadingCache<Map<String, String>, MetricsContext> collectors;
   private final LoadingCache<Map<String, String>, LoadingCache<String, AggregatedMetricsEmitter>> emitters;
 
   private ScheduledExecutorService executorService;
@@ -146,7 +146,7 @@ public abstract class AggregatedMetricsCollectionService extends AbstractSchedul
   }
 
   @Override
-  public final MetricsCollector getCollector(final Map<String, String> tags) {
+  public final MetricsContext getContext(final Map<String, String> tags) {
     return collectors.getUnchecked(tags);
   }
 
@@ -196,20 +196,20 @@ public abstract class AggregatedMetricsCollectionService extends AbstractSchedul
     };
   }
 
-  private CacheLoader<Map<String, String>, MetricsCollector> createCollectorLoader() {
-    return new CacheLoader<Map<String, String>, MetricsCollector>() {
+  private CacheLoader<Map<String, String>, MetricsContext> createCollectorLoader() {
+    return new CacheLoader<Map<String, String>, MetricsContext>() {
       @Override
-      public MetricsCollector load(final Map<String, String> collectorKey) throws Exception {
-        return new MetricsCollectorImpl(collectorKey);
+      public MetricsContext load(final Map<String, String> collectorKey) throws Exception {
+        return new MetricsContextImpl(collectorKey);
       }
     };
   }
 
-  private final class MetricsCollectorImpl implements MetricsCollector {
+  private final class MetricsContextImpl implements MetricsContext {
 
     private final Map<String, String> tags;
 
-    private MetricsCollectorImpl(final Map<String, String> tags) {
+    private MetricsContextImpl(final Map<String, String> tags) {
       this.tags = tags;
     }
 
@@ -224,14 +224,14 @@ public abstract class AggregatedMetricsCollectionService extends AbstractSchedul
     }
 
     @Override
-    public MetricsCollector childCollector(String tagName, String tagValue) {
+    public MetricsContext childContext(String tagName, String tagValue) {
       ImmutableMap<String, String> allTags = ImmutableMap.<String, String>builder()
         .putAll(tags).put(tagName, tagValue).build();
       return collectors.getUnchecked(allTags);
     }
 
     @Override
-    public MetricsCollector childCollector(Map<String, String> tags) {
+    public MetricsContext childContext(Map<String, String> tags) {
       if (tags.isEmpty()) {
         return this;
       }

--- a/cdap-watchdog/src/test/java/co/cask/cdap/metrics/collect/AggregatedMetricsCollectionServiceTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/metrics/collect/AggregatedMetricsCollectionServiceTest.java
@@ -17,7 +17,7 @@ package co.cask.cdap.metrics.collect;
 
 import co.cask.cdap.api.metrics.MetricValue;
 import co.cask.cdap.api.metrics.MetricValues;
-import co.cask.cdap.api.metrics.MetricsCollector;
+import co.cask.cdap.api.metrics.MetricsContext;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.test.SlowTests;
 import com.google.common.collect.ImmutableMap;
@@ -92,10 +92,10 @@ public class AggregatedMetricsCollectionServiceTest {
     try {
       // The first section tests with empty tags.
       // Publish couple metrics with empty tags, they should be aggregated.
-      service.getCollector(EMPTY_TAGS).increment(METRIC, Integer.MAX_VALUE);
-      service.getCollector(EMPTY_TAGS).increment(METRIC, 2);
-      service.getCollector(EMPTY_TAGS).increment(METRIC, 3);
-      service.getCollector(EMPTY_TAGS).increment(METRIC, 4);
+      service.getContext(EMPTY_TAGS).increment(METRIC, Integer.MAX_VALUE);
+      service.getContext(EMPTY_TAGS).increment(METRIC, 2);
+      service.getContext(EMPTY_TAGS).increment(METRIC, 3);
+      service.getContext(EMPTY_TAGS).increment(METRIC, 4);
 
       MetricValues record = published.poll(10, TimeUnit.SECONDS);
       Assert.assertNotNull(record);
@@ -106,13 +106,13 @@ public class AggregatedMetricsCollectionServiceTest {
       Assert.assertNull(published.poll(3, TimeUnit.SECONDS));
 
       // Publish a metric and wait for it so that we know there is around 1 second to publish more metrics to test.
-      service.getCollector(EMPTY_TAGS).increment(METRIC, 1);
+      service.getContext(EMPTY_TAGS).increment(METRIC, 1);
       Assert.assertNotNull(published.poll(3, TimeUnit.SECONDS));
 
       //update the metrics multiple times with gauge.
-      service.getCollector(EMPTY_TAGS).gauge(METRIC, 1);
-      service.getCollector(EMPTY_TAGS).gauge(METRIC, 2);
-      service.getCollector(EMPTY_TAGS).gauge(METRIC, 3);
+      service.getContext(EMPTY_TAGS).gauge(METRIC, 1);
+      service.getContext(EMPTY_TAGS).gauge(METRIC, 2);
+      service.getContext(EMPTY_TAGS).gauge(METRIC, 3);
 
       // gauge just updates the value, so polling should return the most recent value written
       record = published.poll(3, TimeUnit.SECONDS);
@@ -120,9 +120,9 @@ public class AggregatedMetricsCollectionServiceTest {
       Assert.assertEquals(3, getMetricValue(record.getMetrics(), METRIC));
 
       // define collectors for non-empty tags
-      MetricsCollector baseCollector = service.getCollector(baseTags);
-      MetricsCollector flowletInstanceCollector = baseCollector.childCollector(Constants.Metrics.Tag.FLOWLET, FLOWLET)
-        .childCollector(Constants.Metrics.Tag.INSTANCE_ID, INSTANCE);
+      MetricsContext baseCollector = service.getContext(baseTags);
+      MetricsContext flowletInstanceCollector = baseCollector.childContext(Constants.Metrics.Tag.FLOWLET, FLOWLET)
+        .childContext(Constants.Metrics.Tag.INSTANCE_ID, INSTANCE);
 
       // increment metrics for various collectors
       baseCollector.increment(METRIC, Integer.MAX_VALUE);

--- a/cdap-watchdog/src/test/java/co/cask/cdap/metrics/collect/KafkaMetricsCollectionServiceTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/metrics/collect/KafkaMetricsCollectionServiceTest.java
@@ -107,7 +107,7 @@ public class KafkaMetricsCollectionServiceTest {
 
     // publish metrics for different context
     for (int i = 1; i <= 3; i++) {
-      collectionService.getCollector(ImmutableMap.of("tag", "" + i)).increment("processed", i);
+      collectionService.getContext(ImmutableMap.of("tag", "" + i)).increment("processed", i);
     }
 
     // Sleep to make sure metrics get published
@@ -158,7 +158,7 @@ public class KafkaMetricsCollectionServiceTest {
     TimeUnit.SECONDS.sleep(5);
 
     // public a metric
-    collectionService.getCollector(ImmutableMap.of("tag", "test")).increment("metric", 5);
+    collectionService.getContext(ImmutableMap.of("tag", "test")).increment("metric", 5);
 
     // Sleep to make sure metrics get published
     TimeUnit.SECONDS.sleep(2);


### PR DESCRIPTION
… exposing in MetricsCollector for custom datasets.

We want to unify the metrics collection API. We also want to separate it from MetricsContext - so that we can avoid exposing the latter one to the custom user code.

In this PR:
* MetricsCollector is split into two: MetricsCollector and MetricsContext that extends from it. 

Nothing else has been changed: all changes across files are automatic refactoring.