### PR TITLE
[CDAP-2871] document the client dependencies for CM cluster

### DIFF
--- a/cdap-docs/integrations/source/partners/cloudera/configuring.rst
+++ b/cdap-docs/integrations/source/partners/cloudera/configuring.rst
@@ -34,10 +34,10 @@ The CDAP CSD consists of four mandatory roles:
 
 and an optional role |---| Security Auth Service |---| plus a Gateway client configuration. 
 
-CDAP depends on HBase, YARN, HDFS, Zookeeper, and |---| optionally |---| Hive. It must also be placed on a cluster node with full
-client configurations for these dependent services. Therefore, CDAP roles must be colocated on a cluster node with at least
+CDAP depends on HBase, YARN, HDFS, Zookeeper, and |---| optionally |---| Hive. It must also be placed on a cluster host with full
+client configurations for these dependent services. Therefore, CDAP roles must be colocated on a cluster host with at least
 an HDFS Gateway, Yarn Gateway, HBase Gateway, and |---| optionally |---| a Hive Gateway. Note that Gateways are redundant if colocating
-CDAP on cluster nodes with actual services, such as the HBase Master, Yarn Resourcemanager, or HDFS Namenode.
+CDAP on cluster hosts with actual services, such as the HBase Master, Yarn Resourcemanager, or HDFS Namenode.
 
 All services run as the 'cdap' user installed by the parcel.
 

--- a/cdap-docs/integrations/source/partners/cloudera/configuring.rst
+++ b/cdap-docs/integrations/source/partners/cloudera/configuring.rst
@@ -34,8 +34,12 @@ The CDAP CSD consists of four mandatory roles:
 
 and an optional role |---| Security Auth Service |---| plus a Gateway client configuration. 
 
-CDAP depends on HBase, YARN, HDFS, Zookeeper, and |---| optionally |---| Hive. All services run as
-the 'cdap' user installed by the parcel.
+CDAP depends on HBase, YARN, HDFS, Zookeeper, and |---| optionally |---| Hive. It must also be placed on a cluster node with full
+client configurations for these dependent services. Therefore, CDAP roles must be colocated on a cluster node with at least
+an HDFS Gateway, Yarn Gateway, HBase Gateway, and |---| optionally |---| a Hive Gateway. Note that Gateways are redundant if colocating
+CDAP on cluster nodes with actual services, such as the HBase Master, Yarn Resourcemanager, or HDFS Namenode.
+
+All services run as the 'cdap' user installed by the parcel.
 
 
 Prerequisites
@@ -94,6 +98,9 @@ When completing the Wizard, these notes may help:
    - *Add Service* Wizard, Page 2: **Optional Hive dependency** is for the optional CDAP
      "Explore" component which can be enabled later.
      
+   - *Add Service* Wizard, Page 3: **Choosing Role Assignments**. Ensure CDAP roles are assigned to hosts colocated
+     with service or gateway roles for HBase, HDFS, Yarn, and optionally Hive.
+
    - *Add Service* Wizard, Page 3: CDAP **Security Auth** service is an optional service
      for CDAP perimeter security; it can be configured and enabled post-wizard.
      


### PR DESCRIPTION
Documentation updates for https://issues.cask.co/browse/CDAP-2871

Staged here:  http://docs-staging.cask.co/cdap/3.1.0-SNAPSHOT-feature-csd-document-hbase-gateway/en/integrations/partners/cloudera/configuring.html

