### PR TITLE
CDAP-2802: Stop using HiveConf.ConfVars.defaultValue, to support Hive >0.13

### DIFF
--- a/cdap-explore/src/main/java/co/cask/cdap/explore/guice/ExploreRuntimeModule.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/guice/ExploreRuntimeModule.java
@@ -231,8 +231,10 @@ public class ExploreRuntimeModule extends RuntimeModule {
         setupClasspath();
 
         // Set local tmp dir to an absolute location in the twill runnable otherwise Hive complains
+        String localScratchPath = System.getProperty("java.io.tmpdir") + File.separator +
+          "hive-" + System.getProperty("user.name");
         System.setProperty(HiveConf.ConfVars.LOCALSCRATCHDIR.toString(),
-                           new File(HiveConf.ConfVars.LOCALSCRATCHDIR.defaultVal).getAbsolutePath());
+                           new File(localScratchPath).getAbsolutePath());
         LOG.info("Setting {} to {}", HiveConf.ConfVars.LOCALSCRATCHDIR.toString(),
                  System.getProperty(HiveConf.ConfVars.LOCALSCRATCHDIR.toString()));
 


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-2802
http://builds.cask.co/browse/CDAP-DUT2067