### PR TITLE
[CDAP-2890] include templates profile when building parcel to include…

### DIFF
--- a/BUILD.rst
+++ b/BUILD.rst
@@ -70,7 +70,7 @@ Standalone and Distributed CDAP
 
 - Build Cloudera Manager parcel::
 
-    mvn package -DskipTests -P dist,tgz && ./cdap-distributions/bin/build_parcel.sh
+    MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=128m" mvn package -DskipTests -P templates,dist,tgz && ./cdap-distributions/bin/build_parcel.sh
 
 - Show dependency tree::
 


### PR DESCRIPTION
… ETL jars

Same as https://github.com/caskdata/cdap/pull/3063, but for release branch

Fixes one aspect of https://issues.cask.co/browse/CDAP-2890.  Updating ``BUILD.rst`` command for parcel build to include the templates profile, and setting MAVEN_OPTS (required on my machine).

I will update the bamboo builds after merging.