### PR TITLE
Fix broken documentation build

### DIFF
--- a/cdap-docs/examples-manual/build.sh
+++ b/cdap-docs/examples-manual/build.sh
@@ -148,8 +148,8 @@ function download_includes() {
   test_an_include 97e355542831d767a297b52ff09f5674 ../../cdap-examples/SparkPageRank/src/main/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankApp.java
 
   test_an_include afe12d26b79607a846d3eaa58958ea5f ../../cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/SportResults.java
-  test_an_include bbeed2893195fa12553e4eb28016306a ../../cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/UploadService.java
-  test_an_include 1089a092c1f0af1ecfedae646c9c6b99 ../../cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/ScoreCounter.java
+  test_an_include 2d85727db18c3261b60d4cb278846329 ../../cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/UploadService.java
+  test_an_include 1415af829b57768a159653c55c83ca09 ../../cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/ScoreCounter.java
   
   test_an_include 2176f426a50b2d68817cd7da7b7faffb ../../cdap-examples/StreamConversion/src/main/java/co/cask/cdap/examples/streamconversion/StreamConversionApp.java
   test_an_include 8db18c84a0ee405d85014ebbcf2d383e ../../cdap-examples/StreamConversion/src/main/java/co/cask/cdap/examples/streamconversion/StreamConversionMapReduce.java

--- a/cdap-docs/examples-manual/source/examples/sport-results.rst
+++ b/cdap-docs/examples-manual/source/examples/sport-results.rst
@@ -99,7 +99,7 @@ the ``totals`` PartitionedFileSet. The ``beforeSubmit()`` method prepares the Ma
 
 .. literalinclude:: /../../../cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/ScoreCounter.java
     :language: java
-    :lines: 58-84
+    :lines: 57-83
     :dedent: 2
 
 It is worth mentioning that nothing else in ``ScoreCounter`` is specifically programmed to use file partitions.


### PR DESCRIPTION
Update MD5 hashes and update include of a file.

Documentation build was broken as of [build #205](https://builds.cask.co/browse/CDAP-DDBD-205/).

Clean Built at: 

- [CDAP Docs](http://docs-staging.cask.co/cdap/3.1.0-SNAPSHOT-feature-3.1_fix_examples_manual/en/index.html)
- [Log](http://builds.cask.co/browse/CDAP-DDBD385-1/log)