### PR TITLE
CDAP-2907 Support CDH HBase 1.0

### DIFF
--- a/cdap-common/bin/common.sh
+++ b/cdap-common/bin/common.sh
@@ -96,6 +96,12 @@ set_hbase()
       0.98*)
         hbasecompat="$CDAP_HOME/hbase-compat-0.98/lib/*"
         ;;
+      1.0-cdh*)
+        hbasecompat="$CDAP_HOME/hbase-compat-1.0-cdh/lib/*"
+        ;;
+      1.0*)
+        hbasecompat="$CDAP_HOME/hbase-compat-1.0/lib/*"
+        ;;
       *)
         echo "ERROR: Unknown/unsupported version of HBase found: $HBASE_VERSION"
         exit 1

--- a/cdap-data-fabric-tests/pom.xml
+++ b/cdap-data-fabric-tests/pom.xml
@@ -57,7 +57,7 @@
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>
-      <artifactId>cdap-hbase-compat-0.96</artifactId>
+      <artifactId>cdap-hbase-compat-0.98</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
@@ -82,7 +82,7 @@
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>
-      <artifactId>cdap-hbase-compat-0.96</artifactId>
+      <artifactId>cdap-hbase-compat-0.98</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableTest.java
@@ -32,7 +32,7 @@ import co.cask.cdap.data.hbase.HBaseTestFactory;
 import co.cask.cdap.data2.dataset2.lib.table.BufferingTable;
 import co.cask.cdap.data2.dataset2.lib.table.BufferingTableTest;
 import co.cask.cdap.data2.increment.hbase.IncrementHandlerState;
-import co.cask.cdap.data2.increment.hbase96.IncrementHandler;
+import co.cask.cdap.data2.increment.hbase98.IncrementHandler;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;

--- a/cdap-data-fabric/pom.xml
+++ b/cdap-data-fabric/pom.xml
@@ -133,7 +133,7 @@
     <dependency>
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-server</artifactId>
-      <version>${hbase96.version}</version>
+      <version>${hbase98.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataFabricDistributedModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataFabricDistributedModule.java
@@ -28,6 +28,7 @@ import co.cask.tephra.TxConstants;
 import co.cask.tephra.distributed.PooledClientProvider;
 import co.cask.tephra.distributed.ThreadLocalClientProvider;
 import co.cask.tephra.distributed.ThriftClientProvider;
+import co.cask.tephra.metrics.MetricsCollector;
 import co.cask.tephra.metrics.TxMetricsCollector;
 import co.cask.tephra.runtime.TransactionModules;
 import com.google.inject.AbstractModule;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueUtilFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueUtilFactory.java
@@ -31,4 +31,14 @@ public class HBaseQueueUtilFactory extends HBaseVersionSpecificFactory<HBaseQueu
   protected String getHBase98Classname() {
     return "co.cask.cdap.data2.transaction.queue.hbase.HBase98QueueUtil";
   }
+
+  @Override
+  protected String getHBase10Classname() {
+    return "co.cask.cdap.data2.transaction.queue.hbase.HBase10QueueUtil";
+  }
+
+  @Override
+  protected String getHBase10CDHClassname() {
+    return "co.cask.cdap.data2.transaction.queue.hbase.HBase10CDHQueueUtil";
+  }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseTableUtilFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseTableUtilFactory.java
@@ -53,4 +53,14 @@ public class HBaseTableUtilFactory extends HBaseVersionSpecificFactory<HBaseTabl
   protected String getHBase98Classname() {
     return "co.cask.cdap.data2.util.hbase.HBase98TableUtil";
   }
+
+  @Override
+  protected String getHBase10Classname() {
+    return "co.cask.cdap.data2.util.hbase.HBase10TableUtil";
+  }
+
+  @Override
+  protected String getHBase10CDHClassname() {
+    return "co.cask.cdap.data2.util.hbase.HBase10CDHTableUtil";
+  }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseVersionSpecificFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseVersionSpecificFactory.java
@@ -41,6 +41,14 @@ public abstract class HBaseVersionSpecificFactory<T> implements Provider<T> {
         case HBASE_98:
           instance = createInstance(getHBase98Classname());
           break;
+        case HBASE_10:
+          // TODO: remove exception and uncomment when CDAP-2868 is in place
+          throw new ProvisionException("Apache HBase 1.0 is not yet supported.");
+          // instance = createInstance(getHBase10Classname());
+          // break;
+        case HBASE_10_CDH:
+          instance = createInstance(getHBase10CDHClassname());
+          break;
         case UNKNOWN:
           throw new ProvisionException("Unknown HBase version: " + HBaseVersion.getVersionString());
       }
@@ -57,4 +65,6 @@ public abstract class HBaseVersionSpecificFactory<T> implements Provider<T> {
 
   protected abstract String getHBase96Classname();
   protected abstract String getHBase98Classname();
+  protected abstract String getHBase10Classname();
+  protected abstract String getHBase10CDHClassname();
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HTableNameConverterFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HTableNameConverterFactory.java
@@ -29,4 +29,14 @@ public class HTableNameConverterFactory extends HBaseVersionSpecificFactory<HTab
   protected String getHBase98Classname() {
     return "co.cask.cdap.data2.util.hbase.HTable98NameConverter";
   }
+
+  @Override
+  protected String getHBase10Classname() {
+    return "co.cask.cdap.data2.util.hbase.HTable10NameConverter";
+  }
+
+  @Override
+  protected String getHBase10CDHClassname() {
+    return "co.cask.cdap.data2.util.hbase.HTable10CDHNameConverter";
+  }
 }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data/hbase/HBaseTestFactory.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data/hbase/HBaseTestFactory.java
@@ -32,4 +32,14 @@ public class HBaseTestFactory extends HBaseVersionSpecificFactory<HBaseTestBase>
   protected String getHBase98Classname() {
     return "co.cask.cdap.data.hbase.HBase98Test";
   }
+
+  @Override
+  protected String getHBase10Classname() {
+    return "co.cask.cdap.data.hbase.HBase10Test";
+  }
+
+  @Override
+  protected String getHBase10CDHClassname() {
+    return "co.cask.cdap.data.hbase.HBase10CDHTest";
+  }
 }

--- a/cdap-hbase-compat-0.96/pom.xml
+++ b/cdap-hbase-compat-0.96/pom.xml
@@ -59,18 +59,22 @@
     <dependency>
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-common</artifactId>
+      <version>${hbase96.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-client</artifactId>
+      <version>${hbase96.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-protocol</artifactId>
+      <version>${hbase96.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-server</artifactId>
+      <version>${hbase96.version}</version>
     </dependency>
 
     <dependency>
@@ -103,6 +107,7 @@
     <dependency>
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-testing-util</artifactId>
+      <version>${hbase96.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/cdap-hbase-compat-1.0-cdh/pom.xml
+++ b/cdap-hbase-compat-1.0-cdh/pom.xml
@@ -28,8 +28,15 @@
   </parent>
 
   <artifactId>cdap-hbase-compat-1.0-cdh</artifactId>
-  <name>CDAP HBase 1.0 Compatibility</name>
+  <name>CDAP HBase 1.0-CDH Compatibility</name>
   <packaging>jar</packaging>
+
+  <repositories>
+    <repository>
+      <id>cloudera</id>
+      <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
+    </repository>
+  </repositories>
 
   <dependencies>
     <dependency>

--- a/cdap-hbase-compat-1.0-cdh/pom.xml
+++ b/cdap-hbase-compat-1.0-cdh/pom.xml
@@ -122,6 +122,13 @@
       <artifactId>hadoop-hdfs</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- HBase-1.0-CDH depends on org.htrace, not org.apache.htrace (newer) -->
+    <dependency>
+      <groupId>org.htrace</groupId>
+      <artifactId>htrace-core</artifactId>
+      <version>3.0.4</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/cdap-hbase-compat-1.0-cdh/pom.xml
+++ b/cdap-hbase-compat-1.0-cdh/pom.xml
@@ -1,0 +1,339 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright © 2014 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>co.cask.cdap</groupId>
+    <artifactId>cdap</artifactId>
+    <version>3.1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>cdap-hbase-compat-1.0-cdh</artifactId>
+  <name>CDAP HBase 1.0 Compatibility</name>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-data-fabric</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.tephra</groupId>
+      <artifactId>tephra-hbase-compat-1.0-cdh</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-common</artifactId>
+      <version>${hbase10cdh.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-client</artifactId>
+      <version>${hbase10cdh.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-protocol</artifactId>
+      <version>${hbase10cdh.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-server</artifactId>
+      <version>${hbase10cdh.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-data-fabric</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.hbase</groupId>
+          <artifactId>hbase</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-common-unit-test</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-minicluster</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-server</artifactId>
+      <version>${hbase10cdh.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-testing-util</artifactId>
+      <version>${hbase10cdh.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdfs</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.4</version>
+        <executions>
+          <execution>
+            <id>test-jar</id>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>dist</id>
+      <properties>
+        <package.dirs>opt</package.dirs>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jar-plugin</artifactId>
+            <version>2.4</version>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <version>2.8</version>
+            <executions>
+              <execution>
+                <id>copy-dependencies</id>
+                <phase>prepare-package</phase>
+                <goals>
+                  <goal>copy-dependencies</goal>
+                </goals>
+                <configuration>
+                  <excludeArtifactIds>*</excludeArtifactIds>
+                  <includeArtifactIds>tephra-hbase-compat-1.0-cdh</includeArtifactIds>
+                  <silent>true</silent>
+                  <includeScope>compile</includeScope>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-resources-plugin</artifactId>
+            <version>2.6</version>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>rpm-prepare</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-resources-plugin</artifactId>
+            <version>2.6</version>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <version>1.7</version>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>deb-prepare</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-resources-plugin</artifactId>
+            <version>2.6</version>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <version>1.7</version>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>rpm</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <version>1.3.1</version>
+          </plugin>
+
+          <!-- Extra deployment for rpm package. -->
+          <!-- This has to be in child level, otherwise all modules would try to deploy. -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-deploy-plugin</artifactId>
+            <version>2.8</version>
+            <executions>
+              <execution>
+                <id>deploy-rpm</id>
+                <phase>deploy</phase>
+                <goals>
+                  <goal>deploy-file</goal>
+                </goals>
+                <configuration>
+                  <version>${project.version}</version>
+                  <groupId>${dist.deploy.groupId}</groupId>
+                  <artifactId>${project.artifactId}</artifactId>
+                  <packaging>noarch.rpm</packaging>
+                  <generatePom>false</generatePom>
+                  <file>${project.build.directory}/${project.artifactId}-${package.version}-1.noarch.rpm</file>
+                  <classifier>1</classifier>
+                  <repositoryId>continuuity</repositoryId>
+                  <url>${deploy.url}</url>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>deb</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <version>1.3.1</version>
+          </plugin>
+
+          <!-- Extra deployment for deb package -->
+          <!-- This has to be in child level, otherwise all modules would try to deploy. -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-deploy-plugin</artifactId>
+            <version>2.8</version>
+            <executions>
+              <execution>
+                <id>deploy-deb</id>
+                <phase>deploy</phase>
+                <goals>
+                  <goal>deploy-file</goal>
+                </goals>
+                <configuration>
+                  <version>${project.version}</version>
+                  <groupId>${dist.deploy.groupId}</groupId>
+                  <artifactId>${project.artifactId}</artifactId>
+                  <packaging>deb</packaging>
+                  <generatePom>false</generatePom>
+                  <file>${project.build.directory}/${project.artifactId}_${package.version}-1_all.deb</file>
+                  <repositoryId>continuuity</repositoryId>
+                  <url>${deploy.url}</url>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>tgz</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-assembly-plugin</artifactId>
+            <version>2.4</version>
+          </plugin>
+
+          <!-- Extra deployment for tgz package -->
+          <!-- This has to be in child level, otherwise all modules would try to deploy. -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-deploy-plugin</artifactId>
+            <version>2.8</version>
+            <executions>
+              <execution>
+                <id>deploy-tgz</id>
+                <phase>deploy</phase>
+                <goals>
+                  <goal>deploy-file</goal>
+                </goals>
+                <configuration>
+                  <version>${project.version}</version>
+                  <groupId>${dist.deploy.groupId}</groupId>
+                  <artifactId>${project.artifactId}</artifactId>
+                  <packaging>tar.gz</packaging>
+                  <generatePom>false</generatePom>
+                  <file>${project.build.directory}/${project.artifactId}-${package.version}.tar.gz</file>
+                  <repositoryId>continuuity</repositoryId>
+                  <url>${deploy.url}</url>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+  </profiles>
+
+</project>

--- a/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/increment/hbase10cdh/IncrementFilter.java
+++ b/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/increment/hbase10cdh/IncrementFilter.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.increment.hbase10cdh;
+
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.filter.FilterBase;
+
+import java.io.IOException;
+
+/**
+ * Simple filter for increment columns that includes all cell values in a column with a "delta" prefix up to and
+ * including the first cell it finds that is not an increment.  This allows the {@link IncrementHandler}
+ * coprocessor to return the correct value for an increment column by summing the last total sum plus all newer
+ * delta values.
+ */
+public class IncrementFilter extends FilterBase {
+  @Override
+  public ReturnCode filterKeyValue(Cell cell) throws IOException {
+    if (IncrementHandler.isIncrement(cell)) {
+      // all visible increments should be included until we get to a non-increment
+      return ReturnCode.INCLUDE;
+    } else {
+      // as soon as we find a KV to include we can move to the next column
+      return ReturnCode.INCLUDE_AND_NEXT_COL;
+    }
+  }
+}

--- a/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/increment/hbase10cdh/IncrementHandler.java
+++ b/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/increment/hbase10cdh/IncrementHandler.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright © 2014-2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.increment.hbase10cdh;
+
+import co.cask.cdap.data2.dataset2.lib.table.hbase.HBaseTable;
+import co.cask.cdap.data2.increment.hbase.IncrementHandlerState;
+import co.cask.cdap.data2.increment.hbase.TimestampOracle;
+import co.cask.cdap.data2.util.hbase.HTable10CDHNameConverter;
+import co.cask.tephra.hbase10cdh.Filters;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Maps;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.CoprocessorEnvironment;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.Durability;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.coprocessor.BaseRegionObserver;
+import org.apache.hadoop.hbase.coprocessor.ObserverContext;
+import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
+import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.apache.hadoop.hbase.regionserver.HRegion;
+import org.apache.hadoop.hbase.regionserver.InternalScanner;
+import org.apache.hadoop.hbase.regionserver.RegionScanner;
+import org.apache.hadoop.hbase.regionserver.ScanType;
+import org.apache.hadoop.hbase.regionserver.Store;
+import org.apache.hadoop.hbase.regionserver.compactions.CompactionRequest;
+import org.apache.hadoop.hbase.regionserver.wal.WALEdit;
+import org.apache.hadoop.hbase.util.Bytes;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+
+/**
+ * HBase coprocessor that handles reading and writing read-less increment operations.
+ *
+ * <p>Writes of incremental values are performed as normal {@code Put}s, flagged with a special attribute
+ * {@link HBaseTable#DELTA_WRITE}.  The coprocessor intercepts these
+ * writes and rewrites the cell value to use a special marker prefix.</p>
+ *
+ * <p>For read (for {@code Get} and {@code Scan}) operations, all of the delta values are summed up for a column,
+ * up to and including the most recent "full" (non-delta) value.  The sum of these delta values, plus the full value
+ * (if found) is returned for the column.</p>
+ *
+ * <p>To mitigate the performance impact on reading, this coprocessor also overrides the scanner used in flush and
+ * compaction operations, using {@link IncrementSummingScanner} to generate a new "full" value aggregated from
+ * all the successfully committed delta values.</p>
+ */
+public class IncrementHandler extends BaseRegionObserver {
+
+  private HRegion region;
+  private IncrementHandlerState state;
+
+
+  @Override
+  public void start(CoprocessorEnvironment e) throws IOException {
+    if (e instanceof RegionCoprocessorEnvironment) {
+      RegionCoprocessorEnvironment env = (RegionCoprocessorEnvironment) e;
+      this.region = ((RegionCoprocessorEnvironment) e).getRegion();
+      this.state = new IncrementHandlerState(env.getConfiguration(),
+                                             env.getRegion().getTableDesc(),
+                                             new HTable10CDHNameConverter());
+
+      HTableDescriptor tableDesc = env.getRegion().getTableDesc();
+      for (HColumnDescriptor columnDesc : tableDesc.getFamilies()) {
+        state.initFamily(columnDesc.getName(), convertFamilyValues(columnDesc.getValues()));
+      }
+    }
+  }
+
+  @VisibleForTesting
+  public void setTimestampOracle(TimestampOracle timeOracle) {
+    state.setTimestampOracle(timeOracle);
+  }
+
+  private Map<byte[], byte[]> convertFamilyValues(Map<ImmutableBytesWritable, ImmutableBytesWritable> writableValues) {
+    Map<byte[], byte[]> converted = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
+    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> e : writableValues.entrySet()) {
+      converted.put(e.getKey().get(), e.getValue().get());
+    }
+    return converted;
+  }
+
+  @Override
+  public void preGetOp(ObserverContext<RegionCoprocessorEnvironment> ctx, Get get, List<Cell> results)
+    throws IOException {
+    Scan scan = new Scan(get);
+    scan.setMaxVersions();
+    scan.setFilter(Filters.combine(new IncrementFilter(), scan.getFilter()));
+    RegionScanner scanner = null;
+    try {
+      scanner = new IncrementSummingScanner(region, scan.getBatch(), region.getScanner(scan), ScanType.USER_SCAN);
+      scanner.next(results);
+      ctx.bypass();
+    } finally {
+      if (scanner != null) {
+        scanner.close();
+      }
+    }
+  }
+
+  @Override
+  public void prePut(ObserverContext<RegionCoprocessorEnvironment> ctx, Put put, WALEdit edit, Durability durability)
+    throws IOException {
+    // we assume that if any of the column families written to are transactional, the entire write is transactional
+    boolean transactional = state.containsTransactionalFamily(put.getFamilyCellMap().keySet());
+    boolean isIncrement = put.getAttribute(HBaseTable.DELTA_WRITE) != null;
+
+    if (isIncrement || !transactional) {
+      // incremental write
+      NavigableMap<byte[], List<Cell>> newFamilyMap = new TreeMap<>(Bytes.BYTES_COMPARATOR);
+
+      long tsToAssign = 0;
+      if (!transactional) {
+        tsToAssign = state.getUniqueTimestamp();
+      }
+      for (Map.Entry<byte[], List<Cell>> entry : put.getFamilyCellMap().entrySet()) {
+        List<Cell> newCells = new ArrayList<>(entry.getValue().size());
+        for (Cell cell : entry.getValue()) {
+          // rewrite the cell value with a special prefix to identify it as a delta
+          // for 0.98 we can update this to use cell tags
+          byte[] newValue = isIncrement ?
+              Bytes.add(IncrementHandlerState.DELTA_MAGIC_PREFIX, CellUtil.cloneValue(cell)) :
+              CellUtil.cloneValue(cell);
+          newCells.add(CellUtil.createCell(CellUtil.cloneRow(cell), CellUtil.cloneFamily(cell),
+                                           CellUtil.cloneQualifier(cell),
+                                           transactional ? cell.getTimestamp() : tsToAssign,
+                                           cell.getTypeByte(), newValue));
+        }
+        newFamilyMap.put(entry.getKey(), newCells);
+      }
+      put.setFamilyCellMap(newFamilyMap);
+    }
+    // put completes normally with value prefix marker
+  }
+
+  @Override
+  public void preDelete(ObserverContext<RegionCoprocessorEnvironment> e, Delete delete, WALEdit edit,
+                        Durability durability) throws IOException {
+    boolean transactional = state.containsTransactionalFamily(delete.getFamilyCellMap().keySet());
+    if (!transactional) {
+      long tsToAssign = state.getUniqueTimestamp();
+      delete.setTimestamp(tsToAssign);
+      // new key values
+      NavigableMap<byte[], List<Cell>> newFamilyMap = new TreeMap<>(Bytes.BYTES_COMPARATOR);
+      for (Map.Entry<byte[], List<Cell>> entry : delete.getFamilyCellMap().entrySet()) {
+        List<Cell> newCells = new ArrayList<>(entry.getValue().size());
+        for (Cell kv : entry.getValue()) {
+          // replace the timestamp
+          newCells.add(CellUtil.createCell(CellUtil.cloneRow(kv),
+              CellUtil.cloneFamily(kv),
+              CellUtil.cloneQualifier(kv),
+              tsToAssign, kv.getTypeByte(),
+              CellUtil.cloneValue(kv)));
+        }
+        newFamilyMap.put(entry.getKey(), newCells);
+      }
+      delete.setFamilyCellMap(newFamilyMap);
+    }
+  }
+
+  @Override
+  public RegionScanner preScannerOpen(ObserverContext<RegionCoprocessorEnvironment> e, Scan scan, RegionScanner s)
+    throws IOException {
+    // must see all versions to aggregate increments
+    scan.setMaxVersions();
+    scan.setFilter(Filters.combine(new IncrementFilter(), scan.getFilter()));
+    return s;
+  }
+
+  @Override
+  public RegionScanner postScannerOpen(ObserverContext<RegionCoprocessorEnvironment> ctx, Scan scan,
+                                       RegionScanner scanner)
+    throws IOException {
+    return new IncrementSummingScanner(region, scan.getBatch(), scanner, ScanType.USER_SCAN);
+  }
+
+  @Override
+  public InternalScanner preFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store,
+                                  InternalScanner scanner) throws IOException {
+    byte[] family = store.getFamily().getName();
+    return new IncrementSummingScanner(region, IncrementHandlerState.BATCH_UNLIMITED, scanner,
+        ScanType.COMPACT_RETAIN_DELETES, state.getCompactionBound(family), state.getOldestVisibleTimestamp(family));
+  }
+
+  public static boolean isIncrement(Cell cell) {
+    return !CellUtil.isDelete(cell) && cell.getValueLength() == IncrementHandlerState.DELTA_FULL_LENGTH &&
+      Bytes.equals(cell.getValueArray(), cell.getValueOffset(), IncrementHandlerState.DELTA_MAGIC_PREFIX.length,
+                   IncrementHandlerState.DELTA_MAGIC_PREFIX, 0, IncrementHandlerState.DELTA_MAGIC_PREFIX.length);
+  }
+
+  @Override
+  public InternalScanner preCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store,
+                                    InternalScanner scanner, ScanType scanType) throws IOException {
+    byte[] family = store.getFamily().getName();
+    return new IncrementSummingScanner(region, IncrementHandlerState.BATCH_UNLIMITED, scanner, scanType,
+        state.getCompactionBound(family), state.getOldestVisibleTimestamp(family));
+  }
+
+  @Override
+  public InternalScanner preCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store,
+                                    InternalScanner scanner, ScanType scanType, CompactionRequest request)
+    throws IOException {
+    byte[] family = store.getFamily().getName();
+    return new IncrementSummingScanner(region, IncrementHandlerState.BATCH_UNLIMITED, scanner, scanType,
+        state.getCompactionBound(family), state.getOldestVisibleTimestamp(family));
+  }
+}

--- a/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/increment/hbase10cdh/IncrementSummingScanner.java
+++ b/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/increment/hbase10cdh/IncrementSummingScanner.java
@@ -1,0 +1,340 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.increment.hbase10cdh;
+
+import co.cask.cdap.data2.increment.hbase.IncrementHandlerState;
+import com.google.common.base.Preconditions;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.HRegionInfo;
+import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.regionserver.HRegion;
+import org.apache.hadoop.hbase.regionserver.InternalScanner;
+import org.apache.hadoop.hbase.regionserver.RegionScanner;
+import org.apache.hadoop.hbase.regionserver.ScanType;
+import org.apache.hadoop.hbase.util.Bytes;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Transforms reads of the stored delta increments into calculated sums for each column.
+ */
+class IncrementSummingScanner implements RegionScanner {
+  private static final Log LOG = LogFactory.getLog(IncrementSummingScanner.class);
+
+  private final HRegion region;
+  private final WrappedScanner baseScanner;
+  private RegionScanner baseRegionScanner;
+  private final int batchSize;
+  private final ScanType scanType;
+  // Highest timestamp, beyond which we cannot aggregate increments during flush and compaction.
+  // Increments newer than this may still be visible to running transactions
+  private final long compactionUpperBound;
+  // scan start time to use in computing TTL
+  private final long oldestTsByTTL;
+
+  IncrementSummingScanner(HRegion region, int batchSize, InternalScanner internalScanner, ScanType scanType) {
+    this(region, batchSize, internalScanner, scanType, Long.MAX_VALUE, -1);
+  }
+
+  IncrementSummingScanner(HRegion region, int batchSize, InternalScanner internalScanner, ScanType scanType,
+                          long compationUpperBound, long oldestTsByTTL) {
+    this.region = region;
+    this.batchSize = batchSize;
+    this.baseScanner = new WrappedScanner(internalScanner);
+    if (internalScanner instanceof RegionScanner) {
+      this.baseRegionScanner = (RegionScanner) internalScanner;
+    }
+    this.scanType = scanType;
+    this.compactionUpperBound = compationUpperBound;
+    this.oldestTsByTTL = oldestTsByTTL;
+  }
+
+  @Override
+  public HRegionInfo getRegionInfo() {
+    return region.getRegionInfo();
+  }
+
+  @Override
+  public boolean isFilterDone() throws IOException {
+    if (baseRegionScanner != null) {
+      return baseRegionScanner.isFilterDone();
+    }
+    throw new IllegalStateException(
+      "RegionScanner.isFilterDone() called when the wrapped scanner is not a RegionScanner");
+  }
+
+  @Override
+  public boolean reseek(byte[] bytes) throws IOException {
+    if (baseRegionScanner != null) {
+      return baseRegionScanner.reseek(bytes);
+    }
+    throw new IllegalStateException(
+      "RegionScanner.reseek() called when the wrapped scanner is not a RegionScanner");
+  }
+
+  @Override
+  public long getMaxResultSize() {
+    if (baseRegionScanner != null) {
+      return baseRegionScanner.getMaxResultSize();
+    }
+    throw new IllegalStateException(
+      "RegionScanner.isFilterDone() called when the wrapped scanner is not a RegionScanner");
+  }
+
+
+  @Override
+  public long getMvccReadPoint() {
+    if (baseRegionScanner != null) {
+      return baseRegionScanner.getMvccReadPoint();
+    }
+    throw new IllegalStateException(
+      "RegionScanner.isFilterDone() called when the wrapped scanner is not a RegionScanner");
+  }
+
+  @Override
+  public boolean nextRaw(List<Cell> cells) throws IOException {
+    return nextRaw(cells, batchSize);
+  }
+
+  @Override
+  public boolean nextRaw(List<Cell> cells, int limit) throws IOException {
+    return nextInternal(cells, limit);
+  }
+
+  @Override
+  public boolean next(List<Cell> cells) throws IOException {
+    return next(cells, batchSize);
+  }
+
+  @Override
+  public boolean next(List<Cell> cells, int limit) throws IOException {
+    return nextInternal(cells, limit);
+  }
+
+  private boolean nextInternal(List<Cell> cells, int limit) throws IOException {
+    if (LOG.isTraceEnabled()) {
+      LOG.trace("nextInternal called with limit=" + limit);
+    }
+    Cell previousIncrement = null;
+    long runningSum = 0;
+    int addedCnt = 0;
+    baseScanner.startNext();
+    Cell cell = null;
+    while ((cell = baseScanner.peekNextCell(limit)) != null && (limit <= 0 || addedCnt < limit)) {
+      // we use the "peek" semantics so that only once cell is ever emitted per iteration
+      // this makes is clearer and easier to enforce that the returned results are <= limit
+      if (LOG.isTraceEnabled()) {
+        LOG.trace("Checking cell " + cell);
+      }
+      // any cells visible to in-progress transactions must be kept unchanged
+      if (cell.getTimestamp() > compactionUpperBound) {
+        if (LOG.isTraceEnabled()) {
+          LOG.trace("Including cell visible to in-progress, cell=" + cell);
+        }
+        cells.add(cell);
+        addedCnt++;
+        baseScanner.nextCell(limit);
+        continue;
+      }
+
+      // compact any delta writes
+      if (IncrementHandler.isIncrement(cell)) {
+        if (LOG.isTraceEnabled()) {
+          LOG.trace("Found increment for row=" + Bytes.toStringBinary(CellUtil.cloneRow(cell)) + ", " +
+              "column=" + Bytes.toStringBinary(CellUtil.cloneQualifier(cell)));
+        }
+        if (!sameCell(previousIncrement, cell)) {
+          if (previousIncrement != null) {
+            // if different qualifier, and prev qualifier non-null
+            // emit the previous sum
+            if (LOG.isTraceEnabled()) {
+              LOG.trace("Including increment: sum=" + runningSum + ", cell=" + previousIncrement);
+            }
+            cells.add(newCell(previousIncrement, runningSum));
+            previousIncrement = null;
+            addedCnt++;
+            // continue without advancing, current cell will be consumed on the next iteration
+            continue;
+          }
+          previousIncrement = cell;
+          runningSum = 0;
+        }
+        // add this increment to the tally
+        runningSum += Bytes.toLong(cell.getValueArray(),
+            cell.getValueOffset() + IncrementHandlerState.DELTA_MAGIC_PREFIX.length);
+      } else {
+        // otherwise (not an increment)
+        if (previousIncrement != null) {
+          if (sameCell(previousIncrement, cell) && !CellUtil.isDelete(cell)) {
+            // if qualifier matches previous and this is a long, add to running sum, emit
+            runningSum += Bytes.toLong(cell.getValueArray(), cell.getValueOffset());
+            // this cell already processed as part of the previous increment's sum, so consume it
+            baseScanner.nextCell(limit);
+          }
+          if (LOG.isTraceEnabled()) {
+            LOG.trace("Including increment: sum=" + runningSum + ", cell=" + previousIncrement);
+          }
+          // if this put is a different cell from the previous increment, then
+          // we only emit the previous increment, reset it, and continue.
+          // the current cell will be consumed on the next iteration, if we have not yet reached the limit
+          cells.add(newCell(previousIncrement, runningSum));
+          addedCnt++;
+          previousIncrement = null;
+          runningSum = 0;
+
+          continue;
+        }
+        // otherwise emit the current cell
+        if (LOG.isTraceEnabled()) {
+          LOG.trace("Including raw cell: " + cell);
+        }
+
+        // apply any configured TTL
+        if (cell.getTimestamp() > oldestTsByTTL) {
+          cells.add(cell);
+          addedCnt++;
+        }
+      }
+      // if we made it this far, consume the current cell
+      baseScanner.nextCell(limit);
+    }
+    // emit any left over increment, if we hit the end
+    if (previousIncrement != null) {
+      // in any situation where we exited due to limit, previousIncrement should already be null
+      Preconditions.checkState(limit <= 0 || addedCnt < limit);
+      if (LOG.isTraceEnabled()) {
+        LOG.trace("Including leftover increment: sum=" + runningSum + ", cell=" + previousIncrement);
+      }
+      cells.add(newCell(previousIncrement, runningSum));
+    }
+
+    return baseScanner.hasMore();
+  }
+
+  private boolean sameCell(Cell first, Cell second) {
+    if (first == null && second == null) {
+      return true;
+    } else if (first == null || second == null) {
+      return false;
+    }
+
+    return CellUtil.matchingRow(first, second) &&
+      CellUtil.matchingFamily(first, second) &&
+      CellUtil.matchingQualifier(first, second);
+  }
+
+  private Cell newCell(Cell toCopy, long value) {
+    byte[] newValue = Bytes.toBytes(value);
+    if (scanType == ScanType.COMPACT_RETAIN_DELETES) {
+      newValue = Bytes.add(IncrementHandlerState.DELTA_MAGIC_PREFIX, newValue);
+    }
+    return CellUtil.createCell(CellUtil.cloneRow(toCopy), CellUtil.cloneFamily(toCopy),
+                               CellUtil.cloneQualifier(toCopy), toCopy.getTimestamp(),
+                               KeyValue.Type.Put.getCode(), newValue);
+  }
+
+  @Override
+  public void close() throws IOException {
+    baseScanner.close();
+  }
+
+  /**
+   * Wraps the underlying store or region scanner in an API that hides the details of calling and managing the
+   * buffered batch of results.
+   */
+  private static class WrappedScanner implements Closeable {
+    private boolean hasMore;
+    private byte[] currentRow;
+    private List<Cell> cellsToConsume = new ArrayList<>();
+    private int currentIdx;
+    private final InternalScanner scanner;
+
+    public WrappedScanner(InternalScanner scanner) {
+      this.scanner = scanner;
+    }
+
+    /**
+     * Called to signal the start of the next() call by the scanner.
+     */
+    public void startNext() {
+      currentRow = null;
+    }
+
+    /**
+     * Returns the next available cell for the current row, without advancing the pointer.  Calling this method
+     * multiple times in a row will continue to return the same cell.
+     *
+     * @param limit the limit of number of cells to return if the next batch must be fetched by the wrapped scanner
+     * @return the next available cell or null if no more cells are available for the current row
+     * @throws IOException
+     */
+    public Cell peekNextCell(int limit) throws IOException {
+      if (currentIdx >= cellsToConsume.size()) {
+        // finished current batch
+        cellsToConsume.clear();
+        currentIdx = 0;
+        hasMore = scanner.next(cellsToConsume, limit);
+      }
+      Cell cell = null;
+      if (currentIdx < cellsToConsume.size()) {
+        cell = cellsToConsume.get(currentIdx);
+        if (currentRow == null) {
+          currentRow = CellUtil.cloneRow(cell);
+        } else if (!CellUtil.matchingRow(cell, currentRow)) {
+          // moved on to the next row
+          // don't consume current cell and signal no more cells for this row
+          return null;
+        }
+      }
+      return cell;
+    }
+
+    /**
+     * Returns the next available cell for the current row and advances the pointer to the next cell.  This method
+     * can be called multiple times in a row to advance through all the available cells.
+     *
+     * @param limit the limit of number of cells to return if the next batch must be fetched by the wrapped scanner
+     * @return the next available cell or null if no more cells are available for the current row
+     * @throws IOException
+     */
+    public Cell nextCell(int limit) throws IOException {
+      Cell cell = peekNextCell(limit);
+      if (cell != null) {
+        currentIdx++;
+      }
+      return cell;
+    }
+
+    /**
+     * Returns whether or not the underlying scanner has more rows.
+     */
+    public boolean hasMore() {
+      return currentIdx < cellsToConsume.size() ? true : hasMore;
+    }
+
+    @Override
+    public void close() throws IOException {
+      scanner.close();
+    }
+  }
+}

--- a/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/transaction/coprocessor/hbase10cdh/DefaultTransactionProcessor.java
+++ b/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/transaction/coprocessor/hbase10cdh/DefaultTransactionProcessor.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.transaction.coprocessor.hbase10cdh;
+
+import co.cask.cdap.data2.increment.hbase10cdh.IncrementFilter;
+import co.cask.cdap.data2.transaction.coprocessor.DefaultTransactionStateCacheSupplier;
+import co.cask.cdap.data2.util.hbase.HTable10CDHNameConverter;
+import co.cask.tephra.Transaction;
+import co.cask.tephra.coprocessor.TransactionStateCache;
+import co.cask.tephra.hbase10cdh.coprocessor.TransactionProcessor;
+import co.cask.tephra.hbase10cdh.coprocessor.TransactionVisibilityFilter;
+import com.google.common.base.Supplier;
+import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
+import org.apache.hadoop.hbase.filter.Filter;
+import org.apache.hadoop.hbase.regionserver.ScanType;
+
+/**
+ * Implementation of the {@link co.cask.tephra.hbase10cdh.coprocessor.TransactionProcessor}
+ * coprocessor that uses {@link co.cask.cdap.data2.transaction.coprocessor.DefaultTransactionStateCache}
+ * to automatically refresh transaction state.
+ */
+public class DefaultTransactionProcessor extends TransactionProcessor {
+  @Override
+  protected Supplier<TransactionStateCache> getTransactionStateCacheSupplier(RegionCoprocessorEnvironment env) {
+    String sysConfigTablePrefix =
+        new HTable10CDHNameConverter().getSysConfigTablePrefix(env.getRegion().getTableDesc());
+    return new DefaultTransactionStateCacheSupplier(sysConfigTablePrefix, env.getConfiguration());
+  }
+
+  @Override
+  protected Filter getTransactionFilter(Transaction tx, ScanType scanType) {
+    return new TransactionVisibilityFilter(tx, ttlByFamily, allowEmptyValues, scanType, new IncrementFilter());
+  }
+}

--- a/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase10cdh/DequeueFilter.java
+++ b/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase10cdh/DequeueFilter.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright © 2014-2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.transaction.queue.coprocessor.hbase10cdh;
+
+import co.cask.cdap.data2.queue.ConsumerConfig;
+import co.cask.cdap.data2.transaction.queue.QueueEntryRow;
+import co.cask.cdap.data2.transaction.queue.hbase.DequeueScanAttributes;
+import co.cask.tephra.Transaction;
+import com.google.common.primitives.Ints;
+import com.google.common.primitives.Longs;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.exceptions.DeserializationException;
+import org.apache.hadoop.hbase.filter.Filter;
+import org.apache.hadoop.hbase.filter.FilterBase;
+import org.apache.hadoop.hbase.util.Bytes;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInput;
+import java.io.DataInputStream;
+import java.io.DataOutput;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Server-side filter for dequeue operation
+ */
+// todo: unit-test it (without DequeueScanObserver)
+public class DequeueFilter extends FilterBase {
+  private ConsumerConfig consumerConfig;
+  private Transaction transaction;
+  private byte[] stateColumnName;
+
+  private boolean stopScan;
+  private boolean skipRow;
+
+  private int counter;
+  private long writePointer;
+
+  // For Writable
+  private DequeueFilter() {
+  }
+
+  public DequeueFilter(ConsumerConfig consumerConfig, Transaction transaction) {
+    this.consumerConfig = consumerConfig;
+    this.transaction = transaction;
+    this.stateColumnName = Bytes.add(QueueEntryRow.STATE_COLUMN_PREFIX,
+                                     Bytes.toBytes(consumerConfig.getGroupId()));
+  }
+
+  @Override
+  public void reset() throws IOException {
+    stopScan = false;
+    skipRow = false;
+  }
+
+  @Override
+  public boolean filterAllRemaining() {
+    return stopScan;
+  }
+
+  @Override
+  public boolean filterRowKey(byte[] buffer, int offset, int length) {
+    // last 4 bytes in a row key
+    counter = Bytes.toInt(buffer, offset + length - Ints.BYTES, Ints.BYTES);
+    // row key is queue_name + writePointer + counter
+    writePointer = Bytes.toLong(buffer, offset + length - Longs.BYTES - Ints.BYTES, Longs.BYTES);
+
+    // If writes later than the reader pointer, abort the loop, as entries that comes later are all uncommitted.
+    // this is probably not needed due to the limit of the scan to the stop row, but to be safe...
+    if (writePointer > transaction.getReadPointer()) {
+      stopScan = true;
+      return true;
+    }
+
+    // If the write is in the excluded list, ignore it.
+    if (transaction.isExcluded(writePointer)) {
+      return true;
+    }
+
+    return false;
+  }
+
+  @Override
+  public boolean hasFilterRow() {
+    return true;
+  }
+
+  @Override
+  public void filterRowCells(List<Cell> cells) {
+    byte[] dataBytes = null;
+    byte[] metaBytes = null;
+    byte[] stateBytes = null;
+    // list is very short so it is ok to loop thru to find columns
+    for (Cell cell : cells) {
+      if (CellUtil.matchingQualifier(cell, QueueEntryRow.DATA_COLUMN)) {
+        dataBytes = CellUtil.cloneValue(cell);
+      } else if (CellUtil.matchingQualifier(cell, QueueEntryRow.META_COLUMN)) {
+        metaBytes = CellUtil.cloneValue(cell);
+      } else if (CellUtil.matchingQualifier(cell, stateColumnName)) {
+        stateBytes = CellUtil.cloneValue(cell);
+      }
+    }
+
+    if (dataBytes == null || metaBytes == null) {
+      skipRow = true;
+      return;
+    }
+
+    QueueEntryRow.CanConsume canConsume =
+      QueueEntryRow.canConsume(consumerConfig, transaction, writePointer, counter, metaBytes, stateBytes);
+
+    // Only skip the row when canConsumer == NO, so that in case of NO_INCLUDING_ALL_OLDER, the client
+    // can still see the row and move the scan start row.
+    skipRow = canConsume == QueueEntryRow.CanConsume.NO;
+  }
+
+  @Override
+  public ReturnCode filterKeyValue(Cell cell) throws IOException {
+    return ReturnCode.INCLUDE;
+  }
+
+  @Override
+  public boolean filterRow() {
+    return skipRow;
+  }
+
+  /* Writable implementation for HBase 0.94 */
+
+  public void write(DataOutput out) throws IOException {
+    DequeueScanAttributes.write(out, consumerConfig);
+    DequeueScanAttributes.write(out, transaction);
+  }
+
+  public void readFields(DataInput in) throws IOException {
+    this.consumerConfig = DequeueScanAttributes.readConsumerConfig(in);
+    this.transaction = DequeueScanAttributes.readTx(in);
+  }
+
+  /* Serialization support for HBase 0.98+ */
+
+  public byte[] toByteArray() throws IOException {
+    // TODO: in the future actual serialization here should be done using protobufs
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    write(new DataOutputStream(bos));
+    return bos.toByteArray();
+  }
+
+  public static Filter parseFrom(final byte [] pbBytes) throws DeserializationException {
+    DequeueFilter filter = new DequeueFilter();
+    try {
+      filter.readFields(new DataInputStream(new ByteArrayInputStream(pbBytes)));
+    } catch (IOException ioe) {
+      throw new DeserializationException(ioe);
+    }
+    return filter;
+  }
+}

--- a/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase10cdh/DequeueScanObserver.java
+++ b/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase10cdh/DequeueScanObserver.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2014-2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.transaction.queue.coprocessor.hbase10cdh;
+
+import co.cask.cdap.data2.queue.ConsumerConfig;
+import co.cask.cdap.data2.transaction.queue.hbase.DequeueScanAttributes;
+import co.cask.tephra.Transaction;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.coprocessor.BaseRegionObserver;
+import org.apache.hadoop.hbase.coprocessor.ObserverContext;
+import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
+import org.apache.hadoop.hbase.filter.Filter;
+import org.apache.hadoop.hbase.filter.FilterList;
+import org.apache.hadoop.hbase.regionserver.RegionScanner;
+
+import java.io.IOException;
+
+/**
+ *
+ */
+public class DequeueScanObserver extends BaseRegionObserver {
+  @Override
+  public RegionScanner preScannerOpen(ObserverContext<RegionCoprocessorEnvironment> e, Scan scan, RegionScanner s)
+    throws IOException {
+    ConsumerConfig consumerConfig = DequeueScanAttributes.getConsumerConfig(scan);
+    Transaction tx = DequeueScanAttributes.getTx(scan);
+
+    if (consumerConfig == null || tx == null) {
+      return super.preScannerOpen(e, scan, s);
+    }
+
+    Filter dequeueFilter = new DequeueFilter(consumerConfig, tx);
+
+    Filter existing = scan.getFilter();
+    if (existing != null) {
+      Filter combined = new FilterList(FilterList.Operator.MUST_PASS_ALL, existing, dequeueFilter);
+      scan.setFilter(combined);
+    } else {
+      scan.setFilter(dequeueFilter);
+    }
+
+    return super.preScannerOpen(e, scan, s);
+  }
+}

--- a/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase10cdh/HBaseQueueRegionObserver.java
+++ b/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase10cdh/HBaseQueueRegionObserver.java
@@ -1,0 +1,331 @@
+/*
+ * Copyright © 2014-2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.data2.transaction.queue.coprocessor.hbase10cdh;
+
+import co.cask.cdap.common.queue.QueueName;
+import co.cask.cdap.data2.transaction.coprocessor.DefaultTransactionStateCacheSupplier;
+import co.cask.cdap.data2.transaction.queue.ConsumerEntryState;
+import co.cask.cdap.data2.transaction.queue.QueueEntryRow;
+import co.cask.cdap.data2.transaction.queue.hbase.HBaseQueueAdmin;
+import co.cask.cdap.data2.transaction.queue.hbase.SaltedHBaseQueueStrategy;
+import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.CConfigurationReader;
+import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.ConsumerConfigCache;
+import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.ConsumerInstance;
+import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.QueueConsumerConfig;
+import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.data2.util.hbase.HTable10CDHNameConverter;
+import co.cask.tephra.coprocessor.TransactionStateCache;
+import co.cask.tephra.persist.TransactionSnapshot;
+import com.google.common.base.Supplier;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CoprocessorEnvironment;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.coprocessor.BaseRegionObserver;
+import org.apache.hadoop.hbase.coprocessor.ObserverContext;
+import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
+import org.apache.hadoop.hbase.regionserver.InternalScanner;
+import org.apache.hadoop.hbase.regionserver.ScanType;
+import org.apache.hadoop.hbase.regionserver.Store;
+import org.apache.hadoop.hbase.regionserver.compactions.CompactionRequest;
+import org.apache.hadoop.hbase.util.Bytes;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * RegionObserver for queue table. This class should only have JSE and HBase classes dependencies only.
+ * It can also has dependencies on CDAP classes provided that all the transitive dependencies stay within
+ * the mentioned scope.
+ *
+ * This region observer does queue eviction during flush time and compact time by using queue consumer state
+ * information to determine if a queue entry row can be omitted during flush/compact.
+ */
+public final class HBaseQueueRegionObserver extends BaseRegionObserver {
+
+  private static final Log LOG = LogFactory.getLog(HBaseQueueRegionObserver.class);
+
+  private Configuration conf;
+  private byte[] configTableNameBytes;
+  private CConfigurationReader cConfReader;
+  TransactionStateCache txStateCache;
+  private Supplier<TransactionSnapshot> txSnapshotSupplier;
+  private ConsumerConfigCache configCache;
+
+  private int prefixBytes;
+  private String namespaceId;
+  private String appName;
+  private String flowName;
+
+  @Override
+  public void start(CoprocessorEnvironment env) {
+    if (env instanceof RegionCoprocessorEnvironment) {
+      HTableDescriptor tableDesc = ((RegionCoprocessorEnvironment) env).getRegion().getTableDesc();
+      String hTableName = tableDesc.getNameAsString();
+
+      String prefixBytes = tableDesc.getValue(HBaseQueueAdmin.PROPERTY_PREFIX_BYTES);
+      try {
+        // Default to SALT_BYTES for the older salted queue implementation.
+        this.prefixBytes = prefixBytes == null ? SaltedHBaseQueueStrategy.SALT_BYTES : Integer.parseInt(prefixBytes);
+      } catch (NumberFormatException e) {
+        // Shouldn't happen for table created by cdap.
+        LOG.error("Unable to parse value of '" + HBaseQueueAdmin.PROPERTY_PREFIX_BYTES + "' property. " +
+                    "Default to " + SaltedHBaseQueueStrategy.SALT_BYTES, e);
+        this.prefixBytes = SaltedHBaseQueueStrategy.SALT_BYTES;
+      }
+
+      HTable10CDHNameConverter nameConverter = new HTable10CDHNameConverter();
+      namespaceId = nameConverter.from(tableDesc).getNamespace().getId();
+      appName = HBaseQueueAdmin.getApplicationName(hTableName);
+      flowName = HBaseQueueAdmin.getFlowName(hTableName);
+
+      conf = env.getConfiguration();
+      String hbaseNamespacePrefix = nameConverter.getNamespacePrefix(tableDesc);
+      TableId queueConfigTableId = HBaseQueueAdmin.getConfigTableId(namespaceId);
+      final String sysConfigTablePrefix = nameConverter.getSysConfigTablePrefix(tableDesc);
+      txStateCache = new DefaultTransactionStateCacheSupplier(sysConfigTablePrefix, conf).get();
+      txSnapshotSupplier = new Supplier<TransactionSnapshot>() {
+        @Override
+        public TransactionSnapshot get() {
+          return txStateCache.getLatestState();
+        }
+      };
+      configTableNameBytes = nameConverter.toTableName(hbaseNamespacePrefix, queueConfigTableId).getName();
+      cConfReader = new CConfigurationReader(conf, sysConfigTablePrefix);
+      configCache = ConsumerConfigCache.getInstance(conf, configTableNameBytes, cConfReader, txSnapshotSupplier);
+    }
+  }
+
+  @Override
+  public InternalScanner preFlush(ObserverContext<RegionCoprocessorEnvironment> e,
+                                  Store store, InternalScanner scanner) throws IOException {
+    if (!e.getEnvironment().getRegion().isAvailable()) {
+      return scanner;
+    }
+
+    LOG.info("preFlush, creates EvictionInternalScanner");
+    return new EvictionInternalScanner("flush", e.getEnvironment(), scanner);
+  }
+
+  @Override
+  public InternalScanner preCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store,
+                                    InternalScanner scanner, ScanType type,
+                                    CompactionRequest request) throws IOException {
+    if (!e.getEnvironment().getRegion().isAvailable()) {
+      return scanner;
+    }
+
+    LOG.info("preCompact, creates EvictionInternalScanner");
+    return new EvictionInternalScanner("compaction", e.getEnvironment(), scanner);
+  }
+
+  // needed for queue unit-test
+  private ConsumerConfigCache getConfigCache() {
+    if (!configCache.isAlive()) {
+      configCache = ConsumerConfigCache.getInstance(conf, configTableNameBytes, cConfReader, txSnapshotSupplier);
+    }
+    return configCache;
+  }
+
+  // need for queue unit-test
+  private TransactionStateCache getTxStateCache() {
+    return txStateCache;
+  }
+
+  /**
+   * An {@link InternalScanner} that will skip queue entries that are safe to be evicted.
+   */
+  private final class EvictionInternalScanner implements InternalScanner {
+
+    private final String triggeringAction;
+    private final RegionCoprocessorEnvironment env;
+    private final InternalScanner scanner;
+    // This is just for object reused to reduce objects creation.
+    private final ConsumerInstance consumerInstance;
+    private byte[] currentQueue;
+    private byte[] currentQueueRowPrefix;
+    private QueueConsumerConfig consumerConfig;
+    private long totalRows = 0;
+    private long rowsEvicted = 0;
+    // couldn't be evicted due to incomplete view of row
+    private long skippedIncomplete = 0;
+
+    private EvictionInternalScanner(String action, RegionCoprocessorEnvironment env, InternalScanner scanner) {
+      this.triggeringAction = action;
+      this.env = env;
+      this.scanner = scanner;
+      this.consumerInstance = new ConsumerInstance(0, 0);
+    }
+
+    @Override
+    public boolean next(List<Cell> results) throws IOException {
+      return next(results, -1);
+    }
+
+    @Override
+    public boolean next(List<Cell> results, int limit) throws IOException {
+      boolean hasNext = scanner.next(results, limit);
+
+      while (!results.isEmpty()) {
+        totalRows++;
+        // Check if it is eligible for eviction.
+        Cell cell = results.get(0);
+
+        // If current queue is unknown or the row is not a queue entry of current queue,
+        // it either because it scans into next queue entry or simply current queue is not known.
+        // Hence needs to find the currentQueue
+        if (currentQueue == null || !QueueEntryRow.isQueueEntry(currentQueueRowPrefix, prefixBytes, cell.getRowArray(),
+                                                                cell.getRowOffset(), cell.getRowLength())) {
+          // If not eligible, it either because it scans into next queue entry or simply current queue is not known.
+          currentQueue = null;
+        }
+
+        // This row is a queue entry. If currentQueue is null, meaning it's a new queue encountered during scan.
+        if (currentQueue == null) {
+          QueueName queueName = QueueEntryRow.getQueueName(namespaceId, appName, flowName, prefixBytes,
+                                                           cell.getRowArray(), cell.getRowOffset(),
+                                                           cell.getRowLength());
+          currentQueue = queueName.toBytes();
+          currentQueueRowPrefix = QueueEntryRow.getQueueRowPrefix(queueName);
+          consumerConfig = getConfigCache().getConsumerConfig(currentQueue);
+        }
+
+        if (consumerConfig == null) {
+          // no config is present yet, so cannot evict
+          return hasNext;
+        }
+
+        if (canEvict(consumerConfig, results)) {
+          rowsEvicted++;
+          results.clear();
+          hasNext = scanner.next(results, limit);
+        } else {
+          break;
+        }
+      }
+
+      return hasNext;
+    }
+
+    @Override
+    public void close() throws IOException {
+      LOG.info("Region " + env.getRegion().getRegionNameAsString() + " " + triggeringAction +
+                 ", rows evicted: " + rowsEvicted + " / " + totalRows + ", skipped incomplete: " + skippedIncomplete);
+      scanner.close();
+    }
+
+    /**
+     * Determines the given queue entry row can be evicted.
+     * @param result All KeyValues of a queue entry row.
+     * @return true if it can be evicted, false otherwise.
+     */
+    private boolean canEvict(QueueConsumerConfig consumerConfig, List<Cell> result) {
+      // If no consumer group, this queue is dead, should be ok to evict.
+      if (consumerConfig.getNumGroups() == 0) {
+        return true;
+      }
+
+      // If unknown consumer config (due to error), keep the queue.
+      if (consumerConfig.getNumGroups() < 0) {
+        return false;
+      }
+
+      // TODO (terence): Right now we can only evict if we see all the data columns.
+      // It's because it's possible that in some previous flush, only the data columns are flush,
+      // then consumer writes the state columns. In the next flush, it'll only see the state columns and those
+      // should not be evicted otherwise the entry might get reprocessed, depending on the consumer start row state.
+      // This logic is not perfect as if flush happens after enqueue and before dequeue, that entry may never get
+      // evicted (depends on when the next compaction happens, whether the queue configuration has been change or not).
+
+      // There are two data columns, "d" and "m".
+      // If the size == 2, it should not be evicted as well,
+      // as state columns (dequeue) always happen after data columns (enqueue).
+      if (result.size() <= 2) {
+        skippedIncomplete++;
+        return false;
+      }
+
+      // "d" and "m" columns always comes before the state columns, prefixed with "s".
+      Iterator<Cell> iterator = result.iterator();
+      Cell cell = iterator.next();
+      if (!QueueEntryRow.isDataColumn(cell.getQualifierArray(), cell.getQualifierOffset())) {
+        skippedIncomplete++;
+        return false;
+      }
+      cell = iterator.next();
+      if (!QueueEntryRow.isMetaColumn(cell.getQualifierArray(), cell.getQualifierOffset())) {
+        skippedIncomplete++;
+        return false;
+      }
+
+      // Need to determine if this row can be evicted iff all consumer groups have committed process this row.
+      int consumedGroups = 0;
+      // Inspect each state column
+      while (iterator.hasNext()) {
+        cell = iterator.next();
+        if (!QueueEntryRow.isStateColumn(cell.getQualifierArray(), cell.getQualifierOffset())) {
+          continue;
+        }
+        // If any consumer has a state != PROCESSED, it should not be evicted
+        if (!isProcessed(cell, consumerInstance)) {
+          break;
+        }
+        // If it is PROCESSED, check if this row is smaller than the consumer instance startRow.
+        // Essentially a loose check of committed PROCESSED.
+        byte[] startRow = consumerConfig.getStartRow(consumerInstance);
+        if (startRow != null && compareRowKey(cell, startRow) < 0) {
+          consumedGroups++;
+        }
+      }
+
+      // It can be evicted if from the state columns, it's been processed by all consumer groups
+      // Otherwise, this row has to be less than smallest among all current consumers.
+      // The second condition is for handling consumer being removed after it consumed some entries.
+      // However, the second condition alone is not good enough as it's possible that in hash partitioning,
+      // only one consumer is keep consuming when the other consumer never proceed.
+      return consumedGroups == consumerConfig.getNumGroups()
+        || compareRowKey(result.get(0), consumerConfig.getSmallestStartRow()) < 0;
+    }
+
+    private int compareRowKey(Cell cell, byte[] row) {
+      return Bytes.compareTo(cell.getRowArray(), cell.getRowOffset() + prefixBytes,
+                             cell.getRowLength() - prefixBytes, row, 0, row.length);
+    }
+
+    /**
+     * Returns {@code true} if the given {@link KeyValue} has a {@link ConsumerEntryState#PROCESSED} state and
+     * also put the consumer information into the given {@link ConsumerInstance}.
+     * Otherwise, returns {@code false} and the {@link ConsumerInstance} is left untouched.
+     */
+    private boolean isProcessed(Cell cell, ConsumerInstance consumerInstance) {
+      int stateIdx = cell.getValueOffset() + cell.getValueLength() - 1;
+      boolean processed = cell.getValueArray()[stateIdx] == ConsumerEntryState.PROCESSED.getState();
+
+      if (processed) {
+        // Column is "s<groupId>"
+        long groupId = Bytes.toLong(cell.getQualifierArray(), cell.getQualifierOffset() + 1);
+        // Value is "<writePointer><instanceId><state>"
+        int instanceId = Bytes.toInt(cell.getValueArray(), cell.getValueOffset() + Bytes.SIZEOF_LONG);
+        consumerInstance.setGroupInstance(groupId, instanceId);
+      }
+      return processed;
+    }
+  }
+}

--- a/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBase10CDHQueueConsumer.java
+++ b/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBase10CDHQueueConsumer.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2014-2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.transaction.queue.hbase;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.queue.QueueName;
+import co.cask.cdap.data2.transaction.queue.ConsumerEntryState;
+import co.cask.cdap.data2.transaction.queue.QueueEntryRow;
+import com.google.common.primitives.Ints;
+import org.apache.hadoop.hbase.client.HTable;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.filter.BinaryPrefixComparator;
+import org.apache.hadoop.hbase.filter.BitComparator;
+import org.apache.hadoop.hbase.filter.CompareFilter;
+import org.apache.hadoop.hbase.filter.Filter;
+import org.apache.hadoop.hbase.filter.FilterList;
+import org.apache.hadoop.hbase.filter.SingleColumnValueFilter;
+
+/**
+ * HBase 1.0 (CDH) implementation of {@link HBaseQueueConsumer}.
+ */
+final class HBase10CDHQueueConsumer extends HBaseQueueConsumer {
+  private final Filter processedStateFilter;
+
+  HBase10CDHQueueConsumer(CConfiguration cConf, HTable hTable, QueueName queueName,
+                          HBaseConsumerState consumerState, HBaseConsumerStateStore stateStore,
+                          HBaseQueueStrategy queueStrategy) {
+    super(cConf, hTable, queueName, consumerState, stateStore, queueStrategy);
+    this.processedStateFilter = createStateFilter();
+  }
+
+  @Override
+  protected Scan createScan(byte[] startRow, byte[] stopRow, int numRows) {
+    // Scan the table for queue entries.
+    Scan scan = new Scan();
+    scan.setStartRow(startRow);
+    scan.setStopRow(stopRow);
+    scan.addColumn(QueueEntryRow.COLUMN_FAMILY, QueueEntryRow.DATA_COLUMN);
+    scan.addColumn(QueueEntryRow.COLUMN_FAMILY, QueueEntryRow.META_COLUMN);
+    scan.addColumn(QueueEntryRow.COLUMN_FAMILY, stateColumnName);
+    scan.setFilter(createFilter());
+    scan.setMaxVersions(1);
+    return scan;
+  }
+
+  /**
+   * Creates a HBase filter that will filter out rows that that has committed state = PROCESSED.
+   */
+  private Filter createFilter() {
+    return new FilterList(FilterList.Operator.MUST_PASS_ONE, processedStateFilter, new SingleColumnValueFilter(
+      QueueEntryRow.COLUMN_FAMILY, stateColumnName, CompareFilter.CompareOp.GREATER,
+      new BinaryPrefixComparator(Bytes.toBytes(transaction.getReadPointer()))
+    ));
+  }
+
+  /**
+   * Creates a HBase filter that will filter out rows with state column state = PROCESSED (ignoring transaction).
+   */
+  private Filter createStateFilter() {
+    byte[] processedMask = new byte[Ints.BYTES * 2 + 1];
+    processedMask[processedMask.length - 1] = ConsumerEntryState.PROCESSED.getState();
+    return new SingleColumnValueFilter(QueueEntryRow.COLUMN_FAMILY, stateColumnName,
+                                       CompareFilter.CompareOp.NOT_EQUAL,
+                                       new BitComparator(processedMask, BitComparator.BitwiseOp.AND));
+  }
+}

--- a/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBase10CDHQueueUtil.java
+++ b/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBase10CDHQueueUtil.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2014-2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.transaction.queue.hbase;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.queue.QueueName;
+import org.apache.hadoop.hbase.client.HTable;
+
+/**
+ * HBase 1.0 (CDH) implementation of {@link HBaseQueueUtil}.
+ */
+public class HBase10CDHQueueUtil extends HBaseQueueUtil {
+  @Override
+  public HBaseQueueConsumer getQueueConsumer(CConfiguration cConf,
+                                             HTable hTable, QueueName queueName,
+                                             HBaseConsumerState consumerState, HBaseConsumerStateStore stateStore,
+                                             HBaseQueueStrategy queueStrategy) {
+    return new HBase10CDHQueueConsumer(cConf, hTable, queueName, consumerState, stateStore, queueStrategy);
+  }
+}

--- a/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/util/hbase/HBase10CDHTableUtil.java
+++ b/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/util/hbase/HBase10CDHTableUtil.java
@@ -1,0 +1,291 @@
+/*
+ * Copyright © 2014-2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import co.cask.cdap.data2.increment.hbase10cdh.IncrementHandler;
+import co.cask.cdap.data2.transaction.coprocessor.hbase10cdh.DefaultTransactionProcessor;
+import co.cask.cdap.data2.transaction.queue.coprocessor.hbase10cdh.DequeueScanObserver;
+import co.cask.cdap.data2.transaction.queue.coprocessor.hbase10cdh.HBaseQueueRegionObserver;
+import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.proto.Id;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.ClusterStatus;
+import org.apache.hadoop.hbase.Coprocessor;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HRegionInfo;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.NamespaceDescriptor;
+import org.apache.hadoop.hbase.NamespaceNotFoundException;
+import org.apache.hadoop.hbase.RegionLoad;
+import org.apache.hadoop.hbase.ServerName;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.HBaseAdmin;
+import org.apache.hadoop.hbase.client.HTable;
+import org.apache.hadoop.hbase.io.compress.Compression;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ *
+ */
+public class HBase10CDHTableUtil extends HBaseTableUtil {
+
+  private final HTable10CDHNameConverter nameConverter = new HTable10CDHNameConverter();
+
+  @Override
+  public HTable createHTable(Configuration conf, TableId tableId) throws IOException {
+    Preconditions.checkArgument(tableId != null, "Table id should not be null");
+    return new HTable(conf, nameConverter.toTableName(tablePrefix, tableId));
+  }
+
+  @Override
+  public HTableDescriptor createHTableDescriptor(TableId tableId) {
+    Preconditions.checkArgument(tableId != null, "Table id should not be null");
+    return new HTableDescriptor(nameConverter.toTableName(tablePrefix, tableId));
+  }
+
+  @Override
+  public HTableDescriptor getHTableDescriptor(HBaseAdmin admin, TableId tableId) throws IOException {
+    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
+    Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
+    return admin.getTableDescriptor(nameConverter.toTableName(tablePrefix, tableId));
+  }
+
+  @Override
+  public boolean hasNamespace(HBaseAdmin admin, Id.Namespace namespace) throws IOException {
+    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
+    Preconditions.checkArgument(namespace != null, "Namespace should not be null.");
+    try {
+      admin.getNamespaceDescriptor(nameConverter.toHBaseNamespace(tablePrefix, namespace));
+      return true;
+    } catch (NamespaceNotFoundException e) {
+      return false;
+    }
+  }
+
+  @Override
+  public void createNamespaceIfNotExists(HBaseAdmin admin, Id.Namespace namespace) throws IOException {
+    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
+    Preconditions.checkArgument(namespace != null, "Namespace should not be null.");
+    if (!hasNamespace(admin, namespace)) {
+      NamespaceDescriptor namespaceDescriptor =
+        NamespaceDescriptor.create(nameConverter.toHBaseNamespace(tablePrefix, namespace)).build();
+      admin.createNamespace(namespaceDescriptor);
+    }
+  }
+
+  @Override
+  public void deleteNamespaceIfExists(HBaseAdmin admin, Id.Namespace namespace) throws IOException {
+    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
+    Preconditions.checkArgument(namespace != null, "Namespace should not be null.");
+    if (hasNamespace(admin, namespace)) {
+      admin.deleteNamespace(nameConverter.toHBaseNamespace(tablePrefix, namespace));
+    }
+  }
+
+  @Override
+  public void disableTable(HBaseAdmin admin, TableId tableId) throws IOException {
+    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
+    Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
+    admin.disableTable(nameConverter.toTableName(tablePrefix, tableId));
+  }
+
+  @Override
+  public void enableTable(HBaseAdmin admin, TableId tableId) throws IOException {
+    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
+    Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
+    admin.enableTable(nameConverter.toTableName(tablePrefix, tableId));
+  }
+
+  @Override
+  public boolean tableExists(HBaseAdmin admin, TableId tableId) throws IOException {
+    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
+    Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
+    return admin.tableExists(nameConverter.toTableName(tablePrefix, tableId));
+  }
+
+  @Override
+  public void deleteTable(HBaseAdmin admin, TableId tableId) throws IOException {
+    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
+    Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
+    admin.deleteTable(nameConverter.toTableName(tablePrefix, tableId));
+  }
+
+  @Override
+  public void modifyTable(HBaseAdmin admin, HTableDescriptor tableDescriptor) throws IOException {
+    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
+    Preconditions.checkArgument(tableDescriptor != null, "Table descriptor should not be null.");
+    admin.modifyTable(tableDescriptor.getTableName(), tableDescriptor);
+  }
+
+  @Override
+  public List<HRegionInfo> getTableRegions(HBaseAdmin admin, TableId tableId) throws IOException {
+    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
+    Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
+    return admin.getTableRegions(nameConverter.toTableName(tablePrefix, tableId));
+  }
+
+  @Override
+  public List<TableId> listTablesInNamespace(HBaseAdmin admin, Id.Namespace namespaceId) throws IOException {
+    List<TableId> tableIds = Lists.newArrayList();
+    HTableDescriptor[] hTableDescriptors =
+      admin.listTableDescriptorsByNamespace(nameConverter.toHBaseNamespace(tablePrefix, namespaceId));
+    for (HTableDescriptor hTableDescriptor : hTableDescriptors) {
+      if (isCDAPTable(hTableDescriptor)) {
+        tableIds.add(nameConverter.from(hTableDescriptor));
+      }
+    }
+    return tableIds;
+  }
+
+  @Override
+  public List<TableId> listTables(HBaseAdmin admin) throws IOException {
+    List<TableId> tableIds = Lists.newArrayList();
+    HTableDescriptor[] hTableDescriptors = admin.listTables();
+    for (HTableDescriptor hTableDescriptor : hTableDescriptors) {
+      if (isCDAPTable(hTableDescriptor)) {
+        tableIds.add(nameConverter.from(hTableDescriptor));
+      }
+    }
+    return tableIds;
+  }
+
+  @Override
+  public void setCompression(HColumnDescriptor columnDescriptor, CompressionType type) {
+    switch (type) {
+      case LZO:
+        columnDescriptor.setCompressionType(Compression.Algorithm.LZO);
+        break;
+      case SNAPPY:
+        columnDescriptor.setCompressionType(Compression.Algorithm.SNAPPY);
+        break;
+      case GZIP:
+        columnDescriptor.setCompressionType(Compression.Algorithm.GZ);
+        break;
+      case NONE:
+        columnDescriptor.setCompressionType(Compression.Algorithm.NONE);
+        break;
+      default:
+        throw new IllegalArgumentException("Unsupported compression type: " + type);
+    }
+  }
+
+  @Override
+  public void setBloomFilter(HColumnDescriptor columnDescriptor, BloomType type) {
+    switch (type) {
+      case ROW:
+        columnDescriptor.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.ROW);
+        break;
+      case ROWCOL:
+        columnDescriptor.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.ROWCOL);
+        break;
+      case NONE:
+        columnDescriptor.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.NONE);
+        break;
+      default:
+        throw new IllegalArgumentException("Unsupported bloom filter type: " + type);
+    }
+  }
+
+  @Override
+  public CompressionType getCompression(HColumnDescriptor columnDescriptor) {
+    Compression.Algorithm type = columnDescriptor.getCompressionType();
+    switch (type) {
+      case LZO:
+        return CompressionType.LZO;
+      case SNAPPY:
+        return CompressionType.SNAPPY;
+      case GZ:
+        return CompressionType.GZIP;
+      case NONE:
+        return CompressionType.NONE;
+      default:
+        throw new IllegalArgumentException("Unsupported compression type: " + type);
+    }
+  }
+
+  @Override
+  public BloomType getBloomFilter(HColumnDescriptor columnDescriptor) {
+    org.apache.hadoop.hbase.regionserver.BloomType type = columnDescriptor.getBloomFilterType();
+    switch (type) {
+      case ROW:
+        return BloomType.ROW;
+      case ROWCOL:
+        return BloomType.ROWCOL;
+      case NONE:
+        return BloomType.NONE;
+      default:
+        throw new IllegalArgumentException("Unsupported bloom filter type: " + type);
+    }
+  }
+
+  @Override
+  public Class<? extends Coprocessor> getTransactionDataJanitorClassForVersion() {
+    return DefaultTransactionProcessor.class;
+  }
+
+  @Override
+  public Class<? extends Coprocessor> getQueueRegionObserverClassForVersion() {
+    return HBaseQueueRegionObserver.class;
+  }
+
+  @Override
+  public Class<? extends Coprocessor> getDequeueScanObserverClassForVersion() {
+    return DequeueScanObserver.class;
+  }
+
+  @Override
+  public Class<? extends Coprocessor> getIncrementHandlerClassForVersion() {
+    return IncrementHandler.class;
+  }
+
+  @Override
+  public Map<TableId, TableStats> getTableStats(HBaseAdmin admin) throws IOException {
+    // The idea is to walk thru live region servers, collect table region stats and aggregate them towards table total
+    // metrics.
+    Map<TableId, TableStats> datasetStat = Maps.newHashMap();
+    ClusterStatus clusterStatus = admin.getClusterStatus();
+
+    for (ServerName serverName : clusterStatus.getServers()) {
+      Map<byte[], RegionLoad> regionsLoad = clusterStatus.getLoad(serverName).getRegionsLoad();
+
+      for (RegionLoad regionLoad : regionsLoad.values()) {
+        //String tableName = Bytes.toString(HRegionInfo.getTableName(regionLoad.getName()));
+        TableName tableName = HRegionInfo.getTable(regionLoad.getName());
+        if (!admin.tableExists(tableName) || !isCDAPTable(admin.getTableDescriptor(tableName))) {
+          continue;
+        }
+        HTableNameConverter hTableNameConverter = new HTable10CDHNameConverter();
+        TableId tableId = hTableNameConverter.from(new HTableDescriptor(tableName));
+        TableStats stat = datasetStat.get(tableId);
+        if (stat == null) {
+          stat = new TableStats(regionLoad.getStorefileSizeMB(), regionLoad.getMemStoreSizeMB());
+          datasetStat.put(tableId, stat);
+        } else {
+          stat.incStoreFileSizeMB(regionLoad.getStorefileSizeMB());
+          stat.incMemStoreSizeMB(regionLoad.getMemStoreSizeMB());
+        }
+      }
+    }
+    return datasetStat;
+  }
+}

--- a/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/util/hbase/HTable10CDHNameConverter.java
+++ b/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/util/hbase/HTable10CDHNameConverter.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.data2.util.TableId;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.TableName;
+
+/**
+ * Utility methods for dealing with HBase table name conversions in HBase 1.0 (CDH).
+ */
+public class HTable10CDHNameConverter extends HTableNameConverter {
+
+  @Override
+  public String getSysConfigTablePrefix(HTableDescriptor htd) {
+    return getNamespacePrefix(htd) + "_" + Constants.SYSTEM_NAMESPACE + ":";
+  }
+
+  @Override
+  public TableId from(HTableDescriptor htd) {
+    return prefixedTableIdFromTableName(htd.getTableName()).getTableId();
+  }
+
+  @Override
+  public String getNamespacePrefix(HTableDescriptor htd) {
+    return prefixedTableIdFromTableName(htd.getTableName()).getTablePrefix();
+  }
+
+  public TableName toTableName(String tablePrefix, TableId tableId) {
+    return TableName.valueOf(toHBaseNamespace(tablePrefix, tableId.getNamespace()),
+                             getHBaseTableName(tablePrefix, tableId));
+  }
+
+  private PrefixedTableId prefixedTableIdFromTableName(TableName tableName) {
+    return fromHBaseTableName(tableName.getNamespaceAsString(), tableName.getQualifierAsString());
+  }
+}

--- a/cdap-hbase-compat-1.0-cdh/src/test/java/co/cask/cdap/data/hbase/HBase10CDHTest.java
+++ b/cdap-hbase-compat-1.0-cdh/src/test/java/co/cask/cdap/data/hbase/HBase10CDHTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data.hbase;
+
+import com.google.common.base.Function;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HBaseTestingUtility;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.HRegionInfo;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.MiniHBaseCluster;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.regionserver.HRegion;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.JVMClusterUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * {@link HBaseTestBase} implementation supporting HBase 1.0.
+ */
+public class HBase10CDHTest extends HBaseTestBase {
+  private static final Logger LOG = LoggerFactory.getLogger(HBase10CDHTest.class);
+
+  protected HBaseTestingUtility testUtil = new HBaseTestingUtility();
+
+  @Override
+  public Configuration getConfiguration() {
+    return testUtil.getConfiguration();
+  }
+
+  @Override
+  public int getZKClientPort() {
+    return testUtil.getZkCluster().getClientPort();
+  }
+
+  @Override
+  public void startHBase() throws Exception {
+    testUtil.startMiniCluster();
+  }
+
+  @Override
+  public void stopHBase() throws Exception {
+    testUtil.shutdownMiniCluster();
+  }
+
+  @Override
+  public MiniHBaseCluster getHBaseCluster() {
+    return testUtil.getHBaseCluster();
+  }
+
+  @Override
+  public HRegion createHRegion(byte[] tableName, byte[] startKey,
+                               byte[] stopKey, String callingMethod, Configuration conf,
+                               byte[]... families)
+      throws IOException {
+    if (conf == null) {
+      conf = new Configuration();
+    }
+    HTableDescriptor htd = new HTableDescriptor(tableName);
+    for (byte [] family : families) {
+      htd.addFamily(new HColumnDescriptor(family));
+    }
+    HRegionInfo info = new HRegionInfo(htd.getTableName(), startKey, stopKey, false);
+    Path path = new Path(conf.get(HConstants.HBASE_DIR), callingMethod);
+    FileSystem fs = FileSystem.get(conf);
+    if (fs.exists(path)) {
+      if (!fs.delete(path, true)) {
+        throw new IOException("Failed delete of " + path);
+      }
+    }
+    return HRegion.createHRegion(info, path, conf, htd);
+  }
+
+  @Override
+  public void forceRegionFlush(byte[] tableName) throws IOException {
+    MiniHBaseCluster hbaseCluster = getHBaseCluster();
+    if (hbaseCluster != null) {
+      TableName qualifiedTableName = TableName.valueOf(tableName);
+      for (JVMClusterUtil.RegionServerThread t : hbaseCluster.getRegionServerThreads()) {
+        List<HRegion> serverRegions = t.getRegionServer().getOnlineRegions(qualifiedTableName);
+        int cnt = 0;
+        for (HRegion region : serverRegions) {
+          region.flushcache();
+          cnt++;
+        }
+        LOG.info("RegionServer {}: Flushed {} regions for table {}", t.getRegionServer().getServerName().toString(),
+                 cnt, Bytes.toStringBinary(tableName));
+      }
+    }
+  }
+
+  @Override
+  public void forceRegionCompact(byte[] tableName, boolean majorCompact) throws IOException {
+    MiniHBaseCluster hbaseCluster = getHBaseCluster();
+    if (hbaseCluster != null) {
+      TableName qualifiedTableName = TableName.valueOf(tableName);
+      for (JVMClusterUtil.RegionServerThread t : hbaseCluster.getRegionServerThreads()) {
+        List<HRegion> serverRegions = t.getRegionServer().getOnlineRegions(qualifiedTableName);
+        int cnt = 0;
+        for (HRegion region : serverRegions) {
+          region.compactStores(majorCompact);
+          cnt++;
+        }
+        LOG.info("RegionServer {}: Compacted {} regions for table {}", t.getRegionServer().getServerName().toString(),
+                 cnt, Bytes.toStringBinary(tableName));
+      }
+    }
+  }
+
+  @Override
+  public <T> Map<byte[], T> forEachRegion(byte[] tableName, Function<HRegion, T> function) {
+    MiniHBaseCluster hbaseCluster = getHBaseCluster();
+    Map<byte[], T> results = new TreeMap<>(Bytes.BYTES_COMPARATOR);
+    // make sure consumer config cache is updated
+    for (JVMClusterUtil.RegionServerThread t : hbaseCluster.getRegionServerThreads()) {
+      List<HRegion> serverRegions = t.getRegionServer().getOnlineRegions(TableName.valueOf(tableName));
+      for (HRegion region : serverRegions) {
+        results.put(region.getRegionName(), function.apply(region));
+      }
+    }
+    return results;
+  }
+
+  @Override
+  public void waitUntilTableAvailable(byte[] tableName, long timeoutInMillis)
+      throws IOException, InterruptedException {
+    testUtil.waitTableAvailable(tableName, timeoutInMillis);
+    testUtil.waitUntilAllRegionsAssigned(TableName.valueOf(tableName), timeoutInMillis);
+  }
+}

--- a/cdap-hbase-compat-1.0-cdh/src/test/java/co/cask/cdap/data2/increment/hbase10cdh/IncrementHandlerTest.java
+++ b/cdap-hbase-compat-1.0-cdh/src/test/java/co/cask/cdap/data2/increment/hbase10cdh/IncrementHandlerTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.increment.hbase10cdh;
+
+import co.cask.cdap.data2.increment.hbase.AbstractIncrementHandlerTest;
+import co.cask.cdap.data2.increment.hbase.IncrementHandlerState;
+import co.cask.cdap.data2.increment.hbase.TimestampOracle;
+import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
+import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
+import co.cask.cdap.test.SlowTests;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.Coprocessor;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.HTable;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.ResultScanner;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.regionserver.HRegion;
+import org.apache.hadoop.hbase.regionserver.RegionScanner;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.experimental.categories.Category;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Tests for the HBase 0.98+ version of the {@link IncrementHandler} coprocessor.
+ */
+@Category(SlowTests.class)
+public class IncrementHandlerTest extends AbstractIncrementHandlerTest {
+
+  @Override
+  public void assertColumn(HTable table, byte[] row, byte[] col, long expected) throws Exception {
+    Result res = table.get(new Get(row));
+    Cell resA = res.getColumnLatestCell(FAMILY, col);
+    assertFalse(res.isEmpty());
+    assertNotNull(resA);
+    assertEquals(expected, Bytes.toLong(resA.getValue()));
+
+    Scan scan = new Scan(row);
+    scan.addFamily(FAMILY);
+    ResultScanner scanner = table.getScanner(scan);
+    Result scanRes = scanner.next();
+    assertNotNull(scanRes);
+    assertFalse(scanRes.isEmpty());
+    Cell scanResA = scanRes.getColumnLatestCell(FAMILY, col);
+    assertArrayEquals(row, scanResA.getRow());
+    assertEquals(expected, Bytes.toLong(scanResA.getValue()));
+  }
+
+  public void assertColumns(HTable table, byte[] row, byte[][] cols, long[] expected) throws Exception {
+    assertEquals(cols.length, expected.length);
+
+    Get get = new Get(row);
+    Scan scan = new Scan(row);
+    for (byte[] col : cols) {
+      get.addColumn(FAMILY, col);
+      scan.addColumn(FAMILY, col);
+    }
+
+    // check get
+    Result res = table.get(get);
+    assertFalse(res.isEmpty());
+    for (int i = 0; i < cols.length; i++) {
+      Cell resCell = res.getColumnLatestCell(FAMILY, cols[i]);
+      assertNotNull(resCell);
+      assertEquals(expected[i], Bytes.toLong(resCell.getValue()));
+    }
+
+    // check scan
+    ResultScanner scanner = table.getScanner(scan);
+    Result scanRes = scanner.next();
+    assertNotNull(scanRes);
+    assertFalse(scanRes.isEmpty());
+    for (int i = 0; i < cols.length; i++) {
+      Cell scanResCell = scanRes.getColumnLatestCell(FAMILY, cols[i]);
+      assertArrayEquals(row, scanResCell.getRow());
+      assertEquals(expected[i], Bytes.toLong(scanResCell.getValue()));
+    }
+  }
+
+  @Override
+  public HTable createTable(TableId tableId) throws Exception {
+    HBaseTableUtil tableUtil = new HBaseTableUtilFactory(cConf).get();
+    HTableDescriptor tableDesc = tableUtil.createHTableDescriptor(tableId);
+    HColumnDescriptor columnDesc = new HColumnDescriptor(FAMILY);
+    columnDesc.setMaxVersions(Integer.MAX_VALUE);
+    columnDesc.setValue(IncrementHandlerState.PROPERTY_TRANSACTIONAL, "false");
+    tableDesc.addFamily(columnDesc);
+    tableDesc.addCoprocessor(IncrementHandler.class.getName());
+    testUtil.getHBaseAdmin().createTable(tableDesc);
+    testUtil.waitUntilTableAvailable(tableDesc.getName(), 5000);
+    return tableUtil.createHTable(conf, tableId);
+  }
+
+  @Override
+  public RegionWrapper createRegion(TableId tableId, Map<String, String> familyProperties) throws Exception {
+    HColumnDescriptor columnDesc = new HColumnDescriptor(FAMILY);
+    columnDesc.setMaxVersions(Integer.MAX_VALUE);
+    for (Map.Entry<String, String> prop : familyProperties.entrySet()) {
+      columnDesc.setValue(prop.getKey(), prop.getValue());
+    }
+    return new HBase98RegionWrapper(
+        IncrementSummingScannerTest.createRegion(testUtil.getConfiguration(), cConf, tableId, columnDesc));
+  }
+
+  public static ColumnCell convertCell(Cell cell) {
+    return new ColumnCell(CellUtil.cloneRow(cell), CellUtil.cloneFamily(cell), CellUtil.cloneQualifier(cell),
+        cell.getTimestamp(), CellUtil.cloneValue(cell));
+  }
+
+  public class HBase98RegionWrapper implements RegionWrapper {
+    private final HRegion region;
+
+    public HBase98RegionWrapper(HRegion region) {
+      this.region = region;
+    }
+
+    @Override
+    public void initialize() throws IOException {
+      region.initialize();
+    }
+
+    @Override
+    public void put(Put put) throws IOException {
+      region.put(put);
+    }
+
+    @Override
+    public boolean scanRegion(List<ColumnCell> results, byte[] startRow) throws IOException {
+      return scanRegion(results, startRow, null);
+    }
+
+    @Override
+    public boolean scanRegion(List<ColumnCell> results, byte[] startRow, byte[][] columns) throws IOException {
+      Scan scan = new Scan().setMaxVersions().setStartRow(startRow);
+      if (columns != null) {
+        for (int i = 0; i < columns.length; i++) {
+          scan.addColumn(FAMILY, columns[i]);
+        }
+      }
+      RegionScanner rs = region.getScanner(scan);
+      try {
+        List<Cell> tmpResults = new ArrayList<>();
+        boolean hasMore = rs.next(tmpResults);
+        for (Cell cell : tmpResults) {
+          results.add(convertCell(cell));
+        }
+        return hasMore;
+      } finally {
+        rs.close();
+      }
+    }
+
+    @Override
+    public boolean flush() throws IOException {
+      HRegion.FlushResult result = region.flushcache();
+      return result.isCompactionNeeded();
+    }
+
+    @Override
+    public void compact(boolean majorCompact) throws IOException {
+      region.compactStores(majorCompact);
+    }
+
+    @Override
+    public void setCoprocessorTimestampOracle(TimestampOracle timeOracle) {
+      Coprocessor cp = region.getCoprocessorHost().findCoprocessor(IncrementHandler.class.getName());
+      assertNotNull(cp);
+      ((IncrementHandler) cp).setTimestampOracle(timeOracle);
+    }
+
+    @Override
+    public void close() throws IOException {
+      region.close();
+    }
+  }
+}

--- a/cdap-hbase-compat-1.0-cdh/src/test/java/co/cask/cdap/data2/increment/hbase10cdh/IncrementSummingScannerTest.java
+++ b/cdap-hbase-compat-1.0-cdh/src/test/java/co/cask/cdap/data2/increment/hbase10cdh/IncrementSummingScannerTest.java
@@ -1,0 +1,471 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.increment.hbase10cdh;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.data2.dataset2.lib.table.hbase.HBaseTable;
+import co.cask.cdap.data2.increment.hbase.IncrementHandlerState;
+import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
+import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
+import com.google.common.collect.Lists;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.HBaseTestingUtility;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HRegionInfo;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.MockRegionServerServices;
+import org.apache.hadoop.hbase.ServerName;
+import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.regionserver.HRegion;
+import org.apache.hadoop.hbase.regionserver.HRegionFileSystem;
+import org.apache.hadoop.hbase.regionserver.RegionScanner;
+import org.apache.hadoop.hbase.regionserver.ScanType;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.wal.WAL;
+import org.apache.hadoop.hbase.wal.WALFactory;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.net.InetAddress;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link IncrementSummingScanner} implementation.
+ */
+public class IncrementSummingScannerTest {
+  private static final byte[] TRUE = Bytes.toBytes(true);
+  private static HBaseTestingUtility testUtil;
+  private static Configuration conf;
+  private static CConfiguration cConf;
+
+  @BeforeClass
+  public static void setupBeforeClass() throws Exception {
+    testUtil = new HBaseTestingUtility();
+    testUtil.startMiniCluster();
+    conf = testUtil.getConfiguration();
+    cConf = CConfiguration.create();
+  }
+
+  @AfterClass
+  public static void shutdownAfterClass() throws Exception {
+    testUtil.shutdownMiniCluster();
+  }
+
+  @Test
+  public void testIncrementScanning() throws Exception {
+    TableId tableId = TableId.from(Constants.DEFAULT_NAMESPACE, "TestIncrementSummingScanner");
+    byte[] familyBytes = Bytes.toBytes("f");
+    byte[] columnBytes = Bytes.toBytes("c");
+    HRegion region = createRegion(tableId, familyBytes);
+    try {
+      region.initialize();
+
+      // test handling of a single increment value alone
+      Put p = new Put(Bytes.toBytes("r1"));
+      p.add(familyBytes, columnBytes, Bytes.toBytes(3L));
+      p.setAttribute(HBaseTable.DELTA_WRITE, TRUE);
+      region.put(p);
+
+      Scan scan = new Scan();
+      RegionScanner scanner = new IncrementSummingScanner(region, -1, region.getScanner(scan), ScanType.USER_SCAN);
+      List<Cell> results = Lists.newArrayList();
+      scanner.next(results);
+
+      assertEquals(1, results.size());
+      Cell cell = results.get(0);
+      assertNotNull(cell);
+      assertEquals(3L, Bytes.toLong(cell.getValue()));
+
+      // test handling of a single total sum
+      p = new Put(Bytes.toBytes("r2"));
+      p.add(familyBytes, columnBytes, Bytes.toBytes(5L));
+      region.put(p);
+
+      scan = new Scan(Bytes.toBytes("r2"));
+
+      scanner = new IncrementSummingScanner(region, -1, region.getScanner(scan), ScanType.USER_SCAN);
+      results = Lists.newArrayList();
+      scanner.next(results);
+
+      assertEquals(1, results.size());
+      cell = results.get(0);
+      assertNotNull(cell);
+      assertEquals(5L, Bytes.toLong(cell.getValue()));
+
+      // test handling of multiple increment values
+      long now = System.currentTimeMillis();
+      p = new Put(Bytes.toBytes("r3"));
+      for (int i = 0; i < 5; i++) {
+        p.add(familyBytes, columnBytes, now - i, Bytes.toBytes((long) (i + 1)));
+      }
+      p.setAttribute(HBaseTable.DELTA_WRITE, TRUE);
+      region.put(p);
+
+      scan = new Scan(Bytes.toBytes("r3"));
+      scan.setMaxVersions();
+      scanner = new IncrementSummingScanner(region, -1, region.getScanner(scan), ScanType.USER_SCAN);
+      results = Lists.newArrayList();
+      scanner.next(results);
+
+      assertEquals(1, results.size());
+      cell = results.get(0);
+      assertNotNull(cell);
+      assertEquals(15L, Bytes.toLong(cell.getValue()));
+
+      // test handling of multiple increment values followed by a total sum, then other increments
+      now = System.currentTimeMillis();
+      p = new Put(Bytes.toBytes("r4"));
+      for (int i = 0; i < 3; i++) {
+        p.add(familyBytes, columnBytes, now - i, Bytes.toBytes(1L));
+      }
+      p.setAttribute(HBaseTable.DELTA_WRITE, TRUE);
+      region.put(p);
+
+      // this put will appear as a "total" sum prior to all the delta puts
+      p = new Put(Bytes.toBytes("r4"));
+      p.add(familyBytes, columnBytes, now - 5, Bytes.toBytes(5L));
+      region.put(p);
+
+      scan = new Scan(Bytes.toBytes("r4"));
+      scan.setMaxVersions();
+      scanner = new IncrementSummingScanner(region, -1, region.getScanner(scan), ScanType.USER_SCAN);
+      results = Lists.newArrayList();
+      scanner.next(results);
+
+      assertEquals(1, results.size());
+      cell = results.get(0);
+      assertNotNull(cell);
+      assertEquals(8L, Bytes.toLong(cell.getValue()));
+
+      // test handling of an increment column followed by a non-increment column
+      p = new Put(Bytes.toBytes("r4"));
+      p.add(familyBytes, Bytes.toBytes("c2"), Bytes.toBytes("value"));
+      region.put(p);
+
+      scan = new Scan(Bytes.toBytes("r4"));
+      scan.setMaxVersions();
+      scanner = new IncrementSummingScanner(region, -1, region.getScanner(scan), ScanType.USER_SCAN);
+      results = Lists.newArrayList();
+      scanner.next(results);
+
+      assertEquals(2, results.size());
+      cell = results.get(0);
+      assertNotNull(cell);
+      assertEquals(8L, Bytes.toLong(cell.getValue()));
+
+      cell = results.get(1);
+      assertNotNull(cell);
+      assertEquals("value", Bytes.toString(cell.getValue()));
+
+      // test handling of an increment column followed by a delete
+      now = System.currentTimeMillis();
+      Delete d = new Delete(Bytes.toBytes("r5"));
+      d.deleteColumn(familyBytes, columnBytes, now - 3);
+      region.delete(d);
+
+      p = new Put(Bytes.toBytes("r5"));
+      for (int i = 2; i >= 0; i--) {
+        p.add(familyBytes, columnBytes, now - i, Bytes.toBytes(1L));
+      }
+      p.setAttribute(HBaseTable.DELTA_WRITE, TRUE);
+      region.put(p);
+
+      scan = new Scan(Bytes.toBytes("r5"));
+      scan.setMaxVersions();
+      scan.setRaw(true);
+      scanner = new IncrementSummingScanner(region, -1, region.getScanner(scan), ScanType.COMPACT_RETAIN_DELETES);
+      results = Lists.newArrayList();
+      scanner.next(results);
+
+      // delete marker will not be returned for user scan
+      assertEquals(2, results.size());
+      cell = results.get(0);
+      assertNotNull(cell);
+      assertEquals(3L, Bytes.toLong(cell.getValue(), IncrementHandlerState.DELTA_MAGIC_PREFIX.length, 8));
+      // next cell should be the delete
+      cell = results.get(1);
+      assertTrue(CellUtil.isDelete(cell));
+    } finally {
+      region.close();
+    }
+
+  }
+
+  @Test
+  public void testFlushAndCompact() throws Exception {
+    TableId tableId = TableId.from(Constants.DEFAULT_NAMESPACE, "TestFlushAndCompact");
+    byte[] familyBytes = Bytes.toBytes("f");
+    byte[] columnBytes = Bytes.toBytes("c");
+    HRegion region = createRegion(tableId, familyBytes);
+    try {
+      region.initialize();
+
+      // load an initial set of increments
+      long ts = System.currentTimeMillis();
+      byte[] row1 = Bytes.toBytes("row1");
+      for (int i = 0; i < 50; i++) {
+        Put p = new Put(row1);
+        p.add(familyBytes, columnBytes, ts, Bytes.toBytes(1L));
+        p.setAttribute(HBaseTable.DELTA_WRITE, TRUE);
+        ts++;
+        region.put(p);
+      }
+
+      byte[] row2 = Bytes.toBytes("row2");
+      ts = System.currentTimeMillis();
+      // start with a full put
+      Put row2P = new Put(row2);
+      row2P.add(familyBytes, columnBytes, ts++, Bytes.toBytes(10L));
+      region.put(row2P);
+      for (int i = 0; i < 10; i++) {
+        Put p = new Put(row2);
+        p.add(familyBytes, columnBytes, ts++, Bytes.toBytes(1L));
+        p.setAttribute(HBaseTable.DELTA_WRITE, TRUE);
+        region.put(p);
+      }
+
+      // force a region flush
+      region.flushcache();
+      region.waitForFlushesAndCompactions();
+
+      Result r1 = region.get(new Get(row1));
+      assertNotNull(r1);
+      assertFalse(r1.isEmpty());
+      // row1 should have a full put aggregating all 50 incrments
+      Cell r1Cell = r1.getColumnLatestCell(familyBytes, columnBytes);
+      assertNotNull(r1Cell);
+      assertEquals(50L, Bytes.toLong(r1Cell.getValue()));
+
+      Result r2 = region.get(new Get(row2));
+      assertNotNull(r2);
+      assertFalse(r2.isEmpty());
+      // row2 should have a full put aggregating prior put + 10 increments
+      Cell r2Cell = r2.getColumnLatestCell(familyBytes, columnBytes);
+      assertNotNull(r2Cell);
+      assertEquals(20L, Bytes.toLong(r2Cell.getValue()));
+
+      // add 30 more increments to row2
+      for (int i = 0; i < 30; i++) {
+        Put p = new Put(row2);
+        p.add(familyBytes, columnBytes, ts++, Bytes.toBytes(1L));
+        p.setAttribute(HBaseTable.DELTA_WRITE, TRUE);
+        region.put(p);
+      }
+
+      // row2 should now have a full put aggregating prior 20 value + 30 increments
+      r2 = region.get(new Get(row2));
+      assertNotNull(r2);
+      assertFalse(r2.isEmpty());
+      r2Cell = r2.getColumnLatestCell(familyBytes, columnBytes);
+      assertNotNull(r2Cell);
+      assertEquals(50L, Bytes.toLong(r2Cell.getValue()));
+
+      // force another region flush
+      region.flushcache();
+      region.waitForFlushesAndCompactions();
+
+      // add 100 more increments to row2
+      for (int i = 0; i < 100; i++) {
+        Put p = new Put(row2);
+        p.add(familyBytes, columnBytes, ts++, Bytes.toBytes(1L));
+        p.setAttribute(HBaseTable.DELTA_WRITE, TRUE);
+        region.put(p);
+      }
+
+      // row2 should now have a full put aggregating prior 50 value + 100 increments
+      r2 = region.get(new Get(row2));
+      assertNotNull(r2);
+      assertFalse(r2.isEmpty());
+      r2Cell = r2.getColumnLatestCell(familyBytes, columnBytes);
+      assertNotNull(r2Cell);
+      assertEquals(150L, Bytes.toLong(r2Cell.getValue()));
+    } finally {
+      region.close();
+    }
+  }
+
+  @Test
+  public void testIncrementScanningWithBatchAndUVB() throws Exception {
+    TableId tableId = TableId.from(Constants.DEFAULT_NAMESPACE, "TestIncrementSummingScannerWithUpperVisibilityBound");
+    byte[] familyBytes = Bytes.toBytes("f");
+    byte[] columnBytes = Bytes.toBytes("c");
+    HRegion region = createRegion(tableId, familyBytes);
+    try {
+      region.initialize();
+
+      long start = 0;
+      long now = start;
+      long counter1 = 0;
+
+      // adding 5 delta increments
+      for (int i = 0; i < 5; i++) {
+        Put p = new Put(Bytes.toBytes("r1"), now++);
+        p.add(familyBytes, columnBytes, Bytes.toBytes(1L));
+        p.setAttribute(HBaseTable.DELTA_WRITE, TRUE);
+        region.put(p);
+        counter1++;
+      }
+
+      // different combinations of uvb and limit (see batch test above)
+      // At least these cases we want to cover for batch:
+      // * batch=<not set> // unlimited by default
+      // * batch=1
+      // * batch size less than delta inc group size
+      // * batch size greater than delta inc group size
+      // * batch size is bigger than all delta incs available
+      // At least these cases we want to cover for uvb:
+      // * uvb=<not set> // 0
+      // * uvb less than max tx of delta inc
+      // * uvb greater than max tx of delta inc
+      // * multiple uvbs applied to simulate multiple flush & compactions
+      // Also: we want different combinations of batch limit & uvbs
+      for (int i = 0; i < 7; i++) {
+        for (int k = 0; k < 4; k++) {
+          long[] uvbs = new long[k];
+          for (int l = 0; l < uvbs.length; l++) {
+            uvbs[l] = start + (k + 1) * (l + 1);
+          }
+          verifyCounts(region, new Scan().setMaxVersions(), new long[]{counter1}, i > 0 ? i : -1, uvbs);
+        }
+      }
+
+      // Now test same with two groups of increments
+      int counter2 = 0;
+      for (int i = 0; i < 5; i++) {
+        Put p = new Put(Bytes.toBytes("r2"), now + i);
+        p.add(familyBytes, columnBytes, Bytes.toBytes(2L));
+        p.setAttribute(HBaseTable.DELTA_WRITE, TRUE);
+        region.put(p);
+        counter2 += 2;
+      }
+
+      for (int i = 0; i < 12; i++) {
+        for (int k = 0; k < 4; k++) {
+          long[] uvbs = new long[k];
+          for (int l = 0; l < uvbs.length; l++) {
+            uvbs[l] = start + (k + 1) * (l + 1);
+          }
+          verifyCounts(region, new Scan().setMaxVersions(), new long[]{counter1, counter2}, i > 0 ? i : -1, uvbs);
+        }
+      }
+
+    } finally {
+      region.close();
+    }
+  }
+
+  private void verifyCounts(HRegion region, Scan scan, long[] counts) throws Exception {
+    verifyCounts(region, scan, counts, -1);
+  }
+
+  private void verifyCounts(HRegion region, Scan scan, long[] counts, int batch) throws Exception {
+    RegionScanner scanner = new IncrementSummingScanner(region, batch, region.getScanner(scan), ScanType.USER_SCAN);
+    // init with false if loop will execute zero times
+    boolean hasMore = counts.length > 0;
+    for (long count : counts) {
+      List<Cell> results = Lists.newArrayList();
+      hasMore = scanner.next(results);
+      assertEquals(1, results.size());
+      Cell cell = results.get(0);
+      assertNotNull(cell);
+      assertEquals(count, Bytes.toLong(cell.getValue()));
+    }
+    assertFalse(hasMore);
+  }
+
+  private void verifyCounts(HRegion region, Scan scan, long[] counts, int batch, long[] upperVisBound)
+      throws Exception {
+    // The idea is to chain IncrementSummingScanner: first couple respect the upperVisBound and may produce multiple
+    // cells for single value. This is what happens during flush or compaction. Second one will mimic user scan over
+    // flushed or compacted: it should merge all delta increments appropriately.
+    RegionScanner scanner = region.getScanner(scan);
+
+    for (int i = 0; i < upperVisBound.length; i++) {
+      scanner = new IncrementSummingScanner(region, batch, scanner,
+          ScanType.COMPACT_RETAIN_DELETES, upperVisBound[i], -1);
+    }
+    scanner = new IncrementSummingScanner(region, batch, scanner, ScanType.USER_SCAN);
+    // init with false if loop will execute zero times
+    boolean hasMore = counts.length > 0;
+    for (long count : counts) {
+      List<Cell> results = Lists.newArrayList();
+      hasMore = scanner.next(results);
+      assertEquals(1, results.size());
+      Cell cell = results.get(0);
+      assertNotNull(cell);
+      assertEquals(count, Bytes.toLong(cell.getValue()));
+    }
+    assertFalse(hasMore);
+  }
+
+  private HRegion createRegion(TableId tableId, byte[] family) throws Exception {
+    return createRegion(conf, cConf, tableId, new HColumnDescriptor(family));
+  }
+
+  static HRegion createRegion(Configuration hConf, CConfiguration cConf, TableId tableId,
+                              HColumnDescriptor cfd) throws Exception {
+    HBaseTableUtil tableUtil = new HBaseTableUtilFactory(cConf).get();
+    HTableDescriptor htd = tableUtil.createHTableDescriptor(tableId);
+    cfd.setMaxVersions(Integer.MAX_VALUE);
+    cfd.setKeepDeletedCells(true);
+    htd.addFamily(cfd);
+    htd.addCoprocessor(IncrementHandler.class.getName());
+
+    String tableName = htd.getNameAsString();
+    Path tablePath = new Path("/tmp/" + tableName);
+    Path hlogPath = new Path("/tmp/hlog-" + tableName);
+    FileSystem fs = FileSystem.get(hConf);
+    assertTrue(fs.mkdirs(tablePath));
+    WALFactory walFactory = new WALFactory(hConf, null, hlogPath.toString());
+    WAL hLog = walFactory.getWAL(new byte[]{1});
+    HRegionInfo regionInfo = new HRegionInfo(htd.getTableName());
+    HRegionFileSystem regionFS = HRegionFileSystem.createRegionOnFileSystem(hConf, fs, tablePath, regionInfo);
+    return new HRegion(regionFS, hLog, hConf, htd,
+                       new LocalRegionServerServices(hConf, ServerName.valueOf(
+                           InetAddress.getLocalHost().getHostName(), 0, System.currentTimeMillis())));
+  }
+
+  private static class LocalRegionServerServices extends MockRegionServerServices {
+    private final ServerName serverName;
+
+    public LocalRegionServerServices(Configuration conf, ServerName serverName) {
+      super(conf);
+      this.serverName = serverName;
+    }
+
+    @Override
+    public ServerName getServerName() {
+      return serverName;
+    }
+  }
+}

--- a/cdap-hbase-compat-1.0-cdh/src/test/java/co/cask/cdap/data2/transaction/queue/hbase/HBase10CDHQueueTest.java
+++ b/cdap-hbase-compat-1.0-cdh/src/test/java/co/cask/cdap/data2/transaction/queue/hbase/HBase10CDHQueueTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.transaction.queue.hbase;
+
+import co.cask.cdap.test.XSlowTests;
+import org.junit.experimental.categories.Category;
+
+/**
+ * Queue test implementation running on HBase 1.0 (CDH).
+ */
+@Category(XSlowTests.class)
+public class HBase10CDHQueueTest extends HBaseQueueTest {
+  // nothing to override
+}

--- a/cdap-hbase-compat-1.0-cdh/src/test/java/co/cask/cdap/data2/util/hbase/HBase10CDHTableUtilTest.java
+++ b/cdap-hbase-compat-1.0-cdh/src/test/java/co/cask/cdap/data2/util/hbase/HBase10CDHTableUtilTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2014-2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.test.XSlowTests;
+import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
+import org.junit.experimental.categories.Category;
+
+/**
+ *
+ */
+@Category(XSlowTests.class)
+public class HBase10CDHTableUtilTest extends AbstractHBaseTableUtilTest {
+
+  private final HTableNameConverter nameConverter = new HTable10CDHNameConverter();
+
+  @Override
+  protected HBaseTableUtil getTableUtil() {
+    HBase10CDHTableUtil hBaseTableUtil = new HBase10CDHTableUtil();
+    hBaseTableUtil.setCConf(cConf);
+    return hBaseTableUtil;
+  }
+
+  @Override
+  protected HTableNameConverter getNameConverter() {
+    return nameConverter;
+  }
+
+  @Override
+  protected String getTableNameAsString(TableId tableId) {
+    Preconditions.checkArgument(tableId != null, "TableId should not be null.");
+    String tablePrefix = cConf.get(Constants.Dataset.TABLE_PREFIX);
+    if (Constants.DEFAULT_NAMESPACE_ID.equals(tableId.getNamespace())) {
+      return nameConverter.getHBaseTableName(tablePrefix, tableId);
+    }
+    return Joiner.on(':').join(nameConverter.toHBaseNamespace(tablePrefix, tableId.getNamespace()),
+                               nameConverter.getHBaseTableName(tablePrefix, tableId));
+  }
+
+  @Override
+  protected boolean namespacesSupported() {
+    return true;
+  }
+}

--- a/cdap-hbase-compat-1.0-cdh/src/test/java/co/cask/cdap/data2/util/hbase/HTable10CDHNameConverterTest.java
+++ b/cdap-hbase-compat-1.0-cdh/src/test/java/co/cask/cdap/data2/util/hbase/HTable10CDHNameConverterTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.data2.util.TableId;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HTable10CDHNameConverterTest {
+  @Test
+  public void testGetSysConfigTablePrefix() throws Exception {
+    CConfiguration cConf = CConfiguration.create();
+    String tablePrefix = cConf.get(Constants.Dataset.TABLE_PREFIX);
+
+    HBaseTableUtil tableUtil = new HBaseTableUtilFactory(cConf).get();
+    HTableNameConverter hBaseNameConversionUtil = new HTableNameConverterFactory().get();
+
+    HTableDescriptor htd = tableUtil.createHTableDescriptor(TableId.from("user", "some_table"));
+    Assert.assertEquals(tablePrefix + "_system:", hBaseNameConversionUtil.getSysConfigTablePrefix(htd));
+    htd = tableUtil.createHTableDescriptor(TableId.from(Constants.DEFAULT_NAMESPACE_ID, "table_in_default_ns"));
+    Assert.assertEquals(tablePrefix + "_system:", hBaseNameConversionUtil.getSysConfigTablePrefix(htd));
+  }
+}

--- a/cdap-hbase-compat-1.0/pom.xml
+++ b/cdap-hbase-compat-1.0/pom.xml
@@ -1,0 +1,339 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright © 2014 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>co.cask.cdap</groupId>
+    <artifactId>cdap</artifactId>
+    <version>3.1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>cdap-hbase-compat-1.0</artifactId>
+  <name>CDAP HBase 1.0 Compatibility</name>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-data-fabric</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.tephra</groupId>
+      <artifactId>tephra-hbase-compat-1.0</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-common</artifactId>
+      <version>${hbase10.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-client</artifactId>
+      <version>${hbase10.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-protocol</artifactId>
+      <version>${hbase10.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-server</artifactId>
+      <version>${hbase10.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-data-fabric</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.hbase</groupId>
+          <artifactId>hbase</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-common-unit-test</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-minicluster</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-server</artifactId>
+      <version>${hbase10.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-testing-util</artifactId>
+      <version>${hbase10.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdfs</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.4</version>
+        <executions>
+          <execution>
+            <id>test-jar</id>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>dist</id>
+      <properties>
+        <package.dirs>opt</package.dirs>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jar-plugin</artifactId>
+            <version>2.4</version>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <version>2.8</version>
+            <executions>
+              <execution>
+                <id>copy-dependencies</id>
+                <phase>prepare-package</phase>
+                <goals>
+                  <goal>copy-dependencies</goal>
+                </goals>
+                <configuration>
+                  <excludeArtifactIds>*</excludeArtifactIds>
+                  <includeArtifactIds>tephra-hbase-compat-1.0</includeArtifactIds>
+                  <silent>true</silent>
+                  <includeScope>compile</includeScope>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-resources-plugin</artifactId>
+            <version>2.6</version>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>rpm-prepare</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-resources-plugin</artifactId>
+            <version>2.6</version>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <version>1.7</version>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>deb-prepare</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-resources-plugin</artifactId>
+            <version>2.6</version>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <version>1.7</version>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>rpm</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <version>1.3.1</version>
+          </plugin>
+
+          <!-- Extra deployment for rpm package. -->
+          <!-- This has to be in child level, otherwise all modules would try to deploy. -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-deploy-plugin</artifactId>
+            <version>2.8</version>
+            <executions>
+              <execution>
+                <id>deploy-rpm</id>
+                <phase>deploy</phase>
+                <goals>
+                  <goal>deploy-file</goal>
+                </goals>
+                <configuration>
+                  <version>${project.version}</version>
+                  <groupId>${dist.deploy.groupId}</groupId>
+                  <artifactId>${project.artifactId}</artifactId>
+                  <packaging>noarch.rpm</packaging>
+                  <generatePom>false</generatePom>
+                  <file>${project.build.directory}/${project.artifactId}-${package.version}-1.noarch.rpm</file>
+                  <classifier>1</classifier>
+                  <repositoryId>continuuity</repositoryId>
+                  <url>${deploy.url}</url>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>deb</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <version>1.3.1</version>
+          </plugin>
+
+          <!-- Extra deployment for deb package -->
+          <!-- This has to be in child level, otherwise all modules would try to deploy. -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-deploy-plugin</artifactId>
+            <version>2.8</version>
+            <executions>
+              <execution>
+                <id>deploy-deb</id>
+                <phase>deploy</phase>
+                <goals>
+                  <goal>deploy-file</goal>
+                </goals>
+                <configuration>
+                  <version>${project.version}</version>
+                  <groupId>${dist.deploy.groupId}</groupId>
+                  <artifactId>${project.artifactId}</artifactId>
+                  <packaging>deb</packaging>
+                  <generatePom>false</generatePom>
+                  <file>${project.build.directory}/${project.artifactId}_${package.version}-1_all.deb</file>
+                  <repositoryId>continuuity</repositoryId>
+                  <url>${deploy.url}</url>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>tgz</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-assembly-plugin</artifactId>
+            <version>2.4</version>
+          </plugin>
+
+          <!-- Extra deployment for tgz package -->
+          <!-- This has to be in child level, otherwise all modules would try to deploy. -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-deploy-plugin</artifactId>
+            <version>2.8</version>
+            <executions>
+              <execution>
+                <id>deploy-tgz</id>
+                <phase>deploy</phase>
+                <goals>
+                  <goal>deploy-file</goal>
+                </goals>
+                <configuration>
+                  <version>${project.version}</version>
+                  <groupId>${dist.deploy.groupId}</groupId>
+                  <artifactId>${project.artifactId}</artifactId>
+                  <packaging>tar.gz</packaging>
+                  <generatePom>false</generatePom>
+                  <file>${project.build.directory}/${project.artifactId}-${package.version}.tar.gz</file>
+                  <repositoryId>continuuity</repositoryId>
+                  <url>${deploy.url}</url>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+  </profiles>
+
+</project>

--- a/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/increment/hbase10/IncrementFilter.java
+++ b/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/increment/hbase10/IncrementFilter.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.increment.hbase10;
+
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.filter.FilterBase;
+
+import java.io.IOException;
+
+/**
+ * Simple filter for increment columns that includes all cell values in a column with a "delta" prefix up to and
+ * including the first cell it finds that is not an increment.  This allows the {@link IncrementHandler}
+ * coprocessor to return the correct value for an increment column by summing the last total sum plus all newer
+ * delta values.
+ */
+public class IncrementFilter extends FilterBase {
+  @Override
+  public ReturnCode filterKeyValue(Cell cell) throws IOException {
+    if (IncrementHandler.isIncrement(cell)) {
+      // all visible increments should be included until we get to a non-increment
+      return ReturnCode.INCLUDE;
+    } else {
+      // as soon as we find a KV to include we can move to the next column
+      return ReturnCode.INCLUDE_AND_NEXT_COL;
+    }
+  }
+}

--- a/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/increment/hbase10/IncrementHandler.java
+++ b/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/increment/hbase10/IncrementHandler.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright © 2014-2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.increment.hbase10;
+
+import co.cask.cdap.data2.dataset2.lib.table.hbase.HBaseTable;
+import co.cask.cdap.data2.increment.hbase.IncrementHandlerState;
+import co.cask.cdap.data2.increment.hbase.TimestampOracle;
+import co.cask.cdap.data2.util.hbase.HTable10NameConverter;
+import co.cask.tephra.hbase10.Filters;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Maps;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.CoprocessorEnvironment;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.Durability;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.coprocessor.BaseRegionObserver;
+import org.apache.hadoop.hbase.coprocessor.ObserverContext;
+import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
+import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.apache.hadoop.hbase.regionserver.HRegion;
+import org.apache.hadoop.hbase.regionserver.InternalScanner;
+import org.apache.hadoop.hbase.regionserver.RegionScanner;
+import org.apache.hadoop.hbase.regionserver.ScanType;
+import org.apache.hadoop.hbase.regionserver.Store;
+import org.apache.hadoop.hbase.regionserver.compactions.CompactionRequest;
+import org.apache.hadoop.hbase.regionserver.wal.WALEdit;
+import org.apache.hadoop.hbase.util.Bytes;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+
+/**
+ * HBase coprocessor that handles reading and writing read-less increment operations.
+ *
+ * <p>Writes of incremental values are performed as normal {@code Put}s, flagged with a special attribute
+ * {@link HBaseTable#DELTA_WRITE}.  The coprocessor intercepts these
+ * writes and rewrites the cell value to use a special marker prefix.</p>
+ *
+ * <p>For read (for {@code Get} and {@code Scan}) operations, all of the delta values are summed up for a column,
+ * up to and including the most recent "full" (non-delta) value.  The sum of these delta values, plus the full value
+ * (if found) is returned for the column.</p>
+ *
+ * <p>To mitigate the performance impact on reading, this coprocessor also overrides the scanner used in flush and
+ * compaction operations, using {@link IncrementSummingScanner} to generate a new "full" value aggregated from
+ * all the successfully committed delta values.</p>
+ */
+public class IncrementHandler extends BaseRegionObserver {
+
+  private HRegion region;
+  private IncrementHandlerState state;
+
+
+  @Override
+  public void start(CoprocessorEnvironment e) throws IOException {
+    if (e instanceof RegionCoprocessorEnvironment) {
+      RegionCoprocessorEnvironment env = (RegionCoprocessorEnvironment) e;
+      this.region = ((RegionCoprocessorEnvironment) e).getRegion();
+      this.state = new IncrementHandlerState(env.getConfiguration(),
+                                             env.getRegion().getTableDesc(),
+                                             new HTable10NameConverter());
+
+      HTableDescriptor tableDesc = env.getRegion().getTableDesc();
+      for (HColumnDescriptor columnDesc : tableDesc.getFamilies()) {
+        state.initFamily(columnDesc.getName(), convertFamilyValues(columnDesc.getValues()));
+      }
+    }
+  }
+
+  @VisibleForTesting
+  public void setTimestampOracle(TimestampOracle timeOracle) {
+    state.setTimestampOracle(timeOracle);
+  }
+
+  private Map<byte[], byte[]> convertFamilyValues(Map<ImmutableBytesWritable, ImmutableBytesWritable> writableValues) {
+    Map<byte[], byte[]> converted = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
+    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> e : writableValues.entrySet()) {
+      converted.put(e.getKey().get(), e.getValue().get());
+    }
+    return converted;
+  }
+
+  @Override
+  public void preGetOp(ObserverContext<RegionCoprocessorEnvironment> ctx, Get get, List<Cell> results)
+    throws IOException {
+    Scan scan = new Scan(get);
+    scan.setMaxVersions();
+    scan.setFilter(Filters.combine(new IncrementFilter(), scan.getFilter()));
+    RegionScanner scanner = null;
+    try {
+      scanner = new IncrementSummingScanner(region, scan.getBatch(), region.getScanner(scan), ScanType.USER_SCAN);
+      scanner.next(results);
+      ctx.bypass();
+    } finally {
+      if (scanner != null) {
+        scanner.close();
+      }
+    }
+  }
+
+  @Override
+  public void prePut(ObserverContext<RegionCoprocessorEnvironment> ctx, Put put, WALEdit edit, Durability durability)
+    throws IOException {
+    // we assume that if any of the column families written to are transactional, the entire write is transactional
+    boolean transactional = state.containsTransactionalFamily(put.getFamilyCellMap().keySet());
+    boolean isIncrement = put.getAttribute(HBaseTable.DELTA_WRITE) != null;
+
+    if (isIncrement || !transactional) {
+      // incremental write
+      NavigableMap<byte[], List<Cell>> newFamilyMap = new TreeMap<>(Bytes.BYTES_COMPARATOR);
+
+      long tsToAssign = 0;
+      if (!transactional) {
+        tsToAssign = state.getUniqueTimestamp();
+      }
+      for (Map.Entry<byte[], List<Cell>> entry : put.getFamilyCellMap().entrySet()) {
+        List<Cell> newCells = new ArrayList<>(entry.getValue().size());
+        for (Cell cell : entry.getValue()) {
+          // rewrite the cell value with a special prefix to identify it as a delta
+          // for 0.98 we can update this to use cell tags
+          byte[] newValue = isIncrement ?
+              Bytes.add(IncrementHandlerState.DELTA_MAGIC_PREFIX, CellUtil.cloneValue(cell)) :
+              CellUtil.cloneValue(cell);
+          newCells.add(CellUtil.createCell(CellUtil.cloneRow(cell), CellUtil.cloneFamily(cell),
+                                           CellUtil.cloneQualifier(cell),
+                                           transactional ? cell.getTimestamp() : tsToAssign,
+                                           cell.getTypeByte(), newValue));
+        }
+        newFamilyMap.put(entry.getKey(), newCells);
+      }
+      put.setFamilyCellMap(newFamilyMap);
+    }
+    // put completes normally with value prefix marker
+  }
+
+  @Override
+  public void preDelete(ObserverContext<RegionCoprocessorEnvironment> e, Delete delete, WALEdit edit,
+                        Durability durability) throws IOException {
+    boolean transactional = state.containsTransactionalFamily(delete.getFamilyCellMap().keySet());
+    if (!transactional) {
+      long tsToAssign = state.getUniqueTimestamp();
+      delete.setTimestamp(tsToAssign);
+      // new key values
+      NavigableMap<byte[], List<Cell>> newFamilyMap = new TreeMap<>(Bytes.BYTES_COMPARATOR);
+      for (Map.Entry<byte[], List<Cell>> entry : delete.getFamilyCellMap().entrySet()) {
+        List<Cell> newCells = new ArrayList<>(entry.getValue().size());
+        for (Cell kv : entry.getValue()) {
+          // replace the timestamp
+          newCells.add(CellUtil.createCell(CellUtil.cloneRow(kv),
+              CellUtil.cloneFamily(kv),
+              CellUtil.cloneQualifier(kv),
+              tsToAssign, kv.getTypeByte(),
+              CellUtil.cloneValue(kv)));
+        }
+        newFamilyMap.put(entry.getKey(), newCells);
+      }
+      delete.setFamilyCellMap(newFamilyMap);
+    }
+  }
+
+  @Override
+  public RegionScanner preScannerOpen(ObserverContext<RegionCoprocessorEnvironment> e, Scan scan, RegionScanner s)
+    throws IOException {
+    // must see all versions to aggregate increments
+    scan.setMaxVersions();
+    scan.setFilter(Filters.combine(new IncrementFilter(), scan.getFilter()));
+    return s;
+  }
+
+  @Override
+  public RegionScanner postScannerOpen(ObserverContext<RegionCoprocessorEnvironment> ctx, Scan scan,
+                                       RegionScanner scanner)
+    throws IOException {
+    return new IncrementSummingScanner(region, scan.getBatch(), scanner, ScanType.USER_SCAN);
+  }
+
+  @Override
+  public InternalScanner preFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store,
+                                  InternalScanner scanner) throws IOException {
+    byte[] family = store.getFamily().getName();
+    return new IncrementSummingScanner(region, IncrementHandlerState.BATCH_UNLIMITED, scanner,
+        ScanType.COMPACT_RETAIN_DELETES, state.getCompactionBound(family), state.getOldestVisibleTimestamp(family));
+  }
+
+  public static boolean isIncrement(Cell cell) {
+    return !CellUtil.isDelete(cell) && cell.getValueLength() == IncrementHandlerState.DELTA_FULL_LENGTH &&
+      Bytes.equals(cell.getValueArray(), cell.getValueOffset(), IncrementHandlerState.DELTA_MAGIC_PREFIX.length,
+                   IncrementHandlerState.DELTA_MAGIC_PREFIX, 0, IncrementHandlerState.DELTA_MAGIC_PREFIX.length);
+  }
+
+  @Override
+  public InternalScanner preCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store,
+                                    InternalScanner scanner, ScanType scanType) throws IOException {
+    byte[] family = store.getFamily().getName();
+    return new IncrementSummingScanner(region, IncrementHandlerState.BATCH_UNLIMITED, scanner, scanType,
+        state.getCompactionBound(family), state.getOldestVisibleTimestamp(family));
+  }
+
+  @Override
+  public InternalScanner preCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store,
+                                    InternalScanner scanner, ScanType scanType, CompactionRequest request)
+    throws IOException {
+    byte[] family = store.getFamily().getName();
+    return new IncrementSummingScanner(region, IncrementHandlerState.BATCH_UNLIMITED, scanner, scanType,
+        state.getCompactionBound(family), state.getOldestVisibleTimestamp(family));
+  }
+}

--- a/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/increment/hbase10/IncrementSummingScanner.java
+++ b/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/increment/hbase10/IncrementSummingScanner.java
@@ -1,0 +1,340 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.increment.hbase10;
+
+import co.cask.cdap.data2.increment.hbase.IncrementHandlerState;
+import com.google.common.base.Preconditions;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.HRegionInfo;
+import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.regionserver.HRegion;
+import org.apache.hadoop.hbase.regionserver.InternalScanner;
+import org.apache.hadoop.hbase.regionserver.RegionScanner;
+import org.apache.hadoop.hbase.regionserver.ScanType;
+import org.apache.hadoop.hbase.util.Bytes;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Transforms reads of the stored delta increments into calculated sums for each column.
+ */
+class IncrementSummingScanner implements RegionScanner {
+  private static final Log LOG = LogFactory.getLog(IncrementSummingScanner.class);
+
+  private final HRegion region;
+  private final WrappedScanner baseScanner;
+  private RegionScanner baseRegionScanner;
+  private final int batchSize;
+  private final ScanType scanType;
+  // Highest timestamp, beyond which we cannot aggregate increments during flush and compaction.
+  // Increments newer than this may still be visible to running transactions
+  private final long compactionUpperBound;
+  // scan start time to use in computing TTL
+  private final long oldestTsByTTL;
+
+  IncrementSummingScanner(HRegion region, int batchSize, InternalScanner internalScanner, ScanType scanType) {
+    this(region, batchSize, internalScanner, scanType, Long.MAX_VALUE, -1);
+  }
+
+  IncrementSummingScanner(HRegion region, int batchSize, InternalScanner internalScanner, ScanType scanType,
+                          long compationUpperBound, long oldestTsByTTL) {
+    this.region = region;
+    this.batchSize = batchSize;
+    this.baseScanner = new WrappedScanner(internalScanner);
+    if (internalScanner instanceof RegionScanner) {
+      this.baseRegionScanner = (RegionScanner) internalScanner;
+    }
+    this.scanType = scanType;
+    this.compactionUpperBound = compationUpperBound;
+    this.oldestTsByTTL = oldestTsByTTL;
+  }
+
+  @Override
+  public HRegionInfo getRegionInfo() {
+    return region.getRegionInfo();
+  }
+
+  @Override
+  public boolean isFilterDone() throws IOException {
+    if (baseRegionScanner != null) {
+      return baseRegionScanner.isFilterDone();
+    }
+    throw new IllegalStateException(
+      "RegionScanner.isFilterDone() called when the wrapped scanner is not a RegionScanner");
+  }
+
+  @Override
+  public boolean reseek(byte[] bytes) throws IOException {
+    if (baseRegionScanner != null) {
+      return baseRegionScanner.reseek(bytes);
+    }
+    throw new IllegalStateException(
+      "RegionScanner.reseek() called when the wrapped scanner is not a RegionScanner");
+  }
+
+  @Override
+  public long getMaxResultSize() {
+    if (baseRegionScanner != null) {
+      return baseRegionScanner.getMaxResultSize();
+    }
+    throw new IllegalStateException(
+      "RegionScanner.isFilterDone() called when the wrapped scanner is not a RegionScanner");
+  }
+
+
+  @Override
+  public long getMvccReadPoint() {
+    if (baseRegionScanner != null) {
+      return baseRegionScanner.getMvccReadPoint();
+    }
+    throw new IllegalStateException(
+      "RegionScanner.isFilterDone() called when the wrapped scanner is not a RegionScanner");
+  }
+
+  @Override
+  public boolean nextRaw(List<Cell> cells) throws IOException {
+    return nextRaw(cells, batchSize);
+  }
+
+  @Override
+  public boolean nextRaw(List<Cell> cells, int limit) throws IOException {
+    return nextInternal(cells, limit);
+  }
+
+  @Override
+  public boolean next(List<Cell> cells) throws IOException {
+    return next(cells, batchSize);
+  }
+
+  @Override
+  public boolean next(List<Cell> cells, int limit) throws IOException {
+    return nextInternal(cells, limit);
+  }
+
+  private boolean nextInternal(List<Cell> cells, int limit) throws IOException {
+    if (LOG.isTraceEnabled()) {
+      LOG.trace("nextInternal called with limit=" + limit);
+    }
+    Cell previousIncrement = null;
+    long runningSum = 0;
+    int addedCnt = 0;
+    baseScanner.startNext();
+    Cell cell = null;
+    while ((cell = baseScanner.peekNextCell(limit)) != null && (limit <= 0 || addedCnt < limit)) {
+      // we use the "peek" semantics so that only once cell is ever emitted per iteration
+      // this makes is clearer and easier to enforce that the returned results are <= limit
+      if (LOG.isTraceEnabled()) {
+        LOG.trace("Checking cell " + cell);
+      }
+      // any cells visible to in-progress transactions must be kept unchanged
+      if (cell.getTimestamp() > compactionUpperBound) {
+        if (LOG.isTraceEnabled()) {
+          LOG.trace("Including cell visible to in-progress, cell=" + cell);
+        }
+        cells.add(cell);
+        addedCnt++;
+        baseScanner.nextCell(limit);
+        continue;
+      }
+
+      // compact any delta writes
+      if (IncrementHandler.isIncrement(cell)) {
+        if (LOG.isTraceEnabled()) {
+          LOG.trace("Found increment for row=" + Bytes.toStringBinary(CellUtil.cloneRow(cell)) + ", " +
+              "column=" + Bytes.toStringBinary(CellUtil.cloneQualifier(cell)));
+        }
+        if (!sameCell(previousIncrement, cell)) {
+          if (previousIncrement != null) {
+            // if different qualifier, and prev qualifier non-null
+            // emit the previous sum
+            if (LOG.isTraceEnabled()) {
+              LOG.trace("Including increment: sum=" + runningSum + ", cell=" + previousIncrement);
+            }
+            cells.add(newCell(previousIncrement, runningSum));
+            previousIncrement = null;
+            addedCnt++;
+            // continue without advancing, current cell will be consumed on the next iteration
+            continue;
+          }
+          previousIncrement = cell;
+          runningSum = 0;
+        }
+        // add this increment to the tally
+        runningSum += Bytes.toLong(cell.getValueArray(),
+            cell.getValueOffset() + IncrementHandlerState.DELTA_MAGIC_PREFIX.length);
+      } else {
+        // otherwise (not an increment)
+        if (previousIncrement != null) {
+          if (sameCell(previousIncrement, cell) && !CellUtil.isDelete(cell)) {
+            // if qualifier matches previous and this is a long, add to running sum, emit
+            runningSum += Bytes.toLong(cell.getValueArray(), cell.getValueOffset());
+            // this cell already processed as part of the previous increment's sum, so consume it
+            baseScanner.nextCell(limit);
+          }
+          if (LOG.isTraceEnabled()) {
+            LOG.trace("Including increment: sum=" + runningSum + ", cell=" + previousIncrement);
+          }
+          // if this put is a different cell from the previous increment, then
+          // we only emit the previous increment, reset it, and continue.
+          // the current cell will be consumed on the next iteration, if we have not yet reached the limit
+          cells.add(newCell(previousIncrement, runningSum));
+          addedCnt++;
+          previousIncrement = null;
+          runningSum = 0;
+
+          continue;
+        }
+        // otherwise emit the current cell
+        if (LOG.isTraceEnabled()) {
+          LOG.trace("Including raw cell: " + cell);
+        }
+
+        // apply any configured TTL
+        if (cell.getTimestamp() > oldestTsByTTL) {
+          cells.add(cell);
+          addedCnt++;
+        }
+      }
+      // if we made it this far, consume the current cell
+      baseScanner.nextCell(limit);
+    }
+    // emit any left over increment, if we hit the end
+    if (previousIncrement != null) {
+      // in any situation where we exited due to limit, previousIncrement should already be null
+      Preconditions.checkState(limit <= 0 || addedCnt < limit);
+      if (LOG.isTraceEnabled()) {
+        LOG.trace("Including leftover increment: sum=" + runningSum + ", cell=" + previousIncrement);
+      }
+      cells.add(newCell(previousIncrement, runningSum));
+    }
+
+    return baseScanner.hasMore();
+  }
+
+  private boolean sameCell(Cell first, Cell second) {
+    if (first == null && second == null) {
+      return true;
+    } else if (first == null || second == null) {
+      return false;
+    }
+
+    return CellUtil.matchingRow(first, second) &&
+      CellUtil.matchingFamily(first, second) &&
+      CellUtil.matchingQualifier(first, second);
+  }
+
+  private Cell newCell(Cell toCopy, long value) {
+    byte[] newValue = Bytes.toBytes(value);
+    if (scanType == ScanType.COMPACT_RETAIN_DELETES) {
+      newValue = Bytes.add(IncrementHandlerState.DELTA_MAGIC_PREFIX, newValue);
+    }
+    return CellUtil.createCell(CellUtil.cloneRow(toCopy), CellUtil.cloneFamily(toCopy),
+                               CellUtil.cloneQualifier(toCopy), toCopy.getTimestamp(),
+                               KeyValue.Type.Put.getCode(), newValue);
+  }
+
+  @Override
+  public void close() throws IOException {
+    baseScanner.close();
+  }
+
+  /**
+   * Wraps the underlying store or region scanner in an API that hides the details of calling and managing the
+   * buffered batch of results.
+   */
+  private static class WrappedScanner implements Closeable {
+    private boolean hasMore;
+    private byte[] currentRow;
+    private List<Cell> cellsToConsume = new ArrayList<>();
+    private int currentIdx;
+    private final InternalScanner scanner;
+
+    public WrappedScanner(InternalScanner scanner) {
+      this.scanner = scanner;
+    }
+
+    /**
+     * Called to signal the start of the next() call by the scanner.
+     */
+    public void startNext() {
+      currentRow = null;
+    }
+
+    /**
+     * Returns the next available cell for the current row, without advancing the pointer.  Calling this method
+     * multiple times in a row will continue to return the same cell.
+     *
+     * @param limit the limit of number of cells to return if the next batch must be fetched by the wrapped scanner
+     * @return the next available cell or null if no more cells are available for the current row
+     * @throws IOException
+     */
+    public Cell peekNextCell(int limit) throws IOException {
+      if (currentIdx >= cellsToConsume.size()) {
+        // finished current batch
+        cellsToConsume.clear();
+        currentIdx = 0;
+        hasMore = scanner.next(cellsToConsume, limit);
+      }
+      Cell cell = null;
+      if (currentIdx < cellsToConsume.size()) {
+        cell = cellsToConsume.get(currentIdx);
+        if (currentRow == null) {
+          currentRow = CellUtil.cloneRow(cell);
+        } else if (!CellUtil.matchingRow(cell, currentRow)) {
+          // moved on to the next row
+          // don't consume current cell and signal no more cells for this row
+          return null;
+        }
+      }
+      return cell;
+    }
+
+    /**
+     * Returns the next available cell for the current row and advances the pointer to the next cell.  This method
+     * can be called multiple times in a row to advance through all the available cells.
+     *
+     * @param limit the limit of number of cells to return if the next batch must be fetched by the wrapped scanner
+     * @return the next available cell or null if no more cells are available for the current row
+     * @throws IOException
+     */
+    public Cell nextCell(int limit) throws IOException {
+      Cell cell = peekNextCell(limit);
+      if (cell != null) {
+        currentIdx++;
+      }
+      return cell;
+    }
+
+    /**
+     * Returns whether or not the underlying scanner has more rows.
+     */
+    public boolean hasMore() {
+      return currentIdx < cellsToConsume.size() ? true : hasMore;
+    }
+
+    @Override
+    public void close() throws IOException {
+      scanner.close();
+    }
+  }
+}

--- a/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/transaction/coprocessor/hbase10/DefaultTransactionProcessor.java
+++ b/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/transaction/coprocessor/hbase10/DefaultTransactionProcessor.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.transaction.coprocessor.hbase10;
+
+import co.cask.cdap.data2.increment.hbase10.IncrementFilter;
+import co.cask.cdap.data2.transaction.coprocessor.DefaultTransactionStateCacheSupplier;
+import co.cask.cdap.data2.util.hbase.HTable10NameConverter;
+import co.cask.tephra.Transaction;
+import co.cask.tephra.coprocessor.TransactionStateCache;
+import co.cask.tephra.hbase10.coprocessor.TransactionProcessor;
+import co.cask.tephra.hbase10.coprocessor.TransactionVisibilityFilter;
+import com.google.common.base.Supplier;
+import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
+import org.apache.hadoop.hbase.filter.Filter;
+import org.apache.hadoop.hbase.regionserver.ScanType;
+
+/**
+ * Implementation of the {@link co.cask.tephra.hbase10.coprocessor.TransactionProcessor}
+ * coprocessor that uses {@link co.cask.cdap.data2.transaction.coprocessor.DefaultTransactionStateCache}
+ * to automatically refresh transaction state.
+ */
+public class DefaultTransactionProcessor extends TransactionProcessor {
+  @Override
+  protected Supplier<TransactionStateCache> getTransactionStateCacheSupplier(RegionCoprocessorEnvironment env) {
+    String sysConfigTablePrefix = new HTable10NameConverter().getSysConfigTablePrefix(env.getRegion().getTableDesc());
+    return new DefaultTransactionStateCacheSupplier(sysConfigTablePrefix, env.getConfiguration());
+  }
+
+  @Override
+  protected Filter getTransactionFilter(Transaction tx, ScanType scanType) {
+    return new TransactionVisibilityFilter(tx, ttlByFamily, allowEmptyValues, scanType, new IncrementFilter());
+  }
+}

--- a/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase10/DequeueFilter.java
+++ b/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase10/DequeueFilter.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright © 2014-2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.transaction.queue.coprocessor.hbase10;
+
+import co.cask.cdap.data2.queue.ConsumerConfig;
+import co.cask.cdap.data2.transaction.queue.QueueEntryRow;
+import co.cask.cdap.data2.transaction.queue.hbase.DequeueScanAttributes;
+import co.cask.tephra.Transaction;
+import com.google.common.primitives.Ints;
+import com.google.common.primitives.Longs;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.exceptions.DeserializationException;
+import org.apache.hadoop.hbase.filter.Filter;
+import org.apache.hadoop.hbase.filter.FilterBase;
+import org.apache.hadoop.hbase.util.Bytes;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInput;
+import java.io.DataInputStream;
+import java.io.DataOutput;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Server-side filter for dequeue operation
+ */
+// todo: unit-test it (without DequeueScanObserver)
+public class DequeueFilter extends FilterBase {
+  private ConsumerConfig consumerConfig;
+  private Transaction transaction;
+  private byte[] stateColumnName;
+
+  private boolean stopScan;
+  private boolean skipRow;
+
+  private int counter;
+  private long writePointer;
+
+  // For Writable
+  private DequeueFilter() {
+  }
+
+  public DequeueFilter(ConsumerConfig consumerConfig, Transaction transaction) {
+    this.consumerConfig = consumerConfig;
+    this.transaction = transaction;
+    this.stateColumnName = Bytes.add(QueueEntryRow.STATE_COLUMN_PREFIX,
+                                     Bytes.toBytes(consumerConfig.getGroupId()));
+  }
+
+  @Override
+  public void reset() throws IOException {
+    stopScan = false;
+    skipRow = false;
+  }
+
+  @Override
+  public boolean filterAllRemaining() {
+    return stopScan;
+  }
+
+  @Override
+  public boolean filterRowKey(byte[] buffer, int offset, int length) {
+    // last 4 bytes in a row key
+    counter = Bytes.toInt(buffer, offset + length - Ints.BYTES, Ints.BYTES);
+    // row key is queue_name + writePointer + counter
+    writePointer = Bytes.toLong(buffer, offset + length - Longs.BYTES - Ints.BYTES, Longs.BYTES);
+
+    // If writes later than the reader pointer, abort the loop, as entries that comes later are all uncommitted.
+    // this is probably not needed due to the limit of the scan to the stop row, but to be safe...
+    if (writePointer > transaction.getReadPointer()) {
+      stopScan = true;
+      return true;
+    }
+
+    // If the write is in the excluded list, ignore it.
+    if (transaction.isExcluded(writePointer)) {
+      return true;
+    }
+
+    return false;
+  }
+
+  @Override
+  public boolean hasFilterRow() {
+    return true;
+  }
+
+  @Override
+  public void filterRowCells(List<Cell> cells) {
+    byte[] dataBytes = null;
+    byte[] metaBytes = null;
+    byte[] stateBytes = null;
+    // list is very short so it is ok to loop thru to find columns
+    for (Cell cell : cells) {
+      if (CellUtil.matchingQualifier(cell, QueueEntryRow.DATA_COLUMN)) {
+        dataBytes = CellUtil.cloneValue(cell);
+      } else if (CellUtil.matchingQualifier(cell, QueueEntryRow.META_COLUMN)) {
+        metaBytes = CellUtil.cloneValue(cell);
+      } else if (CellUtil.matchingQualifier(cell, stateColumnName)) {
+        stateBytes = CellUtil.cloneValue(cell);
+      }
+    }
+
+    if (dataBytes == null || metaBytes == null) {
+      skipRow = true;
+      return;
+    }
+
+    QueueEntryRow.CanConsume canConsume =
+      QueueEntryRow.canConsume(consumerConfig, transaction, writePointer, counter, metaBytes, stateBytes);
+
+    // Only skip the row when canConsumer == NO, so that in case of NO_INCLUDING_ALL_OLDER, the client
+    // can still see the row and move the scan start row.
+    skipRow = canConsume == QueueEntryRow.CanConsume.NO;
+  }
+
+  @Override
+  public ReturnCode filterKeyValue(Cell cell) throws IOException {
+    return ReturnCode.INCLUDE;
+  }
+
+  @Override
+  public boolean filterRow() {
+    return skipRow;
+  }
+
+  /* Writable implementation for HBase 0.94 */
+
+  public void write(DataOutput out) throws IOException {
+    DequeueScanAttributes.write(out, consumerConfig);
+    DequeueScanAttributes.write(out, transaction);
+  }
+
+  public void readFields(DataInput in) throws IOException {
+    this.consumerConfig = DequeueScanAttributes.readConsumerConfig(in);
+    this.transaction = DequeueScanAttributes.readTx(in);
+  }
+
+  /* Serialization support for HBase 0.98+ */
+
+  public byte[] toByteArray() throws IOException {
+    // TODO: in the future actual serialization here should be done using protobufs
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    write(new DataOutputStream(bos));
+    return bos.toByteArray();
+  }
+
+  public static Filter parseFrom(final byte [] pbBytes) throws DeserializationException {
+    DequeueFilter filter = new DequeueFilter();
+    try {
+      filter.readFields(new DataInputStream(new ByteArrayInputStream(pbBytes)));
+    } catch (IOException ioe) {
+      throw new DeserializationException(ioe);
+    }
+    return filter;
+  }
+}

--- a/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase10/DequeueScanObserver.java
+++ b/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase10/DequeueScanObserver.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2014-2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.transaction.queue.coprocessor.hbase10;
+
+import co.cask.cdap.data2.queue.ConsumerConfig;
+import co.cask.cdap.data2.transaction.queue.hbase.DequeueScanAttributes;
+import co.cask.tephra.Transaction;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.coprocessor.BaseRegionObserver;
+import org.apache.hadoop.hbase.coprocessor.ObserverContext;
+import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
+import org.apache.hadoop.hbase.filter.Filter;
+import org.apache.hadoop.hbase.filter.FilterList;
+import org.apache.hadoop.hbase.regionserver.RegionScanner;
+
+import java.io.IOException;
+
+/**
+ *
+ */
+public class DequeueScanObserver extends BaseRegionObserver {
+  @Override
+  public RegionScanner preScannerOpen(ObserverContext<RegionCoprocessorEnvironment> e, Scan scan, RegionScanner s)
+    throws IOException {
+    ConsumerConfig consumerConfig = DequeueScanAttributes.getConsumerConfig(scan);
+    Transaction tx = DequeueScanAttributes.getTx(scan);
+
+    if (consumerConfig == null || tx == null) {
+      return super.preScannerOpen(e, scan, s);
+    }
+
+    Filter dequeueFilter = new DequeueFilter(consumerConfig, tx);
+
+    Filter existing = scan.getFilter();
+    if (existing != null) {
+      Filter combined = new FilterList(FilterList.Operator.MUST_PASS_ALL, existing, dequeueFilter);
+      scan.setFilter(combined);
+    } else {
+      scan.setFilter(dequeueFilter);
+    }
+
+    return super.preScannerOpen(e, scan, s);
+  }
+}

--- a/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase10/HBaseQueueRegionObserver.java
+++ b/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase10/HBaseQueueRegionObserver.java
@@ -1,0 +1,331 @@
+/*
+ * Copyright © 2014-2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.data2.transaction.queue.coprocessor.hbase10;
+
+import co.cask.cdap.common.queue.QueueName;
+import co.cask.cdap.data2.transaction.coprocessor.DefaultTransactionStateCacheSupplier;
+import co.cask.cdap.data2.transaction.queue.ConsumerEntryState;
+import co.cask.cdap.data2.transaction.queue.QueueEntryRow;
+import co.cask.cdap.data2.transaction.queue.hbase.HBaseQueueAdmin;
+import co.cask.cdap.data2.transaction.queue.hbase.SaltedHBaseQueueStrategy;
+import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.CConfigurationReader;
+import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.ConsumerConfigCache;
+import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.ConsumerInstance;
+import co.cask.cdap.data2.transaction.queue.hbase.coprocessor.QueueConsumerConfig;
+import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.data2.util.hbase.HTable10NameConverter;
+import co.cask.tephra.coprocessor.TransactionStateCache;
+import co.cask.tephra.persist.TransactionSnapshot;
+import com.google.common.base.Supplier;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CoprocessorEnvironment;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.coprocessor.BaseRegionObserver;
+import org.apache.hadoop.hbase.coprocessor.ObserverContext;
+import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
+import org.apache.hadoop.hbase.regionserver.InternalScanner;
+import org.apache.hadoop.hbase.regionserver.ScanType;
+import org.apache.hadoop.hbase.regionserver.Store;
+import org.apache.hadoop.hbase.regionserver.compactions.CompactionRequest;
+import org.apache.hadoop.hbase.util.Bytes;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * RegionObserver for queue table. This class should only have JSE and HBase classes dependencies only.
+ * It can also has dependencies on CDAP classes provided that all the transitive dependencies stay within
+ * the mentioned scope.
+ *
+ * This region observer does queue eviction during flush time and compact time by using queue consumer state
+ * information to determine if a queue entry row can be omitted during flush/compact.
+ */
+public final class HBaseQueueRegionObserver extends BaseRegionObserver {
+
+  private static final Log LOG = LogFactory.getLog(HBaseQueueRegionObserver.class);
+
+  private Configuration conf;
+  private byte[] configTableNameBytes;
+  private CConfigurationReader cConfReader;
+  TransactionStateCache txStateCache;
+  private Supplier<TransactionSnapshot> txSnapshotSupplier;
+  private ConsumerConfigCache configCache;
+
+  private int prefixBytes;
+  private String namespaceId;
+  private String appName;
+  private String flowName;
+
+  @Override
+  public void start(CoprocessorEnvironment env) {
+    if (env instanceof RegionCoprocessorEnvironment) {
+      HTableDescriptor tableDesc = ((RegionCoprocessorEnvironment) env).getRegion().getTableDesc();
+      String hTableName = tableDesc.getNameAsString();
+
+      String prefixBytes = tableDesc.getValue(HBaseQueueAdmin.PROPERTY_PREFIX_BYTES);
+      try {
+        // Default to SALT_BYTES for the older salted queue implementation.
+        this.prefixBytes = prefixBytes == null ? SaltedHBaseQueueStrategy.SALT_BYTES : Integer.parseInt(prefixBytes);
+      } catch (NumberFormatException e) {
+        // Shouldn't happen for table created by cdap.
+        LOG.error("Unable to parse value of '" + HBaseQueueAdmin.PROPERTY_PREFIX_BYTES + "' property. " +
+                    "Default to " + SaltedHBaseQueueStrategy.SALT_BYTES, e);
+        this.prefixBytes = SaltedHBaseQueueStrategy.SALT_BYTES;
+      }
+
+      HTable10NameConverter nameConverter = new HTable10NameConverter();
+      namespaceId = nameConverter.from(tableDesc).getNamespace().getId();
+      appName = HBaseQueueAdmin.getApplicationName(hTableName);
+      flowName = HBaseQueueAdmin.getFlowName(hTableName);
+
+      conf = env.getConfiguration();
+      String hbaseNamespacePrefix = nameConverter.getNamespacePrefix(tableDesc);
+      TableId queueConfigTableId = HBaseQueueAdmin.getConfigTableId(namespaceId);
+      final String sysConfigTablePrefix = nameConverter.getSysConfigTablePrefix(tableDesc);
+      txStateCache = new DefaultTransactionStateCacheSupplier(sysConfigTablePrefix, conf).get();
+      txSnapshotSupplier = new Supplier<TransactionSnapshot>() {
+        @Override
+        public TransactionSnapshot get() {
+          return txStateCache.getLatestState();
+        }
+      };
+      configTableNameBytes = nameConverter.toTableName(hbaseNamespacePrefix, queueConfigTableId).getName();
+      cConfReader = new CConfigurationReader(conf, sysConfigTablePrefix);
+      configCache = ConsumerConfigCache.getInstance(conf, configTableNameBytes, cConfReader, txSnapshotSupplier);
+    }
+  }
+
+  @Override
+  public InternalScanner preFlush(ObserverContext<RegionCoprocessorEnvironment> e,
+                                  Store store, InternalScanner scanner) throws IOException {
+    if (!e.getEnvironment().getRegion().isAvailable()) {
+      return scanner;
+    }
+
+    LOG.info("preFlush, creates EvictionInternalScanner");
+    return new EvictionInternalScanner("flush", e.getEnvironment(), scanner);
+  }
+
+  @Override
+  public InternalScanner preCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store,
+                                    InternalScanner scanner, ScanType type,
+                                    CompactionRequest request) throws IOException {
+    if (!e.getEnvironment().getRegion().isAvailable()) {
+      return scanner;
+    }
+
+    LOG.info("preCompact, creates EvictionInternalScanner");
+    return new EvictionInternalScanner("compaction", e.getEnvironment(), scanner);
+  }
+
+  // needed for queue unit-test
+  private ConsumerConfigCache getConfigCache() {
+    if (!configCache.isAlive()) {
+      configCache = ConsumerConfigCache.getInstance(conf, configTableNameBytes, cConfReader, txSnapshotSupplier);
+    }
+    return configCache;
+  }
+
+  // need for queue unit-test
+  private TransactionStateCache getTxStateCache() {
+    return txStateCache;
+  }
+
+  /**
+   * An {@link InternalScanner} that will skip queue entries that are safe to be evicted.
+   */
+  private final class EvictionInternalScanner implements InternalScanner {
+
+    private final String triggeringAction;
+    private final RegionCoprocessorEnvironment env;
+    private final InternalScanner scanner;
+    // This is just for object reused to reduce objects creation.
+    private final ConsumerInstance consumerInstance;
+    private byte[] currentQueue;
+    private byte[] currentQueueRowPrefix;
+    private QueueConsumerConfig consumerConfig;
+    private long totalRows = 0;
+    private long rowsEvicted = 0;
+    // couldn't be evicted due to incomplete view of row
+    private long skippedIncomplete = 0;
+
+    private EvictionInternalScanner(String action, RegionCoprocessorEnvironment env, InternalScanner scanner) {
+      this.triggeringAction = action;
+      this.env = env;
+      this.scanner = scanner;
+      this.consumerInstance = new ConsumerInstance(0, 0);
+    }
+
+    @Override
+    public boolean next(List<Cell> results) throws IOException {
+      return next(results, -1);
+    }
+
+    @Override
+    public boolean next(List<Cell> results, int limit) throws IOException {
+      boolean hasNext = scanner.next(results, limit);
+
+      while (!results.isEmpty()) {
+        totalRows++;
+        // Check if it is eligible for eviction.
+        Cell cell = results.get(0);
+
+        // If current queue is unknown or the row is not a queue entry of current queue,
+        // it either because it scans into next queue entry or simply current queue is not known.
+        // Hence needs to find the currentQueue
+        if (currentQueue == null || !QueueEntryRow.isQueueEntry(currentQueueRowPrefix, prefixBytes, cell.getRowArray(),
+                                                                cell.getRowOffset(), cell.getRowLength())) {
+          // If not eligible, it either because it scans into next queue entry or simply current queue is not known.
+          currentQueue = null;
+        }
+
+        // This row is a queue entry. If currentQueue is null, meaning it's a new queue encountered during scan.
+        if (currentQueue == null) {
+          QueueName queueName = QueueEntryRow.getQueueName(namespaceId, appName, flowName, prefixBytes,
+                                                           cell.getRowArray(), cell.getRowOffset(),
+                                                           cell.getRowLength());
+          currentQueue = queueName.toBytes();
+          currentQueueRowPrefix = QueueEntryRow.getQueueRowPrefix(queueName);
+          consumerConfig = getConfigCache().getConsumerConfig(currentQueue);
+        }
+
+        if (consumerConfig == null) {
+          // no config is present yet, so cannot evict
+          return hasNext;
+        }
+
+        if (canEvict(consumerConfig, results)) {
+          rowsEvicted++;
+          results.clear();
+          hasNext = scanner.next(results, limit);
+        } else {
+          break;
+        }
+      }
+
+      return hasNext;
+    }
+
+    @Override
+    public void close() throws IOException {
+      LOG.info("Region " + env.getRegion().getRegionNameAsString() + " " + triggeringAction +
+                 ", rows evicted: " + rowsEvicted + " / " + totalRows + ", skipped incomplete: " + skippedIncomplete);
+      scanner.close();
+    }
+
+    /**
+     * Determines the given queue entry row can be evicted.
+     * @param result All KeyValues of a queue entry row.
+     * @return true if it can be evicted, false otherwise.
+     */
+    private boolean canEvict(QueueConsumerConfig consumerConfig, List<Cell> result) {
+      // If no consumer group, this queue is dead, should be ok to evict.
+      if (consumerConfig.getNumGroups() == 0) {
+        return true;
+      }
+
+      // If unknown consumer config (due to error), keep the queue.
+      if (consumerConfig.getNumGroups() < 0) {
+        return false;
+      }
+
+      // TODO (terence): Right now we can only evict if we see all the data columns.
+      // It's because it's possible that in some previous flush, only the data columns are flush,
+      // then consumer writes the state columns. In the next flush, it'll only see the state columns and those
+      // should not be evicted otherwise the entry might get reprocessed, depending on the consumer start row state.
+      // This logic is not perfect as if flush happens after enqueue and before dequeue, that entry may never get
+      // evicted (depends on when the next compaction happens, whether the queue configuration has been change or not).
+
+      // There are two data columns, "d" and "m".
+      // If the size == 2, it should not be evicted as well,
+      // as state columns (dequeue) always happen after data columns (enqueue).
+      if (result.size() <= 2) {
+        skippedIncomplete++;
+        return false;
+      }
+
+      // "d" and "m" columns always comes before the state columns, prefixed with "s".
+      Iterator<Cell> iterator = result.iterator();
+      Cell cell = iterator.next();
+      if (!QueueEntryRow.isDataColumn(cell.getQualifierArray(), cell.getQualifierOffset())) {
+        skippedIncomplete++;
+        return false;
+      }
+      cell = iterator.next();
+      if (!QueueEntryRow.isMetaColumn(cell.getQualifierArray(), cell.getQualifierOffset())) {
+        skippedIncomplete++;
+        return false;
+      }
+
+      // Need to determine if this row can be evicted iff all consumer groups have committed process this row.
+      int consumedGroups = 0;
+      // Inspect each state column
+      while (iterator.hasNext()) {
+        cell = iterator.next();
+        if (!QueueEntryRow.isStateColumn(cell.getQualifierArray(), cell.getQualifierOffset())) {
+          continue;
+        }
+        // If any consumer has a state != PROCESSED, it should not be evicted
+        if (!isProcessed(cell, consumerInstance)) {
+          break;
+        }
+        // If it is PROCESSED, check if this row is smaller than the consumer instance startRow.
+        // Essentially a loose check of committed PROCESSED.
+        byte[] startRow = consumerConfig.getStartRow(consumerInstance);
+        if (startRow != null && compareRowKey(cell, startRow) < 0) {
+          consumedGroups++;
+        }
+      }
+
+      // It can be evicted if from the state columns, it's been processed by all consumer groups
+      // Otherwise, this row has to be less than smallest among all current consumers.
+      // The second condition is for handling consumer being removed after it consumed some entries.
+      // However, the second condition alone is not good enough as it's possible that in hash partitioning,
+      // only one consumer is keep consuming when the other consumer never proceed.
+      return consumedGroups == consumerConfig.getNumGroups()
+        || compareRowKey(result.get(0), consumerConfig.getSmallestStartRow()) < 0;
+    }
+
+    private int compareRowKey(Cell cell, byte[] row) {
+      return Bytes.compareTo(cell.getRowArray(), cell.getRowOffset() + prefixBytes,
+                             cell.getRowLength() - prefixBytes, row, 0, row.length);
+    }
+
+    /**
+     * Returns {@code true} if the given {@link KeyValue} has a {@link ConsumerEntryState#PROCESSED} state and
+     * also put the consumer information into the given {@link ConsumerInstance}.
+     * Otherwise, returns {@code false} and the {@link ConsumerInstance} is left untouched.
+     */
+    private boolean isProcessed(Cell cell, ConsumerInstance consumerInstance) {
+      int stateIdx = cell.getValueOffset() + cell.getValueLength() - 1;
+      boolean processed = cell.getValueArray()[stateIdx] == ConsumerEntryState.PROCESSED.getState();
+
+      if (processed) {
+        // Column is "s<groupId>"
+        long groupId = Bytes.toLong(cell.getQualifierArray(), cell.getQualifierOffset() + 1);
+        // Value is "<writePointer><instanceId><state>"
+        int instanceId = Bytes.toInt(cell.getValueArray(), cell.getValueOffset() + Bytes.SIZEOF_LONG);
+        consumerInstance.setGroupInstance(groupId, instanceId);
+      }
+      return processed;
+    }
+  }
+}

--- a/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBase10QueueConsumer.java
+++ b/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBase10QueueConsumer.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2014-2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.transaction.queue.hbase;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.queue.QueueName;
+import co.cask.cdap.data2.transaction.queue.ConsumerEntryState;
+import co.cask.cdap.data2.transaction.queue.QueueEntryRow;
+import com.google.common.primitives.Ints;
+import org.apache.hadoop.hbase.client.HTable;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.filter.BinaryPrefixComparator;
+import org.apache.hadoop.hbase.filter.BitComparator;
+import org.apache.hadoop.hbase.filter.CompareFilter;
+import org.apache.hadoop.hbase.filter.Filter;
+import org.apache.hadoop.hbase.filter.FilterList;
+import org.apache.hadoop.hbase.filter.SingleColumnValueFilter;
+
+/**
+ * HBase 0.98 implementation of {@link HBaseQueueConsumer}.
+ */
+final class HBase10QueueConsumer extends HBaseQueueConsumer {
+  private final Filter processedStateFilter;
+
+  HBase10QueueConsumer(CConfiguration cConf, HTable hTable, QueueName queueName,
+                       HBaseConsumerState consumerState, HBaseConsumerStateStore stateStore,
+                       HBaseQueueStrategy queueStrategy) {
+    super(cConf, hTable, queueName, consumerState, stateStore, queueStrategy);
+    this.processedStateFilter = createStateFilter();
+  }
+
+  @Override
+  protected Scan createScan(byte[] startRow, byte[] stopRow, int numRows) {
+    // Scan the table for queue entries.
+    Scan scan = new Scan();
+    scan.setStartRow(startRow);
+    scan.setStopRow(stopRow);
+    scan.addColumn(QueueEntryRow.COLUMN_FAMILY, QueueEntryRow.DATA_COLUMN);
+    scan.addColumn(QueueEntryRow.COLUMN_FAMILY, QueueEntryRow.META_COLUMN);
+    scan.addColumn(QueueEntryRow.COLUMN_FAMILY, stateColumnName);
+    scan.setFilter(createFilter());
+    scan.setMaxVersions(1);
+    return scan;
+  }
+
+  /**
+   * Creates a HBase filter that will filter out rows that that has committed state = PROCESSED.
+   */
+  private Filter createFilter() {
+    return new FilterList(FilterList.Operator.MUST_PASS_ONE, processedStateFilter, new SingleColumnValueFilter(
+      QueueEntryRow.COLUMN_FAMILY, stateColumnName, CompareFilter.CompareOp.GREATER,
+      new BinaryPrefixComparator(Bytes.toBytes(transaction.getReadPointer()))
+    ));
+  }
+
+  /**
+   * Creates a HBase filter that will filter out rows with state column state = PROCESSED (ignoring transaction).
+   */
+  private Filter createStateFilter() {
+    byte[] processedMask = new byte[Ints.BYTES * 2 + 1];
+    processedMask[processedMask.length - 1] = ConsumerEntryState.PROCESSED.getState();
+    return new SingleColumnValueFilter(QueueEntryRow.COLUMN_FAMILY, stateColumnName,
+                                       CompareFilter.CompareOp.NOT_EQUAL,
+                                       new BitComparator(processedMask, BitComparator.BitwiseOp.AND));
+  }
+}

--- a/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBase10QueueUtil.java
+++ b/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBase10QueueUtil.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2014-2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.transaction.queue.hbase;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.queue.QueueName;
+import org.apache.hadoop.hbase.client.HTable;
+
+/**
+ * HBase 0.98 implementation of {@link HBaseQueueUtil}.
+ */
+public class HBase10QueueUtil extends HBaseQueueUtil {
+  @Override
+  public HBaseQueueConsumer getQueueConsumer(CConfiguration cConf,
+                                             HTable hTable, QueueName queueName,
+                                             HBaseConsumerState consumerState, HBaseConsumerStateStore stateStore,
+                                             HBaseQueueStrategy queueStrategy) {
+    return new HBase10QueueConsumer(cConf, hTable, queueName, consumerState, stateStore, queueStrategy);
+  }
+}

--- a/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase10TableUtil.java
+++ b/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase10TableUtil.java
@@ -1,0 +1,291 @@
+/*
+ * Copyright © 2014-2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import co.cask.cdap.data2.increment.hbase10.IncrementHandler;
+import co.cask.cdap.data2.transaction.coprocessor.hbase10.DefaultTransactionProcessor;
+import co.cask.cdap.data2.transaction.queue.coprocessor.hbase10.DequeueScanObserver;
+import co.cask.cdap.data2.transaction.queue.coprocessor.hbase10.HBaseQueueRegionObserver;
+import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.proto.Id;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.ClusterStatus;
+import org.apache.hadoop.hbase.Coprocessor;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HRegionInfo;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.NamespaceDescriptor;
+import org.apache.hadoop.hbase.NamespaceNotFoundException;
+import org.apache.hadoop.hbase.RegionLoad;
+import org.apache.hadoop.hbase.ServerName;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.HBaseAdmin;
+import org.apache.hadoop.hbase.client.HTable;
+import org.apache.hadoop.hbase.io.compress.Compression;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ *
+ */
+public class HBase10TableUtil extends HBaseTableUtil {
+
+  private final HTable10NameConverter nameConverter = new HTable10NameConverter();
+
+  @Override
+  public HTable createHTable(Configuration conf, TableId tableId) throws IOException {
+    Preconditions.checkArgument(tableId != null, "Table id should not be null");
+    return new HTable(conf, nameConverter.toTableName(tablePrefix, tableId));
+  }
+
+  @Override
+  public HTableDescriptor createHTableDescriptor(TableId tableId) {
+    Preconditions.checkArgument(tableId != null, "Table id should not be null");
+    return new HTableDescriptor(nameConverter.toTableName(tablePrefix, tableId));
+  }
+
+  @Override
+  public HTableDescriptor getHTableDescriptor(HBaseAdmin admin, TableId tableId) throws IOException {
+    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
+    Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
+    return admin.getTableDescriptor(nameConverter.toTableName(tablePrefix, tableId));
+  }
+
+  @Override
+  public boolean hasNamespace(HBaseAdmin admin, Id.Namespace namespace) throws IOException {
+    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
+    Preconditions.checkArgument(namespace != null, "Namespace should not be null.");
+    try {
+      admin.getNamespaceDescriptor(nameConverter.toHBaseNamespace(tablePrefix, namespace));
+      return true;
+    } catch (NamespaceNotFoundException e) {
+      return false;
+    }
+  }
+
+  @Override
+  public void createNamespaceIfNotExists(HBaseAdmin admin, Id.Namespace namespace) throws IOException {
+    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
+    Preconditions.checkArgument(namespace != null, "Namespace should not be null.");
+    if (!hasNamespace(admin, namespace)) {
+      NamespaceDescriptor namespaceDescriptor =
+        NamespaceDescriptor.create(nameConverter.toHBaseNamespace(tablePrefix, namespace)).build();
+      admin.createNamespace(namespaceDescriptor);
+    }
+  }
+
+  @Override
+  public void deleteNamespaceIfExists(HBaseAdmin admin, Id.Namespace namespace) throws IOException {
+    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
+    Preconditions.checkArgument(namespace != null, "Namespace should not be null.");
+    if (hasNamespace(admin, namespace)) {
+      admin.deleteNamespace(nameConverter.toHBaseNamespace(tablePrefix, namespace));
+    }
+  }
+
+  @Override
+  public void disableTable(HBaseAdmin admin, TableId tableId) throws IOException {
+    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
+    Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
+    admin.disableTable(nameConverter.toTableName(tablePrefix, tableId));
+  }
+
+  @Override
+  public void enableTable(HBaseAdmin admin, TableId tableId) throws IOException {
+    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
+    Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
+    admin.enableTable(nameConverter.toTableName(tablePrefix, tableId));
+  }
+
+  @Override
+  public boolean tableExists(HBaseAdmin admin, TableId tableId) throws IOException {
+    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
+    Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
+    return admin.tableExists(nameConverter.toTableName(tablePrefix, tableId));
+  }
+
+  @Override
+  public void deleteTable(HBaseAdmin admin, TableId tableId) throws IOException {
+    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
+    Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
+    admin.deleteTable(nameConverter.toTableName(tablePrefix, tableId));
+  }
+
+  @Override
+  public void modifyTable(HBaseAdmin admin, HTableDescriptor tableDescriptor) throws IOException {
+    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
+    Preconditions.checkArgument(tableDescriptor != null, "Table descriptor should not be null.");
+    admin.modifyTable(tableDescriptor.getTableName(), tableDescriptor);
+  }
+
+  @Override
+  public List<HRegionInfo> getTableRegions(HBaseAdmin admin, TableId tableId) throws IOException {
+    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
+    Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
+    return admin.getTableRegions(nameConverter.toTableName(tablePrefix, tableId));
+  }
+
+  @Override
+  public List<TableId> listTablesInNamespace(HBaseAdmin admin, Id.Namespace namespaceId) throws IOException {
+    List<TableId> tableIds = Lists.newArrayList();
+    HTableDescriptor[] hTableDescriptors =
+      admin.listTableDescriptorsByNamespace(nameConverter.toHBaseNamespace(tablePrefix, namespaceId));
+    for (HTableDescriptor hTableDescriptor : hTableDescriptors) {
+      if (isCDAPTable(hTableDescriptor)) {
+        tableIds.add(nameConverter.from(hTableDescriptor));
+      }
+    }
+    return tableIds;
+  }
+
+  @Override
+  public List<TableId> listTables(HBaseAdmin admin) throws IOException {
+    List<TableId> tableIds = Lists.newArrayList();
+    HTableDescriptor[] hTableDescriptors = admin.listTables();
+    for (HTableDescriptor hTableDescriptor : hTableDescriptors) {
+      if (isCDAPTable(hTableDescriptor)) {
+        tableIds.add(nameConverter.from(hTableDescriptor));
+      }
+    }
+    return tableIds;
+  }
+
+  @Override
+  public void setCompression(HColumnDescriptor columnDescriptor, CompressionType type) {
+    switch (type) {
+      case LZO:
+        columnDescriptor.setCompressionType(Compression.Algorithm.LZO);
+        break;
+      case SNAPPY:
+        columnDescriptor.setCompressionType(Compression.Algorithm.SNAPPY);
+        break;
+      case GZIP:
+        columnDescriptor.setCompressionType(Compression.Algorithm.GZ);
+        break;
+      case NONE:
+        columnDescriptor.setCompressionType(Compression.Algorithm.NONE);
+        break;
+      default:
+        throw new IllegalArgumentException("Unsupported compression type: " + type);
+    }
+  }
+
+  @Override
+  public void setBloomFilter(HColumnDescriptor columnDescriptor, BloomType type) {
+    switch (type) {
+      case ROW:
+        columnDescriptor.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.ROW);
+        break;
+      case ROWCOL:
+        columnDescriptor.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.ROWCOL);
+        break;
+      case NONE:
+        columnDescriptor.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.NONE);
+        break;
+      default:
+        throw new IllegalArgumentException("Unsupported bloom filter type: " + type);
+    }
+  }
+
+  @Override
+  public CompressionType getCompression(HColumnDescriptor columnDescriptor) {
+    Compression.Algorithm type = columnDescriptor.getCompressionType();
+    switch (type) {
+      case LZO:
+        return CompressionType.LZO;
+      case SNAPPY:
+        return CompressionType.SNAPPY;
+      case GZ:
+        return CompressionType.GZIP;
+      case NONE:
+        return CompressionType.NONE;
+      default:
+        throw new IllegalArgumentException("Unsupported compression type: " + type);
+    }
+  }
+
+  @Override
+  public BloomType getBloomFilter(HColumnDescriptor columnDescriptor) {
+    org.apache.hadoop.hbase.regionserver.BloomType type = columnDescriptor.getBloomFilterType();
+    switch (type) {
+      case ROW:
+        return BloomType.ROW;
+      case ROWCOL:
+        return BloomType.ROWCOL;
+      case NONE:
+        return BloomType.NONE;
+      default:
+        throw new IllegalArgumentException("Unsupported bloom filter type: " + type);
+    }
+  }
+
+  @Override
+  public Class<? extends Coprocessor> getTransactionDataJanitorClassForVersion() {
+    return DefaultTransactionProcessor.class;
+  }
+
+  @Override
+  public Class<? extends Coprocessor> getQueueRegionObserverClassForVersion() {
+    return HBaseQueueRegionObserver.class;
+  }
+
+  @Override
+  public Class<? extends Coprocessor> getDequeueScanObserverClassForVersion() {
+    return DequeueScanObserver.class;
+  }
+
+  @Override
+  public Class<? extends Coprocessor> getIncrementHandlerClassForVersion() {
+    return IncrementHandler.class;
+  }
+
+  @Override
+  public Map<TableId, TableStats> getTableStats(HBaseAdmin admin) throws IOException {
+    // The idea is to walk thru live region servers, collect table region stats and aggregate them towards table total
+    // metrics.
+    Map<TableId, TableStats> datasetStat = Maps.newHashMap();
+    ClusterStatus clusterStatus = admin.getClusterStatus();
+
+    for (ServerName serverName : clusterStatus.getServers()) {
+      Map<byte[], RegionLoad> regionsLoad = clusterStatus.getLoad(serverName).getRegionsLoad();
+
+      for (RegionLoad regionLoad : regionsLoad.values()) {
+        //String tableName = Bytes.toString(HRegionInfo.getTableName(regionLoad.getName()));
+        TableName tableName = HRegionInfo.getTable(regionLoad.getName());
+        if (!admin.tableExists(tableName) || !isCDAPTable(admin.getTableDescriptor(tableName))) {
+          continue;
+        }
+        HTableNameConverter hTableNameConverter = new HTable10NameConverter();
+        TableId tableId = hTableNameConverter.from(new HTableDescriptor(tableName));
+        TableStats stat = datasetStat.get(tableId);
+        if (stat == null) {
+          stat = new TableStats(regionLoad.getStorefileSizeMB(), regionLoad.getMemStoreSizeMB());
+          datasetStat.put(tableId, stat);
+        } else {
+          stat.incStoreFileSizeMB(regionLoad.getStorefileSizeMB());
+          stat.incMemStoreSizeMB(regionLoad.getMemStoreSizeMB());
+        }
+      }
+    }
+    return datasetStat;
+  }
+}

--- a/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/util/hbase/HTable10NameConverter.java
+++ b/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/util/hbase/HTable10NameConverter.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.data2.util.TableId;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.TableName;
+
+/**
+ * Utility methods for dealing with HBase table name conversions in HBase 0.98.
+ */
+public class HTable10NameConverter extends HTableNameConverter {
+
+  @Override
+  public String getSysConfigTablePrefix(HTableDescriptor htd) {
+    return getNamespacePrefix(htd) + "_" + Constants.SYSTEM_NAMESPACE + ":";
+  }
+
+  @Override
+  public TableId from(HTableDescriptor htd) {
+    return prefixedTableIdFromTableName(htd.getTableName()).getTableId();
+  }
+
+  @Override
+  public String getNamespacePrefix(HTableDescriptor htd) {
+    return prefixedTableIdFromTableName(htd.getTableName()).getTablePrefix();
+  }
+
+  public TableName toTableName(String tablePrefix, TableId tableId) {
+    return TableName.valueOf(toHBaseNamespace(tablePrefix, tableId.getNamespace()),
+                             getHBaseTableName(tablePrefix, tableId));
+  }
+
+  private PrefixedTableId prefixedTableIdFromTableName(TableName tableName) {
+    return fromHBaseTableName(tableName.getNamespaceAsString(), tableName.getQualifierAsString());
+  }
+}

--- a/cdap-hbase-compat-1.0/src/test/java/co/cask/cdap/data/hbase/HBase10Test.java
+++ b/cdap-hbase-compat-1.0/src/test/java/co/cask/cdap/data/hbase/HBase10Test.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data.hbase;
+
+import com.google.common.base.Function;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HBaseTestingUtility;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.HRegionInfo;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.MiniHBaseCluster;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.regionserver.HRegion;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.JVMClusterUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * {@link HBaseTestBase} implementation supporting HBase 1.0.
+ */
+public class HBase10Test extends HBaseTestBase {
+  private static final Logger LOG = LoggerFactory.getLogger(HBase10Test.class);
+
+  protected HBaseTestingUtility testUtil = new HBaseTestingUtility();
+
+  @Override
+  public Configuration getConfiguration() {
+    return testUtil.getConfiguration();
+  }
+
+  @Override
+  public int getZKClientPort() {
+    return testUtil.getZkCluster().getClientPort();
+  }
+
+  @Override
+  public void startHBase() throws Exception {
+    testUtil.startMiniCluster();
+  }
+
+  @Override
+  public void stopHBase() throws Exception {
+    testUtil.shutdownMiniCluster();
+  }
+
+  @Override
+  public MiniHBaseCluster getHBaseCluster() {
+    return testUtil.getHBaseCluster();
+  }
+
+  @Override
+  public HRegion createHRegion(byte[] tableName, byte[] startKey,
+                               byte[] stopKey, String callingMethod, Configuration conf,
+                               byte[]... families)
+      throws IOException {
+    if (conf == null) {
+      conf = new Configuration();
+    }
+    HTableDescriptor htd = new HTableDescriptor(tableName);
+    for (byte [] family : families) {
+      htd.addFamily(new HColumnDescriptor(family));
+    }
+    HRegionInfo info = new HRegionInfo(htd.getTableName(), startKey, stopKey, false);
+    Path path = new Path(conf.get(HConstants.HBASE_DIR), callingMethod);
+    FileSystem fs = FileSystem.get(conf);
+    if (fs.exists(path)) {
+      if (!fs.delete(path, true)) {
+        throw new IOException("Failed delete of " + path);
+      }
+    }
+    return HRegion.createHRegion(info, path, conf, htd);
+  }
+
+  @Override
+  public void forceRegionFlush(byte[] tableName) throws IOException {
+    MiniHBaseCluster hbaseCluster = getHBaseCluster();
+    if (hbaseCluster != null) {
+      TableName qualifiedTableName = TableName.valueOf(tableName);
+      for (JVMClusterUtil.RegionServerThread t : hbaseCluster.getRegionServerThreads()) {
+        List<HRegion> serverRegions = t.getRegionServer().getOnlineRegions(qualifiedTableName);
+        int cnt = 0;
+        for (HRegion region : serverRegions) {
+          region.flushcache();
+          cnt++;
+        }
+        LOG.info("RegionServer {}: Flushed {} regions for table {}", t.getRegionServer().getServerName().toString(),
+                 cnt, Bytes.toStringBinary(tableName));
+      }
+    }
+  }
+
+  @Override
+  public void forceRegionCompact(byte[] tableName, boolean majorCompact) throws IOException {
+    MiniHBaseCluster hbaseCluster = getHBaseCluster();
+    if (hbaseCluster != null) {
+      TableName qualifiedTableName = TableName.valueOf(tableName);
+      for (JVMClusterUtil.RegionServerThread t : hbaseCluster.getRegionServerThreads()) {
+        List<HRegion> serverRegions = t.getRegionServer().getOnlineRegions(qualifiedTableName);
+        int cnt = 0;
+        for (HRegion region : serverRegions) {
+          region.compactStores(majorCompact);
+          cnt++;
+        }
+        LOG.info("RegionServer {}: Compacted {} regions for table {}", t.getRegionServer().getServerName().toString(),
+                 cnt, Bytes.toStringBinary(tableName));
+      }
+    }
+  }
+
+  @Override
+  public <T> Map<byte[], T> forEachRegion(byte[] tableName, Function<HRegion, T> function) {
+    MiniHBaseCluster hbaseCluster = getHBaseCluster();
+    Map<byte[], T> results = new TreeMap<>(Bytes.BYTES_COMPARATOR);
+    // make sure consumer config cache is updated
+    for (JVMClusterUtil.RegionServerThread t : hbaseCluster.getRegionServerThreads()) {
+      List<HRegion> serverRegions = t.getRegionServer().getOnlineRegions(TableName.valueOf(tableName));
+      for (HRegion region : serverRegions) {
+        results.put(region.getRegionName(), function.apply(region));
+      }
+    }
+    return results;
+  }
+
+  @Override
+  public void waitUntilTableAvailable(byte[] tableName, long timeoutInMillis)
+      throws IOException, InterruptedException {
+    testUtil.waitTableAvailable(tableName, timeoutInMillis);
+    testUtil.waitUntilAllRegionsAssigned(TableName.valueOf(tableName), timeoutInMillis);
+  }
+}

--- a/cdap-hbase-compat-1.0/src/test/java/co/cask/cdap/data2/increment/hbase10/IncrementHandlerTest.java
+++ b/cdap-hbase-compat-1.0/src/test/java/co/cask/cdap/data2/increment/hbase10/IncrementHandlerTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.increment.hbase10;
+
+import co.cask.cdap.data2.increment.hbase.AbstractIncrementHandlerTest;
+import co.cask.cdap.data2.increment.hbase.IncrementHandlerState;
+import co.cask.cdap.data2.increment.hbase.TimestampOracle;
+import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
+import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
+import co.cask.cdap.test.SlowTests;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.Coprocessor;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.HTable;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.ResultScanner;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.regionserver.HRegion;
+import org.apache.hadoop.hbase.regionserver.RegionScanner;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.experimental.categories.Category;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Tests for the HBase 0.98+ version of the {@link IncrementHandler} coprocessor.
+ */
+@Category(SlowTests.class)
+public class IncrementHandlerTest extends AbstractIncrementHandlerTest {
+
+  @Override
+  public void assertColumn(HTable table, byte[] row, byte[] col, long expected) throws Exception {
+    Result res = table.get(new Get(row));
+    Cell resA = res.getColumnLatestCell(FAMILY, col);
+    assertFalse(res.isEmpty());
+    assertNotNull(resA);
+    assertEquals(expected, Bytes.toLong(resA.getValue()));
+
+    Scan scan = new Scan(row);
+    scan.addFamily(FAMILY);
+    ResultScanner scanner = table.getScanner(scan);
+    Result scanRes = scanner.next();
+    assertNotNull(scanRes);
+    assertFalse(scanRes.isEmpty());
+    Cell scanResA = scanRes.getColumnLatestCell(FAMILY, col);
+    assertArrayEquals(row, scanResA.getRow());
+    assertEquals(expected, Bytes.toLong(scanResA.getValue()));
+  }
+
+  public void assertColumns(HTable table, byte[] row, byte[][] cols, long[] expected) throws Exception {
+    assertEquals(cols.length, expected.length);
+
+    Get get = new Get(row);
+    Scan scan = new Scan(row);
+    for (byte[] col : cols) {
+      get.addColumn(FAMILY, col);
+      scan.addColumn(FAMILY, col);
+    }
+
+    // check get
+    Result res = table.get(get);
+    assertFalse(res.isEmpty());
+    for (int i = 0; i < cols.length; i++) {
+      Cell resCell = res.getColumnLatestCell(FAMILY, cols[i]);
+      assertNotNull(resCell);
+      assertEquals(expected[i], Bytes.toLong(resCell.getValue()));
+    }
+
+    // check scan
+    ResultScanner scanner = table.getScanner(scan);
+    Result scanRes = scanner.next();
+    assertNotNull(scanRes);
+    assertFalse(scanRes.isEmpty());
+    for (int i = 0; i < cols.length; i++) {
+      Cell scanResCell = scanRes.getColumnLatestCell(FAMILY, cols[i]);
+      assertArrayEquals(row, scanResCell.getRow());
+      assertEquals(expected[i], Bytes.toLong(scanResCell.getValue()));
+    }
+  }
+
+  @Override
+  public HTable createTable(TableId tableId) throws Exception {
+    HBaseTableUtil tableUtil = new HBaseTableUtilFactory(cConf).get();
+    HTableDescriptor tableDesc = tableUtil.createHTableDescriptor(tableId);
+    HColumnDescriptor columnDesc = new HColumnDescriptor(FAMILY);
+    columnDesc.setMaxVersions(Integer.MAX_VALUE);
+    columnDesc.setValue(IncrementHandlerState.PROPERTY_TRANSACTIONAL, "false");
+    tableDesc.addFamily(columnDesc);
+    tableDesc.addCoprocessor(IncrementHandler.class.getName());
+    testUtil.getHBaseAdmin().createTable(tableDesc);
+    testUtil.waitUntilTableAvailable(tableDesc.getName(), 5000);
+    return tableUtil.createHTable(conf, tableId);
+  }
+
+  @Override
+  public RegionWrapper createRegion(TableId tableId, Map<String, String> familyProperties) throws Exception {
+    HColumnDescriptor columnDesc = new HColumnDescriptor(FAMILY);
+    columnDesc.setMaxVersions(Integer.MAX_VALUE);
+    for (Map.Entry<String, String> prop : familyProperties.entrySet()) {
+      columnDesc.setValue(prop.getKey(), prop.getValue());
+    }
+    return new HBase98RegionWrapper(
+        IncrementSummingScannerTest.createRegion(testUtil.getConfiguration(), cConf, tableId, columnDesc));
+  }
+
+  public static ColumnCell convertCell(Cell cell) {
+    return new ColumnCell(CellUtil.cloneRow(cell), CellUtil.cloneFamily(cell), CellUtil.cloneQualifier(cell),
+        cell.getTimestamp(), CellUtil.cloneValue(cell));
+  }
+
+  public class HBase98RegionWrapper implements RegionWrapper {
+    private final HRegion region;
+
+    public HBase98RegionWrapper(HRegion region) {
+      this.region = region;
+    }
+
+    @Override
+    public void initialize() throws IOException {
+      region.initialize();
+    }
+
+    @Override
+    public void put(Put put) throws IOException {
+      region.put(put);
+    }
+
+    @Override
+    public boolean scanRegion(List<ColumnCell> results, byte[] startRow) throws IOException {
+      return scanRegion(results, startRow, null);
+    }
+
+    @Override
+    public boolean scanRegion(List<ColumnCell> results, byte[] startRow, byte[][] columns) throws IOException {
+      Scan scan = new Scan().setMaxVersions().setStartRow(startRow);
+      if (columns != null) {
+        for (int i = 0; i < columns.length; i++) {
+          scan.addColumn(FAMILY, columns[i]);
+        }
+      }
+      RegionScanner rs = region.getScanner(scan);
+      try {
+        List<Cell> tmpResults = new ArrayList<>();
+        boolean hasMore = rs.next(tmpResults);
+        for (Cell cell : tmpResults) {
+          results.add(convertCell(cell));
+        }
+        return hasMore;
+      } finally {
+        rs.close();
+      }
+    }
+
+    @Override
+    public boolean flush() throws IOException {
+      HRegion.FlushResult result = region.flushcache();
+      return result.isCompactionNeeded();
+    }
+
+    @Override
+    public void compact(boolean majorCompact) throws IOException {
+      region.compactStores(majorCompact);
+    }
+
+    @Override
+    public void setCoprocessorTimestampOracle(TimestampOracle timeOracle) {
+      Coprocessor cp = region.getCoprocessorHost().findCoprocessor(IncrementHandler.class.getName());
+      assertNotNull(cp);
+      ((IncrementHandler) cp).setTimestampOracle(timeOracle);
+    }
+
+    @Override
+    public void close() throws IOException {
+      region.close();
+    }
+  }
+}

--- a/cdap-hbase-compat-1.0/src/test/java/co/cask/cdap/data2/increment/hbase10/IncrementSummingScannerTest.java
+++ b/cdap-hbase-compat-1.0/src/test/java/co/cask/cdap/data2/increment/hbase10/IncrementSummingScannerTest.java
@@ -1,0 +1,471 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.increment.hbase10;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.data2.dataset2.lib.table.hbase.HBaseTable;
+import co.cask.cdap.data2.increment.hbase.IncrementHandlerState;
+import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
+import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
+import com.google.common.collect.Lists;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.HBaseTestingUtility;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HRegionInfo;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.MockRegionServerServices;
+import org.apache.hadoop.hbase.ServerName;
+import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.regionserver.HRegion;
+import org.apache.hadoop.hbase.regionserver.HRegionFileSystem;
+import org.apache.hadoop.hbase.regionserver.RegionScanner;
+import org.apache.hadoop.hbase.regionserver.ScanType;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.wal.WAL;
+import org.apache.hadoop.hbase.wal.WALFactory;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.net.InetAddress;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link IncrementSummingScanner} implementation.
+ */
+public class IncrementSummingScannerTest {
+  private static final byte[] TRUE = Bytes.toBytes(true);
+  private static HBaseTestingUtility testUtil;
+  private static Configuration conf;
+  private static CConfiguration cConf;
+
+  @BeforeClass
+  public static void setupBeforeClass() throws Exception {
+    testUtil = new HBaseTestingUtility();
+    testUtil.startMiniCluster();
+    conf = testUtil.getConfiguration();
+    cConf = CConfiguration.create();
+  }
+
+  @AfterClass
+  public static void shutdownAfterClass() throws Exception {
+    testUtil.shutdownMiniCluster();
+  }
+
+  @Test
+  public void testIncrementScanning() throws Exception {
+    TableId tableId = TableId.from(Constants.DEFAULT_NAMESPACE, "TestIncrementSummingScanner");
+    byte[] familyBytes = Bytes.toBytes("f");
+    byte[] columnBytes = Bytes.toBytes("c");
+    HRegion region = createRegion(tableId, familyBytes);
+    try {
+      region.initialize();
+
+      // test handling of a single increment value alone
+      Put p = new Put(Bytes.toBytes("r1"));
+      p.add(familyBytes, columnBytes, Bytes.toBytes(3L));
+      p.setAttribute(HBaseTable.DELTA_WRITE, TRUE);
+      region.put(p);
+
+      Scan scan = new Scan();
+      RegionScanner scanner = new IncrementSummingScanner(region, -1, region.getScanner(scan), ScanType.USER_SCAN);
+      List<Cell> results = Lists.newArrayList();
+      scanner.next(results);
+
+      assertEquals(1, results.size());
+      Cell cell = results.get(0);
+      assertNotNull(cell);
+      assertEquals(3L, Bytes.toLong(cell.getValue()));
+
+      // test handling of a single total sum
+      p = new Put(Bytes.toBytes("r2"));
+      p.add(familyBytes, columnBytes, Bytes.toBytes(5L));
+      region.put(p);
+
+      scan = new Scan(Bytes.toBytes("r2"));
+
+      scanner = new IncrementSummingScanner(region, -1, region.getScanner(scan), ScanType.USER_SCAN);
+      results = Lists.newArrayList();
+      scanner.next(results);
+
+      assertEquals(1, results.size());
+      cell = results.get(0);
+      assertNotNull(cell);
+      assertEquals(5L, Bytes.toLong(cell.getValue()));
+
+      // test handling of multiple increment values
+      long now = System.currentTimeMillis();
+      p = new Put(Bytes.toBytes("r3"));
+      for (int i = 0; i < 5; i++) {
+        p.add(familyBytes, columnBytes, now - i, Bytes.toBytes((long) (i + 1)));
+      }
+      p.setAttribute(HBaseTable.DELTA_WRITE, TRUE);
+      region.put(p);
+
+      scan = new Scan(Bytes.toBytes("r3"));
+      scan.setMaxVersions();
+      scanner = new IncrementSummingScanner(region, -1, region.getScanner(scan), ScanType.USER_SCAN);
+      results = Lists.newArrayList();
+      scanner.next(results);
+
+      assertEquals(1, results.size());
+      cell = results.get(0);
+      assertNotNull(cell);
+      assertEquals(15L, Bytes.toLong(cell.getValue()));
+
+      // test handling of multiple increment values followed by a total sum, then other increments
+      now = System.currentTimeMillis();
+      p = new Put(Bytes.toBytes("r4"));
+      for (int i = 0; i < 3; i++) {
+        p.add(familyBytes, columnBytes, now - i, Bytes.toBytes(1L));
+      }
+      p.setAttribute(HBaseTable.DELTA_WRITE, TRUE);
+      region.put(p);
+
+      // this put will appear as a "total" sum prior to all the delta puts
+      p = new Put(Bytes.toBytes("r4"));
+      p.add(familyBytes, columnBytes, now - 5, Bytes.toBytes(5L));
+      region.put(p);
+
+      scan = new Scan(Bytes.toBytes("r4"));
+      scan.setMaxVersions();
+      scanner = new IncrementSummingScanner(region, -1, region.getScanner(scan), ScanType.USER_SCAN);
+      results = Lists.newArrayList();
+      scanner.next(results);
+
+      assertEquals(1, results.size());
+      cell = results.get(0);
+      assertNotNull(cell);
+      assertEquals(8L, Bytes.toLong(cell.getValue()));
+
+      // test handling of an increment column followed by a non-increment column
+      p = new Put(Bytes.toBytes("r4"));
+      p.add(familyBytes, Bytes.toBytes("c2"), Bytes.toBytes("value"));
+      region.put(p);
+
+      scan = new Scan(Bytes.toBytes("r4"));
+      scan.setMaxVersions();
+      scanner = new IncrementSummingScanner(region, -1, region.getScanner(scan), ScanType.USER_SCAN);
+      results = Lists.newArrayList();
+      scanner.next(results);
+
+      assertEquals(2, results.size());
+      cell = results.get(0);
+      assertNotNull(cell);
+      assertEquals(8L, Bytes.toLong(cell.getValue()));
+
+      cell = results.get(1);
+      assertNotNull(cell);
+      assertEquals("value", Bytes.toString(cell.getValue()));
+
+      // test handling of an increment column followed by a delete
+      now = System.currentTimeMillis();
+      Delete d = new Delete(Bytes.toBytes("r5"));
+      d.deleteColumn(familyBytes, columnBytes, now - 3);
+      region.delete(d);
+
+      p = new Put(Bytes.toBytes("r5"));
+      for (int i = 2; i >= 0; i--) {
+        p.add(familyBytes, columnBytes, now - i, Bytes.toBytes(1L));
+      }
+      p.setAttribute(HBaseTable.DELTA_WRITE, TRUE);
+      region.put(p);
+
+      scan = new Scan(Bytes.toBytes("r5"));
+      scan.setMaxVersions();
+      scan.setRaw(true);
+      scanner = new IncrementSummingScanner(region, -1, region.getScanner(scan), ScanType.COMPACT_RETAIN_DELETES);
+      results = Lists.newArrayList();
+      scanner.next(results);
+
+      // delete marker will not be returned for user scan
+      assertEquals(2, results.size());
+      cell = results.get(0);
+      assertNotNull(cell);
+      assertEquals(3L, Bytes.toLong(cell.getValue(), IncrementHandlerState.DELTA_MAGIC_PREFIX.length, 8));
+      // next cell should be the delete
+      cell = results.get(1);
+      assertTrue(CellUtil.isDelete(cell));
+    } finally {
+      region.close();
+    }
+
+  }
+
+  @Test
+  public void testFlushAndCompact() throws Exception {
+    TableId tableId = TableId.from(Constants.DEFAULT_NAMESPACE, "TestFlushAndCompact");
+    byte[] familyBytes = Bytes.toBytes("f");
+    byte[] columnBytes = Bytes.toBytes("c");
+    HRegion region = createRegion(tableId, familyBytes);
+    try {
+      region.initialize();
+
+      // load an initial set of increments
+      long ts = System.currentTimeMillis();
+      byte[] row1 = Bytes.toBytes("row1");
+      for (int i = 0; i < 50; i++) {
+        Put p = new Put(row1);
+        p.add(familyBytes, columnBytes, ts, Bytes.toBytes(1L));
+        p.setAttribute(HBaseTable.DELTA_WRITE, TRUE);
+        ts++;
+        region.put(p);
+      }
+
+      byte[] row2 = Bytes.toBytes("row2");
+      ts = System.currentTimeMillis();
+      // start with a full put
+      Put row2P = new Put(row2);
+      row2P.add(familyBytes, columnBytes, ts++, Bytes.toBytes(10L));
+      region.put(row2P);
+      for (int i = 0; i < 10; i++) {
+        Put p = new Put(row2);
+        p.add(familyBytes, columnBytes, ts++, Bytes.toBytes(1L));
+        p.setAttribute(HBaseTable.DELTA_WRITE, TRUE);
+        region.put(p);
+      }
+
+      // force a region flush
+      region.flushcache();
+      region.waitForFlushesAndCompactions();
+
+      Result r1 = region.get(new Get(row1));
+      assertNotNull(r1);
+      assertFalse(r1.isEmpty());
+      // row1 should have a full put aggregating all 50 incrments
+      Cell r1Cell = r1.getColumnLatestCell(familyBytes, columnBytes);
+      assertNotNull(r1Cell);
+      assertEquals(50L, Bytes.toLong(r1Cell.getValue()));
+
+      Result r2 = region.get(new Get(row2));
+      assertNotNull(r2);
+      assertFalse(r2.isEmpty());
+      // row2 should have a full put aggregating prior put + 10 increments
+      Cell r2Cell = r2.getColumnLatestCell(familyBytes, columnBytes);
+      assertNotNull(r2Cell);
+      assertEquals(20L, Bytes.toLong(r2Cell.getValue()));
+
+      // add 30 more increments to row2
+      for (int i = 0; i < 30; i++) {
+        Put p = new Put(row2);
+        p.add(familyBytes, columnBytes, ts++, Bytes.toBytes(1L));
+        p.setAttribute(HBaseTable.DELTA_WRITE, TRUE);
+        region.put(p);
+      }
+
+      // row2 should now have a full put aggregating prior 20 value + 30 increments
+      r2 = region.get(new Get(row2));
+      assertNotNull(r2);
+      assertFalse(r2.isEmpty());
+      r2Cell = r2.getColumnLatestCell(familyBytes, columnBytes);
+      assertNotNull(r2Cell);
+      assertEquals(50L, Bytes.toLong(r2Cell.getValue()));
+
+      // force another region flush
+      region.flushcache();
+      region.waitForFlushesAndCompactions();
+
+      // add 100 more increments to row2
+      for (int i = 0; i < 100; i++) {
+        Put p = new Put(row2);
+        p.add(familyBytes, columnBytes, ts++, Bytes.toBytes(1L));
+        p.setAttribute(HBaseTable.DELTA_WRITE, TRUE);
+        region.put(p);
+      }
+
+      // row2 should now have a full put aggregating prior 50 value + 100 increments
+      r2 = region.get(new Get(row2));
+      assertNotNull(r2);
+      assertFalse(r2.isEmpty());
+      r2Cell = r2.getColumnLatestCell(familyBytes, columnBytes);
+      assertNotNull(r2Cell);
+      assertEquals(150L, Bytes.toLong(r2Cell.getValue()));
+    } finally {
+      region.close();
+    }
+  }
+
+  @Test
+  public void testIncrementScanningWithBatchAndUVB() throws Exception {
+    TableId tableId = TableId.from(Constants.DEFAULT_NAMESPACE, "TestIncrementSummingScannerWithUpperVisibilityBound");
+    byte[] familyBytes = Bytes.toBytes("f");
+    byte[] columnBytes = Bytes.toBytes("c");
+    HRegion region = createRegion(tableId, familyBytes);
+    try {
+      region.initialize();
+
+      long start = 0;
+      long now = start;
+      long counter1 = 0;
+
+      // adding 5 delta increments
+      for (int i = 0; i < 5; i++) {
+        Put p = new Put(Bytes.toBytes("r1"), now++);
+        p.add(familyBytes, columnBytes, Bytes.toBytes(1L));
+        p.setAttribute(HBaseTable.DELTA_WRITE, TRUE);
+        region.put(p);
+        counter1++;
+      }
+
+      // different combinations of uvb and limit (see batch test above)
+      // At least these cases we want to cover for batch:
+      // * batch=<not set> // unlimited by default
+      // * batch=1
+      // * batch size less than delta inc group size
+      // * batch size greater than delta inc group size
+      // * batch size is bigger than all delta incs available
+      // At least these cases we want to cover for uvb:
+      // * uvb=<not set> // 0
+      // * uvb less than max tx of delta inc
+      // * uvb greater than max tx of delta inc
+      // * multiple uvbs applied to simulate multiple flush & compactions
+      // Also: we want different combinations of batch limit & uvbs
+      for (int i = 0; i < 7; i++) {
+        for (int k = 0; k < 4; k++) {
+          long[] uvbs = new long[k];
+          for (int l = 0; l < uvbs.length; l++) {
+            uvbs[l] = start + (k + 1) * (l + 1);
+          }
+          verifyCounts(region, new Scan().setMaxVersions(), new long[]{counter1}, i > 0 ? i : -1, uvbs);
+        }
+      }
+
+      // Now test same with two groups of increments
+      int counter2 = 0;
+      for (int i = 0; i < 5; i++) {
+        Put p = new Put(Bytes.toBytes("r2"), now + i);
+        p.add(familyBytes, columnBytes, Bytes.toBytes(2L));
+        p.setAttribute(HBaseTable.DELTA_WRITE, TRUE);
+        region.put(p);
+        counter2 += 2;
+      }
+
+      for (int i = 0; i < 12; i++) {
+        for (int k = 0; k < 4; k++) {
+          long[] uvbs = new long[k];
+          for (int l = 0; l < uvbs.length; l++) {
+            uvbs[l] = start + (k + 1) * (l + 1);
+          }
+          verifyCounts(region, new Scan().setMaxVersions(), new long[]{counter1, counter2}, i > 0 ? i : -1, uvbs);
+        }
+      }
+
+    } finally {
+      region.close();
+    }
+  }
+
+  private void verifyCounts(HRegion region, Scan scan, long[] counts) throws Exception {
+    verifyCounts(region, scan, counts, -1);
+  }
+
+  private void verifyCounts(HRegion region, Scan scan, long[] counts, int batch) throws Exception {
+    RegionScanner scanner = new IncrementSummingScanner(region, batch, region.getScanner(scan), ScanType.USER_SCAN);
+    // init with false if loop will execute zero times
+    boolean hasMore = counts.length > 0;
+    for (long count : counts) {
+      List<Cell> results = Lists.newArrayList();
+      hasMore = scanner.next(results);
+      assertEquals(1, results.size());
+      Cell cell = results.get(0);
+      assertNotNull(cell);
+      assertEquals(count, Bytes.toLong(cell.getValue()));
+    }
+    assertFalse(hasMore);
+  }
+
+  private void verifyCounts(HRegion region, Scan scan, long[] counts, int batch, long[] upperVisBound)
+      throws Exception {
+    // The idea is to chain IncrementSummingScanner: first couple respect the upperVisBound and may produce multiple
+    // cells for single value. This is what happens during flush or compaction. Second one will mimic user scan over
+    // flushed or compacted: it should merge all delta increments appropriately.
+    RegionScanner scanner = region.getScanner(scan);
+
+    for (int i = 0; i < upperVisBound.length; i++) {
+      scanner = new IncrementSummingScanner(region, batch, scanner,
+          ScanType.COMPACT_RETAIN_DELETES, upperVisBound[i], -1);
+    }
+    scanner = new IncrementSummingScanner(region, batch, scanner, ScanType.USER_SCAN);
+    // init with false if loop will execute zero times
+    boolean hasMore = counts.length > 0;
+    for (long count : counts) {
+      List<Cell> results = Lists.newArrayList();
+      hasMore = scanner.next(results);
+      assertEquals(1, results.size());
+      Cell cell = results.get(0);
+      assertNotNull(cell);
+      assertEquals(count, Bytes.toLong(cell.getValue()));
+    }
+    assertFalse(hasMore);
+  }
+
+  private HRegion createRegion(TableId tableId, byte[] family) throws Exception {
+    return createRegion(conf, cConf, tableId, new HColumnDescriptor(family));
+  }
+
+  static HRegion createRegion(Configuration hConf, CConfiguration cConf, TableId tableId,
+                              HColumnDescriptor cfd) throws Exception {
+    HBaseTableUtil tableUtil = new HBaseTableUtilFactory(cConf).get();
+    HTableDescriptor htd = tableUtil.createHTableDescriptor(tableId);
+    cfd.setMaxVersions(Integer.MAX_VALUE);
+    cfd.setKeepDeletedCells(true);
+    htd.addFamily(cfd);
+    htd.addCoprocessor(IncrementHandler.class.getName());
+
+    String tableName = htd.getNameAsString();
+    Path tablePath = new Path("/tmp/" + tableName);
+    Path hlogPath = new Path("/tmp/hlog-" + tableName);
+    FileSystem fs = FileSystem.get(hConf);
+    assertTrue(fs.mkdirs(tablePath));
+    WALFactory walFactory = new WALFactory(hConf, null, hlogPath.toString());
+    WAL hLog = walFactory.getWAL(new byte[]{1});
+    HRegionInfo regionInfo = new HRegionInfo(htd.getTableName());
+    HRegionFileSystem regionFS = HRegionFileSystem.createRegionOnFileSystem(hConf, fs, tablePath, regionInfo);
+    return new HRegion(regionFS, hLog, hConf, htd,
+                       new LocalRegionServerServices(hConf, ServerName.valueOf(
+                           InetAddress.getLocalHost().getHostName(), 0, System.currentTimeMillis())));
+  }
+
+  private static class LocalRegionServerServices extends MockRegionServerServices {
+    private final ServerName serverName;
+
+    public LocalRegionServerServices(Configuration conf, ServerName serverName) {
+      super(conf);
+      this.serverName = serverName;
+    }
+
+    @Override
+    public ServerName getServerName() {
+      return serverName;
+    }
+  }
+}

--- a/cdap-hbase-compat-1.0/src/test/java/co/cask/cdap/data2/transaction/queue/hbase/HBase10QueueTest.java
+++ b/cdap-hbase-compat-1.0/src/test/java/co/cask/cdap/data2/transaction/queue/hbase/HBase10QueueTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.transaction.queue.hbase;
+
+import co.cask.cdap.test.XSlowTests;
+import org.junit.experimental.categories.Category;
+
+/**
+ * Queue test implementation running on HBase 0.98.
+ */
+@Category(XSlowTests.class)
+public class HBase10QueueTest extends HBaseQueueTest {
+  // nothing to override
+}

--- a/cdap-hbase-compat-1.0/src/test/java/co/cask/cdap/data2/util/hbase/HBase10TableUtilTest.java
+++ b/cdap-hbase-compat-1.0/src/test/java/co/cask/cdap/data2/util/hbase/HBase10TableUtilTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2014-2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.test.XSlowTests;
+import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
+import org.junit.experimental.categories.Category;
+
+/**
+ *
+ */
+@Category(XSlowTests.class)
+public class HBase10TableUtilTest extends AbstractHBaseTableUtilTest {
+
+  private final HTableNameConverter nameConverter = new HTable10NameConverter();
+
+  @Override
+  protected HBaseTableUtil getTableUtil() {
+    HBase10TableUtil hBaseTableUtil = new HBase10TableUtil();
+    hBaseTableUtil.setCConf(cConf);
+    return hBaseTableUtil;
+  }
+
+  @Override
+  protected HTableNameConverter getNameConverter() {
+    return nameConverter;
+  }
+
+  @Override
+  protected String getTableNameAsString(TableId tableId) {
+    Preconditions.checkArgument(tableId != null, "TableId should not be null.");
+    String tablePrefix = cConf.get(Constants.Dataset.TABLE_PREFIX);
+    if (Constants.DEFAULT_NAMESPACE_ID.equals(tableId.getNamespace())) {
+      return nameConverter.getHBaseTableName(tablePrefix, tableId);
+    }
+    return Joiner.on(':').join(nameConverter.toHBaseNamespace(tablePrefix, tableId.getNamespace()),
+                               nameConverter.getHBaseTableName(tablePrefix, tableId));
+  }
+
+  @Override
+  protected boolean namespacesSupported() {
+    return true;
+  }
+}

--- a/cdap-hbase-compat-1.0/src/test/java/co/cask/cdap/data2/util/hbase/HTable10NameConverterTest.java
+++ b/cdap-hbase-compat-1.0/src/test/java/co/cask/cdap/data2/util/hbase/HTable10NameConverterTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.data2.util.TableId;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HTable10NameConverterTest {
+  @Test
+  public void testGetSysConfigTablePrefix() throws Exception {
+    CConfiguration cConf = CConfiguration.create();
+    String tablePrefix = cConf.get(Constants.Dataset.TABLE_PREFIX);
+
+    HBaseTableUtil tableUtil = new HBaseTableUtilFactory(cConf).get();
+    HTableNameConverter hBaseNameConversionUtil = new HTableNameConverterFactory().get();
+
+    HTableDescriptor htd = tableUtil.createHTableDescriptor(TableId.from("user", "some_table"));
+    Assert.assertEquals(tablePrefix + "_system:", hBaseNameConversionUtil.getSysConfigTablePrefix(htd));
+    htd = tableUtil.createHTableDescriptor(TableId.from(Constants.DEFAULT_NAMESPACE_ID, "table_in_default_ns"));
+    Assert.assertEquals(tablePrefix + "_system:", hBaseNameConversionUtil.getSysConfigTablePrefix(htd));
+  }
+}

--- a/cdap-master/pom.xml
+++ b/cdap-master/pom.xml
@@ -145,7 +145,7 @@
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>
-      <artifactId>cdap-hbase-compat-0.96</artifactId>
+      <artifactId>cdap-hbase-compat-0.98</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
@@ -162,7 +162,8 @@
     <profile>
       <id>dist</id>
       <properties>
-        <package.depends>--depends cdap --depends cdap-hbase-compat-0.96 --depends cdap-hbase-compat-0.98</package.depends>
+        <package.depends>--depends cdap --depends cdap-hbase-compat-0.96 --depends cdap-hbase-compat-0.98
+        --depends cdap-hbase-compat-1.0 --depends cdap-hbase-compat-1.0-cdh</package.depends>
       </properties>
       <build>
         <plugins>

--- a/cdap-watchdog/pom.xml
+++ b/cdap-watchdog/pom.xml
@@ -63,6 +63,30 @@
       <groupId>org.apache.twill</groupId>
       <artifactId>twill-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-common</artifactId>
+      <version>${hbase98.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-client</artifactId>
+      <version>${hbase98.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-protocol</artifactId>
+      <version>${hbase98.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-server</artifactId>
+      <version>${hbase98.version}</version>
+      <scope>provided</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.xerial.snappy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,7 @@
     <hadoop.version>2.3.0</hadoop.version>
     <hbase96.version>0.96.2-hadoop2</hbase96.version>
     <hbase98.version>0.98.6.1-hadoop2</hbase98.version>
+    <hbase10cdh.version>1.0.0-cdh5.4.4</hbase10cdh.version>
     <hive.version>1.1.0</hive.version>
     <hsql.version>2.2.4</hsql.version>
     <http.component.version>4.2.5</http.component.version>
@@ -210,6 +211,17 @@
       <dependency>
         <groupId>co.cask.tephra</groupId>
         <artifactId>tephra-hbase-compat-0.98</artifactId>
+        <version>${tephra.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>co.cask.tephra</groupId>
+        <artifactId>tephra-hbase-compat-1.0-cdh</artifactId>
         <version>${tephra.version}</version>
         <exclusions>
           <exclusion>
@@ -683,12 +695,12 @@
       <dependency>
         <groupId>org.apache.hbase</groupId>
         <artifactId>hbase-common</artifactId>
-        <version>${hbase96.version}</version>
+        <version>${hbase98.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.hbase</groupId>
         <artifactId>hbase-client</artifactId>
-        <version>${hbase96.version}</version>
+        <version>${hbase98.version}</version>
         <exclusions>
           <exclusion>
             <groupId>io.netty</groupId>
@@ -703,12 +715,12 @@
       <dependency>
         <groupId>org.apache.hbase</groupId>
         <artifactId>hbase-protocol</artifactId>
-        <version>${hbase96.version}</version>
+        <version>${hbase98.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.hbase</groupId>
         <artifactId>hbase-server</artifactId>
-        <version>${hbase96.version}</version>
+        <version>${hbase98.version}</version>
         <exclusions>
           <exclusion>
             <groupId>org.mortbay.jetty</groupId>
@@ -1014,7 +1026,7 @@
       <dependency>
         <groupId>org.apache.hbase</groupId>
         <artifactId>hbase-testing-util</artifactId>
-        <version>${hbase96.version}</version>
+        <version>${hbase98.version}</version>
         <scope>test</scope>
         <exclusions>
           <exclusion>
@@ -2048,6 +2060,7 @@
         <module>cdap-data-fabric</module>
         <module>cdap-hbase-compat-0.96</module>
         <module>cdap-hbase-compat-0.98</module>
+        <module>cdap-hbase-compat-1.0-cdh</module>
         <module>cdap-watchdog</module>
         <module>cdap-app-fabric</module>
         <module>cdap-security</module>


### PR DESCRIPTION
NOTE: This change depends on the change for CDAP-2896.  Some of the changes here are actually included in that PR.
NOTE: This ALSO depends on PR #3074. Since the current Tephra 0.5.1-SNAPSHOT version now depends on Twill 0.6.0-incubating-SNAPSHOT, this change cannot be tested until the CDAP update to Twill 0.6.0-incubating-SNAPSHOT has been merged. 

This change adds new compatibility modules:
* cdap-hbase-compat-1.0-cdh - for the version of HBase 1.0 shipped in CDH 5.4
* cdap-hbase-compat-1.0 - for Apache HBase 1.0

The Apache HBase 1.0 support is not complete yet, so it's use is disabled in HBaseVersionSpecificFactory.  Attempts to run on Apache HBase 1.0 will currently throw a ProvisionException.  Once CDAP-2868 is complete, the use of the cdap-hbase-compat-1.0 module can be enabled.