### PR TITLE
(CDAP-2936) Allow setting Spark driver and executor memory size

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/spark/AbstractSpark.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/spark/AbstractSpark.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.api.spark;
 
+import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.annotation.Beta;
 
 import java.util.Map;
@@ -90,6 +91,20 @@ public abstract class AbstractSpark implements Spark {
    */
   protected final void setProperties(Map<String, String> properties) {
     configurer.setProperties(properties);
+  }
+
+  /**
+   * Sets the resources requirement for the Spark driver process.
+   */
+  protected final void setDriverResources(Resources resources) {
+    configurer.setDriverResources(resources);
+  }
+
+  /**
+   * Sets the resources requirement for the Spark executor processes.
+   */
+  protected final void setExecutorResources(Resources resources) {
+    configurer.setExecutorResources(resources);
   }
 
   @Override

--- a/cdap-api/src/main/java/co/cask/cdap/api/spark/SparkConfigurer.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/spark/SparkConfigurer.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.api.spark;
 
+import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.annotation.Beta;
 
 import java.util.Map;
@@ -50,4 +51,14 @@ public interface SparkConfigurer {
    * @param properties the properties to set
    */
   void setProperties(Map<String, String> properties);
+
+  /**
+   * Sets the resources requirement for the Spark driver process.
+   */
+  void setDriverResources(Resources resources);
+
+  /**
+   * Sets the resources requirement for the Spark executor processes.
+   */
+  void setExecutorResources(Resources resources);
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/spark/SparkContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/spark/SparkContext.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.api.spark;
 
+import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.RuntimeContext;
 import co.cask.cdap.api.ServiceDiscoverer;
 import co.cask.cdap.api.annotation.Beta;
@@ -146,4 +147,12 @@ public interface SparkContext extends RuntimeContext, DatasetContext {
    * @return {@link Serializable} {@link Metrics} for {@link Spark} programs
    */
   Metrics getMetrics();
+
+  /**
+   * Override the resources, such as memory and virtual cores, to use for each executor process for the Spark program.
+   * This method should be called in {@link Spark#beforeSubmit(SparkContext)} to take effect.
+   *
+   * @param resources Resources that each executor should use
+   */
+  void setExecutorResources(Resources resources);
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/spark/SparkSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/spark/SparkSpecification.java
@@ -17,12 +17,13 @@
 package co.cask.cdap.api.spark;
 
 import co.cask.cdap.api.ProgramSpecification;
+import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.common.PropertyProvider;
 
 import java.util.Collections;
 import java.util.Map;
-import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * A default specification for {@link Spark} programs
@@ -35,14 +36,19 @@ public final class SparkSpecification implements ProgramSpecification, PropertyP
   private final String description;
   private final String mainClassName;
   private final Map<String, String> properties;
+  private final Resources driverResources;
+  private final Resources executorResources;
 
-  public SparkSpecification(String className, String name, String description, String mainClassName,
-                            @Nonnull Map<String, String> properties) {
+  public SparkSpecification(String className, String name, String description,
+                            String mainClassName, Map<String, String> properties,
+                            @Nullable Resources driverResources, @Nullable Resources executorResources) {
     this.className = className;
     this.name = name;
     this.description = description;
     this.mainClassName = mainClassName;
     this.properties = Collections.unmodifiableMap(properties);
+    this.driverResources = driverResources;
+    this.executorResources = executorResources;
   }
 
   @Override
@@ -72,5 +78,21 @@ public final class SparkSpecification implements ProgramSpecification, PropertyP
   @Override
   public String getProperty(String key) {
     return properties.get(key);
+  }
+
+  /**
+   * @return Resources requirement for the Spark driver process or {@code null} if not specified.
+   */
+  @Nullable
+  public Resources getDriverResources() {
+    return driverResources;
+  }
+
+  /**
+   * @return Resources requirement for the Spark executor processes or {@code null} if not specified.
+   */
+  @Nullable
+  public Resources getExecutorResources() {
+    return executorResources;
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/SparkTwillApplication.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/SparkTwillApplication.java
@@ -16,12 +16,13 @@
 
 package co.cask.cdap.internal.app.runtime.distributed;
 
+import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.spark.Spark;
 import co.cask.cdap.api.spark.SparkSpecification;
 import co.cask.cdap.app.program.Program;
 import co.cask.cdap.proto.ProgramType;
+import com.google.common.base.Objects;
 import org.apache.twill.api.EventHandler;
-import org.apache.twill.api.ResourceSpecification;
 import org.apache.twill.api.TwillApplication;
 
 import java.io.File;
@@ -32,12 +33,12 @@ import java.util.Map;
  */
 public class SparkTwillApplication extends AbstractProgramTwillApplication {
 
-  private final String name;
+  private final SparkSpecification spec;
 
   public SparkTwillApplication(Program program, SparkSpecification spec,
                                Map<String, File> localizeFiles, EventHandler eventHandler) {
     super(program, localizeFiles, eventHandler);
-    this.name = spec.getName();
+    this.spec = spec;
   }
 
   @Override
@@ -47,16 +48,9 @@ public class SparkTwillApplication extends AbstractProgramTwillApplication {
 
   @Override
   protected void addRunnables(Map<String, RunnableResource> runnables) {
-    // TODO (CDAP-2936): Make it configurable
-    ResourceSpecification resourceSpec = ResourceSpecification.Builder.with()
-      .setVirtualCores(1)
-      .setMemory(512, ResourceSpecification.SizeUnit.MEGA)
-      .setInstances(1)
-      .build();
-
-    runnables.put(name, new RunnableResource(
-      new SparkTwillRunnable(name, "hConf.xml", "cConf.xml"),
-      resourceSpec
+    runnables.put(spec.getName(), new RunnableResource(
+      new SparkTwillRunnable(spec.getName(), "hConf.xml", "cConf.xml"),
+      createResourceSpec(Objects.firstNonNull(spec.getDriverResources(), new Resources()), 1)
     ));
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/ExecutionSparkContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/ExecutionSparkContext.java
@@ -95,11 +95,11 @@ public class ExecutionSparkContext extends AbstractSparkContext {
   }
 
   public ExecutionSparkContext(SparkSpecification specification, Id.Program programId, RunId runId,
-                                ClassLoader programClassLoader, long logicalStartTime,
-                                Map<String, String> runtimeArguments,
-                                Transaction transaction, DatasetFramework datasetFramework,
-                                DiscoveryServiceClient discoveryServiceClient, MetricsContext metricsContext,
-                                LoggingContext loggingContext, Configuration hConf, StreamAdmin streamAdmin) {
+                               ClassLoader programClassLoader, long logicalStartTime,
+                               Map<String, String> runtimeArguments,
+                               Transaction transaction, DatasetFramework datasetFramework,
+                               DiscoveryServiceClient discoveryServiceClient, MetricsContext metricsContext,
+                               LoggingContext loggingContext, Configuration hConf, StreamAdmin streamAdmin) {
     super(specification, programId, runId, programClassLoader, logicalStartTime,
           runtimeArguments, discoveryServiceClient, metricsContext, loggingContext);
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkContextFactory.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkContextFactory.java
@@ -16,6 +16,8 @@
 
 package co.cask.cdap.internal.app.runtime.spark;
 
+import co.cask.cdap.api.Resources;
+import co.cask.cdap.api.spark.SparkSpecification;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.tephra.Transaction;
@@ -52,11 +54,19 @@ final class SparkContextFactory {
    * @param transaction the transaction for the spark execution.
    */
   ExecutionSparkContext createExecutionContext(Transaction transaction) {
-    return new ExecutionSparkContext(clientContext.getSpecification(), clientContext.getProgramId(),
+    SparkSpecification spec = updateSpecExecutorResources(clientContext.getSpecification(),
+                                                          clientContext.getExecutorResources());
+    return new ExecutionSparkContext(spec, clientContext.getProgramId(),
                                      clientContext.getRunId(), clientContext.getProgramClassLoader(),
                                      clientContext.getLogicalStartTime(), clientContext.getRuntimeArguments(),
                                      transaction, datasetFramework, clientContext.getDiscoveryServiceClient(),
                                      clientContext.getMetricsContext(), clientContext.getLoggingContext(),
                                      hConf, streamAdmin);
+  }
+
+  private SparkSpecification updateSpecExecutorResources(SparkSpecification originalSpec, Resources executorResources) {
+    return new SparkSpecification(originalSpec.getClassName(), originalSpec.getName(), originalSpec.getDescription(),
+                                  originalSpec.getMainClassName(), originalSpec.getProperties(),
+                                  originalSpec.getDriverResources(), executorResources);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/spark/DefaultSparkConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/spark/DefaultSparkConfigurer.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.internal.app.spark;
 
+import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.spark.Spark;
 import co.cask.cdap.api.spark.SparkConfigurer;
 import co.cask.cdap.api.spark.SparkSpecification;
@@ -38,6 +39,8 @@ public final class DefaultSparkConfigurer implements SparkConfigurer {
   private String description;
   private String mainClassName;
   private Map<String, String> properties;
+  private Resources driverResources;
+  private Resources executorResources;
 
   public DefaultSparkConfigurer(Spark spark) {
     this.spark = spark;
@@ -67,9 +70,20 @@ public final class DefaultSparkConfigurer implements SparkConfigurer {
     this.properties = ImmutableMap.copyOf(properties);
   }
 
+  @Override
+  public void setDriverResources(Resources resources) {
+    this.driverResources = resources;
+  }
+
+  @Override
+  public void setExecutorResources(Resources resources) {
+    this.executorResources = resources;
+  }
+
   public SparkSpecification createSpecification() {
     // Grab all @Property fields
     Reflections.visit(spark, TypeToken.of(spark.getClass()), new PropertyFieldExtractor(properties));
-    return new SparkSpecification(spark.getClass().getName(), name, description, mainClassName, properties);
+    return new SparkSpecification(spark.getClass().getName(), name, description,
+                                  mainClassName, properties, driverResources, executorResources);
   }
 }


### PR DESCRIPTION
- Added methods in SparkConfigurer for setting driver and executor resources
- Added methods in SparkContext for overriding executor resources set through SparkConfigurer.
- Use the driver resources setting when launch the Twill container that serves as driver
- Use the executor resources setting when submitting the Spark job.