### PR TITLE
Feature/ui styling heading

### DIFF
--- a/cdap-ui/app/features/adapters/etlapps.less
+++ b/cdap-ui/app/features/adapters/etlapps.less
@@ -31,10 +31,7 @@ body.theme-cdap.state-adapters-create {
 
   .etlflowcontainer {
     position: relative;
-    h4 {
-      margin-top: 0;
-      font-weight: bold;
-    }
+    h4 { margin-top: 0; }
     .fa-pencil,.fa-times {
       font-size: 12px;
       vertical-align: middle;
@@ -141,6 +138,7 @@ body.theme-cdap.state-adapters-create {
     overflow-x: auto;
     overflow-y: hidden;
     text-overflow: ellipsis;
+    &.panel-title { line-height: 30px; }
   }
 
   .tab-pane .panel-default {
@@ -172,10 +170,7 @@ body.theme-cdap.state-adapters-create {
   }
 
   .plugins {
-    h4 {
-      margin-top: 0;
-      font-weight: bold;
-    }
+    h4 { margin-top: 0; }
     .panel.panel-default {
       margin-bottom: 5px;
       .panel-body{
@@ -234,11 +229,7 @@ body.theme-cdap.state-adapters-create {
     .widget-group-container {
       &.well {
         padding: 10px;
-        h3 {
-          font-size: 16px;
-          font-weight: 500;
-          margin: 0 0 10px 0;
-        }
+        h3 { margin: 0 0 10px 0; }
 
         .row-padding {
           padding: 0 30px;

--- a/cdap-ui/app/features/adapters/templates/create/configuration.html
+++ b/cdap-ui/app/features/adapters/templates/create/configuration.html
@@ -2,10 +2,12 @@
   <div class="panel-heading" ng-click="configurationTabOpen = !configurationTabOpen">
     <div class="panel-title">
       <div class="clearfix">
-        <span class="pull-left" ng-if="AdapterCreateController.model.metadata.type === 'ETLRealtime'">Configuration</span>
-        <span class="pull-left" ng-if="AdapterCreateController.model.metadata.type === 'ETLBatch'">Schedule: Cron Expression</span>
-        <i class="fa fa-fw pull-right"
-            ng-class="{'fa-chevron-down': configurationTabOpen, 'fa-chevron-right': !configurationTabOpen}"></i>
+        <div class="pull-left">
+          <span class="fa fa-fw"
+                ng-class="{'fa-chevron-down': configurationTabOpen, 'fa-chevron-right': !configurationTabOpen}"></span>
+          <span ng-if="AdapterCreateController.model.metadata.type === 'ETLRealtime'">Configuration</span>
+          <span ng-if="AdapterCreateController.model.metadata.type === 'ETLBatch'">Schedule: Cron Expression</span>
+        </div>
       </div>
     </div>
   </div>

--- a/cdap-ui/app/features/adapters/templates/create/metadata.html
+++ b/cdap-ui/app/features/adapters/templates/create/metadata.html
@@ -3,10 +3,10 @@
     <div class="panel-title">
       <div class="clearfix">
         <span class="pull-left">
+          <span class="fa fa-fw"
+              ng-class="{'fa-chevron-down': metadataTabOpen, 'fa-chevron-right': !metadataTabOpen}"></span>
           Metadata
         </span>
-        <i class="fa fa-fw pull-right"
-            ng-class="{'fa-chevron-down': metadataTabOpen, 'fa-chevron-right': !metadataTabOpen}"></i>
       </div>
     </div>
   </div>

--- a/cdap-ui/app/features/admin/templates/namespace/dataset-metadata.html
+++ b/cdap-ui/app/features/admin/templates/namespace/dataset-metadata.html
@@ -29,7 +29,7 @@
     </div>
   </div>
 </div>
-
+<br/>
 <!-- CONTENT -->
 <table class="table table-curved" ng-if="metadata">
   <tr>

--- a/cdap-ui/app/features/apps/templates/tabs/status.html
+++ b/cdap-ui/app/features/apps/templates/tabs/status.html
@@ -2,7 +2,7 @@
 <div class="status">
   <div class="row">
     <div class="col-xs-12">
-      <h2> Programs </h2>
+      <h3>Programs</h3>
       <div class="table-responsive">
         <table class="table table-curved" cask-sortable>
           <thead>

--- a/cdap-ui/app/features/dashboard/style.less
+++ b/cdap-ui/app/features/dashboard/style.less
@@ -126,7 +126,7 @@ body.state-dashboard {
           // A
           color: @cdap-gray;
 
-          .dtitle::before {
+          .dtitle::after {
             display: inline-block;
             width: 0;
             height: 0;

--- a/cdap-ui/app/features/datasets/templates/tabs/programs.html
+++ b/cdap-ui/app/features/datasets/templates/tabs/programs.html
@@ -1,6 +1,6 @@
 <div class="container">
   <div class="row" ng-if="ProgramsController.programs.length > 0">
-    <h2><span>Programs</span></h2>
+    <h3>Programs</h3>
   </div>
 
   <div class="row">

--- a/cdap-ui/app/features/datasets/templates/tabs/status.html
+++ b/cdap-ui/app/features/datasets/templates/tabs/status.html
@@ -2,7 +2,7 @@
   <div ng-if="StatusController.explorable">
     <div class="row">
       <div class="col-xs-8 h2">
-        <h2><span> Schema </span></h2>
+        <h3>Schema</h3>
       </div>
       <div class="col-xs-4">
         <table class="table table-curved table-status">

--- a/cdap-ui/app/features/overview/overview.html
+++ b/cdap-ui/app/features/overview/overview.html
@@ -44,7 +44,7 @@
 </div>
 
 <section class="system-health"> <!-- ng-show="isEnterprise" -->
-  <h2> System Health </h2>
+  <h3> System Health </h3>
   <div class="row">
     <div class="col-xs-12 col-lg-4">
       <div>

--- a/cdap-ui/app/features/overview/overview.less
+++ b/cdap-ui/app/features/overview/overview.less
@@ -98,11 +98,7 @@ body.state-overview {
         right: 10px;
         z-index: 10;
       }
-      p { color: @cdap-bluegray; }
-      h2 {
-        font-weight: 500;
-        padding-bottom: 20px;
-      }
+      h2 { padding-bottom: 20px; }
       h3 { margin: 5px auto; }
       .col-xs-12.col-sm-3:first-child > div { padding-left: 30px; }
       .panel-heading { padding: 0; }
@@ -117,9 +113,8 @@ body.state-overview {
       &.system-health {
         color: @cdap-bluegray;
         padding: 10px;
-        box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3), 0 0 40px rgba(0, 0, 0, 0.1) inset;
-        h2 {
-          font-size: 24px;
+        border: 1px solid #d1d4dc;
+        h3 {
           padding-left: 30px;
           position: relative;
           top: 5px;
@@ -147,7 +142,6 @@ body.state-overview {
         .c3-tooltip-container { text-align: left; }
       }
       &.data-apps {
-        h3 { font-weight: 600; }
         .col-xs-12.col-sm-3 {
           p {
             font-weight: bold;
@@ -205,6 +199,5 @@ body.state-overview {
       }
     }
   }
-
 
 }

--- a/cdap-ui/app/features/overview/templates/data-apps.html
+++ b/cdap-ui/app/features/overview/templates/data-apps.html
@@ -1,7 +1,7 @@
 <div class="row" ng-controller="AppsSectionCtrl as AppsSectionCtrl">
   <div class="col-xs-12 col-md-6">
     <div ng-if="AppsSectionCtrl.dataList.length > 0">
-      <h3 class="text-uppercase"> Data </h3>
+      <h3> Data </h3>
       <div class="row">
         <div class="col-xs-12 col-sm-3">
           <p ng-if="AppsSectionCtrl.dataList.length < 5"> Showing {{ AppsSectionCtrl.dataList.length }} of {{ dataList.length }}</p>
@@ -61,7 +61,7 @@
   </div>
   <div class="col-xs-12 col-md-6">
     <div ng-if="AppsSectionCtrl.apps.length > 0">
-      <h3 class="text-uppercase"> Apps </h3>
+      <h3> Apps </h3>
       <div class="row">
         <div class="col-xs-12 col-sm-3">
           <p ng-if="AppsSectionCtrl.apps.length < 5"> Showing {{ AppsSectionCtrl.apps.length }} of {{ AppsSectionCtrl.apps.length }}</p>

--- a/cdap-ui/app/features/services/templates/tabs/runs/tabs/status.html
+++ b/cdap-ui/app/features/services/templates/tabs/runs/tabs/status.html
@@ -6,7 +6,7 @@
 
   <div class="row">
     <div class="col-xs-9">
-      <h2> Endpoints [{{StatusController.endPoints.length}}] </h2>
+      <h3> Endpoints [{{StatusController.endPoints.length}}] </h3>
         <table class="table table-curved">
           <thead>
             <tr>

--- a/cdap-ui/app/features/streams/templates/tabs/status.html
+++ b/cdap-ui/app/features/streams/templates/tabs/status.html
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="row">
     <div class="col-xs-8 h2">
-      <h2><span> Schema </span></h2>
+      <h3>Schema</h2>
     </div>
     <div class="col-xs-4">
         <table class="table table-curved table-status">

--- a/cdap-ui/app/styles/common.less
+++ b/cdap-ui/app/styles/common.less
@@ -123,7 +123,11 @@ footer {
       @media (max-width: @screen-md-max) { text-align: center; }
     }
   }
-  img { height: 32px; width: 32px; }
+  img {
+    height: 26px;
+    width: 26px;
+    margin-right: 8px;
+  }
   @media (min-width: @screen-md-max) {
     p, ul { height: 32px; margin: 0; }
     span, li { line-height: 32px; vertical-align: middle; }

--- a/cdap-ui/app/styles/themes/cdap.less
+++ b/cdap-ui/app/styles/themes/cdap.less
@@ -18,18 +18,45 @@ body.theme-cdap {
     @cdap-subnav-height: 300px;
 
     blockquote { border: 0; }
+
+    h1 {
+      color: #5F6674;
+      font-size: 30px;
+      font-weight: 400;
+    }
+
     h2 {
+      color: #5F6674;
+      font-size: 20px;
+      font-weight: 300;
       > span {
         display: block;
         margin-top: 10px;
         margin-bottom: 8px;
-        font-size: 28px;
       }
     }
+
+    h3 {
+      color: #5f6673;
+      font-size: 18px;
+      font-weight: 300;
+    }
+
+
+    h4 {
+      color: #5F6674;
+      font-size: 16px;
+      font-weight: 300;
+    }
+
+    p {
+      color: #999;
+    }
+
     section.tab-pane h2 {
-        margin: 0;
-        font-weight: 400px;
-        font-size: 20px;
+      margin: 0;
+      font-weight: 400px;
+      font-size: 20px;
     }
 
     /* we need to be able to calc tab height
@@ -81,6 +108,7 @@ body.theme-cdap {
 
   footer {
     background-color: white;
+    font-size: 11px;
     font-weight: 600;
   }
 }

--- a/cdap-ui/app/styles/themes/cdap/theme.less
+++ b/cdap-ui/app/styles/themes/cdap/theme.less
@@ -35,7 +35,6 @@ body.theme-cdap {
   .alert-warning    { .alert-styles(@alert-warning-bg); }
   .alert-danger     { .alert-styles(@alert-danger-bg); }
 
-
   //
   // Progress bars
   // --------------------------------------------------
@@ -72,16 +71,14 @@ body.theme-cdap {
     margin-top: 10px;
     &[cask-sortable] {
       thead {
-
-
         .empty { cursor: default; }
       }
     }
     tbody {
-      color: @cdap-bluegray;
+      color: #999;
       a {
         color: @cdap-bluegray;
-        &:hover, &:focus { text-decoration: underline; }
+        &:hover, &:focus { text-decoration: none; }
         &.btn-danger { .cask-btn(@background: transparent, @border: 0, @border-radius: 0, @color: @brand-danger, @padding: 0); }
       }
     }
@@ -189,11 +186,10 @@ body.theme-cdap {
 // Message panel (appears on Dev + Management start screens)
   .panel-message {
     background: white;
-    border: 1px solid lightgray;
+    border: 1px solid #d1d4dc;
     margin-bottom: 20px;
     padding: 10px;
     .border-radius(4px);
-    .box-shadow(0 8px 6px -6px @cdap-darkness);
     p { margin-bottom: 0; }
     .btn-close {
       .cask-btn(@background: @cdap-lightgray, @border: 0, @border-radius: 28px, @padding: 0);
@@ -207,23 +203,26 @@ body.theme-cdap {
     }
   }
 
+  .panel { .box-shadow(none); }
+
+  .panel-title {
+    span.fa {
+      font-size: 10px;
+      margin-right: 10px;
+      height: 15px;
+      vertical-align: middle;
+      .border-radius(25px);
+    }
+  }
   .panel-explore {
     background-color: transparent;
     color: @cdap-header;
-    .box-shadow(none);
     > .panel-heading {
       background: white;
       border: 1px solid lightgray;
       padding: 20px;
+      cursor: pointer;
       .border-radius(8px);
-    }
-    .panel-title {
-      font-size: 17px;
-      span.fa {
-        margin-right: 10px;
-        line-height: 1.2;
-        .border-radius(25px);
-      }
     }
     > .panel-collapse {
       > .panel-body {
@@ -307,7 +306,6 @@ body.theme-cdap {
         line-height: 1;
         opacity: 1;
       }
-      .modal-title { font-weight: bold; }
     }
     .modal-dialog { .border-radius(4px); }
     .modal-content {
@@ -365,7 +363,6 @@ body.theme-cdap {
 
     // caskConfirm modal styling (no modal-lg or modal-sm class present)
     &.center {
-      h4 { font-weight: bold; }
       .close { display: none; }
       .modal-content, .modal-footer { text-align: center; }
       .modal-content {
@@ -410,7 +407,9 @@ body.theme-cdap {
           .btn-danger {}
         }
         .modal-footer { text-align: right; }
-        .panel { background-color: transparent; }
+        .panel {
+          background-color: transparent;
+        }
       }
     }
 

--- a/cdap-ui/app/styles/variables.less
+++ b/cdap-ui/app/styles/variables.less
@@ -6,7 +6,7 @@
 @cdap-header:           rgb(60, 67, 85);
 @cdap-darkness:         rgb(102, 110, 130);
 @cdap-bluegray:         rgb(111, 124, 157);
-@cdap-gray:             rgb(157, 157, 157);
+@cdap-gray:             rgb(111, 124, 159);
 @cdap-lightgray:        rgb(102, 110, 131);
 @cdap-darkblue:         rgb(44, 73, 138);
 


### PR DESCRIPTION
*  Adds universal styling for h1 through h4
*  Removes any feature-specific styling that conflicts with this universal styling (i.e., font-weight: bold;)
*  Moves caret/chevron to left of panel headings for consistency
*  Changes h2 to h3 for consistency in tab templates
*  Replaces panel box shadow with a flat 1px border
*  Removes uppercase h3 from Data and Apps on Dev start screen
*  Changes @cdap-gray variable
*  Changes color of non-hyperlinked text in tables
*  Shrinks footer logo and text

![styling1](https://cloud.githubusercontent.com/assets/5335210/8535505/34ed8cfa-23fb-11e5-9ffc-759e10c8bf04.gif)
