### PR TITLE
Correct broken doc build.

### DIFF
--- a/cdap-docs/examples-manual/build.sh
+++ b/cdap-docs/examples-manual/build.sh
@@ -145,7 +145,7 @@ function download_includes() {
   test_an_include d9c7f594204f42adaac7ad866c11ed7a ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseStore.java
   
   test_an_include f8e8f0fba3d26cc26f06325b7c55d715 ../../cdap-examples/SparkKMeans/src/main/java/co/cask/cdap/examples/sparkkmeans/SparkKMeansApp.java
-  test_an_include 8632b56f39c02e695f11c74729fbc456 ../../cdap-examples/SparkPageRank/src/main/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankApp.java
+  test_an_include 97e355542831d767a297b52ff09f5674 ../../cdap-examples/SparkPageRank/src/main/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankApp.java
 
   test_an_include afe12d26b79607a846d3eaa58958ea5f ../../cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/SportResults.java
   test_an_include bbeed2893195fa12553e4eb28016306a ../../cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/UploadService.java

--- a/cdap-docs/examples-manual/source/examples/spark-page-rank.rst
+++ b/cdap-docs/examples-manual/source/examples/spark-page-rank.rst
@@ -36,7 +36,7 @@ of the application are tied together by the class ``SparkPageRankApp``:
 
 .. literalinclude:: /../../../cdap-examples/SparkPageRank/src/main/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankApp.java
    :language: java
-   :lines: 41-76
+   :lines: 40-76
 
 The ``ranks`` ObjectStore Data Storage
 --------------------------------------


### PR DESCRIPTION
Staged at: http://docs-staging.cask.co/cdap/3.1.0-SNAPSHOT-feature-3.1_fix_doc_build/en/examples-manual/examples/spark-page-rank.html