### PR TITLE
[CDAP-2915] SQS realtime source

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/pom.xml
@@ -191,6 +191,21 @@
     </dependency>
     <!-- End for Kafka Source -->
     <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>amazon-sqs-java-messaging-lib</artifactId>
+      <version>1.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.elasticmq</groupId>
+      <artifactId>elasticmq-core_2.10</artifactId>
+      <version>0.6.3</version>
+    </dependency>
+    <dependency>
+      <groupId>org.elasticmq</groupId>
+      <artifactId>elasticmq-rest-sqs_2.10</artifactId>
+      <version>0.6.3</version>
+    </dependency>
+    <dependency>
       <groupId>com.twitter</groupId>
       <artifactId>parquet-avro</artifactId>
       <version>1.6.0</version>

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/realtime/source/SqsSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/realtime/source/SqsSource.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.template.etl.realtime.source;
+
+import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.templates.plugins.PluginConfig;
+import co.cask.cdap.template.etl.api.Emitter;
+import co.cask.cdap.template.etl.api.realtime.RealtimeContext;
+import co.cask.cdap.template.etl.api.realtime.RealtimeSource;
+import co.cask.cdap.template.etl.api.realtime.SourceState;
+import com.amazon.sqs.javamessaging.SQSConnection;
+import com.amazon.sqs.javamessaging.SQSConnectionFactory;
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+
+/**
+ * Realtime source that reads from Amazon SQS.
+ * TODO: CDAP-2978: Extend JMS source so this class can be deleted.
+ */
+@Plugin(type = "source")
+@Name("Sqs")
+@Description("Sqs Realtime Source - Emits a record with a field 'body' of string type")
+public class SqsSource extends RealtimeSource<StructuredRecord> {
+  private static final Logger LOG = LoggerFactory.getLogger(SqsSource.class);
+  private static final String REGION_DESCRIPTION = "Region where the queue is located.";
+  private static final String ACCESSKEY_DESCRIPTION = "Access Key of the AWS account to use.";
+  private static final String ACCESSID_DESCRIPTION = "Access ID of the AWS account to use.";
+  private static final String QUEUENAME_DESCRIPTION = "Name of the queue.";
+  private static final String ENDPOINT_DESCRIPTION = "Endpoint of the SQS server to connect to. Omit this field to" +
+    "connect to AWS.";
+  private static final Schema DEFAULT_SCHEMA = Schema.recordOf(
+    "event",
+    Schema.Field.of("body", Schema.of(Schema.Type.STRING))
+  );
+  private static final int MAX_MESSAGE_COUNT = 20;
+  private static final int TIMEOUT_LENGTH = 1000;
+  private final SqsConfig config;
+  private SQSConnectionFactory connectionFactory;
+  private MessageConsumer consumer;
+  private Session session;
+  private SQSConnection connection;
+
+  public SqsSource(SqsConfig config) {
+    this.config = config;
+  }
+
+  @Override
+  public void initialize(RealtimeContext contex) {
+    try {
+      SQSConnectionFactory.Builder sqsBuild = SQSConnectionFactory.builder()
+        .withRegion(Region.getRegion(Regions.fromName(config.region)));
+      connectionFactory = config.endpoint == null ? sqsBuild.build() : sqsBuild.withEndpoint(config.endpoint).build();
+      connection = connectionFactory.createConnection(config.accessID, config.accessKey);
+      session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+      consumer = session.createConsumer(session.createQueue(config.queueName));
+      connection.start();
+    } catch (Exception e) {
+      if (session != null) {
+        try {
+          session.close();
+        } catch (Exception ex1) {
+          LOG.warn("Exception when closing session", ex1);
+        }
+      }
+      if (connection != null) {
+        try {
+          connection.close();
+        } catch (Exception ex2) {
+          LOG.warn("Exception when closing connection", ex2);
+        }
+      }
+      if (consumer != null) {
+        try {
+          consumer.close();
+        } catch (Exception ex3) {
+          LOG.warn("Exception when closing consumer", ex3);
+        }
+      }
+      LOG.error("Failed to connect to SQS");
+      throw new IllegalStateException("Could not connect to SQS.");
+    }
+  }
+
+  @Override
+  public SourceState poll(Emitter<StructuredRecord> writer, SourceState currentState) throws Exception {
+    Message msg;
+    int count = 0;
+    while ((msg = consumer.receive(TIMEOUT_LENGTH)) != null && count < MAX_MESSAGE_COUNT) {
+      String text = ((TextMessage) msg).getText();
+      if (text.isEmpty()) {
+        msg.acknowledge();
+        continue;
+      }
+
+      StructuredRecord record = StructuredRecord.builder(DEFAULT_SCHEMA)
+        .set("body", text)
+        .build();
+      writer.emit(record);
+      msg.acknowledge();
+      count++;
+    }
+    return currentState;
+  }
+
+  @Override
+  public void destroy() {
+    try {
+      consumer.close();
+      session.close();
+      connection.close();
+    } catch (Exception ex) {
+      throw new RuntimeException("Exception on closing SQS connection: " + ex.getMessage(), ex);
+    }
+  }
+
+  /**
+   * Config class for {@link SqsSource}
+   */
+  public static class SqsConfig extends PluginConfig {
+    @Name("region")
+    @Description(REGION_DESCRIPTION)
+    private String region;
+
+    @Name("accessKey")
+    @Description(ACCESSKEY_DESCRIPTION)
+    private String accessKey;
+
+    @Name("accessID")
+    @Description(ACCESSID_DESCRIPTION)
+    private String accessID;
+
+    @Name("queueName")
+    @Description(QUEUENAME_DESCRIPTION)
+    private String queueName;
+
+    @Name("endpoint")
+    @Nullable
+    @Description(ENDPOINT_DESCRIPTION)
+    private String endpoint;
+
+    public SqsConfig(String region, String accessKey, String accessID, String queueName, @Nullable String endpoint) {
+      this.region = region;
+      this.accessID = accessID;
+      this.accessKey = accessKey;
+      this.queueName = queueName;
+      this.endpoint = endpoint;
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/template/etl/realtime/source/SqsSourceTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/template/etl/realtime/source/SqsSourceTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.template.etl.realtime.source;
+
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.common.utils.Networks;
+import co.cask.cdap.template.etl.api.realtime.SourceState;
+import co.cask.cdap.template.etl.common.MockEmitter;
+import co.cask.cdap.template.etl.common.MockRealtimeContext;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.sqs.AmazonSQSClient;
+import org.elasticmq.Node;
+import org.elasticmq.NodeAddress;
+import org.elasticmq.NodeBuilder;
+import org.elasticmq.rest.RestServer;
+import org.elasticmq.rest.sqs.SQSRestServerBuilder;
+import org.elasticmq.storage.inmemory.InMemoryStorage;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.InetAddress;
+
+public class SqsSourceTest {
+  private Node elasticNode;
+  private RestServer sqsRestServer;
+  private SQSServer sqsServer;
+
+  @Before
+  public void setupElasticMQ() throws Exception {
+    elasticNode = NodeBuilder.withStorage(new InMemoryStorage());
+    sqsServer = new SQSServer(Networks.getRandomPort());
+    NodeAddress nodeAddress = new NodeAddress("http", sqsServer.getHostname(),
+                                              sqsServer.getPort(), "");
+    SQSRestServerBuilder builder = new SQSRestServerBuilder(elasticNode.nativeClient(), sqsServer.getPort(),
+                                                            nodeAddress);
+    sqsRestServer = builder.start();
+  }
+
+  @Test
+  public void testSQS() throws Exception {
+    String queueName = "testQueue";
+    String testMsgExists = "testMessage1";
+    String testMsgOrder = "testMessage2";
+    AmazonSQSClient sqsClient = new AmazonSQSClient(new BasicAWSCredentials(SQSServer.AWS_CRED, SQSServer.AWS_CRED));
+    sqsClient.setEndpoint(sqsServer.getURL(), "sqs", "");
+    sqsClient.createQueue(queueName);
+    String queueURL = sqsClient.getQueueUrl(queueName).getQueueUrl();
+    sqsClient.sendMessage(queueURL, testMsgExists);
+    sqsClient.sendMessage(queueURL, testMsgOrder);
+
+    SqsSource sqsSource = new SqsSource(new SqsSource.SqsConfig("us-west-1", SQSServer.AWS_CRED, SQSServer.AWS_CRED,
+                                                                queueName, sqsServer.getURL()));
+    sqsSource.initialize(new MockRealtimeContext());
+
+    MockEmitter emitter = new MockEmitter();
+    SourceState sourceState = new SourceState();
+    sqsSource.poll(emitter, sourceState);
+
+    Assert.assertEquals(2, emitter.getEmitted().size());
+    Assert.assertEquals(testMsgExists, ((StructuredRecord) emitter.getEmitted().get(0)).get("body"));
+    Assert.assertEquals(testMsgOrder, ((StructuredRecord) emitter.getEmitted().get(1)).get("body"));
+  }
+
+  @After
+  public void stopElasticMQ() {
+    sqsRestServer.stop();
+    elasticNode.shutdown();
+  }
+
+  private class SQSServer {
+    private static final String AWS_CRED = "testKey";
+    private final String sqsHostName;
+    private final int port;
+
+    public SQSServer(int port) throws Exception {
+      this.sqsHostName = InetAddress.getLocalHost().getHostName();
+      this.port = port;
+    }
+
+    public String getHostname() {
+      return sqsHostName;
+    }
+
+    public String getURL() {
+      return "http://" + sqsHostName + ":" + port;
+    }
+
+    public int getPort() {
+      return port;
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/test/java/co/cask/cdap/template/etl/realtime/ETLWorkerTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/test/java/co/cask/cdap/template/etl/realtime/ETLWorkerTest.java
@@ -34,6 +34,7 @@ import co.cask.cdap.template.etl.realtime.sink.RealtimeTableSink;
 import co.cask.cdap.template.etl.realtime.sink.StreamSink;
 import co.cask.cdap.template.etl.realtime.source.JmsSource;
 import co.cask.cdap.template.etl.realtime.source.KafkaSource;
+import co.cask.cdap.template.etl.realtime.source.SqsSource;
 import co.cask.cdap.template.etl.realtime.source.TestSource;
 import co.cask.cdap.template.etl.realtime.source.TwitterSource;
 import co.cask.cdap.template.etl.transform.ProjectionTransform;
@@ -98,7 +99,7 @@ public class ETLWorkerTest extends TestBase {
   @BeforeClass
   public static void setupTests() throws IOException {
     addTemplatePlugins(TEMPLATE_ID, "realtime-sources-1.0.0.jar",
-                       TestSource.class, JmsSource.class, KafkaSource.class, TwitterSource.class);
+                       TestSource.class, JmsSource.class, KafkaSource.class, TwitterSource.class, SqsSource.class);
     addTemplatePlugins(TEMPLATE_ID, "realtime-sinks-1.0.0.jar",
                        RealtimeCubeSink.class, RealtimeTableSink.class, StreamSink.class);
     addTemplatePlugins(TEMPLATE_ID, "transforms-1.0.0.jar",

--- a/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/test/java/co/cask/cdap/template/etl/realtime/RealtimeCubeSinkTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/test/java/co/cask/cdap/template/etl/realtime/RealtimeCubeSinkTest.java
@@ -34,6 +34,7 @@ import co.cask.cdap.template.etl.realtime.sink.RealtimeTableSink;
 import co.cask.cdap.template.etl.realtime.sink.StreamSink;
 import co.cask.cdap.template.etl.realtime.source.JmsSource;
 import co.cask.cdap.template.etl.realtime.source.KafkaSource;
+import co.cask.cdap.template.etl.realtime.source.SqsSource;
 import co.cask.cdap.template.etl.realtime.source.TestSource;
 import co.cask.cdap.template.etl.realtime.source.TwitterSource;
 import co.cask.cdap.template.etl.transform.ProjectionTransform;
@@ -67,7 +68,7 @@ public class RealtimeCubeSinkTest extends TestBase {
   public static void setupTests() throws IOException {
     // todo: should only deploy test source and cube sink
     addTemplatePlugins(TEMPLATE_ID, "realtime-sources-1.0.0.jar",
-                       TestSource.class, JmsSource.class, KafkaSource.class, TwitterSource.class);
+                       TestSource.class, JmsSource.class, KafkaSource.class, TwitterSource.class, SqsSource.class);
     addTemplatePlugins(TEMPLATE_ID, "realtime-sinks-1.0.0.jar",
                        RealtimeCubeSink.class, RealtimeTableSink.class, StreamSink.class);
     addTemplatePlugins(TEMPLATE_ID, "transforms-1.0.0.jar",

--- a/cdap-ui/templates/ETLRealtime/Sqs.json
+++ b/cdap-ui/templates/ETLRealtime/Sqs.json
@@ -1,0 +1,36 @@
+{
+  "id": "Sqs",
+  "groups" : {
+    "position": [ "group1" ],
+    "group1": {
+      "display" : "SQS realtime source",
+      "position" : [ "region", "accessID", "accessKey", "queueName", "endpoint" ],
+      "fields" : {
+        "region" : {
+          "widget": "textbox",
+          "label": "Region"
+        },
+
+        "accessID" : {
+          "widget": "textbox",
+          "label": "AccessID"
+        },
+
+        "accessKey" : {
+          "widget": "textbox",
+          "label": "AccessKey"
+        },
+
+        "queueName" : {
+          "widget": "textbox",
+          "label": "Queue Name"
+        },
+
+        "endpoint" : {
+          "widget": "textbox",
+          "label": "Endpoint"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
JIRA - https://issues.cask.co/browse/CDAP-2915
BUILD - http://builds.cask.co/browse/CDAP-DUT2187-2

Realtime SQS source for ETL. Used in Caskalytics. Tested and works on clusters (with etlrealtimesourcestate disabled).