### PR TITLE
Fixes repeated alerts and confusion about opened tabs in adapter create view

### DIFF
--- a/cdap-ui/app/features/adapters/controllers/create-ctrl.js
+++ b/cdap-ui/app/features/adapters/controllers/create-ctrl.js
@@ -9,10 +9,12 @@ angular.module(PKG.name + '.feature.adapters')
         isCloseable: false,
         partial: '/assets/features/adapters/templates/create/tabs/default.html'
       }
-    ];
+    ],
+      alertpromise;
 
     this.tabs = defaultTabs.slice();
 
+    // Close the tab when user clicks on the 'x' button in the tab.
     this.closeTab = function(index) {
       var tab = this.tabs[index];
       var type = tab.type;
@@ -23,6 +25,22 @@ angular.module(PKG.name + '.feature.adapters')
       }
       this.tabs.splice(index, 1);
     };
+
+    // Delete an already opened tab. This is done when a plugin
+    // is being deleted(transform) or being overwritten (source/sink)by another one.
+    this.deleteTab = function (plugin, pluginType) {
+      var tab = this.tabs.filter(function(tab) {
+        if (pluginType === 'transform' && plugin.$$hashKey === tab.transformid) {
+          return tab;
+        }
+        if (pluginType !== 'transform' && pluginType === tab.type) {
+          return tab;
+        }
+      });
+      if (tab.length) {
+        this.tabs.splice(this.tabs.indexOf(tab[0]), 1);
+      }
+    }
 
     AdapterApiFactory.fetchTemplates()
       .$promise
@@ -96,9 +114,16 @@ angular.module(PKG.name + '.feature.adapters')
             var errorObj = {
               type: 'danger',
               title: 'Error Creating Adapter',
+              scope: $scope,
               content: (angular.isArray(err.messages)? formatErrorMessages(err.messages): err.messages.data)
             };
-            $alert(errorObj);
+            if (!alertpromise) {
+              alertpromise = $alert(errorObj);
+              var e = $scope.$on('alert.hide',function(){
+                alertpromise = null;
+                e(); // un-register from listening to the hide event of a closed alert.
+              });
+            }
           });
 
           // TODO: Should move it to a template.

--- a/cdap-ui/app/features/adapters/controllers/create/default-tab-ctrl.js
+++ b/cdap-ui/app/features/adapters/controllers/create/default-tab-ctrl.js
@@ -16,6 +16,10 @@ angular.module(PKG.name + '.feature.adapters')
     };
 
     this.addSource = function (sourceName) {
+      // Don't add an already added source.
+      if (sourceName === createCtrl.model.source.name) {
+        return;
+      }
       var source = {
         name: sourceName
       };
@@ -36,6 +40,9 @@ angular.module(PKG.name + '.feature.adapters')
         .then(function(properties) {
           source.properties = properties;
           createCtrl.model.setSource(source);
+          // If there is an already existing tab for a source opened,
+          // close it as that source has been overwritten by another one.
+          createCtrl.deleteTab(source, 'source');
         });
     };
 
@@ -64,6 +71,10 @@ angular.module(PKG.name + '.feature.adapters')
     };
 
     this.addSink = function(sinkName) {
+      // Don't add an already added sink.
+      if (sinkName === createCtrl.model.sink.name) {
+        return;
+      }
       var sink = {
         name: sinkName
       };
@@ -79,6 +90,8 @@ angular.module(PKG.name + '.feature.adapters')
         .then(function(properties) {
           sink.properties = properties;
           createCtrl.model.setSink(sink);
+          // Same as line:43
+          createCtrl.deleteTab(sink, 'sink');
         });
     };
 
@@ -158,6 +171,8 @@ angular.module(PKG.name + '.feature.adapters')
           properties: {}
         });
       }
+      // Same as line:43
+      createCtrl.deleteTab(transform, 'transform');
     };
 
   });

--- a/cdap-ui/app/features/adapters/services/AdapterCreateModel.js
+++ b/cdap-ui/app/features/adapters/services/AdapterCreateModel.js
@@ -41,7 +41,7 @@ angular.module(PKG.name + '.feature.adapters')
       this.instance = 1;
     };
 
-    Model.prototype.setMetadata = function (metadata) {
+    Model.prototype.setMetadata = function setMetadata(metadata) {
       // FIXME: There is a timing issue when editing a draft.
       this.metadata.type = metadata.type;
       this.metadata.name = metadata.name;


### PR DESCRIPTION
- Should be able to add the same source/sink any number of times the user want. The UI should still create only object (no overwrites should happen)
- When plugin's property is already being edited (opened in a new tab) and if the plugin is either deleted or overwritten then the tab should be removed to avoid any confusion.
- When publish button is clicked and when the UI does client side validations only one alert message should be opened at a time. No repeated multiple alert messages.

Secure Cluster: http://securecluster1762-1000.dev.continuuity.net
Non-Secure Cluster: http://nodeproxy1736-1000.dev.continuuity.net:9999/

![multiplealerts](https://cloud.githubusercontent.com/assets/1452845/8248963/fc161152-1619-11e5-857d-caa76e3bf70c.gif)