### PR TITLE
Persist WorkflowToken to MDS

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/Store.java
@@ -21,6 +21,7 @@ import co.cask.cdap.api.data.stream.StreamSpecification;
 import co.cask.cdap.api.flow.FlowSpecification;
 import co.cask.cdap.api.schedule.ScheduleSpecification;
 import co.cask.cdap.api.worker.Worker;
+import co.cask.cdap.api.workflow.WorkflowToken;
 import co.cask.cdap.app.ApplicationSpecification;
 import co.cask.cdap.app.program.Program;
 import co.cask.cdap.proto.AdapterStatus;
@@ -151,6 +152,7 @@ public interface Store {
    * @param runid     run id of the program
    * @return          run record for the specified program and runid, null if not found
    */
+  @Nullable
   RunRecord getRun(Id.Program id, String runid);
 
   /**
@@ -457,4 +459,22 @@ public interface Store {
   void setWorkflowProgramStart(Id.Program programId, String programRunId, String workflow, String workflowRunId,
                                String workflowNodeId, long startTimeInSeconds, @Nullable String adapter,
                                @Nullable String twillRunId);
+
+  /**
+   * Updates the {@link WorkflowToken} for a specified run of a workflow.
+   *
+   * @param workflowId {@link Id.Workflow} of the workflow whose {@link WorkflowToken} is to be updated
+   * @param workflowRunId Run Id of the workflow for which the {@link WorkflowToken} is to be updated
+   * @param token the {@link WorkflowToken} to update
+   */
+  void updateWorkflowToken(Id.Workflow workflowId, String workflowRunId, WorkflowToken token);
+
+  /**
+   * Retrieves the {@link WorkflowToken} for a specified run of a workflow.
+   *
+   * @param workflowId {@link Id.Workflow} of the workflow whose {@link WorkflowToken} is to be retrieved
+   * @param workflowRunId Run Id of the workflow for which the {@link WorkflowToken} is to be retrieved
+   * @return the {@link WorkflowToken} for the specified workflow run
+   */
+  WorkflowToken getWorkflowToken(Id.Workflow workflowId, String workflowRunId);
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
@@ -162,9 +162,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   /**
    * Json serializer.
    */
-  protected static final Gson GSON = ApplicationSpecificationAdapter.addTypeAdapters(new GsonBuilder())
-    .registerTypeAdapter(ScheduleSpecification.class, new ScheduleSpecificationCodec())
-    .create();
+  private static final Gson GSON = ApplicationSpecificationAdapter.addTypeAdapters(new GsonBuilder()).create();
 
   /**
    * Store manages non-runtime lifecycle.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/WorkflowClient.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/WorkflowClient.java
@@ -42,6 +42,7 @@ public class WorkflowClient {
   private static final Logger LOG = LoggerFactory.getLogger(WorkflowClient.class);
   private final AsyncHttpClient httpClient;
   private final DiscoveryServiceClient discoveryServiceClient;
+
   @Inject
   WorkflowClient(DiscoveryServiceClient discoveryServiceClient) {
     this.discoveryServiceClient = discoveryServiceClient;
@@ -50,10 +51,10 @@ public class WorkflowClient {
                                                configBuilder.build());
   }
 
-  public void getWorkflowStatus(String accountId, String appId, String workflowId, String runId,
+  public void getWorkflowStatus(String namespaceId, String appId, String workflowId, String runId,
                                 final Callback callback) throws IOException {
     // determine the service provider for the given path
-    String serviceName = String.format("workflow.%s.%s.%s.%s", accountId, appId, workflowId, runId);
+    String serviceName = String.format("workflow.%s.%s.%s.%s", namespaceId, appId, workflowId, runId);
     Discoverable discoverable = new RandomEndpointStrategy(discoveryServiceClient.discover(serviceName)).pick();
 
     if (discoverable == null) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowProgramRunner.java
@@ -23,6 +23,7 @@ import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.app.runtime.ProgramRunner;
+import co.cask.cdap.app.store.Store;
 import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
@@ -31,7 +32,6 @@ import co.cask.cdap.internal.app.runtime.ProgramRunnerFactory;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.tephra.TransactionSystemClient;
 import com.google.common.base.Preconditions;
-import com.google.gson.Gson;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import org.apache.twill.api.RunId;
@@ -44,23 +44,22 @@ import java.net.InetAddress;
  * A {@link ProgramRunner} that runs a {@link Workflow}.
  */
 public class WorkflowProgramRunner implements ProgramRunner {
-  private static final Gson GSON = new Gson();
-
   private final ProgramRunnerFactory programRunnerFactory;
   private final ServiceAnnouncer serviceAnnouncer;
   private final InetAddress hostname;
-
   private final MetricsCollectionService metricsCollectionService;
   private final DatasetFramework datasetFramework;
   private final DiscoveryServiceClient discoveryServiceClient;
   private final TransactionSystemClient txClient;
+  private final Store store;
 
   @Inject
   public WorkflowProgramRunner(ProgramRunnerFactory programRunnerFactory,
                                ServiceAnnouncer serviceAnnouncer,
                                @Named(Constants.AppFabric.SERVER_ADDRESS) InetAddress hostname,
                                MetricsCollectionService metricsCollectionService, DatasetFramework datasetFramework,
-                               DiscoveryServiceClient discoveryServiceClient, TransactionSystemClient txClient) {
+                               DiscoveryServiceClient discoveryServiceClient, TransactionSystemClient txClient,
+                               Store store) {
     this.programRunnerFactory = programRunnerFactory;
     this.serviceAnnouncer = serviceAnnouncer;
     this.hostname = hostname;
@@ -68,6 +67,7 @@ public class WorkflowProgramRunner implements ProgramRunner {
     this.datasetFramework = datasetFramework;
     this.discoveryServiceClient = discoveryServiceClient;
     this.txClient = txClient;
+    this.store = store;
   }
 
   @Override
@@ -85,7 +85,7 @@ public class WorkflowProgramRunner implements ProgramRunner {
 
     WorkflowDriver driver = new WorkflowDriver(program, options, hostname, workflowSpec, programRunnerFactory,
                                                metricsCollectionService, datasetFramework,
-                                               discoveryServiceClient, txClient);
+                                               discoveryServiceClient, txClient, store);
 
     // Controller needs to be created before starting the driver so that the state change of the driver
     // service can be fully captured by the controller.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
@@ -28,6 +28,7 @@ import co.cask.cdap.api.flow.FlowletDefinition;
 import co.cask.cdap.api.schedule.ScheduleSpecification;
 import co.cask.cdap.api.service.ServiceSpecification;
 import co.cask.cdap.api.worker.WorkerSpecification;
+import co.cask.cdap.api.workflow.WorkflowToken;
 import co.cask.cdap.app.ApplicationSpecification;
 import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.program.Programs;
@@ -916,6 +917,27 @@ public class DefaultStore implements Store {
         mds.apps.recordWorkflowProgramStart(programId, programRunId, workflow, workflowRunId, workflowNodeId,
                                             startTimeInSeconds, adapter, twillRunId);
         return null;
+      }
+    });
+  }
+
+  @Override
+  public void updateWorkflowToken(final Id.Workflow workflowId, final String workflowRunId, final WorkflowToken token) {
+    txnl.executeUnchecked(new TransactionExecutor.Function<AppMds, Void>() {
+      @Override
+      public Void apply(AppMds mds) throws Exception {
+        mds.apps.updateWorkflowToken(workflowId, workflowRunId, token);
+        return null;
+      }
+    });
+  }
+
+  @Override
+  public WorkflowToken getWorkflowToken(final Id.Workflow workflowId, final String workflowRunId) {
+    return txnl.executeUnchecked(new TransactionExecutor.Function<AppMds, WorkflowToken>() {
+      @Override
+      public WorkflowToken apply(AppMds mds) throws Exception {
+        return mds.apps.getWorkflowToken(workflowId, workflowRunId);
       }
     });
   }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/AppWithWorkflow.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/AppWithWorkflow.java
@@ -22,6 +22,8 @@ import co.cask.cdap.api.data.stream.Stream;
 import co.cask.cdap.api.dataset.lib.ObjectStores;
 import co.cask.cdap.api.workflow.AbstractWorkflow;
 import co.cask.cdap.api.workflow.AbstractWorkflowAction;
+import co.cask.cdap.api.workflow.WorkflowContext;
+import co.cask.cdap.api.workflow.WorkflowToken;
 import com.google.common.base.Throwables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -66,6 +68,16 @@ public class AppWithWorkflow extends AbstractApplication {
    */
   public static class DummyAction extends AbstractWorkflowAction {
     private static final Logger LOG = LoggerFactory.getLogger(DummyAction.class);
+    public static final String TOKEN_KEY = "tokenKey";
+    public static final String TOKEN_VALUE = "tokenValue";
+
+    @Override
+    public void initialize(WorkflowContext context) throws Exception {
+      super.initialize(context);
+      WorkflowToken workflowToken = context.getToken();
+      workflowToken.put(TOKEN_KEY, TOKEN_VALUE);
+    }
+
     @Override
     public void run() {
       LOG.info("Ran dummy action");

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AppFabricTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AppFabricTestBase.java
@@ -357,8 +357,8 @@ public abstract class AppFabricTestBase {
    * Deploys an application with (optionally) a defined app name and app version
    */
   protected HttpResponse deploy(Class<?> application, @Nullable String apiVersion, @Nullable String namespace,
-                                       @Nullable String appName, @Nullable String appVersion,
-                                       @Nullable Config appConfig) throws Exception {
+                                @Nullable String appName, @Nullable String appVersion,
+                                @Nullable Config appConfig) throws Exception {
     namespace = namespace == null ? Constants.DEFAULT_NAMESPACE : namespace;
     apiVersion = apiVersion == null ? Constants.Gateway.API_VERSION_3_TOKEN : apiVersion;
 
@@ -646,19 +646,7 @@ public abstract class AppFabricTestBase {
     String versionedUrl = getVersionedAPIPath(schedulesUrl, Constants.Gateway.API_VERSION_3_TOKEN, namespace);
     HttpResponse response = doGet(versionedUrl);
     String json = EntityUtils.toString(response.getEntity());
-    return GSON.fromJson(json, new TypeToken<List<ScheduleSpecification>>() {
-    }.getType());
-  }
-
-  /**
-   * @deprecated Use {@link #getProgramRuns(Id.Program, String status)}.
-   */
-  @Deprecated
-  protected int getRuns(String runsUrl) throws Exception {
-    HttpResponse response = doGet(runsUrl);
-    String json = EntityUtils.toString(response.getEntity());
-    List<Map<String, String>> history = GSON.fromJson(json, LIST_RUNRECORD_TYPE);
-    return history.size();
+    return GSON.fromJson(json, new TypeToken<List<ScheduleSpecification>>() { }.getType());
   }
 
   protected void verifyProgramRuns(final Id.Program program, final String status) throws Exception {
@@ -681,7 +669,7 @@ public abstract class AppFabricTestBase {
     HttpResponse response = doGet(getVersionedAPIPath(path, program.getNamespaceId()));
     Assert.assertEquals(200, response.getStatusLine().getStatusCode());
     String json = EntityUtils.toString(response.getEntity());
-    return new Gson().fromJson(json, LIST_RUNRECORD_TYPE);
+    return GSON.fromJson(json, LIST_RUNRECORD_TYPE);
   }
 
   protected boolean datasetExists(Id.DatasetInstance datasetID) throws Exception {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/runtime/WorkflowTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/runtime/WorkflowTest.java
@@ -23,8 +23,10 @@ import co.cask.cdap.ScheduleAppWithMissingWorkflow;
 import co.cask.cdap.WorkflowApp;
 import co.cask.cdap.WorkflowSchedulesWithSameNameApp;
 import co.cask.cdap.app.program.Program;
+import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.app.runtime.ProgramRunner;
+import co.cask.cdap.app.store.Store;
 import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.internal.AppFabricTestHelper;
 import co.cask.cdap.internal.app.deploy.pipeline.ApplicationWithPrograms;
@@ -41,6 +43,7 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterators;
 import com.google.common.util.concurrent.SettableFuture;
+import com.google.inject.Injector;
 import org.apache.twill.common.Threads;
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -54,6 +57,7 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import javax.annotation.Nullable;
 
 /**
  *
@@ -83,11 +87,12 @@ public class WorkflowTest {
   public void testWorkflow() throws Exception {
     final ApplicationWithPrograms app = AppFabricTestHelper.deployApplicationWithManager(WorkflowApp.class,
                                                                                          TEMP_FOLDER_SUPPLIER);
-    ProgramRunnerFactory runnerFactory = AppFabricTestHelper.getInjector().getInstance(ProgramRunnerFactory.class);
+    final Injector injector = AppFabricTestHelper.getInjector();
+    ProgramRunnerFactory runnerFactory = injector.getInstance(ProgramRunnerFactory.class);
 
     ProgramRunner programRunner = runnerFactory.create(ProgramRunnerFactory.Type.WORKFLOW);
 
-    Program program = Iterators.filter(app.getPrograms().iterator(), new Predicate<Program>() {
+    final Program program = Iterators.filter(app.getPrograms().iterator(), new Predicate<Program>() {
       @Override
       public boolean apply(Program input) {
         return input.getType() == ProgramType.WORKFLOW;
@@ -96,13 +101,20 @@ public class WorkflowTest {
 
     String inputPath = createInput();
     String outputPath = new File(tmpFolder.newFolder(), "output").getAbsolutePath();
-    BasicArguments systemArgs = new BasicArguments(ImmutableMap.of(ProgramOptionConstants.RUN_ID,
-                                                                   RunIds.generate().getId()));
+    final String runId = RunIds.generate().getId();
+    BasicArguments systemArgs = new BasicArguments(ImmutableMap.of(ProgramOptionConstants.RUN_ID, runId));
     BasicArguments userArgs = new BasicArguments(ImmutableMap.of("inputPath", inputPath, "outputPath", outputPath));
     ProgramOptions options = new SimpleProgramOptions(program.getName(), systemArgs, userArgs);
 
     final SettableFuture<String> completion = SettableFuture.create();
     programRunner.run(program, options).addListener(new AbstractListener() {
+
+      @Override
+      public void init(ProgramController.State currentState, @Nullable Throwable cause) {
+        LOG.info("Starting");
+        injector.getInstance(Store.class).setStart(program.getId(), runId, System.currentTimeMillis());
+      }
+
       @Override
       public void completed() {
         LOG.info("Completed");
@@ -123,9 +135,7 @@ public class WorkflowTest {
   public void testBadInputInWorkflow() throws Exception {
     // try deploying app containing Workflow configured with non-existent MapReduce program
     try {
-      final ApplicationWithPrograms app = AppFabricTestHelper.deployApplicationWithManager(
-        MissingMapReduceWorkflowApp.class,
-        TEMP_FOLDER_SUPPLIER);
+      AppFabricTestHelper.deployApplicationWithManager(MissingMapReduceWorkflowApp.class, TEMP_FOLDER_SUPPLIER);
       Assert.fail("Should have thrown Exception because MapReduce program is missing in the Application.");
     } catch (Exception ex) {
       Assert.assertEquals(ex.getCause().getMessage(),
@@ -134,9 +144,7 @@ public class WorkflowTest {
 
     // try deploying app containing Workflow configured with non-existent Spark program
     try {
-      final ApplicationWithPrograms app = AppFabricTestHelper.deployApplicationWithManager(
-        MissingSparkWorkflowApp.class,
-        TEMP_FOLDER_SUPPLIER);
+      AppFabricTestHelper.deployApplicationWithManager(MissingSparkWorkflowApp.class, TEMP_FOLDER_SUPPLIER);
       Assert.fail("Should have thrown Exception because Spark program is missing in the Application.");
     } catch (Exception ex) {
       Assert.assertEquals(ex.getCause().getMessage(),
@@ -145,9 +153,7 @@ public class WorkflowTest {
 
     // try deploying app containing Workflow configured with multiple schedules with the same name
     try {
-      final ApplicationWithPrograms app = AppFabricTestHelper.deployApplicationWithManager(
-        WorkflowSchedulesWithSameNameApp.class,
-        TEMP_FOLDER_SUPPLIER);
+      AppFabricTestHelper.deployApplicationWithManager(WorkflowSchedulesWithSameNameApp.class, TEMP_FOLDER_SUPPLIER);
       Assert.fail("Should have thrown Exception because Workflow is configured with schedules having same name.");
     } catch (Exception ex) {
       Assert.assertEquals(ex.getCause().getCause().getMessage(),
@@ -156,8 +162,7 @@ public class WorkflowTest {
 
     // try deploying app containing a schedule for non existent workflow
     try {
-      final ApplicationWithPrograms app = AppFabricTestHelper.deployApplicationWithManager(
-        ScheduleAppWithMissingWorkflow.class, TEMP_FOLDER_SUPPLIER);
+      AppFabricTestHelper.deployApplicationWithManager(ScheduleAppWithMissingWorkflow.class, TEMP_FOLDER_SUPPLIER);
       Assert.fail("Should have thrown Exception because Schedule is configured for non existent Workflow.");
     } catch (Exception ex) {
       Assert.assertEquals(ex.getCause().getMessage(),
@@ -166,8 +171,7 @@ public class WorkflowTest {
 
     // try deploying app containing anonymous workflow
     try {
-      final ApplicationWithPrograms app = AppFabricTestHelper.deployApplicationWithManager(
-        AppWithAnonymousWorkflow.class, TEMP_FOLDER_SUPPLIER);
+      AppFabricTestHelper.deployApplicationWithManager(AppWithAnonymousWorkflow.class, TEMP_FOLDER_SUPPLIER);
       Assert.fail("Should have thrown Exception because Workflow does not have name.");
     } catch (Exception ex) {
       Assert.assertEquals(ex.getCause().getMessage(),
@@ -179,22 +183,29 @@ public class WorkflowTest {
   public void testOneActionWorkflow() throws Exception {
     final ApplicationWithPrograms app = AppFabricTestHelper.deployApplicationWithManager(OneActionWorkflowApp.class,
                                                                                          TEMP_FOLDER_SUPPLIER);
-    ProgramRunnerFactory runnerFactory = AppFabricTestHelper.getInjector().getInstance(ProgramRunnerFactory.class);
+    final Injector injector = AppFabricTestHelper.getInjector();
+    ProgramRunnerFactory runnerFactory = injector.getInstance(ProgramRunnerFactory.class);
     ProgramRunner programRunner = runnerFactory.create(ProgramRunnerFactory.Type.WORKFLOW);
 
-    Program program = Iterators.filter(app.getPrograms().iterator(), new Predicate<Program>() {
+    final Program program = Iterators.filter(app.getPrograms().iterator(), new Predicate<Program>() {
       @Override
       public boolean apply(Program input) {
         return input.getType() == ProgramType.WORKFLOW;
       }
     }).next();
 
-    BasicArguments systemArgs = new BasicArguments(ImmutableMap.of(ProgramOptionConstants.RUN_ID,
-                                                                   RunIds.generate().getId()));
+    final String runId = RunIds.generate().getId();
+    BasicArguments systemArgs = new BasicArguments(ImmutableMap.of(ProgramOptionConstants.RUN_ID, runId));
     ProgramOptions options = new SimpleProgramOptions(program.getName(), systemArgs, new BasicArguments());
 
     final SettableFuture<String> completion = SettableFuture.create();
     programRunner.run(program, options).addListener(new AbstractListener() {
+      @Override
+      public void init(ProgramController.State currentState, @Nullable Throwable cause) {
+        LOG.info("Initializing");
+        injector.getInstance(Store.class).setStart(program.getId(), runId, System.currentTimeMillis());
+      }
+
       @Override
       public void completed() {
         LOG.info("Completed");
@@ -217,13 +228,10 @@ public class WorkflowTest {
 
     File inputFile = new File(inputDir.getPath() + "/words.txt");
     inputFile.deleteOnExit();
-    BufferedWriter writer = new BufferedWriter(new FileWriter(inputFile));
-    try {
+    try (BufferedWriter writer = new BufferedWriter(new FileWriter(inputFile))) {
       writer.write("this text has");
       writer.newLine();
       writer.write("two words text inside");
-    } finally {
-      writer.close();
     }
 
     return inputDir.getAbsolutePath();

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/tx/Transactional.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/tx/Transactional.java
@@ -75,9 +75,7 @@ public class Transactional<T extends Iterable<V>, V> {
   public <R> R executeUnchecked(final TransactionExecutor.Function<T, R> func) {
     try {
       return execute(txFactory, supplier, func);
-    } catch (IOException e) {
-      throw Throwables.propagate(e);
-    } catch (TransactionFailureException e) {
+    } catch (IOException | TransactionFailureException e) {
       throw Throwables.propagate(e);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/RunRecord.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/RunRecord.java
@@ -50,7 +50,8 @@ public final class RunRecord {
   private final Map<String, String> properties;
 
   public RunRecord(String pid, long startTs, @Nullable Long stopTs, ProgramRunStatus status,
-                   @Nullable String adapterName, @Nullable String twillRunId, Map<String, String> properties) {
+                   @Nullable String adapterName, @Nullable String twillRunId,
+                   @Nullable Map<String, String> properties) {
     this.pid = pid;
     this.startTs = startTs;
     this.stopTs = stopTs;
@@ -72,6 +73,11 @@ public final class RunRecord {
   public RunRecord(RunRecord started, @Nullable Long stopTs, ProgramRunStatus status) {
     this(started.pid, started.startTs, stopTs, status, started.getAdapterName(), started.getTwillRunId(),
          started.getProperties());
+  }
+
+  public RunRecord(RunRecord existing, Map<String, String> updatedProperties) {
+    this(existing.pid, existing.startTs, existing.stopTs, existing.status, existing.adapterName, existing.twillRunId,
+         updatedProperties);
   }
 
   public String getPid() {

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/WorkflowTokenDetail.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/WorkflowTokenDetail.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.proto;
+
+import co.cask.cdap.api.workflow.NodeValue;
+import co.cask.cdap.api.workflow.Value;
+import co.cask.cdap.api.workflow.WorkflowToken;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Class to represent {@link WorkflowToken} for a give workflow run.
+ */
+public class WorkflowTokenDetail {
+
+  private final Map<String, List<NodeValueDetail>> tokenData;
+
+  public WorkflowTokenDetail(Map<String, List<NodeValueDetail>> tokenData) {
+    this.tokenData = ImmutableMap.copyOf(tokenData);
+  }
+
+  public Map<String, List<NodeValueDetail>> getTokenData() {
+    return tokenData;
+  }
+
+  /**
+   * Constructs a {@link WorkflowTokenDetail} by flattening the {@link Value} from the output of
+   * {@link WorkflowToken#getAll(WorkflowToken.Scope)}.
+   *
+   * @param data the workflow token data to flatten
+   * @return {@link WorkflowTokenDetail} from the specified workflow token data
+   */
+  public static WorkflowTokenDetail of(Map<String, List<NodeValue>> data) {
+    Map<String, List<NodeValueDetail>> converted = new HashMap<>();
+    for (Map.Entry<String, List<NodeValue>> entry : data.entrySet()) {
+      List<NodeValueDetail> convertedList = new ArrayList<>();
+      for (NodeValue nodeValueEntry : entry.getValue()) {
+        convertedList.add(new NodeValueDetail(nodeValueEntry));
+      }
+      converted.put(entry.getKey(), convertedList);
+    }
+    return new WorkflowTokenDetail(converted);
+  }
+
+  /**
+   * Class to represent node -> value mapping for a given key in a {@link WorkflowToken}.
+   */
+  public static class NodeValueDetail {
+    private final String node;
+    private final String value;
+
+    private NodeValueDetail(NodeValue entry) {
+      this.node = entry.getNodeName();
+      this.value = entry.getValue().toString();
+    }
+
+    public String getNode() {
+      return node;
+    }
+
+    public String getValue() {
+      return value;
+    }
+  }
+}

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/WorkflowTokenNodeDetail.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/WorkflowTokenNodeDetail.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.proto;
+
+import co.cask.cdap.api.workflow.Value;
+import co.cask.cdap.api.workflow.WorkflowToken;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Class to represent {@link WorkflowToken} for a given workflow run at a given node.
+ */
+public class WorkflowTokenNodeDetail {
+
+  private final Map<String, String> tokenDataAtNode;
+
+  public WorkflowTokenNodeDetail(Map<String, String> tokenDataAtNode) {
+    this.tokenDataAtNode = ImmutableMap.copyOf(tokenDataAtNode);
+  }
+
+  public Map<String, String> getTokenDataAtNode() {
+    return tokenDataAtNode;
+  }
+
+  /**
+   * Constructs a {@link WorkflowTokenNodeDetail} by flattening the {@link Value} from the output of
+   * {@link WorkflowToken#getAllFromNode(String, WorkflowToken.Scope)}.
+   *
+   * @param data the workflow token data at a given node to flatten
+   * @return {@link WorkflowTokenNodeDetail} from the given workflow token data at a node
+   */
+  public static WorkflowTokenNodeDetail of(Map<String, Value> data) {
+    Map<String, String> flattened = new HashMap<>();
+    for (Map.Entry<String, Value> entry : data.entrySet()) {
+      flattened.put(entry.getKey(), entry.getValue().toString());
+    }
+    return new WorkflowTokenNodeDetail(flattened);
+  }
+}

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/codec/WorkflowTokenDetailCodec.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/codec/WorkflowTokenDetailCodec.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.proto.codec;
+
+import co.cask.cdap.proto.WorkflowTokenDetail;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSerializationContext;
+
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Codec to serialize/deserialize {@link WorkflowTokenDetail}.
+ */
+public class WorkflowTokenDetailCodec extends AbstractSpecificationCodec<WorkflowTokenDetail> {
+
+  @Override
+  public JsonElement serialize(WorkflowTokenDetail src, Type typeOfSrc, JsonSerializationContext context) {
+    return context.serialize(src.getTokenData());
+  }
+
+  @Override
+  public WorkflowTokenDetail deserialize(JsonElement json, Type typeOfT,
+                                         JsonDeserializationContext context) throws JsonParseException {
+    Map<String, List<WorkflowTokenDetail.NodeValueDetail>> tokenData = new HashMap<>();
+    for (Map.Entry<String, JsonElement> entry : json.getAsJsonObject().entrySet()) {
+      List<WorkflowTokenDetail.NodeValueDetail> nodeValueDetails = deserializeList(entry.getValue(), context,
+                                                                       WorkflowTokenDetail.NodeValueDetail.class);
+      tokenData.put(entry.getKey(), nodeValueDetails);
+    }
+    return new WorkflowTokenDetail(tokenData);
+  }
+}

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/codec/WorkflowTokenNodeDetailCodec.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/codec/WorkflowTokenNodeDetailCodec.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.proto.codec;
+
+import co.cask.cdap.proto.WorkflowTokenNodeDetail;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSerializationContext;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+
+/**
+ * Codec to serialize/deserialize {@link WorkflowTokenNodeDetail}.
+ */
+public class WorkflowTokenNodeDetailCodec extends AbstractSpecificationCodec<WorkflowTokenNodeDetail> {
+
+  @Override
+  public JsonElement serialize(WorkflowTokenNodeDetail src, Type typeOfSrc, JsonSerializationContext context) {
+    return context.serialize(src.getTokenDataAtNode());
+  }
+
+  @Override
+  public WorkflowTokenNodeDetail deserialize(JsonElement json, Type typeOfT,
+                                             JsonDeserializationContext context) throws JsonParseException {
+    Map<String, String> tokenDataAtNode = deserializeMap(json, context, String.class);
+    return new WorkflowTokenNodeDetail(tokenDataAtNode);
+  }
+}


### PR DESCRIPTION
 Added ability to persist WorkflowToken to MDS after every node's execution completes.

The WorkflowToken is stored as a json in a Workflow's RunRecord's properties with the key 'workflowToken'.
Also adds two HTTP endpoints for querying workflow tokens.

Issues addressed:
[CDAP-2713](https://issues.cask.co/browse/CDAP-2713) 
[CDAP-2714](https://issues.cask.co/browse/CDAP-2714)

Build:
https://builds.cask.co/browse/CDAP-DUT2206/

Includes #3128. The changes in this PR are in the last commit.