### PR TITLE
[CDAP-2750] Ported JDBC driver cleanup fixes to DBSink

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/sink/DBSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/sink/DBSink.java
@@ -177,6 +177,7 @@ public class DBSink extends BatchSink<StructuredRecord, DBRecord, NullWritable> 
                 dbSinkConfig.jdbcPluginType, dbSinkConfig.jdbcPluginName, driverClass.getName(),
                 JDBCDriverShim.class.getName());
       driverShim = new JDBCDriverShim(driverClass.newInstance());
+      DBUtils.deregisterAllDrivers(driverClass);
       DriverManager.registerDriver(driverShim);
     }
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/sink/DBSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/sink/DBSink.java
@@ -68,6 +68,7 @@ public class DBSink extends BatchSink<StructuredRecord, DBRecord, NullWritable> 
   private final DBSinkConfig dbSinkConfig;
   private ResultSetMetaData resultSetMetadata;
   private Class<? extends Driver> driverClass;
+  private JDBCDriverShim driverShim;
 
   public DBSink(DBSinkConfig dbSinkConfig) {
     this.dbSinkConfig = dbSinkConfig;
@@ -121,8 +122,8 @@ public class DBSink extends BatchSink<StructuredRecord, DBRecord, NullWritable> 
   @Override
   public void initialize(BatchSinkContext context) throws Exception {
     super.initialize(context);
-    setResultSetMetadata(context);
     driverClass = context.loadPluginClass(getJDBCPluginId());
+    setResultSetMetadata();
   }
 
   @Override
@@ -132,11 +133,17 @@ public class DBSink extends BatchSink<StructuredRecord, DBRecord, NullWritable> 
 
   @Override
   public void destroy() {
+    try {
+      DriverManager.deregisterDriver(driverShim);
+    } catch (SQLException e) {
+      LOG.warn("Error while deregistering JDBC drivers in ETLDBOutputFormat.", e);
+      throw Throwables.propagate(e);
+    }
     DBUtils.cleanup(driverClass);
   }
 
-  private void setResultSetMetadata(BatchSinkContext context) throws Exception {
-    ensureJDBCDriverIsAvailable(context);
+  private void setResultSetMetadata() throws Exception {
+    ensureJDBCDriverIsAvailable();
     Connection connection;
     if (dbSinkConfig.user == null) {
       connection = DriverManager.getConnection(dbSinkConfig.connectionString);
@@ -161,18 +168,16 @@ public class DBSink extends BatchSink<StructuredRecord, DBRecord, NullWritable> 
    *
    * @throws Exception if the driver is not available
    */
-  private void ensureJDBCDriverIsAvailable(BatchSinkContext context) throws Exception {
+  private void ensureJDBCDriverIsAvailable() throws Exception {
     try {
       DriverManager.getDriver(dbSinkConfig.connectionString);
     } catch (SQLException e) {
-      // Load the plugin class to make sure it is available.
-      Class<?> driverClass = context.loadPluginClass(getJDBCPluginId());
-
       // Driver not found. We will try to register it with the DriverManager.
       LOG.debug("Plugin Type: {} and Plugin Name: {}; Driver Class: {} not found. Registering JDBC driver via shim {} ",
                 dbSinkConfig.jdbcPluginType, dbSinkConfig.jdbcPluginName, driverClass.getName(),
                 JDBCDriverShim.class.getName());
-      DriverManager.registerDriver(new JDBCDriverShim((Driver) driverClass.newInstance()));
+      driverShim = new JDBCDriverShim(driverClass.newInstance());
+      DriverManager.registerDriver(driverShim);
     }
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/source/DBSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/source/DBSource.java
@@ -117,7 +117,6 @@ public class DBSource extends BatchSource<LongWritable, DBRecord, StructuredReco
 
   @Override
   public void destroy() {
-    ETLDBInputFormat.deregisterDrivers();
     DBUtils.cleanup(driverClass);
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/common/DBUtils.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/common/DBUtils.java
@@ -45,7 +45,7 @@ public final class DBUtils {
   /**
    * De-register all SQL drivers that are associated with the class
    */
-  public static void deRegisterDriver(Class<? extends Driver> driverClass)
+  public static void deregisterAllDrivers(Class<? extends Driver> driverClass)
     throws NoSuchFieldException, IllegalAccessException, ClassNotFoundException {
     Field field = DriverManager.class.getDeclaredField("registeredDrivers");
     field.setAccessible(true);
@@ -55,12 +55,18 @@ public final class DBUtils {
       Field driverField = driverInfoClass.getDeclaredField("driver");
       driverField.setAccessible(true);
       Driver d = (Driver) driverField.get(driverInfo);
+      if (d == null) {
+        LOG.debug("Found null driver object in drivers list. Ignoring.");
+        continue;
+      }
+      LOG.debug("Removing non-null driver object from drivers list.");
       ClassLoader registeredDriverClassLoader = d.getClass().getClassLoader();
       if (registeredDriverClassLoader == null) {
         LOG.debug("Found null classloader for default driver {}. Ignoring since this may be using system classloader.",
                   d.getClass().getName());
         continue;
       }
+      // Remove all objects in this list that were created using the classloader of the caller.
       if (d.getClass().getClassLoader().equals(driverClass.getClassLoader())) {
         LOG.debug("Removing default driver {} from registeredDrivers", d.getClass().getName());
         list.remove(driverInfo);

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/common/DBUtils.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/common/DBUtils.java
@@ -46,7 +46,7 @@ public final class DBUtils {
    * De-register all SQL drivers that are associated with the class
    */
   public static void deRegisterDriver(Class<? extends Driver> driverClass)
-                     throws NoSuchFieldException, IllegalAccessException, ClassNotFoundException {
+    throws NoSuchFieldException, IllegalAccessException, ClassNotFoundException {
     Field field = DriverManager.class.getDeclaredField("registeredDrivers");
     field.setAccessible(true);
     List<?> list = (List<?>) field.get(null);
@@ -55,7 +55,13 @@ public final class DBUtils {
       Field driverField = driverInfoClass.getDeclaredField("driver");
       driverField.setAccessible(true);
       Driver d = (Driver) driverField.get(driverInfo);
-      if (d.getClass().equals(driverClass)) {
+      ClassLoader registeredDriverClassLoader = d.getClass().getClassLoader();
+      if (registeredDriverClassLoader == null) {
+        LOG.debug("Found null classloader for default driver {}. Ignoring since this may be using system classloader.",
+                  d.getClass().getName());
+        continue;
+      }
+      if (d.getClass().getClassLoader().equals(driverClass.getClassLoader())) {
         LOG.debug("Removing default driver {} from registeredDrivers", d.getClass().getName());
         list.remove(driverInfo);
       }

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/common/ETLDBInputFormat.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/common/ETLDBInputFormat.java
@@ -59,7 +59,7 @@ public class ETLDBInputFormat extends DBInputFormat {
               driver = driverClass.newInstance();
 
               // De-register the default driver that gets registered when driver class is loaded.
-              DBUtils.deRegisterDriver(driverClass);
+              DBUtils.deregisterAllDrivers(driverClass);
             }
             driverShim = new JDBCDriverShim(driver);
             DriverManager.registerDriver(driverShim);

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/common/ETLDBInputFormat.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/common/ETLDBInputFormat.java
@@ -18,24 +18,27 @@ package co.cask.cdap.template.etl.common;
 
 import com.google.common.base.Throwables;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.lib.db.DBConfiguration;
 import org.apache.hadoop.mapreduce.lib.db.DBInputFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.DriverManager;
 import java.sql.SQLException;
-import javax.annotation.Nullable;
 
 /**
  * Class that extends {@link DBInputFormat} to load the database driver class correctly.
  */
 public class ETLDBInputFormat extends DBInputFormat {
   private static final Logger LOG = LoggerFactory.getLogger(ETLDBInputFormat.class);
-  private static Driver driver;
-  private static JDBCDriverShim driverShim;
+  private Driver driver;
+  private JDBCDriverShim driverShim;
 
   @Override
   public Connection getConnection() {
@@ -47,20 +50,20 @@ public class ETLDBInputFormat extends DBInputFormat {
           // throws SQLException if no suitable driver is found
           DriverManager.getDriver(url);
         } catch (SQLException e) {
-          if (driver == null) {
-            ClassLoader classLoader = conf.getClassLoader();
-            Class<? extends Driver> driverClass =
-              (Class<? extends Driver>) classLoader.loadClass(conf.get(DBConfiguration.DRIVER_CLASS_PROPERTY));
-            driver = driverClass.newInstance();
+          if (driverShim == null) {
+            if (driver == null) {
+              ClassLoader classLoader = conf.getClassLoader();
+              @SuppressWarnings("unchecked")
+              Class<? extends Driver> driverClass =
+                (Class<? extends Driver>) classLoader.loadClass(conf.get(DBConfiguration.DRIVER_CLASS_PROPERTY));
+              driver = driverClass.newInstance();
 
-            // De-register the default driver that gets registered when driver class is loaded.
-            DBUtils.deRegisterDriver(driverClass);
-
+              // De-register the default driver that gets registered when driver class is loaded.
+              DBUtils.deRegisterDriver(driverClass);
+            }
             driverShim = new JDBCDriverShim(driver);
             DriverManager.registerDriver(driverShim);
-            LOG.info("Registered JDBC driver via shim {}, hashcode  {}, class {}", driverShim, driverShim.hashCode(),
-                     driverShim.getClass().getName());
-            LOG.info("Actual driver {} {} {}", driver, driver.hashCode(), driver.getClass().getName());
+            LOG.debug("Registered JDBC driver via shim {}. Actual Driver {}.", driverShim, driver);
           }
         }
         if (conf.get(DBConfiguration.USERNAME_PROPERTY) == null) {
@@ -79,19 +82,53 @@ public class ETLDBInputFormat extends DBInputFormat {
     return this.connection;
   }
 
-  public static void deregisterDrivers() {
-    deregisterDriver(driverShim);
+  @Override
+  protected RecordReader createDBRecordReader(DBInputSplit split, Configuration conf) throws IOException {
+    final RecordReader dbRecordReader = super.createDBRecordReader(split, conf);
+    return new RecordReader() {
+      @Override
+      public void initialize(InputSplit split, TaskAttemptContext context) throws IOException, InterruptedException {
+        dbRecordReader.initialize(split, context);
+      }
+
+      @Override
+      public boolean nextKeyValue() throws IOException, InterruptedException {
+        return dbRecordReader.nextKeyValue();
+      }
+
+      @Override
+      public Object getCurrentKey() throws IOException, InterruptedException {
+        return dbRecordReader.getCurrentKey();
+      }
+
+      @Override
+      public Object getCurrentValue() throws IOException, InterruptedException {
+        return dbRecordReader.getCurrentValue();
+      }
+
+      @Override
+      public float getProgress() throws IOException, InterruptedException {
+        return dbRecordReader.getProgress();
+      }
+
+      @Override
+      public void close() throws IOException {
+        dbRecordReader.close();
+        try {
+          DriverManager.deregisterDriver(driverShim);
+        } catch (SQLException e) {
+          throw new IOException(e);
+        }
+      }
+    };
   }
 
-  private static void deregisterDriver(@Nullable Driver driver) {
-    if (driver == null) {
-      return;
-    }
+  @Override
+  protected void closeConnection() {
+    super.closeConnection();
     try {
-      DriverManager.deregisterDriver(driver);
-      LOG.debug("Successfully deregistered driver {} {} {}", driver, driver.hashCode(), driver.getClass().getName());
-    } catch (Throwable e) {
-      LOG.warn("Error while deregistering driver {}", driver.getClass().getName(), e);
+      DriverManager.deregisterDriver(driverShim);
+    } catch (SQLException e) {
       throw Throwables.propagate(e);
     }
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/common/ETLDBOutputFormat.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/common/ETLDBOutputFormat.java
@@ -93,7 +93,7 @@ public class ETLDBOutputFormat<K extends DBWritable, V>  extends DBOutputFormat<
             driver = driverClass.newInstance();
 
             // De-register the default driver that gets registered when driver class is loaded.
-            DBUtils.deRegisterDriver(driverClass);
+            DBUtils.deregisterAllDrivers(driverClass);
           }
 
           driverShim = new JDBCDriverShim(driver);

--- a/cdap-common/src/main/java/co/cask/cdap/common/io/URLConnections.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/io/URLConnections.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.io;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URLConnection;
+
+/**
+ * Utility class for {@link URLConnection}.
+ */
+public class URLConnections {
+  private static final Logger LOG = LoggerFactory.getLogger(URLConnections.class);
+
+  /**
+   * Utility method to set {@link URLConnection#setDefaultUseCaches(boolean)}.
+   */
+  public static void setDefaultUseCaches(boolean useCaches) throws IOException {
+    LOG.info("Turning off default caching in URLConnection");
+    final String currentDir = System.getProperty("user.dir");
+    new File(currentDir).toURI().toURL().openConnection().setDefaultUseCaches(useCaches);
+  }
+}

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
@@ -30,6 +30,7 @@ import co.cask.cdap.common.guice.KafkaClientModule;
 import co.cask.cdap.common.guice.LocationRuntimeModule;
 import co.cask.cdap.common.guice.TwillModule;
 import co.cask.cdap.common.guice.ZKClientModule;
+import co.cask.cdap.common.io.URLConnections;
 import co.cask.cdap.common.kerberos.SecurityUtil;
 import co.cask.cdap.common.runtime.DaemonMain;
 import co.cask.cdap.common.service.RetryOnStartFailureService;
@@ -166,6 +167,13 @@ public class MasterServiceMain extends DaemonMain {
 
   @Override
   public void start() {
+    try {
+      // Workaround for release of file descriptors opened by URLClassLoader - https://issues.cask.co/browse/CDAP-2841
+      URLConnections.setDefaultUseCaches(false);
+    } catch (IOException e) {
+      LOG.error("Could not disable caching of URLJarFiles. This may lead to 'too many open files` exception.", e);
+    }
+
     createSystemHBaseNamespace();
     updateConfigurationTable();
 

--- a/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
+++ b/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
@@ -27,6 +27,7 @@ import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
 import co.cask.cdap.common.guice.IOModule;
 import co.cask.cdap.common.guice.LocationRuntimeModule;
+import co.cask.cdap.common.io.URLConnections;
 import co.cask.cdap.common.utils.DirUtils;
 import co.cask.cdap.common.utils.OSDetector;
 import co.cask.cdap.data.runtime.DataFabricModules;
@@ -150,6 +151,9 @@ public class StandaloneMain {
    * Start the service.
    */
   public void startUp() throws Exception {
+    // Workaround for release of file descriptors opened by URLClassLoader - https://issues.cask.co/browse/CDAP-2841
+    URLConnections.setDefaultUseCaches(false);
+
     cleanupTempDir();
 
     // Start all the services.


### PR DESCRIPTION
- [x] Ported the JDBC driver fixes from #2966 to ``DBSink``. 
- [x] Fixed some exception handling.
- [x] Made the code less static so concurrent adapter runs function much better.

Build: http://builds.cask.co/browse/CDAP-RT39
Jira: [CDAP-2750](https://issues.cask.co/browse/CDAP-2750)

Currently running a test with SDK on Ubuntu.