### PR TITLE
CDAP-2747 - Use IndexedTable for PartitionedFileSet.

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionConsumerResult.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionConsumerResult.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.api.dataset.lib;
+
+import java.util.Iterator;
+
+/**
+ * Returns access to an iterator of the requested partitions as well as a {@link PartitionConsumerState} which can be
+ * used to request partitions created after the previous request of partitions.
+ */
+public class PartitionConsumerResult {
+  private final PartitionConsumerState partitionConsumerState;
+  private final Iterator<Partition> partitionIterator;
+
+  public PartitionConsumerResult(PartitionConsumerState partitionConsumerState, Iterator<Partition> partitionIterator) {
+    this.partitionConsumerState = partitionConsumerState;
+    this.partitionIterator = partitionIterator;
+  }
+
+  public PartitionConsumerState getPartitionConsumerState() {
+    return partitionConsumerState;
+  }
+
+  public Iterator<Partition> getPartitionIterator() {
+    return partitionIterator;
+  }
+}

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionConsumerState.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionConsumerState.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.api.dataset.lib;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.primitives.Longs;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Contains the state necessary to keep track of which partitions are processed and which partitions would need to be
+ * processed as they are created.
+ */
+public class PartitionConsumerState {
+  // useful on initial query of partitions
+  public static final PartitionConsumerState FROM_BEGINNING =
+    new PartitionConsumerState(0, Collections.<Long>emptyList());
+
+  // Read pointer of the transaction from the previous query of partitions. This is used to scan for new partitions
+  // created since then.
+  private final long startVersion;
+  // The list of in progress transactions from the previous query of partitions that are smaller than the startVersion.
+  // We do not need to include the in-progress transaction Ids that are larger than the startVersion because those will
+  // be picked up in the next scan anyways, since we will start the scan from the startVersion.
+  // Keeping track of these in-progress transactions is necessary because these might be creations of partitions that
+  // fall before the startVersion.
+  private final List<Long> versionsToCheck;
+
+  public PartitionConsumerState(long startVersion, List<Long> versionsToCheck) {
+    Preconditions.checkNotNull(versionsToCheck);
+    this.startVersion = startVersion;
+    this.versionsToCheck = ImmutableList.copyOf(versionsToCheck);
+  }
+
+  public long getStartVersion() {
+    return startVersion;
+  }
+
+  public List<Long> getVersionsToCheck() {
+    return versionsToCheck;
+  }
+
+  public static PartitionConsumerState fromBytes(byte[] bytes) {
+    Preconditions.checkArgument((bytes.length - 1) % Longs.BYTES == 0,
+                                "bytes does not have length divisible by Longs.BYTES");
+    ByteBuffer bb = ByteBuffer.wrap(bytes);
+    byte serializationFormatVersion = bb.get();
+    Preconditions.checkArgument(serializationFormatVersion == 0,
+                                "Unsupported serialization format: {}", serializationFormatVersion);
+    long startVersion = bb.getLong();
+    List<Long> versionsToCheck = Lists.newArrayList();
+    while (bb.hasRemaining()) {
+      versionsToCheck.add(bb.getLong());
+    }
+    return new PartitionConsumerState(startVersion, versionsToCheck);
+  }
+
+  public byte[] toBytes() {
+    int numLongs = 1 + versionsToCheck.size();
+    // first byte for serialization format version
+    ByteBuffer bb = ByteBuffer.allocate(1 + Longs.BYTES * numLongs);
+    // currently, serialization format is 0
+    bb.put((byte) 0);
+    bb.putLong(startVersion);
+    for (long l : versionsToCheck) {
+      bb.putLong(l);
+    }
+    return bb.array();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    PartitionConsumerState that = (PartitionConsumerState) o;
+
+    if (startVersion != that.startVersion) {
+      return false;
+    }
+    return versionsToCheck.equals(that.versionsToCheck);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = (int) (startVersion ^ (startVersion >>> 32));
+    result = 31 * result + versionsToCheck.hashCode();
+    return result;
+  }
+}

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionMetadata.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionMetadata.java
@@ -51,6 +51,9 @@ public class PartitionMetadata implements Iterable<Map.Entry<String, String>> {
     return metadata;
   }
 
+  /**
+   * @return the creation time of the partition, in milliseconds.
+   */
   public long getCreationTime() {
     return creationTime;
   }

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionedFileSet.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionedFileSet.java
@@ -88,6 +88,17 @@ public interface PartitionedFileSet extends Dataset, InputFormatProvider, Output
   Set<PartitionDetail> getPartitions(@Nullable PartitionFilter filter);
 
   /**
+   * Incrementally consumes partitions. This method can be used to retrieve partitions that have been created since the
+   * last call to this method. Note that it is the client's responsibility to maintain state of the partitions processed
+   * in the iterator returned in the PartitionConsumerResult.
+   *
+   * @param partitionConsumerState the state from which to start consuming from
+   * @return {@link PartitionConsumerResult} which holds the state of consumption as well as an iterator to the consumed
+   * {@link Partition}s
+   */
+  PartitionConsumerResult consumePartitions(PartitionConsumerState partitionConsumerState);
+
+  /**
    * Return a partition output for a specific partition key, in preparation for creating a new partition.
    * Obtain the location to write from the PartitionOutput, then call the {@link PartitionOutput#addPartition}
    * to add the partition to this dataset.

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionConsumer.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionConsumer.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.dataset2.lib.partitioned;
+
+import co.cask.cdap.api.dataset.lib.Partition;
+import co.cask.cdap.api.dataset.lib.PartitionConsumerResult;
+import co.cask.cdap.api.dataset.lib.PartitionConsumerState;
+import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
+
+import java.util.Iterator;
+
+/**
+ * A simple consumer for {@link Partition}s of a {@link PartitionedFileSet}
+ */
+public class PartitionConsumer {
+  private final PartitionedFileSet partitionedFileSet;
+  private PartitionConsumerState partitionConsumerState;
+
+  /**
+   * Creates an instance of PartitionConsumer which consumes, starting from the given PartitionConsumerState
+   *
+   * @param partitionedFileSet the PartitionedFileSet to consume from
+   * @param partitionConsumerState the PartitionConsumerState to begin consuming from
+   */
+  public PartitionConsumer(PartitionedFileSet partitionedFileSet,
+                           PartitionConsumerState partitionConsumerState) {
+    this.partitionedFileSet = partitionedFileSet;
+    this.partitionConsumerState = partitionConsumerState;
+  }
+
+  /**
+   * Creates an instance of a PartitionConsumer which begins consuming from the beginning.
+   *
+   * @param partitionedFileSet the PartitionedFileSet to consume from
+   */
+  public PartitionConsumer(PartitionedFileSet partitionedFileSet) {
+    this(partitionedFileSet, PartitionConsumerState.FROM_BEGINNING);
+  }
+
+  /**
+   * @return an iterator to {@link Partition}s of the underlying {@link PartitionedFileSet} created since the last
+   * call to this method. This excludes partitions created in in-progress transactions including the one in which the
+   * call to this method is made.
+   */
+  public Iterator<Partition> consumePartitions() {
+    PartitionConsumerResult partitionConsumerResult = partitionedFileSet.consumePartitions(partitionConsumerState);
+    partitionConsumerState = partitionConsumerResult.getPartitionConsumerState();
+    return partitionConsumerResult.getPartitionIterator();
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetDefinition.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetDefinition.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.data2.dataset2.lib.partitioned;
 
+import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.dataset.DatasetAdmin;
 import co.cask.cdap.api.dataset.DatasetContext;
 import co.cask.cdap.api.dataset.DatasetDefinition;
@@ -24,12 +25,13 @@ import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.dataset.lib.AbstractDatasetDefinition;
 import co.cask.cdap.api.dataset.lib.FileSet;
 import co.cask.cdap.api.dataset.lib.FileSetArguments;
+import co.cask.cdap.api.dataset.lib.IndexedTable;
+import co.cask.cdap.api.dataset.lib.IndexedTableDefinition;
 import co.cask.cdap.api.dataset.lib.PartitionKey;
 import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
 import co.cask.cdap.api.dataset.lib.PartitionedFileSetArguments;
 import co.cask.cdap.api.dataset.lib.PartitionedFileSetProperties;
 import co.cask.cdap.api.dataset.lib.Partitioning;
-import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.explore.client.ExploreFacade;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
@@ -50,11 +52,12 @@ import java.util.Map;
 public class PartitionedFileSetDefinition extends AbstractDatasetDefinition<PartitionedFileSet, DatasetAdmin> {
 
   private static final Logger LOG = LoggerFactory.getLogger(PartitionedFileSetDefinition.class);
-
+  private static final String INDEXED_COLS = Bytes.toString(PartitionedFileSetDataset.WRITE_PTR_COL) + ','
+    + Bytes.toString(PartitionedFileSetDataset.CREATION_TIME_COL);
   protected static final String PARTITION_TABLE_NAME = "partitions";
   protected static final String FILESET_NAME = "files";
 
-  protected final DatasetDefinition<? extends Table, ?> tableDef;
+  protected final DatasetDefinition<? extends IndexedTable, ?> indexedTableDef;
   protected final DatasetDefinition<? extends FileSet, ?> filesetDef;
 
   @Inject
@@ -62,20 +65,25 @@ public class PartitionedFileSetDefinition extends AbstractDatasetDefinition<Part
 
   public PartitionedFileSetDefinition(String name,
                                       DatasetDefinition<? extends FileSet, ?> filesetDef,
-                                      DatasetDefinition<? extends Table, ?> tableDef) {
+                                      DatasetDefinition<? extends IndexedTable, ?> indexedTableDef) {
     super(name);
-    Preconditions.checkArgument(tableDef != null, "Table definition is required");
+    Preconditions.checkArgument(indexedTableDef != null, "IndexedTable definition is required");
     Preconditions.checkArgument(filesetDef != null, "FileSet definition is required");
     this.filesetDef = filesetDef;
-    this.tableDef = tableDef;
+    this.indexedTableDef = indexedTableDef;
   }
 
   @Override
   public DatasetSpecification configure(String instanceName, DatasetProperties properties) {
+    // define the columns for indexing on the partitionsTable
+    DatasetProperties indexedTableProperties = DatasetProperties.builder()
+      .addAll(properties.getProperties())
+      .add(IndexedTableDefinition.INDEX_COLUMNS_CONF_KEY, INDEXED_COLS)
+      .build();
     return DatasetSpecification.builder(instanceName, getName())
       .properties(properties.getProperties())
       .datasets(filesetDef.configure(FILESET_NAME, properties),
-                tableDef.configure(PARTITION_TABLE_NAME, properties))
+                indexedTableDef.configure(PARTITION_TABLE_NAME, indexedTableProperties))
       .build();
   }
 
@@ -85,7 +93,7 @@ public class PartitionedFileSetDefinition extends AbstractDatasetDefinition<Part
     return new PartitionedFileSetAdmin(
         datasetContext, spec, getExploreProvider(),
         filesetDef.getAdmin(datasetContext, spec.getSpecification(FILESET_NAME), classLoader),
-        tableDef.getAdmin(datasetContext, spec.getSpecification(PARTITION_TABLE_NAME), classLoader));
+        indexedTableDef.getAdmin(datasetContext, spec.getSpecification(PARTITION_TABLE_NAME), classLoader));
   }
 
   @Override
@@ -97,10 +105,10 @@ public class PartitionedFileSetDefinition extends AbstractDatasetDefinition<Part
     // make any necessary updates to the arguments
     arguments = updateArgumentsIfNeeded(arguments, partitioning);
 
-    FileSet fileset = filesetDef.getDataset(datasetContext, spec.getSpecification(FILESET_NAME), arguments,
-                                            classLoader);
-    Table table = tableDef.getDataset(datasetContext, spec.getSpecification(PARTITION_TABLE_NAME), arguments,
-                                      classLoader);
+    FileSet fileset = filesetDef.getDataset(datasetContext, spec.getSpecification(FILESET_NAME),
+                                            arguments, classLoader);
+    IndexedTable table = indexedTableDef.getDataset(datasetContext, spec.getSpecification(PARTITION_TABLE_NAME),
+                                                    arguments, classLoader);
 
     return new PartitionedFileSetDataset(datasetContext, spec.getName(), partitioning, fileset, table, spec, arguments,
                                          getExploreProvider());

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetModule.java
@@ -19,10 +19,10 @@ package co.cask.cdap.data2.dataset2.lib.partitioned;
 import co.cask.cdap.api.dataset.DatasetAdmin;
 import co.cask.cdap.api.dataset.DatasetDefinition;
 import co.cask.cdap.api.dataset.lib.FileSet;
+import co.cask.cdap.api.dataset.lib.IndexedTable;
 import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
 import co.cask.cdap.api.dataset.module.DatasetDefinitionRegistry;
 import co.cask.cdap.api.dataset.module.DatasetModule;
-import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.data2.dataset2.lib.file.FileSetAdmin;
 
 /**
@@ -33,10 +33,10 @@ public class PartitionedFileSetModule implements DatasetModule {
   public void register(DatasetDefinitionRegistry registry) {
 
     DatasetDefinition<FileSet, FileSetAdmin> fileSetDef = registry.get("fileSet");
-    DatasetDefinition<Table, ? extends DatasetAdmin> tableDef = registry.get("table");
+    DatasetDefinition<IndexedTable, ? extends DatasetAdmin> indexedTableDef = registry.get("indexedTable");
 
     // file dataset
-    registry.add(new PartitionedFileSetDefinition(PartitionedFileSet.class.getName(), fileSetDef, tableDef));
-    registry.add(new PartitionedFileSetDefinition("partitionedFileSet", fileSetDef, tableDef));
+    registry.add(new PartitionedFileSetDefinition(PartitionedFileSet.class.getName(), fileSetDef, indexedTableDef));
+    registry.add(new PartitionedFileSetDefinition("partitionedFileSet", fileSetDef, indexedTableDef));
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetDataset.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.dataset.DataSetException;
 import co.cask.cdap.api.dataset.DatasetContext;
 import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.dataset.lib.FileSet;
+import co.cask.cdap.api.dataset.lib.IndexedTable;
 import co.cask.cdap.api.dataset.lib.PartitionDetail;
 import co.cask.cdap.api.dataset.lib.PartitionFilter;
 import co.cask.cdap.api.dataset.lib.PartitionKey;
@@ -30,7 +31,6 @@ import co.cask.cdap.api.dataset.lib.TimePartitionDetail;
 import co.cask.cdap.api.dataset.lib.TimePartitionOutput;
 import co.cask.cdap.api.dataset.lib.TimePartitionedFileSet;
 import co.cask.cdap.api.dataset.lib.TimePartitionedFileSetArguments;
-import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.explore.client.ExploreFacade;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Supplier;
@@ -67,7 +67,7 @@ public class TimePartitionedFileSetDataset extends PartitionedFileSetDataset imp
     .build();
 
   public TimePartitionedFileSetDataset(DatasetContext datasetContext, String name,
-                                       FileSet fileSet, Table partitionTable,
+                                       FileSet fileSet, IndexedTable partitionTable,
                                        DatasetSpecification spec, Map<String, String> arguments,
                                        Provider<ExploreFacade> exploreFacadeProvider) {
     super(datasetContext, name, PARTITIONING, fileSet, partitionTable, spec, arguments,

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetDefinition.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetDefinition.java
@@ -22,12 +22,12 @@ import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.dataset.lib.FileSet;
 import co.cask.cdap.api.dataset.lib.FileSetArguments;
+import co.cask.cdap.api.dataset.lib.IndexedTable;
 import co.cask.cdap.api.dataset.lib.PartitionKey;
 import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
 import co.cask.cdap.api.dataset.lib.PartitionedFileSetArguments;
 import co.cask.cdap.api.dataset.lib.PartitionedFileSetProperties;
 import co.cask.cdap.api.dataset.lib.TimePartitionedFileSetArguments;
-import co.cask.cdap.api.dataset.table.Table;
 import com.google.common.collect.Maps;
 
 import java.io.IOException;
@@ -41,7 +41,7 @@ public class TimePartitionedFileSetDefinition extends PartitionedFileSetDefiniti
 
   public TimePartitionedFileSetDefinition(String name,
                                           DatasetDefinition<? extends FileSet, ?> filesetDef,
-                                          DatasetDefinition<? extends Table, ?> tableDef) {
+                                          DatasetDefinition<? extends IndexedTable, ?> tableDef) {
     super(name, filesetDef, tableDef);
   }
 
@@ -65,10 +65,10 @@ public class TimePartitionedFileSetDefinition extends PartitionedFileSetDefiniti
     // make any necessary updates to the arguments
     arguments = updateArgumentsIfNeeded(arguments);
 
-    FileSet fileset = filesetDef.getDataset(datasetContext, spec.getSpecification(FILESET_NAME), arguments,
-                                            classLoader);
-    Table table = tableDef.getDataset(datasetContext, spec.getSpecification(PARTITION_TABLE_NAME), arguments,
-                                      classLoader);
+    FileSet fileset = filesetDef.getDataset(datasetContext, spec.getSpecification(FILESET_NAME),
+                                            arguments, classLoader);
+    IndexedTable table = indexedTableDef.getDataset(datasetContext, spec.getSpecification(PARTITION_TABLE_NAME),
+                                                    arguments, classLoader);
 
     return new TimePartitionedFileSetDataset(datasetContext, spec.getName(), fileset, table, spec, arguments,
                                              getExploreProvider());

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetModule.java
@@ -19,10 +19,10 @@ package co.cask.cdap.data2.dataset2.lib.partitioned;
 import co.cask.cdap.api.dataset.DatasetAdmin;
 import co.cask.cdap.api.dataset.DatasetDefinition;
 import co.cask.cdap.api.dataset.lib.FileSet;
+import co.cask.cdap.api.dataset.lib.IndexedTable;
 import co.cask.cdap.api.dataset.lib.TimePartitionedFileSet;
 import co.cask.cdap.api.dataset.module.DatasetDefinitionRegistry;
 import co.cask.cdap.api.dataset.module.DatasetModule;
-import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.data2.dataset2.lib.file.FileSetAdmin;
 
 /**
@@ -34,10 +34,11 @@ public class TimePartitionedFileSetModule implements DatasetModule {
   public void register(DatasetDefinitionRegistry registry) {
 
     DatasetDefinition<FileSet, FileSetAdmin> fileSetDef = registry.get("fileSet");
-    DatasetDefinition<Table, ? extends DatasetAdmin> tableDef = registry.get("table");
+    DatasetDefinition<IndexedTable, ? extends DatasetAdmin> indexedTableDef = registry.get("indexedTable");
 
     // file dataset
-    registry.add(new TimePartitionedFileSetDefinition(TimePartitionedFileSet.class.getName(), fileSetDef, tableDef));
-    registry.add(new TimePartitionedFileSetDefinition("timePartitionedFileSet", fileSetDef, tableDef));
+    registry.add(new TimePartitionedFileSetDefinition(TimePartitionedFileSet.class.getName(), fileSetDef,
+                                                      indexedTableDef));
+    registry.add(new TimePartitionedFileSetDefinition("timePartitionedFileSet", fileSetDef, indexedTableDef));
   }
 }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionConsumerStateTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionConsumerStateTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.dataset2.lib.partitioned;
+
+import co.cask.cdap.api.dataset.lib.PartitionConsumerState;
+import com.google.common.collect.Lists;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class PartitionConsumerStateTest {
+
+  @Test
+  public void testByteSerialization() {
+    testSerDe(new PartitionConsumerState(2L, Lists.newArrayList(1L, 2L, 3L)));
+    testSerDe(new PartitionConsumerState(0L, Lists.newArrayList(3L, 5L, 100L, 61L, 12L)));
+    testSerDe(new PartitionConsumerState(Long.MAX_VALUE, Lists.<Long>newArrayList()));
+  }
+
+  private void testSerDe(PartitionConsumerState stateToSerialize) {
+    byte[] bytes = stateToSerialize.toBytes();
+    // Assert that the serialization format version is 0
+    Assert.assertEquals(0, bytes[0]);
+    PartitionConsumerState deserializedState = PartitionConsumerState.fromBytes(bytes);
+    Assert.assertEquals(stateToSerialize, deserializedState);
+  }
+}

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetTest.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.data2.dataset2.lib.partitioned;
 
 import co.cask.cdap.api.dataset.DataSetException;
+import co.cask.cdap.api.dataset.lib.Partition;
 import co.cask.cdap.api.dataset.lib.PartitionDetail;
 import co.cask.cdap.api.dataset.lib.PartitionFilter;
 import co.cask.cdap.api.dataset.lib.PartitionKey;
@@ -28,10 +29,14 @@ import co.cask.cdap.data2.dataset2.DatasetFrameworkTestUtil;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.test.SlowTests;
 import co.cask.tephra.TransactionAware;
+import co.cask.tephra.TransactionContext;
 import co.cask.tephra.TransactionExecutor;
+import co.cask.tephra.TransactionManager;
+import co.cask.tephra.inmemory.InMemoryTxSystemClient;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -50,8 +55,10 @@ import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 
 /**
@@ -133,6 +140,156 @@ public class PartitionedFileSetTest {
   public void testDecodeIncomplete() {
     byte[] rowKey = PartitionedFileSetDataset.generateRowKey(PARTITION_KEY, PARTITIONING_1);
     PartitionedFileSetDataset.parseRowKey(rowKey, PARTITIONING_2);
+  }
+
+  @Test
+  public void testPartitionConsumer() throws Exception {
+    // exercises the edge case of partition consumption, when partitions are being consumed, while another in-progress
+    // transaction has added a partition, but it has not yet committed, so the partition is not available for the
+    // consumer
+    PartitionedFileSet dataset1 = dsFrameworkUtil.getInstance(pfsInstance);
+    PartitionedFileSet dataset2 = dsFrameworkUtil.getInstance(pfsInstance);
+    TransactionManager txManager = dsFrameworkUtil.getTxManager();
+    InMemoryTxSystemClient txClient = new InMemoryTxSystemClient(txManager);
+
+    // producer simply adds initial partition
+    TransactionContext txContext1 = new TransactionContext(txClient, (TransactionAware) dataset1);
+    txContext1.start();
+    PartitionKey partitionKey1 = generateUniqueKey();
+    dataset1.getPartitionOutput(partitionKey1).addPartition();
+    txContext1.finish();
+
+    // consumer simply consumes initial partition
+    TransactionContext txContext2 = new TransactionContext(txClient, (TransactionAware) dataset2);
+    txContext2.start();
+    PartitionConsumer partitionConsumer = new PartitionConsumer(dataset2);
+    Iterator<Partition> partitionIterator = partitionConsumer.consumePartitions();
+    Assert.assertEquals(partitionKey1, partitionIterator.next().getPartitionKey());
+    Assert.assertFalse(partitionIterator.hasNext());
+    txContext2.finish();
+
+    // producer adds a second partition, but does not yet commit the transaction
+    txContext1.start();
+    PartitionKey partitionKey2 = generateUniqueKey();
+    dataset1.getPartitionOutput(partitionKey2).addPartition();
+
+    // consumer attempts to consume at a time after the partition was added, but before it committed. Because of this,
+    // the partition is not visible and will not be consumed
+    txContext2.start();
+    Assert.assertFalse(partitionConsumer.consumePartitions().hasNext());
+    txContext2.finish();
+
+    // producer commits the transaction in which the second partition was added
+    txContext1.finish();
+
+    // the next time the consumer runs, it processes the second partition
+    txContext2.start();
+    partitionIterator = partitionConsumer.consumePartitions();
+    Assert.assertEquals(partitionKey2, partitionIterator.next().getPartitionKey());
+    Assert.assertFalse(partitionIterator.hasNext());
+    txContext2.finish();
+  }
+
+  @Test
+  public void testSimplePartitionConsuming() throws Exception {
+    final PartitionedFileSet dataset = dsFrameworkUtil.getInstance(pfsInstance);
+    final TransactionAware txAwareDataset = (TransactionAware) dataset;
+
+    final Set<PartitionKey> partitionKeys1 = Sets.newHashSet();
+    for (int i = 0; i < 10; i++) {
+      partitionKeys1.add(generateUniqueKey());
+    }
+
+    final Set<PartitionKey> partitionKeys2 = Sets.newHashSet();
+    for (int i = 0; i < 15; i++) {
+      partitionKeys2.add(generateUniqueKey());
+    }
+
+    final PartitionConsumer partitionConsumer = new PartitionConsumer(dataset);
+    dsFrameworkUtil.newInMemoryTransactionExecutor(txAwareDataset).execute(new TransactionExecutor.Subroutine() {
+      @Override
+      public void apply() throws Exception {
+        for (PartitionKey partitionKey : partitionKeys1) {
+          dataset.getPartitionOutput(partitionKey).addPartition();
+        }
+      }
+    });
+
+    dsFrameworkUtil.newInMemoryTransactionExecutor(txAwareDataset).execute(new TransactionExecutor.Subroutine() {
+      @Override
+      public void apply() throws Exception {
+        // Initial consumption results in the partitions corresponding to partitionKeys1 to be consumed because only
+        // those partitions are added to the dataset at this point
+        List<Partition> consumedPartitions = Lists.newArrayList();
+        Iterators.addAll(consumedPartitions, partitionConsumer.consumePartitions());
+
+        Set<PartitionKey> retrievedKeys = Sets.newHashSet();
+        for (Partition consumedPartition : consumedPartitions) {
+          retrievedKeys.add(consumedPartition.getPartitionKey());
+        }
+        Assert.assertEquals(partitionKeys1, retrievedKeys);
+      }
+    });
+
+    dsFrameworkUtil.newInMemoryTransactionExecutor(txAwareDataset).execute(new TransactionExecutor.Subroutine() {
+      @Override
+      public void apply() throws Exception {
+        for (PartitionKey partitionKey : partitionKeys2) {
+          dataset.getPartitionOutput(partitionKey).addPartition();
+        }
+      }
+    });
+
+    dsFrameworkUtil.newInMemoryTransactionExecutor(txAwareDataset).execute(new TransactionExecutor.Subroutine() {
+      @Override
+      public void apply() throws Exception {
+        // using the same PartitionConsumer (which remembers the PartitionConsumerState) to consume additional
+        // partitions results in only the newly added partitions (corresponding to partitionKeys2) to be returned
+        List<Partition> consumedPartitions = Lists.newArrayList();
+        Iterators.addAll(consumedPartitions, partitionConsumer.consumePartitions());
+
+        Set<PartitionKey> retrievedKeys = Sets.newHashSet();
+        for (Partition consumedPartition : consumedPartitions) {
+          retrievedKeys.add(consumedPartition.getPartitionKey());
+        }
+        Assert.assertEquals(partitionKeys2, retrievedKeys);
+      }
+    });
+
+    dsFrameworkUtil.newInMemoryTransactionExecutor(txAwareDataset).execute(new TransactionExecutor.Subroutine() {
+      @Override
+      public void apply() throws Exception {
+        // consuming the partitions again, without adding any new partitions returns an empty iterator
+        Assert.assertFalse(partitionConsumer.consumePartitions().hasNext());
+      }
+    });
+
+    dsFrameworkUtil.newInMemoryTransactionExecutor(txAwareDataset).execute(new TransactionExecutor.Subroutine() {
+      @Override
+      public void apply() throws Exception {
+        // creating a new PartitionConsumer resets the consumption state. Consuming from it then returns an iterator
+        // with all the partition keys
+        List<Partition> consumedPartitions = Lists.newArrayList();
+        Iterators.addAll(consumedPartitions, new PartitionConsumer(dataset).consumePartitions());
+
+        Set<PartitionKey> retrievedKeys = Sets.newHashSet();
+        for (Partition consumedPartition : consumedPartitions) {
+          retrievedKeys.add(consumedPartition.getPartitionKey());
+        }
+        Set<PartitionKey> allKeys = Sets.newHashSet();
+        allKeys.addAll(partitionKeys1);
+        allKeys.addAll(partitionKeys2);
+        Assert.assertEquals(allKeys, retrievedKeys);
+      }
+    });
+  }
+
+  private PartitionKey generateUniqueKey() {
+    return PartitionKey.builder()
+      .addIntField("i", 1)
+      .addLongField("l", 17L)
+      .addStringField("s", UUID.randomUUID().toString())
+      .build();
   }
 
   @Test
@@ -230,24 +387,30 @@ public class PartitionedFileSetTest {
 
   @Test
   public void testAddRemoveGetPartition() throws Exception {
-    PartitionedFileSet pfs = dsFrameworkUtil.getInstance(pfsInstance);
-    PartitionOutput output = pfs.getPartitionOutput(PARTITION_KEY);
-    Location outputLocation = output.getLocation();
-    OutputStream out = outputLocation.getOutputStream();
-    out.close();
-    output.addPartition();
-    Assert.assertTrue(outputLocation.exists());
-    Assert.assertNotNull(pfs.getPartition(PARTITION_KEY));
-    Assert.assertTrue(pfs.getPartition(PARTITION_KEY).getLocation().exists());
-    pfs.dropPartition(PARTITION_KEY);
-    Assert.assertFalse(outputLocation.exists());
-    Assert.assertNull(pfs.getPartition(PARTITION_KEY));
-    pfs.dropPartition(PARTITION_KEY);
+    final PartitionedFileSet pfs = dsFrameworkUtil.getInstance(pfsInstance);
+
+    dsFrameworkUtil.newTransactionExecutor((TransactionAware) pfs).execute(new TransactionExecutor.Subroutine() {
+      @Override
+      public void apply() throws Exception {
+        PartitionOutput output = pfs.getPartitionOutput(PARTITION_KEY);
+        Location outputLocation = output.getLocation();
+        OutputStream out = outputLocation.getOutputStream();
+        out.close();
+        output.addPartition();
+        Assert.assertTrue(outputLocation.exists());
+        Assert.assertNotNull(pfs.getPartition(PARTITION_KEY));
+        Assert.assertTrue(pfs.getPartition(PARTITION_KEY).getLocation().exists());
+        pfs.dropPartition(PARTITION_KEY);
+        Assert.assertFalse(outputLocation.exists());
+        Assert.assertNull(pfs.getPartition(PARTITION_KEY));
+        pfs.dropPartition(PARTITION_KEY);
+      }
+    });
   }
 
   @Test
   public void testAddRemoveGetPartitionExternal() throws Exception {
-    File absolutePath = tmpFolder.newFolder();
+    final File absolutePath = tmpFolder.newFolder();
     absolutePath.mkdirs();
 
     dsFrameworkUtil.createInstance("partitionedFileSet", pfsExternalInstance, PartitionedFileSetProperties.builder()
@@ -255,32 +418,37 @@ public class PartitionedFileSetTest {
       .setBasePath(absolutePath.getPath())
       .setDataExternal(true)
       .build());
-    PartitionedFileSet pfs = dsFrameworkUtil.getInstance(pfsExternalInstance);
-    Location baseLocation = pfs.getEmbeddedFileSet().getBaseLocation();
-    Assert.assertTrue(pfsBaseLocation.exists());
+    final PartitionedFileSet pfs = dsFrameworkUtil.getInstance(pfsExternalInstance);
 
-    // attempt to write a new partition - should fail
-    try {
-      PartitionOutput output = pfs.getPartitionOutput(PARTITION_KEY);
-      Assert.fail("External partitioned file set should not allow writing files");
-    } catch (UnsupportedOperationException e) {
-      // expected
-    }
+    dsFrameworkUtil.newTransactionExecutor((TransactionAware) pfs).execute(new TransactionExecutor.Subroutine() {
+      @Override
+      public void apply() throws Exception {
+        Location baseLocation = pfs.getEmbeddedFileSet().getBaseLocation();
+        Assert.assertTrue(pfsBaseLocation.exists());
 
-    // create an external file and addit as a partition
-    File someFile = new File(absolutePath, "some.file");
-    OutputStream out = new FileOutputStream(someFile);
-    out.close();
-    Assert.assertTrue(someFile.exists());
-    pfs.addPartition(PARTITION_KEY, "some.file");
-    Assert.assertNotNull(pfs.getPartition(PARTITION_KEY));
-    Assert.assertTrue(pfs.getPartition(PARTITION_KEY).getLocation().exists());
+        // attempt to write a new partition - should fail
+        try {
+          PartitionOutput output = pfs.getPartitionOutput(PARTITION_KEY);
+          Assert.fail("External partitioned file set should not allow writing files");
+        } catch (UnsupportedOperationException e) {
+          // expected
+        }
 
-    // now drop the partition and validate the file is still there
-    pfs.dropPartition(PARTITION_KEY);
-    Assert.assertNull(pfs.getPartition(PARTITION_KEY));
-    Assert.assertTrue(someFile.exists());
+        // create an external file and addit as a partition
+        File someFile = new File(absolutePath, "some.file");
+        OutputStream out = new FileOutputStream(someFile);
+        out.close();
+        Assert.assertTrue(someFile.exists());
+        pfs.addPartition(PARTITION_KEY, "some.file");
+        Assert.assertNotNull(pfs.getPartition(PARTITION_KEY));
+        Assert.assertTrue(pfs.getPartition(PARTITION_KEY).getLocation().exists());
 
+        // now drop the partition and validate the file is still there
+        pfs.dropPartition(PARTITION_KEY);
+        Assert.assertNull(pfs.getPartition(PARTITION_KEY));
+        Assert.assertTrue(someFile.exists());
+      }
+    });
     // drop the dataset and validate that the base dir still exists
     dsFrameworkUtil.deleteInstance(pfsExternalInstance);
     Assert.assertTrue(pfsBaseLocation.exists());

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetTest.java
@@ -42,7 +42,6 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.text.DateFormat;
-import java.text.ParseException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
@@ -99,73 +98,78 @@ public class TimePartitionedFileSetTest {
   }
 
   @Test
-  public void testAddGetPartitions() throws IOException, ParseException, DatasetManagementException {
-    TimePartitionedFileSet fileSet = dsFrameworkUtil.getInstance(TPFS_INSTANCE);
+  public void testAddGetPartitions() throws Exception {
+    final TimePartitionedFileSet fileSet = dsFrameworkUtil.getInstance(TPFS_INSTANCE);
 
-    // this is an arbitrary data to use as the test time
-    long time = DATE_FORMAT.parse("12/10/14 5:10 am").getTime();
-    long time2 = time + HOUR;
-    String firstPath = "first/partition";
-    String secondPath = "second/partition";
+    dsFrameworkUtil.newTransactionExecutor((TransactionAware) fileSet).execute(new TransactionExecutor.Subroutine() {
+      @Override
+      public void apply() throws Exception {
+        // this is an arbitrary data to use as the test time
+        long time = DATE_FORMAT.parse("12/10/14 5:10 am").getTime();
+        long time2 = time + HOUR;
+        String firstPath = "first/partition";
+        String secondPath = "second/partition";
 
-    // make sure the file set has no partitions initially
-    validateTimePartition(fileSet, time, null);
-    validateTimePartitions(fileSet, 0L, MAX, Collections.<Long, String>emptyMap());
+        // make sure the file set has no partitions initially
+        validateTimePartition(fileSet, time, null);
+        validateTimePartitions(fileSet, 0L, MAX, Collections.<Long, String>emptyMap());
 
-    // add a partition, verify getPartition() works
-    fileSet.addPartition(time, firstPath);
-    validateTimePartition(fileSet, time, firstPath);
+        // add a partition, verify getPartition() works
+        fileSet.addPartition(time, firstPath);
+        validateTimePartition(fileSet, time, firstPath);
 
-    Map<Long, String> expectNone = Collections.emptyMap();
-    Map<Long, String> expectFirst = ImmutableMap.of(time, firstPath);
-    Map<Long, String> expectSecond = ImmutableMap.of(time2, secondPath);
-    Map<Long, String> expectBoth = ImmutableMap.of(time, firstPath, time2, secondPath);
+        Map<Long, String> expectNone = Collections.emptyMap();
+        Map<Long, String> expectFirst = ImmutableMap.of(time, firstPath);
+        Map<Long, String> expectSecond = ImmutableMap.of(time2, secondPath);
+        Map<Long, String> expectBoth = ImmutableMap.of(time, firstPath, time2, secondPath);
 
-    // verify various ways to list partitions with various ranges
-    validateTimePartitions(fileSet, time + MINUTE, MAX, expectNone);
-    validateTimePartitions(fileSet, 0L, time, expectNone);
-    validateTimePartitions(fileSet, 0L, MAX, expectFirst);
-    validateTimePartitions(fileSet, 0L, time + MINUTE, expectFirst);
-    validateTimePartitions(fileSet, 0L, time + MINUTE, expectFirst);
-    validateTimePartitions(fileSet, 0L, time + HOUR, expectFirst);
-    validateTimePartitions(fileSet, time - HOUR, time + HOUR, expectFirst);
+        // verify various ways to list partitions with various ranges
+        validateTimePartitions(fileSet, time + MINUTE, MAX, expectNone);
+        validateTimePartitions(fileSet, 0L, time, expectNone);
+        validateTimePartitions(fileSet, 0L, MAX, expectFirst);
+        validateTimePartitions(fileSet, 0L, time + MINUTE, expectFirst);
+        validateTimePartitions(fileSet, 0L, time + MINUTE, expectFirst);
+        validateTimePartitions(fileSet, 0L, time + HOUR, expectFirst);
+        validateTimePartitions(fileSet, time - HOUR, time + HOUR, expectFirst);
 
-    // add and verify another partition
-    fileSet.addPartition(time2, secondPath);
-    validateTimePartition(fileSet, time2, secondPath);
+        // add and verify another partition
+        fileSet.addPartition(time2, secondPath);
+        validateTimePartition(fileSet, time2, secondPath);
 
-    // verify various ways to list partitions with various ranges
-    validateTimePartitions(fileSet, 0L, MAX, expectBoth);
-    validateTimePartitions(fileSet, time, time + 30 * MINUTE, expectFirst);
-    validateTimePartitions(fileSet, time + 30 * MINUTE, time2, expectNone);
-    validateTimePartitions(fileSet, time + 30 * MINUTE, time2 + 30 * MINUTE, expectSecond);
-    validateTimePartitions(fileSet, time - 30 * MINUTE, time2 + 30 * MINUTE, expectBoth);
+        // verify various ways to list partitions with various ranges
+        validateTimePartitions(fileSet, 0L, MAX, expectBoth);
+        validateTimePartitions(fileSet, time, time + 30 * MINUTE, expectFirst);
+        validateTimePartitions(fileSet, time + 30 * MINUTE, time2, expectNone);
+        validateTimePartitions(fileSet, time + 30 * MINUTE, time2 + 30 * MINUTE, expectSecond);
+        validateTimePartitions(fileSet, time - 30 * MINUTE, time2 + 30 * MINUTE, expectBoth);
 
-    // try to add another partition with the same key
-    try {
-      fileSet.addPartition(time2, "third/partition");
-      Assert.fail("Should have thrown Exception for duplicate partition");
-    } catch (DataSetException e) {
-      //expected
-    }
+        // try to add another partition with the same key
+        try {
+          fileSet.addPartition(time2, "third/partition");
+          Assert.fail("Should have thrown Exception for duplicate partition");
+        } catch (DataSetException e) {
+          //expected
+        }
 
-    // remove first partition and validate
-    fileSet.dropPartition(time);
-    validateTimePartition(fileSet, time, null);
+        // remove first partition and validate
+        fileSet.dropPartition(time);
+        validateTimePartition(fileSet, time, null);
 
-    // verify various ways to list partitions with various ranges
-    validateTimePartitions(fileSet, 0L, MAX, expectSecond);
-    validateTimePartitions(fileSet, time, time + 30 * MINUTE, expectNone);
-    validateTimePartitions(fileSet, time + 30 * MINUTE, time2, expectNone);
-    validateTimePartitions(fileSet, time + 30 * MINUTE, time2 + 30 * MINUTE, expectSecond);
-    validateTimePartitions(fileSet, time - 30 * MINUTE, time2 + 30 * MINUTE, expectSecond);
+        // verify various ways to list partitions with various ranges
+        validateTimePartitions(fileSet, 0L, MAX, expectSecond);
+        validateTimePartitions(fileSet, time, time + 30 * MINUTE, expectNone);
+        validateTimePartitions(fileSet, time + 30 * MINUTE, time2, expectNone);
+        validateTimePartitions(fileSet, time + 30 * MINUTE, time2 + 30 * MINUTE, expectSecond);
+        validateTimePartitions(fileSet, time - 30 * MINUTE, time2 + 30 * MINUTE, expectSecond);
 
-    // try to delete  another partition with the same key
-    try {
-      fileSet.dropPartition(time);
-    } catch (DataSetException e) {
-      Assert.fail("Should not have have thrown Exception for removing non-existent partition");
-    }
+        // try to delete  another partition with the same key
+        try {
+          fileSet.dropPartition(time);
+        } catch (DataSetException e) {
+          Assert.fail("Should not have have thrown Exception for removing non-existent partition");
+        }
+      }
+    });
   }
 
   /**


### PR DESCRIPTION
Index partitions on transaction id, to allow consumption of partitions as they are created/committed, along with a simple consumer which holds its state in memory.

https://issues.cask.co/browse/CDAP-2747
http://builds.cask.co/browse/CDAP-DUT2124-21

This is based off the design here:
https://wiki.cask.co/display/CE/Periodically+consuming+partitions+of+a+PartitionedFileSetDataset

The design (API and implementation) for the client side to this functionality (likely a periodically-running workflow) has yet to be finalized.