### PR TITLE
CDAP-2855 Fail on errors in scripts for Docker/VM

### DIFF
--- a/cdap-distributions/src/packer/scripts/apt-cleanup.sh
+++ b/cdap-distributions/src/packer/scripts/apt-cleanup.sh
@@ -31,3 +31,5 @@ apt-get purge -y fuse
 # Autoremove and clean
 apt-get autoremove -y
 apt-get autoclean
+
+exit 0

--- a/cdap-distributions/src/packer/scripts/apt-setup.sh
+++ b/cdap-distributions/src/packer/scripts/apt-setup.sh
@@ -26,3 +26,5 @@ apt-get update
 
 # Update system
 apt-get dist-upgrade -y
+
+exit 0

--- a/cdap-distributions/src/packer/scripts/cookbook-dir.sh
+++ b/cdap-distributions/src/packer/scripts/cookbook-dir.sh
@@ -24,6 +24,10 @@ cd /var/chef/cookbooks
 
 # Initialize Git repository
 touch .gitignore
+
+which git || echo "Cannot locate git" && exit 1
 git init
 git add .gitignore
 git commit -m 'Initial commit'
+
+exit 0

--- a/cdap-distributions/src/packer/scripts/cookbook-setup.sh
+++ b/cdap-distributions/src/packer/scripts/cookbook-setup.sh
@@ -20,8 +20,10 @@
 
 # Grab cookbooks using knife
 for cb in hadoop idea maven nodejs cdap ; do
-  knife cookbook site install $cb
+  knife cookbook site install $cb || echo "Cannot fetch cookbook $cb" && exit 1
 done
 
 # Do not change HOME for cdap user
 sed -i '/ home /d' /var/chef/cookbooks/cdap/recipes/sdk.rb
+
+exit 0

--- a/cdap-distributions/src/packer/scripts/eclipse-cookbook.sh
+++ b/cdap-distributions/src/packer/scripts/eclipse-cookbook.sh
@@ -18,10 +18,13 @@
 # Download Eclipse cookbook for Chef from https://github.com/geocent-cookbooks/eclipse
 #
 
-cd /var/chef/cookbooks
+cd /var/chef/cookbooks || echo "Cannot change to cookbook directory" && exit 1
 
 # Check out the cookbook from GitHub
-git clone https://github.com/geocent-cookbooks/eclipse.git
+which git || echo "Cannot locate git" && exit 1
+git clone https://github.com/geocent-cookbooks/eclipse.git || echo "Cannot checkout eclipse cookbook" && exit 1
 
 # Remove .git, so it's no longer tracked by git
 rm -rf eclipse/.git
+
+exit 0

--- a/cdap-distributions/src/packer/scripts/fill-maven-cache.sh
+++ b/cdap-distributions/src/packer/scripts/fill-maven-cache.sh
@@ -18,5 +18,7 @@ __tmpdir=/tmp/cdap-examples.$$
 mkdir -p ${__tmpdir}
 cp -a /opt/cdap/sdk/examples ${__tmpdir}
 chown -R cdap ${__tmpdir}
-su - cdap -c "cd ${__tmpdir}/examples && MAVEN_OPTS='-Xmx512m -XX:MaxPermSize=128m' mvn package -DskipTests"
+su - cdap -c "cd ${__tmpdir}/examples && MAVEN_OPTS='-Xmx512m -XX:MaxPermSize=128m' mvn package -DskipTests" || exit 1
 rm -rf ${__tmpdir}
+
+exit 0

--- a/cdap-distributions/src/packer/scripts/lxde.sh
+++ b/cdap-distributions/src/packer/scripts/lxde.sh
@@ -22,7 +22,7 @@
 apt-get install -y lxde
 
 # Symlink idea
-ln -sf /opt/idea* /opt/idea
+ln -sf /opt/idea* /opt/idea || echo "Unable to symlink IDEA" && exit 1
 # Copy icons
 cp -f /opt/idea/bin/idea.png /usr/share/pixmaps
 cp -f /usr/local/eclipse/icon.xpm /usr/share/pixmaps/eclipse.xpm
@@ -94,3 +94,5 @@ sed -i \
 
 # Fix permissions
 chown -R cdap:cdap ~cdap
+
+exit 0

--- a/cdap-distributions/src/packer/scripts/motd.sh
+++ b/cdap-distributions/src/packer/scripts/motd.sh
@@ -39,3 +39,5 @@ Logs for the SDK are found at /opt/cdap/sdk/logs, data is stored at
 
 EOF
 done
+
+exit 0

--- a/cdap-distributions/src/packer/scripts/network-cleanup.sh
+++ b/cdap-distributions/src/packer/scripts/network-cleanup.sh
@@ -16,3 +16,5 @@
 
 # Remove UDEV persistent network rules
 rm -f /etc/udev/rules.d/70-persistent-net.rules
+
+exit 0

--- a/cdap-distributions/src/packer/scripts/random-root-password.sh
+++ b/cdap-distributions/src/packer/scripts/random-root-password.sh
@@ -29,3 +29,5 @@ echo "root:`apg -a 1 -m 14 -n 1`" | chpasswd
 
 # Remove apg
 apt-get purge -y apg
+
+exit 0

--- a/cdap-distributions/src/packer/scripts/remove-chef.sh
+++ b/cdap-distributions/src/packer/scripts/remove-chef.sh
@@ -23,3 +23,5 @@ apt-get purge -y chef
 
 # Remove directory
 rm -rf /var/chef
+
+exit 0

--- a/cdap-distributions/src/packer/scripts/sdk-cleanup.sh
+++ b/cdap-distributions/src/packer/scripts/sdk-cleanup.sh
@@ -26,3 +26,5 @@ rm -rf /opt/cdap/conf /opt/cdap/sdk/data /opt/cdap/sdk/logs
 
 # Make cdap own /opt/cdap
 chown -R cdap:cdap /opt/cdap
+
+exit 0

--- a/cdap-distributions/src/packer/scripts/slim.sh
+++ b/cdap-distributions/src/packer/scripts/slim.sh
@@ -25,3 +25,5 @@ apt-get install -y slim
 echo 'sessiondir /usr/share/xsessions/' >> /etc/slim.conf
 echo 'default_user cdap' >> /etc/slim.conf
 echo 'auto_login yes' >> /etc/slim.conf
+
+exit 0

--- a/cdap-distributions/src/packer/scripts/vbox-guest-additions.sh
+++ b/cdap-distributions/src/packer/scripts/vbox-guest-additions.sh
@@ -19,11 +19,13 @@
 #
 
 # Mount ISO
-mount -o ro,loop /root/VBoxGuestAdditions.iso /mnt
+mount -o ro,loop /root/VBoxGuestAdditions.iso /mnt || echo "Cannot mount VirtualBox Guest Additions ISO" && exit 1
 
 # Run installer
-/mnt/VBoxLinuxAdditions.run
+/mnt/VBoxLinuxAdditions.run || echo "Failed installing VirtualBox Guest Additions" && exit 1
 
 # Unmount and remove ISO
 umount /mnt
 rm -f /root/VBoxGuestAdditions.iso
+
+exit 0

--- a/cdap-distributions/src/packer/scripts/xorg.sh
+++ b/cdap-distributions/src/packer/scripts/xorg.sh
@@ -31,3 +31,4 @@ for i in mouse synaptics wacom ; do
   apt-get purge -y xserver-xorg-input-$i
 done
 
+exit 0

--- a/cdap-distributions/src/packer/scripts/zero-disk.sh
+++ b/cdap-distributions/src/packer/scripts/zero-disk.sh
@@ -22,4 +22,6 @@
 dd if=/dev/zero of=/deleteme bs=1M
 
 # Remove file to free space
-rm -f /deleteme
+rm -f /deleteme || echo "Unable to delete zero-filled /deleteme" && exit 1
+
+exit 0


### PR DESCRIPTION
This error checks cases where we could potentially fail to produce the desired output. Specifically, this will fail the build if the Maven cache cannot be filled.