### PR TITLE
Adding deletion of namespace to documentation.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/NamespaceHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/NamespaceHttpHandler.java
@@ -160,13 +160,9 @@ public class NamespaceHttpHandler extends AbstractAppFabricHttpHandler {
     }
   }
 
-  /**
-   * DO NOT DOCUMENT THIS API
-   */
   @DELETE
   @Path("/unrecoverable/namespaces/{namespace-id}")
   public void delete(HttpRequest request, HttpResponder responder, @PathParam("namespace-id") String namespace) {
-    // NOTE: DO NOT DOCUMENT
     if (!cConf.getBoolean(Constants.Dangerous.UNRECOVERABLE_RESET, Constants.Dangerous.DEFAULT_UNRECOVERABLE_RESET)) {
       responder.sendStatus(HttpResponseStatus.FORBIDDEN);
       return;
@@ -185,9 +181,6 @@ public class NamespaceHttpHandler extends AbstractAppFabricHttpHandler {
     }
   }
 
-  /**
-   * DO NOT DOCUMENT THIS API
-   */
   @DELETE
   @Path("/unrecoverable/namespaces/{namespace-id}/datasets")
   public void deleteDatasets(HttpRequest request, HttpResponder responder,

--- a/cdap-docs/developers-manual/source/building-blocks/namespaces.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/namespaces.rst
@@ -4,9 +4,9 @@
 
 .. _namespaces:
 
-============================================
+==========
 Namespaces
-============================================
+==========
 
 Overview
 ========
@@ -64,7 +64,7 @@ the entity ID, since an entity cannot exist independently of a namespace.
 
 
 Using Namespaces
-==============================
+================
 The best practices with using namespaces would be to create desired namespaces and use
 them for all operations. Otherwise, CDAP will use the ``default`` namespace for any operations
 undertaken.
@@ -83,6 +83,15 @@ present, and is recommended for:
 It is the namespace used when no other namespace is specified. However, for most usecases
 beyond the proof-of-concept stage, we recommend that you create appropriate namespaces and
 operate CDAP within them.
+
+Namespaces can be deleted. When a namespace is deleted, all components (applications,
+streams, flows, datasets, MapReduce programs, metrics, etc.) are first deleted, and then
+the namespace itself is removed. In the case of the ``default`` namespace, the name is
+retained, as the ``default`` namespace is always available in CDAP. 
+
+As this is an unrecoverable operation, extreme caution must be used when deleting
+namespaces. It can only be done if all programs of the namespace have been stopped, and if
+the ``cdap-site.xml`` parameter ``enable.unrecoverable.reset`` has been enabled.
 
 
 .. rubric::  Examples of Using Namespaces

--- a/cdap-docs/reference-manual/source/http-restful-api/dataset.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/dataset.rst
@@ -1,13 +1,13 @@
 .. meta::
     :author: Cask Data, Inc.
     :description: HTTP RESTful Interface to the Cask Data Application Platform
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 .. _http-restful-api-dataset:
 
-===========================================================
+========================
 Dataset HTTP RESTful API
-===========================================================
+========================
 
 .. highlight:: console
 
@@ -206,14 +206,15 @@ You can delete a Dataset by issuing an HTTP DELETE request to the URL::
    * - Description
      - Deletes the Dataset *mydataset* in the namespace *default*
 
+.. _http-restful-api-dataset-deleting-all:
 
 Deleting all Datasets
 ---------------------
 
-If the property ``enable.unrecoverable.reset`` in ``cdap-site.xml`` is set to ``true``, you can delete all Datasets
-by issuing an HTTP DELETE request to the URL::
+If the property ``enable.unrecoverable.reset`` in ``cdap-site.xml`` is set to ``true``, 
+you can delete all Datasets (in a namespace) by issuing an HTTP DELETE request to the URL::
 
-  DELETE <base-url>/namespaces/<namespace>/unrecoverable/data/datasets
+  DELETE <base-url>/unrecoverable/namespaces/<namespace>/datasets
 
 .. list-table::
    :widths: 20 80
@@ -233,12 +234,19 @@ by issuing an HTTP DELETE request to the URL::
      - Description
    * - ``200 OK``
      - All Datasets were successfully deleted
+   * - ``403 Forbidden``
+     - Property to enable unrecoverable methods is not enabled
+   * - ``409 Conflict``
+     - Programs are currently running in the namespace
 
+This command will only work if all programs in the namespace are not running.
 
 If the property ``enable.unrecoverable.reset`` in ``cdap-site.xml`` is not set to
 ``true``, this operation will return a Status Code ``403 Forbidden``. Note that this
 operation can only be performed if all programs are stopped. If there's at least one
-program that is running, this operation will return a Status Code ``400 Bad Request``.
+program that is running, this operation will return a Status Code ``409 Conflict``.
+
+This method must be exercised with extreme caution, as there is no recovery from it.
 
 Truncating a Dataset
 --------------------

--- a/cdap-docs/reference-manual/source/http-restful-api/namespace.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/namespace.rst
@@ -6,9 +6,9 @@
 .. _http-restful-api-namespace:
 .. _http-restful-api-v3-namespace:
 
-===========================================================
+==========================
 Namespace HTTP RESTful API
-===========================================================
+==========================
 
 .. highlight:: console
 
@@ -22,6 +22,7 @@ by the ``<base-url>``, as descibed under :ref:`Conventions <http-restful-api-con
 
 Create a Namespace
 ------------------
+
 To create a namespace, submit an HTTP PUT request::
 
   PUT <base-url>/namespaces/<namespace>
@@ -116,6 +117,7 @@ response, such as::
 
 Editing a Namespace
 -------------------
+
 To edit an existing namespace, submit an HTTP PUT request to::
 
   PUT <base-url>/namespaces/<namespace>/properties
@@ -178,4 +180,35 @@ for when you `Create a Namespace`_.
    * - Description
      - Set the *description* property of the Namespace named *dev*,
        and set the *scheduler.queue.name* to *A*. 
-    
+
+.. _http-restful-api-namespace-deleting:
+
+Deleting a Namespace
+--------------------
+
+To delete an existing namespace (including all applications, streams, flows, datasets, metrics,
+and other components), submit an HTTP DELETE request to::
+
+  DELETE <base-url>/unrecoverable/namespaces/<namespace>
+
+.. list-table::
+   :widths: 20 80
+   :header-rows: 1
+
+   * - Parameter
+     - Description
+   * - ``<namespace>``
+     - Namespace
+
+To prevent accidental use of this method, it will only work if the ``cdap-site.xml`` parameter
+``enable.unrecoverable.reset`` has been enabled.
+This method must be exercised with extreme caution, as there is no recovery from it.
+
+Both the CDAP CLI and the CDAP UI expose this function; they also require the parameter to be 
+enabled in order for their functions to work.
+
+In the case of the ``default`` namespace, after everything has been deleted, the ``default`` 
+namespace is retained, as it is always available in CDAP.
+
+To delete only the datasets of a namespace, there is a 
+:ref:`specific dataset endpoint <http-restful-api-dataset-deleting-all>` for that.


### PR DESCRIPTION
Staged at:
-[Deleting a Namespace](http://docs-staging.cask.co/cdap/3.0.1-feature-r3.0.1_delete_namespaces/en/reference-manual/http-restful-api/namespace.html#deleting-a-namespace)
-[Deleting all Datasets](http://docs-staging.cask.co/cdap/3.0.1-feature-r3.0.1_delete_namespaces/en/reference-manual/http-restful-api/dataset.html#deleting-all-datasets)
-[Namespaces: Using Namespaces](http://docs-staging.cask.co/cdap/3.0.1-feature-r3.0.1_delete_namespaces/en/developers-manual/building-blocks/namespaces.html#using-namespaces)