### PR TITLE
Upgrade tool fixes

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/config/DefaultConfigStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/config/DefaultConfigStore.java
@@ -82,8 +82,7 @@ public class DefaultConfigStore implements ConfigStore {
 
   public static void setupDatasets(DatasetFramework dsFramework) throws DatasetManagementException, IOException {
     dsFramework.addInstance(Table.class.getName(), Id.DatasetInstance.from(
-                              Constants.DEFAULT_NAMESPACE_ID, Joiner.on(".").join(Constants.SYSTEM_NAMESPACE,
-                                                                                  Constants.ConfigStore.CONFIG_TABLE)),
+                              Constants.SYSTEM_NAMESPACE_ID, Constants.ConfigStore.CONFIG_TABLE),
                             DatasetProperties.EMPTY);
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/store/ScheduleStoreTableUtil.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/store/ScheduleStoreTableUtil.java
@@ -53,8 +53,7 @@ public class ScheduleStoreTableUtil extends MetaTableUtil {
    */
   public static void setupDatasets(DatasetFramework datasetFramework) throws IOException, DatasetManagementException {
     Id.DatasetInstance scheduleStoreDatasetInstance =
-      Id.DatasetInstance.from(Constants.DEFAULT_NAMESPACE_ID, (Joiner.on(".").join(Constants.SYSTEM_NAMESPACE,
-                                                                                   SCHEDULE_STORE_DATASET_NAME)));
+      Id.DatasetInstance.from(Constants.SYSTEM_NAMESPACE_ID, SCHEDULE_STORE_DATASET_NAME);
     datasetFramework.addInstance(Table.class.getName(), scheduleStoreDatasetInstance, DatasetProperties.EMPTY);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
@@ -130,8 +130,7 @@ public class DefaultStore implements Store {
    */
   public static void setupDatasets(DatasetFramework framework) throws IOException, DatasetManagementException {
     framework.addInstance(Table.class.getName(), Id.DatasetInstance.from(
-                            Constants.DEFAULT_NAMESPACE_ID, (Joiner.on(".").join(Constants.SYSTEM_NAMESPACE,
-                                                                                 APP_META_TABLE))),
+                            Constants.SYSTEM_NAMESPACE_ID, APP_META_TABLE),
                           DatasetProperties.EMPTY);
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetMetaTableUtil.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetMetaTableUtil.java
@@ -74,12 +74,10 @@ public class DatasetMetaTableUtil {
     }
 
     datasetFramework.addInstance(DatasetTypeMDS.class.getName(), Id.DatasetInstance.from(
-                                   Constants.DEFAULT_NAMESPACE_ID, Joiner.on(".").join(Constants.SYSTEM_NAMESPACE,
-                                                                                       META_TABLE_NAME)),
+                                   Constants.SYSTEM_NAMESPACE_ID, META_TABLE_NAME),
                                  DatasetProperties.EMPTY);
     datasetFramework.addInstance(DatasetInstanceMDS.class.getName(), Id.DatasetInstance.from(
-                                   Constants.DEFAULT_NAMESPACE_ID, Joiner.on(".").join(Constants.SYSTEM_NAMESPACE,
-                                                                                       INSTANCE_TABLE_NAME)),
+                                   Constants.SYSTEM_NAMESPACE_ID, INSTANCE_TABLE_NAME),
                                  DatasetProperties.EMPTY);
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/UsageRegistry.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/UsageRegistry.java
@@ -21,6 +21,7 @@ import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.dataset2.DatasetManagementException;
 import co.cask.cdap.data2.dataset2.tx.Transactional;
 import co.cask.cdap.proto.Id;
 import co.cask.tephra.TransactionExecutor;
@@ -32,6 +33,7 @@ import com.google.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Set;
@@ -341,4 +343,14 @@ public class UsageRegistry {
       return Iterators.singletonIterator(usageDataset);
     }
   }
+
+  /**
+   * Adds datasets and types to the given {@link DatasetFramework} used by usage registry.
+   *
+   * @param datasetFramework framework to add types and datasets to
+   */
+  public static void setupDatasets(DatasetFramework datasetFramework) throws IOException, DatasetManagementException {
+    datasetFramework.addInstance(Table.class.getName(), USAGE_INSTANCE_ID, DatasetProperties.EMPTY);
+  }
+
 }

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/DatasetUpgrader.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/DatasetUpgrader.java
@@ -95,10 +95,7 @@ public class DatasetUpgrader extends AbstractUpgrader {
   private void upgradeUserTables() throws Exception {
     HBaseAdmin hAdmin = new HBaseAdmin(hConf);
     for (HTableDescriptor desc : hAdmin.listTables()) {
-      String tableName = desc.getNameAsString();
-      if (!isTableInSystemNamespace(tableName) &&
-           isUserTable(tableName) &&
-           isTableCreatedByCDAP(desc)) {
+      if (isCDAPUserTable(desc)) {
         upgradeUserTable(desc);
       }
     }
@@ -137,26 +134,29 @@ public class DatasetUpgrader extends AbstractUpgrader {
     LOG.info("Upgraded hbase table: {}", tableId);
   }
 
-  // Note: This check can be safely used for user table since we create meta.
-  // CDAP-2963 should be fixed so that we can make use of this check generically for all cdap tables
-  private boolean isTableCreatedByCDAP(HTableDescriptor desc) {
-    return (desc.getValue("cdap.version") != null);
-  }
 
-  private boolean isTableInSystemNamespace(String tableName) {
-    // dataset in system namespace starts with <prefix>_system ex: cdap_system
-    return tableName.startsWith(String.format("%s_%s", this.datasetTablePrefix, "system"));
-  }
-
-  private boolean isUserTable(String tableName) {
+  private boolean isCDAPUserTable(HTableDescriptor desc) {
+    String tableName = desc.getNameAsString();
+    // If table is in system namespace: (starts with <tablePrefix>_system
+    // or if it is not created by CDAP it is not user table
+    if (tableName.startsWith(String.format("%s_%s", this.datasetTablePrefix, Constants.SYSTEM_NAMESPACE)) ||
+       (!isTableCreatedByCDAP(desc))) {
+      return false;
+    }
     // User tables are named differently in default vs non-default namespace
     // User table in default namespace starts with cdap.user
     // User table in Non-default namespace is a table that doesn't have
     //    system.queue or system.stream or system.sharded.queue
-   return defaultNSUserTablePrefix.matcher(tableName).matches() ||
-          // Note: if the user has created a dataset called system.* then we will not upgrade the table.
-          // CDAP-2977 should be fixed to have a cleaner fix for this.
-          !(tableName.contains("system.queue") || tableName.contains("system.stream") ||
-            tableName.contains("system.sharded.queue"));
+    return defaultNSUserTablePrefix.matcher(tableName).matches() ||
+      // Note: if the user has created a dataset called system.* then we will not upgrade the table.
+      // CDAP-2977 should be fixed to have a cleaner fix for this.
+      !(tableName.contains("system.queue") || tableName.contains("system.stream") ||
+        tableName.contains("system.sharded.queue"));
+  }
+
+  // Note: This check can be safely used for user table since we create meta.
+  // CDAP-2963 should be fixed so that we can make use of this check generically for all cdap tables
+  private boolean isTableCreatedByCDAP(HTableDescriptor desc) {
+    return (desc.getValue("cdap.version") != null);
   }
 }

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
@@ -43,6 +43,7 @@ import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.DatasetManagementException;
 import co.cask.cdap.data2.dataset2.DefaultDatasetDefinitionRegistry;
 import co.cask.cdap.data2.dataset2.InMemoryDatasetFramework;
+import co.cask.cdap.data2.registry.UsageRegistry;
 import co.cask.cdap.data2.transaction.queue.QueueAdmin;
 import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.gateway.auth.AuthModule;
@@ -396,6 +397,9 @@ public class UpgradeTool {
     // metrics data
     DefaultMetricDatasetFactory factory = new DefaultMetricDatasetFactory(cConf, datasetFramework);
     DefaultMetricDatasetFactory.setupDatasets(factory);
+
+    // Usage registry
+    UsageRegistry.setupDatasets(datasetFramework);
   }
 
   /**

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/LogSaverTableUtil.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/LogSaverTableUtil.java
@@ -52,9 +52,8 @@ public class LogSaverTableUtil extends MetaTableUtil {
    * @param datasetFramework framework to add types and datasets to
    */
   public static void setupDatasets(DatasetFramework datasetFramework) throws IOException, DatasetManagementException {
-    Id.DatasetInstance logMetaDatasetInstance = Id.DatasetInstance.from(Constants.DEFAULT_NAMESPACE_ID,
-                                                                        (Joiner.on(".").join(Constants.SYSTEM_NAMESPACE,
-                                                                                             TABLE_NAME)));
+    Id.DatasetInstance logMetaDatasetInstance = Id.DatasetInstance.from(Constants.SYSTEM_NAMESPACE_ID,
+                                                                        TABLE_NAME);
     datasetFramework.addInstance(Table.class.getName(), logMetaDatasetInstance, DatasetProperties.EMPTY);
   }
 }


### PR DESCRIPTION
* Upgrades all tables in system namespace
* Upgrades all user table across all namespace
* Avoids creating redundant empty tables after the upgrade
* Avoids upgrading non-cdap managed tables

JIRA: https://issues.cask.co/browse/CDAP-2962
Build: http://builds.cask.co/browse/CDAP-RBT308