### PR TITLE
Fixes bower component (lodash) path from dist/lodash.js to just lodash.js

### DIFF
--- a/cdap-ui/Gulpfile.js
+++ b/cdap-ui/Gulpfile.js
@@ -110,9 +110,9 @@ gulp.task('js:lib', function() {
 
       './bower_components/d3/d3.min.js',
       './bower_components/d3-tip/index.js',
-      './bower_components/epoch/epoch.min.js',
 
-      './bower_components/lodash/dist/lodash.js',
+      './bower_components/epoch/epoch.min.js',
+      './bower_components/lodash/lodash.js',
       './bower_components/graphlib/dist/graphlib.core.js',
       './bower_components/dagre/dist/dagre.core.js',
       './bower_components/dagre-d3/dist/dagre-d3.core.js',


### PR DESCRIPTION
DagreD3 updated the version of lodash from 2.* to 3.* straight away.  (https://github.com/cpettitt/dagre-d3/commit/e746821ab29e0cab58dc8a9f12a12f475ff2f0bc)
Lodash changed its built files location from dist/lodash.js to just ./lodash.js  (https://github.com/lodash/lodash/wiki/Changelog#v300)

So when we took an update from DagreD3 we didn't update the path of lodash. That is the reason the UI was failing.

TODO: 
  Remove epoch.js and protractor completely in a separate PR