### PR TITLE
Improvements to CDAP timeline

### DIFF
--- a/cdap-docs/_common/common_conf.py
+++ b/cdap-docs/_common/common_conf.py
@@ -325,6 +325,7 @@ html_theme_options = {
       "older": [ 
         ['2.8.0', '2.8.0', '2015-03-23'], 
         ['2.7.1', '2.7.1', '2015-02-05'], 
+        ['2.6.3', '2.6.3', '2015-05-15'], 
         ['2.6.2', '2.6.2', '2015-03-23'], 
         ['2.6.1', '2.6.1', '2015-01-29'], 
         ['2.6.0', '2.6.0', '2015-01-10'], 
@@ -348,17 +349,7 @@ def get_manual_titles_bash():
     for title in html_theme_options["manual_titles"]:
         manual_titles += "'%s'" % title
     manual_titles += SUFFIX
-    return manual_titles 
-
-def get_json_versions():
-    return "versionscallback(%s);" % html_theme_options["versions_data"]
-
-def print_json_versions():
-    print "versionscallback(%s);" % html_theme_options["versions_data"]
-
-def print_json_versions_file():
-    head, tail = os.path.split(html_theme_options["versions"])
-    print tail
+    return manual_titles
 
 # Add any paths that contain custom themes here, relative to this directory.
 html_theme_path = ['_themes','../../_common/_themes']

--- a/cdap-docs/_common/highlevel_conf.py
+++ b/cdap-docs/_common/highlevel_conf.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2015 Cask Data, Inc.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -15,8 +15,14 @@
 # the License.
 
 # conf.py to build high-level document comprised of multiple manuals
-# relies on settings in common_conf.py
-# Includes handler to build a common index of all manuals combined
+# Relies on settings in common_conf.py
+
+# Search Index
+# Includes handler to build a common search index of all manuals combined
+
+# JSON Creation (json-versions.js)
+# Creates a JSON file with timeline and formatting information fron the data in the 
+# common_conf.py ("versions_data")
 
 import codecs
 import os
@@ -28,6 +34,9 @@ from sphinx.util.console import bold
 
 sys.path.append(os.path.abspath('../../_common'))
 from common_conf import *
+
+# Search Index
+# Includes handler to build a common search index of all manuals combined
 
 def setup(app):
     # Define handler to build the common index
@@ -158,3 +167,190 @@ def merger(dict1, dict2, offset):
         
         dict1[term]=new_files
     return dict1
+
+# JSON Creation (json-versions.js)
+# Creates a JSON file with timeline and formatting information fron the data in the 
+# common_conf.py ("versions_data")
+
+def _build_timeline():
+    # Takes data in versions_data
+    #   "versions_data":
+    #     { "development": [
+    #         ['3.1.0-SNAPSHOT', '3.1.0'], 
+    #         ], 
+    #       "current": ['3.0.0', '3.0.0', '2015-05-05'], 
+    #       "older": [ 
+    #         ['2.8.0', '2.8.0', '2015-03-23'], 
+    #         ['2.7.1', '2.7.1', '2015-02-05'], 
+    #         ['2.6.3', '2.6.3', '2015-05-15'], 
+    #         ['2.6.2', '2.6.2', '2015-03-23'], 
+    #         ['2.6.1', '2.6.1', '2015-01-29'], 
+    #         ['2.6.0', '2.6.0', '2015-01-10'], 
+    #         ['2.5.2', '2.5.2', '2014-11-14'], 
+    #         ['2.5.1', '2.5.1', '2014-10-15'], 
+    #         ['2.5.0', '2.5.0', '2014-09-26'],
+    #         ],
+    #     },
+    # and creates a timeline of the form:
+    # 'timeline': [
+    #     ['0', '3.0.0', '2015-05-05', ' (43 days)'],
+    #     ['0', '2.8.0', '2015-03-23', ' (46 days)'],
+    #     ['0', '2.7.1', '2015-02-05', ' (26 days)'],
+    #     ['0', '2.6.0', '2015-01-10', ' (106 days)'],
+    #     ['1', '2.6.1', '2015-01-29', ' (19 days)'],
+    #     ['1', '2.6.2', '2015-03-23', ' (53 days)'],
+    #     ['0', '2.5.0', '2014-09-26', ''],
+    #     ['1', '2.5.1', '2014-10-15', ' (19 days)'],
+    #     ['1', '2.5.2', '2014-11-14', ' (30 days)'],
+    # ]
+    # It modifies the "older", adding an extra element ('1') to flag the highest version 
+    # of the minor index 
+    versions_data = html_theme_options["versions_data"]
+    older = versions_data["older"]
+    rev_older = list(older)
+    rev_older.reverse() # Now in lowest to highest versions
+    current = versions_data["current"]
+    data = []
+    data_index = []
+    
+    # Make look-up dictionary
+    data_lookup_dict = {}
+    for release in rev_older:
+        data_lookup_dict[release[0]] = release[2]
+        
+    # Find and flag highest version of minor index
+    versions = []
+    releases = len(older)
+    for i in range(0, releases):
+        style = ''
+        version = older[i][0]
+        version_major_minor = version[:version.rfind('.')]
+        if i < (releases-1):
+            next_version = older[i+1][0]
+            next_version_major_minor = next_version[:next_version.rfind('.')]
+            if version_major_minor not in versions and version_major_minor >= next_version_major_minor:
+                versions.append(version_major_minor)
+                style = '1'
+        elif i == (releases-1):
+            if version_major_minor not in versions:
+                versions.append(version_major_minor)
+                style = '1'
+        older[i].append(style)
+        
+    # Build Timeline
+    previous_date = ''
+    for release in rev_older:
+        version = release[0]
+        date = release[2]
+        if not data:
+            # First entry; always set indent to 0
+            indent = '0'
+            _add_to_start_of_timeline(data, data_index, indent, version, date)
+        else:
+            if version.endswith('0'):
+                # is this a x.x.0 release?
+                # yes: put at start of timeline
+                previous_date = data_lookup_dict[data_index[0]]
+                # Find the previous *.*.0 release
+                for i in range(0, len(data_index)):
+                    if data_index[i].endswith('0'):
+                        previous_date = data_lookup_dict[data_index[i]]
+                indent = '0'
+                _add_to_start_of_timeline(data, data_index, indent, version, date)
+            else:
+                # no:
+                # is there an x.x.0 release for this?
+                version_major_minor = version[:version.rfind('.')]
+                version_zero = version_major_minor + '.0'
+                if version_zero in data_index:
+                    # yes: put after last one in that series
+                    index = 0
+                    in_range = False
+                    for i in range(0, len(data_index)):
+                        entry = data_index[i]
+                        entry_major_minor = entry[:entry.rfind('.')]
+                        if entry_major_minor == version_major_minor:
+                            index = i
+                            in_range = True
+                        if in_range and entry_major_minor != version_major_minor:
+                            index += 1
+                            break
+                        if i == (len(data_index)-1):
+                            index = i +1
+                    indent = '1'
+                    _insert_into_timeline(data, data_index, index, indent, version, date)
+                else:
+                    # no: add at top as the top level (indent=0)
+                    index = 0
+                    indent = '0'
+                    _insert_into_timeline(data, data_index, index, indent, version, date)
+    current = html_theme_options["versions_data"]["current"]
+    _add_to_start_of_timeline(data, data_index, '0', current[0], current[2])
+    # Calculate dates
+    current_date = ''
+    points = len(data)
+    for i in range(0, points):
+        # if d[0] = '0' doing outer level;
+        level = data[i][0]
+        date =  data[i][2]
+        if level == '0':
+            current_date = date
+            # Find next '0' level:
+            index = -1
+            for k in range(i+1, points):
+                if data[k][0] == '0':
+                    index = k
+                    break
+            if index != -1:
+                delta_string = diff_between_date_strings(date, data[index][2])
+            else:
+                delta_string = ''
+        elif level == '1':
+            # Dated from previous "0" level (current_date)
+            delta_string = diff_between_date_strings(date, current_date)
+            current_date = date
+        data[i].append(delta_string)
+    versions_data['older'] = older
+    versions_data['timeline'] = data
+    return versions_data
+
+def _add_to_start_of_timeline(data, data_index, indent, version, date):
+    _insert_into_timeline(data, data_index, 0, indent, version, date)
+
+def _append_to_timeline(data, data_index, indent, version, date, style):
+    _insert_into_timeline(data, data_index, len(data), indent, version, date)
+
+def _insert_into_timeline(data, data_index, index, indent, version, date):
+    data.insert(index, [indent, version, date])
+    data_index.insert(index, version)
+
+def diff_between_date_strings(date_a, date_b):
+    date_format = '%Y-%m-%d'
+    a = datetime.strptime(date_a, date_format)
+    b = datetime.strptime(date_b, date_format)
+    delta = b - a
+    diff = abs(delta.days)
+    if diff == 1:
+        days = "day"
+    else:
+        days = "days"
+    delta_string = " (%s %s)" % (diff, days)
+    return delta_string
+
+def get_json_versions():
+    return "versionscallback(%s);" % _build_timeline()
+
+def print_json_versions():
+    print get_json_versions()
+
+def pretty_print_json_versions():
+    data_dict = _build_timeline()
+    for key in data_dict.keys():
+        print "Key: %s" % key
+        data = data_dict[key]
+        for d in data:
+            print d
+
+def print_json_versions_file():
+    head, tail = os.path.split(html_theme_options["versions"])
+    print tail

--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -298,10 +298,6 @@ function zip_extras() {
     return
   fi
   # Add JSON file
-#   cd ${SCRIPT_PATH}/${BUILD}/${SOURCE}
-#   JSON_FILE=`python -c 'import conf; conf.print_json_versions_file();'`
-#   local json_file_path=${SCRIPT_PATH}/${BUILD}/${PROJECT_VERSION}/${JSON_FILE}
-#   echo `python -c 'import conf; conf.print_json_versions();'` > ${json_file_path}
   build_json
   # Add .htaccess file (404 file)
   cd ${SCRIPT_PATH}

--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -53,6 +53,8 @@ function usage() {
   echo "    docs-web       Clean build of HTML docs and Javadocs, zipped for placing on docs.cask.co webserver"
   echo ""
   echo "    javadocs       Build Javadocs"
+  echo "    json           Build JSON file (json-versions.js)"
+  echo "    print-json     Prints what would be the JSON file (json-versions.js)"
   echo "    licenses       Clean build of License Dependency PDFs"
   echo "    sdk            Build SDK"
   echo "    version        Print the version information"
@@ -76,7 +78,9 @@ function run_command() {
     docs-web-part )     build_docs_web ${ARG_2} ${ARG_3};;
     docs-web )          build_docs_web ${ARG_2} ${ARG_3}; exit 0;;
     javadocs )          build_javadocs; exit 0;;
+    json )              build_json; exit 0;;
     licenses )          build_license_depends; exit 0;;
+    print-json )        print_json; exit 0;;
     sdk )               build_sdk; exit 0;;
     version )           print_version; exit 0;;
     test )              test; exit 0;;
@@ -213,6 +217,29 @@ function build_docs_javadocs() {
   build_docs_inner_level "build"
 }
 
+
+function build_json() {
+  version
+  if [ -d ${SCRIPT_PATH}/${BUILD}/${SOURCE} ]; then
+    cd ${SCRIPT_PATH}/${BUILD}/${SOURCE}
+    JSON_FILE=`python -c 'import conf; conf.print_json_versions_file();'`
+    local json_file_path=${SCRIPT_PATH}/${BUILD}/${PROJECT_VERSION}/${JSON_FILE}
+    python -c 'import conf; conf.print_json_versions();' > ${json_file_path}
+  else
+    echo "Could not find '${SCRIPT_PATH}/${BUILD}/${SOURCE}'; can not build JSON file"
+  fi
+}
+
+function print_json() {
+  version
+  if [ -d ${SCRIPT_PATH}/${BUILD}/${SOURCE} ]; then
+    cd ${SCRIPT_PATH}/${BUILD}/${SOURCE}
+    python -c 'import conf; conf.pretty_print_json_versions();'
+  else
+    echo "Could not find '${SCRIPT_PATH}/${BUILD}/${SOURCE}'; can not print JSON file"
+  fi
+}
+
 function build_docs() {
   _build_docs "docs" ${GOOGLE_ANALYTICS_WEB} ${WEB} ${TRUE}
 }
@@ -271,10 +298,11 @@ function zip_extras() {
     return
   fi
   # Add JSON file
-  cd ${SCRIPT_PATH}/${BUILD}/${SOURCE}
-  JSON_FILE=`python -c 'import conf; conf.print_json_versions_file();'`
-  local json_file_path=${SCRIPT_PATH}/${BUILD}/${PROJECT_VERSION}/${JSON_FILE}
-  echo `python -c 'import conf; conf.print_json_versions();'` > ${json_file_path}
+#   cd ${SCRIPT_PATH}/${BUILD}/${SOURCE}
+#   JSON_FILE=`python -c 'import conf; conf.print_json_versions_file();'`
+#   local json_file_path=${SCRIPT_PATH}/${BUILD}/${PROJECT_VERSION}/${JSON_FILE}
+#   echo `python -c 'import conf; conf.print_json_versions();'` > ${json_file_path}
+  build_json
   # Add .htaccess file (404 file)
   cd ${SCRIPT_PATH}
   rewrite ${COMMON_SOURCE}/${HTACCESS} ${BUILD}/${PROJECT_VERSION}/.${HTACCESS} "<version>" "${PROJECT_VERSION}"


### PR DESCRIPTION
These changes support modifications to the CDAP timeline, displayed at http://docs.cask.co/cdap/index.html. The changes modify the json-versions.js so that it results in a condensed timeline, and with improved formatting of the list of "Older" releases.

- Added targets to build and display the JSON file (json-versions.js) to the build script.
- Moved scripts that manipulate the JSON file from the common configuration to the high-level configuration file, so that the common conf.py is more just configuration rather than scripting.