### PR TITLE
Updating text about Node.js version

### DIFF
--- a/cdap-docs/_common/common_conf.py
+++ b/cdap-docs/_common/common_conf.py
@@ -32,6 +32,7 @@ cdap_apps_version = "0.4.0"
 
 node_js_version = "v0.10.* through v0.12.*"
 
+recommended_node_js_version = "v0.12.0"
 
 import sys
 import os
@@ -170,6 +171,11 @@ if node_js_version:
     rst_epilog = rst_epilog + """
 .. |node-js-version| replace:: %(node_js_version)s
 """ % {'node_js_version': node_js_version}
+
+if recommended_node_js_version:
+    rst_epilog = rst_epilog + """
+.. |recommended-node-js-version| replace:: %(recommended_node_js_version)s
+""" % {'recommended_node_js_version': recommended_node_js_version}
 
 if version:
     rst_epilog = rst_epilog + """

--- a/cdap-docs/admin-manual/source/installation/installation.rst
+++ b/cdap-docs/admin-manual/source/installation/installation.rst
@@ -127,7 +127,7 @@ Once you have installed the JDK, you'll need to set the JAVA_HOME environment va
 
 Node.js Runtime
 +++++++++++++++
-You can download the appropriate version of Node.js (from |node-js-version|) from `nodejs.org <http://nodejs.org>`__:
+You can download the appropriate version of Node.js from `nodejs.org <http://nodejs.org>`__:
 
 #. The version of Node.js must be from |node-js-version|; we recommend |recommended-node-js-version|.
 #. Download the appropriate Linux or Solaris binary ``.tar.gz`` from

--- a/cdap-docs/admin-manual/source/installation/installation.rst
+++ b/cdap-docs/admin-manual/source/installation/installation.rst
@@ -129,7 +129,7 @@ Node.js Runtime
 +++++++++++++++
 You can download the appropriate version of Node.js (from |node-js-version|) from `nodejs.org <http://nodejs.org>`__:
 
-#. The version of Node.js must be from |node-js-version|.
+#. The version of Node.js must be from |node-js-version|; we recommend |recommended-node-js-version|.
 #. Download the appropriate Linux or Solaris binary ``.tar.gz`` from
    `nodejs.org/download/ <http://nodejs.org/dist/>`__.
 

--- a/cdap-docs/developers-manual/source/getting-started/standalone/index.rst
+++ b/cdap-docs/developers-manual/source/getting-started/standalone/index.rst
@@ -27,7 +27,7 @@ The CDAP SDK runs on Linux, MacOS and Windows, and has three requirements:
 
 - `JDK 7 <http://www.oracle.com/technetwork/java/javase/downloads/index.html>`__ 
   (required to run CDAP; note that $JAVA_HOME should be set)
-- `Node.js <http://nodejs.org/dist/>`__ (|node-js-version|; required to run the CDAP UI)
+- `Node.js <http://nodejs.org/dist/>`__ (|node-js-version|; required to run the CDAP UI; we recommend |recommended-node-js-version|)
 - `Apache Maven 3.0+ <http://maven.apache.org>`__ (required to build CDAP applications)
 
 We recommend using an IDE when building CDAP applications, such as either `IntelliJ

--- a/cdap-docs/integrations/source/partners/cloudera/configuring.rst
+++ b/cdap-docs/integrations/source/partners/cloudera/configuring.rst
@@ -41,7 +41,7 @@ the 'cdap' user installed by the parcel.
 Prerequisites
 =======================================
 
-#. Node.js (from |node-js-version|) must be installed on the node(s) where the UI
+#. Node.js (from |node-js-version|; we recommend |recommended-node-js-version|) must be installed on the node(s) where the UI
    role instance will run. You can download the appropriate version of Node.js from `nodejs.org
    <http://nodejs.org/dist/>`__.
 

--- a/cdap-docs/reference-manual/source/faq.rst
+++ b/cdap-docs/reference-manual/source/faq.rst
@@ -84,7 +84,7 @@ in your environment; we recommend the Oracle JDK.
 
 .. rubric:: What Version of Node.JS is Required by CDAP?
 
-The version of Node.js must be from |node-js-version|.
+The version of Node.js must be from |node-js-version|; we recommend |recommended-node-js-version|.
 
 
 Hadoop


### PR DESCRIPTION
- Add text " ; we recommend |recommended-node-js-version|" everywhere that Node.js is described.
- Set recommended version to "v0.12.0".

Staged at (and pages of interest):

- [Installation](http://docs-staging.cask.co/cdap/3.0.1-feature-r3.0.1_update_nodejs_text/en/admin-manual/installation/installation.html#node-js-runtime)
- [Getting Started: Standalone](http://docs-staging.cask.co/cdap/3.0.1-feature-r3.0.1_update_nodejs_text/en/developers-manual/getting-started/standalone/index.html#standalone-index)
- [FAQ](http://docs-staging.cask.co/cdap/3.0.1-feature-r3.0.1_update_nodejs_text/en/reference-manual/faq.html#platforms-and-language)
- [Integrations: Configuring Cloudera](http://docs-staging.cask.co/cdap/3.0.1-feature-r3.0.1_update_nodejs_text/en/integrations/partners/cloudera/configuring.html#prerequisites)