### PR TITLE
CDAP-2846 support for snapshot versions to the artifact store

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactDetail.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactDetail.java
@@ -16,19 +16,24 @@
 
 package co.cask.cdap.internal.app.runtime.artifact;
 
-import co.cask.cdap.common.exception.NotFoundException;
-import co.cask.cdap.proto.Id;
-
 /**
- * Thrown when an artifact does not exist.
+ * Details about an artifact, including info about the artifact itself and metadata about the contents of the artifact.
  */
-public class ArtifactNotExistsException extends NotFoundException {
+public class ArtifactDetail {
+  private final ArtifactInfo info;
+  private final ArtifactMeta meta;
 
-  public ArtifactNotExistsException(Id.Namespace namespace, String name) {
-    super("artifact", namespace.getId() + ":" + name);
+  public ArtifactDetail(ArtifactInfo info, ArtifactMeta meta) {
+    this.info = info;
+    this.meta = meta;
   }
 
-  public ArtifactNotExistsException(Id.Artifact artifactId) {
-    super("artifact", artifactId.toString());
+  public ArtifactInfo getInfo() {
+    return info;
   }
+
+  public ArtifactMeta getMeta() {
+    return meta;
+  }
+
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactInfo.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactInfo.java
@@ -17,20 +17,19 @@
 package co.cask.cdap.internal.app.runtime.artifact;
 
 import co.cask.cdap.proto.Id;
+import com.google.common.base.Objects;
 import org.apache.twill.filesystem.Location;
 
 /**
- * Information about an artifact.
+ * Information about the artifact itself, but nothing about the contents of the artifact.
  */
 public class ArtifactInfo {
   private final Id.Artifact id;
   private final Location location;
-  private final ArtifactMeta meta;
 
-  public ArtifactInfo(Id.Artifact id, Location location, ArtifactMeta meta) {
+  public ArtifactInfo(Id.Artifact id, Location location) {
     this.id = id;
     this.location = location;
-    this.meta = meta;
   }
 
   public Id.Artifact getId() {
@@ -41,7 +40,22 @@ public class ArtifactInfo {
     return location;
   }
 
-  public ArtifactMeta getMeta() {
-    return meta;
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    ArtifactInfo that = (ArtifactInfo) o;
+
+    return Objects.equal(id, that.id) && Objects.equal(location, that.location);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(id, location);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStore.java
@@ -19,6 +19,7 @@ package co.cask.cdap.internal.app.runtime.artifact;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.dataset.DatasetDefinition;
 import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.table.ConflictDetection;
 import co.cask.cdap.api.dataset.table.Row;
 import co.cask.cdap.api.dataset.table.Scan;
 import co.cask.cdap.api.dataset.table.Scanner;
@@ -31,25 +32,31 @@ import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.tx.DatasetContext;
 import co.cask.cdap.data2.dataset2.tx.Transactional;
+import co.cask.cdap.internal.filesystem.LocationCodec;
 import co.cask.cdap.proto.Id;
+import co.cask.tephra.TransactionConflictException;
 import co.cask.tephra.TransactionExecutor;
 import co.cask.tephra.TransactionExecutorFactory;
+import co.cask.tephra.TransactionFailureException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Supplier;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.google.common.io.ByteStreams;
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.inject.Inject;
 import org.apache.twill.filesystem.Location;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.twill.filesystem.LocationFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * This class manages artifacts as well as metadata for each artifact. Artifacts and their metadata cannot be changed
@@ -74,8 +81,6 @@ import java.util.Map;
  * {artifact-version}:{artifact-name} as the column, and AppClass as the value
  */
 public class ArtifactStore {
-  private static final Logger LOG = LoggerFactory.getLogger(ArtifactStore.class);
-  private static final Gson GSON = new Gson();
   private static final String ARTIFACTS_PATH = "artifacts";
   private static final String ARTIFACT_PREFIX = "r:";
   private static final String PLUGIN_PREFIX = "p:";
@@ -84,18 +89,25 @@ public class ArtifactStore {
 
   private final NamespacedLocationFactory locationFactory;
   private final Transactional<DatasetContext<Table>, Table> metaTable;
+  private final Gson gson;
 
   @Inject
-  ArtifactStore(final DatasetFramework datasetFramework, NamespacedLocationFactory locationFactory,
+  ArtifactStore(final DatasetFramework datasetFramework,
+                NamespacedLocationFactory namespacedLocationFactory,
+                LocationFactory locationFactory,
                 TransactionExecutorFactory txExecutorFactory) {
-    this.locationFactory = locationFactory;
+    this.locationFactory = namespacedLocationFactory;
+    this.gson = new GsonBuilder()
+      .registerTypeAdapter(Location.class, new LocationCodec(locationFactory))
+      .create();
     this.metaTable = Transactional.of(txExecutorFactory, new Supplier<DatasetContext<Table>>() {
       @Override
       public DatasetContext<Table> get() {
         try {
           return DatasetContext.of((Table) DatasetsUtil.getOrCreateDataset(
             datasetFramework, META_ID, Table.class.getName(),
-            DatasetProperties.EMPTY, DatasetDefinition.NO_ARGUMENTS, null));
+            DatasetProperties.builder().add(Table.PROPERTY_CONFLICT_LEVEL, ConflictDetection.COLUMN.name()).build(),
+            DatasetDefinition.NO_ARGUMENTS, null));
         } catch (Exception e) {
           // there's nothing much we can do here
           throw Throwables.propagate(e);
@@ -105,79 +117,24 @@ public class ArtifactStore {
   }
 
   /**
-   * Write the artifact and its metadata to the store. Once added, artifacts cannot be changed.
-   * TODO: add support for snapshot versions, which can be changed
-   *
-   * @param artifactId the id of the artifact to add
-   * @param artifactMeta the metadata for the artifact
-   * @param archiveContents the contents of the artifact
-   * @throws WriteConflictException if the artifact is already currently being written
-   * @throws ArtifactAlreadyExistsException if a non-snapshot version of the artifact already exists
-   * @throws IOException if there was an exception persisting the artifact contents to the filesystem,
-   *                     of persisting the artifact metadata to the metastore
-   */
-  public void write(Id.Artifact artifactId, ArtifactMeta artifactMeta, InputStream archiveContents)
-    throws WriteConflictException, ArtifactAlreadyExistsException, IOException {
-
-    Location fileDirectory =
-      locationFactory.get(artifactId.getNamespace(), ARTIFACTS_PATH).append(artifactId.getName());
-    Locations.mkdirsIfNotExists(fileDirectory);
-    Location lock = fileDirectory.append(artifactId.getVersion() + ".lock");
-    if (!lock.createNew()) {
-      throw new WriteConflictException(artifactId);
-    }
-
-    ArtifactMeta meta = readMeta(artifactId);
-    if (meta != null) {
-      lock.delete();
-      throw new ArtifactAlreadyExistsException(artifactId);
-    }
-
-    Location file = fileDirectory.append(artifactId.getVersion());
-    if (file.exists()) {
-      // this really shouldn't happen often.
-      // it's possible if there was a previous attempt to add this file,
-      // the file was added, but the metadata was not successfully written and the file
-      // was the not able to get cleaned up after the failed metadata write.
-      // in either case, should be ok to just delete it.
-      file.delete();
-    }
-
-    // write the file contents
-    try {
-      ByteStreams.copy(archiveContents, file.getOutputStream());
-      try {
-        writeMeta(artifactId, artifactMeta);
-      } catch (Exception e) {
-        LOG.error("Exception while writing metadata for artifact " + artifactId, e);
-        // delete file to clean up after ourselves
-        file.delete();
-        throw new IOException(e);
-      }
-    } finally {
-      lock.delete();
-    }
-  }
-
-  /**
    * Get information about all artifacts in the given namespace. If there are no artifacts in the namespace,
    * this will return an empty list. Note that existence of the namespace is not checked.
    *
    * @param namespace the namespace to get artifact information about
-   * @return list of artifact info about every artifact in the given namespace
+   * @return unmodifiable list of artifact info about every artifact in the given namespace
    * @throws IOException if there was an exception reading the artifact information from the metastore
    */
-  public List<ArtifactInfo> getArtifacts(final Id.Namespace namespace) throws IOException {
-    return metaTable.executeUnchecked(new TransactionExecutor.Function<DatasetContext<Table>, List<ArtifactInfo>>() {
+  public List<ArtifactDetail> getArtifacts(final Id.Namespace namespace) throws IOException {
+    return metaTable.executeUnchecked(new TransactionExecutor.Function<DatasetContext<Table>, List<ArtifactDetail>>() {
       @Override
-      public List<ArtifactInfo> apply(DatasetContext<Table> context) throws Exception {
-        List<ArtifactInfo> archives = Lists.newArrayList();
+      public List<ArtifactDetail> apply(DatasetContext<Table> context) throws Exception {
+        List<ArtifactDetail> archives = Lists.newArrayList();
         Scanner scanner = context.get().scan(scanArtifacts(namespace));
         Row row;
         while ((row = scanner.next()) != null) {
           addArchivesToList(archives, row);
         }
-        return archives;
+        return Collections.unmodifiableList(archives);
       }
     });
   }
@@ -187,27 +144,31 @@ public class ArtifactStore {
    *
    * @param namespace the namespace to get artifacts from
    * @param artifactName the name of the artifact to get
-   * @return a list of information about all versions of the given artifact
+   * @return unmodifiable list of information about all versions of the given artifact
    * @throws ArtifactNotExistsException if no version of the given artifact exists
    * @throws IOException if there was an exception reading the artifact information from the metastore
    */
-  public List<ArtifactInfo> getArtifacts(final Id.Namespace namespace, final String artifactName)
+  public List<ArtifactDetail> getArtifacts(final Id.Namespace namespace, final String artifactName)
     throws ArtifactNotExistsException, IOException {
 
-    return metaTable.executeUnchecked(new TransactionExecutor.Function<DatasetContext<Table>, List<ArtifactInfo>>() {
-      @Override
-      public List<ArtifactInfo> apply(DatasetContext<Table> context) throws Exception {
-        List<ArtifactInfo> archives = Lists.newArrayList();
+    List<ArtifactDetail> artifacts = metaTable.executeUnchecked(
+      new TransactionExecutor.Function<DatasetContext<Table>, List<ArtifactDetail>>() {
+        @Override
+        public List<ArtifactDetail> apply(DatasetContext<Table> context) throws Exception {
+          List<ArtifactDetail> archives = Lists.newArrayList();
 
-        ArtifactKey artifactKey = new ArtifactKey(namespace, artifactName);
-        Row row = context.get().get(artifactKey.getRowKey());
-        if (row == null) {
-          throw new ArtifactNotExistsException(namespace, artifactName);
+          ArtifactKey artifactKey = new ArtifactKey(namespace, artifactName);
+          Row row = context.get().get(artifactKey.getRowKey());
+          if (!row.isEmpty()) {
+            addArchivesToList(archives, row);
+          }
+          return archives;
         }
-        addArchivesToList(archives, row);
-        return archives;
-      }
-    });
+      });
+    if (artifacts.isEmpty()) {
+      throw new ArtifactNotExistsException(namespace, artifactName);
+    }
+    return Collections.unmodifiableList(artifacts);
   }
 
   /**
@@ -218,12 +179,21 @@ public class ArtifactStore {
    * @throws ArtifactNotExistsException if the given artifact does not exist
    * @throws IOException if there was an exception reading the artifact information from the metastore
    */
-  public ArtifactInfo getArtifact(Id.Artifact artifactId) throws ArtifactNotExistsException, IOException {
-    ArtifactMeta meta = readMeta(artifactId);
-    if (meta == null) {
+  public ArtifactDetail getArtifact(final Id.Artifact artifactId) throws ArtifactNotExistsException, IOException {
+    ArtifactData data = metaTable.executeUnchecked(
+      new TransactionExecutor.Function<DatasetContext<Table>, ArtifactData>() {
+        @Override
+        public ArtifactData apply(DatasetContext<Table> context) throws Exception {
+          ArtifactCell artifactCell = new ArtifactCell(artifactId);
+          byte[] value = context.get().get(artifactCell.rowkey, artifactCell.column);
+          return value == null ? null : gson.fromJson(Bytes.toString(value), ArtifactData.class);
+        }
+      });
+
+    if (data == null) {
       throw new ArtifactNotExistsException(artifactId);
     }
-    return new ArtifactInfo(artifactId, getLocation(artifactId), meta);
+    return new ArtifactDetail(new ArtifactInfo(artifactId, data.location), data.meta);
   }
 
   /**
@@ -231,23 +201,23 @@ public class ArtifactStore {
    * in that artifact.
    *
    * @param namespace the namespace to look for plugins in
-   * @return a map of artifact id to plugin classes in the artifact for all plugin classes in the namespace.
+   * @return unmodifiable map of artifact info to plugin classes in the namespace.
    *         The map will never be null. If there are no plugin classes, an empty map will be returned.
    * @throws IOException if there was an exception reading metadata from the metastore
    */
-  public Map<Id.Artifact, List<PluginClass>> getPluginClasses(final Id.Namespace namespace) throws IOException {
+  public Map<ArtifactInfo, List<PluginClass>> getPluginClasses(final Id.Namespace namespace) throws IOException {
     return metaTable.executeUnchecked(
-      new TransactionExecutor.Function<DatasetContext<Table>, Map<Id.Artifact, List<PluginClass>>>() {
+      new TransactionExecutor.Function<DatasetContext<Table>, Map<ArtifactInfo, List<PluginClass>>>() {
         @Override
-        public Map<Id.Artifact, List<PluginClass>> apply(DatasetContext<Table> context) throws Exception {
-          Map<Id.Artifact, List<PluginClass>> result = Maps.newHashMap();
+        public Map<ArtifactInfo, List<PluginClass>> apply(DatasetContext<Table> context) throws Exception {
+          Map<ArtifactInfo, List<PluginClass>> result = Maps.newHashMap();
 
           Scanner scanner = context.get().scan(scanPlugins(namespace));
           Row row;
           while ((row = scanner.next()) != null) {
             addPluginsToMap(result, row);
           }
-          return result;
+          return Collections.unmodifiableMap(result);
         }
       });
   }
@@ -258,17 +228,17 @@ public class ArtifactStore {
    *
    * @param namespace the namespace to look for plugins in
    * @param type the type of plugin to look for
-   * @return a map of artifact id to plugin classes in the artifact for all plugin classes in the namespace.
+   * @return a map of artifact info to plugin classes for all plugin classes of the given type in the namespace.
    *         The map will never be null. If there are no plugin classes, an empty map will be returned.
    * @throws IOException if there was an exception reading metadata from the metastore
    */
-  public Map<Id.Artifact, List<PluginClass>> getPluginClasses(final Id.Namespace namespace,
-                                                              final String type) throws IOException {
+  public Map<ArtifactInfo, List<PluginClass>> getPluginClasses(final Id.Namespace namespace,
+                                                               final String type) throws IOException {
     return metaTable.executeUnchecked(
-      new TransactionExecutor.Function<DatasetContext<Table>, Map<Id.Artifact, List<PluginClass>>>() {
+      new TransactionExecutor.Function<DatasetContext<Table>, Map<ArtifactInfo, List<PluginClass>>>() {
         @Override
-        public Map<Id.Artifact, List<PluginClass>> apply(DatasetContext<Table> context) throws Exception {
-          Map<Id.Artifact, List<PluginClass>> result = Maps.newHashMap();
+        public Map<ArtifactInfo, List<PluginClass>> apply(DatasetContext<Table> context) throws Exception {
+          Map<ArtifactInfo, List<PluginClass>> result = Maps.newHashMap();
 
           Scanner scanner = context.get().scan(scanPlugins(namespace, type));
           Row row;
@@ -287,26 +257,126 @@ public class ArtifactStore {
    * @param namespace the namespace to look for plugins in
    * @param type the type of plugin to look for
    * @param name the name of the plugin to look for
-   * @return a map of artifact id to plugin classes in the artifact for all plugin classes in the namespace.
-   *         The map will never be null. If there are no plugin classes, an empty map will be returned.
+   * @return a map of artifact info to plugin classes of the given type and name in the namespace.
+   *         The map will never be null, and will never be empty.
+   * @throws PluginNotExistsException if no plugin with the given type and name exists in the namespace
    * @throws IOException if there was an exception reading metadata from the metastore
    */
-  public Map<Id.Artifact, List<PluginClass>> getPluginClasses(final Id.Namespace namespace, final String type,
-                                                              final String name) throws IOException {
-    return metaTable.executeUnchecked(
-      new TransactionExecutor.Function<DatasetContext<Table>, Map<Id.Artifact, List<PluginClass>>>() {
+  public Map<ArtifactInfo, List<PluginClass>> getPluginClasses(
+    final Id.Namespace namespace, final String type, final String name) throws IOException, PluginNotExistsException {
+
+    Map<ArtifactInfo, List<PluginClass>> plugins = metaTable.executeUnchecked(
+      new TransactionExecutor.Function<DatasetContext<Table>, Map<ArtifactInfo, List<PluginClass>>>() {
         @Override
-        public Map<Id.Artifact, List<PluginClass>> apply(DatasetContext<Table> context) throws Exception {
-          Map<Id.Artifact, List<PluginClass>> result = Maps.newHashMap();
+        public Map<ArtifactInfo, List<PluginClass>> apply(DatasetContext<Table> context) throws Exception {
+          Map<ArtifactInfo, List<PluginClass>> result = Maps.newHashMap();
 
           PluginKey pluginKey = new PluginKey(namespace, type, name);
           Row row = context.get().get(pluginKey.getRowKey());
-          if (row != null) {
+          if (!row.isEmpty()) {
             addPluginsToMap(result, row);
           }
           return result;
         }
       });
+    if (plugins.isEmpty()) {
+      throw new PluginNotExistsException(namespace, type, name);
+    }
+    return plugins;
+  }
+
+  /**
+   * Get the plugin class for a specific plugin type, name, and belonging to a specific artifact.
+   * Results are returned as a map from artifact to plugins in that artifact.
+   *
+   * @param artifactId the id of the artifact the plugin is from
+   * @param type the type of plugin to look for
+   * @param name the name of the plugin to look for
+   * @return a map entry containing the artifact info and plugin class details. Never null
+   * @throws PluginNotExistsException if no such plugin exists
+   * @throws IOException if there was an exception reading metadata from the metastore
+   */
+  public Map.Entry<ArtifactInfo, PluginClass> getPluginClass(
+    final Id.Artifact artifactId, final String type, final String name) throws IOException, PluginNotExistsException {
+    Map.Entry<ArtifactInfo, PluginClass> plugin = metaTable.executeUnchecked(
+      new TransactionExecutor.Function<DatasetContext<Table>, Map.Entry<ArtifactInfo, PluginClass>>() {
+        @Override
+        public Map.Entry<ArtifactInfo, PluginClass> apply(DatasetContext<Table> context) throws Exception {
+          PluginKey pluginKey = new PluginKey(artifactId.getNamespace(), type, name);
+          ArtifactColumn column = new ArtifactColumn(artifactId.getVersion().getVersion(), artifactId.getName());
+          byte[] value = context.get().get(pluginKey.getRowKey(), column.getColumn());
+          if (value == null) {
+            return null;
+          }
+          PluginData pluginData = gson.fromJson(Bytes.toString(value), PluginData.class);
+          return Maps.immutableEntry(new ArtifactInfo(artifactId, pluginData.artifactLocation), pluginData.pluginClass);
+        }
+      });
+    if (plugin == null) {
+      throw new PluginNotExistsException(artifactId, type, name);
+    }
+    return plugin;
+  }
+
+  /**
+   * Write the artifact and its metadata to the store. Once added, artifacts cannot be changed unless they are
+   * snapshot versions.
+   *
+   * @param artifactId the id of the artifact to add
+   * @param artifactMeta the metadata for the artifact
+   * @param artifactContents the contents of the artifact
+   * @throws WriteConflictException if the artifact is already currently being written
+   * @throws ArtifactAlreadyExistsException if a non-snapshot version of the artifact already exists
+   * @throws IOException if there was an exception persisting the artifact contents to the filesystem,
+   *                     of persisting the artifact metadata to the metastore
+   */
+  public void write(final Id.Artifact artifactId, final ArtifactMeta artifactMeta, final InputStream artifactContents)
+    throws WriteConflictException, ArtifactAlreadyExistsException, IOException {
+
+    Location fileDirectory =
+      locationFactory.get(artifactId.getNamespace(), ARTIFACTS_PATH).append(artifactId.getName());
+    Locations.mkdirsIfNotExists(fileDirectory);
+
+    // write the file contents
+    final Location destination = fileDirectory.append(artifactId.getVersion().getVersion()).getTempFile(".jar");
+    ByteStreams.copy(artifactContents, destination.getOutputStream());
+
+    // now try and write the metadata for the artifact
+    try {
+      boolean written = metaTable.execute(new TransactionExecutor.Function<DatasetContext<Table>, Boolean>() {
+
+        @Override
+        public Boolean apply(DatasetContext<Table> context) throws Exception {
+          Table table = context.get();
+
+          ArtifactCell artifactCell = new ArtifactCell(artifactId);
+          byte[] existingMetaBytes = table.get(artifactCell.rowkey, artifactCell.column);
+          boolean isSnapshot = artifactId.getVersion().isSnapshot();
+          if (existingMetaBytes != null && !isSnapshot) {
+            // non-snapshot artifacts are immutable. If there is existing metadata, stop here.
+            return false;
+          }
+
+          // write artifact metadata
+          ArtifactData data = new ArtifactData(destination, artifactMeta);
+          writeMeta(table, artifactId, data);
+          if (existingMetaBytes != null) {
+            cleanupOldSnapshot(table, artifactId, existingMetaBytes, data);
+          }
+          return true;
+        }
+      });
+
+      if (!written) {
+        throw new ArtifactAlreadyExistsException(artifactId);
+      }
+    } catch (TransactionConflictException e) {
+      destination.delete();
+      throw new WriteConflictException(artifactId);
+    } catch (TransactionFailureException | InterruptedException e) {
+      destination.delete();
+      throw new IOException(e);
+    }
   }
 
   /**
@@ -319,16 +389,16 @@ public class ArtifactStore {
   @VisibleForTesting
   void clear(Id.Namespace namespace) throws IOException {
     locationFactory.get(namespace, ARTIFACTS_PATH).delete();
-    for (final ArtifactInfo artifactInfo : getArtifacts(namespace)) {
+    for (final ArtifactDetail artifactDetail : getArtifacts(namespace)) {
 
       metaTable.executeUnchecked(new TransactionExecutor.Function<DatasetContext<Table>, Void>() {
         @Override
         public Void apply(DatasetContext<Table> context) throws Exception {
-          final Id.Artifact artifactId = artifactInfo.getId();
+          final Id.Artifact artifactId = artifactDetail.getInfo().getId();
           ArtifactKey artifactKey = new ArtifactKey(artifactId.getNamespace(), artifactId.getName());
           context.get().delete(artifactKey.getRowKey());
 
-          for (PluginClass pluginClass : artifactInfo.getMeta().getPlugins()) {
+          for (PluginClass pluginClass : artifactDetail.getMeta().getPlugins()) {
             PluginKey pluginKey =
               new PluginKey(artifactId.getNamespace(), pluginClass.getType(), pluginClass.getName());
             context.get().delete(pluginKey.getRowKey());
@@ -339,82 +409,78 @@ public class ArtifactStore {
     }
   }
 
+  // write a new artifact snapshot and clean up the old snapshot data
+  private void writeMeta(Table table, Id.Artifact artifactId, ArtifactData data) throws IOException {
+    ArtifactCell artifactCell = new ArtifactCell(artifactId);
+    table.put(artifactCell.rowkey, artifactCell.column, Bytes.toBytes(gson.toJson(data)));
 
-  private void writeMeta(final Id.Artifact artifactId, final ArtifactMeta artifactMeta) throws IOException {
-    metaTable.executeUnchecked(new TransactionExecutor.Function<DatasetContext<Table>, Object>() {
+    // column for plugin meta and app meta. {artifact-name}:{artifact-version}
+    // does not need to contain namespace because namespace is in the rowkey
+    ArtifactColumn artifactColumn =
+      new ArtifactColumn(artifactId.getVersion().getVersion(), artifactId.getName());
 
-      @Override
-      public Void apply(DatasetContext<Table> context) throws Exception {
-        Table table = context.get();
+    // write pluginClass metadata
+    for (PluginClass pluginClass : data.meta.getPlugins()) {
+      // p:{namespace}:{type}:{name}
+      PluginKey pluginKey =
+        new PluginKey(artifactId.getNamespace(), pluginClass.getType(), pluginClass.getName());
+      byte[] pluginDataBytes = Bytes.toBytes(gson.toJson(new PluginData(pluginClass, data.location)));
+      table.put(pluginKey.getRowKey(), artifactColumn.getColumn(), pluginDataBytes);
+    }
 
-        // write artifact metadata
-        ArtifactCell artifactCell = new ArtifactCell(artifactId);
-        byte[] artifactMetaBytes = Bytes.toBytes(GSON.toJson(artifactMeta));
-        table.put(artifactCell.rowkey, artifactCell.column, artifactMetaBytes);
-
-        // column for plugin meta and app meta. {artifact-name}:{artifact-version}
-        // does not need to contain namespace because namespace is in the rowkey
-        ArtifactColumn artifactColumn = new ArtifactColumn(artifactId.getVersion(), artifactId.getName());
-
-        // write pluginClass metadata
-        for (PluginClass pluginClass : artifactMeta.getPlugins()) {
-          // p:{namespace}:{type}:{name}
-          PluginKey pluginKey = new PluginKey(artifactId.getNamespace(), pluginClass.getType(), pluginClass.getName());
-          byte[] pluginClassBytes = Bytes.toBytes(GSON.toJson(pluginClass));
-          table.put(pluginKey.getRowKey(), artifactColumn.getColumn(), pluginClassBytes);
-        }
-
-        // TODO: write appClass metadata
-        return null;
-      }
-    });
+    // TODO: write appClass metadata
   }
 
-  private Location getLocation(Id.Artifact artifactId) throws IOException {
-    return locationFactory.get(artifactId.getNamespace(), ARTIFACTS_PATH)
-      .append(artifactId.getName())
-      .append(artifactId.getVersion());
+  // if we are overwriting a previous snapshot, need to clean up the old snapshot data
+  // this means cleaning up the old jar, and performing a diff of the metadata to remove plugins
+  // that used to be in the old jar but are not in the current jar
+  private void cleanupOldSnapshot(Table table, Id.Artifact artifactId,
+                                  byte[] oldData, ArtifactData newData) throws IOException {
+    ArtifactData oldMeta = gson.fromJson(Bytes.toString(oldData), ArtifactData.class);
+
+    // delete old plugins that were removed
+    Set<PluginClass> oldPlugins = Sets.newHashSet(oldMeta.meta.getPlugins());
+    Set<PluginClass> currentPlugins = Sets.newHashSet(newData.meta.getPlugins());
+    Set<PluginClass> pluginsToRemove = Sets.difference(oldPlugins, currentPlugins);
+    ArtifactColumn artifactColumn = new ArtifactColumn(artifactId.getVersion().getVersion(), artifactId.getName());
+    for (PluginClass pluginClass : pluginsToRemove) {
+      PluginKey pluginKey = new PluginKey(artifactId.getNamespace(), pluginClass.getType(), pluginClass.getName());
+      table.delete(pluginKey.getRowKey(), artifactColumn.getColumn());
+    }
+
+    // delete the old jar file
+    oldMeta.location.delete();
   }
 
-  private ArtifactMeta readMeta(final Id.Artifact artifactId) throws IOException {
-    return metaTable.executeUnchecked(new TransactionExecutor.Function<DatasetContext<Table>, ArtifactMeta>() {
-      @Override
-      public ArtifactMeta apply(DatasetContext<Table> context) throws Exception {
-        byte[] rowkey = new ArtifactKey(artifactId.getNamespace(), artifactId.getName()).getRowKey();
-        byte[] column = Bytes.toBytes(artifactId.getVersion());
-        byte[] value = context.get().get(rowkey, column);
-        return value == null ? null : GSON.fromJson(Bytes.toString(value), ArtifactMeta.class);
-      }
-    });
-  }
-
-  private void addArchivesToList(List<ArtifactInfo> archives, Row row) throws IOException {
+  private void addArchivesToList(List<ArtifactDetail> archives, Row row) throws IOException {
     ArtifactKey artifactKey = ArtifactKey.parse(row.getRow());
 
     for (Map.Entry<byte[], byte[]> columnVal : row.getColumns().entrySet()) {
       String version = Bytes.toString(columnVal.getKey());
-      ArtifactMeta meta = GSON.fromJson(Bytes.toString(columnVal.getValue()), ArtifactMeta.class);
+      ArtifactData data = gson.fromJson(Bytes.toString(columnVal.getValue()), ArtifactData.class);
       Id.Artifact artifactId = Id.Artifact.from(artifactKey.namespace, artifactKey.name, version);
-      archives.add(new ArtifactInfo(artifactId, getLocation(artifactId), meta));
+      archives.add(new ArtifactDetail(new ArtifactInfo(artifactId, data.location), data.meta));
     }
   }
 
   // given a row representing plugin metadata, add all plugins in the row to the given map
-  private void addPluginsToMap(Map<Id.Artifact, List<PluginClass>> map, Row row) throws IOException {
+  private void addPluginsToMap(Map<ArtifactInfo, List<PluginClass>> map, Row row) throws IOException {
     // plugin key contains namespace, plugin type, and plugin name
     PluginKey pluginKey = PluginKey.parse(row.getRow());
 
     // column is the artifact name and version, value is the serialized PluginClass
     for (Map.Entry<byte[], byte[]> column : row.getColumns().entrySet()) {
       ArtifactColumn artifactColumn = ArtifactColumn.parse(column.getKey());
+      PluginData pluginData = gson.fromJson(Bytes.toString(column.getValue()), PluginData.class);
+
       Id.Artifact artifactId =
         Id.Artifact.from(pluginKey.namespace, artifactColumn.name, artifactColumn.version);
+      ArtifactInfo artifactInfo = new ArtifactInfo(artifactId, pluginData.artifactLocation);
 
-      if (!map.containsKey(artifactId)) {
-        map.put(artifactId, Lists.<PluginClass>newArrayList());
+      if (!map.containsKey(artifactInfo)) {
+        map.put(artifactInfo, Lists.<PluginClass>newArrayList());
       }
-      PluginClass pluginClass = GSON.fromJson(Bytes.toString(column.getValue()), PluginClass.class);
-      map.get(artifactId).add(pluginClass);
+      map.get(artifactInfo).add(pluginData.pluginClass);
     }
   }
 
@@ -510,7 +576,29 @@ public class ArtifactStore {
 
     private ArtifactCell(Id.Artifact artifactId) {
       rowkey = new ArtifactKey(artifactId.getNamespace(), artifactId.getName()).getRowKey();
-      column = Bytes.toBytes(artifactId.getVersion());
+      column = Bytes.toBytes(artifactId.getVersion().getVersion());
+    }
+  }
+
+  // Data that will be stored for an artifact. Same as ArtifactDetail, expected without the id since that is redundant.
+  private static class ArtifactData {
+    private final Location location;
+    private final ArtifactMeta meta;
+
+    public ArtifactData(Location location, ArtifactMeta meta) {
+      this.location = location;
+      this.meta = meta;
+    }
+  }
+
+  // Data that will be stored for a plugin.
+  private static class PluginData {
+    private final PluginClass pluginClass;
+    private final Location artifactLocation;
+
+    public PluginData(PluginClass pluginClass, Location artifactLocation) {
+      this.pluginClass = pluginClass;
+      this.artifactLocation = artifactLocation;
     }
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/PluginNotExistsException.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/PluginNotExistsException.java
@@ -20,15 +20,16 @@ import co.cask.cdap.common.exception.NotFoundException;
 import co.cask.cdap.proto.Id;
 
 /**
- * Thrown when an artifact does not exist.
+ * Thrown when a plugin does not exist.
  */
-public class ArtifactNotExistsException extends NotFoundException {
+public class PluginNotExistsException extends NotFoundException {
 
-  public ArtifactNotExistsException(Id.Namespace namespace, String name) {
-    super("artifact", namespace.getId() + ":" + name);
+  public PluginNotExistsException(Id.Namespace namespace, String type, String name) {
+    super("plugin", String.format("%s:%s:%s", namespace.getId(), type, name));
   }
 
-  public ArtifactNotExistsException(Id.Artifact artifactId) {
-    super("artifact", artifactId.toString());
+  public PluginNotExistsException(Id.Artifact artifactId, String type, String name) {
+    super("plugin", String.format("%s:%s:%s:%s:%s",
+      artifactId.getNamespace().getId(), type, name, artifactId.getName(), artifactId.getVersion()));
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/WriteConflictException.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/WriteConflictException.java
@@ -26,6 +26,7 @@ import co.cask.cdap.proto.Id;
 public class WriteConflictException extends ConflictException {
 
   public WriteConflictException(Id.Artifact artifactId) {
-    super(String.format("Archive %s already exists.", artifactId));
+    super(String.format("Write conflict while writing artifact %s.", artifactId));
   }
+
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/filesystem/LocationCodec.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/filesystem/LocationCodec.java
@@ -27,6 +27,8 @@ import org.apache.twill.filesystem.Location;
 import org.apache.twill.filesystem.LocationFactory;
 
 import java.lang.reflect.Type;
+import java.net.URI;
+import java.net.URISyntaxException;
 
 /**
  * Codec for {@link Location}. We write {@link java.net.URI} for location.
@@ -49,6 +51,11 @@ public final class LocationCodec implements JsonSerializer<Location>, JsonDeseri
   public Location deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) {
     JsonObject jsonObj = json.getAsJsonObject();
     String uri = jsonObj.get("uri").getAsString();
-    return lf.create(uri);
+    try {
+      return lf.create(new URI(uri));
+    } catch (URISyntaxException e) {
+      // should never happen
+      throw new IllegalStateException("Invalid uri " + uri + " found. Cannot deserialize location.", e);
+    }
   }
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/Id.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/Id.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.proto;
 
+import co.cask.cdap.proto.artifact.ArtifactVersion;
 import com.google.common.base.CharMatcher;
 import com.google.common.base.Charsets;
 import com.google.common.base.Objects;
@@ -1260,9 +1261,9 @@ public abstract class Id {
   public static class Artifact extends NamespacedId {
     private final Namespace namespace;
     private final String name;
-    private final String version;
+    private final ArtifactVersion version;
 
-    public Artifact(Namespace namespace, String name, String version) {
+    public Artifact(Namespace namespace, String name, ArtifactVersion version) {
       // TODO: enforce name, version characters
       Preconditions.checkNotNull(namespace, "Namespace cannot be null.");
       Preconditions.checkNotNull(name, "Name cannot be null.");
@@ -1280,7 +1281,7 @@ public abstract class Id {
       return name;
     }
 
-    public String getVersion() {
+    public ArtifactVersion getVersion() {
       return version;
     }
 
@@ -1292,7 +1293,7 @@ public abstract class Id {
 
     @Override
     public String getId() {
-      return String.format("%s-%s", name, version);
+      return String.format("%s-%s", name, version.getVersion());
     }
 
     @Override
@@ -1326,7 +1327,7 @@ public abstract class Id {
     }
 
     public static Artifact from(Namespace namespace, String name, String version) {
-      return new Artifact(namespace, name, version);
+      return new Artifact(namespace, name, new ArtifactVersion(version));
     }
   }
 

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/artifact/ArtifactVersion.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/artifact/ArtifactVersion.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.proto.artifact;
+
+import co.cask.cdap.api.annotation.Beta;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.annotation.Nullable;
+
+/**
+ * Represents version of an artifact. It will try to parse the version string of format
+ *
+ * <pre>
+ * {@code
+ * parse version string in format of [major].[minor].[fix](-|.)[suffix]
+ * }
+ * </pre>
+ */
+@Beta
+public final class ArtifactVersion implements Comparable<ArtifactVersion> {
+
+  private static final Pattern PATTERN = Pattern.compile("(\\d+)(?:\\.(\\d+))?(?:\\.(\\d+))?(?:[.\\-](.*))?");
+
+  private final String version;
+  private final Integer major;
+  private final Integer minor;
+  private final Integer fix;
+  private final String suffix;
+
+  /**
+   * Constructs an instance by parsing the given string.
+   *
+   * @param str the version string. The whole string needs to match with the version pattern supported by this class.
+   */
+  public ArtifactVersion(String str) {
+    this(str, false);
+  }
+
+  /**
+   * Constructs an instance by parsing the given string.
+   *
+   * @param str the version stirng.
+   * @param matchSuffix if {@code true}, try to match the version pattern by the suffix of the string. Otherwise match
+   *                    the whole string.
+   */
+  public ArtifactVersion(String str, boolean matchSuffix) {
+    String tmpVersion = null;
+    Integer major = null;
+    Integer minor = null;
+    Integer fix = null;
+    String suffix = null;
+    if (str != null) {
+      Matcher matcher = PATTERN.matcher(str);
+      boolean matches = matchSuffix ? (matcher.find() && matcher.hitEnd()) : matcher.matches();
+
+      if (matches) {
+        tmpVersion = matcher.group(0);
+        major = valueOf(matcher.group(1));
+        minor = valueOf(matcher.group(2));
+        fix = valueOf(matcher.group(3));
+        suffix = matcher.group(4);
+      }
+    }
+
+    this.version = tmpVersion;
+    this.major = major;
+    this.minor = minor;
+    this.fix = fix;
+    this.suffix = suffix;
+  }
+
+  @Nullable
+  public String getVersion() {
+    return version;
+  }
+
+  @Nullable
+  public Integer getMajor() {
+    return major;
+  }
+
+  @Nullable
+  public Integer getMinor() {
+    return minor;
+  }
+
+  @Nullable
+  public Integer getFix() {
+    return fix;
+  }
+
+  @Nullable
+  public String getSuffix() {
+    return suffix;
+  }
+
+  public boolean isSnapshot() {
+    return suffix != null && "snapshot".equals(suffix.toLowerCase());
+  }
+
+  @Override
+  public int compareTo(ArtifactVersion other) {
+    int cmp = compare(major, other.major);
+    if (cmp != 0) {
+      return cmp;
+    }
+
+    cmp = compare(minor, other.minor);
+    if (cmp != 0) {
+      return cmp;
+    }
+
+    cmp = compare(fix, other.fix);
+    if (cmp != 0) {
+      return cmp;
+    }
+
+    // All numerical part of the version are the same, compare the suffix.
+    // A special case is no suffix is "greater" than with suffix. This is usually true (e.g. release > snapshot)
+    if (suffix == null) {
+      return other.suffix == null ? 0 : 1;
+    }
+    return other.suffix == null ? -1 : suffix.compareTo(other.suffix);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    ArtifactVersion that = (ArtifactVersion) o;
+    return !(version != null ? !version.equals(that.version) : that.version != null);
+  }
+
+  @Override
+  public int hashCode() {
+    return version != null ? version.hashCode() : 0;
+  }
+
+  @Override
+  public String toString() {
+    return version;
+  }
+
+  /**
+   * Compares two {@link Comparable}s that can be null. Returns -1, 0, 1 if first is smaller, equal, larger than second,
+   * based on comparison defined by the {@link Comparable}.
+   * The {@code null} value is smaller than any non-null value and only equals to {@code null}.
+   */
+  private <T extends Comparable<T>> int compare(@Nullable T first, @Nullable T second) {
+    if (first == null && second == null) {
+      return 0;
+    }
+    if (first == null) {
+      return -1;
+    }
+    if (second == null) {
+      return 1;
+    }
+    return first.compareTo(second);
+  }
+
+  /**
+   * Parses the given string as integer. If failed, returns {@code null}.
+   */
+  @Nullable
+  private Integer valueOf(@Nullable String str) {
+    try {
+      if (str == null) {
+        return null;
+      }
+      return Integer.valueOf(str);
+    } catch (NumberFormatException e) {
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
Snapshot versions are mutable unlike other artifacts.
Also fixing up some bugs where the absence of a plugin or artifact
was not correctly throwing a not found exception.
Also changing ArtifactStore to return unmodifiable collections,
and to return location of the artifact when getting plugins.