### PR TITLE
CDAP-2665 adding an ArtifactStore that can be used to persist

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -59,6 +59,7 @@ import co.cask.cdap.internal.app.namespace.DefaultNamespaceAdmin;
 import co.cask.cdap.internal.app.namespace.NamespaceAdmin;
 import co.cask.cdap.internal.app.runtime.adapter.AdapterService;
 import co.cask.cdap.internal.app.runtime.adapter.PluginRepository;
+import co.cask.cdap.internal.app.runtime.artifact.ArtifactStore;
 import co.cask.cdap.internal.app.runtime.batch.InMemoryTransactionServiceManager;
 import co.cask.cdap.internal.app.runtime.distributed.TransactionServiceManager;
 import co.cask.cdap.internal.app.runtime.schedule.DistributedSchedulerService;
@@ -294,6 +295,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
       );
 
       bind(Store.class).to(DefaultStore.class);
+      bind(ArtifactStore.class).in(Scopes.SINGLETON);
       bind(AdapterService.class).in(Scopes.SINGLETON);
       bind(ProgramLifecycleService.class).in(Scopes.SINGLETON);
       bind(PluginRepository.class).in(Scopes.SINGLETON);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactAlreadyExistsException.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactAlreadyExistsException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.artifact;
+
+import co.cask.cdap.common.exception.ConflictException;
+import co.cask.cdap.proto.Id;
+
+/**
+ * Thrown when an artifact already exists.
+ */
+public class ArtifactAlreadyExistsException extends ConflictException {
+
+  public ArtifactAlreadyExistsException(Id.Artifact artifactId) {
+    super(String.format("Archive %s already exists.", artifactId));
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactInfo.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactInfo.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.artifact;
+
+import co.cask.cdap.proto.Id;
+import org.apache.twill.filesystem.Location;
+
+/**
+ * Information about an artifact.
+ */
+public class ArtifactInfo {
+  private final Id.Artifact id;
+  private final Location location;
+  private final ArtifactMeta meta;
+
+  public ArtifactInfo(Id.Artifact id, Location location, ArtifactMeta meta) {
+    this.id = id;
+    this.location = location;
+    this.meta = meta;
+  }
+
+  public Id.Artifact getId() {
+    return id;
+  }
+
+  public Location getLocation() {
+    return location;
+  }
+
+  public ArtifactMeta getMeta() {
+    return meta;
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactMeta.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactMeta.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.internal.app.runtime.artifact;
 
 import co.cask.cdap.api.templates.plugins.PluginClass;
+import com.google.common.collect.ImmutableList;
 
 import java.util.List;
 import java.util.Objects;
@@ -28,7 +29,7 @@ public class ArtifactMeta {
   private final List<PluginClass> plugins;
 
   public ArtifactMeta(List<PluginClass> plugins) {
-    this.plugins = plugins;
+    this.plugins = ImmutableList.copyOf(plugins);
   }
 
   public List<PluginClass> getPlugins() {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactMeta.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactMeta.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.artifact;
+
+import co.cask.cdap.api.templates.plugins.PluginClass;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Metadata about an artifact, such as what plugins are contained in the artifact.
+ */
+public class ArtifactMeta {
+  private final List<PluginClass> plugins;
+
+  public ArtifactMeta(List<PluginClass> plugins) {
+    this.plugins = plugins;
+  }
+
+  public List<PluginClass> getPlugins() {
+    return plugins;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    ArtifactMeta that = (ArtifactMeta) o;
+
+    return Objects.equals(plugins, that.plugins);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(plugins);
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactNotExistsException.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactNotExistsException.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.artifact;
+
+import co.cask.cdap.common.exception.NotFoundException;
+import co.cask.cdap.proto.Id;
+
+/**
+ * Thrown when an artifact does not exist.
+ */
+public class ArtifactNotExistsException extends NotFoundException {
+
+  public ArtifactNotExistsException(Id.Namespace namespace, String name) {
+    super("artifact", namespace.toString() + ":" + name);
+  }
+
+  public ArtifactNotExistsException(Id.Artifact artifactId) {
+    super("artifact", artifactId.toString());
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStore.java
@@ -1,0 +1,515 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.artifact;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.dataset.DatasetDefinition;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.table.Row;
+import co.cask.cdap.api.dataset.table.Scan;
+import co.cask.cdap.api.dataset.table.Scanner;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.api.templates.plugins.PluginClass;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.io.Locations;
+import co.cask.cdap.common.namespace.NamespacedLocationFactory;
+import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.dataset2.tx.DatasetContext;
+import co.cask.cdap.data2.dataset2.tx.Transactional;
+import co.cask.cdap.proto.Id;
+import co.cask.tephra.TransactionExecutor;
+import co.cask.tephra.TransactionExecutorFactory;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Supplier;
+import com.google.common.base.Throwables;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.io.ByteStreams;
+import com.google.gson.Gson;
+import com.google.inject.Inject;
+import org.apache.twill.filesystem.Location;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This class manages artifacts as well as metadata for each artifact. Artifacts and their metadata cannot be changed
+ * once they are written, with the exception of snapshot versions. An Artifact can contain
+ * plugin classes and/or application classes. We may want to extend this to include other types of classes, such
+ * as datasets.
+ *
+ * Every time an artifact is added, the artifact contents are stored at a location based on its id:
+ * /namespaces/{namespace-id}/artifacts/{artifact-name}/{artifact-version}
+ *
+ * Several writes are also performed on the meta table, one for metadata about the artifact itself, and one
+ * for each entity contained in the artifact.
+ *
+ * Artifact metadata is stored with r:{namespace}:{artifact-name} as the rowkey, {artifact-version} as the column,
+ * and ArtifactMeta as the value.
+ *
+ * PluginClass metadata is stored with p:{namespace}:{plugin-type}:{plugin-name} as the rowkey,
+ * {artifact-version}:{artifact-name} as the column, and PluginClass as the value
+ *
+ * TODO: (CDAP-2764) add this part when we have a better idea of what needs to be in AppClass.
+ * AppClass metadata is stored with a:{namespace}:{app-name} as the rowkey,
+ * {artifact-version}:{artifact-name} as the column, and AppClass as the value
+ */
+public class ArtifactStore {
+  private static final Logger LOG = LoggerFactory.getLogger(ArtifactStore.class);
+  private static final Gson GSON = new Gson();
+  private static final String ARTIFACTS_PATH = "artifacts";
+  private static final String ARTIFACT_PREFIX = "r:";
+  private static final String PLUGIN_PREFIX = "p:";
+  private static final Id.DatasetInstance META_ID =
+    Id.DatasetInstance.from(Constants.SYSTEM_NAMESPACE, "artifact.meta");
+
+  private final NamespacedLocationFactory locationFactory;
+  private final Transactional<DatasetContext<Table>, Table> metaTable;
+
+  @Inject
+  ArtifactStore(final DatasetFramework datasetFramework, NamespacedLocationFactory locationFactory,
+                TransactionExecutorFactory txExecutorFactory) {
+    this.locationFactory = locationFactory;
+    this.metaTable = Transactional.of(txExecutorFactory, new Supplier<DatasetContext<Table>>() {
+      @Override
+      public DatasetContext<Table> get() {
+        try {
+          return DatasetContext.of((Table) DatasetsUtil.getOrCreateDataset(
+            datasetFramework, META_ID, Table.class.getName(),
+            DatasetProperties.EMPTY, DatasetDefinition.NO_ARGUMENTS, null));
+        } catch (Exception e) {
+          // there's nothing much we can do here
+          throw Throwables.propagate(e);
+        }
+      }
+    });
+  }
+
+  /**
+   * Write the artifact and its metadata to the store. Once added, artifacts cannot be changed.
+   * TODO: add support for snapshot versions, which can be changed
+   *
+   * @param artifactId the id of the artifact to add
+   * @param artifactMeta the metadata for the artifact
+   * @param archiveContents the contents of the artifact
+   * @throws WriteConflictException if the artifact is already currently being written
+   * @throws ArtifactAlreadyExistsException if a non-snapshot version of the artifact already exists
+   * @throws IOException if there was an exception persisting the artifact contents to the filesystem,
+   *                     of persisting the artifact metadata to the metastore
+   */
+  public void write(Id.Artifact artifactId, ArtifactMeta artifactMeta, InputStream archiveContents)
+    throws WriteConflictException, ArtifactAlreadyExistsException, IOException {
+
+    ArtifactMeta meta = readMeta(artifactId);
+    if (meta != null) {
+      throw new ArtifactAlreadyExistsException(artifactId);
+    }
+
+    Location fileDirectory =
+      locationFactory.get(artifactId.getNamespace(), ARTIFACTS_PATH).append(artifactId.getName());
+    Locations.mkdirsIfNotExists(fileDirectory);
+    Location lock = fileDirectory.append(artifactId.getVersion() + ".lock");
+    if (!lock.createNew()) {
+      throw new WriteConflictException(artifactId);
+    }
+
+    Location file = fileDirectory.append(artifactId.getVersion());
+    if (file.exists()) {
+      // this really shouldn't happen often.
+      // it's possible if there was a previous attempt to add this file,
+      // the file was added, but the metadata was not successfully written and the file
+      // was the not able to get cleaned up after the failed metadata write.
+      // in either case, should be ok to just delete it.
+      file.delete();
+    }
+
+    // write the file contents
+    try {
+      ByteStreams.copy(archiveContents, file.getOutputStream());
+      try {
+        writeMeta(artifactId, artifactMeta);
+      } catch (Exception e) {
+        LOG.error("Exception while writing metadata for artifact " + artifactId, e);
+        // delete file to clean up after ourselves
+        file.delete();
+        throw new IOException(e);
+      }
+    } finally {
+      lock.delete();
+    }
+  }
+
+  /**
+   * Get information about all artifacts in the given namespace. If there are no artifacts in the namespace,
+   * this will return an empty list. Note that existence of the namespace is not checked.
+   *
+   * @param namespace the namespace to get artifact information about
+   * @return list of artifact info about every artifact in the given namespace
+   * @throws IOException if there was an exception reading the artifact information from the metastore
+   */
+  public List<ArtifactInfo> getArtifacts(final Id.Namespace namespace) throws IOException {
+    return metaTable.executeUnchecked(new TransactionExecutor.Function<DatasetContext<Table>, List<ArtifactInfo>>() {
+      @Override
+      public List<ArtifactInfo> apply(DatasetContext<Table> context) throws Exception {
+        List<ArtifactInfo> archives = Lists.newArrayList();
+        Scanner scanner = context.get().scan(scanArtifacts(namespace));
+        Row row;
+        while ((row = scanner.next()) != null) {
+          addArchivesToList(archives, row);
+        }
+        return archives;
+      }
+    });
+  }
+
+  /**
+   * Get information about all versions of the given artifact.
+   *
+   * @param namespace the namespace to get artifacts from
+   * @param artifactName the name of the artifact to get
+   * @return a list of information about all versions of the given artifact
+   * @throws ArtifactNotExistsException if no version of the given artifact exists
+   * @throws IOException if there was an exception reading the artifact information from the metastore
+   */
+  public List<ArtifactInfo> getArtifacts(final Id.Namespace namespace, final String artifactName)
+    throws ArtifactNotExistsException, IOException {
+
+    return metaTable.executeUnchecked(new TransactionExecutor.Function<DatasetContext<Table>, List<ArtifactInfo>>() {
+      @Override
+      public List<ArtifactInfo> apply(DatasetContext<Table> context) throws Exception {
+        List<ArtifactInfo> archives = Lists.newArrayList();
+
+        ArtifactKey artifactKey = new ArtifactKey(namespace, artifactName);
+        Row row = context.get().get(artifactKey.getRowKey());
+        if (row == null) {
+          throw new ArtifactNotExistsException(namespace, artifactName);
+        }
+        addArchivesToList(archives, row);
+        return archives;
+      }
+    });
+  }
+
+  /**
+   * Get information about the given artifact.
+   *
+   * @param artifactId the artifact to get
+   * @return information about the artifact
+   * @throws ArtifactNotExistsException if the given artifact does not exist
+   * @throws IOException if there was an exception reading the artifact information from the metastore
+   */
+  public ArtifactInfo getArtifact(Id.Artifact artifactId) throws ArtifactNotExistsException, IOException {
+    ArtifactMeta meta = readMeta(artifactId);
+    if (meta == null) {
+      throw new ArtifactNotExistsException(artifactId);
+    }
+    return new ArtifactInfo(artifactId, getLocation(artifactId), meta);
+  }
+
+  /**
+   * Get all plugin classes in a given namespace. Results are returned as a map from artifact to plugins
+   * in that artifact.
+   *
+   * @param namespace the namespace to look for plugins in
+   * @return a map of artifact id to plugin classes in the artifact for all plugin classes in the namespace.
+   *         The map will never be null. If there are no plugin classes, an empty map will be returned.
+   * @throws IOException if there was an exception reading metadata from the metastore
+   */
+  public Map<Id.Artifact, List<PluginClass>> getPluginClasses(final Id.Namespace namespace) throws IOException {
+    return metaTable.executeUnchecked(
+      new TransactionExecutor.Function<DatasetContext<Table>, Map<Id.Artifact, List<PluginClass>>>() {
+        @Override
+        public Map<Id.Artifact, List<PluginClass>> apply(DatasetContext<Table> context) throws Exception {
+          Map<Id.Artifact, List<PluginClass>> result = Maps.newHashMap();
+
+          Scanner scanner = context.get().scan(scanPlugins(namespace));
+          Row row;
+          while ((row = scanner.next()) != null) {
+            addPluginsToMap(result, row);
+          }
+          return result;
+        }
+      });
+  }
+
+  /**
+   * Get all plugin classes of a specific type in the given namespace.
+   * Results are returned as a map from artifact to plugins in that artifact.
+   *
+   * @param namespace the namespace to look for plugins in
+   * @param type the type of plugin to look for
+   * @return a map of artifact id to plugin classes in the artifact for all plugin classes in the namespace.
+   *         The map will never be null. If there are no plugin classes, an empty map will be returned.
+   * @throws IOException if there was an exception reading metadata from the metastore
+   */
+  public Map<Id.Artifact, List<PluginClass>> getPluginClasses(final Id.Namespace namespace,
+                                                              final String type) throws IOException {
+    return metaTable.executeUnchecked(
+      new TransactionExecutor.Function<DatasetContext<Table>, Map<Id.Artifact, List<PluginClass>>>() {
+        @Override
+        public Map<Id.Artifact, List<PluginClass>> apply(DatasetContext<Table> context) throws Exception {
+          Map<Id.Artifact, List<PluginClass>> result = Maps.newHashMap();
+
+          Scanner scanner = context.get().scan(scanPlugins(namespace, type));
+          Row row;
+          while ((row = scanner.next()) != null) {
+            addPluginsToMap(result, row);
+          }
+          return result;
+        }
+      });
+  }
+
+  /**
+   * Get all plugin classes of a specific type and name in the given namespace.
+   * Results are returned as a map from artifact to plugins in that artifact.
+   *
+   * @param namespace the namespace to look for plugins in
+   * @param type the type of plugin to look for
+   * @param name the name of the plugin to look for
+   * @return a map of artifact id to plugin classes in the artifact for all plugin classes in the namespace.
+   *         The map will never be null. If there are no plugin classes, an empty map will be returned.
+   * @throws IOException if there was an exception reading metadata from the metastore
+   */
+  public Map<Id.Artifact, List<PluginClass>> getPluginClasses(final Id.Namespace namespace, final String type,
+                                                              final String name) throws IOException {
+    return metaTable.executeUnchecked(
+      new TransactionExecutor.Function<DatasetContext<Table>, Map<Id.Artifact, List<PluginClass>>>() {
+        @Override
+        public Map<Id.Artifact, List<PluginClass>> apply(DatasetContext<Table> context) throws Exception {
+          Map<Id.Artifact, List<PluginClass>> result = Maps.newHashMap();
+
+          PluginKey pluginKey = new PluginKey(namespace, type, name);
+          Row row = context.get().get(pluginKey.getRowKey());
+          if (row != null) {
+            addPluginsToMap(result, row);
+          }
+          return result;
+        }
+      });
+  }
+
+  /**
+   * Clear all data in the given namespace. Not terribly efficient, can do more deletes than needed.
+   * This is purely for unit tests, so it's not a big concern.
+   *
+   * @param namespace the namespace to delete data in
+   * @throws IOException if there was some problem deleting the data
+   */
+  @VisibleForTesting
+  void clear(Id.Namespace namespace) throws IOException {
+    locationFactory.get(namespace, ARTIFACTS_PATH).delete();
+    for (final ArtifactInfo artifactInfo : getArtifacts(namespace)) {
+
+      metaTable.executeUnchecked(new TransactionExecutor.Function<DatasetContext<Table>, Void>() {
+        @Override
+        public Void apply(DatasetContext<Table> context) throws Exception {
+          final Id.Artifact artifactId = artifactInfo.getId();
+          ArtifactKey artifactKey = new ArtifactKey(artifactId.getNamespace(), artifactId.getName());
+          context.get().delete(artifactKey.getRowKey());
+
+          for (PluginClass pluginClass : artifactInfo.getMeta().getPlugins()) {
+            PluginKey pluginKey =
+              new PluginKey(artifactId.getNamespace(), pluginClass.getType(), pluginClass.getName());
+            context.get().delete(pluginKey.getRowKey());
+          }
+          return null;
+        }
+      });
+    }
+  }
+
+
+  private void writeMeta(final Id.Artifact artifactId, final ArtifactMeta artifactMeta) throws IOException {
+    metaTable.executeUnchecked(new TransactionExecutor.Function<DatasetContext<Table>, Object>() {
+
+      @Override
+      public Void apply(DatasetContext<Table> context) throws Exception {
+        Table table = context.get();
+
+        // write artifact metadata
+        ArtifactCell artifactCell = new ArtifactCell(artifactId);
+        byte[] artifactMetaBytes = Bytes.toBytes(GSON.toJson(artifactMeta));
+        table.put(artifactCell.rowkey, artifactCell.column, artifactMetaBytes);
+
+        // column for plugin meta and app meta. {artifact-name}:{artifact-version}
+        // does not need to contain namespace because namespace is in the rowkey
+        ArtifactColumn artifactColumn = new ArtifactColumn(artifactId.getVersion(), artifactId.getName());
+
+        // write pluginClass metadata
+        for (PluginClass pluginClass : artifactMeta.getPlugins()) {
+          // p:{namespace}:{type}:{name}
+          PluginKey pluginKey = new PluginKey(artifactId.getNamespace(), pluginClass.getType(), pluginClass.getName());
+          byte[] pluginClassBytes = Bytes.toBytes(GSON.toJson(pluginClass));
+          table.put(pluginKey.getRowKey(), artifactColumn.getColumn(), pluginClassBytes);
+        }
+
+        // TODO: write appClass metadata
+        return null;
+      }
+    });
+  }
+
+  private Location getLocation(Id.Artifact artifactId) throws IOException {
+    return locationFactory.get(artifactId.getNamespace(), ARTIFACTS_PATH)
+      .append(artifactId.getName())
+      .append(artifactId.getVersion());
+  }
+
+  private ArtifactMeta readMeta(final Id.Artifact artifactId) throws IOException {
+    return metaTable.executeUnchecked(new TransactionExecutor.Function<DatasetContext<Table>, ArtifactMeta>() {
+      @Override
+      public ArtifactMeta apply(DatasetContext<Table> context) throws Exception {
+        byte[] rowkey = new ArtifactKey(artifactId.getNamespace(), artifactId.getName()).getRowKey();
+        byte[] column = Bytes.toBytes(artifactId.getVersion());
+        byte[] value = context.get().get(rowkey, column);
+        return value == null ? null : GSON.fromJson(Bytes.toString(value), ArtifactMeta.class);
+      }
+    });
+  }
+
+  private void addArchivesToList(List<ArtifactInfo> archives, Row row) throws IOException {
+    ArtifactKey artifactKey = ArtifactKey.parse(row.getRow());
+
+    for (Map.Entry<byte[], byte[]> columnVal : row.getColumns().entrySet()) {
+      String version = Bytes.toString(columnVal.getKey());
+      ArtifactMeta meta = GSON.fromJson(Bytes.toString(columnVal.getValue()), ArtifactMeta.class);
+      Id.Artifact artifactId = Id.Artifact.from(artifactKey.namespace, artifactKey.name, version);
+      archives.add(new ArtifactInfo(artifactId, getLocation(artifactId), meta));
+    }
+  }
+
+  // given a row representing plugin metadata, add all plugins in the row to the given map
+  private void addPluginsToMap(Map<Id.Artifact, List<PluginClass>> map, Row row) throws IOException {
+    // plugin key contains namespace, plugin type, and plugin name
+    PluginKey pluginKey = PluginKey.parse(row.getRow());
+
+    // column is the artifact name and version, value is the serialized PluginClass
+    for (Map.Entry<byte[], byte[]> column : row.getColumns().entrySet()) {
+      ArtifactColumn artifactColumn = ArtifactColumn.parse(column.getKey());
+      Id.Artifact artifactId =
+        Id.Artifact.from(pluginKey.namespace, artifactColumn.name, artifactColumn.version);
+
+      if (!map.containsKey(artifactId)) {
+        map.put(artifactId, Lists.<PluginClass>newArrayList());
+      }
+      PluginClass pluginClass = GSON.fromJson(Bytes.toString(column.getValue()), PluginClass.class);
+      map.get(artifactId).add(pluginClass);
+    }
+  }
+
+  private Scan scanArtifacts(Id.Namespace namespace) {
+    return new Scan(
+      Bytes.toBytes(String.format("%s%s:", ARTIFACT_PREFIX, namespace.getId())),
+      Bytes.toBytes(String.format("%s%s;", ARTIFACT_PREFIX, namespace.getId())));
+  }
+
+  private Scan scanPlugins(Id.Namespace namespace) {
+    return new Scan(
+      Bytes.toBytes(String.format("%s%s:", PLUGIN_PREFIX, namespace.getId())),
+      Bytes.toBytes(String.format("%s%s;", PLUGIN_PREFIX, namespace.getId())));
+  }
+
+  private Scan scanPlugins(Id.Namespace namespace, String type) {
+    return new Scan(
+      Bytes.toBytes(String.format("%s%s:%s:", PLUGIN_PREFIX, namespace.getId(), type)),
+      Bytes.toBytes(String.format("%s%s:%s;", PLUGIN_PREFIX, namespace.getId(), type)));
+  }
+
+  private static class PluginKey {
+    private final Id.Namespace namespace;
+    private final String type;
+    private final String name;
+
+    private PluginKey(Id.Namespace namespace, String type, String name) {
+      this.namespace = namespace;
+      this.type = type;
+      this.name = name;
+    }
+
+    private byte[] getRowKey() {
+      return Bytes.toBytes(String.format("%s%s:%s:%s", PLUGIN_PREFIX, namespace.getId(), type, name));
+    }
+
+    private static PluginKey parse(byte[] rowkey) {
+      String key = Bytes.toString(rowkey);
+      int namespaceEnd = key.indexOf(':', PLUGIN_PREFIX.length());
+      Id.Namespace namespace = Id.Namespace.from(key.substring(PLUGIN_PREFIX.length(), namespaceEnd));
+      int typeEnd = key.indexOf(':', namespaceEnd + 1);
+      String type = key.substring(namespaceEnd + 1, typeEnd);
+      String name = key.substring(typeEnd + 1);
+      return new PluginKey(namespace, type, name);
+    }
+  }
+
+  private static class ArtifactColumn {
+    private final String version;
+    private final String name;
+
+    private ArtifactColumn(String version, String name) {
+      this.version = version;
+      this.name = name;
+    }
+
+    private byte[] getColumn() {
+      return Bytes.toBytes(String.format("%s:%s", version, name));
+    }
+
+    private static ArtifactColumn parse(byte[] columnBytes) {
+      String columnStr = Bytes.toString(columnBytes);
+      int separatorIndex = columnStr.indexOf(':');
+      return new ArtifactColumn(columnStr.substring(0, separatorIndex), columnStr.substring(separatorIndex + 1));
+    }
+  }
+
+  // utilities for creating and parsing row keys for artifacts. Keys are of the form 'r:{namespace}:{artifact-name}'
+  private static class ArtifactKey {
+    private final Id.Namespace namespace;
+    private final String name;
+
+    private ArtifactKey(Id.Namespace namespace, String name) {
+      this.namespace = namespace;
+      this.name = name;
+    }
+
+    private byte[] getRowKey() {
+      return Bytes.toBytes(String.format("%s%s:%s", ARTIFACT_PREFIX, namespace.getId(), name));
+    }
+
+    private static ArtifactKey parse(byte[] rowkey) {
+      String key = Bytes.toString(rowkey);
+      int separatorIdx = key.indexOf(':', ARTIFACT_PREFIX.length());
+      return new ArtifactKey(Id.Namespace.from(key.substring(ARTIFACT_PREFIX.length(), separatorIdx)),
+        key.substring(separatorIdx + 1));
+    }
+  }
+
+  private static class ArtifactCell {
+    private final byte[] rowkey;
+    private final byte[] column;
+
+    private ArtifactCell(Id.Artifact artifactId) {
+      rowkey = new ArtifactKey(artifactId.getNamespace(), artifactId.getName()).getRowKey();
+      column = Bytes.toBytes(artifactId.getVersion());
+    }
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStore.java
@@ -119,17 +119,18 @@ public class ArtifactStore {
   public void write(Id.Artifact artifactId, ArtifactMeta artifactMeta, InputStream archiveContents)
     throws WriteConflictException, ArtifactAlreadyExistsException, IOException {
 
-    ArtifactMeta meta = readMeta(artifactId);
-    if (meta != null) {
-      throw new ArtifactAlreadyExistsException(artifactId);
-    }
-
     Location fileDirectory =
       locationFactory.get(artifactId.getNamespace(), ARTIFACTS_PATH).append(artifactId.getName());
     Locations.mkdirsIfNotExists(fileDirectory);
     Location lock = fileDirectory.append(artifactId.getVersion() + ".lock");
     if (!lock.createNew()) {
       throw new WriteConflictException(artifactId);
+    }
+
+    ArtifactMeta meta = readMeta(artifactId);
+    if (meta != null) {
+      lock.delete();
+      throw new ArtifactAlreadyExistsException(artifactId);
     }
 
     Location file = fileDirectory.append(artifactId.getVersion());

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/WriteConflictException.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/WriteConflictException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.artifact;
+
+import co.cask.cdap.common.exception.ConflictException;
+import co.cask.cdap.proto.Id;
+
+/**
+ * Thrown when there is a write conflict adding an artifact, such as when multiple writers are trying to
+ * write the same artifact at the same time.
+ */
+public class WriteConflictException extends ConflictException {
+
+  public WriteConflictException(Id.Artifact artifactId) {
+    super(String.format("Archive %s already exists.", artifactId));
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStoreTest.java
@@ -1,0 +1,401 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.artifact;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.templates.plugins.PluginClass;
+import co.cask.cdap.api.templates.plugins.PluginPropertyField;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.internal.AppFabricTestHelper;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.test.SlowTests;
+import com.google.common.base.Charsets;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.io.CharStreams;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ */
+// suppressing warnings for Bytes.toBytes() when we know the result is not null
+@SuppressWarnings("ConstantConditions")
+public class ArtifactStoreTest {
+  private static ArtifactStore artifactStore;
+
+  @BeforeClass
+  public static void set() throws Exception {
+    artifactStore = AppFabricTestHelper.getInjector().getInstance(ArtifactStore.class);
+  }
+
+  @After
+  public void cleanup() throws IOException {
+    artifactStore.clear(Constants.DEFAULT_NAMESPACE_ID);
+  }
+
+  @Test
+  public void testAddGetSingleArtifact() throws Exception {
+    Id.Artifact artifactId = Id.Artifact.from(Constants.DEFAULT_NAMESPACE_ID, "myplugins", "1.0.0");
+    List<PluginClass> plugins = ImmutableList.of(
+      new PluginClass("atype", "plugin1", "", "c.c.c.plugin1", "cfg", ImmutableMap.<String, PluginPropertyField>of()),
+      new PluginClass("atype", "plugin2", "", "c.c.c.plugin2", "cfg", ImmutableMap.<String, PluginPropertyField>of())
+    );
+    ArtifactMeta artifactMeta = new ArtifactMeta(plugins);
+
+    String artifactContents = "my artifact contents";
+    artifactStore.write(artifactId, artifactMeta, new ByteArrayInputStream(Bytes.toBytes(artifactContents)));
+
+    ArtifactInfo artifactInfo = artifactStore.getArtifact(artifactId);
+    assertEqual(artifactId, artifactMeta, artifactContents, artifactInfo);
+  }
+
+  @Test(expected = ArtifactAlreadyExistsException.class)
+  public void testImmutability() throws Exception {
+    Id.Artifact artifactId = Id.Artifact.from(Constants.DEFAULT_NAMESPACE_ID, "myplugins", "1.0.0");
+    ArtifactMeta artifactMeta = new ArtifactMeta(ImmutableList.<PluginClass>of());
+
+    String artifactContents = "abc123";
+    // this should work
+    artifactStore.write(artifactId, artifactMeta, new ByteArrayInputStream(Bytes.toBytes(artifactContents)));
+    // this should throw an exception, since artifacts are immutable
+    artifactStore.write(artifactId, artifactMeta, new ByteArrayInputStream(Bytes.toBytes(artifactContents)));
+  }
+
+  @Test
+  public void testNamespaceIsolation() throws Exception {
+    Id.Namespace namespace1 = Id.Namespace.from("ns1");
+    Id.Namespace namespace2 = Id.Namespace.from("ns2");
+    Id.Artifact artifact1 = Id.Artifact.from(namespace1, "myplugins", "1.0.0");
+    Id.Artifact artifact2 = Id.Artifact.from(namespace2, "myplugins", "1.0.0");
+    String contents1 = "first contents";
+    String contents2 = "second contents";
+    List<PluginClass> plugins1 = ImmutableList.of(
+      new PluginClass("atype", "plugin1", "", "c.c.c.plugin1", "cfg", ImmutableMap.<String, PluginPropertyField>of())
+    );
+    List<PluginClass> plugins2 = ImmutableList.of(
+      new PluginClass("atype", "plugin2", "", "c.c.c.plugin2", "cfg", ImmutableMap.<String, PluginPropertyField>of())
+    );
+    ArtifactMeta meta1 = new ArtifactMeta(plugins1);
+    ArtifactMeta meta2 = new ArtifactMeta(plugins2);
+
+    artifactStore.write(artifact1, meta1, new ByteArrayInputStream(Bytes.toBytes(contents1)));
+    artifactStore.write(artifact2, meta2, new ByteArrayInputStream(Bytes.toBytes(contents2)));
+
+    try {
+      ArtifactInfo info1 = artifactStore.getArtifact(artifact1);
+      ArtifactInfo info2 = artifactStore.getArtifact(artifact2);
+
+      assertEqual(artifact1, meta1, contents1, info1);
+      assertEqual(artifact2, meta2, contents2, info2);
+
+      List<ArtifactInfo> namespace1Artifacts = artifactStore.getArtifacts(namespace1);
+      List<ArtifactInfo> namespace2Artifacts = artifactStore.getArtifacts(namespace2);
+      Assert.assertEquals(1, namespace1Artifacts.size());
+      assertEqual(artifact1, meta1, contents1, namespace1Artifacts.get(0));
+      Assert.assertEquals(1, namespace2Artifacts.size());
+      assertEqual(artifact2, meta2, contents2, namespace2Artifacts.get(0));
+    } finally {
+      artifactStore.clear(namespace1);
+      artifactStore.clear(namespace2);
+    }
+  }
+
+  @Test
+  public void testGetArtifacts() throws Exception {
+    // add 1 version of another artifact1
+    Id.Artifact artifact1V1 = Id.Artifact.from(Constants.DEFAULT_NAMESPACE_ID, "artifact1", "1.0.0");
+    String contents1V1 = "first contents v1";
+    List<PluginClass> plugins1V1 = ImmutableList.of(
+      new PluginClass("atype", "plugin1", "", "c.c.c.plugin1", "cfg", ImmutableMap.<String, PluginPropertyField>of())
+    );
+    ArtifactMeta meta1V1 = new ArtifactMeta(plugins1V1);
+    artifactStore.write(artifact1V1, meta1V1, new ByteArrayInputStream(Bytes.toBytes(contents1V1)));
+
+    // add 2 versions of an artifact2
+    Id.Artifact artifact2V1 = Id.Artifact.from(Constants.DEFAULT_NAMESPACE_ID, "artifact2", "0.1.0");
+    Id.Artifact artifact2V2 = Id.Artifact.from(Constants.DEFAULT_NAMESPACE_ID, "artifact2", "0.1.1");
+    String contents2V1 = "second contents v1";
+    String contents2V2 = "second contents v2";
+    List<PluginClass> plugins2V1 = ImmutableList.of(
+      new PluginClass("atype", "plugin2", "", "c.c.c.plugin2", "cfg", ImmutableMap.<String, PluginPropertyField>of())
+    );
+    List<PluginClass> plugins2V2 = ImmutableList.of(
+      new PluginClass("atype", "plugin2", "", "c.c.c.plugin2", "cfg", ImmutableMap.<String, PluginPropertyField>of())
+    );
+    ArtifactMeta meta2V1 = new ArtifactMeta(plugins2V1);
+    ArtifactMeta meta2V2 = new ArtifactMeta(plugins2V2);
+    artifactStore.write(artifact2V1, meta2V1, new ByteArrayInputStream(Bytes.toBytes(contents2V1)));
+    artifactStore.write(artifact2V2, meta2V2, new ByteArrayInputStream(Bytes.toBytes(contents2V2)));
+
+    // test we get 1 version of artifact1 and 2 versions of artifact2
+    List<ArtifactInfo> artifact1Versions =
+      artifactStore.getArtifacts(artifact1V1.getNamespace(), artifact1V1.getName());
+    Assert.assertEquals(1, artifact1Versions.size());
+    assertEqual(artifact1V1, meta1V1, contents1V1, artifact1Versions.get(0));
+
+    List<ArtifactInfo> artifact2Versions =
+      artifactStore.getArtifacts(artifact2V1.getNamespace(), artifact2V1.getName());
+    Assert.assertEquals(2, artifact2Versions.size());
+    assertEqual(artifact2V1, meta2V1, contents2V1, artifact2Versions.get(0));
+    assertEqual(artifact2V2, meta2V2, contents2V2, artifact2Versions.get(1));
+
+    // test we get all 3 in the getArtifacts() call for the namespace
+    List<ArtifactInfo> artifactVersions = artifactStore.getArtifacts(Constants.DEFAULT_NAMESPACE_ID);
+    Assert.assertEquals(3, artifactVersions.size());
+    assertEqual(artifact1V1, meta1V1, contents1V1, artifactVersions.get(0));
+    assertEqual(artifact2V1, meta2V1, contents2V1, artifactVersions.get(1));
+    assertEqual(artifact2V2, meta2V2, contents2V2, artifactVersions.get(2));
+  }
+
+  @Test
+  public void testGetPlugins() throws Exception {
+    // we have 2 plugins of type A and 2 plugins of type B
+    PluginClass pluginA1 = new PluginClass(
+      "A", "p1", "desc", "c.p1", "cfg",
+      ImmutableMap.of(
+        "threshold", new PluginPropertyField("thresh", "description", "double", true),
+        "retry", new PluginPropertyField("retries", "description", "int", false)
+      )
+    );
+    PluginClass pluginA2 = new PluginClass(
+      "A", "p2", "desc", "c.p2", "conf",
+      ImmutableMap.of(
+        "stream", new PluginPropertyField("stream", "description", "string", true)
+      )
+    );
+    PluginClass pluginB1 = new PluginClass(
+      "B", "p1", "desc", "c.p1", "cfg",
+      ImmutableMap.of(
+        "createIfNotExist", new PluginPropertyField("createIfNotExist", "desc", "boolean", false)
+      )
+    );
+    PluginClass pluginB2 = new PluginClass(
+      "B", "p2", "desc", "c.p2", "stuff",
+      ImmutableMap.of(
+        "numer", new PluginPropertyField("numerator", "description", "double", true),
+        "denom", new PluginPropertyField("denominator", "description", "double", true)
+      )
+    );
+
+    // add artifacts
+
+    // not interested in artifact contents for this test, using some dummy value
+    byte[] contents = new byte[] { 0 };
+
+    // artifact artifactX-1.0.0 contains plugin A1
+    Id.Artifact artifactXv100 = Id.Artifact.from(Constants.DEFAULT_NAMESPACE_ID, "artifactX", "1.0.0");
+    ArtifactMeta metaXv100 = new ArtifactMeta(ImmutableList.of(pluginA1));
+    artifactStore.write(artifactXv100, metaXv100, new ByteArrayInputStream(contents));
+
+    // artifact artifactX-1.1.0 contains plugin A1
+    Id.Artifact artifactXv110 = Id.Artifact.from(Constants.DEFAULT_NAMESPACE_ID, "artifactX", "1.1.0");
+    ArtifactMeta metaXv110 = new ArtifactMeta(ImmutableList.of(pluginA1));
+    artifactStore.write(artifactXv110, metaXv110, new ByteArrayInputStream(contents));
+
+    // artifact artifactX-2.0.0 contains plugins A1 and A2
+    Id.Artifact artifactXv200 = Id.Artifact.from(Constants.DEFAULT_NAMESPACE_ID, "artifactX", "2.0.0");
+    ArtifactMeta metaXv200 = new ArtifactMeta(ImmutableList.of(pluginA1, pluginA2));
+    artifactStore.write(artifactXv200, metaXv200, new ByteArrayInputStream(contents));
+
+    // artifact artifactY-1.0.0 contains plugin B1
+    Id.Artifact artifactYv100 = Id.Artifact.from(Constants.DEFAULT_NAMESPACE_ID, "artifactY", "1.0.0");
+    ArtifactMeta metaYv100 = new ArtifactMeta(ImmutableList.of(pluginB1));
+    artifactStore.write(artifactYv100, metaYv100, new ByteArrayInputStream(contents));
+
+    // artifact artifactY-2.0.0 contains plugin B2
+    Id.Artifact artifactYv200 = Id.Artifact.from(Constants.DEFAULT_NAMESPACE_ID, "artifactY", "2.0.0");
+    ArtifactMeta metaYv200 = new ArtifactMeta(ImmutableList.of(pluginB2));
+    artifactStore.write(artifactYv200, metaYv200, new ByteArrayInputStream(contents));
+
+    // artifact artifactZ-1.0.0 contains plugins A1 and B1
+    Id.Artifact artifactZv100 = Id.Artifact.from(Constants.DEFAULT_NAMESPACE_ID, "artifactZ", "1.0.0");
+    ArtifactMeta metaZv100 = new ArtifactMeta(ImmutableList.of(pluginA1, pluginB1));
+    artifactStore.write(artifactZv100, metaZv100, new ByteArrayInputStream(contents));
+
+    // artifact artifactZ-2.0.0 contains plugins A1, A2, B1, and B2
+    Id.Artifact artifactZv200 = Id.Artifact.from(Constants.DEFAULT_NAMESPACE_ID, "artifactZ", "2.0.0");
+    ArtifactMeta metaZv200 = new ArtifactMeta(ImmutableList.of(pluginA1, pluginA2, pluginB1, pluginB2));
+    artifactStore.write(artifactZv200, metaZv200, new ByteArrayInputStream(contents));
+
+    // test getting all plugins in the namespace
+    Map<Id.Artifact, List<PluginClass>> expected = Maps.newHashMap();
+    expected.put(artifactXv100, ImmutableList.of(pluginA1));
+    expected.put(artifactXv110, ImmutableList.of(pluginA1));
+    expected.put(artifactXv200, ImmutableList.of(pluginA1, pluginA2));
+    expected.put(artifactYv100, ImmutableList.of(pluginB1));
+    expected.put(artifactYv200, ImmutableList.of(pluginB2));
+    expected.put(artifactZv100, ImmutableList.of(pluginA1, pluginB1));
+    expected.put(artifactZv200, ImmutableList.of(pluginA1, pluginA2, pluginB1, pluginB2));
+    Map<Id.Artifact, List<PluginClass>> actual = artifactStore.getPluginClasses(Constants.DEFAULT_NAMESPACE_ID);
+    Assert.assertEquals(expected, actual);
+
+    // test getting all plugins by namespace and type
+    // get all of type A
+    expected = Maps.newHashMap();
+    expected.put(artifactXv100, ImmutableList.of(pluginA1));
+    expected.put(artifactXv110, ImmutableList.of(pluginA1));
+    expected.put(artifactXv200, ImmutableList.of(pluginA1, pluginA2));
+    expected.put(artifactZv100, ImmutableList.of(pluginA1));
+    expected.put(artifactZv200, ImmutableList.of(pluginA1, pluginA2));
+    actual = artifactStore.getPluginClasses(Constants.DEFAULT_NAMESPACE_ID, "A");
+    Assert.assertEquals(expected, actual);
+    // get all of type B
+    expected = Maps.newHashMap();
+    expected.put(artifactYv100, ImmutableList.of(pluginB1));
+    expected.put(artifactYv200, ImmutableList.of(pluginB2));
+    expected.put(artifactZv100, ImmutableList.of(pluginB1));
+    expected.put(artifactZv200, ImmutableList.of(pluginB1, pluginB2));
+    actual = artifactStore.getPluginClasses(Constants.DEFAULT_NAMESPACE_ID, "B");
+    Assert.assertEquals(expected, actual);
+
+    // test getting plugins by namespace, type, and name
+    // get all of type A and name p1
+    expected = Maps.newHashMap();
+    expected.put(artifactXv100, ImmutableList.of(pluginA1));
+    expected.put(artifactXv110, ImmutableList.of(pluginA1));
+    expected.put(artifactXv200, ImmutableList.of(pluginA1));
+    expected.put(artifactZv100, ImmutableList.of(pluginA1));
+    expected.put(artifactZv200, ImmutableList.of(pluginA1));
+    actual = artifactStore.getPluginClasses(Constants.DEFAULT_NAMESPACE_ID, "A", "p1");
+    Assert.assertEquals(expected, actual);
+    // get all of type A and name p2
+    expected = Maps.newHashMap();
+    expected.put(artifactXv200, ImmutableList.of(pluginA2));
+    expected.put(artifactZv200, ImmutableList.of(pluginA2));
+    actual = artifactStore.getPluginClasses(Constants.DEFAULT_NAMESPACE_ID, "A", "p2");
+    Assert.assertEquals(expected, actual);
+    // get all of type B and name p1
+    expected = Maps.newHashMap();
+    expected.put(artifactYv100, ImmutableList.of(pluginB1));
+    expected.put(artifactZv100, ImmutableList.of(pluginB1));
+    expected.put(artifactZv200, ImmutableList.of(pluginB1));
+    actual = artifactStore.getPluginClasses(Constants.DEFAULT_NAMESPACE_ID, "B", "p1");
+    Assert.assertEquals(expected, actual);
+    // get all of type B and name p2
+    expected = Maps.newHashMap();
+    expected.put(artifactYv200, ImmutableList.of(pluginB2));
+    expected.put(artifactZv200, ImmutableList.of(pluginB2));
+    actual = artifactStore.getPluginClasses(Constants.DEFAULT_NAMESPACE_ID, "B", "p2");
+    Assert.assertEquals(expected, actual);
+
+    // test some things that should return empty maps
+    // namespace with nothing in it
+    Assert.assertTrue(artifactStore.getPluginClasses(Id.Namespace.from("something")).isEmpty());
+    // type with no plugins
+    Assert.assertTrue(artifactStore.getPluginClasses(Constants.DEFAULT_NAMESPACE_ID, "C").isEmpty());
+    // name with no plugins
+    Assert.assertTrue(artifactStore.getPluginClasses(Constants.DEFAULT_NAMESPACE_ID, "A", "p3").isEmpty());
+  }
+
+  @Test
+  public void testSamePluginDifferentArtifacts() throws Exception {
+    // add one artifact with a couple plugins
+    Id.Artifact artifact1 = Id.Artifact.from(Constants.DEFAULT_NAMESPACE_ID, "plugins1", "1.0.0");
+    List<PluginClass> plugins = ImmutableList.of(
+      new PluginClass("atype", "plugin1", "", "c.c.c.plugin1", "cfg", ImmutableMap.<String, PluginPropertyField>of()),
+      new PluginClass("atype", "plugin2", "", "c.c.c.plugin2", "cfg", ImmutableMap.<String, PluginPropertyField>of())
+    );
+    ArtifactMeta meta1 = new ArtifactMeta(plugins);
+    artifactStore.write(artifact1, meta1, new ByteArrayInputStream(Bytes.toBytes("something")));
+
+    // add a different artifact with the same plugins
+    Id.Artifact artifact2 = Id.Artifact.from(Constants.DEFAULT_NAMESPACE_ID, "plugins2", "1.0.0");
+    ArtifactMeta meta2 = new ArtifactMeta(plugins);
+    artifactStore.write(artifact2, meta2, new ByteArrayInputStream(Bytes.toBytes("something")));
+
+    Map<Id.Artifact, List<PluginClass>> expected = Maps.newHashMap();
+    expected.put(artifact1, plugins);
+    expected.put(artifact2, plugins);
+    Map<Id.Artifact, List<PluginClass>> actual = artifactStore.getPluginClasses(Constants.DEFAULT_NAMESPACE_ID);
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Category(SlowTests.class)
+  @Test
+  public void testConcurrentAdd() throws Exception {
+    // start up a bunch of threads that will try and write the same artifact at the same time
+    // only one of them should be able to write it
+    int numThreads = 10;
+    final Id.Artifact artifactId = Id.Artifact.from(Constants.DEFAULT_NAMESPACE_ID, "abc", "1.0.0");
+    final List<String> successfulWriters = Collections.synchronizedList(Lists.<String>newArrayList());
+
+    // use a barrier so they all try and write at the same time
+    final CyclicBarrier barrier = new CyclicBarrier(numThreads);
+    final CountDownLatch latch = new CountDownLatch(numThreads);
+    ExecutorService executorService = Executors.newFixedThreadPool(numThreads);
+    for (int i = 0; i < numThreads; i++) {
+      final String writer = String.valueOf(i);
+      executorService.execute(new Runnable() {
+        @Override
+        public void run() {
+          try {
+            barrier.await();
+            ArtifactMeta meta = new ArtifactMeta(ImmutableList.of(new PluginClass(
+              "plugin-type", "plugin" + writer, "", "classname", "cfg",
+              ImmutableMap.<String, PluginPropertyField>of())));
+            artifactStore.write(artifactId, meta, new ByteArrayInputStream(Bytes.toBytes(writer)));
+            successfulWriters.add(writer);
+          } catch (InterruptedException | BrokenBarrierException | IOException e) {
+            // something went wrong, fail the test
+            throw new RuntimeException(e);
+          } catch (ArtifactAlreadyExistsException | WriteConflictException e) {
+            // these are ok, all but one thread should see this
+          } finally {
+            latch.countDown();
+          }
+        }
+      });
+    }
+
+    // wait for all writers to finish
+    latch.await();
+    // only one writer should have been able to write
+    Assert.assertEquals(1, successfulWriters.size());
+    String successfulWriter = successfulWriters.get(0);
+    // check that the contents weren't mixed between writers
+    ArtifactInfo info = artifactStore.getArtifact(artifactId);
+    ArtifactMeta expectedMeta = new ArtifactMeta(ImmutableList.of(new PluginClass(
+      "plugin-type", "plugin" + successfulWriter, "", "classname", "cfg",
+      ImmutableMap.<String, PluginPropertyField>of())));
+    assertEqual(artifactId, expectedMeta, String.valueOf(successfulWriter), info);
+  }
+
+  private void assertEqual(Id.Artifact expectedId, ArtifactMeta expectedMeta,
+                           String expectedContents, ArtifactInfo actual) throws IOException {
+    Assert.assertEquals(expectedId, actual.getId());
+    Assert.assertEquals(expectedMeta, actual.getMeta());
+    Assert.assertEquals(expectedContents, CharStreams.toString(
+      new InputStreamReader(actual.getLocation().getInputStream(), Charsets.UTF_8)));
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStoreTest.java
@@ -87,7 +87,11 @@ public class ArtifactStoreTest {
 
     String artifactContents = "abc123";
     // this should work
-    artifactStore.write(artifactId, artifactMeta, new ByteArrayInputStream(Bytes.toBytes(artifactContents)));
+    try {
+      artifactStore.write(artifactId, artifactMeta, new ByteArrayInputStream(Bytes.toBytes(artifactContents)));
+    } catch (ArtifactAlreadyExistsException e) {
+      Assert.fail();
+    }
     // this should throw an exception, since artifacts are immutable
     artifactStore.write(artifactId, artifactMeta, new ByteArrayInputStream(Bytes.toBytes(artifactContents)));
   }
@@ -346,7 +350,7 @@ public class ArtifactStoreTest {
   public void testConcurrentAdd() throws Exception {
     // start up a bunch of threads that will try and write the same artifact at the same time
     // only one of them should be able to write it
-    int numThreads = 10;
+    int numThreads = 20;
     final Id.Artifact artifactId = Id.Artifact.from(Constants.DEFAULT_NAMESPACE_ID, "abc", "1.0.0");
     final List<String> successfulWriters = Collections.synchronizedList(Lists.<String>newArrayList());
 

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/Id.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/Id.java
@@ -1253,4 +1253,81 @@ public abstract class Id {
       return new DatasetInstance(Namespace.from(namespaceId), instanceId);
     }
   }
+
+  /**
+   * Artifact Id identifies an artifact by its namespace, name, and version.
+   */
+  public static class Artifact extends NamespacedId {
+    private final Namespace namespace;
+    private final String name;
+    private final String version;
+
+    public Artifact(Namespace namespace, String name, String version) {
+      // TODO: enforce name, version characters
+      Preconditions.checkNotNull(namespace, "Namespace cannot be null.");
+      Preconditions.checkNotNull(name, "Name cannot be null.");
+      Preconditions.checkNotNull(version, "Version cannot be null.");
+      this.namespace = namespace;
+      this.name = name;
+      this.version = version;
+    }
+
+    public Namespace getNamespace() {
+      return namespace;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public String getVersion() {
+      return version;
+    }
+
+    @Nullable
+    @Override
+    protected Id getParent() {
+      return null;
+    }
+
+    @Override
+    public String getId() {
+      return String.format("%s-%s", name, version);
+    }
+
+    @Override
+    public String toString() {
+      return Objects.toStringHelper(this)
+        .add("namespace", namespace)
+        .add("name", name)
+        .add("version", version)
+        .toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+
+      Artifact that = (Artifact) o;
+
+      return Objects.equal(namespace, that.namespace) &&
+        Objects.equal(name, that.name)
+        && Objects.equal(version, that.version);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(namespace, name, version);
+    }
+
+    public static Artifact from(Namespace namespace, String name, String version) {
+      return new Artifact(namespace, name, version);
+    }
+  }
+
 }


### PR DESCRIPTION
artifacts and their metadata. The store keeps the artifacts
on hdfs and metadata about the artifacts in a table. Artifact
metadata consists of information about the plugins contained
in the artifact. In the future, it will also contain info
about application classes in the artifact. The table also stores
a mapping from plugin to artifact to allow lookups by plugin
in addition to lookups by artifact id.

Not yet used anywhere, but the next step will be to use it as
the backing for plugins and plugin jars.