### PR TITLE
removes 'All Rights Reserved' from footer text

### DIFF
--- a/cdap-ui/app/index.html
+++ b/cdap-ui/app/index.html
@@ -34,7 +34,7 @@
           <div class="col-xs-12 col-md-6 text-uppercase">
             <p>
               <img src="/assets/img/cask.png" alt="" />
-              <span>Copyright &copy; 2015 Cask Data, Inc. All Rights Reserved.</span>
+              <span>Copyright &copy; 2015 Cask Data, Inc.</span>
             </p>
           </div>
           <div class="col-xs-12 col-md-6">


### PR DESCRIPTION
* Removes "All Rights Reserved" from UI copyright text in the footer

![screen shot 2015-06-29 at 3 01 52 pm](https://cloud.githubusercontent.com/assets/5335210/8419595/dcf04b18-1e6f-11e5-9972-eeeffc9ce556.png)
