### PR TITLE
Make AlreadyExistsException extend ConflictException

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/AlreadyExistsException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/AlreadyExistsException.java
@@ -21,7 +21,7 @@ import co.cask.cdap.proto.Id;
 /**
  * Thrown when an element already exists.
  */
-public class AlreadyExistsException extends Exception {
+public class AlreadyExistsException extends ConflictException {
 
   private final Id objectId;
 


### PR DESCRIPTION
- Fixes DatasetInstanceHandlerTest.testBasics

http://builds.cask.co/browse/CDAP-DUT2152