### PR TITLE
Fix Installation Guide instructions for SDK zip

### DIFF
--- a/cdap-docs/developers-manual/source/getting-started/standalone/index.rst
+++ b/cdap-docs/developers-manual/source/getting-started/standalone/index.rst
@@ -30,6 +30,8 @@ The CDAP SDK runs on Linux, MacOS and Windows, and has three requirements:
 - `Node.js <http://nodejs.org/dist/>`__ (|node-js-version|; required to run the CDAP UI)
 - `Apache Maven 3.0+ <http://maven.apache.org>`__ (required to build CDAP applications)
 
+.. _recommend-using-an-ide:
+
 We recommend using an IDE when building CDAP applications, such as either `IntelliJ
 <https://www.jetbrains.com/idea/>`__ or `Eclipse, <https://www.eclipse.org/>`__ as
 described in the section on :ref:`development environment setup. <dev-env>`

--- a/cdap-docs/developers-manual/source/getting-started/standalone/zip.rst
+++ b/cdap-docs/developers-manual/source/getting-started/standalone/zip.rst
@@ -21,6 +21,10 @@ Once downloaded, unzip it to a directory on your machine:
   .. parsed-literal::
     |$| unzip cdap-sdk-|release|.zip
 
+.. include:: index.rst  
+  :start-after: .. _system-requirements:
+  :end-before: .. _recommend-using-an-ide:
+
 .. include:: ../dev-env.rst  
    :start-line: 7
 


### PR DESCRIPTION
Add to the standalone/zip (which is linked on the Cask website as the "Installation Guide" for the SDK zip) instructions on the dependency requirements.

Staged at: http://docs-staging.cask.co/cdap/3.0.1-feature-r3.0.1_download_instructions/en/developers-manual/getting-started/standalone/zip.html
Current: http://docs.cask.co/cdap/3.0.0/en/developers-manual/getting-started/standalone/zip.html