### PR TITLE
Fix/ui authenticated nodeproxy

### DIFF
--- a/cdap-ui/app/features/home/home-ctrl.js
+++ b/cdap-ui/app/features/home/home-ctrl.js
@@ -1,5 +1,6 @@
 angular.module(PKG.name + '.feature.home')
-  .controller('HomeController', function ($state, rNsList, mySessionStorage, myLoadingService, myAlert, $filter, EventPipe) {
+  .controller('HomeController', function ($state, rNsList, mySessionStorage, myLoadingService, $filter, EventPipe, StatusFactory) {
+    // Needed to inject StatusFactory here for angular to instantiate the service and start polling.
     // check that $state.params.namespace is valid
     var n = rNsList.filter(function (one) {
       return one.name === $state.params.namespace;

--- a/cdap-ui/app/features/home/routes.js
+++ b/cdap-ui/app/features/home/routes.js
@@ -23,7 +23,7 @@ angular.module(PKG.name+'.feature.home')
       .state('home', {
         url: '/',
         templateUrl: '/assets/features/home/home.html',
-        onEnter: function(MY_CONFIG, myAuth, $state, myLoadingService) {
+        onEnter: function(MY_CONFIG, myAuth, $state, myLoadingService, myAuth) {
           if (!MY_CONFIG.securityEnabled) {
             // Skip even the login view. Don't show login if security is disabled.
             myAuth.login({username:'admin'})
@@ -31,6 +31,12 @@ angular.module(PKG.name+'.feature.home')
                 myLoadingService.showLoadingIcon();
                 $state.go('overview');
               });
+          } else {
+            if (myAuth.isAuthenticated) {
+              $state.go('overview');
+            } else {
+              $state.go('login');
+            }
           }
         }
       })

--- a/cdap-ui/app/features/overview/controllers/overview-ctrl.js
+++ b/cdap-ui/app/features/overview/controllers/overview-ctrl.js
@@ -3,7 +3,7 @@
  */
 
 angular.module(PKG.name+'.feature.overview').controller('OverviewCtrl',
-function ($scope, $state, myLocalStorage, MY_CONFIG, Widget, MyMetricsQueryHelper, myHelpers, MyChartHelpers, MyDataSource, EventPipe) {
+function ($scope, $state, myLocalStorage, MY_CONFIG, Widget, MyMetricsQueryHelper, MyChartHelpers, MyDataSource, ServiceStatusFactory) {
 
   var dataSrc = new MyDataSource($scope);
   if(!$state.params.namespace) {
@@ -29,33 +29,8 @@ function ($scope, $state, myLocalStorage, MY_CONFIG, Widget, MyMetricsQueryHelpe
   };
 
   this.isEnterprise = MY_CONFIG.isEnterprise;
-  this.systemStatus = '#C9C9D1';
-  dataSrc.poll({
-    _cdapPath: '/system/services/status',
-    interval: 10000
-  },
-  function success(res) {
-    var serviceStatuses = Object.keys(res).map(function(value) {
-      return res[value];
-    });
-    if (serviceStatuses.indexOf('NOTOK') > -1) {
-      this.systemStatus = 'yellow';
-    }
-    if (serviceStatuses.indexOf('OK') === -1) {
-      this.systemStatus = 'red';
-    }
-    if (serviceStatuses.indexOf('NOTOK') === -1) {
-      this.systemStatus = 'green';
-    }
-  }.bind(this),
-  function error(res) {
-    if (res.auth_uri) {
-      EventPipe.emit('backendDown', 'Invalid Auth Token. Please refresh to re-authenticate.');
-    } else {
-      EventPipe.emit('backendDown');
-    }
-  }
-  );
+  // this.systemStatus = '#C9C9D1';
+  this.systemStatus = ServiceStatusFactory.systemStatus;
 
   this.wdgts = [];
   // type field is overridden by what is rendered in view because we do not use widget.getPartial()

--- a/cdap-ui/app/main.js
+++ b/cdap-ui/app/main.js
@@ -141,14 +141,14 @@ angular
       return {
         'request': function(config) {
           if ($rootScope.currentUser) {
-            angular.extend({
+            angular.extend(config, {
               user: $rootScope.currentUser || null,
               headers: {
                 // Accessing stuff from $rootScope is bad. This is done as to resolve circular dependency.
                 // $http <- myAuthPromise <- myAuth <- $http <- $templateFactory <- $view <- $state
-                authorization: ($rootScope.currentUser.token ? 'Bearer ' + $rootScope.currentUser.token: null)
+                Authorization: ($rootScope.currentUser.token ? 'Bearer ' + $rootScope.currentUser.token: null)
               }
-            }, config);
+            });
           }
           return config;
         }
@@ -217,16 +217,25 @@ angular
    * attached to the <body> tag, mostly responsible for
    *  setting the className based events from $state and caskTheme
    */
-  .controller('BodyCtrl', function ($scope, $cookies, $cookieStore, caskTheme, CASK_THEME_EVENT, $rootScope, $state, $log, MYSOCKET_EVENT, MyDataSource) {
+  .controller('BodyCtrl', function ($scope, $cookies, $cookieStore, caskTheme, CASK_THEME_EVENT, $rootScope, $state, $log, MYSOCKET_EVENT, MyDataSource, MY_CONFIG, MYAUTH_EVENT) {
 
     var activeThemeClass = caskTheme.getClassName();
     var dataSource = new MyDataSource($scope);
-    dataSource.request({
-      _cdapPath: '/version'
-    })
-      .then(function(res) {
-        $scope.version = res.version;
-      });
+    if (MY_CONFIG.securityEnabled) {
+      $rootScope.$on(MYAUTH_EVENT.loginSuccess, getVersion);
+    } else {
+      getVersion();
+    }
+
+    function getVersion() {
+      dataSource.request({
+        _cdapPath: '/version'
+      })
+        .then(function(res) {
+          $scope.version = res.version;
+        });
+    }
+
     $scope.$on(CASK_THEME_EVENT.changed, function (event, newClassName) {
       if(!event.defaultPrevented) {
         $scope.bodyClass = $scope.bodyClass.replace(activeThemeClass, newClassName);

--- a/cdap-ui/app/services/auth.js
+++ b/cdap-ui/app/services/auth.js
@@ -96,8 +96,10 @@ module.service('myAuth', function myAuthService (MYAUTH_EVENT, MyAuthUser, myAut
    * logout
    */
   this.logout = function () {
-    persist(null);
-    $rootScope.$broadcast(MYAUTH_EVENT.logoutSuccess);
+    if (this.currentUser){
+      persist(null);
+      $rootScope.$broadcast(MYAUTH_EVENT.logoutSuccess);
+    }
   };
 
   /**

--- a/cdap-ui/app/services/data/datasource.js
+++ b/cdap-ui/app/services/data/datasource.js
@@ -73,8 +73,7 @@ angular.module(PKG.name+'.services')
       // myAuth.isAuthenticated is not used. There should be a better way to do this.
       if ($rootScope.currentUser && $rootScope.currentUser.token) {
         re.headers = {
-          Authorization: 'Bearer '+ $rootScope.currentUser.token,
-          'X-ApiKey': ''
+          Authorization: 'Bearer '+ $rootScope.currentUser.token
         };
       }
 
@@ -102,8 +101,7 @@ angular.module(PKG.name+'.services')
       }
       if ($rootScope.currentUser && $rootScope.currentUser.token) {
         re.headers = {
-          Authorization: 'Bearer '+ $rootScope.currentUser.token,
-          'X-ApiKey': ''
+          Authorization: 'Bearer '+ $rootScope.currentUser.token
         };
       }
 
@@ -311,8 +309,7 @@ angular.module(PKG.name+'.services')
         }
         if ($rootScope.currentUser && $rootScope.currentUser.token) {
           generatedResource.headers = {
-            Authorization: 'Bearer '+ $rootScope.currentUser.token,
-            'X-ApiKey': ''
+            Authorization: 'Bearer '+ $rootScope.currentUser.token
           };
         }
 

--- a/cdap-ui/app/services/data/datasource.js
+++ b/cdap-ui/app/services/data/datasource.js
@@ -34,7 +34,7 @@ angular.module(PKG.name+'.services')
    */
 
   .factory('MyDataSource', function ($log, $rootScope, caskWindowManager, mySocket,
-    MYSOCKET_EVENT, $q, $filter, myCdapUrl, MyPromise) {
+    MYSOCKET_EVENT, $q, $filter, myCdapUrl, MyPromise, MyAuthUser) {
 
     var instances = {}; // keyed by scopeid
 
@@ -69,6 +69,15 @@ angular.module(PKG.name+'.services')
         }
       }
 
+      // FIXME: There is a circular dependency and that is why
+      // myAuth.isAuthenticated is not used. There should be a better way to do this.
+      if ($rootScope.currentUser && $rootScope.currentUser.token) {
+        re.headers = {
+          Authorization: 'Bearer '+ $rootScope.currentUser.token,
+          'X-ApiKey': ''
+        };
+      }
+
       mySocket.send({
         action: 'poll-start',
         resource: re
@@ -89,6 +98,12 @@ angular.module(PKG.name+'.services')
           id: resource.id,
           json: resource.json,
           method: resource.method
+        };
+      }
+      if ($rootScope.currentUser && $rootScope.currentUser.token) {
+        re.headers = {
+          Authorization: 'Bearer '+ $rootScope.currentUser.token,
+          'X-ApiKey': ''
         };
       }
 
@@ -293,6 +308,12 @@ angular.module(PKG.name+'.services')
 
         if (resource.data) {
           generatedResource.body = resource.data;
+        }
+        if ($rootScope.currentUser && $rootScope.currentUser.token) {
+          generatedResource.headers = {
+            Authorization: 'Bearer '+ $rootScope.currentUser.token,
+            'X-ApiKey': ''
+          };
         }
 
         if (!resource.url) {

--- a/cdap-ui/app/services/data/socket.js
+++ b/cdap-ui/app/services/data/socket.js
@@ -13,7 +13,7 @@ angular.module(PKG.name+'.services')
 .provider('mySocket', function () {
 
   this.prefix = '/_sock';
-  
+
   this.$get = function (MYSOCKET_EVENT, $rootScope, SockJS, $log, myCdapUrl, EventPipe) {
 
     var self = this,

--- a/cdap-ui/app/services/namespace.js
+++ b/cdap-ui/app/services/namespace.js
@@ -1,5 +1,5 @@
 angular.module(PKG.name + '.services')
-  .service('myNamespace', function myNamespace($q, MyDataSource, EventPipe, $http) {
+  .service('myNamespace', function myNamespace($q, MyDataSource, EventPipe, $http, $rootScope, myAuth, MYAUTH_EVENT) {
 
     this.namespaceList = [];
 
@@ -58,21 +58,26 @@ angular.module(PKG.name + '.services')
 
       _.debounce(function() {
         $http.get('http://' + window.location.host + '/backendstatus', {ignoreLoadingBar: true})
-                .success(success).error(error);
-              }, 2000)();
+             .success(success)
+             .error(error);
+      }, 2000)();
 
     }
 
     function success() {
       EventPipe.emit('backendUp');
-      startPolling();
+      if (myAuth.isAuthenticated) {
+        startPolling();
+      }
     }
 
     function error() {
       EventPipe.emit('backendDown');
-      startPolling();
+      if (myAuth.isAuthenticated) {
+        startPolling();
+      }
     }
 
-    startPolling();
+    $rootScope.$on(MYAUTH_EVENT.loginSuccess, startPolling);
 
   });

--- a/cdap-ui/app/services/namespace.js
+++ b/cdap-ui/app/services/namespace.js
@@ -54,30 +54,4 @@ angular.module(PKG.name + '.services')
       return ns[0].name || name;
     };
 
-    function startPolling() {
-
-      _.debounce(function() {
-        $http.get('http://' + window.location.host + '/backendstatus', {ignoreLoadingBar: true})
-             .success(success)
-             .error(error);
-      }, 2000)();
-
-    }
-
-    function success() {
-      EventPipe.emit('backendUp');
-      if (myAuth.isAuthenticated) {
-        startPolling();
-      }
-    }
-
-    function error() {
-      EventPipe.emit('backendDown');
-      if (myAuth.isAuthenticated) {
-        startPolling();
-      }
-    }
-
-    $rootScope.$on(MYAUTH_EVENT.loginSuccess, startPolling);
-
   });

--- a/cdap-ui/app/services/servicestatusfactory.js
+++ b/cdap-ui/app/services/servicestatusfactory.js
@@ -1,0 +1,30 @@
+angular.module(PKG.name + '.services')
+  .service('ServiceStatusFactory', function(MyDataSource, $alert, $timeout, EventPipe, $state, myAuth) {
+    this.systemStatus = 'green';
+
+    // Apart from invalid token there should be no scenario
+    // when we should stop this poll.
+    var dataSrc = new MyDataSource();
+    var pollPromise = dataSrc.poll({
+      _cdapPath: '/system/services/status',
+      interval: 10000
+    },
+    function success(res) {
+      var serviceStatuses = Object.keys(res).map(function(value) {
+        return res[value];
+      });
+      if (serviceStatuses.indexOf('NOTOK') > -1) {
+        this.systemStatus = 'yellow';
+      }
+      if (serviceStatuses.indexOf('OK') === -1) {
+        this.systemStatus = 'red';
+      }
+      if (serviceStatuses.indexOf('NOTOK') === -1) {
+        this.systemStatus = 'green';
+      }
+    }.bind(this),
+    function error(err) {
+      EventPipe.emit('backendDown');
+    }
+    );
+  });

--- a/cdap-ui/app/services/statusfactory.js
+++ b/cdap-ui/app/services/statusfactory.js
@@ -1,0 +1,43 @@
+angular.module(PKG.name + '.services')
+  .service('StatusFactory', function($http, EventPipe, myAuth, $rootScope, MYAUTH_EVENT, MY_CONFIG, $alert, $timeout, myAuth, $state) {
+
+    this.startPolling = function () {
+      beginPolling.bind(this)();
+    }
+    function beginPolling() {
+
+      _.debounce(function() {
+        $http.get('http://' + window.location.host + '/backendstatus', {ignoreLoadingBar: true})
+             .success(success.bind(this))
+             .error(error.bind(this));
+      }.bind(this), 2000)();
+
+    }
+
+    function success() {
+      EventPipe.emit('backendUp');
+      this.startPolling();
+    }
+
+    function error(err) {
+      if (!reAuthenticate(err)) {
+        this.startPolling();
+        EventPipe.emit('backendDown');
+      }
+    }
+
+
+
+    function reAuthenticate(err) {
+      if (angular.isObject(err) && err.auth_uri) {
+        $timeout(function() {
+          EventPipe.emit('backendUp');
+          myAuth.logout();
+        });
+        return true;
+      }
+      return false;
+    }
+
+    this.startPolling();
+  });

--- a/cdap-ui/server/express.js
+++ b/cdap-ui/server/express.js
@@ -144,19 +144,16 @@ function makeApp (authAddress, cdapConfig) {
               cdapConfig['router.server.port'] +
               '/v3/namespaces';
 
-      request({
+      req.pipe(
+        request({
           method: 'GET',
           url: link,
           rejectUnauthorized: false,
           requestCert: true,
-          agent: false
-        }, function(err, response) {
-          if (!err && response.statusCode === 200) {
-            res.status(200).send();
-          } else {
-            res.status(404).send();
-          }
-      });
+          agent: false,
+          headers: req.headers
+        })
+      ).pipe(res);
     }
   ]);
 


### PR DESCRIPTION
- Fixes Authentication in UI
- Handles re-directs when auth token is invalid
- Handles /backendstatus and /version end point calls to be made only after authentication (if security is enabled).
- Streams response back from backend for /v3/namespace end point instead of sending out a 404.

Security Enabled cluster having this code: http://securecluster1762-1000.dev.continuuity.net:9999
Security Disabled cluster having the same code: http://nodeproxy1736-1000.dev.continuuity.net:9999

