### PR TITLE
[CDAP-2893] Log parser transform

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/pom.xml
@@ -190,6 +190,11 @@
       <artifactId>parquet-avro</artifactId>
       <version>1.6.0</version>
     </dependency>
+    <dependency>
+      <groupId>net.sf.uadetector</groupId>
+      <artifactId>uadetector-resources</artifactId>
+      <version>2014.04</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/source/FileBatchSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/source/FileBatchSource.java
@@ -90,7 +90,6 @@ public class FileBatchSource extends BatchSource<LongWritable, Object, Structure
   private static final String FILESYSTEM_DESCRIPTION = "Distributed file system to read in from.";
   private static final Gson GSON = new Gson();
   private static final Logger LOG = LoggerFactory.getLogger(FileBatchSource.class);
-  private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd-HH-mm");
   private static final Type ARRAYLIST_DATE_TYPE  = new TypeToken<ArrayList<Date>>() { }.getType();
   private static final Type MAP_STRING_STRING_TYPE = new TypeToken<Map<String, String>>() { }.getType();
 
@@ -112,6 +111,9 @@ public class FileBatchSource extends BatchSource<LongWritable, Object, Structure
 
   @Override
   public void prepareRun(BatchSourceContext context) throws Exception {
+    //SimpleDateFormat needs to be local because it is not threadsafe
+    SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd-HH-mm");
+
     //calculate date one minute ago, rounded down to the nearest minute
     prevMinute = new Date(context.getLogicalStartTime() - TimeUnit.MINUTES.toMillis(1));
     Calendar cal = Calendar.getInstance();
@@ -149,7 +151,7 @@ public class FileBatchSource extends BatchSource<LongWritable, Object, Structure
       conf.set(LAST_TIME_READ, datesToRead);
     }
 
-    conf.set(CUTOFF_READ_TIME, DATE_FORMAT.format(prevMinute));
+    conf.set(CUTOFF_READ_TIME, dateFormat.format(prevMinute));
     if (config.inputFormatClass != null) {
       ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
       Class<? extends FileInputFormat> classType = (Class<? extends FileInputFormat>)

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/common/BatchFileFilter.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/common/BatchFileFilter.java
@@ -54,9 +54,9 @@ public class BatchFileFilter extends Configured implements PathFilter {
   private static final Logger LOG = LoggerFactory.getLogger(FileBatchSource.class);
   //length of 'YYYY-MM-dd-HH-mm"
   private static final int DATE_LENGTH = 16;
-  private static final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd-HH-mm");
   private static final Gson GSON = new Gson();
   private static final Type ARRAYLIST_DATE_TYPE  = new TypeToken<ArrayList<Date>>() { }.getType();
+  private final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd-HH-mm");
   private boolean useTimeFilter;
   private Pattern regex;
   private String pathName;

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/transform/LogParserTransform.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/transform/LogParserTransform.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.template.etl.transform;
+
+import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.templates.plugins.PluginConfig;
+import co.cask.cdap.template.etl.api.Emitter;
+import co.cask.cdap.template.etl.api.Transform;
+import co.cask.cdap.template.etl.api.TransformContext;
+import net.sf.uadetector.ReadableUserAgent;
+import net.sf.uadetector.UserAgentStringParser;
+import net.sf.uadetector.service.UADetectorServiceFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.ByteBuffer;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.annotation.Nullable;
+
+/**
+ * Parses log formats to extract access information
+ */
+@Plugin(type = "transform")
+@Name("LogParser")
+@Description("Parses logs from any input source for relevant information such as URI, IP, Browser, Device, and " +
+  "Timestamp.")
+public class LogParserTransform extends Transform<StructuredRecord, StructuredRecord> {
+  private static final Schema LOG_SCHEMA = Schema.recordOf(
+    "event",
+    Schema.Field.of("uri", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("ip", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("browser", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("device", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("ts", Schema.of(Schema.Type.LONG))
+  );
+  private static final String LOG_FORMAT_DESCRIPTION = "Log format to parse. Currently only supports S3 and " +
+    "CLF Log format.";
+  private static final String INPUT_NAME_DESCRIPTION = "Name of the field in the input schema which encodes the " +
+    "log information. The given field must be of type String or Bytes";
+  private static final Logger LOG = LoggerFactory.getLogger(LogParserTransform.class);
+  //Regex used to parse a CLF log, each field is commented above
+  private static final Pattern CLF_LOG_PATTERN = Pattern.compile(
+    //   IP                    id    user      date          request     code     size    referrer    user agent
+    "^([\\d.]+|[:][:][\\d]) (\\S+) (\\S+) \\[([^\\]]+)\\] \"([^\"]+)\" (\\d{3}) ([-\"\\d]+) \"([^\"]+)\" \"([^\"]+)\"");
+  //Regex used to parse a S3 log, each field is commented above
+  private static final Pattern S3_LOG_PATTERN = Pattern.compile(
+    // bucket owner name   time           ip                    req   reqID operation  key    request
+    "^(\\S+) (\\S+) \\[(\\p{Print}+)\\] ([\\d.]+|[:][:][\\d]) (\\S+) (\\S+) (\\S+) (\\S+) \"([^\"]+)\" " +
+      //  HTTP stat error code  bytes sent     obj size  time    turn time  referrer         user agent
+      "(\\d{3}) (\\p{Print}+) ([-\"\\d]+) ([-\"\\d]+) ([\\d]+) ([-\"\\d]+) \"(\\p{Print}+)\" \"([^\"]+)\" " +
+      //  version id
+      "(\\p{Print}+)");
+  //Regex used to parse the request field for the URI
+  private static final Pattern REQUEST_PAGE_PATTERN = Pattern.compile("(\\S+)\\s(\\S+).*");
+  //Indices of which group request, time, ip, and user agent are in the S3 regex
+  private static final int[] S3_INDICES = {9, 3, 4, 17};
+  //Indices of which group request, time, ip, and user agent are in the CLF regex
+  private static final int[] CLF_INDICES = {5, 4, 1, 9};
+  //Number of groups matched in the S3 regex
+  private static final int S3_REGEX_LENGTH = 18;
+  //Number of groups matched in the CLF regex
+  private static final int CLF_REGEX_LENGTH = 9;
+  private static final String S3_LOG = "S3";
+  private static final String CLF_LOG = "CLF";
+  private final LogParserConfig config;
+  private final SimpleDateFormat sdf = new SimpleDateFormat("dd/MMM/yyyy:HH:mm:ss Z");
+
+  public LogParserTransform(LogParserConfig config) {
+    this.config = config;
+  }
+
+  @Override
+  public void initialize(TransformContext context) throws Exception {
+    if (!S3_LOG.equals(config.logFormat) && !CLF_LOG.equals(config.logFormat)) {
+      LOG.error("Log format not currently supported.");
+      throw new IllegalStateException("Unsupported log format");
+    }
+  }
+
+  @Override
+  public void transform(StructuredRecord input, Emitter<StructuredRecord> emitter) throws Exception {
+    String log = getLog(input);
+    if (log == null) {
+      LOG.error("Couldn't read schema, log message was null");
+      return;
+    }
+
+    StructuredRecord output;
+    if (S3_LOG.equals(config.logFormat)) {
+      Matcher logMatcher = S3_LOG_PATTERN.matcher(log);
+      if (!logMatcher.matches() || logMatcher.groupCount() < S3_REGEX_LENGTH) {
+        LOG.debug("Couldn't parse log because log did not match the S3 format, log: {}", log);
+        return;
+      }
+      output = parseRequest(logMatcher, S3_INDICES);
+    } else {
+      Matcher logMatcher = CLF_LOG_PATTERN.matcher(log);
+      if (!logMatcher.matches() || logMatcher.groupCount() < CLF_REGEX_LENGTH) {
+        LOG.debug("Couldn't parse log because the log did not match the CLF format. log: {}", log);
+        return;
+      }
+      output = parseRequest(logMatcher, CLF_INDICES);
+    }
+
+    if (output != null) {
+      emitter.emit(output);
+    }
+  }
+
+  /**
+   * Gets the log message from the input
+   * @param input the StructuredRecord to extract the log from
+   * @return the log message, or null on failure
+   */
+  @Nullable
+  private String getLog(StructuredRecord input) {
+    Schema.Field inputField = input.getSchema().getField(config.inputName);
+    if (inputField == null) {
+      LOG.debug("Invalid inputName, no known inputField matches given input of " + config.inputName);
+      return null;
+    }
+
+    Schema inputSchema = inputField.getSchema();
+    if (inputSchema.isNullableSimple()) {
+      inputSchema = inputSchema.getNonNullable();
+    }
+    Schema.Type inputType = inputSchema.getType();
+
+    if (!Schema.Type.STRING.equals(inputType) && !Schema.Type.BYTES.equals(inputType)) {
+      LOG.error("Unsupported inputType in schema, only Schema.Type.BYTES and Schema.Type.STRING are supported. " +
+                  "InputType: {}", inputType.toString());
+      return null;
+    }
+
+    if (Schema.Type.STRING.equals(inputType)) {
+      return input.get(config.inputName);
+    } else {
+      Object data = input.get(config.inputName);
+      if (data instanceof ByteBuffer) {
+        return Bytes.toString((ByteBuffer) input.get(config.inputName));
+      } else if (data instanceof byte[]) {
+        return Bytes.toString((byte[]) input.get(config.inputName));
+      } else {
+        LOG.debug("Not a byte type, type is {}", data.getClass().toString());
+        return null;
+      }
+    }
+  }
+
+  /**
+   * Parses a request for the URI, IP, Browser, Device, and Time
+   * @param logMatcher the regex matcher to use
+   * @param indices array of indices that define what position in the regex the fields are,
+   *                 in the order of Request, Time, IP, and User Agent
+   */
+  @Nullable
+  private StructuredRecord parseRequest(Matcher logMatcher, int[] indices) {
+    String request = logMatcher.group(indices[0]);
+    Matcher requestMatcher = REQUEST_PAGE_PATTERN.matcher(request);
+    if (!requestMatcher.matches() || requestMatcher.groupCount() < 2) {
+      LOG.debug("Couldn't parse uri because request does not match request pattern, request: {}", request);
+      return null;
+    }
+
+    String uri = requestMatcher.group(2);
+    long ts = System.currentTimeMillis();
+    try {
+      ts = sdf.parse(logMatcher.group(indices[1])).getTime();
+    } catch (ParseException e) {
+      LOG.debug("Couldn't parse time from the input record, using current timestamp instead. Exception: {}",
+                e.getMessage());
+    }
+
+    String ip = logMatcher.group(indices[2]);
+    UserAgentStringParser parser = UADetectorServiceFactory.getResourceModuleParser();
+    ReadableUserAgent userAgent = parser.parse(logMatcher.group(indices[3]));
+    String browser = userAgent.getFamily().getName();
+    String device = userAgent.getDeviceCategory().getCategory().getName();
+
+    return StructuredRecord.builder(LOG_SCHEMA)
+      .set("uri", uri)
+      .set("ip", ip)
+      .set("browser", browser)
+      .set("device", device)
+      .set("ts", ts)
+      .build();
+  }
+
+  /**
+   * Config class for LogParserTransform
+   */
+  public static class LogParserConfig extends PluginConfig {
+    @Name("logFormat")
+    @Description(LOG_FORMAT_DESCRIPTION)
+    private String logFormat;
+
+    @Name("inputName")
+    @Description(INPUT_NAME_DESCRIPTION)
+    private String inputName;
+
+    public LogParserConfig(String logFormat, String inputName) {
+      this.logFormat = logFormat;
+      this.inputName = inputName;
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/template/etl/transform/LogParserTransformTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/template/etl/transform/LogParserTransformTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.template.etl.transform;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.template.etl.api.Transform;
+import co.cask.cdap.template.etl.common.MockEmitter;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+
+public class LogParserTransformTest {
+  private static final Schema STRING_SCHEMA = Schema.recordOf(
+    "event",
+    Schema.Field.of("body", Schema.of(Schema.Type.STRING))
+  );
+  private static final Schema BYTE_SCHEMA = Schema.recordOf(
+    "event",
+    Schema.Field.of("body", Schema.of(Schema.Type.BYTES))
+  );
+  private static final LogParserTransform.LogParserConfig S3_CONFIG =
+    new LogParserTransform.LogParserConfig("S3", "body");
+  private static final Transform<StructuredRecord, StructuredRecord> S3_TRANSFORM = new LogParserTransform(S3_CONFIG);
+  private static final LogParserTransform.LogParserConfig CLF_CONFIG =
+    new LogParserTransform.LogParserConfig("CLF", "body");
+  private static final Transform<StructuredRecord, StructuredRecord> CLF_TRANSFORM =
+    new LogParserTransform(CLF_CONFIG);
+
+  @Test
+  public void transformS3Log() throws Exception {
+    StructuredRecord botRecord = StructuredRecord.builder(STRING_SCHEMA)
+      .set("body", "13a9f69e4a00effd6b4b891dcbcabef632ef9a9da7c localhost " +
+        "[22/Jan/2015:11:03:21 +0000] 122.122.111.11 - 6006CA0AE4 REST.GET.OBJECT " +
+        "ubuntu/this/is/some/folder " +
+        "\"GET /my/uri.gif releases/dists/precise/releases/i18n/Translation-en HTTP/1.1\" " +
+        "403 AccessDenied 231 - 10 - \"-\" \"Debian APT-HTTP/1.3 (0.8.16~exp12ubuntu10.  17)\" -")
+      .build();
+
+    StructuredRecord browserRecord = StructuredRecord.builder(STRING_SCHEMA)
+      .set("body", "13a9f69e4a00effd6b4b891dcef632ef9afe38cc8b0 localhost " +
+             "[31/Jan/2015:21:57:57 +0000] 133.133.133.133 - 0E94306589 REST.GET.OBJECT " +
+             "downloads/this/is/another/folder/with/a/file/file.zip " +
+             "\"GET /my/uri.jpg HTTP/1.1\" 304 - - 195750039 198 - " +
+             "\"-\" \"Mozilla/5.0 Gecko/20100115 Firefox/3.6\" -")
+      .build();
+
+    MockEmitter<StructuredRecord> emitter = new MockEmitter<>();
+    S3_TRANSFORM.transform(botRecord, emitter);
+    StructuredRecord output = emitter.getEmitted().get(0);
+    Assert.assertEquals("/my/uri.gif", output.get("uri"));
+    Assert.assertEquals("122.122.111.11", output.get("ip"));
+    Assert.assertEquals("unknown", output.get("browser"));
+    Assert.assertEquals("", output.get("device"));
+    Assert.assertEquals(1421924601000L, output.get("ts"));
+
+    S3_TRANSFORM.transform(browserRecord, emitter);
+    output = emitter.getEmitted().get(1);
+    Assert.assertEquals("/my/uri.jpg", output.get("uri"));
+    Assert.assertEquals("133.133.133.133", output.get("ip"));
+    Assert.assertEquals("Firefox", output.get("browser"));
+    Assert.assertEquals("Personal computer", output.get("device"));
+    Assert.assertEquals(1422741477000L, output.get("ts"));
+  }
+
+  @Test
+  public void transformCLFLog() throws Exception {
+    StructuredRecord record = StructuredRecord.builder(BYTE_SCHEMA)
+      .set("body", ByteBuffer.wrap((Bytes.toBytes("127.0.0.1 - frank [10/Oct/2000:13:55:36 -0700] " +
+                                                    "\"GET /apache_pb.gif HTTP/1.0\" 200 2326 " +
+                                                    "\"http://www.example.com/start.html\" \"Mozilla/5.0 " +
+                                                    "(Macintosh; Intel Mac OS X 10_10_3) AppleWebKit/537.36 " +
+                                                    "(KHTML, like Gecko) Chrome/43.0.2357.124 Safari/537.36\""))))
+      .build();
+
+    MockEmitter<StructuredRecord> emitter = new MockEmitter<>();
+    CLF_TRANSFORM.transform(record, emitter);
+    StructuredRecord output = emitter.getEmitted().get(0);
+    Assert.assertEquals("/apache_pb.gif", output.get("uri"));
+    Assert.assertEquals("127.0.0.1", output.get("ip"));
+    Assert.assertEquals("Chrome", output.get("browser"));
+    Assert.assertEquals("Personal computer", output.get("device"));
+    Assert.assertEquals(971211336000L, output.get("ts"));
+  }
+}

--- a/cdap-ui/templates/common/LogParser.json
+++ b/cdap-ui/templates/common/LogParser.json
@@ -1,0 +1,21 @@
+{
+  "id": "LogParser",
+  "groups" : {
+    "position": [ "group1" ],
+    "group1": {
+      "display" : "Log Parser Transform",
+      "position" : [ "logFormat", "inputName" ],
+      "fields" : {
+        "logFormat": {
+          "widget": "textbox",
+          "label": "Log Format"
+        },
+
+        "inputName": {
+          "widget": "textbox",
+          "label": "Input Name"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
JIRA - https://issues.cask.co/browse/CDAP-2893
BUILD - http://builds.cask.co/browse/CDAP-DUT2134-2

Custom Transform that parses various log formats (currently only CLF and S3) and extracts information such as URI, IP, browser, device, and time. Part of the Caskalytics project.