### PR TITLE
[CDAP-2849] - FileBatchSource reads in twice

### DIFF
--- a/cdap-ui/templates/ETLBatch/FileBatchSource.json
+++ b/cdap-ui/templates/ETLBatch/FileBatchSource.json
@@ -1,0 +1,41 @@
+{
+  "id": "FileBatchSource",
+  "groups" : {
+    "position": [ "group1" ],
+    "group1": {
+      "display" : "File Batch Source",
+      "position" : [ "fileSystem", "fileSystemProperties", "path", "fileRegex", "timeTable", "inputFormatClass"],
+      "fields" : {
+        "fileSystem" : {
+          "widget": "textbox",
+          "label": "File System"
+        },
+
+        "fileSystemProperties" : {
+          "widget": "json-editor",
+          "label": "File System Properties"
+        },
+
+        "path" : {
+          "widget": "textbox",
+          "label": "Path"
+        },
+
+        "fileRegex" : {
+          "widget": "textbox",
+          "label": "File Regex"
+        },
+
+        "timeTable" : {
+          "widget": "textbox",
+          "label": "Time Table"
+        },
+
+        "inputFormatClass" : {
+          "widget": "textbox",
+          "label": "Input Format Class"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
JIRA -  https://issues.cask.co/browse/CDAP-2849
Build - http://builds.cask.co/browse/CDAP-DUT2093-1

FileBatchSource would read in twice if the mapreduce took longer than the duration of the workflow, since the last time read wouldn't be updated until onFinish(). Thus, we now update it in prepareRun() and revert it in onFinish() if the mapreduce failed.