### PR TITLE
Feature/ui ns gear smaller devices

### DIFF
--- a/cdap-ui/app/directives/navbar/navbar.html
+++ b/cdap-ui/app/directives/navbar/navbar.html
@@ -16,10 +16,11 @@
 </div>
 <div class="collapse navbar-collapse" ng-class="{in:navbarCollapsed}">
 
-  <ul class="nav navbar-nav hidden-sm" id="navbar-namespace">
-    <li class="dropdown">
+  <ul class="nav navbar-nav" id="navbar-namespace">
+    <li class="dropdown" ng-class="{one:namespaces.length<2}">
       <a href="" class="dropdown-toggle">
-        <span ng-bind="$state.params.namespace && getDisplayName($state.params.namespace) | myEllipsis: 10"></span>
+        <span ng-bind="$state.params.namespace && getDisplayName($state.params.namespace) | myEllipsis: 10" ng-if="namespaces.length > 1"></span>
+        <span ng-bind="$state.params.namespace && getDisplayName($state.params.namespace) | myEllipsis: 10" tooltip="Only one namespace to display" tooltip-placement="right" ng-if="namespaces.length < 2"></span>
         <span class="caret"></span>
       </a>
     </li>
@@ -39,7 +40,7 @@
     </ul>
   </nav>
 
-  <ul class="nav navbar-nav navbar-right hidden-sm">
+  <ul class="nav navbar-nav navbar-right">
 
     <li class="hidden" id="navbar-search">
       <form class="navbar-form" ng-submit="doSearch()">

--- a/cdap-ui/app/styles/themes/cdap/header.less
+++ b/cdap-ui/app/styles/themes/cdap/header.less
@@ -11,7 +11,7 @@ body {
         .fa-cog:before { font-size: 16px; }
       }
 
-      @media (max-width: @screen-sm-max) {
+      @media (max-width: @screen-md-max) {
         a.dropdown-toggle {
           padding-left: 10px;
           span.fa-cog { display: none; }
@@ -33,7 +33,7 @@ body {
         }
       }
 
-      @media (min-width: @screen-md-min) {
+      @media (min-width: @screen-lg-min) {
         a.dropdown-toggle {
           color: lightgray;
           padding: 5px 3px;
@@ -46,7 +46,7 @@ body {
       }
     }
 
-    @media (min-width: @screen-md-min) {
+    @media (min-width: @screen-lg-min) {
       li.dropdown {
         background-color: transparent;
         .border-radius(4px 4px 0 0);
@@ -169,7 +169,7 @@ body {
         }
       }
     }
-    @media (max-width: @screen-sm-max) {
+    @media (max-width: @screen-md-max) {
       // Disable dropdown menu animations on smaller devices
       ul.dropdown-menu.am-flip-x {
         .transition(none);
@@ -181,22 +181,26 @@ body {
         display: block;
         max-height: 0;
         visibility: visible;
-        > ul.navbar-nav {
+        ul.navbar-nav {
           display: none;
+          visibility: hidden;
         }
         &.in {
-          > ul.navbar-nav {
+          margin-top: 15px;
+          max-height: 800px;
+          ul.navbar-nav {
             display: block;
+            visibility: visible;
             &.navbar-right {
 
             }
           }
         }
       }
-      .navbar-collapse.in {
-        margin-top: 15px;
-        max-height: none;
-      }
+      // .navbar-collapse.in {
+
+      //   max-height: none;
+      // }
       .navbar-inverse {
         .navbar-toggle {
           &:hover, &:focus { background-color: lighten(@cdap-header, 10%); }

--- a/cdap-ui/app/styles/themes/cdap/header.less
+++ b/cdap-ui/app/styles/themes/cdap/header.less
@@ -2,352 +2,420 @@
 @import "../../../../bower_components/bootstrap/less/mixins.less";
 
 body {
-  header [my-navbar] {
-    .navbar-right li.dropdown {
-      padding: 11px 5px;
-      a.dropdown-toggle {
-        height: auto;
-        text-align: left;
-        .fa-cog:before { font-size: 16px; }
-      }
+  header.navbar {
 
-      @media (max-width: @screen-md-max) {
-        a.dropdown-toggle {
-          padding-left: 10px;
-          span.fa-cog { display: none; }
-          &:before {
-            content: 'Settings';
-            padding-right: 5px;
-          }
+    [my-navbar] {
+      padding-top: 10px;
+      padding-bottom: 15px;
+
+      // Logo
+      a.navbar-brand {
+        position: relative;
+        top: 1px;
+
+        &.first {
+          background-image: none;
+          font-size: 40px;
+          top: -8px;
         }
-        ul.dropdown-menu {
-          > li > a {
-            padding-left: 10px;
-            padding-top: 5px;
-            padding-bottom: 5px;
-          }
-          li.nav-subsection {
-            color: #9d9d9d;
-            padding-left: 10px;
-          }
+
+        > strong {
+          display: inline-block;
+          visibility: hidden;
+          width: 84px;
         }
       }
 
-      @media (min-width: @screen-lg-min) {
-        a.dropdown-toggle {
-          color: lightgray;
-          padding: 5px 3px;
-          text-align: right;
-        }
-        ul.dropdown-menu {
-          > li > a { padding-left: 14px; }
-          li.nav-subsection { margin: 10px 0 0 10px; }
-        }
-      }
-    }
+      div.navbar-collapse {
 
-    @media (min-width: @screen-lg-min) {
-      li.dropdown {
-        background-color: transparent;
-        .border-radius(4px 4px 0 0);
-        .transition(background-color 0.2s ease-in);
-        &.open {
-          background-color: @brand-primary;
-          a.dropdown-toggle {
-            background-color: @cdap-white;
-            color:@cdap-header;
-            font-size: 14px;
-            .border-radius(4px);
-          }
-        }
+        &.in {
+          @media (max-width: @screen-md-max) {
+            margin-top: 15px;
+            max-height: 800px;
+            overflow-y: visible;
 
-        ul.dropdown-menu {
-          background-color: @brand-primary;
-          border: 0;
-          margin: 0;
-          padding: 0;
-          top: 50px !important;
-          li {
-            position: relative;
-            &:not(:last-child) { border-bottom:1px solid rgba(0,0,0,0.1); }
+            ul.navbar-nav {
+              display: block;
+              visibility: visible;
+            }
+
+            div.error-button {
+              float: left;
+              min-width: 140px;
+              text-align: center;
+              visibility: visible;
+            }
           }
-          a {
-            color: white;
-            font-size: 14px;
-            margin: 7px;
-            padding: 10px;
-            max-width: 95%;
-            text-overflow: ellipsis;
-            overflow: hidden;
-            &:hover, &:focus {
-              background-color: white;
-              color: @cdap-darkness;
-              outline: none;
-              .border-radius(4px);
-              span { color: @cdap-darkness; }
+          @media (max-width: @screen-xs-max) {
+            div.error-button {
+              float: none;
+              div.popover { max-width: 100%; }
             }
           }
         }
-      }
-      .navbar-collapse > ul.nav:first-child {
-        margin-left: 10px;
-        width: 160px;
-      }
-      .nav:first-child {
-        ul.dropdown-menu {
-          .border-radius(0 0 4px 4px);
-          left: 0;
-          width: 160px;
-          max-height: 500px;
-          overflow-y: auto;
-          li:nth-last-child(2) { border-bottom: 0; }
-        }
-        li.dropdown {
-          width: 100%;
-          a.dropdown-toggle {
-            white-space: nowrap;
-            span {
-              color: lightgray;
-              &:first-child { padding-right: 5px; }
-            }
-          }
-          &.open {
-            width: 160px;
-            z-index: 10;
-            a.dropdown-toggle {
-              margin: 7px;
-              padding: 10px;
-              overflow: auto;
-              .border-radius(4px);
-              span {
-                &:first-child {
-                  color: @cdap-darkness;
-                  float: left;
+
+        > ul.navbar-nav {
+
+          // Namespace dropdown
+          &:first-child {
+            @media (min-width: @screen-sm-min) { float: left; }
+            li.dropdown {
+              @media (max-width: @screen-md-max) {
+                &.one {
+                  a.dropdown-toggle {
+                    cursor: default;
+                    .caret { display: none; }
+                  }
+                  &.open {
+                    ul.dropdown-menu { padding: 0; }
+                  }
                 }
-                &:last-child { display: none; }
+              }
+            }
+
+            @media (min-width: @screen-lg-min) {
+              margin-left: 10px;
+              visibility: visible;
+              width: 160px;
+
+              ul.dropdown-menu {
+                .border-radius(0 0 4px 4px);
+                left: 0;
+                width: 160px;
+                max-height: 500px;
+                overflow-y: auto;
+                float: none;
+                li:nth-last-child(2) { border-bottom: 0; }
+              }
+
+              li.dropdown {
+                width: 100%;
+                a.dropdown-toggle {
+                  white-space: nowrap;
+                  span:first-child { padding-right: 5px; }
+                  .tooltip.right { visibility: hidden; }
+                }
+
+                &.open {
+                  width: 160px;
+                  z-index: 10;
+                  a.dropdown-toggle {
+                    margin: 7px;
+                    padding: 10px;
+                    overflow: auto;
+                    .border-radius(4px);
+                    span {
+                      &:first-child { float: left; }
+                      &:last-child { display: none; }
+                    }
+                  }
+                }
+              }
+            }
+          }
+
+          // Settings dropdown
+          &.navbar-right {
+            @media (min-width: @screen-sm-min) {
+              float: left;
+              padding-left: 20px;
+            }
+            @media (min-width: @screen-lg-min) {
+              float: none;
+              padding-left: 0;
+            }
+            li.dropdown {
+              padding: 11px 5px;
+              @media (max-width: @screen-xs-max) { padding-top: 0; }
+              @media (min-width: @screen-sm-min) { padding-bottom: 0; }
+              @media (min-width: @screen-lg-min) {
+                padding-top: 11px;
+                padding-bottom: 11px;
+              }
+
+              &.open {
+                span {
+                  &.fa-cog { padding: 0 5px; }
+                  &.caret { display: none; }
+                }
+              }
+
+              a.dropdown-toggle {
+                height: auto;
+                .fa-cog:before { font-size: 16px; }
+                @media (max-width: @screen-md-max) {
+                  padding-top: 0;
+                  padding-left: 10px;
+                  span.fa-cog { display: none; }
+                  &:before {
+                    content: 'Settings';
+                    padding-right: 5px;
+                  }
+                }
+                @media (min-width: @screen-lg-min) {
+                  padding: 5px 3px;
+                }
+              }
+
+              ul.dropdown-menu {
+                @media (min-width: @screen-sm-min) {
+                  .border-radius(4px 0 4px 4px);
+                  li.nav-subsection { border: 0; }
+                }
+                @media (max-width: @screen-md-max) {
+                  > li > a {
+                    padding-left: 10px;
+                    padding-top: 5px;
+                    padding-bottom: 5px;
+                  }
+                  li.nav-subsection { padding-left: 10px; }
+                }
+                @media (min-width: @screen-lg-min) {
+                  > li > a { padding-left: 14px; }
+                  li.nav-subsection { margin: 10px 0 0 10px; }
+                }
+              }
+            }
+          }
+
+          // Namespace and Settings dropdowns
+          li.dropdown {
+            @media (max-width: @screen-md-max) {
+              min-width: 140px;
+              a.dropdown-toggle { padding-bottom: 0; }
+              li.disabled { display: none; }
+              &.open {
+                a.dropdown-toggle {
+                  background-color: transparent;
+                  text-align: left;
+                  .transition(all 0.2s ease-in);
+                  &:hover, &:focus { background-color: transparent; }
+                  .caret { display: none; }
+                }
+              }
+            }
+            @media (min-width: @screen-lg-min) {
+              background-color: transparent;
+              .border-radius(4px 4px 0 0);
+              .transition(background-color 0.2s ease-in);
+              &.open {
+                a.dropdown-toggle {
+                  font-size: 14px;
+                  .border-radius(4px);
+                }
+              }
+
+              ul.dropdown-menu {
+                border: 0;
+                margin: 0;
+                padding: 0;
+                top: 50px !important;
+                li { position: relative; }
+                a {
+                  font-size: 14px;
+                  margin: 7px;
+                  padding: 10px;
+                  max-width: 95%;
+                  text-overflow: ellipsis;
+                  overflow: hidden;
+                  &:hover, &:focus {
+                    outline: none;
+                    .border-radius(4px);
+                  }
+                }
               }
             }
           }
         }
 
+        ul.navbar-nav {
+          @media (max-width: @screen-md-max) {
+            display: none;
+            visibility: hidden;
+            ul.dropdown-menu {
+              min-width: 140px;
+              &.am-flip-x {
+                .transition(none);
+                -webkit-animation-duration: 0s;
+                animation-duration: 0s;
+              }
+            }
+          }
+        }
+
+        // Main nav
+        nav {
+          @media (min-width: @screen-sm-min) {
+            position: absolute;
+            top: 18px;
+            left: 50%;
+            margin-left: -148px;
+            > ul.navbar-nav {
+              .border-radius(25px);
+              display: block;
+              float: left;
+              margin: 0;
+              visibility: visible;
+              > li { float: left; }
+              li {
+                width: 140px;
+                overflow: hidden;
+                text-align: center;
+                &.active > a { cursor: default; }
+                > a {
+                  .border-radius(25px);
+                  font-size: 15px;
+                  letter-spacing: 0.5px;
+                  margin: 1px;
+                  padding: 10px;
+                  text-transform: capitalize;
+                }
+              }
+            }
+          }
+          @media (max-width: @screen-md-max) {
+            ul.navbar-nav {
+              > .active > a { background-color: transparent; }
+            }
+          }
+          @media (min-width: @screen-md-min) { margin-left: -180px; }
+        }
+
+        @media (max-width: @screen-md-max) {
+          border-top: 0;
+          display: block;
+          max-height: 0;
+          visibility: visible;
+
+          div.error-button { visibility: hidden; }
+        }
       }
     }
   }
 
   &.theme-cdap {
-    header {
+    header.navbar {
       background-color: @cdap-header;
+
       [my-navbar] {
-        padding-top: 10px;
-        padding-bottom: 15px;
-        .navbar-brand {
-          background: url('@{img-path}/cdap.png') no-repeat 15px center;
-          background-size: 100px auto;
-          position: relative;
-          top: 1px;
 
-          &.first {
-            background: none;
-            font-size: 40px;
-            color: @cdap-orange;
-            top: -8px;
-          }
-
-          > strong {
-            display: inline-block;
-            visibility: hidden;
-            width: 84px;
+        // Mobile nav menu
+        button.navbar-toggle {
+          @media (max-width: @screen-md-max) {
+            &:hover, &:focus { background-color: lighten(@cdap-header, 10%); }
           }
         }
-        ul.dropdown-menu {
-          li {
-            &.nav-subsection { color: lightgray; }
-            a {
-              &:disabled { color: lightgray; }
+
+        a.navbar-brand {
+          &.first { color: @cdap-orange; }
+          &:last-of-type { background: url('@{img-path}/cdap.png') 15px center / 100px auto no-repeat; }
+        }
+
+        div.navbar-collapse {
+
+          > ul.navbar-nav {
+
+            // Namespace dropdown
+            &:first-child {
+              li.dropdown {
+                @media (max-width: @screen-md-max) {
+                  &.one {
+                    &.open {
+                      a.dropdown-toggle { color: @cdap-gray; }
+                    }
+                  }
+                }
+                @media (min-width: @screen-lg-min) {
+                  li.dropdown {
+                    a.dropdown-toggle span { color: lightgray; }
+                    &.open {
+                      a.droptown-toggle span:first-child { color: @cdap-darkness; }
+                    }
+                  }
+                }
+              }
             }
-          }
-        }
-      }
-    }
-    @media (max-width: @screen-md-max) {
-      // Disable dropdown menu animations on smaller devices
-      ul.dropdown-menu.am-flip-x {
-        .transition(none);
-        -webkit-animation-duration: 0s;
-        animation-duration: 0s;
-      }
-      .navbar-collapse {
-        border-top: 0;
-        display: block;
-        max-height: 0;
-        visibility: visible;
-        ul.navbar-nav {
-          display: none;
-          visibility: hidden;
-        }
-        &.in {
-          margin-top: 15px;
-          max-height: 800px;
-          ul.navbar-nav {
-            display: block;
-            visibility: visible;
+
+            // Settings dropdown
             &.navbar-right {
+              li.dropdown {
 
-            }
-          }
-        }
-      }
-      // .navbar-collapse.in {
+                &.open {
+                  span.fa-cog { color: @cdap-darkness; }
+                }
 
-      //   max-height: none;
-      // }
-      .navbar-inverse {
-        .navbar-toggle {
-          &:hover, &:focus { background-color: lighten(@cdap-header, 10%); }
-        }
-        .navbar-nav {
-          > .open {
-            > a, > a:hover, > a:focus {
-              background-color: white;
-              color: @cdap-darkness;
-            }
-          }
-          > .active > a {
-            background-color: transparent;
-            color: @cdap-orange;
-          }
-        }
-      }
-    }
-    @media (min-width: @screen-sm-min) {
-      [my-navbar] {
-        nav {
-          position: absolute;
-          top: 18px;
-          left: 50%;
-          margin-left: -180px;
+                a.dropdown-toggle {
+                  @media (min-width: @screen-lg-min) {
+                    color: lightgray;
+                  }
+                }
 
-          > ul.nav {
-            background-color: @cdap-darkness;
-            .border-radius(25px);
-            display: block;
-            float: left;
-            margin: 0;
-            > li {
-              float: left;
-            }
-
-            li {
-              width: 140px;
-              overflow: hidden;
-              text-align: center;
-              &.active > a {
-                cursor: default;
-                color: @cdap-orange;
-                background-color: @gray-lighter;
+                ul.dropdown-menu {
+                  @media (max-width: @screen-md-max) {
+                    li.nav-subsection { color: #9d9d9d; }
+                  }
+                }
               }
-              > a {
-                .border-radius(25px);
-                font-size: 15px;
-                letter-spacing: 0.5px;
-                margin: 1px;
-                padding: 10px;
-                color: lightgray;
-                text-transform: capitalize;
-                &:hover, &:focus { color: @cdap-orange; }
+            }
+
+            // Namespace and Settings dropdowns
+            li.dropdown {
+              @media (max-width: @screen-md-max) {
+                a.dropdown-toggle { color: @cdap-gray; }
+              }
+              @media (min-width: @screen-lg-min) {
+                &.open {
+                  background-color: @brand-primary;
+                  a.dropdown-toggle {
+                    background-color: @cdap-white;
+                    color: @cdap-header;
+                  }
+                }
+                ul.dropdown-menu {
+                  background-color: @brand-primary;
+                  li:not(:last-child) { border-bottom: 1px solid rgba(0,0,0,0.1); }
+                  a {
+                    color: white;
+                    &:hover, &:focus {
+                      background-color: white;
+                      color: @cdap-darkness;
+
+                      span { color: @cdap-darkness; }
+                    }
+                  }
+                }
               }
             }
           }
-        }
 
-        // li.dropdown {
-        //   background-color: transparent;
-        //   .border-radius(4px 4px 0 0);
-        //   .transition(background-color 0.2s ease-in);
-        //   &.open {
-        //     background-color: @brand-primary;
-        //     a.dropdown-toggle {
-        //       background-color: @cdap-white;
-        //       color:@cdap-header;
-        //       font-size: 14px;
-        //       .border-radius(4px);
-        //     }
-        //   }
+          ul.navbar-nav {
+            ul.dropdown-menu {
+              li.nav-subsection { color: lightgray; }
+              a:disabled { color: lightgray; }
+            }
+          }
 
-        //   ul.dropdown-menu {
-        //     background-color: @brand-primary;
-        //     border: 0;
-        //     margin: 0;
-        //     padding: 0;
-        //     top: 50px !important;
-        //     li {
-        //       position: relative;
-        //       &:not(:last-child) { border-bottom:1px solid rgba(0,0,0,0.1); }
-        //     }
-        //     a {
-        //       color: white;
-        //       font-size: 14px;
-        //       margin: 7px;
-        //       padding: 10px;
-        //       max-width: 95%;
-        //       text-overflow: ellipsis;
-        //       overflow: hidden;
-        //       &:hover, &:focus {
-        //         background-color: white;
-        //         color: @cdap-darkness;
-        //         outline: none;
-        //         .border-radius(4px);
-        //         span { color: @cdap-darkness; }
-        //       }
-        //     }
-        //   }
-        // }
-        // .navbar-collapse > ul.nav:first-child {
-        //   margin-left: 10px;
-        //   width: 160px;
-        // }
-        // .nav:first-child {
-        //   ul.dropdown-menu {
-        //     .border-radius(0 0 4px 4px);
-        //     left: 0;
-        //     width: 160px;
-        //     max-height: 500px;
-        //     overflow-y: auto;
-        //     li:nth-last-child(2) { border-bottom: 0; }
-        //   }
-        //   li.dropdown {
-        //     width: 100%;
-        //     a.dropdown-toggle {
-        //       white-space: nowrap;
-        //       span {
-        //         color: lightgray;
-        //         &:first-child { padding-right: 5px; }
-        //       }
-        //     }
-        //     &.open {
-        //       width: 160px;
-        //       a.dropdown-toggle {
-        //         margin: 7px;
-        //         padding: 10px;
-        //         overflow: auto;
-        //         .border-radius(4px);
-        //         span {
-        //           &:first-child {
-        //             color: @cdap-darkness;
-        //             float: left;
-        //           }
-        //           &:last-child { display: none; }
-        //         }
-        //       }
-        //     }
-        //   }
-
-        // }
-        .navbar-right li.dropdown {
-          ul.dropdown-menu {
-            .border-radius(4px 0 4px 4px);
-            li {
-              &.nav-subsection { border: 0; }
+          // Main nav
+          nav {
+            @media (min-width: @screen-sm-min) {
+              > ul.navbar-nav {
+                background-color: @cdap-darkness;
+                li {
+                  &.active > a {
+                    color: @cdap-orange;
+                    background-color: @gray-lighter;
+                  }
+                  > a {
+                    color: lightgray;
+                    &:hover, &:focus { color: @cdap-orange; }
+                  }
+                }
+              }
+            }
+            @media (max-width: @screen-md-max) {
+              ul.navbar-nav {
+                > .active > a { color: @cdap-orange; }
+              }
             }
           }
         }

--- a/cdap-ui/app/styles/themes/cdap/header.less
+++ b/cdap-ui/app/styles/themes/cdap/header.less
@@ -13,7 +13,7 @@ body {
 
       @media (max-width: @screen-sm-max) {
         a.dropdown-toggle {
-          padding-left: 11px;
+          padding-left: 10px;
           span.fa-cog { display: none; }
           &:before {
             content: 'Settings';
@@ -33,7 +33,7 @@ body {
         }
       }
 
-      @media (min-width: @screen-sm-min) {
+      @media (min-width: @screen-md-min) {
         a.dropdown-toggle {
           color: lightgray;
           padding: 5px 3px;
@@ -43,6 +43,93 @@ body {
           > li > a { padding-left: 14px; }
           li.nav-subsection { margin: 10px 0 0 10px; }
         }
+      }
+    }
+
+    @media (min-width: @screen-md-min) {
+      li.dropdown {
+        background-color: transparent;
+        .border-radius(4px 4px 0 0);
+        .transition(background-color 0.2s ease-in);
+        &.open {
+          background-color: @brand-primary;
+          a.dropdown-toggle {
+            background-color: @cdap-white;
+            color:@cdap-header;
+            font-size: 14px;
+            .border-radius(4px);
+          }
+        }
+
+        ul.dropdown-menu {
+          background-color: @brand-primary;
+          border: 0;
+          margin: 0;
+          padding: 0;
+          top: 50px !important;
+          li {
+            position: relative;
+            &:not(:last-child) { border-bottom:1px solid rgba(0,0,0,0.1); }
+          }
+          a {
+            color: white;
+            font-size: 14px;
+            margin: 7px;
+            padding: 10px;
+            max-width: 95%;
+            text-overflow: ellipsis;
+            overflow: hidden;
+            &:hover, &:focus {
+              background-color: white;
+              color: @cdap-darkness;
+              outline: none;
+              .border-radius(4px);
+              span { color: @cdap-darkness; }
+            }
+          }
+        }
+      }
+      .navbar-collapse > ul.nav:first-child {
+        margin-left: 10px;
+        width: 160px;
+      }
+      .nav:first-child {
+        ul.dropdown-menu {
+          .border-radius(0 0 4px 4px);
+          left: 0;
+          width: 160px;
+          max-height: 500px;
+          overflow-y: auto;
+          li:nth-last-child(2) { border-bottom: 0; }
+        }
+        li.dropdown {
+          width: 100%;
+          a.dropdown-toggle {
+            white-space: nowrap;
+            span {
+              color: lightgray;
+              &:first-child { padding-right: 5px; }
+            }
+          }
+          &.open {
+            width: 160px;
+            z-index: 10;
+            a.dropdown-toggle {
+              margin: 7px;
+              padding: 10px;
+              overflow: auto;
+              .border-radius(4px);
+              span {
+                &:first-child {
+                  color: @cdap-darkness;
+                  float: left;
+                }
+                &:last-child { display: none; }
+              }
+            }
+          }
+        }
+
       }
     }
   }
@@ -89,6 +176,23 @@ body {
         -webkit-animation-duration: 0s;
         animation-duration: 0s;
       }
+      .navbar-collapse {
+        border-top: 0;
+        display: block;
+        max-height: 0;
+        visibility: visible;
+        > ul.navbar-nav {
+          display: none;
+        }
+        &.in {
+          > ul.navbar-nav {
+            display: block;
+            &.navbar-right {
+
+            }
+          }
+        }
+      }
       .navbar-collapse.in {
         margin-top: 15px;
         max-height: none;
@@ -122,6 +226,12 @@ body {
           > ul.nav {
             background-color: @cdap-darkness;
             .border-radius(25px);
+            display: block;
+            float: left;
+            margin: 0;
+            > li {
+              float: left;
+            }
 
             li {
               width: 140px;
@@ -146,89 +256,89 @@ body {
           }
         }
 
-        li.dropdown {
-          background-color: transparent;
-          .border-radius(4px 4px 0 0);
-          .transition(background-color 0.2s ease-in);
-          &.open {
-            background-color: @brand-primary;
-            a.dropdown-toggle {
-              background-color: @cdap-white;
-              color:@cdap-header;
-              font-size: 14px;
-              .border-radius(4px);
-            }
-          }
+        // li.dropdown {
+        //   background-color: transparent;
+        //   .border-radius(4px 4px 0 0);
+        //   .transition(background-color 0.2s ease-in);
+        //   &.open {
+        //     background-color: @brand-primary;
+        //     a.dropdown-toggle {
+        //       background-color: @cdap-white;
+        //       color:@cdap-header;
+        //       font-size: 14px;
+        //       .border-radius(4px);
+        //     }
+        //   }
 
-          ul.dropdown-menu {
-            background-color: @brand-primary;
-            border: 0;
-            margin: 0;
-            padding: 0;
-            top: 50px !important;
-            li {
-              position: relative;
-              &:not(:last-child) { border-bottom:1px solid rgba(0,0,0,0.1); }
-            }
-            a {
-              color: white;
-              font-size: 14px;
-              margin: 7px;
-              padding: 10px;
-              max-width: 95%;
-              text-overflow: ellipsis;
-              overflow: hidden;
-              &:hover, &:focus {
-                background-color: white;
-                color: @cdap-darkness;
-                outline: none;
-                .border-radius(4px);
-                span { color: @cdap-darkness; }
-              }
-            }
-          }
-        }
-        .navbar-collapse > ul.nav:first-child {
-          margin-left: 10px;
-          width: 160px;
-        }
-        .nav:first-child {
-          ul.dropdown-menu {
-            .border-radius(0 0 4px 4px);
-            left: 0;
-            width: 160px;
-            max-height: 500px;
-            overflow-y: auto;
-            li:nth-last-child(2) { border-bottom: 0; }
-          }
-          li.dropdown {
-            width: 100%;
-            a.dropdown-toggle {
-              white-space: nowrap;
-              span {
-                color: lightgray;
-                &:first-child { padding-right: 5px; }
-              }
-            }
-            &.open {
-              width: 160px;
-              a.dropdown-toggle {
-                margin: 7px;
-                padding: 10px;
-                overflow: auto;
-                .border-radius(4px);
-                span {
-                  &:first-child {
-                    color: @cdap-darkness;
-                    float: left;
-                  }
-                  &:last-child { display: none; }
-                }
-              }
-            }
-          }
+        //   ul.dropdown-menu {
+        //     background-color: @brand-primary;
+        //     border: 0;
+        //     margin: 0;
+        //     padding: 0;
+        //     top: 50px !important;
+        //     li {
+        //       position: relative;
+        //       &:not(:last-child) { border-bottom:1px solid rgba(0,0,0,0.1); }
+        //     }
+        //     a {
+        //       color: white;
+        //       font-size: 14px;
+        //       margin: 7px;
+        //       padding: 10px;
+        //       max-width: 95%;
+        //       text-overflow: ellipsis;
+        //       overflow: hidden;
+        //       &:hover, &:focus {
+        //         background-color: white;
+        //         color: @cdap-darkness;
+        //         outline: none;
+        //         .border-radius(4px);
+        //         span { color: @cdap-darkness; }
+        //       }
+        //     }
+        //   }
+        // }
+        // .navbar-collapse > ul.nav:first-child {
+        //   margin-left: 10px;
+        //   width: 160px;
+        // }
+        // .nav:first-child {
+        //   ul.dropdown-menu {
+        //     .border-radius(0 0 4px 4px);
+        //     left: 0;
+        //     width: 160px;
+        //     max-height: 500px;
+        //     overflow-y: auto;
+        //     li:nth-last-child(2) { border-bottom: 0; }
+        //   }
+        //   li.dropdown {
+        //     width: 100%;
+        //     a.dropdown-toggle {
+        //       white-space: nowrap;
+        //       span {
+        //         color: lightgray;
+        //         &:first-child { padding-right: 5px; }
+        //       }
+        //     }
+        //     &.open {
+        //       width: 160px;
+        //       a.dropdown-toggle {
+        //         margin: 7px;
+        //         padding: 10px;
+        //         overflow: auto;
+        //         .border-radius(4px);
+        //         span {
+        //           &:first-child {
+        //             color: @cdap-darkness;
+        //             float: left;
+        //           }
+        //           &:last-child { display: none; }
+        //         }
+        //       }
+        //     }
+        //   }
 
-        }
+        // }
         .navbar-right li.dropdown {
           ul.dropdown-menu {
             .border-radius(4px 0 4px 4px);

--- a/cdap-ui/app/styles/variables.less
+++ b/cdap-ui/app/styles/variables.less
@@ -70,4 +70,4 @@
 // Adapters when plugin added
 @selected-plugin-bg:           #2c498b;
 
-@grid-float-breakpoint:     @screen-md-min;
+@grid-float-breakpoint:     @screen-lg-min;

--- a/cdap-ui/app/styles/variables.less
+++ b/cdap-ui/app/styles/variables.less
@@ -69,3 +69,5 @@
 
 // Adapters when plugin added
 @selected-plugin-bg:           #2c498b;
+
+@grid-float-breakpoint:     @screen-md-min;


### PR DESCRIPTION
In this PR:
* Namespace and Settings dropdown menus now visible across all device widths
* "one" class added to namespace dropdown via ng-class, allowing for a tooltip and special styling when there is only one namespace to display
* Improved organization of header styles

![header](https://cloud.githubusercontent.com/assets/5335210/8296067/72e5b5ba-1900-11e5-89d3-6ca510c44225.gif)
