### PR TITLE
CDAP-2710 API changes to specify unique names for the different occur…

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/AbstractWorkflow.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/AbstractWorkflow.java
@@ -95,7 +95,7 @@ public abstract class AbstractWorkflow implements Workflow {
 
   /**
    * Adds a custom action to the {@link Workflow}.
-   * @param uniqueName the unique name to be assigned to the {@link WorkflowNode} who represents the action
+   * @param uniqueName the unique name to be assigned to the {@link WorkflowNode} that represents the action
    * @param action     the action to be added
    */
   protected final void addAction(String uniqueName, WorkflowAction action) {
@@ -112,7 +112,7 @@ public abstract class AbstractWorkflow implements Workflow {
 
   /**
    * Adds a MapReduce program to the {@link Workflow}.
-   * @param uniqueName the unique name to be assigned to the {@link WorkflowNode} who represents the MapReduce program
+   * @param uniqueName the unique name to be assigned to the {@link WorkflowNode} that represents the MapReduce program
    * @param mapReduce the name of MapReduce program to be added
    */
   protected final void addMapReduce(String uniqueName, String mapReduce) {
@@ -129,7 +129,7 @@ public abstract class AbstractWorkflow implements Workflow {
 
   /**
    * Adds a Spark program to the {@link Workflow}.
-   * @param uniqueName the unique name to be assigned to the {@link WorkflowNode} who represents the Spark program
+   * @param uniqueName the unique name to be assigned to the {@link WorkflowNode} that represents the Spark program
    * @param spark      the name of the Spark program to be added
    */
   protected final void addSpark(String uniqueName, String spark) {
@@ -156,7 +156,7 @@ public abstract class AbstractWorkflow implements Workflow {
 
   /**
    * Adds a condition to the {@link Workflow}.
-   * @param uniqueName the unique name to be assigned to the {@link WorkflowNode} who represents the condition
+   * @param uniqueName the unique name to be assigned to the {@link WorkflowNode} that represents the condition
    * @param predicate the {@link Predicate} to be evaluated to determine which branch to take
    * @return the {@link WorkflowConditionConfigurer} to configure the branches in the condition
    */

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/AbstractWorkflow.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/AbstractWorkflow.java
@@ -96,7 +96,7 @@ public abstract class AbstractWorkflow implements Workflow {
   /**
    * Adds a custom action to the {@link Workflow}.
    * @param uniqueName the unique name to be assigned to the {@link WorkflowNode} that represents the action
-   * @param action     the action to be added
+   * @param action the action to be added
    */
   protected final void addAction(String uniqueName, WorkflowAction action) {
     configurer.addAction(uniqueName, action);
@@ -130,7 +130,7 @@ public abstract class AbstractWorkflow implements Workflow {
   /**
    * Adds a Spark program to the {@link Workflow}.
    * @param uniqueName the unique name to be assigned to the {@link WorkflowNode} that represents the Spark program
-   * @param spark      the name of the Spark program to be added
+   * @param spark the name of the Spark program to be added
    */
   protected final void addSpark(String uniqueName, String spark) {
     configurer.addSpark(uniqueName, spark);

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/AbstractWorkflow.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/AbstractWorkflow.java
@@ -94,6 +94,15 @@ public abstract class AbstractWorkflow implements Workflow {
   }
 
   /**
+   * Adds a custom action to the {@link Workflow}.
+   * @param uniqueName the unique name to be assigned to the {@link WorkflowNode} who represents the action
+   * @param action     the action to be added
+   */
+  protected final void addAction(String uniqueName, WorkflowAction action) {
+    configurer.addAction(uniqueName, action);
+  }
+
+  /**
    * Adds a MapReduce program to the {@link Workflow}.
    * @param mapReduce the name of MapReduce program to be added
    */
@@ -102,11 +111,29 @@ public abstract class AbstractWorkflow implements Workflow {
   }
 
   /**
+   * Adds a MapReduce program to the {@link Workflow}.
+   * @param uniqueName the unique name to be assigned to the {@link WorkflowNode} who represents the MapReduce program
+   * @param mapReduce the name of MapReduce program to be added
+   */
+  protected final void addMapReduce(String uniqueName, String mapReduce) {
+    configurer.addMapReduce(uniqueName, mapReduce);
+  }
+
+  /**
    * Adds a Spark program to the {@link Workflow}.
    * @param spark the name of the Spark program to be added
    */
   protected final void addSpark(String spark) {
     configurer.addSpark(spark);
+  }
+
+  /**
+   * Adds a Spark program to the {@link Workflow}.
+   * @param uniqueName the unique name to be assigned to the {@link WorkflowNode} who represents the Spark program
+   * @param spark      the name of the Spark program to be added
+   */
+  protected final void addSpark(String uniqueName, String spark) {
+    configurer.addSpark(uniqueName, spark);
   }
 
   /**
@@ -125,5 +152,16 @@ public abstract class AbstractWorkflow implements Workflow {
   protected final WorkflowConditionConfigurer<? extends WorkflowConfigurer> condition(
     Predicate<WorkflowContext> predicate) {
     return configurer.condition(predicate);
+  }
+
+  /**
+   * Adds a condition to the {@link Workflow}.
+   * @param uniqueName the unique name to be assigned to the {@link WorkflowNode} who represents the condition
+   * @param predicate the {@link Predicate} to be evaluated to determine which branch to take
+   * @return the {@link WorkflowConditionConfigurer} to configure the branches in the condition
+   */
+  protected final WorkflowConditionConfigurer<? extends WorkflowConfigurer> condition(
+    String uniqueName, Predicate<WorkflowContext> predicate) {
+    return configurer.condition(uniqueName, predicate);
   }
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowConditionConfigurer.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowConditionConfigurer.java
@@ -43,7 +43,7 @@ public interface WorkflowConditionConfigurer<T> {
    * otherwise the Application deployment will fail.
    * @param uniqueName the uniqueName to be assigned to the {@link WorkflowNode}
    *                   which represents the MapReduce program
-   * @param mapReduce  the name of the MapReduce program to be added to the {@link Workflow}
+   * @param mapReduce the name of the MapReduce program to be added to the {@link Workflow}
    */
   WorkflowConditionConfigurer<T> addMapReduce(String uniqueName, String mapReduce);
 
@@ -67,7 +67,7 @@ public interface WorkflowConditionConfigurer<T> {
    * otherwise the Application deployment will fail.
    * @param uniqueName the uniqueName to be assigned to the {@link WorkflowNode}
    *                   which represents the Spark program
-   * @param spark      the name of the Spark program to be added to the {@link Workflow}
+   * @param spark the name of the Spark program to be added to the {@link Workflow}
    */
   WorkflowConditionConfigurer<T> addSpark(String uniqueName, String spark);
 
@@ -91,7 +91,7 @@ public interface WorkflowConditionConfigurer<T> {
    * otherwise the Application deployment will fail.
    * @param uniqueName the uniqueName to be assigned to the {@link WorkflowNode}
    *                   which represents the Spark program
-   * @param action     to be added to the {@link Workflow}
+   * @param action the action to be added to the {@link Workflow}
    * @return the configurer for the current condition
    */
   WorkflowConditionConfigurer<T> addAction(String uniqueName, WorkflowAction action);
@@ -119,7 +119,7 @@ public interface WorkflowConditionConfigurer<T> {
    * otherwise the Application deployment will fail.
    * @param uniqueName the uniqueName to be assigned to the {@link WorkflowNode}
    *                   which represents the condition
-   * @param condition  the {@link Predicate} to be evaluated for the condition
+   * @param condition the {@link Predicate} to be evaluated for the condition
    * @return the configurer for the condition
    */
   WorkflowConditionConfigurer<? extends WorkflowConditionConfigurer<T>> condition(String uniqueName,

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowConditionConfigurer.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowConditionConfigurer.java
@@ -31,6 +31,23 @@ public interface WorkflowConditionConfigurer<T> {
   WorkflowConditionConfigurer<T> addMapReduce(String mapReduce);
 
   /**
+   * {@link Workflow} consists of multiple {@link WorkflowNode}s.
+   * Same MapReduce program can be added multiple times in the {@link Workflow} at
+   * different {@link WorkflowNode}s.
+   * <p>
+   * This method allows associating the uniqueName to the {@link WorkflowNode}
+   * which represents the MapReduce program. The uniqueName helps querying for the
+   * values that were added to the {@link WorkflowToken} by the particular node.
+   * <p>
+   * The uniqueName must be unique across all {@link WorkflowNode} in the Workflow,
+   * otherwise the Application deployment will fail.
+   * @param uniqueName the uniqueName to be assigned to the {@link WorkflowNode}
+   *                   which represents the MapReduce program
+   * @param mapReduce  the name of the MapReduce program to be added to the {@link Workflow}
+   */
+  WorkflowConditionConfigurer<T> addMapReduce(String uniqueName, String mapReduce);
+
+  /**
    * Adds a Spark program as a next sequential step to the current branch of the {@link WorkflowConditionNode}.
    * @param spark the name of the Spark program to be added
    * @return the configurer for the current condition
@@ -38,11 +55,46 @@ public interface WorkflowConditionConfigurer<T> {
   WorkflowConditionConfigurer<T> addSpark(String spark);
 
   /**
+   * {@link Workflow} consists of multiple {@link WorkflowNode}s.
+   * Same Spark program can be added multiple times in the {@link Workflow} at
+   * different {@link WorkflowNode}s.
+   * <p>
+   * This method allows associating the uniqueName to the {@link WorkflowNode}
+   * which represents the Spark program. The uniqueName helps querying for the
+   * values that were added to the {@link WorkflowToken} by the particular node.
+   * <p>
+   * The uniqueName must be unique across all {@link WorkflowNode} in the Workflow,
+   * otherwise the Application deployment will fail.
+   * @param uniqueName the uniqueName to be assigned to the {@link WorkflowNode}
+   *                   which represents the Spark program
+   * @param spark      the name of the Spark program to be added to the {@link Workflow}
+   */
+  WorkflowConditionConfigurer<T> addSpark(String uniqueName, String spark);
+
+  /**
    * Adds custom action a a next sequential step to the current branch of the {@link WorkflowConditionNode}.
    * @param action {@link WorkflowAction} to be added
    * @return the configurer for the current condition
    */
   WorkflowConditionConfigurer<T> addAction(WorkflowAction action);
+
+  /**
+   * {@link Workflow} consists of multiple {@link WorkflowNode}s.
+   * Same Workflow action can be added multiple times in the {@link Workflow} at
+   * different {@link WorkflowNode}s.
+   * <p>
+   * This method allows associating the uniqueName to the {@link WorkflowNode}
+   * which represents the Workflow action. The uniqueName helps querying for the
+   * values that were added to the {@link WorkflowToken} by the particular node.
+   * <p>
+   * The uniqueName must be unique across all {@link WorkflowNode} in the Workflow,
+   * otherwise the Application deployment will fail.
+   * @param uniqueName the uniqueName to be assigned to the {@link WorkflowNode}
+   *                   which represents the Spark program
+   * @param action     to be added to the {@link Workflow}
+   * @return the configurer for the current condition
+   */
+  WorkflowConditionConfigurer<T> addAction(String uniqueName, WorkflowAction action);
 
   /**
    * Forks the current branch of the {@link WorkflowConditionNode}.
@@ -55,6 +107,23 @@ public interface WorkflowConditionConfigurer<T> {
    * @return the configurer for the nested condition
    */
   WorkflowConditionConfigurer<? extends WorkflowConditionConfigurer<T>> condition(Predicate<WorkflowContext> condition);
+
+  /**
+   * Multiple conditions can be added to the {@link Workflow}.
+   * <p>
+   * This method allows associating the uniqueName to the {@link WorkflowNode}
+   * which represents the condition. The uniqueName helps querying for the
+   * values that were added to the {@link WorkflowToken} by the particular node.
+   * <p>
+   * The uniqueName must be unique across all {@link WorkflowNode} in the Workflow,
+   * otherwise the Application deployment will fail.
+   * @param uniqueName the uniqueName to be assigned to the {@link WorkflowNode}
+   *                   which represents the condition
+   * @param condition  the {@link Predicate} to be evaluated for the condition
+   * @return the configurer for the condition
+   */
+  WorkflowConditionConfigurer<? extends WorkflowConditionConfigurer<T>> condition(String uniqueName,
+                                                                                  Predicate<WorkflowContext> condition);
 
   /**
    * Adds a branch to the {@link WorkflowConditionNode} which is executed if the condition evaluates to the false.

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowConfigurer.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowConfigurer.java
@@ -70,7 +70,7 @@ public interface WorkflowConfigurer {
    * otherwise the Application deployment will fail.
    * @param uniqueName the uniqueName to be assigned to the {@link WorkflowNode}
    *                   which represents the MapReduce program
-   * @param mapReduce  the name of the MapReduce program to be added to the {@link Workflow}
+   * @param mapReduce the name of the MapReduce program to be added to the {@link Workflow}
    */
   void addMapReduce(String uniqueName, String mapReduce);
 
@@ -97,7 +97,7 @@ public interface WorkflowConfigurer {
    * otherwise the Application deployment will fail.
    * @param uniqueName the uniqueName to be assigned to the {@link WorkflowNode}
    *                   which represents the Spark program
-   * @param spark      the name of the Spark program to be added to the {@link Workflow}
+   * @param spark the name of the Spark program to be added to the {@link Workflow}
    */
   void addSpark(String uniqueName, String spark);
 
@@ -121,7 +121,7 @@ public interface WorkflowConfigurer {
    * otherwise the Application deployment will fail.
    * @param uniqueName the uniqueName to be assigned to the {@link WorkflowNode}
    *                   which represents the Spark program
-   * @param action     to be added to the {@link Workflow}
+   * @param action the action to be added to the {@link Workflow}
    */
   void addAction(String uniqueName, WorkflowAction action);
 
@@ -149,7 +149,7 @@ public interface WorkflowConfigurer {
    * otherwise the Application deployment will fail.
    * @param uniqueName the uniqueName to be assigned to the {@link WorkflowNode}
    *                   which represents the condition
-   * @param condition  the {@link Predicate} to be evaluated for the condition
+   * @param condition the {@link Predicate} to be evaluated for the condition
    * @return the configurer for the condition
    */
   WorkflowConditionConfigurer<? extends WorkflowConfigurer> condition(String uniqueName,

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowConfigurer.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowConfigurer.java
@@ -58,6 +58,23 @@ public interface WorkflowConfigurer {
   void addMapReduce(String mapReduce);
 
   /**
+   * {@link Workflow} consists of multiple {@link WorkflowNode}s.
+   * Same MapReduce program can be added multiple times in the {@link Workflow} at
+   * different {@link WorkflowNode}s.
+   * <p>
+   * This method allows associating the uniqueName to the {@link WorkflowNode}
+   * which represents the MapReduce program. The uniqueName helps querying for the
+   * values that were added to the {@link WorkflowToken} by the particular node.
+   * <p>
+   * The uniqueName must be unique across all {@link WorkflowNode} in the Workflow,
+   * otherwise the Application deployment will fail.
+   * @param uniqueName the uniqueName to be assigned to the {@link WorkflowNode}
+   *                   which represents the MapReduce program
+   * @param mapReduce  the name of the MapReduce program to be added to the {@link Workflow}
+   */
+  void addMapReduce(String uniqueName, String mapReduce);
+
+  /**
    * Adds a Spark program as a next sequential step in the {@link Workflow}. Spark program must be
    * configured when the Application is defined. Application deployment will fail if the Spark program
    * does not exist.
@@ -68,11 +85,45 @@ public interface WorkflowConfigurer {
   void addSpark(String spark);
 
   /**
+   * {@link Workflow} consists of multiple {@link WorkflowNode}s.
+   * Same Spark program can be added multiple times in the {@link Workflow} at
+   * different {@link WorkflowNode}s.
+   * <p>
+   * This method allows associating the uniqueName to the {@link WorkflowNode}
+   * which represents the Spark program. The uniqueName helps querying for the
+   * values that were added to the {@link WorkflowToken} by the particular node.
+   * <p>
+   * The uniqueName must be unique across all {@link WorkflowNode} in the Workflow,
+   * otherwise the Application deployment will fail.
+   * @param uniqueName the uniqueName to be assigned to the {@link WorkflowNode}
+   *                   which represents the Spark program
+   * @param spark      the name of the Spark program to be added to the {@link Workflow}
+   */
+  void addSpark(String uniqueName, String spark);
+
+  /**
    * Adds a custom action as a next sequential step in the {@link Workflow}
    *
    * @param action to be added to the {@link Workflow}
    */
   void addAction(WorkflowAction action);
+
+  /**
+   * {@link Workflow} consists of multiple {@link WorkflowNode}s.
+   * Same Workflow action can be added multiple times in the {@link Workflow} at
+   * different {@link WorkflowNode}s.
+   * <p>
+   * This method allows associating the uniqueName to the {@link WorkflowNode}
+   * which represents the Workflow action. The uniqueName helps querying for the
+   * values that were added to the {@link WorkflowToken} by the particular node.
+   * <p>
+   * The uniqueName must be unique across all {@link WorkflowNode} in the Workflow,
+   * otherwise the Application deployment will fail.
+   * @param uniqueName the uniqueName to be assigned to the {@link WorkflowNode}
+   *                   which represents the Spark program
+   * @param action     to be added to the {@link Workflow}
+   */
+  void addAction(String uniqueName, WorkflowAction action);
 
   /**
    * Forks the execution of the {@link Workflow} into multiple branches
@@ -86,4 +137,21 @@ public interface WorkflowConfigurer {
    * @return the configurer for the condition
    */
   WorkflowConditionConfigurer<? extends WorkflowConfigurer> condition(Predicate<WorkflowContext> condition);
+
+  /**
+   * Multiple conditions can be added to the {@link Workflow}.
+   * <p>
+   * This method allows associating the uniqueName to the {@link WorkflowNode}
+   * which represents the condition. The uniqueName helps querying for the
+   * values that were added to the {@link WorkflowToken} by the particular node.
+   * <p>
+   * The uniqueName must be unique across all {@link WorkflowNode} in the Workflow,
+   * otherwise the Application deployment will fail.
+   * @param uniqueName the uniqueName to be assigned to the {@link WorkflowNode}
+   *                   which represents the condition
+   * @param condition  the {@link Predicate} to be evaluated for the condition
+   * @return the configurer for the condition
+   */
+  WorkflowConditionConfigurer<? extends WorkflowConfigurer> condition(String uniqueName,
+                                                                      Predicate<WorkflowContext> condition);
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowForkConfigurer.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowForkConfigurer.java
@@ -127,7 +127,7 @@ public interface WorkflowForkConfigurer<T> {
    * @return the configurer for the condition
    */
   WorkflowConditionConfigurer<? extends WorkflowForkConfigurer<T>> condition(String uniqueName,
-                                                                      Predicate<WorkflowContext> condition);
+                                                                             Predicate<WorkflowContext> condition);
 
   /**
    * Adds a branch to the {@link WorkflowForkNode}

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowForkConfigurer.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowForkConfigurer.java
@@ -34,6 +34,23 @@ public interface WorkflowForkConfigurer<T> {
   WorkflowForkConfigurer<T> addMapReduce(String mapReduce);
 
   /**
+   * {@link Workflow} consists of multiple {@link WorkflowNode}s.
+   * Same MapReduce program can be added multiple times in the {@link Workflow} at
+   * different {@link WorkflowNode}s.
+   * <p>
+   * This method allows associating the uniqueName to the {@link WorkflowNode}
+   * which represents the MapReduce program. The uniqueName helps querying for the
+   * values that were added to the {@link WorkflowToken} by the particular node.
+   * <p>
+   * The uniqueName must be unique across all {@link WorkflowNode} in the Workflow,
+   * otherwise the Application deployment will fail.
+   * @param uniqueName the uniqueName to be assigned to the {@link WorkflowNode}
+   *                   which represents the MapReduce program
+   * @param mapReduce  the name of the MapReduce program to be added to the {@link Workflow}
+   */
+  WorkflowForkConfigurer<T> addMapReduce(String uniqueName, String mapReduce);
+
+  /**
    * Adds a Spark program as a next sequential step to the current branch of the {@link WorkflowForkNode}
    * @param spark the name of the Spark program to be added
    * @return the configurer for the current fork
@@ -41,11 +58,46 @@ public interface WorkflowForkConfigurer<T> {
   WorkflowForkConfigurer<T> addSpark(String spark);
 
   /**
+   * {@link Workflow} consists of multiple {@link WorkflowNode}s.
+   * Same Spark program can be added multiple times in the {@link Workflow} at
+   * different {@link WorkflowNode}s.
+   * <p>
+   * This method allows associating the uniqueName to the {@link WorkflowNode}
+   * which represents the Spark program. The uniqueName helps querying for the
+   * values that were added to the {@link WorkflowToken} by the particular node.
+   * <p>
+   * The uniqueName must be unique across all {@link WorkflowNode} in the Workflow,
+   * otherwise the Application deployment will fail.
+   * @param uniqueName the uniqueName to be assigned to the {@link WorkflowNode}
+   *                   which represents the Spark program
+   * @param spark      the name of the Spark program to be added to the {@link Workflow}
+   */
+  WorkflowForkConfigurer<T> addSpark(String uniqueName, String spark);
+
+  /**
    * Adds custom action a a next sequential step to the current branch of the {@link WorkflowForkNode}
    * @param action {@link WorkflowAction} to be added to the fork
    * @return the configurer for the current fork
    */
   WorkflowForkConfigurer<T> addAction(WorkflowAction action);
+
+  /**
+   * {@link Workflow} consists of multiple {@link WorkflowNode}s.
+   * Same Workflow action can be added multiple times in the {@link Workflow} at
+   * different {@link WorkflowNode}s.
+   * <p>
+   * This method allows associating the uniqueName to the {@link WorkflowNode}
+   * which represents the Workflow action. The uniqueName helps querying for the
+   * values that were added to the {@link WorkflowToken} by the particular node.
+   * <p>
+   * The uniqueName must be unique across all {@link WorkflowNode} in the Workflow,
+   * otherwise the Application deployment will fail.
+   * @param uniqueName the uniqueName to be assigned to the {@link WorkflowNode}
+   *                   which represents the Spark program
+   * @param action     to be added to the {@link Workflow}
+   * @return the configurer for the current condition
+   */
+  WorkflowForkConfigurer<T> addAction(String uniqueName, WorkflowAction action);
 
   /**
    * Adds a nested fork to the current fork
@@ -59,6 +111,23 @@ public interface WorkflowForkConfigurer<T> {
    * @return the configurer for the condition
    */
   WorkflowConditionConfigurer<? extends WorkflowForkConfigurer<T>> condition(Predicate<WorkflowContext> condition);
+
+  /**
+   * Multiple conditions can be added to the {@link Workflow}.
+   * <p>
+   * This method allows associating the uniqueName to the {@link WorkflowNode}
+   * which represents the condition. The uniqueName helps querying for the
+   * values that were added to the {@link WorkflowToken} by the particular node.
+   * <p>
+   * The uniqueName must be unique across all {@link WorkflowNode} in the Workflow,
+   * otherwise the Application deployment will fail.
+   * @param uniqueName the uniqueName to be assigned to the {@link WorkflowNode}
+   *                   which represents the condition
+   * @param condition  the {@link Predicate} to be evaluated for the condition
+   * @return the configurer for the condition
+   */
+  WorkflowConditionConfigurer<? extends WorkflowForkConfigurer<T>> condition(String uniqueName,
+                                                                      Predicate<WorkflowContext> condition);
 
   /**
    * Adds a branch to the {@link WorkflowForkNode}

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowForkConfigurer.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowForkConfigurer.java
@@ -46,7 +46,7 @@ public interface WorkflowForkConfigurer<T> {
    * otherwise the Application deployment will fail.
    * @param uniqueName the uniqueName to be assigned to the {@link WorkflowNode}
    *                   which represents the MapReduce program
-   * @param mapReduce  the name of the MapReduce program to be added to the {@link Workflow}
+   * @param mapReduce the name of the MapReduce program to be added to the {@link Workflow}
    */
   WorkflowForkConfigurer<T> addMapReduce(String uniqueName, String mapReduce);
 
@@ -70,7 +70,7 @@ public interface WorkflowForkConfigurer<T> {
    * otherwise the Application deployment will fail.
    * @param uniqueName the uniqueName to be assigned to the {@link WorkflowNode}
    *                   which represents the Spark program
-   * @param spark      the name of the Spark program to be added to the {@link Workflow}
+   * @param spark the name of the Spark program to be added to the {@link Workflow}
    */
   WorkflowForkConfigurer<T> addSpark(String uniqueName, String spark);
 
@@ -94,7 +94,7 @@ public interface WorkflowForkConfigurer<T> {
    * otherwise the Application deployment will fail.
    * @param uniqueName the uniqueName to be assigned to the {@link WorkflowNode}
    *                   which represents the Spark program
-   * @param action     to be added to the {@link Workflow}
+   * @param action the action to be added to the {@link Workflow}
    * @return the configurer for the current condition
    */
   WorkflowForkConfigurer<T> addAction(String uniqueName, WorkflowAction action);
@@ -123,7 +123,7 @@ public interface WorkflowForkConfigurer<T> {
    * otherwise the Application deployment will fail.
    * @param uniqueName the uniqueName to be assigned to the {@link WorkflowNode}
    *                   which represents the condition
-   * @param condition  the {@link Predicate} to be evaluated for the condition
+   * @param condition the {@link Predicate} to be evaluated for the condition
    * @return the configurer for the condition
    */
   WorkflowConditionConfigurer<? extends WorkflowForkConfigurer<T>> condition(String uniqueName,

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/ApplicationVerificationStage.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/ApplicationVerificationStage.java
@@ -188,22 +188,22 @@ public class ApplicationVerificationStage extends AbstractStage<ApplicationDeplo
   }
 
   private void verifyWorkflowSpecifications(ApplicationSpecification appSpec, WorkflowSpecification workflowSpec) {
-    Set<String> nodeNames = Sets.newHashSet();
-    verifyWorkflowNodeList(appSpec, workflowSpec, workflowSpec.getNodes(), nodeNames);
+    Set<String> existingNodeNames = Sets.newHashSet();
+    verifyWorkflowNodeList(appSpec, workflowSpec, workflowSpec.getNodes(), existingNodeNames);
   }
 
   private void verifyWorkflowNode(ApplicationSpecification appSpec, WorkflowSpecification workflowSpec,
-                                  WorkflowNode node, Set<String> nodeNames) {
+                                  WorkflowNode node, Set<String> existingNodeNames) {
     WorkflowNodeType nodeType = node.getType();
     switch (nodeType) {
       case ACTION:
         verifyWorkflowAction(appSpec, node);
         break;
       case FORK:
-        verifyWorkflowFork(appSpec, workflowSpec, node, nodeNames);
+        verifyWorkflowFork(appSpec, workflowSpec, node, existingNodeNames);
         break;
       case CONDITION:
-        verifyWorkflowCondition(appSpec, workflowSpec, node, nodeNames);
+        verifyWorkflowCondition(appSpec, workflowSpec, node, existingNodeNames);
         break;
       default:
         break;
@@ -211,31 +211,31 @@ public class ApplicationVerificationStage extends AbstractStage<ApplicationDeplo
   }
 
   private void verifyWorkflowFork(ApplicationSpecification appSpec, WorkflowSpecification workflowSpec,
-                                  WorkflowNode node, Set<String> nodeNames) {
+                                  WorkflowNode node, Set<String> existingNodeNames) {
     WorkflowForkNode forkNode = (WorkflowForkNode) node;
     Preconditions.checkNotNull(forkNode.getBranches(), String.format("Fork is added in the Workflow '%s' without" +
                                                                        " any branches", workflowSpec.getName()));
 
     for (List<WorkflowNode> branch : forkNode.getBranches()) {
-      verifyWorkflowNodeList(appSpec, workflowSpec, branch, nodeNames);
+      verifyWorkflowNodeList(appSpec, workflowSpec, branch, existingNodeNames);
     }
   }
 
   private void verifyWorkflowCondition(ApplicationSpecification appSpec, WorkflowSpecification workflowSpec,
-                                       WorkflowNode node, Set<String> nodeNames) {
+                                       WorkflowNode node, Set<String> existingNodeNames) {
     WorkflowConditionNode condition = (WorkflowConditionNode) node;
-    verifyWorkflowNodeList(appSpec, workflowSpec, condition.getIfBranch(), nodeNames);
-    verifyWorkflowNodeList(appSpec, workflowSpec, condition.getElseBranch(), nodeNames);
+    verifyWorkflowNodeList(appSpec, workflowSpec, condition.getIfBranch(), existingNodeNames);
+    verifyWorkflowNodeList(appSpec, workflowSpec, condition.getElseBranch(), existingNodeNames);
   }
 
   private void verifyWorkflowNodeList(ApplicationSpecification appSpec, WorkflowSpecification workflowSpec,
-                                    List<WorkflowNode> nodeList, Set<String> nodeNames) {
+                                    List<WorkflowNode> nodeList, Set<String> existingNodeNames) {
     for (WorkflowNode n : nodeList) {
-      if (nodeNames.contains(n.getNodeId())) {
+      if (existingNodeNames.contains(n.getNodeId())) {
         throw new RuntimeException(String.format("Node with the name '%s' added multiple times.", n.getNodeId()));
       }
-      nodeNames.add(n.getNodeId());
-      verifyWorkflowNode(appSpec, workflowSpec, n, nodeNames);
+      existingNodeNames.add(n.getNodeId());
+      verifyWorkflowNode(appSpec, workflowSpec, n, existingNodeNames);
     }
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/ApplicationVerificationStage.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/ApplicationVerificationStage.java
@@ -229,7 +229,7 @@ public class ApplicationVerificationStage extends AbstractStage<ApplicationDeplo
   }
 
   private void verifyWorkflowNodeList(ApplicationSpecification appSpec, WorkflowSpecification workflowSpec,
-                                    List<WorkflowNode> nodeList, Set<String> existingNodeNames) {
+                                      List<WorkflowNode> nodeList, Set<String> existingNodeNames) {
     for (WorkflowNode n : nodeList) {
       if (existingNodeNames.contains(n.getNodeId())) {
         throw new RuntimeException(String.format("Node with the name '%s' added multiple times.", n.getNodeId()));

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/workflow/DefaultWorkflowConditionConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/workflow/DefaultWorkflowConditionConfigurer.java
@@ -19,12 +19,15 @@ package co.cask.cdap.internal.app.workflow;
 import co.cask.cdap.api.Predicate;
 import co.cask.cdap.api.schedule.SchedulableProgramType;
 import co.cask.cdap.api.workflow.WorkflowAction;
+import co.cask.cdap.api.workflow.WorkflowActionSpecification;
 import co.cask.cdap.api.workflow.WorkflowConditionConfigurer;
 import co.cask.cdap.api.workflow.WorkflowConditionNode;
 import co.cask.cdap.api.workflow.WorkflowContext;
 import co.cask.cdap.api.workflow.WorkflowForkConfigurer;
 import co.cask.cdap.api.workflow.WorkflowForkNode;
 import co.cask.cdap.api.workflow.WorkflowNode;
+import co.cask.cdap.internal.workflow.DefaultWorkflowActionSpecification;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 
 import java.util.List;
@@ -42,8 +45,10 @@ public class DefaultWorkflowConditionConfigurer<T extends WorkflowConditionAdder
   private List<WorkflowNode> currentBranch;
   private boolean addingToIfBranch = true;
   private final String predicateClassName;
+  private final String uniqueName;
 
-  public DefaultWorkflowConditionConfigurer(T parentConfigurer, String predicateClassName) {
+  public DefaultWorkflowConditionConfigurer(String uniqueName, T parentConfigurer, String predicateClassName) {
+    this.uniqueName = uniqueName;
     this.parentConfigurer = parentConfigurer;
     this.predicateClassName = predicateClassName;
     currentBranch = Lists.newArrayList();
@@ -51,19 +56,43 @@ public class DefaultWorkflowConditionConfigurer<T extends WorkflowConditionAdder
 
   @Override
   public WorkflowConditionConfigurer<T> addMapReduce(String mapReduce) {
-    currentBranch.add(WorkflowNodeCreator.createWorkflowActionNode(mapReduce, SchedulableProgramType.MAPREDUCE));
+    currentBranch.add(WorkflowNodeCreator.createWorkflowActionNode(mapReduce, mapReduce,
+                                                                   SchedulableProgramType.MAPREDUCE));
+    return this;
+  }
+
+  @Override
+  public WorkflowConditionConfigurer<T> addMapReduce(String uniqueName, String mapReduce) {
+    currentBranch.add(WorkflowNodeCreator.createWorkflowActionNode(uniqueName, mapReduce,
+                                                                   SchedulableProgramType.MAPREDUCE));
     return this;
   }
 
   @Override
   public WorkflowConditionConfigurer<T> addSpark(String spark) {
-    currentBranch.add(WorkflowNodeCreator.createWorkflowActionNode(spark, SchedulableProgramType.SPARK));
+    currentBranch.add(WorkflowNodeCreator.createWorkflowActionNode(spark, spark, SchedulableProgramType.SPARK));
+    return this;
+  }
+
+  @Override
+  public WorkflowConditionConfigurer<T> addSpark(String uniqueName, String spark) {
+    currentBranch.add(WorkflowNodeCreator.createWorkflowActionNode(uniqueName, spark, SchedulableProgramType.SPARK));
     return this;
   }
 
   @Override
   public WorkflowConditionConfigurer<T> addAction(WorkflowAction action) {
-    currentBranch.add(WorkflowNodeCreator.createWorkflowCustomActionNode(action));
+    Preconditions.checkArgument(action != null, "WorkflowAction is null.");
+    WorkflowActionSpecification spec = new DefaultWorkflowActionSpecification(action);
+    currentBranch.add(WorkflowNodeCreator.createWorkflowCustomActionNode(spec.getName(), spec));
+    return this;
+  }
+
+  @Override
+  public WorkflowConditionConfigurer<T> addAction(String uniqueName, WorkflowAction action) {
+    Preconditions.checkArgument(action != null, "WorkflowAction is null.");
+    WorkflowActionSpecification spec = new DefaultWorkflowActionSpecification(action);
+    currentBranch.add(WorkflowNodeCreator.createWorkflowCustomActionNode(uniqueName, spec));
     return this;
   }
 
@@ -77,7 +106,14 @@ public class DefaultWorkflowConditionConfigurer<T extends WorkflowConditionAdder
   public WorkflowConditionConfigurer<? extends WorkflowConditionConfigurer<T>> condition(
     Predicate<WorkflowContext> predicate) {
     String predicateClassName = predicate.getClass().getName();
-    return new DefaultWorkflowConditionConfigurer<>(this, predicateClassName);
+    return new DefaultWorkflowConditionConfigurer<>(predicate.getClass().getSimpleName(), this, predicateClassName);
+  }
+
+  @Override
+  public WorkflowConditionConfigurer<? extends WorkflowConditionConfigurer<T>> condition(
+    String uniqueName, Predicate<WorkflowContext> predicate) {
+    String predicateClassName = predicate.getClass().getName();
+    return new DefaultWorkflowConditionConfigurer<>(uniqueName, this, predicateClassName);
   }
 
   @Override
@@ -95,14 +131,14 @@ public class DefaultWorkflowConditionConfigurer<T extends WorkflowConditionAdder
     } else {
       elseBranch.addAll(currentBranch);
     }
-    parentConfigurer.addWorkflowConditionNode(predicateClassName, ifBranch, elseBranch);
+    parentConfigurer.addWorkflowConditionNode(uniqueName, predicateClassName, ifBranch, elseBranch);
     return parentConfigurer;
   }
 
   @Override
-  public void addWorkflowConditionNode(String predicateClassName, List<WorkflowNode> ifBranch,
+  public void addWorkflowConditionNode(String uniqueName, String predicateClassName, List<WorkflowNode> ifBranch,
                                        List<WorkflowNode> elseBranch) {
-    currentBranch.add(new WorkflowConditionNode(null, predicateClassName, ifBranch, elseBranch));
+    currentBranch.add(new WorkflowConditionNode(uniqueName, predicateClassName, ifBranch, elseBranch));
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/workflow/DefaultWorkflowConditionConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/workflow/DefaultWorkflowConditionConfigurer.java
@@ -45,10 +45,10 @@ public class DefaultWorkflowConditionConfigurer<T extends WorkflowConditionAdder
   private List<WorkflowNode> currentBranch;
   private boolean addingToIfBranch = true;
   private final String predicateClassName;
-  private final String uniqueName;
+  private final String conditionUniqueName;
 
-  public DefaultWorkflowConditionConfigurer(String uniqueName, T parentConfigurer, String predicateClassName) {
-    this.uniqueName = uniqueName;
+  public DefaultWorkflowConditionConfigurer(String conditionUniqueName, T parentConfigurer, String predicateClassName) {
+    this.conditionUniqueName = conditionUniqueName;
     this.parentConfigurer = parentConfigurer;
     this.predicateClassName = predicateClassName;
     currentBranch = Lists.newArrayList();
@@ -126,7 +126,7 @@ public class DefaultWorkflowConditionConfigurer<T extends WorkflowConditionAdder
     } else {
       elseBranch.addAll(currentBranch);
     }
-    parentConfigurer.addWorkflowConditionNode(uniqueName, predicateClassName, ifBranch, elseBranch);
+    parentConfigurer.addWorkflowConditionNode(conditionUniqueName, predicateClassName, ifBranch, elseBranch);
     return parentConfigurer;
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/workflow/DefaultWorkflowConditionConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/workflow/DefaultWorkflowConditionConfigurer.java
@@ -56,9 +56,7 @@ public class DefaultWorkflowConditionConfigurer<T extends WorkflowConditionAdder
 
   @Override
   public WorkflowConditionConfigurer<T> addMapReduce(String mapReduce) {
-    currentBranch.add(WorkflowNodeCreator.createWorkflowActionNode(mapReduce, mapReduce,
-                                                                   SchedulableProgramType.MAPREDUCE));
-    return this;
+    return addMapReduce(mapReduce, mapReduce);
   }
 
   @Override
@@ -70,8 +68,7 @@ public class DefaultWorkflowConditionConfigurer<T extends WorkflowConditionAdder
 
   @Override
   public WorkflowConditionConfigurer<T> addSpark(String spark) {
-    currentBranch.add(WorkflowNodeCreator.createWorkflowActionNode(spark, spark, SchedulableProgramType.SPARK));
-    return this;
+    return addSpark(spark, spark);
   }
 
   @Override
@@ -105,15 +102,13 @@ public class DefaultWorkflowConditionConfigurer<T extends WorkflowConditionAdder
   @SuppressWarnings("unchecked")
   public WorkflowConditionConfigurer<? extends WorkflowConditionConfigurer<T>> condition(
     Predicate<WorkflowContext> predicate) {
-    String predicateClassName = predicate.getClass().getName();
-    return new DefaultWorkflowConditionConfigurer<>(predicate.getClass().getSimpleName(), this, predicateClassName);
+    return condition(predicate.getClass().getSimpleName(), predicate);
   }
 
   @Override
   public WorkflowConditionConfigurer<? extends WorkflowConditionConfigurer<T>> condition(
     String uniqueName, Predicate<WorkflowContext> predicate) {
-    String predicateClassName = predicate.getClass().getName();
-    return new DefaultWorkflowConditionConfigurer<>(uniqueName, this, predicateClassName);
+    return new DefaultWorkflowConditionConfigurer<>(uniqueName, this, predicate.getClass().getName());
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/workflow/DefaultWorkflowConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/workflow/DefaultWorkflowConfigurer.java
@@ -73,7 +73,7 @@ public class DefaultWorkflowConfigurer implements WorkflowConfigurer, WorkflowFo
 
   @Override
   public void addMapReduce(String mapReduce) {
-    nodes.add(WorkflowNodeCreator.createWorkflowActionNode(mapReduce, mapReduce, SchedulableProgramType.MAPREDUCE));
+    addMapReduce(mapReduce, mapReduce);
   }
 
   @Override
@@ -83,7 +83,7 @@ public class DefaultWorkflowConfigurer implements WorkflowConfigurer, WorkflowFo
 
   @Override
   public void addSpark(String spark) {
-    nodes.add(WorkflowNodeCreator.createWorkflowActionNode(spark, spark, SchedulableProgramType.SPARK));
+    addSpark(spark, spark);
   }
 
   @Override
@@ -112,8 +112,7 @@ public class DefaultWorkflowConfigurer implements WorkflowConfigurer, WorkflowFo
 
   @Override
   public WorkflowConditionConfigurer<? extends WorkflowConfigurer> condition(Predicate<WorkflowContext> predicate) {
-    return new DefaultWorkflowConditionConfigurer<>(predicate.getClass().getSimpleName(), this,
-                                                    predicate.getClass().getName());
+    return condition(predicate.getClass().getSimpleName(), predicate);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/workflow/DefaultWorkflowForkConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/workflow/DefaultWorkflowForkConfigurer.java
@@ -51,9 +51,7 @@ public class DefaultWorkflowForkConfigurer<T extends WorkflowForkJoiner & Workfl
 
   @Override
   public WorkflowForkConfigurer<T> addMapReduce(String mapReduce) {
-    currentBranch.add(WorkflowNodeCreator.createWorkflowActionNode(mapReduce, mapReduce,
-                                                                   SchedulableProgramType.MAPREDUCE));
-    return this;
+    return addMapReduce(mapReduce, mapReduce);
   }
 
   @Override
@@ -65,8 +63,7 @@ public class DefaultWorkflowForkConfigurer<T extends WorkflowForkJoiner & Workfl
 
   @Override
   public WorkflowForkConfigurer<T> addSpark(String spark) {
-    currentBranch.add(WorkflowNodeCreator.createWorkflowActionNode(spark, spark, SchedulableProgramType.SPARK));
-    return this;
+    return addSpark(spark, spark);
   }
 
   @Override
@@ -100,15 +97,13 @@ public class DefaultWorkflowForkConfigurer<T extends WorkflowForkJoiner & Workfl
   @Override
   public WorkflowConditionConfigurer<? extends WorkflowForkConfigurer<T>> condition(
     Predicate<WorkflowContext> predicate) {
-    String predicateClassName = predicate.getClass().getName();
-    return new DefaultWorkflowConditionConfigurer<>(predicate.getClass().getSimpleName(), this, predicateClassName);
+    return condition(predicate.getClass().getSimpleName(), predicate);
   }
 
   @Override
   public WorkflowConditionConfigurer<? extends WorkflowForkConfigurer<T>> condition(
     String uniqueName, Predicate<WorkflowContext> predicate) {
-    String predicateClassName = predicate.getClass().getName();
-    return new DefaultWorkflowConditionConfigurer<>(uniqueName, this, predicateClassName);
+    return new DefaultWorkflowConditionConfigurer<>(uniqueName, this, predicate.getClass().getName());
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/workflow/WorkflowConditionAdder.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/workflow/WorkflowConditionAdder.java
@@ -27,10 +27,11 @@ import java.util.List;
 public interface WorkflowConditionAdder {
   /**
    * Adds a {@link WorkflowConditionNode} to the Workflow.
+   * @param uniqueName the uniqueName associated with the {@link WorkflowNode}
    * @param predicateClassName the name of the predicate class associated with this {@link WorkflowConditionNode}
    * @param ifBranch the branch that is executed when the predicate evaluates to the true
    * @param elseBranch the branch that is executed when the predicate evaluates to the false
    */
-  void addWorkflowConditionNode(String predicateClassName, List<WorkflowNode> ifBranch,
+  void addWorkflowConditionNode(String uniqueName, String predicateClassName, List<WorkflowNode> ifBranch,
                                 List<WorkflowNode> elseBranch);
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/workflow/WorkflowNodeCreator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/workflow/WorkflowNodeCreator.java
@@ -18,11 +18,9 @@ package co.cask.cdap.internal.app.workflow;
 
 import co.cask.cdap.api.schedule.SchedulableProgramType;
 import co.cask.cdap.api.workflow.ScheduleProgramInfo;
-import co.cask.cdap.api.workflow.WorkflowAction;
 import co.cask.cdap.api.workflow.WorkflowActionNode;
 import co.cask.cdap.api.workflow.WorkflowActionSpecification;
 import co.cask.cdap.api.workflow.WorkflowNode;
-import co.cask.cdap.internal.workflow.DefaultWorkflowActionSpecification;
 import com.google.common.base.Preconditions;
 
 /**
@@ -32,7 +30,8 @@ final class WorkflowNodeCreator {
 
   private WorkflowNodeCreator() {}
 
-  static WorkflowNode createWorkflowActionNode(String programName, SchedulableProgramType programType) {
+  static WorkflowNode createWorkflowActionNode(String uniqueName, String programName,
+                                               SchedulableProgramType programType) {
     switch (programType) {
       case MAPREDUCE:
         Preconditions.checkNotNull(programName, "MapReduce name is null.");
@@ -49,13 +48,10 @@ final class WorkflowNodeCreator {
         break;
     }
 
-    return new WorkflowActionNode(null, new ScheduleProgramInfo(programType, programName));
+    return new WorkflowActionNode(uniqueName, new ScheduleProgramInfo(programType, programName));
   }
 
-  static WorkflowNode createWorkflowCustomActionNode(WorkflowAction action) {
-    Preconditions.checkArgument(action != null, "WorkflowAction is null.");
-    WorkflowActionSpecification spec = new DefaultWorkflowActionSpecification(action);
-    return new WorkflowActionNode(null, spec);
+  static WorkflowNode createWorkflowCustomActionNode(String uniqueName, WorkflowActionSpecification spec) {
+    return new WorkflowActionNode(uniqueName, spec);
   }
-
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/GoodWorkflowApp.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/GoodWorkflowApp.java
@@ -49,38 +49,38 @@ public class GoodWorkflowApp extends AbstractApplication {
       setName("GoodWorkflow");
       setDescription("GoodWorkflow description");
 
-      addAction(new DummyAction());
+      addAction("a1", new DummyAction());
 
       // complex fork
       fork()
-        .addMapReduce("DummyMR")
+        .addMapReduce("mr1", "DummyMR")
         .fork()
-          .addAction(new DummyAction())
+          .addAction("a2", new DummyAction())
           .fork()
             .fork()
-              .addMapReduce("DummyMR")
-              .addAction(new DummyAction())
+              .addMapReduce("mr2", "DummyMR")
+              .addAction("a3", new DummyAction())
             .also()
-              .addMapReduce("DummyMR")
+              .addMapReduce("mr3", "DummyMR")
             .join()
-            .addMapReduce("DummyMR")
+            .addMapReduce("mr4", "DummyMR")
           .also()
-            .addMapReduce("DummyMR")
+            .addMapReduce("mr5", "DummyMR")
           .join()
         .also()
-          .addAction(new DummyAction())
+          .addAction("a4", new DummyAction())
         .join()
       .also()
-        .addAction(new DummyAction())
+        .addAction("a5", new DummyAction())
       .join();
 
-      addMapReduce("DummyMR");
+      addMapReduce("mr6", "DummyMR");
 
       // simple fork
       fork()
-        .addAction(new DummyAction())
+        .addAction("a6", new DummyAction())
       .also()
-        .addMapReduce("DummyMR")
+        .addMapReduce("mr7", "DummyMR")
       .join();
     }
   }
@@ -121,7 +121,7 @@ public class GoodWorkflowApp extends AbstractApplication {
         .addMapReduce("MR8")
       .join();
 
-     condition(new MyVerificationPredicate())
+     condition("anotherMyVerificationPredicate", new MyVerificationPredicate())
        .addSpark("SP1")
        .addSpark("SP2")
      .otherwise()

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/NonUniqueProgramsInWorkflowApp.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/NonUniqueProgramsInWorkflowApp.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap;
+
+import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.api.mapreduce.AbstractMapReduce;
+import co.cask.cdap.api.workflow.AbstractWorkflow;
+
+/**
+ * App to test the non unique program names in the Workflow.
+ */
+public class NonUniqueProgramsInWorkflowApp extends AbstractApplication {
+
+  @Override
+  public void configure() {
+    addMapReduce(new NoOpMR());
+    addWorkflow(new NonUniqueProgramsInWorkflow());
+  }
+
+  /**
+   *
+   */
+  public static class NoOpMR extends AbstractMapReduce {
+  }
+
+  public static class NonUniqueProgramsInWorkflow extends AbstractWorkflow {
+
+    @Override
+    protected void configure() {
+      addMapReduce("NoOpMR");
+      addMapReduce("NoOpMR");
+    }
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/NonUniqueProgramsInWorkflowApp.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/NonUniqueProgramsInWorkflowApp.java
@@ -32,11 +32,14 @@ public class NonUniqueProgramsInWorkflowApp extends AbstractApplication {
   }
 
   /**
-   *
+   * No operation MapReduce program.
    */
   public static class NoOpMR extends AbstractMapReduce {
   }
 
+  /**
+   * Workflow containing same MapReduce program multiple times.
+   */
   public static class NonUniqueProgramsInWorkflow extends AbstractWorkflow {
 
     @Override

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/NonUniqueProgramsInWorkflowWithForkApp.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/NonUniqueProgramsInWorkflowWithForkApp.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap;
+
+import co.cask.cdap.api.Predicate;
+import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.api.mapreduce.AbstractMapReduce;
+import co.cask.cdap.api.workflow.AbstractWorkflow;
+import co.cask.cdap.api.workflow.AbstractWorkflowAction;
+import co.cask.cdap.api.workflow.WorkflowContext;
+
+import javax.annotation.Nullable;
+
+/**
+ * App to test the non unique conditions in the Workflow fork.
+ */
+public class NonUniqueProgramsInWorkflowWithForkApp extends AbstractApplication {
+  @Override
+  public void configure() {
+    addMapReduce(new NoOpMR());
+    addWorkflow(new NonUniqueProgramsInWorkflowWithFork());
+  }
+
+  /**
+   *
+   */
+  public static class NoOpMR extends AbstractMapReduce {
+  }
+
+  public static class NonUniqueProgramsInWorkflowWithFork extends AbstractWorkflow {
+
+    @Override
+    protected void configure() {
+      fork()
+        .condition(new MyTestPredicate())
+          .addAction(new MyDummyAction())
+        .otherwise()
+          .condition(new MyTestPredicate())
+            .addMapReduce("NoOpMR")
+          .end()
+        .end()
+      .join();
+    }
+  }
+
+  public static final class MyTestPredicate implements Predicate<WorkflowContext> {
+
+    @Override
+    public boolean apply(@Nullable WorkflowContext input) {
+      return false;
+    }
+  }
+
+  public static final class MyDummyAction extends AbstractWorkflowAction {
+
+    @Override
+    public void run() {
+
+    }
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/NonUniqueProgramsInWorkflowWithForkApp.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/NonUniqueProgramsInWorkflowWithForkApp.java
@@ -36,11 +36,14 @@ public class NonUniqueProgramsInWorkflowWithForkApp extends AbstractApplication 
   }
 
   /**
-   *
+   * No operation MapReduce program.
    */
   public static class NoOpMR extends AbstractMapReduce {
   }
 
+  /**
+   * Workflow program with two condition nodes added with the same predicate {@link MyTestPredicate}.
+   */
   public static class NonUniqueProgramsInWorkflowWithFork extends AbstractWorkflow {
 
     @Override
@@ -57,6 +60,9 @@ public class NonUniqueProgramsInWorkflowWithForkApp extends AbstractApplication 
     }
   }
 
+  /**
+   * Sample {@link Predicate} to test the unique names in the Workflow.
+   */
   public static final class MyTestPredicate implements Predicate<WorkflowContext> {
 
     @Override
@@ -65,6 +71,9 @@ public class NonUniqueProgramsInWorkflowWithForkApp extends AbstractApplication 
     }
   }
 
+  /**
+   * Sample action added to the Workflow.
+   */
   public static final class MyDummyAction extends AbstractWorkflowAction {
 
     @Override

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/verification/WorkflowVerificationTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/verification/WorkflowVerificationTest.java
@@ -56,6 +56,7 @@ public class WorkflowVerificationTest {
 
     WorkflowNode node = nodes.get(0);
     Assert.assertTrue(node.getType() == WorkflowNodeType.ACTION);
+    Assert.assertEquals("MR1", node.getNodeId());
     WorkflowActionNode actionNode = (WorkflowActionNode) node;
     Assert.assertTrue(actionNode.getProgram().equals(new ScheduleProgramInfo(SchedulableProgramType.MAPREDUCE,
                                                                              "MR1")));
@@ -70,12 +71,13 @@ public class WorkflowVerificationTest {
 
     node = forkBranch1.get(0);
     Assert.assertTrue(node.getType() == WorkflowNodeType.ACTION);
+    Assert.assertEquals("MR2", node.getNodeId());
     actionNode = (WorkflowActionNode) node;
     Assert.assertTrue(actionNode.getProgram().equals(new ScheduleProgramInfo(SchedulableProgramType.MAPREDUCE,
                                                                              "MR2")));
     node = forkBranch1.get(1);
     Assert.assertTrue(node.getType() == WorkflowNodeType.CONDITION);
-
+    Assert.assertEquals("MyVerificationPredicate", node.getNodeId());
     WorkflowConditionNode condition = (WorkflowConditionNode) node;
     Assert.assertTrue(condition.getPredicateClassName().contains("MyVerificationPredicate"));
     List<WorkflowNode> ifNodes = condition.getIfBranch();
@@ -85,29 +87,34 @@ public class WorkflowVerificationTest {
 
     node = ifNodes.get(0);
     Assert.assertTrue(node.getType() == WorkflowNodeType.ACTION);
+    Assert.assertEquals("MR3", node.getNodeId());
     actionNode = (WorkflowActionNode) node;
     Assert.assertTrue(actionNode.getProgram().equals(new ScheduleProgramInfo(SchedulableProgramType.MAPREDUCE,
                                                                              "MR3")));
 
     node = ifNodes.get(1);
     Assert.assertTrue(node.getType() == WorkflowNodeType.ACTION);
+    Assert.assertEquals("MR4", node.getNodeId());
     actionNode = (WorkflowActionNode) node;
     Assert.assertTrue(actionNode.getProgram().equals(new ScheduleProgramInfo(SchedulableProgramType.MAPREDUCE,
                                                                              "MR4")));
 
     node = elseNodes.get(0);
     Assert.assertTrue(node.getType() == WorkflowNodeType.ACTION);
+    Assert.assertEquals("MR5", node.getNodeId());
     actionNode = (WorkflowActionNode) node;
     Assert.assertTrue(actionNode.getProgram().equals(new ScheduleProgramInfo(SchedulableProgramType.MAPREDUCE,
                                                                              "MR5")));
 
     node = elseNodes.get(1);
     Assert.assertTrue(node.getType() == WorkflowNodeType.ACTION);
+    Assert.assertEquals("MR6", node.getNodeId());
     actionNode = (WorkflowActionNode) node;
     Assert.assertTrue(actionNode.getProgram().equals(new ScheduleProgramInfo(SchedulableProgramType.MAPREDUCE,
                                                                              "MR6")));
     node = forkBranch1.get(2);
     Assert.assertTrue(node.getType() == WorkflowNodeType.ACTION);
+    Assert.assertEquals("MR7", node.getNodeId());
     actionNode = (WorkflowActionNode) node;
     Assert.assertTrue(actionNode.getProgram().equals(new ScheduleProgramInfo(SchedulableProgramType.MAPREDUCE,
                                                                              "MR7")));
@@ -117,11 +124,13 @@ public class WorkflowVerificationTest {
 
     node = forkBranch2.get(0);
     Assert.assertTrue(node.getType() == WorkflowNodeType.ACTION);
+    Assert.assertEquals("MR8", node.getNodeId());
     actionNode = (WorkflowActionNode) node;
     Assert.assertTrue(actionNode.getProgram().equals(new ScheduleProgramInfo(SchedulableProgramType.MAPREDUCE,
                                                                              "MR8")));
 
     node = nodes.get(2);
+    Assert.assertEquals("anotherMyVerificationPredicate", node.getNodeId());
     Assert.assertTrue(node.getType() == WorkflowNodeType.CONDITION);
     ifNodes = ((WorkflowConditionNode) node).getIfBranch();
     elseNodes = ((WorkflowConditionNode) node).getElseBranch();
@@ -129,12 +138,14 @@ public class WorkflowVerificationTest {
     Assert.assertTrue(ifNodes.size() == 2);
     node = ifNodes.get(0);
     Assert.assertTrue(node.getType() == WorkflowNodeType.ACTION);
+    Assert.assertEquals("SP1", node.getNodeId());
     actionNode = (WorkflowActionNode) node;
     Assert.assertTrue(actionNode.getProgram().equals(new ScheduleProgramInfo(SchedulableProgramType.SPARK,
                                                                              "SP1")));
 
     node = ifNodes.get(1);
     Assert.assertTrue(node.getType() == WorkflowNodeType.ACTION);
+    Assert.assertEquals("SP2", node.getNodeId());
     actionNode = (WorkflowActionNode) node;
     Assert.assertTrue(actionNode.getProgram().equals(new ScheduleProgramInfo(SchedulableProgramType.SPARK,
                                                                              "SP2")));
@@ -143,12 +154,14 @@ public class WorkflowVerificationTest {
 
     node = elseNodes.get(0);
     Assert.assertTrue(node.getType() == WorkflowNodeType.ACTION);
+    Assert.assertEquals("SP3", node.getNodeId());
     actionNode = (WorkflowActionNode) node;
     Assert.assertTrue(actionNode.getProgram().equals(new ScheduleProgramInfo(SchedulableProgramType.SPARK,
                                                                              "SP3")));
 
     node = elseNodes.get(1);
     Assert.assertTrue(node.getType() == WorkflowNodeType.ACTION);
+    Assert.assertEquals("SP4", node.getNodeId());
     actionNode = (WorkflowActionNode) node;
     Assert.assertTrue(actionNode.getProgram().equals(new ScheduleProgramInfo(SchedulableProgramType.SPARK,
                                                                              "SP4")));
@@ -165,18 +178,21 @@ public class WorkflowVerificationTest {
 
     node = anotherForkBranch1.get(0);
     Assert.assertTrue(node.getType() == WorkflowNodeType.ACTION);
+    Assert.assertEquals("SP5", node.getNodeId());
     actionNode = (WorkflowActionNode) node;
     Assert.assertTrue(actionNode.getProgram().equals(new ScheduleProgramInfo(SchedulableProgramType.SPARK,
                                                                              "SP5")));
 
     node = anotherForkBranch2.get(0);
     Assert.assertTrue(node.getType() == WorkflowNodeType.ACTION);
+    Assert.assertEquals("SP6", node.getNodeId());
     actionNode = (WorkflowActionNode) node;
     Assert.assertTrue(actionNode.getProgram().equals(new ScheduleProgramInfo(SchedulableProgramType.SPARK,
                                                                              "SP6")));
 
     node = nodes.get(3);
     Assert.assertTrue(node.getType() == WorkflowNodeType.ACTION);
+    Assert.assertEquals("SP7", node.getNodeId());
     actionNode = (WorkflowActionNode) node;
     Assert.assertTrue(actionNode.getProgram().equals(new ScheduleProgramInfo(SchedulableProgramType.SPARK,
                                                                              "SP7")));
@@ -189,6 +205,7 @@ public class WorkflowVerificationTest {
 
     WorkflowNode node = nodes.get(0);
     Assert.assertTrue(node.getType() == WorkflowNodeType.ACTION);
+    Assert.assertEquals("a1", node.getNodeId());
     WorkflowActionNode actionNode = (WorkflowActionNode) node;
     Assert.assertTrue(actionNode.getProgram().equals(new ScheduleProgramInfo(SchedulableProgramType.CUSTOM_ACTION,
                                                                              "DummyAction")));
@@ -206,6 +223,7 @@ public class WorkflowVerificationTest {
     Assert.assertTrue(fork1Branch2.size() == 1);
 
     actionNode = (WorkflowActionNode) fork1Branch1.get(0);
+    Assert.assertEquals("mr1", actionNode.getNodeId());
     Assert.assertTrue(actionNode.getProgram().equals(new ScheduleProgramInfo(SchedulableProgramType.MAPREDUCE,
                                                                              "DummyMR")));
     Assert.assertNull(actionNode.getActionSpecification());
@@ -217,6 +235,7 @@ public class WorkflowVerificationTest {
     Assert.assertTrue(fork2Branch2.size() == 1);
 
     actionNode = (WorkflowActionNode) fork2Branch1.get(0);
+    Assert.assertEquals("a2", actionNode.getNodeId());
     Assert.assertTrue(actionNode.getProgram().equals(new ScheduleProgramInfo(SchedulableProgramType.CUSTOM_ACTION,
                                                                              "DummyAction")));
     Assert.assertNotNull(actionNode.getActionSpecification());
@@ -234,36 +253,43 @@ public class WorkflowVerificationTest {
     Assert.assertTrue(fork4Branch2.size() == 1);
 
     actionNode = (WorkflowActionNode) fork4Branch1.get(0);
+    Assert.assertEquals("mr2", actionNode.getNodeId());
     Assert.assertTrue(actionNode.getProgram().equals(new ScheduleProgramInfo(SchedulableProgramType.MAPREDUCE,
                                                                              "DummyMR")));
     Assert.assertNull(actionNode.getActionSpecification());
 
     actionNode = (WorkflowActionNode) fork4Branch1.get(1);
+    Assert.assertEquals("a3", actionNode.getNodeId());
     Assert.assertTrue(actionNode.getProgram().equals(new ScheduleProgramInfo(SchedulableProgramType.CUSTOM_ACTION,
                                                                              "DummyAction")));
     Assert.assertNotNull(actionNode.getActionSpecification());
 
     actionNode = (WorkflowActionNode) fork4Branch2.get(0);
+    Assert.assertEquals("mr3", actionNode.getNodeId());
     Assert.assertTrue(actionNode.getProgram().equals(new ScheduleProgramInfo(SchedulableProgramType.MAPREDUCE,
                                                                              "DummyMR")));
     Assert.assertNull(actionNode.getActionSpecification());
 
-    actionNode = (WorkflowActionNode) fork4Branch1.get(0);
+    actionNode = (WorkflowActionNode) fork3Branch1.get(1);
+    Assert.assertEquals("mr4", actionNode.getNodeId());
     Assert.assertTrue(actionNode.getProgram().equals(new ScheduleProgramInfo(SchedulableProgramType.MAPREDUCE,
                                                                              "DummyMR")));
     Assert.assertNull(actionNode.getActionSpecification());
 
-    actionNode = (WorkflowActionNode) fork4Branch2.get(0);
+    actionNode = (WorkflowActionNode) fork3Branch2.get(0);
+    Assert.assertEquals("mr5", actionNode.getNodeId());
     Assert.assertTrue(actionNode.getProgram().equals(new ScheduleProgramInfo(SchedulableProgramType.MAPREDUCE,
                                                                              "DummyMR")));
     Assert.assertNull(actionNode.getActionSpecification());
 
     actionNode = (WorkflowActionNode) fork2Branch2.get(0);
+    Assert.assertEquals("a4", actionNode.getNodeId());
     Assert.assertTrue(actionNode.getProgram().equals(new ScheduleProgramInfo(SchedulableProgramType.CUSTOM_ACTION,
                                                                              "DummyAction")));
     Assert.assertNotNull(actionNode.getActionSpecification());
 
     actionNode = (WorkflowActionNode) fork1Branch2.get(0);
+    Assert.assertEquals("a5", actionNode.getNodeId());
     Assert.assertTrue(actionNode.getProgram().equals(new ScheduleProgramInfo(SchedulableProgramType.CUSTOM_ACTION,
                                                                              "DummyAction")));
     Assert.assertNotNull(actionNode.getActionSpecification());
@@ -271,6 +297,7 @@ public class WorkflowVerificationTest {
     node = nodes.get(2);
     Assert.assertTrue(node.getType() == WorkflowNodeType.ACTION);
     actionNode = (WorkflowActionNode) node;
+    Assert.assertEquals("mr6", actionNode.getNodeId());
     Assert.assertTrue(actionNode.getProgram().equals(new ScheduleProgramInfo(SchedulableProgramType.MAPREDUCE,
                                                                              "DummyMR")));
     Assert.assertNull(actionNode.getActionSpecification());
@@ -283,11 +310,13 @@ public class WorkflowVerificationTest {
     Assert.assertTrue(fork5Branch2.size() == 1);
 
     actionNode = (WorkflowActionNode) fork5Branch1.get(0);
+    Assert.assertEquals("a6", actionNode.getNodeId());
     Assert.assertTrue(actionNode.getProgram().equals(new ScheduleProgramInfo(SchedulableProgramType.CUSTOM_ACTION,
                                                                              "DummyAction")));
     Assert.assertNotNull(actionNode.getActionSpecification());
 
     actionNode = (WorkflowActionNode) fork5Branch2.get(0);
+    Assert.assertEquals("mr7", actionNode.getNodeId());
     Assert.assertTrue(actionNode.getProgram().equals(new ScheduleProgramInfo(SchedulableProgramType.MAPREDUCE,
                                                                              "DummyMR")));
     Assert.assertNull(actionNode.getActionSpecification());

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/runtime/WorkflowTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/runtime/WorkflowTest.java
@@ -18,6 +18,8 @@ package co.cask.cdap.runtime;
 import co.cask.cdap.AppWithAnonymousWorkflow;
 import co.cask.cdap.MissingMapReduceWorkflowApp;
 import co.cask.cdap.MissingSparkWorkflowApp;
+import co.cask.cdap.NonUniqueProgramsInWorkflowApp;
+import co.cask.cdap.NonUniqueProgramsInWorkflowWithForkApp;
 import co.cask.cdap.OneActionWorkflowApp;
 import co.cask.cdap.ScheduleAppWithMissingWorkflow;
 import co.cask.cdap.WorkflowApp;
@@ -172,6 +174,24 @@ public class WorkflowTest {
     } catch (Exception ex) {
       Assert.assertEquals(ex.getCause().getMessage(),
                           "'' name is not an ID. ID should be non empty and can contain only characters A-Za-z0-9_-");
+    }
+
+    // try deploying app containing workflow with non-unique programs
+    try {
+      final ApplicationWithPrograms app = AppFabricTestHelper.deployApplicationWithManager(
+        NonUniqueProgramsInWorkflowApp.class, TEMP_FOLDER_SUPPLIER);
+      Assert.fail("Should have thrown Exception because Workflow does not have name.");
+    } catch (Exception ex) {
+      Assert.assertEquals(ex.getCause().getMessage(), "Node with the name 'NoOpMR' added multiple times.");
+    }
+
+    // try deploying app containing workflow fork with non-unique programs
+    try {
+      final ApplicationWithPrograms app = AppFabricTestHelper.deployApplicationWithManager(
+        NonUniqueProgramsInWorkflowWithForkApp.class, TEMP_FOLDER_SUPPLIER);
+      Assert.fail("Should have thrown Exception because Workflow does not have name.");
+    } catch (Exception ex) {
+      Assert.assertEquals(ex.getCause().getMessage(), "Node with the name 'MyTestPredicate' added multiple times.");
     }
   }
 


### PR DESCRIPTION
…rences of the same program in the Workflow

Link to JIRA - https://issues.cask.co/browse/CDAP-2710
1. Added ability to specify uniqueName while adding MapReduce, Spark, Custom Actions and Condition nodes in the Workflow. 
2. In case of condition node, the name of the predicate is by default assigned to the name of the node.
3. If node names in the Workflow are not unique then the application deployment will fail.
4. Added test cases.
