### PR TITLE
CDAP-2913 EMR install script

### DIFF
--- a/cdap-distributions/src/emr/install.sh
+++ b/cdap-distributions/src/emr/install.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+#
+# Copyright © 2015 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+#
+# Install CDAP under hadoop user for EMR
+#
+
+# Fetch repo file for YUM
+curl http://repository.cask.co/centos/6/x86_64/cdap/3.0/cask.repo > /etc/yum.repos.d/cdap-3.0.repo
+rpm --import http://repository.cask.co/centos/6/x86_64/cdap/3.0/pubkey.gpg
+# Enable EPEL packages (req'd for nodejs)
+sed -i -e '0,/enabled=0/s//enabled=1/' /etc/yum.repos.d/epel.repo
+yum makecache
+# Install dependencies
+yum install --downloadonly chkconfig -y
+rpm --install --force /var/cache/yum/x86_64/latest/amzn-main/packages/chkconfig-*
+yum install gyp http-parser-devel redhat-rpm-config icu -y
+yum install nodejs nodejs-devel npm -y
+yum install -y cdap-{gateway,kafka,master,ui}
+# Update permissions and symlink logs
+mkdir -p /mnt/var/log/cdap /mnt/cdap/kafka-logs
+chown -R hadoop:hadoop /var/cdap/run /var/run/cdap /var/tmp/cdap /mnt/var/log/cdap /mnt/cdap/kafka-logs
+rm -rf /var/log/cdap
+ln -sf /mnt/var/log/cdap /var/log/cdap
+# Configure CDAP
+__ipaddr=`ifconfig eth0 | grep addr: | cut -d: -f2 | head -n 1 | awk '{print $1}'`
+sed \
+  -e 's/yarn/hadoop/' \
+  -e "s/FQDN1:2181,FQDN2/${__ipaddr}/" \
+  -e 's:/data/cdap/kafka-logs:/mnt/cdap/kafka-logs:' \
+  -e "s/FQDN1:9092,FQDN2:9092/${__ipaddr}:9092/" \
+  -e "s/LOCAL-ROUTER-IP/${__ipaddr}/" \
+  -e 's/LOCAL-APP-FABRIC-IP//' \
+  -e 's/LOCAL-DATA-FABRIC-IP//' \
+  -e 's/LOCAL-WATCHDOG-IP//' \
+  -e "s/ROUTER-HOST-IP/${__ipaddr}/" \
+  -e 's/router.server.port/router.bind.port/' \
+  -e 's/10000/11015/' \
+  /etc/cdap/conf/cdap-site.xml.example > /etc/cdap/conf/cdap-site.xml
+# Create HDFS directory
+su - hadoop -c "hadoop fs -mkdir -p /cdap"
+# Start services
+for i in \
+  /opt/cdap/gateway/bin/svc-router \
+  /opt/cdap/kafka/bin/svc-kafka-server \
+  /opt/cdap/master/bin/svc-master \
+  /opt/cdap/ui/bin/svc-ui
+  do
+  su - hadoop -c "$i start"
+  done

--- a/cdap-distributions/src/emr/install.sh
+++ b/cdap-distributions/src/emr/install.sh
@@ -21,8 +21,8 @@
 die() { echo "ERROR: ${*}"; exit 1; };
 
 # Fetch repo file for YUM
-curl http://repository.cask.co/centos/6/x86_64/cdap/3.0/cask.repo > /etc/yum.repos.d/cdap-3.0.repo
-rpm --import http://repository.cask.co/centos/6/x86_64/cdap/3.0/pubkey.gpg
+curl http://repository.cask.co/centos/6/x86_64/cdap/3.0/cask.repo > /etc/yum.repos.d/cdap-3.0.repo || die "Cannot fetch repo"
+rpm --import http://repository.cask.co/centos/6/x86_64/cdap/3.0/pubkey.gpg || die "Cannot import GPG key from repo"
 # Enable EPEL packages (req'd for nodejs)
 sed -i -e '0,/enabled=0/s//enabled=1/' /etc/yum.repos.d/epel.repo || die "Unable to enable EPEL"
 yum makecache


### PR DESCRIPTION
This script does everything necessary to install CDAP on an Amazon EMR cluster.

- Setup YUM repository and install CDAP packages
- Install CDAP dependencies
- Create `kafka.log.dir` directory
- Configure CDAP
- Create `hdfs.namespace` HDFS directory
- Start CDAP services