### PR TITLE
CDAP-2846 artifact plugins extend another artifact

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactInfo.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactInfo.java
@@ -17,8 +17,9 @@
 package co.cask.cdap.internal.app.runtime.artifact;
 
 import co.cask.cdap.proto.Id;
-import com.google.common.base.Objects;
 import org.apache.twill.filesystem.Location;
+
+import java.util.Objects;
 
 /**
  * Information about the artifact itself, but nothing about the contents of the artifact.
@@ -51,11 +52,11 @@ public class ArtifactInfo {
 
     ArtifactInfo that = (ArtifactInfo) o;
 
-    return Objects.equal(id, that.id) && Objects.equal(location, that.location);
+    return Objects.equals(id, that.id) && Objects.equals(location, that.location);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(id, location);
+    return Objects.hash(id, location);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactMeta.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactMeta.java
@@ -18,22 +18,37 @@ package co.cask.cdap.internal.app.runtime.artifact;
 
 import co.cask.cdap.api.templates.plugins.PluginClass;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 /**
- * Metadata about an artifact, such as what plugins are contained in the artifact.
+ * Metadata about an artifact, such as what plugins are contained in the artifact, and what other artifacts can use
+ * the plugins in this artifact.
  */
 public class ArtifactMeta {
   private final List<PluginClass> plugins;
+  // can't call this 'extends' since that's a reserved keyword
+  private final Set<ArtifactRange> usableBy;
 
   public ArtifactMeta(List<PluginClass> plugins) {
+    this(plugins, ImmutableSet.<ArtifactRange>of());
+  }
+
+  public ArtifactMeta(List<PluginClass> plugins, Set<ArtifactRange> usableBy) {
     this.plugins = ImmutableList.copyOf(plugins);
+    this.usableBy = ImmutableSet.copyOf(usableBy);
   }
 
   public List<PluginClass> getPlugins() {
     return plugins;
+  }
+
+  public Set<ArtifactRange> getUsableBy() {
+    return usableBy;
   }
 
   @Override
@@ -47,11 +62,19 @@ public class ArtifactMeta {
 
     ArtifactMeta that = (ArtifactMeta) o;
 
-    return Objects.equals(plugins, that.plugins);
+    return Objects.equals(plugins, that.plugins) && Objects.equals(usableBy, that.usableBy);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(plugins);
+    return Objects.hash(plugins, usableBy);
+  }
+
+  @Override
+  public String toString() {
+    return "ArtifactMeta{" +
+      "plugins=" + plugins +
+      ", usableBy=" + usableBy +
+      '}';
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactMeta.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactMeta.java
@@ -27,7 +27,10 @@ import java.util.Set;
 
 /**
  * Metadata about an artifact, such as what plugins are contained in the artifact, and what other artifacts can use
- * the plugins in this artifact.
+ * the plugins in this artifact. For example, we could have an etl-batch-lib artifact that contains
+ * 20 different plugins that are meant to be used by the application contained in the etl-batch artifact.
+ * In this case, the artifact meta for etl-batch-lib would contain details about each of those 20 plugins, as well
+ * as information about which versions of the etl-batch artifact can use the plugins it contains.
  */
 public class ArtifactMeta {
   private final List<PluginClass> plugins;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRange.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRange.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.artifact;
+
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.artifact.ArtifactVersion;
+
+import java.util.Objects;
+
+/**
+ * Represents a range of versions for an artifact. The lower version is inclusive and the upper version is exclusive.
+ */
+public class ArtifactRange {
+  private final Id.Namespace namespace;
+  private final String name;
+  private final ArtifactVersion lower;
+  private final ArtifactVersion upper;
+
+  public ArtifactRange(Id.Namespace namespace, String name, ArtifactVersion lower, ArtifactVersion upper) {
+    this.namespace = namespace;
+    this.name = name;
+    this.lower = lower;
+    this.upper = upper;
+  }
+
+  public Id.Namespace getNamespace() {
+    return namespace;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public ArtifactVersion getLower() {
+    return lower;
+  }
+
+  public ArtifactVersion getUpper() {
+    return upper;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    ArtifactRange that = (ArtifactRange) o;
+
+    return Objects.equals(namespace, that.namespace) &&
+      Objects.equals(name, that.name) &&
+      Objects.equals(lower, that.lower) &&
+      Objects.equals(upper, that.upper);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(namespace, name, lower, upper);
+  }
+
+  @Override
+  public String toString() {
+    return "ArtifactRange{" +
+      "namespace=" + namespace +
+      ", name='" + name + '\'' +
+      ", lower=" + lower +
+      ", upper=" + upper +
+      '}';
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStore.java
@@ -332,7 +332,7 @@ public class ArtifactStore {
   private boolean matches(PluginData pluginData, ArtifactVersion version) {
     ArtifactVersion lower = new ArtifactVersion(pluginData.parentVersionLower);
     ArtifactVersion upper = new ArtifactVersion(pluginData.parentVersionUpper);
-    return lower.compareTo(version) <= 0 && upper.compareTo(version) > 0;
+    return version.compareTo(lower) >= 0 && version.compareTo(upper) < 0;
   }
 
   /**
@@ -510,9 +510,11 @@ public class ArtifactStore {
     }
   }
 
+  // this method examines all plugins in the given row and checks if they extend the given parent artifact.
+  // if so, information about the plugin artifact and the plugin details are added to the given map.
   private void addPluginsToMap(Id.Artifact parentArtifactId, Map<ArtifactInfo, List<PluginClass>> map,
                                Row row) throws IOException {
-    // column is the artifact name and version, value is the serialized PluginClass
+    // column is the artifact namespace, name, and version. value is the serialized PluginData
     for (Map.Entry<byte[], byte[]> column : row.getColumns().entrySet()) {
       ArtifactColumn artifactColumn = ArtifactColumn.parse(column.getKey());
       PluginData pluginData = gson.fromJson(Bytes.toString(column.getValue()), PluginData.class);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStore.java
@@ -34,16 +34,18 @@ import co.cask.cdap.data2.dataset2.tx.DatasetContext;
 import co.cask.cdap.data2.dataset2.tx.Transactional;
 import co.cask.cdap.internal.filesystem.LocationCodec;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.artifact.ArtifactVersion;
 import co.cask.tephra.TransactionConflictException;
 import co.cask.tephra.TransactionExecutor;
 import co.cask.tephra.TransactionExecutorFactory;
 import co.cask.tephra.TransactionFailureException;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Joiner;
+import com.google.common.base.Splitter;
 import com.google.common.base.Supplier;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import com.google.common.io.ByteStreams;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -54,9 +56,9 @@ import org.apache.twill.filesystem.LocationFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * This class manages artifacts as well as metadata for each artifact. Artifacts and their metadata cannot be changed
@@ -64,26 +66,58 @@ import java.util.Set;
  * plugin classes and/or application classes. We may want to extend this to include other types of classes, such
  * as datasets.
  *
- * Every time an artifact is added, the artifact contents are stored at a location based on its id:
+ * Every time an artifact is added, the artifact contents are stored at a base location based on its id:
  * /namespaces/{namespace-id}/artifacts/{artifact-name}/{artifact-version}
+ * Several metadata writes are then performed.
  *
- * Several writes are also performed on the meta table, one for metadata about the artifact itself, and one
- * for each entity contained in the artifact.
- *
- * Artifact metadata is stored with r:{namespace}:{artifact-name} as the rowkey, {artifact-version} as the column,
- * and ArtifactMeta as the value.
- *
- * PluginClass metadata is stored with p:{namespace}:{plugin-type}:{plugin-name} as the rowkey,
- * {artifact-version}:{artifact-name} as the column, and PluginClass as the value
+ * The first adds metadata about the artifact, with
+ * rowkey r:{namespace}:{artifact-name}, column {artifact-version}, and ArtifactDetail as the value
  *
  * TODO: (CDAP-2764) add this part when we have a better idea of what needs to be in AppClass.
- * AppClass metadata is stored with a:{namespace}:{app-name} as the rowkey,
- * {artifact-version}:{artifact-name} as the column, and AppClass as the value
+ * The second adds metadata about any Application Class contained in the artifact, with
+ * rowkey a:{namespace}:{classname}, column {artifact-name}:{artifact-version}, and AppClass as the value
+ *
+ * The third adds metadata about any Plugin contained in the artifact, with
+ * rowkey p:{parent-namespace}:{parent-name}:{plugin-type}:{plugin-name},
+ * column {artifact-namespace}:{artifact-name}:{artifact-version},
+ * and PluginDetailCodec as the value
+ *
+ * For example, suppose we add a system artifact etlbatch-3.1.0, which contains an ETLBatch application class.
+ * The meta table will look like:
+ *
+ * rowkey                            columns
+ * a:system:ETLBatch                 etlbatch:3.1.0 -> {AppData}
+ * r:system:etlbatch                 3.1.0 -> {ArtifactData}
+ *
+ * After that, a system artifact etlbatch-lib-3.1.0 is added, which extends etlbatch and contains
+ * stream sink and table sink plugins. The meta table will look like:
+ *
+ * rowkey                            columns
+ * a:system:ETLBatch                 etlbatch:3.1.0 -> {AppData}
+ * p:system:etlbatch:sink:stream     system:etlbatch-lib:3.1.0 -> {PluginData}
+ * p:system:etlbatch:sink:table      system:etlbatch-lib:3.1.0 -> {PluginData}
+ * r:system:etlbatch                 3.1.0 -> {ArtifactData}
+ * r:system:etlbatch-lib             3.1.0 -> {ArtifactData}
+ *
+ * Finally a user adds artifact custom-sources-1.0.0 to the default namespace,
+ * which extends etlbatch and contains a db source plugin. The meta table will look like:
+ *
+ * rowkey                            columns
+ * a:system:ETLBatch                 etlbatch:3.1.0 -> {AppData}
+ * p:system:etlbatch:sink:stream     system:etlbatch-lib:3.1.0 -> {PluginData}
+ * p:system:etlbatch:sink:table      system:etlbatch-lib:3.1.0 -> {PluginData}
+ * p:system:etlbatch:source:db       default:custom-sources:1.0.0 -> {PluginData}
+ * r:default:custom-sources          1.0.0 -> {ArtifactData}
+ * r:system:etlbatch                 3.1.0 -> {ArtifactData}
+ * r:system:etlbatch-lib             3.1.0 -> {ArtifactData}
+ *
+ * With this schema we can perform a scan to look up AppClasses, a scan to look up plugins that extend a specific
+ * artifact, and a scan to look up artifacts.
  */
 public class ArtifactStore {
   private static final String ARTIFACTS_PATH = "artifacts";
-  private static final String ARTIFACT_PREFIX = "r:";
-  private static final String PLUGIN_PREFIX = "p:";
+  private static final String ARTIFACT_PREFIX = "r";
+  private static final String PLUGIN_PREFIX = "p";
   private static final Id.DatasetInstance META_ID =
     Id.DatasetInstance.from(Constants.SYSTEM_NAMESPACE, "artifact.meta");
 
@@ -197,42 +231,42 @@ public class ArtifactStore {
   }
 
   /**
-   * Get all plugin classes in a given namespace. Results are returned as a map from artifact to plugins
-   * in that artifact.
+   * Get all plugin classes that extend the given parent artifact.
+   * Results are returned as a map from plugin artifact to plugins in that artifact.
    *
-   * @param namespace the namespace to look for plugins in
-   * @return unmodifiable map of artifact info to plugin classes in the namespace.
+   * @param parentArtifactId the id of the artifact to find plugins for
+   * @return a map of artifact info to plugin classes for all plugin classes of the given type in the namespace.
    *         The map will never be null. If there are no plugin classes, an empty map will be returned.
    * @throws IOException if there was an exception reading metadata from the metastore
    */
-  public Map<ArtifactInfo, List<PluginClass>> getPluginClasses(final Id.Namespace namespace) throws IOException {
+  public Map<ArtifactInfo, List<PluginClass>> getPluginClasses(final Id.Artifact parentArtifactId) throws IOException {
     return metaTable.executeUnchecked(
       new TransactionExecutor.Function<DatasetContext<Table>, Map<ArtifactInfo, List<PluginClass>>>() {
         @Override
         public Map<ArtifactInfo, List<PluginClass>> apply(DatasetContext<Table> context) throws Exception {
           Map<ArtifactInfo, List<PluginClass>> result = Maps.newHashMap();
 
-          Scanner scanner = context.get().scan(scanPlugins(namespace));
+          Scanner scanner = context.get().scan(scanPlugins(parentArtifactId));
           Row row;
           while ((row = scanner.next()) != null) {
-            addPluginsToMap(result, row);
+            addPluginsToMap(parentArtifactId, result, row);
           }
-          return Collections.unmodifiableMap(result);
+          return result;
         }
       });
   }
 
   /**
-   * Get all plugin classes of a specific type in the given namespace.
-   * Results are returned as a map from artifact to plugins in that artifact.
+   * Get all plugin classes of the given type that extend the given parent artifact.
+   * Results are returned as a map from plugin artifact to plugins in that artifact.
    *
-   * @param namespace the namespace to look for plugins in
+   * @param parentArtifactId the id of the artifact to find plugins for
    * @param type the type of plugin to look for
    * @return a map of artifact info to plugin classes for all plugin classes of the given type in the namespace.
    *         The map will never be null. If there are no plugin classes, an empty map will be returned.
    * @throws IOException if there was an exception reading metadata from the metastore
    */
-  public Map<ArtifactInfo, List<PluginClass>> getPluginClasses(final Id.Namespace namespace,
+  public Map<ArtifactInfo, List<PluginClass>> getPluginClasses(final Id.Artifact parentArtifactId,
                                                                final String type) throws IOException {
     return metaTable.executeUnchecked(
       new TransactionExecutor.Function<DatasetContext<Table>, Map<ArtifactInfo, List<PluginClass>>>() {
@@ -240,10 +274,10 @@ public class ArtifactStore {
         public Map<ArtifactInfo, List<PluginClass>> apply(DatasetContext<Table> context) throws Exception {
           Map<ArtifactInfo, List<PluginClass>> result = Maps.newHashMap();
 
-          Scanner scanner = context.get().scan(scanPlugins(namespace, type));
+          Scanner scanner = context.get().scan(scanPlugins(parentArtifactId, type));
           Row row;
           while ((row = scanner.next()) != null) {
-            addPluginsToMap(result, row);
+            addPluginsToMap(parentArtifactId, result, row);
           }
           return result;
         }
@@ -251,10 +285,10 @@ public class ArtifactStore {
   }
 
   /**
-   * Get all plugin classes of a specific type and name in the given namespace.
-   * Results are returned as a map from artifact to plugins in that artifact.
+   * Get all plugin classes of the given type and name that extend the given parent artifact.
+   * Results are returned as a map from plugin artifact to plugins in that artifact.
    *
-   * @param namespace the namespace to look for plugins in
+   * @param parentArtifactId the id of the artifact to find plugins for
    * @param type the type of plugin to look for
    * @param name the name of the plugin to look for
    * @return a map of artifact info to plugin classes of the given type and name in the namespace.
@@ -262,60 +296,43 @@ public class ArtifactStore {
    * @throws PluginNotExistsException if no plugin with the given type and name exists in the namespace
    * @throws IOException if there was an exception reading metadata from the metastore
    */
-  public Map<ArtifactInfo, List<PluginClass>> getPluginClasses(
-    final Id.Namespace namespace, final String type, final String name) throws IOException, PluginNotExistsException {
+  public Map<ArtifactInfo, PluginClass> getPluginClasses(final Id.Artifact parentArtifactId,
+                                                         final String type, final String name)
+    throws IOException, PluginNotExistsException {
 
-    Map<ArtifactInfo, List<PluginClass>> plugins = metaTable.executeUnchecked(
-      new TransactionExecutor.Function<DatasetContext<Table>, Map<ArtifactInfo, List<PluginClass>>>() {
+    Map<ArtifactInfo, PluginClass> plugins = metaTable.executeUnchecked(
+      new TransactionExecutor.Function<DatasetContext<Table>, Map<ArtifactInfo, PluginClass>>() {
         @Override
-        public Map<ArtifactInfo, List<PluginClass>> apply(DatasetContext<Table> context) throws Exception {
-          Map<ArtifactInfo, List<PluginClass>> result = Maps.newHashMap();
+        public Map<ArtifactInfo, PluginClass> apply(DatasetContext<Table> context) throws Exception {
+          Map<ArtifactInfo, PluginClass> result = Maps.newHashMap();
 
-          PluginKey pluginKey = new PluginKey(namespace, type, name);
+          PluginKey pluginKey = new PluginKey(parentArtifactId.getNamespace(), parentArtifactId.getName(), type, name);
           Row row = context.get().get(pluginKey.getRowKey());
           if (!row.isEmpty()) {
-            addPluginsToMap(result, row);
+            // column is the artifact name and version, value is the serialized PluginClass
+            for (Map.Entry<byte[], byte[]> column : row.getColumns().entrySet()) {
+              ArtifactColumn artifactColumn = ArtifactColumn.parse(column.getKey());
+              PluginData pluginData = gson.fromJson(Bytes.toString(column.getValue()), PluginData.class);
+              // filter out plugins that don't extend this version of the parent artifact
+              if (matches(pluginData, parentArtifactId.getVersion())) {
+                ArtifactInfo artifactInfo = new ArtifactInfo(artifactColumn.artifactId, pluginData.artifactLocation);
+                result.put(artifactInfo, pluginData.pluginClass);
+              }
+            }
           }
           return result;
         }
       });
     if (plugins.isEmpty()) {
-      throw new PluginNotExistsException(namespace, type, name);
+      throw new PluginNotExistsException(parentArtifactId.getNamespace(), type, name);
     }
     return plugins;
   }
 
-  /**
-   * Get the plugin class for a specific plugin type, name, and belonging to a specific artifact.
-   * Results are returned as a map from artifact to plugins in that artifact.
-   *
-   * @param artifactId the id of the artifact the plugin is from
-   * @param type the type of plugin to look for
-   * @param name the name of the plugin to look for
-   * @return a map entry containing the artifact info and plugin class details. Never null
-   * @throws PluginNotExistsException if no such plugin exists
-   * @throws IOException if there was an exception reading metadata from the metastore
-   */
-  public Map.Entry<ArtifactInfo, PluginClass> getPluginClass(
-    final Id.Artifact artifactId, final String type, final String name) throws IOException, PluginNotExistsException {
-    Map.Entry<ArtifactInfo, PluginClass> plugin = metaTable.executeUnchecked(
-      new TransactionExecutor.Function<DatasetContext<Table>, Map.Entry<ArtifactInfo, PluginClass>>() {
-        @Override
-        public Map.Entry<ArtifactInfo, PluginClass> apply(DatasetContext<Table> context) throws Exception {
-          PluginKey pluginKey = new PluginKey(artifactId.getNamespace(), type, name);
-          ArtifactColumn column = new ArtifactColumn(artifactId.getVersion().getVersion(), artifactId.getName());
-          byte[] value = context.get().get(pluginKey.getRowKey(), column.getColumn());
-          if (value == null) {
-            return null;
-          }
-          PluginData pluginData = gson.fromJson(Bytes.toString(value), PluginData.class);
-          return Maps.immutableEntry(new ArtifactInfo(artifactId, pluginData.artifactLocation), pluginData.pluginClass);
-        }
-      });
-    if (plugin == null) {
-      throw new PluginNotExistsException(artifactId, type, name);
-    }
-    return plugin;
+  private boolean matches(PluginData pluginData, ArtifactVersion version) {
+    ArtifactVersion lower = new ArtifactVersion(pluginData.parentVersionLower);
+    ArtifactVersion upper = new ArtifactVersion(pluginData.parentVersionUpper);
+    return lower.compareTo(version) <= 0 && upper.compareTo(version) > 0;
   }
 
   /**
@@ -375,12 +392,13 @@ public class ArtifactStore {
             return false;
           }
 
-          // write artifact metadata
           ArtifactData data = new ArtifactData(destination, artifactMeta);
-          writeMeta(table, artifactId, data);
+          // cleanup existing metadata if it exists and this is a snapshot
           if (existingMetaBytes != null) {
-            cleanupOldSnapshot(table, artifactId, existingMetaBytes, data);
+            cleanupOldSnapshot(table, artifactId, existingMetaBytes);
           }
+          // write artifact metadata
+          writeMeta(table, artifactId, data);
           return true;
         }
       });
@@ -398,33 +416,35 @@ public class ArtifactStore {
   }
 
   /**
-   * Clear all data in the given namespace. Not terribly efficient, can do more deletes than needed.
-   * This is purely for unit tests, so it's not a big concern.
+   * Clear all data in the given namespace. Used only in unit tests.
    *
    * @param namespace the namespace to delete data in
    * @throws IOException if there was some problem deleting the data
    */
   @VisibleForTesting
-  void clear(Id.Namespace namespace) throws IOException {
+  void clear(final Id.Namespace namespace) throws IOException {
     locationFactory.get(namespace, ARTIFACTS_PATH).delete();
-    for (final ArtifactDetail artifactDetail : getArtifacts(namespace)) {
 
-      metaTable.executeUnchecked(new TransactionExecutor.Function<DatasetContext<Table>, Void>() {
-        @Override
-        public Void apply(DatasetContext<Table> context) throws Exception {
-          final Id.Artifact artifactId = artifactDetail.getInfo().getId();
-          ArtifactKey artifactKey = new ArtifactKey(artifactId.getNamespace(), artifactId.getName());
-          context.get().delete(artifactKey.getRowKey());
-
-          for (PluginClass pluginClass : artifactDetail.getMeta().getPlugins()) {
-            PluginKey pluginKey =
-              new PluginKey(artifactId.getNamespace(), pluginClass.getType(), pluginClass.getName());
-            context.get().delete(pluginKey.getRowKey());
-          }
-          return null;
+    metaTable.executeUnchecked(new TransactionExecutor.Function<DatasetContext<Table>, Void>() {
+      @Override
+      public Void apply(DatasetContext<Table> context) throws Exception {
+        Table table = context.get();
+        Scanner scanner = table.scan(scanArtifacts(namespace));
+        Row row;
+        while ((row = scanner.next()) != null) {
+          table.delete(row.getRow());
         }
-      });
-    }
+        Scan pluginsScan = new Scan(
+          Bytes.toBytes(String.format("%s:%s:", PLUGIN_PREFIX, namespace.getId())),
+          Bytes.toBytes(String.format("%s:%s;", PLUGIN_PREFIX, namespace.getId()))
+        );
+        scanner = table.scan(pluginsScan);
+        while ((row = scanner.next()) != null) {
+          table.delete(row.getRow());
+        }
+        return null;
+      }
+    });
   }
 
   // write a new artifact snapshot and clean up the old snapshot data
@@ -434,37 +454,46 @@ public class ArtifactStore {
 
     // column for plugin meta and app meta. {artifact-name}:{artifact-version}
     // does not need to contain namespace because namespace is in the rowkey
-    ArtifactColumn artifactColumn =
-      new ArtifactColumn(artifactId.getVersion().getVersion(), artifactId.getName());
+    ArtifactColumn artifactColumn = new ArtifactColumn(artifactId);
 
     // write pluginClass metadata
     for (PluginClass pluginClass : data.meta.getPlugins()) {
-      // p:{namespace}:{type}:{name}
-      PluginKey pluginKey =
-        new PluginKey(artifactId.getNamespace(), pluginClass.getType(), pluginClass.getName());
-      byte[] pluginDataBytes = Bytes.toBytes(gson.toJson(new PluginData(pluginClass, data.location)));
-      table.put(pluginKey.getRowKey(), artifactColumn.getColumn(), pluginDataBytes);
+      // write metadata for each artifact this plugin extends
+      for (ArtifactRange artifactRange : data.meta.getUsableBy()) {
+        // p:{namespace}:{type}:{name}
+        PluginKey pluginKey = new PluginKey(
+          artifactRange.getNamespace(), artifactRange.getName(), pluginClass.getType(), pluginClass.getName());
+
+        byte[] pluginDataBytes = Bytes.toBytes(gson.toJson(new PluginData(pluginClass, artifactRange, data.location)));
+        table.put(pluginKey.getRowKey(), artifactColumn.getColumn(), pluginDataBytes);
+      }
     }
 
     // TODO: write appClass metadata
   }
 
   // if we are overwriting a previous snapshot, need to clean up the old snapshot data
-  // this means cleaning up the old jar, and performing a diff of the metadata to remove plugins
-  // that used to be in the old jar but are not in the current jar
-  private void cleanupOldSnapshot(Table table, Id.Artifact artifactId,
-                                  byte[] oldData, ArtifactData newData) throws IOException {
-    ArtifactData oldMeta = gson.fromJson(Bytes.toString(oldData), ArtifactData.class);
+  // this means cleaning up the old jar, and deleting plugin and app rows.
+  private void cleanupOldSnapshot(Table table, Id.Artifact artifactId, byte[] oldData) throws IOException {
+    // delete old artifact data
+    ArtifactCell artifactCell = new ArtifactCell(artifactId);
+    table.delete(artifactCell.rowkey, artifactCell.column);
 
-    // delete old plugins that were removed
-    Set<PluginClass> oldPlugins = Sets.newHashSet(oldMeta.meta.getPlugins());
-    Set<PluginClass> currentPlugins = Sets.newHashSet(newData.meta.getPlugins());
-    Set<PluginClass> pluginsToRemove = Sets.difference(oldPlugins, currentPlugins);
-    ArtifactColumn artifactColumn = new ArtifactColumn(artifactId.getVersion().getVersion(), artifactId.getName());
-    for (PluginClass pluginClass : pluginsToRemove) {
-      PluginKey pluginKey = new PluginKey(artifactId.getNamespace(), pluginClass.getType(), pluginClass.getName());
-      table.delete(pluginKey.getRowKey(), artifactColumn.getColumn());
+    // delete old plugins
+    ArtifactData oldMeta = gson.fromJson(Bytes.toString(oldData), ArtifactData.class);
+    ArtifactColumn artifactColumn = new ArtifactColumn(artifactId);
+
+    for (PluginClass pluginClass : oldMeta.meta.getPlugins()) {
+      // write metadata for each artifact this plugin extends
+      for (ArtifactRange artifactRange : oldMeta.meta.getUsableBy()) {
+        // p:{namespace}:{type}:{name}
+        PluginKey pluginKey = new PluginKey(
+          artifactRange.getNamespace(), artifactRange.getName(), pluginClass.getType(), pluginClass.getName());
+        table.delete(pluginKey.getRowKey(), artifactColumn.getColumn());
+      }
     }
+
+    // TODO: delete appClass metadata
 
     // delete the old jar file
     oldMeta.location.delete();
@@ -481,88 +510,84 @@ public class ArtifactStore {
     }
   }
 
-  // given a row representing plugin metadata, add all plugins in the row to the given map
-  private void addPluginsToMap(Map<ArtifactInfo, List<PluginClass>> map, Row row) throws IOException {
-    // plugin key contains namespace, plugin type, and plugin name
-    PluginKey pluginKey = PluginKey.parse(row.getRow());
-
+  private void addPluginsToMap(Id.Artifact parentArtifactId, Map<ArtifactInfo, List<PluginClass>> map,
+                               Row row) throws IOException {
     // column is the artifact name and version, value is the serialized PluginClass
     for (Map.Entry<byte[], byte[]> column : row.getColumns().entrySet()) {
       ArtifactColumn artifactColumn = ArtifactColumn.parse(column.getKey());
       PluginData pluginData = gson.fromJson(Bytes.toString(column.getValue()), PluginData.class);
 
-      Id.Artifact artifactId =
-        Id.Artifact.from(pluginKey.namespace, artifactColumn.name, artifactColumn.version);
-      ArtifactInfo artifactInfo = new ArtifactInfo(artifactId, pluginData.artifactLocation);
+      // filter out plugins that don't extend this version of the parent artifact
+      if (matches(pluginData, parentArtifactId.getVersion())) {
+        ArtifactInfo artifactInfo = new ArtifactInfo(artifactColumn.artifactId, pluginData.artifactLocation);
 
-      if (!map.containsKey(artifactInfo)) {
-        map.put(artifactInfo, Lists.<PluginClass>newArrayList());
+        if (!map.containsKey(artifactInfo)) {
+          map.put(artifactInfo, Lists.<PluginClass>newArrayList());
+        }
+        map.get(artifactInfo).add(pluginData.pluginClass);
       }
-      map.get(artifactInfo).add(pluginData.pluginClass);
     }
   }
 
   private Scan scanArtifacts(Id.Namespace namespace) {
     return new Scan(
-      Bytes.toBytes(String.format("%s%s:", ARTIFACT_PREFIX, namespace.getId())),
-      Bytes.toBytes(String.format("%s%s;", ARTIFACT_PREFIX, namespace.getId())));
+      Bytes.toBytes(String.format("%s:%s:", ARTIFACT_PREFIX, namespace.getId())),
+      Bytes.toBytes(String.format("%s:%s;", ARTIFACT_PREFIX, namespace.getId())));
   }
 
-  private Scan scanPlugins(Id.Namespace namespace) {
+  private Scan scanPlugins(Id.Artifact parentArtifactId) {
     return new Scan(
-      Bytes.toBytes(String.format("%s%s:", PLUGIN_PREFIX, namespace.getId())),
-      Bytes.toBytes(String.format("%s%s;", PLUGIN_PREFIX, namespace.getId())));
+      Bytes.toBytes(String.format("%s:%s:%s:",
+        PLUGIN_PREFIX, parentArtifactId.getNamespace().getId(), parentArtifactId.getName())),
+      Bytes.toBytes(String.format("%s:%s:%s;",
+        PLUGIN_PREFIX, parentArtifactId.getNamespace().getId(), parentArtifactId.getName())));
   }
 
-  private Scan scanPlugins(Id.Namespace namespace, String type) {
+  private Scan scanPlugins(Id.Artifact parentArtifactId, String type) {
     return new Scan(
-      Bytes.toBytes(String.format("%s%s:%s:", PLUGIN_PREFIX, namespace.getId(), type)),
-      Bytes.toBytes(String.format("%s%s:%s;", PLUGIN_PREFIX, namespace.getId(), type)));
+      Bytes.toBytes(String.format("%s:%s:%s:%s:",
+        PLUGIN_PREFIX, parentArtifactId.getNamespace().getId(), parentArtifactId.getName(), type)),
+      Bytes.toBytes(String.format("%s:%s:%s:%s;",
+        PLUGIN_PREFIX, parentArtifactId.getNamespace().getId(), parentArtifactId.getName(), type)));
   }
 
   private static class PluginKey {
-    private final Id.Namespace namespace;
+    private final Id.Namespace parentArtifactNamespace;
+    private final String parentArtifactName;
     private final String type;
     private final String name;
 
-    private PluginKey(Id.Namespace namespace, String type, String name) {
-      this.namespace = namespace;
+    private PluginKey(Id.Namespace parentArtifactNamespace, String parentArtifactName, String type, String name) {
+      this.parentArtifactNamespace = parentArtifactNamespace;
+      this.parentArtifactName = parentArtifactName;
       this.type = type;
       this.name = name;
     }
 
+    // p:system:etlbatch:sink:table
     private byte[] getRowKey() {
-      return Bytes.toBytes(String.format("%s%s:%s:%s", PLUGIN_PREFIX, namespace.getId(), type, name));
-    }
-
-    private static PluginKey parse(byte[] rowkey) {
-      String key = Bytes.toString(rowkey);
-      int namespaceEnd = key.indexOf(':', PLUGIN_PREFIX.length());
-      Id.Namespace namespace = Id.Namespace.from(key.substring(PLUGIN_PREFIX.length(), namespaceEnd));
-      int typeEnd = key.indexOf(':', namespaceEnd + 1);
-      String type = key.substring(namespaceEnd + 1, typeEnd);
-      String name = key.substring(typeEnd + 1);
-      return new PluginKey(namespace, type, name);
+      return Bytes.toBytes(
+        Joiner.on(':').join(PLUGIN_PREFIX, parentArtifactNamespace.getId(), parentArtifactName, type, name));
     }
   }
 
   private static class ArtifactColumn {
-    private final String version;
-    private final String name;
+    private final Id.Artifact artifactId;
 
-    private ArtifactColumn(String version, String name) {
-      this.version = version;
-      this.name = name;
+    private ArtifactColumn(Id.Artifact artifactId) {
+      this.artifactId = artifactId;
     }
 
     private byte[] getColumn() {
-      return Bytes.toBytes(String.format("%s:%s", version, name));
+      return Bytes.toBytes(String.format("%s:%s:%s",
+        artifactId.getNamespace().getId(), artifactId.getName(), artifactId.getVersion().getVersion()));
     }
 
     private static ArtifactColumn parse(byte[] columnBytes) {
       String columnStr = Bytes.toString(columnBytes);
-      int separatorIndex = columnStr.indexOf(':');
-      return new ArtifactColumn(columnStr.substring(0, separatorIndex), columnStr.substring(separatorIndex + 1));
+      Iterator<String> parts = Splitter.on(':').limit(3).split(columnStr).iterator();
+      Id.Namespace namespace = Id.Namespace.from(parts.next());
+      return new ArtifactColumn(Id.Artifact.from(namespace, parts.next(), parts.next()));
     }
   }
 
@@ -577,14 +602,16 @@ public class ArtifactStore {
     }
 
     private byte[] getRowKey() {
-      return Bytes.toBytes(String.format("%s%s:%s", ARTIFACT_PREFIX, namespace.getId(), name));
+      return Bytes.toBytes(Joiner.on(':').join(ARTIFACT_PREFIX, namespace.getId(), name));
     }
 
     private static ArtifactKey parse(byte[] rowkey) {
       String key = Bytes.toString(rowkey);
-      int separatorIdx = key.indexOf(':', ARTIFACT_PREFIX.length());
-      return new ArtifactKey(Id.Namespace.from(key.substring(ARTIFACT_PREFIX.length(), separatorIdx)),
-        key.substring(separatorIdx + 1));
+      Iterator<String> parts = Splitter.on(':').limit(4).split(key).iterator();
+      // first part is the artifact prefix
+      parts.next();
+      // next is namespace, then name
+      return new ArtifactKey(Id.Namespace.from(parts.next()), parts.next());
     }
   }
 
@@ -612,10 +639,14 @@ public class ArtifactStore {
   // Data that will be stored for a plugin.
   private static class PluginData {
     private final PluginClass pluginClass;
+    private final String parentVersionLower;
+    private final String parentVersionUpper;
     private final Location artifactLocation;
 
-    public PluginData(PluginClass pluginClass, Location artifactLocation) {
+    public PluginData(PluginClass pluginClass, ArtifactRange usableBy, Location artifactLocation) {
       this.pluginClass = pluginClass;
+      this.parentVersionLower = usableBy.getLower().getVersion();
+      this.parentVersionUpper = usableBy.getUpper().getVersion();
       this.artifactLocation = artifactLocation;
     }
   }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStoreTest.java
@@ -456,7 +456,6 @@ public class ArtifactStoreTest {
       Id.Artifact.from(Constants.DEFAULT_NAMESPACE_ID, "parent", "2.0.0")
     );
     for (Id.Artifact badId : badIds) {
-      Map<ArtifactInfo, List<PluginClass>> result = artifactStore.getPluginClasses(badId);
       Assert.assertTrue(artifactStore.getPluginClasses(badId).isEmpty());
       Assert.assertTrue(artifactStore.getPluginClasses(badId, "atype").isEmpty());
       try {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStoreTest.java
@@ -22,10 +22,12 @@ import co.cask.cdap.api.templates.plugins.PluginPropertyField;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.internal.AppFabricTestHelper;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.artifact.ArtifactVersion;
 import co.cask.cdap.test.SlowTests;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.io.CharStreams;
@@ -41,6 +43,7 @@ import java.io.InputStreamReader;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
@@ -90,26 +93,17 @@ public class ArtifactStoreTest {
 
   @Test
   public void testGetNonexistantPlugin() throws IOException {
-    Id.Namespace namespace = Id.Namespace.from("ns1");
+    Id.Artifact parentArtifact = Id.Artifact.from(Constants.DEFAULT_NAMESPACE_ID, "abc", "1.2.3");
 
     // no plugins in a namespace should return an empty collection
-    Assert.assertTrue(artifactStore.getPluginClasses(namespace).isEmpty());
+    Assert.assertTrue(artifactStore.getPluginClasses(parentArtifact).isEmpty());
 
     // no plugins in namespace of a given type should return an empty map
-    Assert.assertTrue(artifactStore.getPluginClasses(namespace, "sometype").isEmpty());
+    Assert.assertTrue(artifactStore.getPluginClasses(parentArtifact, "sometype").isEmpty());
 
     // no plugins in namespace of a given type and name should throw an exception
     try {
-      artifactStore.getPluginClasses(namespace, "sometype", "somename");
-      Assert.fail();
-    } catch (PluginNotExistsException e) {
-      // expected
-    }
-
-    // no plugins in namespace of a given type and name and artifact should throw an exception
-    try {
-      Id.Artifact artifactId = Id.Artifact.from(namespace, "A", "1.0.0");
-      artifactStore.getPluginClass(artifactId, "sometype", "somename");
+      artifactStore.getPluginClasses(parentArtifact, "sometype", "somename");
       Assert.fail();
     } catch (PluginNotExistsException e) {
       // expected
@@ -150,17 +144,19 @@ public class ArtifactStoreTest {
 
   @Test
   public void testSnapshotMutability() throws Exception {
+    ArtifactRange parentArtifacts = new ArtifactRange(
+      Constants.DEFAULT_NAMESPACE_ID, "parent", new ArtifactVersion("1.0.0"), new ArtifactVersion("2.0.0"));
     // write the snapshot once
     PluginClass plugin1 = new PluginClass("atype", "plugin1", "", "c.c.c.plugin1", "cfg",
       ImmutableMap.<String, PluginPropertyField>of());
     PluginClass plugin2 = new PluginClass("atype", "plugin2", "", "c.c.c.plugin2", "cfg",
       ImmutableMap.<String, PluginPropertyField>of());
     Id.Artifact artifactId = Id.Artifact.from(Constants.DEFAULT_NAMESPACE_ID, "myplugins", "1.0.0-SNAPSHOT");
-    ArtifactMeta artifactMeta = new ArtifactMeta(ImmutableList.of(plugin1, plugin2));
+    ArtifactMeta artifactMeta = new ArtifactMeta(ImmutableList.of(plugin1, plugin2), ImmutableSet.of(parentArtifacts));
     artifactStore.write(artifactId, artifactMeta, new ByteArrayInputStream(Bytes.toBytes("abc123")));
 
     // update meta and jar contents
-    artifactMeta = new ArtifactMeta(ImmutableList.of(plugin2));
+    artifactMeta = new ArtifactMeta(ImmutableList.of(plugin2), ImmutableSet.of(parentArtifacts));
     artifactStore.write(artifactId, artifactMeta, new ByteArrayInputStream(Bytes.toBytes("xyz321")));
 
     // check the metadata and contents got updated
@@ -168,10 +164,11 @@ public class ArtifactStoreTest {
     assertEqual(artifactId, artifactMeta, "xyz321", detail);
 
     // check that plugin1 was deleted and plugin2 remains
-    Assert.assertEquals(Maps.immutableEntry(detail.getInfo(), plugin2),
-      artifactStore.getPluginClass(artifactId, plugin2.getType(), plugin2.getName()));
+    Id.Artifact parentArtifactId = Id.Artifact.from(Constants.DEFAULT_NAMESPACE_ID, "parent", "1.0.0");
+    Assert.assertEquals(ImmutableMap.of(detail.getInfo(), plugin2),
+      artifactStore.getPluginClasses(parentArtifactId, plugin2.getType(), plugin2.getName()));
     try {
-      artifactStore.getPluginClass(artifactId, plugin1.getType(), plugin1.getName());
+      artifactStore.getPluginClasses(parentArtifactId, plugin1.getType(), plugin1.getName());
       Assert.fail();
     } catch (PluginNotExistsException e) {
       // expected
@@ -266,6 +263,8 @@ public class ArtifactStoreTest {
 
   @Test
   public void testGetPlugins() throws Exception {
+    ArtifactRange parentArtifacts = new ArtifactRange(
+      Constants.DEFAULT_NAMESPACE_ID, "parent", new ArtifactVersion("1.0.0"), new ArtifactVersion("2.0.0"));
     // we have 2 plugins of type A and 2 plugins of type B
     PluginClass pluginA1 = new PluginClass(
       "A", "p1", "desc", "c.p1", "cfg",
@@ -301,46 +300,48 @@ public class ArtifactStoreTest {
 
     // artifact artifactX-1.0.0 contains plugin A1
     Id.Artifact artifactXv100 = Id.Artifact.from(Constants.DEFAULT_NAMESPACE_ID, "artifactX", "1.0.0");
-    ArtifactMeta metaXv100 = new ArtifactMeta(ImmutableList.of(pluginA1));
+    ArtifactMeta metaXv100 = new ArtifactMeta(ImmutableList.of(pluginA1), ImmutableSet.of(parentArtifacts));
     artifactStore.write(artifactXv100, metaXv100, new ByteArrayInputStream(contents));
     ArtifactInfo artifactXv100Info = artifactStore.getArtifact(artifactXv100).getInfo();
 
     // artifact artifactX-1.1.0 contains plugin A1
     Id.Artifact artifactXv110 = Id.Artifact.from(Constants.DEFAULT_NAMESPACE_ID, "artifactX", "1.1.0");
-    ArtifactMeta metaXv110 = new ArtifactMeta(ImmutableList.of(pluginA1));
+    ArtifactMeta metaXv110 = new ArtifactMeta(ImmutableList.of(pluginA1), ImmutableSet.of(parentArtifacts));
     artifactStore.write(artifactXv110, metaXv110, new ByteArrayInputStream(contents));
     ArtifactInfo artifactXv110Info = artifactStore.getArtifact(artifactXv110).getInfo();
 
     // artifact artifactX-2.0.0 contains plugins A1 and A2
     Id.Artifact artifactXv200 = Id.Artifact.from(Constants.DEFAULT_NAMESPACE_ID, "artifactX", "2.0.0");
-    ArtifactMeta metaXv200 = new ArtifactMeta(ImmutableList.of(pluginA1, pluginA2));
+    ArtifactMeta metaXv200 = new ArtifactMeta(ImmutableList.of(pluginA1, pluginA2), ImmutableSet.of(parentArtifacts));
     artifactStore.write(artifactXv200, metaXv200, new ByteArrayInputStream(contents));
     ArtifactInfo artifactXv200Info = artifactStore.getArtifact(artifactXv200).getInfo();
 
     // artifact artifactY-1.0.0 contains plugin B1
     Id.Artifact artifactYv100 = Id.Artifact.from(Constants.DEFAULT_NAMESPACE_ID, "artifactY", "1.0.0");
-    ArtifactMeta metaYv100 = new ArtifactMeta(ImmutableList.of(pluginB1));
+    ArtifactMeta metaYv100 = new ArtifactMeta(ImmutableList.of(pluginB1), ImmutableSet.of(parentArtifacts));
     artifactStore.write(artifactYv100, metaYv100, new ByteArrayInputStream(contents));
     ArtifactInfo artifactYv100Info = artifactStore.getArtifact(artifactYv100).getInfo();
 
     // artifact artifactY-2.0.0 contains plugin B2
     Id.Artifact artifactYv200 = Id.Artifact.from(Constants.DEFAULT_NAMESPACE_ID, "artifactY", "2.0.0");
-    ArtifactMeta metaYv200 = new ArtifactMeta(ImmutableList.of(pluginB2));
+    ArtifactMeta metaYv200 = new ArtifactMeta(ImmutableList.of(pluginB2), ImmutableSet.of(parentArtifacts));
     artifactStore.write(artifactYv200, metaYv200, new ByteArrayInputStream(contents));
     ArtifactInfo artifactYv200Info = artifactStore.getArtifact(artifactYv200).getInfo();
 
     // artifact artifactZ-1.0.0 contains plugins A1 and B1
     Id.Artifact artifactZv100 = Id.Artifact.from(Constants.DEFAULT_NAMESPACE_ID, "artifactZ", "1.0.0");
-    ArtifactMeta metaZv100 = new ArtifactMeta(ImmutableList.of(pluginA1, pluginB1));
+    ArtifactMeta metaZv100 = new ArtifactMeta(ImmutableList.of(pluginA1, pluginB1), ImmutableSet.of(parentArtifacts));
     artifactStore.write(artifactZv100, metaZv100, new ByteArrayInputStream(contents));
     ArtifactInfo artifactZv100Info = artifactStore.getArtifact(artifactZv100).getInfo();
 
     // artifact artifactZ-2.0.0 contains plugins A1, A2, B1, and B2
     Id.Artifact artifactZv200 = Id.Artifact.from(Constants.DEFAULT_NAMESPACE_ID, "artifactZ", "2.0.0");
-    ArtifactMeta metaZv200 = new ArtifactMeta(ImmutableList.of(pluginA1, pluginA2, pluginB1, pluginB2));
+    ArtifactMeta metaZv200 = new ArtifactMeta(
+      ImmutableList.of(pluginA1, pluginA2, pluginB1, pluginB2), ImmutableSet.of(parentArtifacts));
     artifactStore.write(artifactZv200, metaZv200, new ByteArrayInputStream(contents));
     ArtifactInfo artifactZv200Info = artifactStore.getArtifact(artifactZv200).getInfo();
 
+    Id.Artifact parentArtifactId = Id.Artifact.from(Constants.DEFAULT_NAMESPACE_ID, "parent", "1.0.0");
     // test getting all plugins in the namespace
     Map<ArtifactInfo, List<PluginClass>> expected = Maps.newHashMap();
     expected.put(artifactXv100Info, ImmutableList.of(pluginA1));
@@ -350,7 +351,7 @@ public class ArtifactStoreTest {
     expected.put(artifactYv200Info, ImmutableList.of(pluginB2));
     expected.put(artifactZv100Info, ImmutableList.of(pluginA1, pluginB1));
     expected.put(artifactZv200Info, ImmutableList.of(pluginA1, pluginA2, pluginB1, pluginB2));
-    Map<ArtifactInfo, List<PluginClass>> actual = artifactStore.getPluginClasses(Constants.DEFAULT_NAMESPACE_ID);
+    Map<ArtifactInfo, List<PluginClass>> actual = artifactStore.getPluginClasses(parentArtifactId);
     Assert.assertEquals(expected, actual);
 
     // test getting all plugins by namespace and type
@@ -361,7 +362,7 @@ public class ArtifactStoreTest {
     expected.put(artifactXv200Info, ImmutableList.of(pluginA1, pluginA2));
     expected.put(artifactZv100Info, ImmutableList.of(pluginA1));
     expected.put(artifactZv200Info, ImmutableList.of(pluginA1, pluginA2));
-    actual = artifactStore.getPluginClasses(Constants.DEFAULT_NAMESPACE_ID, "A");
+    actual = artifactStore.getPluginClasses(parentArtifactId, "A");
     Assert.assertEquals(expected, actual);
     // get all of type B
     expected = Maps.newHashMap();
@@ -369,97 +370,119 @@ public class ArtifactStoreTest {
     expected.put(artifactYv200Info, ImmutableList.of(pluginB2));
     expected.put(artifactZv100Info, ImmutableList.of(pluginB1));
     expected.put(artifactZv200Info, ImmutableList.of(pluginB1, pluginB2));
-    actual = artifactStore.getPluginClasses(Constants.DEFAULT_NAMESPACE_ID, "B");
+    actual = artifactStore.getPluginClasses(parentArtifactId, "B");
     Assert.assertEquals(expected, actual);
 
     // test getting plugins by namespace, type, and name
     // get all of type A and name p1
-    expected = Maps.newHashMap();
-    expected.put(artifactXv100Info, ImmutableList.of(pluginA1));
-    expected.put(artifactXv110Info, ImmutableList.of(pluginA1));
-    expected.put(artifactXv200Info, ImmutableList.of(pluginA1));
-    expected.put(artifactZv100Info, ImmutableList.of(pluginA1));
-    expected.put(artifactZv200Info, ImmutableList.of(pluginA1));
-    actual = artifactStore.getPluginClasses(Constants.DEFAULT_NAMESPACE_ID, "A", "p1");
-    Assert.assertEquals(expected, actual);
+    Map<ArtifactInfo, PluginClass> expectedMap = Maps.newHashMap();
+    expectedMap.put(artifactXv100Info, pluginA1);
+    expectedMap.put(artifactXv110Info, pluginA1);
+    expectedMap.put(artifactXv200Info, pluginA1);
+    expectedMap.put(artifactZv100Info, pluginA1);
+    expectedMap.put(artifactZv200Info, pluginA1);
+    Map<ArtifactInfo, PluginClass> actualMap = artifactStore.getPluginClasses(parentArtifactId, "A", "p1");
+    Assert.assertEquals(expectedMap, actualMap);
     // get all of type A and name p2
-    expected = Maps.newHashMap();
-    expected.put(artifactXv200Info, ImmutableList.of(pluginA2));
-    expected.put(artifactZv200Info, ImmutableList.of(pluginA2));
-    actual = artifactStore.getPluginClasses(Constants.DEFAULT_NAMESPACE_ID, "A", "p2");
-    Assert.assertEquals(expected, actual);
+    expectedMap = Maps.newHashMap();
+    expectedMap.put(artifactXv200Info, pluginA2);
+    expectedMap.put(artifactZv200Info, pluginA2);
+    actualMap = artifactStore.getPluginClasses(parentArtifactId, "A", "p2");
+    Assert.assertEquals(expectedMap, actualMap);
     // get all of type B and name p1
-    expected = Maps.newHashMap();
-    expected.put(artifactYv100Info, ImmutableList.of(pluginB1));
-    expected.put(artifactZv100Info, ImmutableList.of(pluginB1));
-    expected.put(artifactZv200Info, ImmutableList.of(pluginB1));
-    actual = artifactStore.getPluginClasses(Constants.DEFAULT_NAMESPACE_ID, "B", "p1");
-    Assert.assertEquals(expected, actual);
+    expectedMap = Maps.newHashMap();
+    expectedMap.put(artifactYv100Info, pluginB1);
+    expectedMap.put(artifactZv100Info, pluginB1);
+    expectedMap.put(artifactZv200Info, pluginB1);
+    actualMap = artifactStore.getPluginClasses(parentArtifactId, "B", "p1");
+    Assert.assertEquals(expectedMap, actualMap);
     // get all of type B and name p2
-    expected = Maps.newHashMap();
-    expected.put(artifactYv200Info, ImmutableList.of(pluginB2));
-    expected.put(artifactZv200Info, ImmutableList.of(pluginB2));
-    actual = artifactStore.getPluginClasses(Constants.DEFAULT_NAMESPACE_ID, "B", "p2");
-    Assert.assertEquals(expected, actual);
-
-    // test getting plugin by artifact, plugin type, and plugin name
-    Assert.assertEquals(Maps.immutableEntry(artifactXv100Info, pluginA1),
-      artifactStore.getPluginClass(artifactXv100, pluginA1.getType(), pluginA1.getName()));
-    Assert.assertEquals(Maps.immutableEntry(artifactXv110Info, pluginA1),
-      artifactStore.getPluginClass(artifactXv110, pluginA1.getType(), pluginA1.getName()));
-    Assert.assertEquals(Maps.immutableEntry(artifactXv200Info, pluginA1),
-      artifactStore.getPluginClass(artifactXv200, pluginA1.getType(), pluginA1.getName()));
-    Assert.assertEquals(Maps.immutableEntry(artifactXv200Info, pluginA2),
-      artifactStore.getPluginClass(artifactXv200, pluginA2.getType(), pluginA2.getName()));
-
-    Assert.assertEquals(Maps.immutableEntry(artifactYv100Info, pluginB1),
-      artifactStore.getPluginClass(artifactYv100, pluginB1.getType(), pluginB1.getName()));
-    Assert.assertEquals(Maps.immutableEntry(artifactYv200Info, pluginB2),
-      artifactStore.getPluginClass(artifactYv200, pluginB2.getType(), pluginB2.getName()));
-
-    Assert.assertEquals(Maps.immutableEntry(artifactZv100Info, pluginA1),
-      artifactStore.getPluginClass(artifactZv100, pluginA1.getType(), pluginA1.getName()));
-    Assert.assertEquals(Maps.immutableEntry(artifactZv100Info, pluginB1),
-      artifactStore.getPluginClass(artifactZv100, pluginB1.getType(), pluginB1.getName()));
-    Assert.assertEquals(Maps.immutableEntry(artifactZv200Info, pluginA1),
-      artifactStore.getPluginClass(artifactZv200, pluginA1.getType(), pluginA1.getName()));
-    Assert.assertEquals(Maps.immutableEntry(artifactZv200Info, pluginA2),
-      artifactStore.getPluginClass(artifactZv200, pluginA2.getType(), pluginA2.getName()));
-    Assert.assertEquals(Maps.immutableEntry(artifactZv200Info, pluginB1),
-      artifactStore.getPluginClass(artifactZv200, pluginB1.getType(), pluginB1.getName()));
-    Assert.assertEquals(Maps.immutableEntry(artifactZv200Info, pluginB2),
-      artifactStore.getPluginClass(artifactZv200, pluginB2.getType(), pluginB2.getName()));
-
-    // test some things that should return empty maps
-    // namespace with nothing in it
-    Assert.assertTrue(artifactStore.getPluginClasses(Id.Namespace.from("something")).isEmpty());
-    // type with no plugins
-    Assert.assertTrue(artifactStore.getPluginClasses(Constants.DEFAULT_NAMESPACE_ID, "C").isEmpty());
+    expectedMap = Maps.newHashMap();
+    expectedMap.put(artifactYv200Info, pluginB2);
+    expectedMap.put(artifactZv200Info, pluginB2);
+    actualMap = artifactStore.getPluginClasses(parentArtifactId, "B", "p2");
+    Assert.assertEquals(expectedMap, actualMap);
   }
 
   @Test
   public void testSamePluginDifferentArtifacts() throws Exception {
+    ArtifactRange parentArtifacts = new ArtifactRange(
+      Constants.DEFAULT_NAMESPACE_ID, "parent", new ArtifactVersion("1.0.0"), new ArtifactVersion("2.0.0"));
     // add one artifact with a couple plugins
     Id.Artifact artifact1 = Id.Artifact.from(Constants.DEFAULT_NAMESPACE_ID, "plugins1", "1.0.0");
     List<PluginClass> plugins = ImmutableList.of(
       new PluginClass("atype", "plugin1", "", "c.c.c.plugin1", "cfg", ImmutableMap.<String, PluginPropertyField>of()),
       new PluginClass("atype", "plugin2", "", "c.c.c.plugin2", "cfg", ImmutableMap.<String, PluginPropertyField>of())
     );
-    ArtifactMeta meta1 = new ArtifactMeta(plugins);
+    ArtifactMeta meta1 = new ArtifactMeta(plugins, ImmutableSet.of(parentArtifacts));
     artifactStore.write(artifact1, meta1, new ByteArrayInputStream(Bytes.toBytes("something")));
     ArtifactInfo artifact1Info = artifactStore.getArtifact(artifact1).getInfo();
 
     // add a different artifact with the same plugins
     Id.Artifact artifact2 = Id.Artifact.from(Constants.DEFAULT_NAMESPACE_ID, "plugins2", "1.0.0");
-    ArtifactMeta meta2 = new ArtifactMeta(plugins);
+    ArtifactMeta meta2 = new ArtifactMeta(plugins, ImmutableSet.of(parentArtifacts));
     artifactStore.write(artifact2, meta2, new ByteArrayInputStream(Bytes.toBytes("something")));
     ArtifactInfo artifact2Info = artifactStore.getArtifact(artifact2).getInfo();
 
+    Id.Artifact parentArtifactId = Id.Artifact.from(Constants.DEFAULT_NAMESPACE_ID, "parent", "1.0.0");
     Map<ArtifactInfo, List<PluginClass>> expected = Maps.newHashMap();
     expected.put(artifact1Info, plugins);
     expected.put(artifact2Info, plugins);
-    Map<ArtifactInfo, List<PluginClass>> actual = artifactStore.getPluginClasses(Constants.DEFAULT_NAMESPACE_ID);
+    Map<ArtifactInfo, List<PluginClass>> actual = artifactStore.getPluginClasses(parentArtifactId);
     Assert.assertEquals(expected, actual);
+  }
+
+  // this test tests that when an artifact specifies a range of artifact versions it extends,
+  // those versions are honored
+  @Test
+  public void testPluginParentVersions() throws Exception {
+    // write an artifact that extends parent-[1.0.0, 2.0.0)
+    Id.Artifact artifactId = Id.Artifact.from(Constants.DEFAULT_NAMESPACE_ID, "plugins", "0.1.0");
+    Set<ArtifactRange> parentArtifacts = ImmutableSet.of(new ArtifactRange(
+      Constants.DEFAULT_NAMESPACE_ID, "parent", new ArtifactVersion("1.0.0"), new ArtifactVersion("2.0.0")));
+    List<PluginClass> plugins = ImmutableList.of(
+      new PluginClass("atype", "plugin1", "", "c.c.c.plugin1", "cfg", ImmutableMap.<String, PluginPropertyField>of())
+    );
+    ArtifactMeta meta = new ArtifactMeta(plugins, parentArtifacts);
+    artifactStore.write(artifactId, meta, new ByteArrayInputStream(Bytes.toBytes("some contents")));
+    ArtifactInfo artifactInfo = artifactStore.getArtifact(artifactId).getInfo();
+
+    // check ids that are out of range. They should not return anything
+    List<Id.Artifact> badIds = Lists.newArrayList(
+      // ids that are too low
+      Id.Artifact.from(Constants.DEFAULT_NAMESPACE_ID, "parent", "0.9.9"),
+      Id.Artifact.from(Constants.DEFAULT_NAMESPACE_ID, "parent", "1.0.0-SNAPSHOT"),
+      // ids that are too high
+      Id.Artifact.from(Constants.DEFAULT_NAMESPACE_ID, "parent", "2.0.0")
+    );
+    for (Id.Artifact badId : badIds) {
+      Map<ArtifactInfo, List<PluginClass>> result = artifactStore.getPluginClasses(badId);
+      Assert.assertTrue(artifactStore.getPluginClasses(badId).isEmpty());
+      Assert.assertTrue(artifactStore.getPluginClasses(badId, "atype").isEmpty());
+      try {
+        artifactStore.getPluginClasses(badId, "atype", "plugin1");
+        Assert.fail();
+      } catch (PluginNotExistsException e) {
+        // expected
+      }
+    }
+
+    // check ids that are in range return what we expect
+    List<Id.Artifact> goodIds = Lists.newArrayList(
+      // ids that are too low
+      Id.Artifact.from(Constants.DEFAULT_NAMESPACE_ID, "parent", "1.0.0"),
+      // ids that are too high
+      Id.Artifact.from(Constants.DEFAULT_NAMESPACE_ID, "parent", "1.9.9"),
+      Id.Artifact.from(Constants.DEFAULT_NAMESPACE_ID, "parent", "1.99.999"),
+      Id.Artifact.from(Constants.DEFAULT_NAMESPACE_ID, "parent", "2.0.0-SNAPSHOT")
+    );
+    Map<ArtifactInfo, List<PluginClass>> expectedPluginsMapList = ImmutableMap.of(artifactInfo, plugins);
+    Map<ArtifactInfo, PluginClass> expectedPluginsMap = ImmutableMap.of(artifactInfo, plugins.get(0));
+    for (Id.Artifact goodId : goodIds) {
+      Assert.assertEquals(expectedPluginsMapList, artifactStore.getPluginClasses(goodId));
+      Assert.assertEquals(expectedPluginsMapList, artifactStore.getPluginClasses(goodId, "atype"));
+      Assert.assertEquals(expectedPluginsMap, artifactStore.getPluginClasses(goodId, "atype", "plugin1"));
+    }
   }
 
   @Category(SlowTests.class)
@@ -516,6 +539,8 @@ public class ArtifactStoreTest {
   @Category(SlowTests.class)
   @Test
   public void testConcurrentSnapshotWrite() throws Exception {
+    final ArtifactRange parentArtifacts = new ArtifactRange(
+      Constants.DEFAULT_NAMESPACE_ID, "parent", new ArtifactVersion("1.0.0"), new ArtifactVersion("2.0.0"));
     // start up a bunch of threads that will try and write the same artifact at the same time
     // only one of them should be able to write it
     int numThreads = 20;
@@ -532,9 +557,12 @@ public class ArtifactStoreTest {
         public void run() {
           try {
             barrier.await();
-            ArtifactMeta meta = new ArtifactMeta(ImmutableList.of(new PluginClass(
-              "plugin-type", "plugin" + writer, "", "classname", "cfg",
-              ImmutableMap.<String, PluginPropertyField>of())));
+            ArtifactMeta meta = new ArtifactMeta(
+              ImmutableList.of(new PluginClass(
+                "plugin-type", "plugin" + writer, "", "classname", "cfg",
+                ImmutableMap.<String, PluginPropertyField>of())),
+              ImmutableSet.of(parentArtifacts)
+            );
             artifactStore.write(artifactId, meta, new ByteArrayInputStream(Bytes.toBytes(writer)));
           } catch (InterruptedException | BrokenBarrierException | ArtifactAlreadyExistsException | IOException e) {
             // something went wrong, fail the test
@@ -558,14 +586,17 @@ public class ArtifactStoreTest {
     String pluginName = detail.getMeta().getPlugins().get(0).getName();
     String winnerWriter = pluginName.substring("plugin".length());
 
-    ArtifactMeta expectedMeta = new ArtifactMeta(ImmutableList.of(new PluginClass(
-      "plugin-type", "plugin" + winnerWriter, "", "classname", "cfg",
-      ImmutableMap.<String, PluginPropertyField>of())));
+    ArtifactMeta expectedMeta = new ArtifactMeta(
+      ImmutableList.of(new PluginClass(
+        "plugin-type", "plugin" + winnerWriter, "", "classname", "cfg",
+        ImmutableMap.<String, PluginPropertyField>of())),
+      ImmutableSet.of(parentArtifacts));
     assertEqual(artifactId, expectedMeta, winnerWriter, detail);
-    
+
     // check only 1 plugin remains and that its the correct one
+    Id.Artifact parentArtifactId = Id.Artifact.from(Constants.DEFAULT_NAMESPACE_ID, "parent", "1.0.0");
     Map<ArtifactInfo, List<PluginClass>> pluginMap =
-      artifactStore.getPluginClasses(artifactId.getNamespace(), "plugin-type");
+      artifactStore.getPluginClasses(parentArtifactId, "plugin-type");
     Map<ArtifactInfo, List<PluginClass>> expected = Maps.newHashMap();
     expected.put(detail.getInfo(), Lists.newArrayList(
       new PluginClass("plugin-type", "plugin" + winnerWriter, "", "classname", "cfg",


### PR DESCRIPTION
Doing some refactoring to reflect the fact that plugins extend
a set of parent artifacts and are not stand alone objects. Changes
the table schema to support finding the plugins that extend a
given parent artifact.