### PR TITLE
refines active/hover state styling for slanted tabs

### DIFF
--- a/cdap-ui/app/styles/themes/cdap/tabs.less
+++ b/cdap-ui/app/styles/themes/cdap/tabs.less
@@ -14,18 +14,19 @@ body.theme-cdap {
             background-color: transparent;
             border: 1px solid transparent;
             color: @cdap-orange;
+            cursor: pointer;
           }
         }
         &.active > a {
           border-right: 0;
-          cursor: pointer;
           &:hover {
             background-color: #ebecf1;
             border-right: 1px solid #d1d3da;
             border-top: 1px solid #d1d3da;
             border-left: 1px solid #d1d3da;
             border-bottom: 1px solid transparent;
-            color: @cdap-orange;
+            color: @cdap-gray;
+            cursor: default;
           }
         }
       }


### PR DESCRIPTION
* Removes pointer cursor when hovering over active tab
* Removes orange font color when hovering over active tab

![active](https://cloud.githubusercontent.com/assets/5335210/8534205/0588a78a-23ef-11e5-96f3-a0df75655e8d.gif)
