### PR TITLE
Fix/ui suspend resume workflow runlevel

### DIFF
--- a/cdap-ui/app/directives/program-status/program-status.js
+++ b/cdap-ui/app/directives/program-status/program-status.js
@@ -6,6 +6,7 @@ angular.module(PKG.name + '.commons')
       scope: {
         type: '@',
         runid: '@',
+        pollInterval: '@',
         runs: '='
       },
       templateUrl: 'program-status/program-status.html',
@@ -23,7 +24,8 @@ angular.module(PKG.name + '.commons')
           }
 
           pollPromise = dataSrc.poll({
-            _cdapNsPath: path
+            _cdapNsPath: path,
+            interval: $scope.pollInterval || 10000
           }, function (res) {
             var startMs = res.start * 1000;
             $scope.start = new Date(startMs);

--- a/cdap-ui/app/directives/program-status/program-status.js
+++ b/cdap-ui/app/directives/program-status/program-status.js
@@ -10,6 +10,7 @@ angular.module(PKG.name + '.commons')
       },
       templateUrl: 'program-status/program-status.html',
       controller: function($scope, MyDataSource, $state) {
+        var pollPromise;
         // $scope.runs comes from parent controller
         if ($scope.runs.length !== 0) {
           var dataSrc = new MyDataSource($scope),
@@ -21,13 +22,16 @@ angular.module(PKG.name + '.commons')
             path = '/apps/' + $state.params.appId + '/' + $scope.type + '/' + $state.params.programId + '/runs/' + $scope.runid;
           }
 
-          dataSrc.poll({
+          pollPromise = dataSrc.poll({
             _cdapNsPath: path
           }, function (res) {
             var startMs = res.start * 1000;
             $scope.start = new Date(startMs);
             $scope.status = res.status;
             $scope.duration = (res.end ? (res.end * 1000) - startMs : 0);
+            if (['COMPLETED', 'KILLED', 'STOPPED', 'FAILED'].indexOf($scope.status) !== -1) {
+              dataSrc.stopPoll(pollPromise.__pollId__);
+            }
           });
         }
 

--- a/cdap-ui/app/directives/start-stop-button/start-stop-button.html
+++ b/cdap-ui/app/directives/start-stop-button/start-stop-button.html
@@ -6,20 +6,21 @@
     <span class="fa fa-play"> </span>
     <span>Start</span>
   </div>
-  <div ng-if="(status === 'RUNNING' || status === 'STARTED') && isStoppable === 'false'"
+  <div ng-if="(['RUNNING', 'STARTED', 'SUSPENDED'].indexOf(status) !== -1) && isStoppable === 'false'"
        class="btn btn-success btn-md"
-       ng-disabled="status === 'RUNNING' && isStoppable === 'false'">
+       ng-disabled="status === 'RUNNING' && isRestartable === 'false'"
+       ng-click="do('start')">
        <span class="fa fa-play"></span>
        <span>Start</span>
   </div>
-  <div ng-if="(status === 'RUNNING' || status === 'STARTED') && isStoppable === 'true'"
+  <div ng-if="(['RUNNING', 'STARTED'].indexOf(status) !== -1) && isStoppable === 'true'"
        class="btn btn-danger btn-md"
        ng-click="do('stop')">
     <span class="fa fa-stop"> </span>
     <span>Stop</span>
   </div>
 
-  <div ng-if="status === 'STARTING' || status === 'STOPPING'"
+  <div ng-if="['STARTING', 'STOPPING'].indexOf(status) !== -1"
        class="btn btn-md"
        ng-class="{'btn-success': status === 'STARTING', 'btn-danger': status === 'STOPPING'}"
        >
@@ -32,6 +33,30 @@
   </button>
 
   <ul class="dropdown-menu dropdown-menu-right" role="menu" ng-if="status === 'STOPPED'">
+    <li>
+      <a href="#" ng-click="openRuntime()">
+        <span class="fa fa-wrench pull-right"></span>
+        <span> Runtime Arguments </span>
+      </a>
+    </li>
+    <li>
+      <a href="#" ng-click="openPreferences()">
+        <span class="fa fa-cog pull-right"></span>
+        <span> Preferences </span>
+      </a>
+    </li>
+  </ul>
+
+  <button class="btn btn-md btn-success dropdown-toggle"
+          dropdown-toggle ng-if="(['RUNNING', 'STARTED', 'SUSPENDED'].indexOf(status) !== -1) && isStoppable === 'false'"
+          ng-disabled="status === 'RUNNING' && isRestartable === 'false'">
+    <span class="caret"></span>
+  </button>
+
+  <ul class="dropdown-menu dropdown-menu-right"
+      role="menu"
+      ng-disabled="status === 'RUNNING' && isRestartable === 'false'"
+      ng-if="(['RUNNING', 'STARTED'].indexOf(status) !== -1) && isStoppable === 'false'">
     <li>
       <a href="#" ng-click="openRuntime()">
         <span class="fa fa-wrench pull-right"></span>

--- a/cdap-ui/app/directives/start-stop-button/start-stop-button.js
+++ b/cdap-ui/app/directives/start-stop-button/start-stop-button.js
@@ -5,12 +5,14 @@ angular.module(PKG.name + '.commons')
       scope: {
         type: '@',
         isStoppable: '@',
+        isRestartable: '@',
         preferencesHandler: '&',
         runtimeHandler: '&'
       },
       templateUrl: 'start-stop-button/start-stop-button.html',
       controller: function($scope, $state, MyDataSource, myRuntimeService, myProgramPreferencesService) {
         $scope.isStoppable = ($scope.isStoppable === 'true');
+        $scope.isRestartable = ($scope.isRestartable === 'true');
 
         $scope.runtimeArgs = [];
         var path = '/apps/' + $state.params.appId +

--- a/cdap-ui/app/features/workflows/controllers/tabs/runs/tabs/status-ctrl.js
+++ b/cdap-ui/app/features/workflows/controllers/tabs/runs/tabs/status-ctrl.js
@@ -9,8 +9,6 @@ angular.module(PKG.name + '.feature.workflows')
         match,
         runparams;
 
-    vm.runStatus = null;
-
     if ($state.params.runid) {
       match = filterFilter($scope.RunsController.runs, {runid: $state.params.runid});
       if (match.length) {
@@ -19,6 +17,7 @@ angular.module(PKG.name + '.feature.workflows')
     }
 
     var vm = this;
+    vm.runStatus = null;
 
     vm.data = {};
 

--- a/cdap-ui/app/features/workflows/templates/detail.html
+++ b/cdap-ui/app/features/workflows/templates/detail.html
@@ -12,7 +12,8 @@
   <div class="col-sm-6 text-right">
     <my-start-stop-button
       type="workflows"
-      is-stoppable="true">
+      is-stoppable="false"
+      is-restartable="true">
     </my-start-stop-button>
   </div>
 </div>

--- a/cdap-ui/app/features/workflows/templates/tabs/runs/run-detail.html
+++ b/cdap-ui/app/features/workflows/templates/tabs/runs/run-detail.html
@@ -11,6 +11,7 @@
 <my-program-status
   data-type="workflows"
   data-runid="{{ RunsController.runs.selected.runid }}"
+  data-poll-interval="1000"
   data-runs="RunsController.runs"
 ></my-program-status>
 

--- a/cdap-ui/app/features/workflows/templates/tabs/runs/tabs/status.html
+++ b/cdap-ui/app/features/workflows/templates/tabs/runs/tabs/status.html
@@ -1,3 +1,50 @@
 <div ng-controller="WorkflowsRunsStatusController as StatusController">
+  <div class="btn-group pull-right">
+    <div class="btn btn-default btn-danger"
+         ng-disabled="StatusController.runStatus !== 'RUNNING'"
+         ng-click="StatusController.stop()"
+         >
+
+      <span ng-if="StatusController.runStatus !== 'STOPPING'">
+        <span class="fa fa-stop"></span>
+        <span>Stop run</span>
+      </span>
+      <span ng-if="StatusController.runStatus === 'STOPPING'">
+        <span class="fa fa-refresh fa-spin"></span>
+        <span>Stopping run</span>
+      </span>
+    </div>
+
+    <div class="btn btn-default btn-warning"
+         ng-if="['SUSPENDED', 'RESUMING'].indexOf(StatusController.runStatus) === -1"
+         ng-disabled="['COMPLETED', 'KILLED', 'STOPPING', 'SUSPENDING'].indexOf(StatusController.runStatus) !== -1 || RunsController.runs.length === 0"
+         ng-click="StatusController.suspend()">
+      <span ng-if="StatusController.runStatus !== 'SUSPENDING'">
+        <span class="fa fa-pause"></span>
+        <span>Suspend run</span>
+      </span>
+      <span ng-if="StatusController.runStatus === 'SUSPENDING'">
+        <span class="fa fa-refresh fa-spin"></span>
+        <span>Suspending run</span>
+      </span>
+    </div>
+
+    <div class="btn btn-default btn-warning"
+         ng-disabled="StatusController.runStatus === 'RESUMING'"
+         ng-if="StatusController.runStatus === 'SUSPENDED' || StatusController.runStatus === 'RESUMING'"
+         ng-click="StatusController.resume()">
+      <span ng-if="StatusController.runStatus !== 'RESUMING'">
+        <span class="fa fa-play"></span>
+        <span>Resume Run</span>
+      </span>
+      <span ng-if="StatusController.runStatus === 'RESUMING'">
+        <span class="fa fa-refresh fa-spin"></span>
+        <span>Resuming Run</span>
+      </span>
+    </div>
+
+
+  </div>
+
   <my-workflow-graph data-model="StatusController.data" data-click="StatusController.workflowProgramClick"></my-workflow-graph>
 </div>

--- a/cdap-ui/app/features/workflows/templates/tabs/runs/tabs/status.html
+++ b/cdap-ui/app/features/workflows/templates/tabs/runs/tabs/status.html
@@ -1,50 +1,52 @@
 <div ng-controller="WorkflowsRunsStatusController as StatusController">
-  <div class="btn-group pull-right">
-    <div class="btn btn-default btn-danger"
-         ng-disabled="StatusController.runStatus !== 'RUNNING'"
-         ng-click="StatusController.stop()"
-         >
+  <div class="text-right">
+    <div class="btn-group">
+      
+      <div class="btn btn-default btn-danger"
+           ng-disabled="StatusController.runStatus !== 'RUNNING'"
+           ng-click="StatusController.stop()"
+           >
+        <span ng-if="StatusController.runStatus !== 'STOPPING'">
+          <span class="fa fa-stop"></span>
+          <span>Stop run</span>
+        </span>
+        <span ng-if="StatusController.runStatus === 'STOPPING'">
+          <span class="fa fa-refresh fa-spin"></span>
+          <span>Stopping run</span>
+        </span>
+      </div>
 
-      <span ng-if="StatusController.runStatus !== 'STOPPING'">
-        <span class="fa fa-stop"></span>
-        <span>Stop run</span>
-      </span>
-      <span ng-if="StatusController.runStatus === 'STOPPING'">
-        <span class="fa fa-refresh fa-spin"></span>
-        <span>Stopping run</span>
-      </span>
+      <div class="btn btn-default btn-warning"
+           ng-if="['SUSPENDED', 'RESUMING'].indexOf(StatusController.runStatus) === -1"
+           ng-disabled="['COMPLETED', 'KILLED', 'STOPPING', 'SUSPENDING'].indexOf(StatusController.runStatus) !== -1 || RunsController.runs.length === 0"
+           ng-click="StatusController.suspend()">
+        <span ng-if="StatusController.runStatus !== 'SUSPENDING'">
+          <span class="fa fa-pause"></span>
+          <span>Suspend run</span>
+        </span>
+        <span ng-if="StatusController.runStatus === 'SUSPENDING'">
+          <span class="fa fa-refresh fa-spin"></span>
+          <span>Suspending run</span>
+        </span>
+      </div>
+
+      <div class="btn btn-default btn-warning"
+           ng-disabled="StatusController.runStatus === 'RESUMING'"
+           ng-if="StatusController.runStatus === 'SUSPENDED' || StatusController.runStatus === 'RESUMING'"
+           ng-click="StatusController.resume()">
+        <span ng-if="StatusController.runStatus !== 'RESUMING'">
+          <span class="fa fa-play"></span>
+          <span>Resume Run</span>
+        </span>
+        <span ng-if="StatusController.runStatus === 'RESUMING'">
+          <span class="fa fa-refresh fa-spin"></span>
+          <span>Resuming Run</span>
+        </span>
+      </div>
+
     </div>
-
-    <div class="btn btn-default btn-warning"
-         ng-if="['SUSPENDED', 'RESUMING'].indexOf(StatusController.runStatus) === -1"
-         ng-disabled="['COMPLETED', 'KILLED', 'STOPPING', 'SUSPENDING'].indexOf(StatusController.runStatus) !== -1 || RunsController.runs.length === 0"
-         ng-click="StatusController.suspend()">
-      <span ng-if="StatusController.runStatus !== 'SUSPENDING'">
-        <span class="fa fa-pause"></span>
-        <span>Suspend run</span>
-      </span>
-      <span ng-if="StatusController.runStatus === 'SUSPENDING'">
-        <span class="fa fa-refresh fa-spin"></span>
-        <span>Suspending run</span>
-      </span>
-    </div>
-
-    <div class="btn btn-default btn-warning"
-         ng-disabled="StatusController.runStatus === 'RESUMING'"
-         ng-if="StatusController.runStatus === 'SUSPENDED' || StatusController.runStatus === 'RESUMING'"
-         ng-click="StatusController.resume()">
-      <span ng-if="StatusController.runStatus !== 'RESUMING'">
-        <span class="fa fa-play"></span>
-        <span>Resume Run</span>
-      </span>
-      <span ng-if="StatusController.runStatus === 'RESUMING'">
-        <span class="fa fa-refresh fa-spin"></span>
-        <span>Resuming Run</span>
-      </span>
-    </div>
-
-
   </div>
 
-  <my-workflow-graph data-model="StatusController.data" data-click="StatusController.workflowProgramClick"></my-workflow-graph>
+  <my-workflow-graph data-model="StatusController.data"
+                     data-click="StatusController.workflowProgramClick"></my-workflow-graph>
 </div>

--- a/cdap-ui/app/main.js
+++ b/cdap-ui/app/main.js
@@ -118,7 +118,7 @@ angular
               promise = myDataSrc.request(config);
               break;
             case 'POLL-STOP':
-              promise = myDataSrc.pollStop(config);
+              promise = myDataSrc.stopPoll(config);
               break;
           }
           return promise;

--- a/cdap-ui/app/services/data/datasource.js
+++ b/cdap-ui/app/services/data/datasource.js
@@ -206,7 +206,7 @@ angular.module(PKG.name+'.services')
         generatedResource = {
           json: resource.json,
           id: id,
-          interval: resource.interval || myHelpers.objectQuery(resource, 'params', 'interval') ,
+          interval: resource.interval || myHelpers.objectQuery(resource, 'options', 'interval') ,
           body: resource.body,
           method: resource.method || 'GET'
         };

--- a/cdap-ui/app/services/data/datasource.js
+++ b/cdap-ui/app/services/data/datasource.js
@@ -33,8 +33,7 @@ angular.module(PKG.name+'.services')
 
    */
 
-  .factory('MyDataSource', function ($log, $rootScope, caskWindowManager, mySocket,
-    MYSOCKET_EVENT, $q, $filter, myCdapUrl, MyPromise, MyAuthUser) {
+  .factory('MyDataSource', function ($log, $rootScope, caskWindowManager, mySocket, MYSOCKET_EVENT, $q, $filter, myCdapUrl, MyPromise, myHelpers) {
 
     var instances = {}; // keyed by scopeid
 
@@ -204,11 +203,10 @@ angular.module(PKG.name+'.services')
       var id = generateUUID();
       var generatedResource = {};
       var promise = new MyPromise(function(resolve, reject) {
-
         generatedResource = {
           json: resource.json,
           id: id,
-          interval: resource.interval,
+          interval: resource.interval || myHelpers.objectQuery(resource, 'params', 'interval') ,
           body: resource.body,
           method: resource.method || 'GET'
         };
@@ -249,13 +247,24 @@ angular.module(PKG.name+'.services')
      */
     DataSource.prototype.stopPoll = function(resourceId) {
       var filterFilter = $filter('filter');
-      var id = resourceId;
+      // Duck Typing for angular's $resource.
+      var defer = $q.defer();
+      var id;
+      if (angular.isObject(resourceId)) {
+        id = resourceId.params.pollId;
+      } else {
+        id = resourceId;
+      }
       var match = filterFilter(this.bindings, { 'resource': {id: id} });
 
       if (match.length) {
         _pollStop(match[0].resource);
         this.bindings.splice(this.bindings.indexOf(match[0]), 1);
+        defer.resolve({});
+      } else {
+        defer.reject({});
       }
+      return defer.promise;
     };
 
     /**

--- a/cdap-ui/app/services/workflows/myworkflowapi.js
+++ b/cdap-ui/app/services/workflows/myworkflowapi.js
@@ -5,11 +5,14 @@ angular.module(PKG.name + '.services')
         schedulepath = '/apps/:appId/schedules/:scheduleId',
         basepath = '/apps/:appId/workflows/:workflowId';
 
-    function getConfig (method, type, path, isArray) {
+    function getConfig (method, type, path, isArray, interval) {
       var config = {
         url: url({ _cdapNsPath: path }),
         method: method,
-        options: { type: type}
+        options: {
+          type: type,
+          interval: interval || 10000
+        }
       };
       if (isArray) {
         config.isArray = true;
@@ -35,7 +38,7 @@ angular.module(PKG.name + '.services')
       runs: getConfig('GET', 'REQUEST', basepath + '/runs', true),
       runDetail: getConfig('GET', 'REQUEST', basepath + '/runs/:runId'),
       pollRuns: getConfig('GET', 'POLL', basepath + '/runs', true),
-      pollRunDetail: getConfig('GET', 'POLL', basepath + '/runs/:runId'),
+      pollRunDetail: getConfig('GET', 'POLL', basepath + '/runs/:runId', false, 1000),
       stopPollRunDetail: getConfig('GET', 'POLL-STOP', basepath + '/runs/:runId'),
       stopRun: getConfig('POST', 'REQUEST', basepath + '/runs/:runId/stop'),
       suspendRun: getConfig('POST', 'REQUEST', basepath + '/runs/:runId/suspend'),

--- a/cdap-ui/app/services/workflows/myworkflowapi.js
+++ b/cdap-ui/app/services/workflows/myworkflowapi.js
@@ -31,11 +31,18 @@ angular.module(PKG.name + '.services')
       start: getConfig('POST', 'REQUEST', basepath + '/start'),
       stop: getConfig('POST', 'REQUEST', basepath + '/stop'),
       pollStatus: getConfig('GET', 'POLL', basepath + '/status'),
+
       runs: getConfig('GET', 'REQUEST', basepath + '/runs', true),
       runDetail: getConfig('GET', 'REQUEST', basepath + '/runs/:runId'),
       pollRuns: getConfig('GET', 'POLL', basepath + '/runs', true),
       pollRunDetail: getConfig('GET', 'POLL', basepath + '/runs/:runId'),
+      stopPollRunDetail: getConfig('GET', 'POLL-STOP', basepath + '/runs/:runId'),
+      stopRun: getConfig('POST', 'REQUEST', basepath + '/runs/:runId/stop'),
+      suspendRun: getConfig('POST', 'REQUEST', basepath + '/runs/:runId/suspend'),
+      resumeRun: getConfig('POST', 'REQUEST', basepath + '/runs/:runId/resume'),
+
       logs: getConfig('GET', 'REQUEST', basepath + '/runs/:runId/logs/next', true),
+
       schedules: getConfig('GET', 'REQUEST', basepath + '/schedules', true),
       schedulesPreviousRunTime: getConfig('GET', 'REQUEST', basepath + '/previousruntime', true),
       pollScheduleStatus: getConfig('GET', 'POLL', schedulepath + '/status'),


### PR DESCRIPTION
- Adds the ability to Stop/Suspend/Resume a workflow at run level. 
- Adds the ability to Start multiple runs of a workflow from UI.
- Adds the ability to have ```my-start-stop-button``` directive to be restartable, stoppable and non-stoppable (not sure if we use this option any more)
- Adds the ability to poll for data using $resource'y way and stop the poll by the same mechanism.
![stopworflowrun](https://cloud.githubusercontent.com/assets/1452845/8222347/f0b574b6-151e-11e5-9ded-6abc1aaa3452.gif)


TODO:
  - Decide on design (placement of pause and resume buttons)
  - One minor refactoring of MyDataSource usage in status-ctrl (hopefully we completely avoid its usage)

#### Note:
 Will create a cluster to test this tonight.