### PR TITLE
Feature/cdap 2866 Ensure files are read in even after failure

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/source/FileBatchSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/source/FileBatchSource.java
@@ -31,6 +31,7 @@ import co.cask.cdap.template.etl.api.PipelineConfigurer;
 import co.cask.cdap.template.etl.api.batch.BatchSource;
 import co.cask.cdap.template.etl.api.batch.BatchSourceContext;
 import co.cask.cdap.template.etl.common.BatchFileFilter;
+import com.google.common.collect.Lists;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import org.apache.hadoop.conf.Configuration;
@@ -43,8 +44,10 @@ import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Type;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
@@ -88,13 +91,13 @@ public class FileBatchSource extends BatchSource<LongWritable, Object, Structure
   private static final Gson GSON = new Gson();
   private static final Logger LOG = LoggerFactory.getLogger(FileBatchSource.class);
   private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd-HH-mm");
-
+  private static final Type ARRAYLIST_DATE_TYPE  = new TypeToken<ArrayList<Date>>() { }.getType();
   private static final Type MAP_STRING_STRING_TYPE = new TypeToken<Map<String, String>>() { }.getType();
 
   private final FileBatchConfig config;
   private KeyValueTable table;
   private Date prevMinute;
-  private String previousTimeRead;
+  private String datesToRead;
 
   public FileBatchSource(FileBatchConfig config) {
     this.config = config;
@@ -133,13 +136,17 @@ public class FileBatchSource extends BatchSource<LongWritable, Object, Structure
 
     if (config.timeTable != null) {
       table = context.getDataset(config.timeTable);
-      String lastTimeRead = Bytes.toString(table.read(LAST_TIME_READ));
-      if (lastTimeRead == null) {
-        lastTimeRead = "0";
+      String datesToRead = Bytes.toString(table.read(LAST_TIME_READ));
+      if (datesToRead == null) {
+        List<Date> firstRun = Lists.newArrayList(new Date(0));
+        datesToRead = GSON.toJson(firstRun, ARRAYLIST_DATE_TYPE);
       }
-      previousTimeRead = lastTimeRead;
-      table.write(LAST_TIME_READ, DATE_FORMAT.format(prevMinute));
-      conf.set(LAST_TIME_READ, lastTimeRead);
+      List<Date> attempted = Lists.newArrayList(prevMinute);
+      String updatedDatesToRead = GSON.toJson(attempted, ARRAYLIST_DATE_TYPE);
+      if (!updatedDatesToRead.equals(datesToRead)) {
+        table.write(LAST_TIME_READ, updatedDatesToRead);
+      }
+      conf.set(LAST_TIME_READ, datesToRead);
     }
 
     conf.set(CUTOFF_READ_TIME, DATE_FORMAT.format(prevMinute));
@@ -165,7 +172,11 @@ public class FileBatchSource extends BatchSource<LongWritable, Object, Structure
   @Override
   public void onRunFinish(boolean succeeded, BatchSourceContext context) {
     if (!succeeded && table != null && USE_TIMEFILTER.equals(config.fileRegex)) {
-      table.write(LAST_TIME_READ, previousTimeRead);
+      List<Date> existing = GSON.fromJson(Bytes.toString(table.read(LAST_TIME_READ)), ARRAYLIST_DATE_TYPE);
+      List<Date> failed = GSON.fromJson(datesToRead, ARRAYLIST_DATE_TYPE);
+      failed.add(prevMinute);
+      failed.addAll(existing);
+      table.write(LAST_TIME_READ, GSON.toJson(failed, ARRAYLIST_DATE_TYPE));
     }
   }
 


### PR DESCRIPTION
JIRA- https://issues.cask.co/browse/CDAP-2739
BUILD - http://builds.cask.co/browse/CDAP-DUT2108-1

An arraylist of times that still need to be read are now stored in the table. If the file date falls within one of the ranges specified by this arraylist, then the file is accepted. If not, then the file is rejected.