### PR TITLE
fixes widget dropdown reloading/flickering

### DIFF
--- a/cdap-ui/app/features/dashboard/services/query-helper.js
+++ b/cdap-ui/app/features/dashboard/services/query-helper.js
@@ -9,6 +9,10 @@ angular.module(PKG.name + '.feature.dashboard')
         // For an empty context, we want no tags. Splitting it by '.' yields [""]
         parts = [];
       }
+      // FIXME: If user enters a random context and hits Add (during widget creation)
+      // and then tries to reopen the dashboard, this will error out and let the dashboard hang empty.
+      // We should either catch random context during widget creation or skip this error and show an
+      // empty widget with no chart/data.
       if (parts.length % 2 !== 0) {
         throw 'Metrics context has uneven number of parts: ' + context;
       }

--- a/cdap-ui/app/features/dashboard/services/query-helper.js
+++ b/cdap-ui/app/features/dashboard/services/query-helper.js
@@ -9,10 +9,6 @@ angular.module(PKG.name + '.feature.dashboard')
         // For an empty context, we want no tags. Splitting it by '.' yields [""]
         parts = [];
       }
-      // FIXME: If user enters a random context and hits Add (during widget creation)
-      // and then tries to reopen the dashboard, this will error out and let the dashboard hang empty.
-      // We should either catch random context during widget creation or skip this error and show an
-      // empty widget with no chart/data.
       if (parts.length % 2 !== 0) {
         throw 'Metrics context has uneven number of parts: ' + context;
       }

--- a/cdap-ui/app/features/dashboard/templates/dashboard.html
+++ b/cdap-ui/app/features/dashboard/templates/dashboard.html
@@ -17,7 +17,6 @@
       ui-sref-active="active"
       ng-repeat="dashboard in dashboards | orderBy:$index">
     <a ui-sref="dashboard.user({tab: $index})"
-        ui-sref-opts="{reload: true}"
         role="tab"
         ng-click="activeTabClick($event, $index)"
         tooltip="{{dashboard.title}}"


### PR DESCRIPTION
* Removes ui-sref-opts attribute, which was causing reload of the widget dropdown and preventing it from staying in focus
* Adds a FIXME note for addressing input of random strings (Metric) when creating a widget

![dd](https://cloud.githubusercontent.com/assets/5335210/8534131/55a06c18-23ee-11e5-9393-0b305170771e.gif)
