### PR TITLE
Modifies Gulpfile to speed up build process for development

### DIFF
--- a/cdap-ui/Gulpfile.js
+++ b/cdap-ui/Gulpfile.js
@@ -162,24 +162,84 @@ gulp.task('js:$modal', function() {
   .pipe(gulp.dest('./bower_components/angular-bootstrap'));
 });
 
+function getEs6Features(isNegate) {
+  /*
+    When we move a feature to use es6 all we need to do is add it here for the build/dev process.
+    Eventually when all the features are ported to es6 then we should use a better package manager
+    like webpack or jspm for development and replace the js:app,js:lib,js:aceworkers & js:$modal gulp tasks
+    with the package manager build step. The transition process is going to be painful but the end goal is better (hopefully :])
+  */
+  var es6features = [
+    'workflows'
+  ];
+  var returnVal = [];
+  es6features.forEach(function(feature) {
+    returnVal = returnVal.concat([
+      (isNegate? '!': '') + './app/features/' + feature + '/module.js',
+      (isNegate? '!': '') + './app/features/' + feature + '/**/*js',
+    ]);
+  });
+  return returnVal;
+}
 
 
 /*
   application javascript
  */
-gulp.task('js:app', function() {
+gulp.task('watch:js:app', function() {
   var PKG = JSON.stringify({
     name: pkg.name,
     v: pkg.version
   });
 
+  return gulp.src(
+      [
+        './app/main.js',
+        '!./app/lib/c3.js',
+        './app/features/*/module.js',
+        './app/**/*.js',
+        '!./app/**/*-test.js'
+      ].concat(getEs6Features(true))
+    )
+    .pipe(plug.ngAnnotate())
+    .pipe(plug.wrapper({
+       header: '\n(function (PKG){ /* ${filename} */\n',
+       footer: '\n})('+PKG+');\n'
+    }))
+    .pipe(plug.concat('app.js'))
+    .pipe(gulp.dest('./dist/assets/bundle'));
+});
+
+gulp.task('watch:js:app:babel', function() {
+  var PKG = JSON.stringify({
+    name: pkg.name,
+    v: pkg.version
+  });
+  return gulp.src(getEs6Features())
+    .pipe(plug.ngAnnotate())
+    .pipe(plug.sourcemaps.init())
+    .pipe(plug.wrapper({
+       header: '\n(function (PKG){ /* ${filename} */\n',
+       footer: '\n})('+PKG+');\n'
+    }))
+    .pipe(plug.babel())
+    .pipe(plug.concat('app.es6.js'))
+    .pipe(plug.sourcemaps.write("."))
+    .pipe(gulp.dest('./dist/assets/bundle'));
+});
+
+gulp.task('js:app', function() {
+  var PKG = JSON.stringify({
+    name: pkg.name,
+    v: pkg.version
+  });
   return gulp.src([
-      './app/main.js',
-      '!./app/lib/c3.js',
-      './app/features/*/module.js',
-      './app/**/*.js',
-      '!./app/**/*-test.js'
-    ])
+    './app/main.js',
+    '!./app/lib/c3.js',
+    './app/features/*/module.js',
+    './app/**/*.js',
+    '!./app/**/*-test.js'
+  ])
     .pipe(plug.ngAnnotate())
     .pipe(plug.sourcemaps.init())
     .pipe(plug.wrapper({
@@ -191,7 +251,6 @@ gulp.task('js:app', function() {
     .pipe(plug.sourcemaps.write("."))
     .pipe(gulp.dest('./dist/assets/bundle'));
 });
-
 
 
 /*
@@ -326,13 +385,15 @@ gulp.task('rev:replace', ['html:main', 'rev:manifest'], function() {
 /*
   alias tasks
  */
-gulp.task('lib', ['js:$modal', 'js:lib', 'js:aceworkers', 'css:lib']);
-gulp.task('app', ['js:app', 'css:app']);
 gulp.task('js', ['js:$modal', 'js:lib', 'js:aceworkers', 'js:app']);
+gulp.task('watch:js', ['js:$modal', 'js:lib', 'js:aceworkers', 'watch:js:app', 'watch:js:app:babel']);
 gulp.task('css', ['css:lib', 'css:app']);
 gulp.task('style', ['css']);
 
+
+gulp.task('watch:build', ['watch:js', 'css', 'img', 'tpl', 'html']);
 gulp.task('build', ['js', 'css', 'img', 'tpl', 'html']);
+
 gulp.task('distribute', ['build', 'rev:replace']);
 
 gulp.task('default', ['lint', 'build']);
@@ -342,13 +403,15 @@ gulp.task('default', ['lint', 'build']);
 /*
   watch
  */
-gulp.task('watch', ['build'], function() {
+gulp.task('watch', ['watch:build'], function() {
   plug.livereload.listen();
 
   gulp.watch('./dist/**/*')
     .on('change', plug.livereload.changed);
 
-  gulp.watch(['./app/**/*.js', '!./app/**/*-test.js'], ['js:app']);
+  gulp.watch(['./app/**/*.js', '!./app/features/workflows/**/*.js', '!./app/**/*-test.js'], ['watch:js:app']);
+  gulp.watch(['./app/features/workflows/**/*.js'], ['watch:js:app:babel']);
+
   gulp.watch('./app/**/*.{less,css}', ['css']);
   gulp.watch(['./app/directives/**/*.html', './app/features/home/home.html'], ['tpl']);
   gulp.watch('./app/features/**/*.html', ['html:partials']);

--- a/cdap-ui/app/index.html
+++ b/cdap-ui/app/index.html
@@ -60,6 +60,10 @@
     <script type="text/javascript" src="/assets/bundle/lib.js"></script>
     <script type="text/javascript" src="/config.js"></script>
     <script type="text/javascript" src="/assets/bundle/app.js"></script>
+    <!-- This will throw a 404 not found when we run only gulp build.
+        This is temporary and should be fixed by the end of the release
+    -->
+    <script type="text/javascript" src="/assets/bundle/app.es6.js"></script>
     <script type="text/javascript" src="/assets/bundle/tpl.js"></script>
 
     <!-- TODO: REMOVE BEFORE RELEASE -->


### PR DESCRIPTION
- Separates out dev build vs prod build (ui js build process)
Mainly addresses ```gulp watch``` when developing UI. ```gulp build``` should still work exactly the same.