### PR TITLE
Add a MapReduce job with Workflow in SparkPageRank example

### DIFF
--- a/cdap-examples/SparkPageRank/src/main/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankApp.java
+++ b/cdap-examples/SparkPageRank/src/main/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankApp.java
@@ -179,11 +179,12 @@ public class SparkPageRankApp extends AbstractApplication {
    */
   public static final class TotalPagesHandler extends AbstractHttpServiceHandler {
 
+    public static final String TOTAL_PAGES_PATH = "total";
 
     @UseDataSet("rankscount")
     private ObjectStore<Integer> store;
 
-    @Path("total/{pr}")
+    @Path(TOTAL_PAGES_PATH + "/{pr}")
     @GET
     public void centers(HttpServiceRequest request, HttpServiceResponder responder,
                         @PathParam("pr") String pageRank) {

--- a/cdap-examples/SparkPageRank/src/main/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankApp.java
+++ b/cdap-examples/SparkPageRank/src/main/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankApp.java
@@ -187,9 +187,9 @@ public class SparkPageRankApp extends AbstractApplication {
     @Path(TOTAL_PAGES_PATH + "/{pr}")
     @GET
     public void centers(HttpServiceRequest request, HttpServiceResponder responder,
-                        @PathParam("pr") String pageRank) {
+                        @PathParam("pr") Integer pageRank) {
 
-      Integer totalPages = store.read(Bytes.toBytes(Integer.parseInt(pageRank)));
+      Integer totalPages = store.read(Bytes.toBytes(pageRank));
       if (totalPages == null) {
         responder.sendString(HttpURLConnection.HTTP_NO_CONTENT,
                              String.format("No pages found with pr: %s", pageRank), Charsets.UTF_8);


### PR DESCRIPTION
- Adds a MapReduce job in SparkPageRankProgram which calculates total number of pages for a given rank. 
- Adds a workflow which runs the Spark program followed by MapReduce.
- Updated the unit tests for the above additions.

- Doc updates will come in a separate PR. 

Build: http://builds.cask.co/browse/CDAP-DUT2105-2