### PR TITLE
Fixes non-explorable secure environments to show datasets even though its not explorable

### DIFF
--- a/cdap-ui/app/features/datasets/routes.js
+++ b/cdap-ui/app/features/datasets/routes.js
@@ -26,18 +26,24 @@ angular.module(PKG.name + '.feature.datasets')
             // Checking whether dataset is explorable
             myExploreApi.list(params)
               .$promise
-              .then(function (res) {
-                var datasetId = $stateParams.datasetId;
-                datasetId = datasetId.replace(/[\.\-]/g, '_');
+              .then(
+                function success(res) {
+                  var datasetId = $stateParams.datasetId;
+                  datasetId = datasetId.replace(/[\.\-]/g, '_');
 
-                var match = filterFilter(res, datasetId);
+                  var match = filterFilter(res, datasetId);
 
-                if (match.length === 0) {
+                  if (match.length === 0) {
+                    defer.resolve(false);
+                  } else {
+                    defer.resolve(true);
+                  }
+                },
+                function error(res) {
+                  console.info(res);
                   defer.resolve(false);
-                } else {
-                  defer.resolve(true);
                 }
-              });
+              );
             return defer.promise;
           }
         },


### PR DESCRIPTION
If explorer service is not enabled the UI shouldn't depend on it to show anything. Right now UI uses /explore/tables end point to view any dataset (to check if its explorable or not). If this call fails the UI should go to a default detailed view of a dataset.

