### PR TITLE
Port Improved Search Results to Release 3.0.1

### DIFF
--- a/cdap-docs/_common/_themes/cdap/search.html
+++ b/cdap-docs/_common/_themes/cdap/search.html
@@ -11,6 +11,8 @@
 {% set title = _('Search') %}
 {% set script_files = script_files + ['_static/searchtools.js'] %}
 {% block extrahead %}
+{# Hide extra navigation on search result page #}
+  <link rel="stylesheet" href="{{ pathto('_static/hide-nav.css', 1) }}" type="text/css" />
   <script type="text/javascript">
     jQuery(function() { Search.loadIndex("{{ pathto('searchindex.js', 1) }}"); });
   </script>

--- a/cdap-docs/_common/_themes/cdap/static/searchtools.js_t
+++ b/cdap-docs/_common/_themes/cdap/static/searchtools.js_t
@@ -10,9 +10,16 @@
  */
  
 var manuals = {
-{% for manual in theme_manuals -%}
-    "{{ manual }}":"{{ theme_manual_titles[loop.index0] }}",
-{%- endfor %} };
+  {% for manual in theme_manuals -%}
+      "{{ manual }}":"{{ theme_manual_titles[loop.index0] }}"{% if not loop.last -%},{%- endif %}
+  {%- endfor %} 
+};
+
+var manualsArray = new Array(
+  {% for manual in theme_manuals -%}
+      "{{ manual }}"{% if not loop.last -%},{%- endif %}
+  {%- endfor %} 
+);
 
 {{ search_language_stemming_code|safe }}
 
@@ -207,21 +214,41 @@ var Search = {
         results[i][4] = Scorer.score(results[i]);
     }
 
-    // now sort the results by score (in opposite order of appearance, since the
-    // display function below uses pop() to retrieve items) and then
-    // alphabetically
+    // Sort the results first by the manual, then by score, then alphabetical
+    // In opposite order of appearance, since the
+    // display function below uses pop() to retrieve items
+    
     results.sort(function(a, b) {
-      var left = a[4];
-      var right = b[4];
-      if (left > right) {
-        return 1;
-      } else if (left < right) {
+
+      function manualID(item){
+        var manual = (item[0].split('/'));
+        if (manual.length == 0) {
+          return -1;
+        } else {
+          return $.inArray( manual[0], manualsArray );
+        }
+      }
+      var manual_left = manualID(a);
+      var manual_right = manualID(b);
+      
+      if (manual_left > manual_right) {
         return -1;
+      } else if (manual_left < manual_right) {
+        return 1;
       } else {
-        // same score: sort alphabetically
-        left = a[1].toLowerCase();
-        right = b[1].toLowerCase();
-        return (left > right) ? -1 : ((left < right) ? 1 : 0);
+        // same manual; sort by score
+        var left = a[4];
+        var right = b[4];
+        if (left > right) {
+          return 1;
+        } else if (left < right) {
+          return -1;
+        } else {
+          // same score: sort alphabetically
+          left = a[1].toLowerCase();
+          right = b[1].toLowerCase();
+          return (left > right) ? -1 : ((left < right) ? 1 : 0);
+        }
       }
     });
 
@@ -230,6 +257,7 @@ var Search = {
     //console.info('search results:', Search.lastresults);
 
     // print the results
+    var currentManual = "";
     var resultCount = results.length;
     function displayNextItem() {
       // results left, load the summary and display it
@@ -249,12 +277,20 @@ var Search = {
             highlightstring + item[2]).html(item[1]));
         } else {
           // normal html builders
+          // Print Manual title if a new manual
+          var manual = (item[0].split('/')); //.split('-');
+          if ( manual.length > 1) {
+            manual = manual[0];
+          } else {
+            manual = "";
+          }
+          if ( manual != currentManual ) {
+            Search.output.append("<p></p><b>" + manuals[manual] + "</b>");
+            currentManual = manual;
+          }
           listItem.append($('<a/>').attr('href',
             item[0] + DOCUMENTATION_OPTIONS.FILE_SUFFIX +
             highlightstring + item[2]).html(item[1]));
-          var manual = (item[0].split('/')); //.split('-');
-          if ( manual.length > 1)
-            listItem.append(" <i>" + manuals[manual[0]] + "</i>");
         }
         if (item[3]) {
           listItem.append($('<span> (' + item[3] + ')</span>'));
@@ -290,10 +326,10 @@ var Search = {
         if (!resultCount)
           Search.status.text(_('Your search did not match any documents. Please make sure that all words are spelled correctly and that you\'ve selected enough categories.'));
         else
-          if (resultCount==1)
-            Search.status.text(_('Search finished, found one page matching the search query:'));
+          if (resultCount == 1)
+            Search.status.text(_('Search finished; found one page matching the search query:'));
           else
-            Search.status.text(_('Search finished, found %s pages matching the search query:').replace('%s', resultCount));
+            Search.status.text(_('Search finished; found %s pages matching the search query, organized by manual, then sorted by score:').replace('%s', resultCount));
         Search.status.fadeIn(500);
       }
     }

--- a/cdap-docs/_common/common_conf.py
+++ b/cdap-docs/_common/common_conf.py
@@ -106,8 +106,8 @@ extensions = [
 
 intersphinx_mapping = {
   'introduction': ('../../introduction/',         os.path.abspath('../../introduction/build/html/objects.inv')),
-  'apptemplates': ('../../application-templates', os.path.abspath('../../application-templates/build/html/objects.inv')),
   'developers':   ('../../developers-manual/',    os.path.abspath('../../developers-manual/build/html/objects.inv')),
+  'apptemplates': ('../../application-templates', os.path.abspath('../../application-templates/build/html/objects.inv')),
   'admin':        ('../../admin-manual/',         os.path.abspath('../../admin-manual/build/html/objects.inv')),
   'integrations': ('../../integrations/',         os.path.abspath('../../integrations/build/html/objects.inv')),
   'examples':     ('../../examples-manual',       os.path.abspath('../../examples-manual/build/html/objects.inv')),


### PR DESCRIPTION
Brings (most) of https://github.com/caskdata/cdap/pull/2728 to Release 3.0.1. (It leaves the "New" icon on Application Templates.)

It brings the re-organized search results (divided into groups based on the manual, and then scored within the group) in the documentation to the next Release.

Staged at: [Search page](http://docs-staging.cask.co/cdap/3.0.1-feature-r3.0.1_fix_search_results/en/search.html)
[Example Search of "Hadoop"](http://docs-staging.cask.co/cdap/3.0.1-feature-r3.0.1_fix_search_results/en/search.html?q=Hadoop)