### PR TITLE
[CDAP-2743] [CDAP-2750] Shutdown a dangling MySQL Abandoned Cleanup Thread in DBSource and DBSink's destroy method.

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/common/TrackedTransform.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/common/TrackedTransform.java
@@ -46,7 +46,7 @@ public class TrackedTransform<IN, OUT> implements Transformation<IN, OUT>, Destr
   @Override
   public void destroy() {
     if (transform instanceof Destroyable) {
-      Destroyables.destroyQuietly((Destroyable) transform);
+      ((Destroyable) transform).destroy();
     }
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/common/TrackedTransform.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/common/TrackedTransform.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.template.etl.common;
 
 import co.cask.cdap.api.metrics.Metrics;
+import co.cask.cdap.template.etl.api.Destroyable;
 import co.cask.cdap.template.etl.api.Emitter;
 import co.cask.cdap.template.etl.api.Transformation;
 
@@ -27,7 +28,7 @@ import co.cask.cdap.template.etl.api.Transformation;
  * @param <IN> Type of input object
  * @param <OUT> Type of output object
  */
-public class TrackedTransform<IN, OUT> implements Transformation<IN, OUT> {
+public class TrackedTransform<IN, OUT> implements Transformation<IN, OUT>, Destroyable {
   private final Transformation transform;
   private final Metrics metrics;
 
@@ -40,5 +41,12 @@ public class TrackedTransform<IN, OUT> implements Transformation<IN, OUT> {
   public void transform(IN input, Emitter<OUT> emitter) throws Exception {
     metrics.count("records.in", 1);
     transform.transform(input, emitter);
+  }
+
+  @Override
+  public void destroy() {
+    if (transform instanceof Destroyable) {
+      Destroyables.destroyQuietly((Destroyable) transform);
+    }
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/source/DBSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/source/DBSource.java
@@ -40,8 +40,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.Driver;
-import java.sql.DriverManager;
-import java.util.Enumeration;
 
 /**
  * Batch source to read from a Database table

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/source/DBSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/source/DBSource.java
@@ -40,6 +40,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.Driver;
+import java.sql.DriverManager;
+import java.util.Enumeration;
 
 /**
  * Batch source to read from a Database table
@@ -92,9 +94,8 @@ public class DBSource extends BatchSource<LongWritable, DBRecord, StructuredReco
 
     Job job = context.getHadoopJob();
     Configuration hConf = job.getConfiguration();
-    String jdbcPluginId = getJDBCPluginId();
     // Load the plugin class to make sure it is available.
-    Class<? extends Driver> driverClass = context.loadPluginClass(jdbcPluginId);
+    Class<? extends Driver> driverClass = context.loadPluginClass(getJDBCPluginId());
     if (dbSourceConfig.user == null && dbSourceConfig.password == null) {
       DBConfiguration.configureDB(hConf, driverClass.getName(), dbSourceConfig.connectionString);
     } else {
@@ -118,6 +119,7 @@ public class DBSource extends BatchSource<LongWritable, DBRecord, StructuredReco
 
   @Override
   public void destroy() {
+    ETLDBInputFormat.deregisterDrivers();
     DBUtils.cleanup(driverClass);
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/common/DBRecord.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/common/DBRecord.java
@@ -120,8 +120,7 @@ public class DBRecord implements Writable, DBWritable {
   public void write(DataOutput out) throws IOException {
     Schema recordSchema = record.getSchema();
     List<Schema.Field> schemaFields = recordSchema.getFields();
-    for (int i = 0; i < schemaFields.size(); i++) {
-      Schema.Field field = schemaFields.get(i);
+    for (Schema.Field field : schemaFields) {
       String fieldName = field.getName();
       Schema.Type fieldType = field.getSchema().getType();
       Object fieldValue = record.get(fieldName);
@@ -246,17 +245,14 @@ public class DBRecord implements Writable, DBWritable {
           return toReturn;
         case Types.CLOB:
           String s;
-          StringBuffer sbf = new StringBuffer();
+          StringBuilder sbf = new StringBuilder();
           Clob clob = (Clob) original;
           try {
-            BufferedReader br = new BufferedReader(clob.getCharacterStream(1, (int) clob.length()));
-            try {
+            try (BufferedReader br = new BufferedReader(clob.getCharacterStream(1, (int) clob.length()))) {
               while ((s = br.readLine()) != null) {
                 sbf.append(s);
                 sbf.append(System.getProperty("line.separator"));
               }
-            } finally {
-              br.close();
             }
           } catch (IOException e) {
             throw new SQLException(e);

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/common/DBUtils.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/common/DBUtils.java
@@ -46,17 +46,17 @@ public final class DBUtils {
    * @param classLoader the unfiltered classloader of the jdbc driver class
    */
   private static void shutDownMySQLAbandonedConnectionCleanupThread(ClassLoader classLoader) {
+    if (classLoader == null) {
+      return;
+    }
     try {
-      if (classLoader == null) {
-        return;
-      }
       Class<?> mysqlCleanupThreadClass = classLoader.loadClass("com.mysql.jdbc.AbandonedConnectionCleanupThread");
       Method shutdownMethod = mysqlCleanupThreadClass.getMethod("shutdown");
       shutdownMethod.invoke(null);
       LOG.info("Successfully shutdown MySQL connection cleanup thread.");
     } catch (Throwable e) {
       // cleanup failed, ignoring silently
-      LOG.warn("Failed to shutdown MySQL connection cleanup thread. Ignoring.", e);
+      LOG.warn("Failed to shutdown MySQL connection cleanup thread. Ignoring.");
     }
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/common/DBUtils.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/common/DBUtils.java
@@ -43,9 +43,9 @@ public final class DBUtils {
   }
 
   /**
-   * De-register all SQL drivers that are associated with the classloader
+   * De-register all SQL drivers that are associated with the class
    */
-  public static void deRegisterDriver(ClassLoader classLoader)
+  public static void deRegisterDriver(Class<? extends Driver> driverClass)
                      throws NoSuchFieldException, IllegalAccessException, ClassNotFoundException {
     Field field = DriverManager.class.getDeclaredField("registeredDrivers");
     field.setAccessible(true);
@@ -55,13 +55,7 @@ public final class DBUtils {
       Field driverField = driverInfoClass.getDeclaredField("driver");
       driverField.setAccessible(true);
       Driver d = (Driver) driverField.get(driverInfo);
-      ClassLoader registeredDriverClassLoader = d.getClass().getClassLoader();
-      if (registeredDriverClassLoader == null) {
-        LOG.debug("Found null classloader for default driver {}. Ignoring since this may be using system classloader.",
-                 d.getClass().getName());
-        continue;
-      }
-      if (registeredDriverClassLoader.equals(classLoader)) {
+      if (d.getClass().equals(driverClass)) {
         LOG.debug("Removing default driver {} from registeredDrivers", d.getClass().getName());
         list.remove(driverInfo);
       }

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/common/DBUtils.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/common/DBUtils.java
@@ -25,7 +25,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.sql.Driver;
 import java.sql.DriverManager;
-import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.List;
 
 /**
  * Utility methods for Database plugins shared by {@link DBSource} and {@link DBSink}
@@ -49,7 +49,7 @@ public final class DBUtils {
                      throws NoSuchFieldException, IllegalAccessException, ClassNotFoundException {
     Field field = DriverManager.class.getDeclaredField("registeredDrivers");
     field.setAccessible(true);
-    CopyOnWriteArrayList<?> list = (CopyOnWriteArrayList<?>) field.get(null);
+    List<?> list = (List<?>) field.get(null);
     for (Object driverInfo : list) {
       Class<?> driverInfoClass = DBUtils.class.getClassLoader().loadClass("java.sql.DriverInfo");
       Field driverField = driverInfoClass.getDeclaredField("driver");

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/common/DBUtils.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/common/DBUtils.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.template.etl.common;
+
+import co.cask.cdap.template.etl.batch.sink.DBSink;
+import co.cask.cdap.template.etl.batch.source.DBSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Method;
+
+/**
+ * Utility methods for MySQL shared by {@link DBSource} and {@link DBSink}
+ */
+public final class DBUtils {
+  private static final Logger LOG = LoggerFactory.getLogger(DBUtils.class);
+
+  /**
+   * Performs any Database related cleanup
+   *
+   * @param classLoader the unfiltered classloader of the jdbc driver class
+   */
+  public static void cleanup(ClassLoader classLoader) {
+    shutDownMySQLAbandonedConnectionCleanupThread(classLoader);
+  }
+
+  /**
+   * Shuts down a cleanup thread com.mysql.jdbc.AbandonedConnectionCleanupThread that mysql driver fails to destroy
+   * If this is not done, the thread keeps a reference to the classloader, thereby causing OOMs or too many open files
+   *
+   * @param classLoader the unfiltered classloader of the jdbc driver class
+   */
+  private static void shutDownMySQLAbandonedConnectionCleanupThread(ClassLoader classLoader) {
+    try {
+      if (classLoader == null) {
+        return;
+      }
+      Class<?> mysqlCleanupThreadClass = classLoader.loadClass("com.mysql.jdbc.AbandonedConnectionCleanupThread");
+      if (mysqlCleanupThreadClass == null) {
+        // Ignore. Could perhaps be a different database other than MySQL.
+        return;
+      }
+      Method shutdownMethod = mysqlCleanupThreadClass.getMethod("shutdown");
+      if (shutdownMethod != null) {
+        shutdownMethod.invoke(null);
+        LOG.info("Successfully shutdown MySQL connection cleanup thread.");
+      }
+    } catch (Throwable e) {
+      // cleanup failed, ignoring silently
+      LOG.info("Failed to shutdown MySQL connection cleanup thread. Ignoring.", e);
+    }
+  }
+
+  private DBUtils() {
+    throw new AssertionError("Should not instantiate static utility class.");
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/common/ETLDBInputFormat.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/common/ETLDBInputFormat.java
@@ -49,11 +49,12 @@ public class ETLDBInputFormat extends DBInputFormat {
         } catch (SQLException e) {
           if (driver == null) {
             ClassLoader classLoader = conf.getClassLoader();
-            Class<?> driverClass = classLoader.loadClass(conf.get(DBConfiguration.DRIVER_CLASS_PROPERTY));
-            driver = (Driver) driverClass.newInstance();
+            Class<? extends Driver> driverClass =
+              (Class<? extends Driver>) classLoader.loadClass(conf.get(DBConfiguration.DRIVER_CLASS_PROPERTY));
+            driver = driverClass.newInstance();
 
             // De-register the default driver that gets registered when driver class is loaded.
-            DBUtils.deRegisterDriver(classLoader);
+            DBUtils.deRegisterDriver(driverClass);
 
             driverShim = new JDBCDriverShim(driver);
             DriverManager.registerDriver(driverShim);

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/common/ETLDBInputFormat.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/common/ETLDBInputFormat.java
@@ -18,31 +18,72 @@ package co.cask.cdap.template.etl.common;
 
 import com.google.common.base.Throwables;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.lib.db.DBConfiguration;
 import org.apache.hadoop.mapreduce.lib.db.DBInputFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.reflect.Field;
 import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.concurrent.CopyOnWriteArrayList;
+import javax.annotation.Nullable;
 
 /**
  * Class that extends {@link DBInputFormat} to load the database driver class correctly.
  */
 public class ETLDBInputFormat extends DBInputFormat {
   private static final Logger LOG = LoggerFactory.getLogger(ETLDBInputFormat.class);
+  private static Driver driver;
+  private static JDBCDriverShim driverShim;
 
   @Override
   public Connection getConnection() {
-    Configuration conf = getConf();
-    ClassLoader classLoader = conf.getClassLoader();
     if (this.connection == null) {
+      Configuration conf = getConf();
       try {
-        LOG.debug("Registering JDBC driver via shim - " + JDBCDriverShim.class.getName());
-        Class<?> driverClass = classLoader.loadClass(conf.get(DBConfiguration.DRIVER_CLASS_PROPERTY));
         String url = conf.get(DBConfiguration.URL_PROPERTY);
-        DriverManager.registerDriver(new JDBCDriverShim((Driver) driverClass.newInstance()));
+        try {
+          // throws SQLException if no suitable driver is found
+          DriverManager.getDriver(url);
+        } catch (SQLException e) {
+          if (driver == null) {
+            ClassLoader classLoader = conf.getClassLoader();
+            Class<?> driverClass = classLoader.loadClass(conf.get(DBConfiguration.DRIVER_CLASS_PROPERTY));
+            driver = (Driver) driverClass.newInstance();
+
+            Field field = DriverManager.class.getDeclaredField("registeredDrivers");
+            field.setAccessible(true);
+            CopyOnWriteArrayList<?> list = (CopyOnWriteArrayList<?>) field.get(null);
+            for (Object driverInfo : list) {
+              Class<?> driverInfoClass = classLoader.loadClass("java.sql.DriverInfo");
+              Field driverField = driverInfoClass.getDeclaredField("driver");
+              driverField.setAccessible(true);
+              Driver d = (Driver) driverField.get(driverInfo);
+              ClassLoader registeredDriverClassLoader = d.getClass().getClassLoader();
+              if (registeredDriverClassLoader == null) {
+                LOG.info("Found null classloader for driver {}. Ignoring since this may be using system classloader.",
+                         d.getClass().getName());
+                continue;
+              }
+              if (registeredDriverClassLoader.equals(driver.getClass().getClassLoader())) {
+                LOG.info("Removing driver {} from registeredDrivers", d.getClass().getName());
+                list.remove(driverInfo);
+              }
+            }
+
+            driverShim = new JDBCDriverShim(driver);
+            DriverManager.registerDriver(driverShim);
+            LOG.info("Registered JDBC driver via shim {}, hashcode  {}, class {}", driverShim, driverShim.hashCode(),
+                     driverShim.getClass().getName());
+            LOG.info("Actual driver {} {} {}", driver, driver.hashCode(), driver.getClass().getName());
+          }
+        }
         if (conf.get(DBConfiguration.USERNAME_PROPERTY) == null) {
           this.connection = DriverManager.getConnection(url);
         } else {
@@ -57,5 +98,23 @@ public class ETLDBInputFormat extends DBInputFormat {
       }
     }
     return this.connection;
+  }
+
+  public static void deregisterDrivers() {
+    deregisterDriver(driverShim);
+    deregisterDriver(driver);
+  }
+
+  private static void deregisterDriver(@Nullable Driver driver) {
+    if (driver == null) {
+      return;
+    }
+    try {
+      DriverManager.deregisterDriver(driver);
+      LOG.info("Successfully deregistered driver {} {} {}", driver, driver.hashCode(), driver.getClass().getName());
+    } catch (Throwable e) {
+      LOG.warn("Error while deregistering driver {}", driver.getClass().getName());
+      throw Throwables.propagate(e);
+    }
   }
 }

--- a/cdap-standalone/src/main/java/org/apache/hadoop/util/ReflectionUtils.java
+++ b/cdap-standalone/src/main/java/org/apache/hadoop/util/ReflectionUtils.java
@@ -1,0 +1,322 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.hadoop.util;
+
+import co.cask.cdap.internal.app.runtime.adapter.PluginClassLoader;
+import org.apache.commons.logging.Log;
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.conf.Configurable;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.DataInputBuffer;
+import org.apache.hadoop.io.DataOutputBuffer;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.io.serializer.Deserializer;
+import org.apache.hadoop.io.serializer.SerializationFactory;
+import org.apache.hadoop.io.serializer.Serializer;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * General reflection utils.
+ * This is a copy of ReflectionUtils in hadoop-common-2.3.0.jar.
+ * This copy has been modified not to cache constructors in method {@link #newInstance(Class, Configuration)}.
+ * Caching of constructors causes {@link PluginClassLoader}s to be retained when running adapters, thus causing OOM.
+ */
+@InterfaceAudience.Public
+@InterfaceStability.Evolving
+public class ReflectionUtils {
+
+  private static final Class<?>[] EMPTY_ARRAY = new Class[]{};
+  private static volatile SerializationFactory serialFactory = null;
+
+  /**
+   * Check and set 'configuration' if necessary.
+   *
+   * @param theObject object for which to set configuration
+   * @param conf Configuration
+   */
+  public static void setConf(Object theObject, Configuration conf) {
+    if (conf != null) {
+      if (theObject instanceof Configurable) {
+        ((Configurable) theObject).setConf(conf);
+      }
+      setJobConf(theObject, conf);
+    }
+  }
+
+  /**
+   * This code is to support backward compatibility and break the compile  
+   * time dependency of core on mapred.
+   * This should be made deprecated along with the mapred package HADOOP-1230. 
+   * Should be removed when mapred package is removed.
+   */
+  private static void setJobConf(Object theObject, Configuration conf) {
+    //If JobConf and JobConfigurable are in classpath, AND
+    //theObject is of type JobConfigurable AND
+    //conf is of type JobConf then
+    //invoke configure on theObject
+    try {
+      Class<?> jobConfClass =
+        conf.getClassByNameOrNull("org.apache.hadoop.mapred.JobConf");
+      if (jobConfClass == null) {
+        return;
+      }
+
+      Class<?> jobConfigurableClass =
+        conf.getClassByNameOrNull("org.apache.hadoop.mapred.JobConfigurable");
+      if (jobConfigurableClass == null) {
+        return;
+      }
+      if (jobConfClass.isAssignableFrom(conf.getClass()) &&
+        jobConfigurableClass.isAssignableFrom(theObject.getClass())) {
+        Method configureMethod =
+          jobConfigurableClass.getMethod("configure", jobConfClass);
+        configureMethod.invoke(theObject, conf);
+      }
+    } catch (Exception e) {
+      throw new RuntimeException("Error in configuring object", e);
+    }
+  }
+
+  /** Create an object for the given class and initialize it from conf
+   *
+   * @param theClass class of which an object is created
+   * @param conf Configuration
+   * @return a new object
+   */
+  @SuppressWarnings("unchecked")
+  public static <T> T newInstance(Class<T> theClass, Configuration conf) {
+    T result;
+    try {
+      Constructor<T> meth = theClass.getDeclaredConstructor(EMPTY_ARRAY);
+      meth.setAccessible(true);
+      result = meth.newInstance();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+    setConf(result, conf);
+    return result;
+  }
+
+  private static ThreadMXBean threadBean =
+    ManagementFactory.getThreadMXBean();
+
+  public static void setContentionTracing(boolean val) {
+    threadBean.setThreadContentionMonitoringEnabled(val);
+  }
+
+  private static String getTaskName(long id, String name) {
+    if (name == null) {
+      return Long.toString(id);
+    }
+    return id + " (" + name + ")";
+  }
+
+  /**
+   * Print all of the thread's information and stack traces.
+   *
+   * @param stream the stream to
+   * @param title a string title for the stack trace
+   */
+  public static synchronized void printThreadInfo(PrintWriter stream,
+                                                  String title) {
+    final int stackDepth = 20;
+    boolean contention = threadBean.isThreadContentionMonitoringEnabled();
+    long[] threadIds = threadBean.getAllThreadIds();
+    stream.println("Process Thread Dump: " + title);
+    stream.println(threadIds.length + " active threads");
+    for (long tid: threadIds) {
+      ThreadInfo info = threadBean.getThreadInfo(tid, stackDepth);
+      if (info == null) {
+        stream.println("  Inactive");
+        continue;
+      }
+      stream.println("Thread " +
+                       getTaskName(info.getThreadId(),
+                                   info.getThreadName()) + ":");
+      Thread.State state = info.getThreadState();
+      stream.println("  State: " + state);
+      stream.println("  Blocked count: " + info.getBlockedCount());
+      stream.println("  Waited count: " + info.getWaitedCount());
+      if (contention) {
+        stream.println("  Blocked time: " + info.getBlockedTime());
+        stream.println("  Waited time: " + info.getWaitedTime());
+      }
+      if (state == Thread.State.WAITING) {
+        stream.println("  Waiting on " + info.getLockName());
+      } else  if (state == Thread.State.BLOCKED) {
+        stream.println("  Blocked on " + info.getLockName());
+        stream.println("  Blocked by " +
+                         getTaskName(info.getLockOwnerId(),
+                                     info.getLockOwnerName()));
+      }
+      stream.println("  Stack:");
+      for (StackTraceElement frame: info.getStackTrace()) {
+        stream.println("    " + frame.toString());
+      }
+    }
+    stream.flush();
+  }
+
+  private static long previousLogTime = 0;
+
+  /**
+   * Log the current thread stacks at INFO level.
+   * @param log the logger that logs the stack trace
+   * @param title a descriptive title for the call stacks
+   * @param minInterval the minimum time from the last 
+   */
+  public static void logThreadInfo(Log log,
+                                   String title,
+                                   long minInterval) {
+    boolean dumpStack = false;
+    if (log.isInfoEnabled()) {
+      synchronized (ReflectionUtils.class) {
+        long now = Time.now();
+        if (now - previousLogTime >= minInterval * 1000) {
+          previousLogTime = now;
+          dumpStack = true;
+        }
+      }
+      if (dumpStack) {
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        printThreadInfo(new PrintWriter(buffer), title);
+        log.info(buffer.toString());
+      }
+    }
+  }
+
+  /**
+   * Return the correctly-typed {@link Class} of the given object.
+   *
+   * @param o object whose correctly-typed <code>Class</code> is to be obtained
+   * @return the correctly typed <code>Class</code> of the given object.
+   */
+  @SuppressWarnings("unchecked")
+  public static <T> Class<T> getClass(T o) {
+    return (Class<T>) o.getClass();
+  }
+
+  /**
+   * A pair of input/output buffers that we use to clone writables.
+   */
+  private static class CopyInCopyOutBuffer {
+    DataOutputBuffer outBuffer = new DataOutputBuffer();
+    DataInputBuffer inBuffer = new DataInputBuffer();
+    /**
+     * Move the data from the output buffer to the input buffer.
+     */
+    void moveData() {
+      inBuffer.reset(outBuffer.getData(), outBuffer.getLength());
+    }
+  }
+
+  /**
+   * Allocate a buffer for each thread that tries to clone objects.
+   */
+  private static ThreadLocal<CopyInCopyOutBuffer> cloneBuffers
+    = new ThreadLocal<CopyInCopyOutBuffer>() {
+    @Override
+    protected synchronized CopyInCopyOutBuffer initialValue() {
+      return new CopyInCopyOutBuffer();
+    }
+  };
+
+  private static SerializationFactory getFactory(Configuration conf) {
+    if (serialFactory == null) {
+      serialFactory = new SerializationFactory(conf);
+    }
+    return serialFactory;
+  }
+
+  /**
+   * Make a copy of the writable object using serialization to a buffer
+   * @param src the object to copy from
+   * @param dst the object to copy into, which is destroyed
+   * @return dst param (the copy)
+   * @throws IOException
+   */
+  @SuppressWarnings("unchecked")
+  public static <T> T copy(Configuration conf,
+                           T src, T dst) throws IOException {
+    CopyInCopyOutBuffer buffer = cloneBuffers.get();
+    buffer.outBuffer.reset();
+    SerializationFactory factory = getFactory(conf);
+    Class<T> cls = (Class<T>) src.getClass();
+    Serializer<T> serializer = factory.getSerializer(cls);
+    serializer.open(buffer.outBuffer);
+    serializer.serialize(src);
+    buffer.moveData();
+    Deserializer<T> deserializer = factory.getDeserializer(cls);
+    deserializer.open(buffer.inBuffer);
+    dst = deserializer.deserialize(dst);
+    return dst;
+  }
+
+  @Deprecated
+  public static void cloneWritableInto(Writable dst,
+                                       Writable src) throws IOException {
+    CopyInCopyOutBuffer buffer = cloneBuffers.get();
+    buffer.outBuffer.reset();
+    src.write(buffer.outBuffer);
+    buffer.moveData();
+    dst.readFields(buffer.inBuffer);
+  }
+
+  /**
+   * Gets all the declared fields of a class including fields declared in
+   * superclasses.
+   */
+  public static List<Field> getDeclaredFieldsIncludingInherited(Class<?> clazz) {
+    List<Field> fields = new ArrayList<Field>();
+    while (clazz != null) {
+      for (Field field : clazz.getDeclaredFields()) {
+        fields.add(field);
+      }
+      clazz = clazz.getSuperclass();
+    }
+
+    return fields;
+  }
+
+  /**
+   * Gets all the declared methods of a class including methods declared in
+   * superclasses.
+   */
+  public static List<Method> getDeclaredMethodsIncludingInherited(Class<?> clazz) {
+    List<Method> methods = new ArrayList<Method>();
+    while (clazz != null) {
+      for (Method method : clazz.getDeclaredMethods()) {
+        methods.add(method);
+      }
+      clazz = clazz.getSuperclass();
+    }
+
+    return methods;
+  }
+}


### PR DESCRIPTION
This thread maintains a reference to the classloader, thereby causing OOM as well as too many open files errors.

Also fixed a related issue where the BatchSource and BatchSink's destroy methods were not being called by making TrackedTransform a Destroyable.

Jira: 
[CDAP-2743](https://issues.cask.co/browse/CDAP-2743) 
[CDAP-2750](https://issues.cask.co/browse/CDAP-2750)

Build: http://builds.cask.co/browse/CDAP-RT38
