### PR TITLE
Table#get is guaranteed not to return null.

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetDataset.java
@@ -136,7 +136,7 @@ public class PartitionedFileSetDataset extends AbstractDataset implements Partit
   protected void addPartition(PartitionKey key, String path, boolean explorable, Map<String, String> metadata) {
     byte[] rowKey = generateRowKey(key, partitioning);
     Row row = partitionsTable.get(rowKey);
-    if (row != null && !row.isEmpty()) {
+    if (!row.isEmpty()) {
       if (key.equals(partitionsAddedInSameTx.get(path))) {
         LOG.warn("Dataset {} already added a partition with key {} in this transaction. " +
                    "Partitions no longer need to be added in the onFinish() of MapReduce. Please check your app. ",

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetDataset.java
@@ -222,7 +222,7 @@ public class TimePartitionedFileSetDataset extends PartitionedFileSetDataset imp
   public void addLegacyPartition(long time, String path) {
     final byte[] rowKey = Bytes.toBytes(time);
     Row row = partitionsTable.get(rowKey);
-    if (row != null && !row.isEmpty()) {
+    if (!row.isEmpty()) {
       throw new DataSetException(String.format("Dataset '%s' already has a partition with time: %d.",
                                                getName(), time));
     }
@@ -241,7 +241,7 @@ public class TimePartitionedFileSetDataset extends PartitionedFileSetDataset imp
     }
     final byte[] rowKey = Bytes.toBytes(time);
     Row row = partitionsTable.get(rowKey);
-    if (row == null) {
+    if (row.isEmpty()) {
       return null;
     }
     byte[] pathBytes = row.get(RELATIVE_PATH);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/MetadataStoreDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/MetadataStoreDataset.java
@@ -63,7 +63,7 @@ public class MetadataStoreDataset extends AbstractDataset {
   @Nullable
   public <T> T get(MDSKey id, Type typeOfT) {
     Row row = table.get(id.getKey());
-    if (row == null || row.isEmpty()) {
+    if (row.isEmpty()) {
       return null;
     }
 


### PR DESCRIPTION
The javadoc on the `Row get(byte[] row)` method of `Table` class says that it never returns `null`.
I have checked the two implementations of this method to verify that, and then make use of this fact to update the calls to the method.

http://builds.cask.co/browse/CDAP-DUT2082-2 (GREEN)