### PR TITLE
[CDAP-2767] Fix error messages in namespace delete

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/NamespaceHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/NamespaceHttpHandler.java
@@ -162,7 +162,10 @@ public class NamespaceHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/unrecoverable/namespaces/{namespace-id}")
   public void delete(HttpRequest request, HttpResponder responder, @PathParam("namespace-id") String namespace) {
     if (!cConf.getBoolean(Constants.Dangerous.UNRECOVERABLE_RESET, Constants.Dangerous.DEFAULT_UNRECOVERABLE_RESET)) {
-      responder.sendStatus(HttpResponseStatus.FORBIDDEN);
+      responder.sendString(HttpResponseStatus.FORBIDDEN,
+                           String.format("Namespace '%s' cannot be deleted because '%s' is not enabled. " +
+                                           "Please enable it and restart CDAP Master.",
+                                         namespace, Constants.Dangerous.UNRECOVERABLE_RESET));
       return;
     }
     Id.Namespace namespaceId = Id.Namespace.from(namespace);
@@ -184,7 +187,10 @@ public class NamespaceHttpHandler extends AbstractAppFabricHttpHandler {
   public void deleteDatasets(HttpRequest request, HttpResponder responder,
                              @PathParam("namespace-id") String namespace) {
     if (!cConf.getBoolean(Constants.Dangerous.UNRECOVERABLE_RESET, Constants.Dangerous.DEFAULT_UNRECOVERABLE_RESET)) {
-      responder.sendStatus(HttpResponseStatus.FORBIDDEN);
+      responder.sendString(HttpResponseStatus.FORBIDDEN,
+                           String.format("All datasets in namespace %s cannot be deleted because '%s' is not enabled." +
+                                           " Please enable it and restart CDAP Master.",
+                                         namespace, Constants.Dangerous.UNRECOVERABLE_RESET));
       return;
     }
     Id.Namespace namespaceId = Id.Namespace.from(namespace);
@@ -194,7 +200,8 @@ public class NamespaceHttpHandler extends AbstractAppFabricHttpHandler {
     } catch (NotFoundException e) {
       responder.sendString(HttpResponseStatus.NOT_FOUND, String.format("Namespace %s not found.", namespace));
     } catch (NamespaceCannotBeDeletedException e) {
-      responder.sendString(HttpResponseStatus.CONFLICT, e.getMessage());
+      responder.sendString(HttpResponseStatus.CONFLICT, String.format("Datasets in namespace %s cannot be deleted. " +
+                                                                       "Reason: %s", namespace, e.getReason()));
     } catch (Exception e) {
       LOG.error("Internal error while deleting namespace.", e);
       responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, e.getMessage());

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdmin.java
@@ -258,20 +258,19 @@ public final class DefaultNamespaceAdmin implements NamespaceAdmin {
 
     if (checkProgramsRunning(namespaceId)) {
       throw new NamespaceCannotBeDeletedException(namespaceId,
-                                                  "Some programs are currently running in namespace " + namespaceId);
+                                                  String.format("Some programs are currently running in namespace " +
+                                                                  "'%s', please stop them before deleting datasets " +
+                                                                  "in the namespace.",
+                                                                namespaceId));
     }
 
-    LOG.info("Deleting data in namespace '{}'.", namespaceId);
     try {
       dsFramework.deleteAllInstances(namespaceId);
-    } catch (DatasetManagementException e) {
-      LOG.warn("Error while deleting data in namespace {}", namespaceId, e);
-      throw new NamespaceCannotBeDeletedException(namespaceId, e);
-    } catch (IOException e) {
-      LOG.warn("Error while deleting data in namespace {}", namespaceId, e);
+    } catch (DatasetManagementException | IOException e) {
+      LOG.warn("Error while deleting datasets in namespace {}", namespaceId, e);
       throw new NamespaceCannotBeDeletedException(namespaceId, e);
     }
-    LOG.info("Deleted data in namespace '{}'.", namespaceId);
+    LOG.debug("Deleted datasets in namespace '{}'.", namespaceId);
   }
 
   public synchronized void updateProperties(Id.Namespace namespaceId, NamespaceMeta namespaceMeta)

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/CannotBeDeletedException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/CannotBeDeletedException.java
@@ -24,25 +24,31 @@ import co.cask.cdap.proto.Id;
 public class CannotBeDeletedException extends ConflictException {
 
   private final Id objectId;
+  private final String reason;
 
   public CannotBeDeletedException(Id id) {
     super(String.format("'%s' could not be deleted", id.getIdRep()));
     this.objectId = id;
+    this.reason = null;
   }
 
   public CannotBeDeletedException(Id id, String reason) {
     super(String.format("'%s' could not be deleted. Reason: %s", id.getIdRep(), reason));
     this.objectId = id;
+    this.reason = reason;
   }
 
   public CannotBeDeletedException(Id id, Throwable cause) {
     super(String.format("'%s' could not be deleted. Reason: %s", id.getIdRep(), cause.getMessage()), cause);
     this.objectId = id;
+    this.reason = cause.getMessage();
   }
 
   public Id getObjectId() {
     return objectId;
   }
 
-
+  public String getReason() {
+    return reason;
+  }
 }

--- a/cdap-common/src/main/java/co/cask/cdap/common/namespace/AbstractNamespaceClient.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/namespace/AbstractNamespaceClient.java
@@ -39,7 +39,7 @@ import java.util.List;
  * Common implementation of methods to interact with namespace service.
  */
 public abstract class AbstractNamespaceClient {
-  private static final String NAMESPACE_ENTITY_TYPE = "namespace";
+  private static final Gson GSON = new Gson();
 
   protected abstract HttpResponse execute(HttpRequest request) throws IOException, UnauthorizedException;
   protected abstract URL resolve(String resource) throws IOException;
@@ -51,7 +51,7 @@ public abstract class AbstractNamespaceClient {
       return ObjectResponse.fromJsonBody(response, new TypeToken<List<NamespaceMeta>>() { })
         .getResponseObject();
     }
-    throw new IOException("Cannot list namespaces. Reason: " + "getDetails(response)");
+    throw new IOException(String.format("Cannot list namespaces. Reason: %s", response));
   }
 
   public NamespaceMeta get(String namespaceId) throws NamespaceNotFoundException, IOException, UnauthorizedException {
@@ -62,7 +62,7 @@ public abstract class AbstractNamespaceClient {
     } else if (response.getResponseCode() == HttpURLConnection.HTTP_OK) {
       return ObjectResponse.fromJsonBody(response, NamespaceMeta.class).getResponseObject();
     }
-    throw new IOException("Cannot get namespace. Reason: " + "getDetails(response)");
+    throw new IOException("Cannot get namespace. Reason: " + response);
   }
 
   public void delete(String namespaceId)
@@ -75,11 +75,11 @@ public abstract class AbstractNamespaceClient {
     if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
       throw new NamespaceNotFoundException(namespace);
     } else if (HttpURLConnection.HTTP_FORBIDDEN == response.getResponseCode()) {
-      throw new NamespaceCannotBeDeletedException(namespace);
+      throw new NamespaceCannotBeDeletedException(namespace, response.getResponseBodyAsString());
     } else if (response.getResponseCode() == HttpURLConnection.HTTP_OK) {
       return;
     }
-    throw new IOException("Cannot delete namespace. Reason: " + "getDetails(response)");
+    throw new IOException("Cannot delete namespace. Reason: " + response);
   }
 
   public void create(NamespaceMeta namespaceMeta)
@@ -88,7 +88,7 @@ public abstract class AbstractNamespaceClient {
 
     Id.Namespace namespace = Id.Namespace.from(namespaceMeta.getName());
     URL url = resolve(String.format("namespaces/%s", namespace.getId()));
-    HttpResponse response = execute(HttpRequest.put(url).withBody(new Gson().toJson(namespaceMeta)).build());
+    HttpResponse response = execute(HttpRequest.put(url).withBody(GSON.toJson(namespaceMeta)).build());
     String responseBody = response.getResponseBodyAsString();
     if (response.getResponseCode() == HttpURLConnection.HTTP_OK) {
       if (responseBody != null && responseBody.equals(String.format("Namespace '%s' already exists.",
@@ -100,7 +100,7 @@ public abstract class AbstractNamespaceClient {
     if (response.getResponseCode() == HttpURLConnection.HTTP_BAD_REQUEST) {
       throw new BadRequestException("Bad request: " + responseBody);
     }
-    throw new IOException("Cannot get create namespace. Reason: " + "getDetails(response)");
+    throw new IOException(String.format("Cannot create namespace %s. Reason: %s", namespaceMeta.getName(), response));
   }
 
   public void deleteAll() throws

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
@@ -35,7 +35,6 @@ import co.cask.common.http.HttpMethod;
 import co.cask.common.http.HttpRequest;
 import co.cask.common.http.HttpRequests;
 import co.cask.common.http.HttpResponse;
-import com.google.common.base.Charsets;
 import com.google.common.base.Joiner;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
@@ -102,10 +101,10 @@ class DatasetServiceClient {
     }
     if (HttpResponseStatus.OK.getCode() != response.getResponseCode()) {
       throw new DatasetManagementException(String.format("Cannot retrieve dataset instance %s info, details: %s",
-                                                         instanceName, getDetails(response)));
+                                                         instanceName, response));
     }
 
-    return GSON.fromJson(new String(response.getResponseBody(), Charsets.UTF_8), DatasetMeta.class);
+    return GSON.fromJson(response.getResponseBodyAsString(), DatasetMeta.class);
   }
 
   @Nullable
@@ -117,20 +116,20 @@ class DatasetServiceClient {
     HttpResponse response = doGet("datasets");
     if (HttpResponseStatus.OK.getCode() != response.getResponseCode()) {
       throw new DatasetManagementException(String.format("Cannot retrieve all dataset instances, details: %s",
-                                                         getDetails(response)));
+                                                         response));
     }
 
-    return GSON.fromJson(new String(response.getResponseBody(), Charsets.UTF_8), SUMMARY_LIST_TYPE);
+    return GSON.fromJson(response.getResponseBodyAsString(), SUMMARY_LIST_TYPE);
   }
 
   public Collection<DatasetModuleMeta> getAllModules() throws DatasetManagementException {
     HttpResponse response = doGet("modules");
     if (HttpResponseStatus.OK.getCode() != response.getResponseCode()) {
       throw new DatasetManagementException(String.format("Cannot retrieve all dataset instances, details: %s",
-                                                         getDetails(response)));
+                                                         response));
     }
 
-    return GSON.fromJson(new String(response.getResponseBody(), Charsets.UTF_8), MODULE_META_LIST_TYPE);
+    return GSON.fromJson(response.getResponseBodyAsString(), MODULE_META_LIST_TYPE);
   }
 
   public DatasetTypeMeta getType(String typeName) throws DatasetManagementException {
@@ -140,9 +139,9 @@ class DatasetServiceClient {
     }
     if (HttpResponseStatus.OK.getCode() != response.getResponseCode()) {
       throw new DatasetManagementException(String.format("Cannot retrieve dataset type %s info, details: %s",
-                                                         typeName, getDetails(response)));
+                                                         typeName, response));
     }
-    return GSON.fromJson(new String(response.getResponseBody(), Charsets.UTF_8), DatasetTypeMeta.class);
+    return GSON.fromJson(response.getResponseBodyAsString(), DatasetTypeMeta.class);
   }
 
   public void addInstance(String datasetInstanceName, String datasetType, DatasetProperties props)
@@ -154,11 +153,11 @@ class DatasetServiceClient {
 
     if (HttpResponseStatus.CONFLICT.getCode() == response.getResponseCode()) {
       throw new InstanceConflictException(String.format("Failed to add instance %s due to conflict, details: %s",
-                                                         datasetInstanceName, getDetails(response)));
+                                                         datasetInstanceName, response));
     }
     if (HttpResponseStatus.OK.getCode() != response.getResponseCode()) {
       throw new DatasetManagementException(String.format("Failed to add instance %s, details: %s",
-                                                          datasetInstanceName, getDetails(response)));
+                                                          datasetInstanceName, response));
     }
   }
 
@@ -170,11 +169,11 @@ class DatasetServiceClient {
 
     if (HttpResponseStatus.CONFLICT.getCode() == response.getResponseCode()) {
       throw new InstanceConflictException(String.format("Failed to add instance %s due to conflict, details: %s",
-                                                        datasetInstanceName, getDetails(response)));
+                                                        datasetInstanceName, response));
     }
     if (HttpResponseStatus.OK.getCode() != response.getResponseCode()) {
       throw new DatasetManagementException(String.format("Failed to add instance %s, details: %s",
-                                                         datasetInstanceName, getDetails(response)));
+                                                         datasetInstanceName, response));
     }
   }
 
@@ -182,11 +181,11 @@ class DatasetServiceClient {
     HttpResponse response = doDelete("datasets/" + datasetInstanceName);
     if (HttpResponseStatus.CONFLICT.getCode() == response.getResponseCode()) {
       throw new InstanceConflictException(String.format("Failed to delete instance %s due to conflict, details: %s",
-                                                        datasetInstanceName, getDetails(response)));
+                                                        datasetInstanceName, response));
     }
     if (HttpResponseStatus.OK.getCode() != response.getResponseCode()) {
       throw new DatasetManagementException(String.format("Failed to delete instance %s, details: %s",
-                                                         datasetInstanceName, getDetails(response)));
+                                                         datasetInstanceName, response));
     }
   }
 
@@ -199,11 +198,10 @@ class DatasetServiceClient {
 
     if (HttpResponseStatus.CONFLICT.getCode() == response.getResponseCode()) {
       throw new ModuleConflictException(String.format("Failed to add module %s due to conflict, details: %s",
-                                                      moduleName, getDetails(response)));
+                                                      moduleName, response));
     }
     if (HttpResponseStatus.OK.getCode() != response.getResponseCode()) {
-      throw new DatasetManagementException(String.format("Failed to add module %s, details: %s",
-                                                         moduleName, getDetails(response)));
+      throw new DatasetManagementException(String.format("Failed to add module %s, details: %s", moduleName, response));
     }
   }
 
@@ -213,11 +211,11 @@ class DatasetServiceClient {
 
     if (HttpResponseStatus.CONFLICT.getCode() == response.getResponseCode()) {
       throw new ModuleConflictException(String.format("Failed to delete module %s due to conflict, details: %s",
-                                                      moduleName, getDetails(response)));
+                                                      moduleName, response));
     }
     if (HttpResponseStatus.OK.getCode() != response.getResponseCode()) {
       throw new DatasetManagementException(String.format("Failed to delete module %s, details: %s",
-                                                         moduleName, getDetails(response)));
+                                                         moduleName, response));
     }
   }
 
@@ -225,24 +223,21 @@ class DatasetServiceClient {
     HttpResponse response = doDelete("modules");
 
     if (HttpResponseStatus.OK.getCode() != response.getResponseCode()) {
-      throw new DatasetManagementException(String.format("Failed to delete modules, details: %s",
-                                                         getDetails(response)));
+      throw new DatasetManagementException(String.format("Failed to delete modules, details: %s", response));
     }
   }
 
   public void createNamespace() throws DatasetManagementException {
     HttpResponse response = doPut("admin/create", GSON.toJson(namespaceId));
     if (HttpResponseStatus.OK.getCode() != response.getResponseCode()) {
-      throw new DatasetManagementException(String.format("Failed to create namespace, details: %s",
-                                                         getDetails(response)));
+      throw new DatasetManagementException(String.format("Failed to create namespace, details: %s", response));
     }
   }
 
   public void deleteNamespace() throws DatasetManagementException {
     HttpResponse response = doDelete("admin/delete");
     if (HttpResponseStatus.OK.getCode() != response.getResponseCode()) {
-      throw new DatasetManagementException(String.format("Failed to delete namespace, details: %s",
-                                                         getDetails(response)));
+      throw new DatasetManagementException(String.format("Failed to delete namespace, details: %s", response));
     }
   }
 
@@ -314,14 +309,6 @@ class DatasetServiceClient {
 
   private HttpResponse doRequest(HttpMethod method, String url) throws DatasetManagementException {
     return doRequest(method, url, null, (InputSupplier<? extends InputStream>) null);
-  }
-
-  private String getDetails(HttpResponse response) throws DatasetManagementException {
-    return String.format("Response code: %s, message:'%s', body: '%s'",
-                         response.getResponseCode(), response.getResponseMessage(),
-                         response.getResponseBody() == null ?
-                           "null" : new String(response.getResponseBody(), Charsets.UTF_8));
-
   }
 
   private String resolve(String resource) throws DatasetManagementException {

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/ExploreHttpClient.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/ExploreHttpClient.java
@@ -96,8 +96,8 @@ abstract class ExploreHttpClient implements Explore {
     if (response.getResponseCode() == HttpURLConnection.HTTP_OK) {
       return QueryHandle.fromId(parseResponseAsMap(response, "handle"));
     }
-    throw new ExploreException("Cannot enable explore on stream " + stream.getId() + ". Reason: " +
-                                 getDetails(response));
+    throw new ExploreException(String.format("Cannot enable explore on stream %s. Reason: %s",
+                                             stream.getId(), response));
   }
 
   protected QueryHandle doDisableExploreStream(Id.Stream stream) throws ExploreException {
@@ -106,8 +106,8 @@ abstract class ExploreHttpClient implements Explore {
     if (response.getResponseCode() == HttpURLConnection.HTTP_OK) {
       return QueryHandle.fromId(parseResponseAsMap(response, "handle"));
     }
-    throw new ExploreException("Cannot disable explore on stream " + stream.getId() + ". Reason: " +
-                                 getDetails(response));
+    throw new ExploreException(String.format("Cannot disable explore on stream %s. Reason: %s",
+                                             stream.getId(), response));
   }
 
   protected QueryHandle doAddPartition(Id.DatasetInstance datasetInstance,
@@ -121,8 +121,8 @@ abstract class ExploreHttpClient implements Explore {
     if (response.getResponseCode() == HttpURLConnection.HTTP_OK) {
       return QueryHandle.fromId(parseResponseAsMap(response, "handle"));
     }
-    throw new ExploreException("Cannot add partition with key " + key + "to dataset " + datasetInstance.getId() +
-                                 ". Reason: " + getDetails(response));
+    throw new ExploreException(String.format("Cannot add partition with key %s to dataset %s. Reason: %s",
+                                             key, datasetInstance.getId(), response));
   }
 
   protected QueryHandle doDropPartition(Id.DatasetInstance datasetInstance, PartitionKey key) throws ExploreException {
@@ -134,8 +134,8 @@ abstract class ExploreHttpClient implements Explore {
     if (response.getResponseCode() == HttpURLConnection.HTTP_OK) {
       return QueryHandle.fromId(parseResponseAsMap(response, "handle"));
     }
-    throw new ExploreException("Cannot drop partition with key " + key + "from dataset " + datasetInstance.getId() +
-                                 ". Reason: " + getDetails(response));
+    throw new ExploreException(String.format("Cannot drop partition with key %s from dataset %s. Reason: %s",
+                                             key, datasetInstance.getId(), response));
   }
 
   protected QueryHandle doEnableExploreDataset(Id.DatasetInstance datasetInstance) throws ExploreException {
@@ -144,8 +144,8 @@ abstract class ExploreHttpClient implements Explore {
     if (response.getResponseCode() == HttpURLConnection.HTTP_OK) {
       return QueryHandle.fromId(parseResponseAsMap(response, "handle"));
     }
-    throw new ExploreException("Cannot enable explore on dataset " + datasetInstance.getId() + ". Reason: " +
-                                 getDetails(response));
+    throw new ExploreException(String.format("Cannot enable explore on dataset %s. Reason: %s",
+                                             datasetInstance.getId(), response));
   }
 
   protected QueryHandle doDisableExploreDataset(Id.DatasetInstance datasetInstance) throws ExploreException {
@@ -155,8 +155,8 @@ abstract class ExploreHttpClient implements Explore {
     if (response.getResponseCode() == HttpURLConnection.HTTP_OK) {
       return QueryHandle.fromId(parseResponseAsMap(response, "handle"));
     }
-    throw new ExploreException("Cannot disable explore on dataset " + datasetInstance.getId() + ". Reason: " +
-                                 getDetails(response));
+    throw new ExploreException(String.format("Cannot disable explore on dataset %s. Reason: %s",
+                                             datasetInstance.getId(), response));
   }
 
   @Override
@@ -166,7 +166,7 @@ abstract class ExploreHttpClient implements Explore {
     if (response.getResponseCode() == HttpURLConnection.HTTP_OK) {
       return QueryHandle.fromId(parseResponseAsMap(response, "handle"));
     }
-    throw new ExploreException("Cannot execute query. Reason: " + getDetails(response));
+    throw new ExploreException("Cannot execute query. Reason: " + response);
   }
 
   @Override
@@ -178,7 +178,7 @@ abstract class ExploreHttpClient implements Explore {
     } else if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
       throw new HandleNotFoundException("Handle " + handle.getHandle() + "not found.");
     }
-    throw new ExploreException("Cannot get status. Reason: " + getDetails(response));
+    throw new ExploreException("Cannot get status. Reason: " + response);
   }
 
   @Override
@@ -190,7 +190,7 @@ abstract class ExploreHttpClient implements Explore {
     } else if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
       throw new HandleNotFoundException("Handle " + handle.getHandle() + "not found.");
     }
-    throw new ExploreException("Cannot get result schema. Reason: " + getDetails(response));
+    throw new ExploreException("Cannot get result schema. Reason: " + response);
   }
 
   @Override
@@ -203,7 +203,7 @@ abstract class ExploreHttpClient implements Explore {
     } else if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
       throw new HandleNotFoundException("Handle " + handle.getHandle() + "not found.");
     }
-    throw new ExploreException("Cannot get next results. Reason: " + getDetails(response));
+    throw new ExploreException("Cannot get next results. Reason: " + response);
   }
 
   @Override
@@ -217,7 +217,7 @@ abstract class ExploreHttpClient implements Explore {
     } else if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
       throw new HandleNotFoundException("Handle " + handle.getHandle() + "not found.");
     }
-    throw new ExploreException("Cannot get results preview. Reason: " + getDetails(response));
+    throw new ExploreException("Cannot get results preview. Reason: " + response);
   }
 
   @Override
@@ -228,7 +228,7 @@ abstract class ExploreHttpClient implements Explore {
     } else if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
       throw new HandleNotFoundException("Handle " + handle.getHandle() + "not found.");
     }
-    throw new ExploreException("Cannot close operation. Reason: " + getDetails(response));
+    throw new ExploreException("Cannot close operation. Reason: " + response);
   }
 
   @Override
@@ -238,7 +238,7 @@ abstract class ExploreHttpClient implements Explore {
     if (response.getResponseCode() == HttpURLConnection.HTTP_OK) {
       return parseJson(response, QUERY_INFO_LIST_TYPE);
     }
-    throw new ExploreException("Cannot get list of queries. Reason: " + getDetails(response));
+    throw new ExploreException("Cannot get list of queries. Reason: " + response);
   }
 
   @Override
@@ -251,7 +251,7 @@ abstract class ExploreHttpClient implements Explore {
     if (response.getResponseCode() == HttpURLConnection.HTTP_OK) {
       return QueryHandle.fromId(parseResponseAsMap(response, "handle"));
     }
-    throw new ExploreException("Cannot get the columns. Reason: " + getDetails(response));
+    throw new ExploreException("Cannot get the columns. Reason: " + response);
   }
 
   @Override
@@ -260,7 +260,7 @@ abstract class ExploreHttpClient implements Explore {
     if (response.getResponseCode() == HttpURLConnection.HTTP_OK) {
       return QueryHandle.fromId(parseResponseAsMap(response, "handle"));
     }
-    throw new ExploreException("Cannot get the catalogs. Reason: " + getDetails(response));
+    throw new ExploreException("Cannot get the catalogs. Reason: " + response);
   }
 
   @Override
@@ -271,7 +271,7 @@ abstract class ExploreHttpClient implements Explore {
     if (response.getResponseCode() == HttpURLConnection.HTTP_OK) {
       return QueryHandle.fromId(parseResponseAsMap(response, "handle"));
     }
-    throw new ExploreException("Cannot get the schemas. Reason: " + getDetails(response));
+    throw new ExploreException("Cannot get the schemas. Reason: " + response);
   }
 
   @Override
@@ -283,7 +283,7 @@ abstract class ExploreHttpClient implements Explore {
     if (response.getResponseCode() == HttpURLConnection.HTTP_OK) {
       return QueryHandle.fromId(parseResponseAsMap(response, "handle"));
     }
-    throw new ExploreException("Cannot get the functions. Reason: " + getDetails(response));
+    throw new ExploreException("Cannot get the functions. Reason: " + response);
   }
 
   @Override
@@ -292,7 +292,7 @@ abstract class ExploreHttpClient implements Explore {
     if (response.getResponseCode() == HttpURLConnection.HTTP_OK) {
       return parseJson(response, MetaDataInfo.class);
     }
-    throw new ExploreException("Cannot get information " + infoType.name() + ". Reason: " + getDetails(response));
+    throw new ExploreException("Cannot get information " + infoType.name() + ". Reason: " + response);
   }
 
   @Override
@@ -304,7 +304,7 @@ abstract class ExploreHttpClient implements Explore {
     if (response.getResponseCode() == HttpURLConnection.HTTP_OK) {
       return QueryHandle.fromId(parseResponseAsMap(response, "handle"));
     }
-    throw new ExploreException("Cannot get the tables. Reason: " + getDetails(response));
+    throw new ExploreException("Cannot get the tables. Reason: " + response);
   }
 
   @Override
@@ -313,7 +313,7 @@ abstract class ExploreHttpClient implements Explore {
     if (response.getResponseCode() == HttpURLConnection.HTTP_OK) {
       return parseJson(response, TABLES_TYPE);
     }
-    throw new ExploreException("Cannot get the tables. Reason: " + getDetails(response));
+    throw new ExploreException("Cannot get the tables. Reason: " + response);
   }
 
   @Override
@@ -326,7 +326,7 @@ abstract class ExploreHttpClient implements Explore {
       throw new TableNotFoundException("Table " + database + table + " not found.");
     }
     throw new ExploreException("Cannot get the schema of table " + database + table +
-                               ". Reason: " + getDetails(response));
+                               ". Reason: " + response);
   }
 
   @Override
@@ -335,7 +335,7 @@ abstract class ExploreHttpClient implements Explore {
     if (response.getResponseCode() == HttpURLConnection.HTTP_OK) {
       return QueryHandle.fromId(parseResponseAsMap(response, "handle"));
     }
-    throw new ExploreException("Cannot get the tables. Reason: " + getDetails(response));
+    throw new ExploreException("Cannot get the tables. Reason: " + response);
   }
 
   @Override
@@ -344,7 +344,7 @@ abstract class ExploreHttpClient implements Explore {
     if (response.getResponseCode() == HttpURLConnection.HTTP_OK) {
       return QueryHandle.fromId(parseResponseAsMap(response, "handle"));
     }
-    throw new ExploreException("Cannot get the tables. Reason: " + getDetails(response));
+    throw new ExploreException("Cannot get the tables. Reason: " + response);
   }
 
   @Override
@@ -353,7 +353,7 @@ abstract class ExploreHttpClient implements Explore {
     if (response.getResponseCode() == HttpURLConnection.HTTP_OK) {
       return QueryHandle.fromId(parseResponseAsMap(response, "handle"));
     }
-    throw new ExploreException("Cannot add a namespace. Reason: " + getDetails(response));
+    throw new ExploreException("Cannot add a namespace. Reason: " + response);
   }
 
   @Override
@@ -362,7 +362,7 @@ abstract class ExploreHttpClient implements Explore {
     if (response.getResponseCode() == HttpURLConnection.HTTP_OK) {
       return QueryHandle.fromId(parseResponseAsMap(response, "handle"));
     }
-    throw new ExploreException("Cannot remove a namespace. Reason: " + getDetails(response));
+    throw new ExploreException("Cannot remove a namespace. Reason: " + response);
   }
 
   private String parseResponseAsMap(HttpResponse response, String key) throws ExploreException {
@@ -378,7 +378,7 @@ abstract class ExploreHttpClient implements Explore {
   }
 
   private <T> T parseJson(HttpResponse response, Type type) throws ExploreException {
-    String responseString = new String(response.getResponseBody(), Charsets.UTF_8);
+    String responseString = response.getResponseBodyAsString();
     try {
       return GSON.fromJson(responseString, type);
     } catch (JsonSyntaxException e) {
@@ -433,14 +433,6 @@ abstract class ExploreHttpClient implements Explore {
                       newHeaders == null ? "null" : Joiner.on(",").withKeyValueSeparator("=").join(newHeaders),
                       body == null ? "null" : body), e);
     }
-  }
-
-  private String getDetails(HttpResponse response) {
-    return String.format("Response code: %s, message:'%s', body: '%s'",
-                         response.getResponseCode(), response.getResponseMessage(),
-                         response.getResponseBody() == null ?
-                           "null" : new String(response.getResponseBody(), Charsets.UTF_8));
-
   }
 
   private String resolve(String resource) {

--- a/cdap-notifications-api/src/main/java/co/cask/cdap/notifications/feeds/client/RemoteNotificationFeedManager.java
+++ b/cdap-notifications-api/src/main/java/co/cask/cdap/notifications/feeds/client/RemoteNotificationFeedManager.java
@@ -87,7 +87,7 @@ public class RemoteNotificationFeedManager implements NotificationFeedManager {
     } else if (response.getResponseCode() == HttpURLConnection.HTTP_CONFLICT) {
       return false;
     }
-    throw new NotificationFeedException("Cannot create notification feed. Reason: " + getDetails(response));
+    throw new NotificationFeedException("Cannot create notification feed. Reason: " + response);
   }
 
   @Override
@@ -99,7 +99,7 @@ public class RemoteNotificationFeedManager implements NotificationFeedManager {
     if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
       throw new NotificationFeedNotFoundException(feed);
     } else if (response.getResponseCode() != HttpURLConnection.HTTP_OK) {
-      throw new NotificationFeedException("Cannot delete notification feed. Reason: " + getDetails(response));
+      throw new NotificationFeedException("Cannot delete notification feed. Reason: " + response);
     }
   }
 
@@ -113,7 +113,7 @@ public class RemoteNotificationFeedManager implements NotificationFeedManager {
     if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
       throw new NotificationFeedNotFoundException(feed);
     } else if (response.getResponseCode() != HttpURLConnection.HTTP_OK) {
-      throw new NotificationFeedException("Cannot get notification feed. Reason: " + getDetails(response));
+      throw new NotificationFeedException("Cannot get notification feed. Reason: " + response);
     }
     return ObjectResponse.fromJsonBody(response, Id.NotificationFeed.class).getResponseObject();
   }
@@ -127,15 +127,7 @@ public class RemoteNotificationFeedManager implements NotificationFeedManager {
         ObjectResponse.fromJsonBody(response, new TypeToken<List<Id.NotificationFeed>>() { }.getType());
       return r.getResponseObject();
     }
-    throw new NotificationFeedException("Cannot list notification feeds. Reason: " + getDetails(response));
-  }
-
-  private String getDetails(HttpResponse response) {
-    return String.format("Response code: %s, message:'%s', body: '%s'",
-                         response.getResponseCode(), response.getResponseMessage(),
-                         response.getResponseBody() == null ?
-                           "null" : new String(response.getResponseBody(), Charsets.UTF_8));
-
+    throw new NotificationFeedException("Cannot list notification feeds. Reason: " + response);
   }
 
   private URL resolve(String resource) throws NotificationFeedException {

--- a/pom.xml
+++ b/pom.xml
@@ -97,8 +97,8 @@
     <commons.codec.version>1.6</commons.codec.version>
     <commons.cli.version>1.2</commons.cli.version>
     <concurrent.trees.version>2.4.0</concurrent.trees.version>
-    <cask.common.cli.version>0.7.0</cask.common.cli.version>
-    <cask.common.version>0.6.1</cask.common.version>
+    <cask.common.cli.version>0.7.1</cask.common.cli.version>
+    <cask.common.version>0.7.1</cask.common.version>
     <cdap.hive.version>0.13.0</cdap.hive.version>
     <findbugs.jsr305.version>2.0.1</findbugs.jsr305.version>
     <flume.version>1.2.0</flume.version>


### PR DESCRIPTION
Fixed error messages in namespace delete operations.

Also fixed some cdap clients to reuse HttpResponse.toString instead of redefining the logic in private methods.