### PR TITLE
CDAP-2941 fix filter classloader's get resource(s)

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/lang/FilterClassLoader.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/lang/FilterClassLoader.java
@@ -108,16 +108,28 @@ public final class FilterClassLoader extends ClassLoader {
 
   @Override
   public URL getResource(String name) {
+    URL resource = bootstrapClassLoader.getResource(name);
+    if (resource != null) {
+      return resource;
+    }
     return resourceAcceptor.apply(name) ? super.getResource(name) : null;
   }
 
   @Override
   public Enumeration<URL> getResources(String name) throws IOException {
+    Enumeration<URL> resources = bootstrapClassLoader.getResources(name);
+    if (resources.hasMoreElements()) {
+      return resources;
+    }
     return resourceAcceptor.apply(name) ? super.getResources(name) : Collections.<URL>emptyEnumeration();
   }
 
   @Override
   public InputStream getResourceAsStream(String name) {
+    InputStream resourceStream = bootstrapClassLoader.getResourceAsStream(name);
+    if (resourceStream != null) {
+      return resourceStream;
+    }
     return resourceAcceptor.apply(name) ? super.getResourceAsStream(name) : null;
   }
 

--- a/cdap-common/src/test/java/co/cask/cdap/common/lang/FilterClassLoaderTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/lang/FilterClassLoaderTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.lang;
+
+import co.cask.cdap.api.app.Application;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import javax.script.ScriptEngineFactory;
+
+/**
+ */
+public class FilterClassLoaderTest {
+
+  @Test(expected = ClassNotFoundException.class)
+  public void testSystemInternalsHidden() throws ClassNotFoundException {
+    FilterClassLoader classLoader = FilterClassLoader.create(this.getClass().getClassLoader());
+    classLoader.loadClass(FilterClassLoader.class.getName());
+  }
+
+  @Test
+  public void testAPIVisible() throws ClassNotFoundException {
+    FilterClassLoader classLoader = FilterClassLoader.create(this.getClass().getClassLoader());
+    Assert.assertSame(Application.class, classLoader.loadClass(Application.class.getName()));
+  }
+
+  @Test
+  public void testBootstrapResourcesVisible() throws IOException {
+    FilterClassLoader classLoader = FilterClassLoader.create(this.getClass().getClassLoader());
+    Assert.assertNotNull(classLoader.getResource("META-INF/services/" + ScriptEngineFactory.class.getName()));
+  }
+}


### PR DESCRIPTION
The FilterClassLoader should try and use its bootstrap classloader
before doing any filtering. This is so that java system classes
and resources are available. For example, the classloader must be
able to get the javax.script engines as resources.