### PR TITLE
[CDAP-1202] Scheduler APIs (Only AbstractSchedulerService) now takes …

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/Store.java
@@ -19,6 +19,7 @@ package co.cask.cdap.app.store;
 import co.cask.cdap.api.ProgramSpecification;
 import co.cask.cdap.api.data.stream.StreamSpecification;
 import co.cask.cdap.api.flow.FlowSpecification;
+import co.cask.cdap.api.schedule.SchedulableProgramType;
 import co.cask.cdap.api.schedule.ScheduleSpecification;
 import co.cask.cdap.api.worker.Worker;
 import co.cask.cdap.app.ApplicationSpecification;
@@ -314,6 +315,7 @@ public interface Store {
    * @param newValue name of the new stream to connect to
    */
   void changeFlowletSteamConnection(Id.Program flow, String flowletId, String oldValue, String newValue);
+
   /**
    * Adds a schedule for a particular program. If the schedule with the name already exists, the method will
    * throw RuntimeException.
@@ -328,6 +330,18 @@ public interface Store {
    * @param scheduleName the name of the schedule to be removed from the program
    */
   void deleteSchedule(Id.Program program, String scheduleName);
+
+  /**
+   * Deletes all schedules of the given {@link Id.Program}
+   * @param program defines program from which schedules are to be deleted
+   */
+  void deleteSchedules(Id.Program program);
+
+  /**
+   * Deletes all schedules from the given {@link Id.Namespace}
+   * @param namespaceId defines the namespace from which schedules are to be deleted
+   */
+  void deleteSchedules(Id.Namespace namespaceId);
 
   /**
    * Check if a program exists.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/CreateSchedulesStage.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/CreateSchedulesStage.java
@@ -77,16 +77,14 @@ public class CreateSchedulesStage extends AbstractStage<ApplicationWithPrograms>
       ProgramType programType = ProgramType.valueOfSchedulableType(newScheduleSpec.getProgram().getProgramType());
       scheduler.updateSchedule(Id.Program.from(input.getId(), programType,
                                                newScheduleSpec.getProgram().getProgramName()),
-                               newScheduleSpec.getProgram().getProgramType(),
-                               newScheduleSpec.getSchedule());
+                               newScheduleSpec);
     }
 
     for (Map.Entry<String, ScheduleSpecification> entry : mapDiff.entriesOnlyOnRight().entrySet()) {
       ScheduleSpecification scheduleSpec = entry.getValue();
       ProgramType programType = ProgramType.valueOfSchedulableType(scheduleSpec.getProgram().getProgramType());
       scheduler.schedule(Id.Program.from(input.getId(), programType, scheduleSpec.getProgram().getProgramName()),
-                         scheduleSpec.getProgram().getProgramType(),
-                         scheduleSpec.getSchedule());
+                         scheduleSpec, false);
     }
 
     // Note: the mapDiff also has a entriesInCommon method returning all entries in left and right maps

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/AdapterService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/AdapterService.java
@@ -483,15 +483,13 @@ public class AdapterService extends AbstractIdleService {
     throws NotFoundException, SchedulerException {
     Id.Program workflowId = getProgramId(namespace, adapterSpec);
     ScheduleSpecification scheduleSpec = adapterSpec.getScheduleSpecification();
-    scheduler.schedule(workflowId, scheduleSpec.getProgram().getProgramType(), scheduleSpec.getSchedule(),
+    scheduler.schedule(workflowId, scheduleSpec,
                        ImmutableMap.of(
                          ProgramOptionConstants.ADAPTER_NAME, adapterSpec.getName(),
                          ProgramOptionConstants.ADAPTER_SPEC, GSON.toJson(adapterSpec),
                          // hack for scheduler weirdness in unit tests, remove once CDAP-2281 is done
                          Constants.Scheduler.IGNORE_LAZY_START, String.valueOf(true)
                        ));
-    //TODO: Scheduler API should also manage the MDS.
-    store.addSchedule(workflowId, scheduleSpec);
   }
 
   private void stopWorkflowAdapter(Id.Namespace namespace, AdapterDefinition adapterSpec)
@@ -500,8 +498,6 @@ public class AdapterService extends AbstractIdleService {
     String scheduleName = adapterSpec.getScheduleSpecification().getSchedule().getName();
     try {
       scheduler.deleteSchedule(workflowId, SchedulableProgramType.WORKFLOW, scheduleName);
-      //TODO: Scheduler API should also manage the MDS.
-      store.deleteSchedule(workflowId, scheduleName);
     } catch (NotFoundException e) {
       // its possible a stop was already called and the schedule was deleted, but then there
       // was some failure stopping the active run.  In that case, the next time stop is called

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/Scheduler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/Scheduler.java
@@ -18,6 +18,7 @@ package co.cask.cdap.internal.app.runtime.schedule;
 
 import co.cask.cdap.api.schedule.SchedulableProgramType;
 import co.cask.cdap.api.schedule.Schedule;
+import co.cask.cdap.api.schedule.ScheduleSpecification;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ScheduledRuntime;
@@ -34,23 +35,34 @@ public interface Scheduler {
    * Schedule a program to be run in a defined schedule.
    *
    * @param program Program that needs to be run.
-   * @param programType type of program.
-   * @param schedule Schedule with which the program runs.
+   * @param scheduleSpec specification of the schedule.
    * @throws SchedulerException on unforeseen error.
    */
-  void schedule(Id.Program program, SchedulableProgramType programType, Schedule schedule)
+  void schedule(Id.Program program, ScheduleSpecification scheduleSpec)
     throws SchedulerException;
 
   /**
    * Schedule a program to be run in a defined schedule.
    *
    * @param program Program that needs to be run.
-   * @param programType type of program.
-   * @param schedule Schedule with which the program runs.
-   * @param properties system properties to be passed to the schedule
+   * @param scheduleSpec specification of the schedule.
+   * @param updateMds indicates whether to update the application specification in the MDS with this schedule. This is
+   *                  needed because during application deployment, the app spec in the MDS already contains a schedule
+   *                  spec, so we do not want to add it again/override it.
    * @throws SchedulerException on unforeseen error.
    */
-  void schedule(Id.Program program, SchedulableProgramType programType, Schedule schedule,
+  void schedule(Id.Program program, ScheduleSpecification scheduleSpec, boolean updateMds)
+    throws SchedulerException;
+
+  /**
+   * Schedule a program to be run in a defined schedule.
+   *
+   * @param program Program that needs to be run.
+   * @param scheduleSpec specification of the schedule.
+   * @param properties system properties to be passed to the schedule.
+   * @throws SchedulerException on unforeseen error.
+   */
+  void schedule(Id.Program program, ScheduleSpecification scheduleSpec,
                 Map<String, String> properties) throws SchedulerException;
 
   /**
@@ -152,28 +164,26 @@ public interface Scheduler {
    * Update the given schedule. The schedule with the same name than the given {@code schedule} will be replaced.
    *
    * @param program the program for which schedule needs to be updated
-   * @param programType the type of the program
-   * @param schedule the new schedule. The schedule with the same name will be replaced
+   * @param scheduleSpec the specification of the schedule
    * @throws NotFoundException if the {@code schedule} does not exist, or if the application the {@code program}
    *                           belongs to does not exist.
    * @throws SchedulerException on unforeseen error.
    */
-  void updateSchedule(Id.Program program, SchedulableProgramType programType, Schedule schedule)
+  void updateSchedule(Id.Program program, ScheduleSpecification scheduleSpec)
     throws NotFoundException, SchedulerException;
 
   /**
    * Update the given schedule. The schedule with the same name than the given {@code schedule} will be replaced.
    *
    * @param program the program for which schedule needs to be updated
-   * @param programType the type of the program
-   * @param schedule the new schedule. The schedule with the same name will be replaced
+   * @param scheduleSpec the specification of the schedule
    * @param properties properties that can be passed to the quartz scheduler
    * @throws NotFoundException if the {@code schedule} does not exist, or if the application the {@code program}
    *                           belongs to does not exist.
    * @throws SchedulerException on unforeseen error.
    */
-  void updateSchedule(Id.Program program, SchedulableProgramType programType, Schedule schedule,
-                             Map<String, String> properties) throws NotFoundException, SchedulerException;
+  void updateSchedule(Id.Program program, ScheduleSpecification scheduleSpec,
+                      Map<String, String> properties) throws NotFoundException, SchedulerException;
 
   /**
    * Deletes the schedule.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/TimeScheduler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/TimeScheduler.java
@@ -118,15 +118,22 @@ final class TimeScheduler implements Scheduler {
   }
 
   @Override
-  public void schedule(Id.Program program, SchedulableProgramType programType, Schedule schedule)
+  public void schedule(Id.Program program, ScheduleSpecification scheduleSpec)
     throws SchedulerException {
-    schedule(program, programType, schedule, ImmutableMap.<String, String>of());
+    schedule(program, scheduleSpec, ImmutableMap.<String, String>of());
   }
 
   @Override
-  public void schedule(Id.Program program, SchedulableProgramType programType, Schedule schedule,
+  public void schedule(Id.Program program, ScheduleSpecification scheduleSpec,
+                       boolean updateMds) throws SchedulerException {
+    throw new UnsupportedOperationException("MDS operations are not supported through TimeScheduler.");
+  }
+
+  @Override
+  public void schedule(Id.Program program, ScheduleSpecification scheduleSpec,
                        Map<String, String> properties) throws SchedulerException {
-    schedule(program, programType, ImmutableList.of(schedule), properties);
+    schedule(program, scheduleSpec.getProgram().getProgramType(), ImmutableList.of(scheduleSpec.getSchedule()),
+             properties);
   }
 
   @Override
@@ -260,17 +267,17 @@ final class TimeScheduler implements Scheduler {
   }
 
   @Override
-  public void updateSchedule(Id.Program program, SchedulableProgramType programType, Schedule schedule)
+  public void updateSchedule(Id.Program program, ScheduleSpecification scheduleSpec)
     throws NotFoundException, SchedulerException {
-    updateSchedule(program, programType, schedule, ImmutableMap.<String, String>of());
+    updateSchedule(program, scheduleSpec, ImmutableMap.<String, String>of());
   }
 
   @Override
-  public void updateSchedule(Id.Program program, SchedulableProgramType programType, Schedule schedule,
+  public void updateSchedule(Id.Program program, ScheduleSpecification scheduleSpec,
                              Map<String, String> properties) throws NotFoundException, SchedulerException {
     // TODO modify the update flow [CDAP-1618]
-    deleteSchedule(program, programType, schedule.getName());
-    schedule(program, programType, schedule, properties);
+    deleteSchedule(program, scheduleSpec.getProgram().getProgramType(), scheduleSpec.getSchedule().getName());
+    schedule(program, scheduleSpec, properties);
   }
 
   @Override
@@ -296,14 +303,8 @@ final class TimeScheduler implements Scheduler {
   }
 
   @Override
-  public void deleteSchedules(Id.Program program, SchedulableProgramType programType)
-    throws SchedulerException {
-    checkInitialized();
-    try {
-      scheduler.deleteJob(jobKeyFor(program, programType));
-    } catch (org.quartz.SchedulerException e) {
-      throw new SchedulerException(e);
-    }
+  public void deleteSchedules(Id.Program program, SchedulableProgramType programType) throws SchedulerException {
+    deleteSchedulerJob(program, programType);
   }
 
   @Override
@@ -313,13 +314,22 @@ final class TimeScheduler implements Scheduler {
     }
   }
 
+  private void deleteSchedulerJob(Id.Program program, SchedulableProgramType programType) throws SchedulerException {
+    checkInitialized();
+    try {
+      scheduler.deleteJob(jobKeyFor(program, programType));
+    } catch (org.quartz.SchedulerException e) {
+      throw new SchedulerException(e);
+    }
+  }
+
   private void deleteAllSchedules(Id.Namespace namespaceId, ApplicationSpecification appSpec)
     throws SchedulerException {
     for (ScheduleSpecification scheduleSpec : appSpec.getSchedules().values()) {
       Id.Application appId = Id.Application.from(namespaceId.getId(), appSpec.getName());
       ProgramType programType = ProgramType.valueOfSchedulableType(scheduleSpec.getProgram().getProgramType());
       Id.Program programId = Id.Program.from(appId, programType, scheduleSpec.getProgram().getProgramName());
-      deleteSchedules(programId, scheduleSpec.getProgram().getProgramType());
+      deleteSchedulerJob(programId, scheduleSpec.getProgram().getProgramType());
     }
   }
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/AppWithSchedule.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/AppWithSchedule.java
@@ -35,22 +35,25 @@ import java.util.concurrent.TimeUnit;
  * Application with workflow scheduling.
  */
 public class AppWithSchedule extends AbstractApplication {
+  public static final String NAME = "AppWithSchedule";
+  public static final String SCHEDULE_NAME = "SampleSchedule";
 
   @Override
   public void configure() {
     try {
-      setName("AppWithSchedule");
+      setName(NAME);
       setDescription("Sample application");
       ObjectStores.createObjectStore(getConfigurer(), "input", String.class);
       ObjectStores.createObjectStore(getConfigurer(), "output", String.class);
       addWorkflow(new SampleWorkflow());
+      addWorkflow(new SampleWorkflow1());
 
       Map<String, String> scheduleProperties = Maps.newHashMap();
       scheduleProperties.put("oneKey", "oneValue");
       scheduleProperties.put("anotherKey", "anotherValue");
       scheduleProperties.put("someKey", "someValue");
 
-      scheduleWorkflow(Schedules.createTimeSchedule("SampleSchedule", "Sample schedule", "0/1 * * * * ?"),
+      scheduleWorkflow(Schedules.createTimeSchedule(SCHEDULE_NAME, "Sample schedule", "0/1 * * * * ?"),
                        "SampleWorkflow", scheduleProperties);
     } catch (UnsupportedTypeException e) {
       throw Throwables.propagate(e);
@@ -61,12 +64,27 @@ public class AppWithSchedule extends AbstractApplication {
    * Sample workflow. Schedules a dummy MR job.
    */
   public static class SampleWorkflow extends AbstractWorkflow {
+    public static final String NAME = "SampleWorkflow";
 
     @Override
     public void configure() {
-        setName("SampleWorkflow");
+        setName(NAME);
         setDescription("SampleWorkflow description");
         addAction(new DummyAction());
+    }
+  }
+
+  /**
+   * Sample workflow. Schedules a dummy MR job.
+   */
+  public static class SampleWorkflow1 extends AbstractWorkflow {
+    public static final String NAME = "SampleWorkflow1";
+
+    @Override
+    public void configure() {
+      setName(NAME);
+      setDescription("SampleWorkflow1 description");
+      addAction(new DummyAction());
     }
   }
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/SchedulerTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/SchedulerTestBase.java
@@ -20,7 +20,9 @@ import co.cask.cdap.AppWithStreamSizeSchedule;
 import co.cask.cdap.api.metrics.MetricStore;
 import co.cask.cdap.api.schedule.SchedulableProgramType;
 import co.cask.cdap.api.schedule.Schedule;
+import co.cask.cdap.api.schedule.ScheduleSpecification;
 import co.cask.cdap.api.schedule.Schedules;
+import co.cask.cdap.api.workflow.ScheduleProgramInfo;
 import co.cask.cdap.app.runtime.ProgramRuntimeService;
 import co.cask.cdap.app.store.Store;
 import co.cask.cdap.common.NamespaceCannotBeDeletedException;
@@ -28,13 +30,13 @@ import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.utils.Tasks;
-import co.cask.cdap.config.PreferencesStore;
 import co.cask.cdap.internal.AppFabricTestHelper;
 import co.cask.cdap.internal.app.namespace.NamespaceAdmin;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.ProgramType;
 import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.Injector;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -77,7 +79,6 @@ public abstract class SchedulerTestBase {
   @BeforeClass
   public static void init() throws Exception {
     injector = AppFabricTestHelper.getInjector(CCONF);
-    PreferencesStore preferencesStore = injector.getInstance(PreferencesStore.class);
     streamSizeScheduler = injector.getInstance(StreamSizeScheduler.class);
     store = injector.getInstance(Store.class);
     metricStore = injector.getInstance(MetricStore.class);
@@ -137,7 +138,10 @@ public abstract class SchedulerTestBase {
 
     // Update the schedule2's data trigger
     // Both schedules should now trigger execution after 1 MB of data received
-    streamSizeScheduler.updateSchedule(PROGRAM_ID, PROGRAM_TYPE, UPDATE_SCHEDULE_2);
+    ScheduleSpecification updatedScheduleSpec =
+      new ScheduleSpecification(UPDATE_SCHEDULE_2, new ScheduleProgramInfo(PROGRAM_TYPE, PROGRAM_ID.getId()),
+                                ImmutableMap.<String, String>of());
+    streamSizeScheduler.updateSchedule(PROGRAM_ID, updatedScheduleSpec);
     metricsPublisher.increment(1024 * 1024);
     waitForRuns(store, PROGRAM_ID, 8, 5);
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/guice/AppFabricTestModule.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/guice/AppFabricTestModule.java
@@ -18,6 +18,7 @@ package co.cask.cdap.internal.guice;
 
 import co.cask.cdap.api.schedule.SchedulableProgramType;
 import co.cask.cdap.api.schedule.Schedule;
+import co.cask.cdap.api.schedule.ScheduleSpecification;
 import co.cask.cdap.app.guice.AppFabricServiceRuntimeModule;
 import co.cask.cdap.app.guice.ProgramRunnerRuntimeModule;
 import co.cask.cdap.app.guice.ServiceStoreModules;
@@ -106,11 +107,16 @@ public final class AppFabricTestModule extends AbstractModule {
   private Scheduler createNoopScheduler() {
     return new Scheduler() {
       @Override
-      public void schedule(Id.Program program, SchedulableProgramType programType, Schedule schedule) {
+      public void schedule(Id.Program program, ScheduleSpecification scheduleSpec) {
       }
 
       @Override
-      public void schedule(Id.Program program, SchedulableProgramType programType, Schedule schedule,
+      public void schedule(Id.Program program, ScheduleSpecification scheduleSpec,
+                           boolean updateMds) throws SchedulerException {
+      }
+
+      @Override
+      public void schedule(Id.Program program, ScheduleSpecification scheduleSpec,
                            Map<String, String> properties) {
       }
 
@@ -147,12 +153,12 @@ public final class AppFabricTestModule extends AbstractModule {
       }
 
       @Override
-      public void updateSchedule(Id.Program program, SchedulableProgramType programType, Schedule schedule) {
+      public void updateSchedule(Id.Program program, ScheduleSpecification scheduleSpec) {
       }
 
       @Override
-      public void updateSchedule(Id.Program program, SchedulableProgramType programType, Schedule schedule,
-                                 Map<String, String> properties) {
+      public void updateSchedule(Id.Program program,
+                                 ScheduleSpecification scheduleSpec, Map<String, String> properties) {
       }
 
       @Override


### PR DESCRIPTION
…care of MDS operations on schedules like add update and delete.

Also refactored the ``Scheduler`` interface to achieve this, mostly around passing in the entire ``ScheduleSpecification`` as opposed to just the ``Schedule`` object, because the MDS needs it.
Also added a way to add a schedule without updating the MDS. This is needed during the deployment pipeline, where ``ApplicationRegistrationStage`` already adds ``ScheduleSpecification`` to MDS (via ``ApplicationSpecification``.

Jira: [CDAP-1202](https://issues.cask.co/browse/CDAP-1202)
Build: http://builds.cask.co/browse/CDAP-DUT2128
