### PR TITLE
with application classpath and classAcceptor to exclude hadoop classes

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/twill/HadoopClassExcluder.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/twill/HadoopClassExcluder.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.common.twill;
+
+import org.apache.twill.api.ClassAcceptor;
+
+import java.net.URL;
+
+/**
+ * Exclude hadoop classes
+ */
+public class HadoopClassExcluder extends ClassAcceptor {
+
+  @Override
+  public boolean accept(String className, URL classUrl, URL classPathUrl) {
+    // exclude hadoop but not hbase and hive packages
+    return !(className.startsWith("org.apache.hadoop")
+      && !className.startsWith("org.apache.hadoop.hbase") && !className.startsWith("org.apache.hadoop.hive"));
+  }
+}


### PR DESCRIPTION
After https://issues.apache.org/jira/browse/TWILL-117, we can include the classpath common for ApplicationMaster and all runnables and also a classAcceptor to filter the classes to include in the bundler jar for AM and runnables.

Since we can use the jars from the classpath specified by "yarn.application.classpath" for hadoop classes, we can exclude the hadoop classes while building the bundler jar.