### PR TITLE
docs fix app.template.* to match cdap-default.xml

### DIFF
--- a/cdap-docs/admin-manual/source/installation/cdap-site.rst
+++ b/cdap-docs/admin-manual/source/installation/cdap-site.rst
@@ -24,8 +24,11 @@ see the :ref:`configuration-security` section.
      - Default Value
      - Description
    * - ``app.template.dir``
-     - ``/opt/cdap/master/plugins``
+     - ``/opt/cdap/master/templates``
      - Directory where all archives for application templates are stored
+   * - ``app.template.plugin.dir``
+     - ``${app.template.dir}/plugins``
+     - Directory where template plugins are stored
    * - ``app.bind.address``
      - ``127.0.0.1``
      - App-Fabric server host address


### PR DESCRIPTION
same as https://github.com/caskdata/cdap/pull/3071 but for develop branch

updating cdap-site.xml appendix in docs to match cdap-default.xml:
   - [x] fixing default value for ``app.template.dir``
   - [x] adding ``app.template.plugin.dir``