### PR TITLE
CDAP-2955: NoSuchMethodException when trying to explore Datasets/Stream

### DIFF
--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive13ExploreService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive13ExploreService.java
@@ -78,7 +78,8 @@ public class Hive13ExploreService extends BaseHiveExploreService {
   protected List<QueryResult> doFetchNextResults(OperationHandle handle, FetchOrientation fetchOrientation,
                                                  int size) throws Exception {
     Class cliServiceClass = Class.forName("org.apache.hive.service.cli.CLIService");
-    Method fetchResultsMethod = cliServiceClass.getMethod("fetchResults");
+    Method fetchResultsMethod = cliServiceClass.getMethod(
+      "fetchResults", OperationHandle.class, FetchOrientation.class, Long.TYPE);
     RowSet rowSet = (RowSet) fetchResultsMethod.invoke(getCliService(), handle, fetchOrientation, size);
 
     ImmutableList.Builder<QueryResult> rowsBuilder = ImmutableList.builder();


### PR DESCRIPTION
- Hive13ExploreService.doFetchNextResults wasn't getting the
  correct fetchResults method

- [x] Verified that the NoSuchMethodException no longer occurs in distributed cluster on Hive 0.13