### PR TITLE
CDAP-2548 : Upgrade usage.registry dataset type from Table to UsageDataset

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/config/DefaultConfigStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/config/DefaultConfigStore.java
@@ -82,8 +82,7 @@ public class DefaultConfigStore implements ConfigStore {
 
   public static void setupDatasets(DatasetFramework dsFramework) throws DatasetManagementException, IOException {
     dsFramework.addInstance(Table.class.getName(), Id.DatasetInstance.from(
-                              Constants.DEFAULT_NAMESPACE_ID, Joiner.on(".").join(Constants.SYSTEM_NAMESPACE,
-                                                                                  Constants.ConfigStore.CONFIG_TABLE)),
+                              Constants.SYSTEM_NAMESPACE_ID, Constants.ConfigStore.CONFIG_TABLE),
                             DatasetProperties.EMPTY);
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/store/ScheduleStoreTableUtil.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/store/ScheduleStoreTableUtil.java
@@ -53,8 +53,7 @@ public class ScheduleStoreTableUtil extends MetaTableUtil {
    */
   public static void setupDatasets(DatasetFramework datasetFramework) throws IOException, DatasetManagementException {
     Id.DatasetInstance scheduleStoreDatasetInstance =
-      Id.DatasetInstance.from(Constants.DEFAULT_NAMESPACE_ID, (Joiner.on(".").join(Constants.SYSTEM_NAMESPACE,
-                                                                                   SCHEDULE_STORE_DATASET_NAME)));
+      Id.DatasetInstance.from(Constants.SYSTEM_NAMESPACE_ID, SCHEDULE_STORE_DATASET_NAME);
     datasetFramework.addInstance(Table.class.getName(), scheduleStoreDatasetInstance, DatasetProperties.EMPTY);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
@@ -130,9 +130,7 @@ public class DefaultStore implements Store {
    */
   public static void setupDatasets(DatasetFramework framework) throws IOException, DatasetManagementException {
     framework.addInstance(Table.class.getName(), Id.DatasetInstance.from(
-                            Constants.DEFAULT_NAMESPACE_ID, (Joiner.on(".").join(Constants.SYSTEM_NAMESPACE,
-                                                                                 APP_META_TABLE))),
-                          DatasetProperties.EMPTY);
+                            Constants.SYSTEM_NAMESPACE_ID, APP_META_TABLE), DatasetProperties.EMPTY);
   }
 
   @Nullable

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetMetaTableUtil.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetMetaTableUtil.java
@@ -74,13 +74,9 @@ public class DatasetMetaTableUtil {
     }
 
     datasetFramework.addInstance(DatasetTypeMDS.class.getName(), Id.DatasetInstance.from(
-                                   Constants.DEFAULT_NAMESPACE_ID, Joiner.on(".").join(Constants.SYSTEM_NAMESPACE,
-                                                                                       META_TABLE_NAME)),
-                                 DatasetProperties.EMPTY);
+                                   Constants.SYSTEM_NAMESPACE_ID, META_TABLE_NAME), DatasetProperties.EMPTY);
     datasetFramework.addInstance(DatasetInstanceMDS.class.getName(), Id.DatasetInstance.from(
-                                   Constants.DEFAULT_NAMESPACE_ID, Joiner.on(".").join(Constants.SYSTEM_NAMESPACE,
-                                                                                       INSTANCE_TABLE_NAME)),
-                                 DatasetProperties.EMPTY);
+                                   Constants.SYSTEM_NAMESPACE_ID, INSTANCE_TABLE_NAME), DatasetProperties.EMPTY);
   }
 
   /**

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/UsageRegistry.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/UsageRegistry.java
@@ -17,9 +17,11 @@
 package co.cask.cdap.data2.registry;
 
 import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
+import co.cask.cdap.data2.datafabric.dataset.instance.DatasetInstanceManager;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.tx.Transactional;
 import co.cask.cdap.proto.Id;
@@ -320,6 +322,29 @@ public class UsageRegistry {
         return input.getUsageDataset().getAdapters(id);
       }
     });
+  }
+
+  /**
+   * Upgrades the UsageRegistry. In its current implementation it changed the type of usage.registry table in
+   * dataset.instances table from table to UsageDataset.
+   *
+   * @param datasetInstanceManager {@link DatasetInstanceManager} for the dataset instance meta data
+   */
+  public void upgrade(DatasetInstanceManager datasetInstanceManager) {
+    DatasetSpecification oldDatasetSpecification = datasetInstanceManager.get(USAGE_INSTANCE_ID);
+
+    if (!oldDatasetSpecification.getType().equals(UsageDataset.class.getSimpleName())) {
+      LOG.info("Upgrading {} dataset from Table to UsageDataset type", USAGE_INSTANCE_ID);
+      DatasetSpecification newDatasetSpecification = DatasetSpecification.builder(oldDatasetSpecification.getName(),
+                                                                                  UsageDataset.class.getSimpleName())
+        .properties(oldDatasetSpecification.getProperties())
+        .datasets(oldDatasetSpecification.getSpecifications().values())
+        .build();
+      datasetInstanceManager.delete(USAGE_INSTANCE_ID);
+      datasetInstanceManager.add(Constants.SYSTEM_NAMESPACE_ID, newDatasetSpecification);
+    } else {
+      LOG.info("{} dataset is of type UsageDataset. No upgrade required.", USAGE_INSTANCE_ID);
+    }
   }
 
   /**

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
@@ -134,6 +134,7 @@ public class UpgradeTool {
               "  1. User Datasets (Upgrades the coprocessor jars for tables, and the base paths for file sets)\n" +
               "  2. System Datasets\n" +
               "  3. StreamConversionAdapter\n" +
+              "  4. UsageRegistry Dataset Type\n" +
               "  Note: Once you run the upgrade tool you cannot rollback to the previous version."),
     HELP("Show this help.");
 

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
@@ -38,11 +38,14 @@ import co.cask.cdap.data.runtime.DataFabricDistributedModule;
 import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;
 import co.cask.cdap.data.stream.StreamAdminModules;
 import co.cask.cdap.data2.datafabric.dataset.DatasetMetaTableUtil;
+import co.cask.cdap.data2.datafabric.dataset.instance.DatasetInstanceManager;
+import co.cask.cdap.data2.datafabric.dataset.service.mds.MDSDatasetsRegistry;
 import co.cask.cdap.data2.dataset2.DatasetDefinitionRegistryFactory;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.DatasetManagementException;
 import co.cask.cdap.data2.dataset2.DefaultDatasetDefinitionRegistry;
 import co.cask.cdap.data2.dataset2.InMemoryDatasetFramework;
+import co.cask.cdap.data2.registry.UsageRegistry;
 import co.cask.cdap.data2.transaction.queue.QueueAdmin;
 import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.internal.app.namespace.NamespaceAdmin;
@@ -63,6 +66,7 @@ import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.templates.AdapterDefinition;
 import co.cask.tephra.TransactionExecutorFactory;
+import co.cask.tephra.TransactionSystemClient;
 import co.cask.tephra.distributed.TransactionService;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.AbstractModule;
@@ -113,6 +117,7 @@ public class UpgradeTool {
   private final TransactionService txService;
   private final ZKClientService zkClientService;
   private final NamespacedLocationFactory namespacedLocationFactory;
+  private final MDSDatasetsRegistry mdsDatasetsRegistry;
 
   private Store store;
   private QuartzScheduler qs;
@@ -151,6 +156,8 @@ public class UpgradeTool {
     this.zkClientService = injector.getInstance(ZKClientService.class);
     this.namespacedLocationFactory = injector.getInstance(NamespacedLocationFactory.class);
     this.dsFramework = injector.getInstance(DatasetFramework.class);
+    this.mdsDatasetsRegistry = injector.getInstance(Key.get(MDSDatasetsRegistry.class,
+                                                            Names.named("mdsDatasetsRegistry")));
     this.adapterService = injector.getInstance(AdapterService.class);
 
     Runtime.getRuntime().addShutdownHook(new Thread() {
@@ -199,6 +206,22 @@ public class UpgradeTool {
 
         @Provides
         @Singleton
+        @Named("mdsDatasetsRegistry")
+        public MDSDatasetsRegistry getMDSDatasetsRegistry (TransactionSystemClient txClient,
+                            @Named("datasetMDS") DatasetFramework framework) {
+          return new MDSDatasetsRegistry(txClient, framework);
+        }
+
+        @Provides
+        @Singleton
+        @Named("datasetInstanceManager")
+        public DatasetInstanceManager getDatasetInstanceManager (@Named("mdsDatasetsRegistry")
+                                                                 MDSDatasetsRegistry mdsDatasetsRegistry) {
+          return new DatasetInstanceManager(mdsDatasetsRegistry);
+        }
+
+        @Provides
+        @Singleton
         @Named("defaultStore")
         public Store getStore(DatasetFramework dsFramework,
                               CConfiguration cConf, LocationFactory locationFactory,
@@ -221,11 +244,12 @@ public class UpgradeTool {
   /**
    * Do the start up work
    */
-  private void startUp() throws IOException, DatasetManagementException {
+  private void startUp() throws Exception {
     // Start all the services.
     zkClientService.startAndWait();
     txService.startAndWait();
     initializeDSFramework(cConf, dsFramework);
+    mdsDatasetsRegistry.startUp();
   }
 
   /**
@@ -238,6 +262,7 @@ public class UpgradeTool {
       if (qs != null) {
         qs.shutdown();
       }
+      mdsDatasetsRegistry.shutDown();
     } catch (Throwable e) {
       LOG.error("Exception while trying to stop upgrade process", e);
       Runtime.getRuntime().halt(1);
@@ -337,6 +362,10 @@ public class UpgradeTool {
     queueAdmin.upgrade();
 
     upgradeAdapters();
+
+    UsageRegistry usageRegistry = injector.getInstance(UsageRegistry.class);
+    usageRegistry.upgrade(injector.getInstance(Key.get(DatasetInstanceManager.class,
+                                                       Names.named("datasetInstanceManager"))));
   }
 
   /**

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/LogSaverTableUtil.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/LogSaverTableUtil.java
@@ -52,9 +52,8 @@ public class LogSaverTableUtil extends MetaTableUtil {
    * @param datasetFramework framework to add types and datasets to
    */
   public static void setupDatasets(DatasetFramework datasetFramework) throws IOException, DatasetManagementException {
-    Id.DatasetInstance logMetaDatasetInstance = Id.DatasetInstance.from(Constants.DEFAULT_NAMESPACE_ID,
-                                                                        (Joiner.on(".").join(Constants.SYSTEM_NAMESPACE,
-                                                                                             TABLE_NAME)));
+    Id.DatasetInstance logMetaDatasetInstance = Id.DatasetInstance.from(Constants.SYSTEM_NAMESPACE_ID,
+                                                                        TABLE_NAME);
     datasetFramework.addInstance(Table.class.getName(), logMetaDatasetInstance, DatasetProperties.EMPTY);
   }
 }


### PR DESCRIPTION
Did a complete test on cluster: It works.
1. Deployed 3.0.0 cluster through coopr autobuild
2. Deployed Purchase app
3. Sent some events to the stream (which will create usage.registry table)
4. Verified through hbase shell that dataset.instance has the table type for above table as Table.
5. Stopped all services
6. Beamed the fix version branch from the PR. 
7. Ran the upgrade tool 
8. After upgrade verified that the type in dataset.instance is changed to UsageDataset
9. Started all services
10. Ran flow, services, workflow and queries for results.
