### PR TITLE
Feature/partitioned file set arguments add partitions

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionFilter.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionFilter.java
@@ -141,6 +141,13 @@ public class PartitionFilter {
       Preconditions.checkState(!map.isEmpty(), "Partition filter cannot be empty.");
       return new PartitionFilter(map);
     }
+
+    /**
+     * @return <tt>true</tt> if no conditions have been set on this builder.
+     */
+    public boolean isEmpty() {
+      return map.isEmpty();
+    }
   }
 
   @Override

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionedFileSetArguments.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionedFileSetArguments.java
@@ -19,6 +19,7 @@ package co.cask.cdap.api.dataset.lib;
 import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.dataset.lib.Partitioning.FieldType;
 
+import java.util.Iterator;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -121,6 +122,7 @@ public class PartitionedFileSetArguments {
    *
    * @param arguments the runtime arguments for a partitioned dataset
    * @param partitioning the declared partitioning for the dataset, needed for proper interpretation of values
+   * @return the PartitionFilter specified in the arguments or null if no filter is specified.
    */
   @Nullable
   public static PartitionFilter getInputPartitionFilter(Map<String, String> arguments, Partitioning partitioning) {
@@ -148,7 +150,7 @@ public class PartitionedFileSetArguments {
       @SuppressWarnings({ "unchecked", "unused" }) // we know it's type safe, but Java does not
       PartitionFilter.Builder unused = builder.addRangeCondition(fieldName, lowerValue, upperValue);
     }
-    return builder.build();
+    return builder.isEmpty() ? null : builder.build();
   }
 
   // helper to convert a string value into a field value in a partition key or filter
@@ -170,4 +172,15 @@ public class PartitionedFileSetArguments {
                       where, kind, stringValue, fieldName, fieldType.name()), e);
     }
   }
+
+  public static void addPartitions(Map<String, String> arguments, Iterator<Partition> partitionIterator) {
+    while (partitionIterator.hasNext()) {
+      addPartition(arguments, partitionIterator.next());
+    }
+  }
+
+  public static void addPartition(Map<String, String> arguments, Partition partition) {
+    FileSetArguments.addInputPath(arguments, partition.getRelativePath());
+  }
+
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionedFileSetArguments.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionedFileSetArguments.java
@@ -173,13 +173,27 @@ public class PartitionedFileSetArguments {
     }
   }
 
-  public static void addPartitions(Map<String, String> arguments, Iterator<Partition> partitionIterator) {
+  /**
+   * Sets partitions as input for a PartitionedFileSet. If both a PartitionFilter and Partition(s) are specified, the
+   * PartitionFilter takes precedence and the specified Partition(s) will be ignored.
+   *
+   * @param arguments the runtime arguments for a partitioned dataset
+   * @param partitionIterator the iterator of partitions to add as input
+   */
+  public static void addInputPartitions(Map<String, String> arguments, Iterator<Partition> partitionIterator) {
     while (partitionIterator.hasNext()) {
-      addPartition(arguments, partitionIterator.next());
+      addInputPartition(arguments, partitionIterator.next());
     }
   }
 
-  public static void addPartition(Map<String, String> arguments, Partition partition) {
+  /**
+   * Sets a partition as input for a PartitionedFileSet. If both a PartitionFilter and Partition(s) are specified, the
+   * PartitionFilter takes precedence and the specified Partition(s) will be ignored.
+   *
+   * @param arguments the runtime arguments for a partitioned dataset
+   * @param partition the partition to add as input
+   */
+  public static void addInputPartition(Map<String, String> arguments, Partition partition) {
     FileSetArguments.addInputPath(arguments, partition.getRelativePath());
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetDataset.java
@@ -514,6 +514,10 @@ public class PartitionedFileSetDataset extends AbstractDataset implements Partit
     } catch (Exception e) {
       throw new DataSetException("Partition filter must be correctly specified in arguments.");
     }
+    if (filter == null) {
+      // no PartitionFilter specified. Perhaps input paths were specified. Embedded FileSet will deal with that.
+      return files.getInputFormatConfiguration();
+    }
     Collection<String> inputPaths = getPartitionPaths(filter);
     List<Location> inputLocations = Lists.newArrayListWithExpectedSize(inputPaths.size());
     for (String path : inputPaths) {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetDataset.java
@@ -25,7 +25,6 @@ import co.cask.cdap.api.dataset.lib.PartitionDetail;
 import co.cask.cdap.api.dataset.lib.PartitionFilter;
 import co.cask.cdap.api.dataset.lib.PartitionKey;
 import co.cask.cdap.api.dataset.lib.PartitionMetadata;
-import co.cask.cdap.api.dataset.lib.PartitionedFileSetArguments;
 import co.cask.cdap.api.dataset.lib.PartitionedFileSetProperties;
 import co.cask.cdap.api.dataset.lib.Partitioning;
 import co.cask.cdap.api.dataset.lib.TimePartitionDetail;
@@ -145,14 +144,7 @@ public class TimePartitionedFileSetDataset extends PartitionedFileSetDataset imp
     Long startTime = TimePartitionedFileSetArguments.getInputStartTime(getRuntimeArguments());
     Long endTime = TimePartitionedFileSetArguments.getInputEndTime(getRuntimeArguments());
     if (startTime == null && endTime == null) {
-      PartitionFilter inputPartitionFilter =
-        PartitionedFileSetArguments.getInputPartitionFilter(getRuntimeArguments(), partitioning);
-      if (inputPartitionFilter == null) {
-        throw new DataSetException(
-          String.format("Neither a start time, end time, nor a partition filter was specified for dataset: %s",
-                        getName()));
-      }
-      // no times specified; a partition filter was specified. super will deal with that
+      // no times specified; perhaps a partition filter was specified. super will deal with that
       return super.getInputFormatConfiguration();
     }
     if (startTime == null) {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetDataset.java
@@ -25,6 +25,7 @@ import co.cask.cdap.api.dataset.lib.PartitionDetail;
 import co.cask.cdap.api.dataset.lib.PartitionFilter;
 import co.cask.cdap.api.dataset.lib.PartitionKey;
 import co.cask.cdap.api.dataset.lib.PartitionMetadata;
+import co.cask.cdap.api.dataset.lib.PartitionedFileSetArguments;
 import co.cask.cdap.api.dataset.lib.PartitionedFileSetProperties;
 import co.cask.cdap.api.dataset.lib.Partitioning;
 import co.cask.cdap.api.dataset.lib.TimePartitionDetail;
@@ -144,7 +145,14 @@ public class TimePartitionedFileSetDataset extends PartitionedFileSetDataset imp
     Long startTime = TimePartitionedFileSetArguments.getInputStartTime(getRuntimeArguments());
     Long endTime = TimePartitionedFileSetArguments.getInputEndTime(getRuntimeArguments());
     if (startTime == null && endTime == null) {
-      // no times specified, perhaps a partition filter was specified? super will deal with that
+      PartitionFilter inputPartitionFilter =
+        PartitionedFileSetArguments.getInputPartitionFilter(getRuntimeArguments(), partitioning);
+      if (inputPartitionFilter == null) {
+        throw new DataSetException(
+          String.format("Neither a start time, end time, nor a partition filter was specified for dataset: %s",
+                        getName()));
+      }
+      // no times specified; a partition filter was specified. super will deal with that
       return super.getInputFormatConfiguration();
     }
     if (startTime == null) {

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetArgumentsTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetArgumentsTest.java
@@ -92,14 +92,14 @@ public class PartitionedFileSetArgumentsTest {
     List<Partition> partitions = Lists.newArrayList();
     for (String relativePath : relativePaths) {
       BasicPartition basicPartition = new BasicPartition(null, relativePath, null);
-      PartitionedFileSetArguments.addPartition(arguments, basicPartition);
-      // add the partitions to a list to also test the addPartitions(Map, Iterator) method below
+      PartitionedFileSetArguments.addInputPartition(arguments, basicPartition);
+      // add the partitions to a list to also test the addInputPartitions(Map, Iterator) method below
       partitions.add(basicPartition);
     }
     Assert.assertEquals(relativePaths, FileSetArguments.getInputPaths(arguments));
 
     arguments = Maps.newHashMap();
-    PartitionedFileSetArguments.addPartitions(arguments, partitions.iterator());
+    PartitionedFileSetArguments.addInputPartitions(arguments, partitions.iterator());
     Assert.assertEquals(relativePaths, FileSetArguments.getInputPaths(arguments));
 
   }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetArgumentsTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetArgumentsTest.java
@@ -16,16 +16,21 @@
 
 package co.cask.cdap.data2.dataset2.lib.partitioned;
 
+import co.cask.cdap.api.dataset.lib.FileSetArguments;
+import co.cask.cdap.api.dataset.lib.Partition;
 import co.cask.cdap.api.dataset.lib.PartitionFilter;
 import co.cask.cdap.api.dataset.lib.PartitionKey;
 import co.cask.cdap.api.dataset.lib.PartitionedFileSetArguments;
 import co.cask.cdap.api.dataset.lib.Partitioning;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -76,5 +81,26 @@ public class PartitionedFileSetArgumentsTest {
       .build();
     PartitionedFileSetArguments.setInputPartitionFilter(arguments, filter);
     Assert.assertEquals(filter, PartitionedFileSetArguments.getInputPartitionFilter(arguments, PARTITIONING));
+  }
+
+
+  @Test
+  public void testGetPartitionPaths() throws Exception {
+    Map<String, String> arguments = Maps.newHashMap();
+
+    Collection<String> relativePaths = Lists.newArrayList("path1", "relative/path.part100", "some\\ other*path");
+    List<Partition> partitions = Lists.newArrayList();
+    for (String relativePath : relativePaths) {
+      BasicPartition basicPartition = new BasicPartition(null, relativePath, null);
+      PartitionedFileSetArguments.addPartition(arguments, basicPartition);
+      // add the partitions to a list to also test the addPartitions(Map, Iterator) method below
+      partitions.add(basicPartition);
+    }
+    Assert.assertEquals(relativePaths, FileSetArguments.getInputPaths(arguments));
+
+    arguments = Maps.newHashMap();
+    PartitionedFileSetArguments.addPartitions(arguments, partitions.iterator());
+    Assert.assertEquals(relativePaths, FileSetArguments.getInputPaths(arguments));
+
   }
 }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetTest.java
@@ -512,8 +512,6 @@ public class TimePartitionedFileSetTest {
     arguments.clear();
     TimePartitionedFileSetArguments.setInputEndTime(arguments, time8 + 30 * MINUTE);
     testInputConfigurationFailure(arguments, " with only an end time");
-    arguments.clear();
-    testInputConfigurationFailure(arguments, " without a time range");
   }
 
   private void testInputConfiguration(Map<String, String> arguments, final String expectedPath) throws Exception {

--- a/cdap-unit-test/src/test/java/co/cask/cdap/partitioned/AppWithMapReduceConsumingPartitions.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/partitioned/AppWithMapReduceConsumingPartitions.java
@@ -145,7 +145,7 @@ public class AppWithMapReduceConsumingPartitions extends AbstractApplication {
       finalPartitionConsumerState = partitionConsumerResult.getPartitionConsumerState();
 
       Map<String, String> arguments = Maps.newHashMap();
-      PartitionedFileSetArguments.addPartitions(arguments, partitionConsumerResult.getPartitionIterator());
+      PartitionedFileSetArguments.addInputPartitions(arguments, partitionConsumerResult.getPartitionIterator());
 
       mapReduceContext.setInput(partitionedFileSetName, mapReduceContext.getDataset(partitionedFileSetName, arguments));
     }

--- a/cdap-unit-test/src/test/java/co/cask/cdap/partitioned/AppWithMapReduceConsumingPartitions.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/partitioned/AppWithMapReduceConsumingPartitions.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.partitioned;
+
+import co.cask.cdap.api.Resources;
+import co.cask.cdap.api.annotation.UseDataSet;
+import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.data.batch.BatchWritable;
+import co.cask.cdap.api.dataset.DatasetSpecification;
+import co.cask.cdap.api.dataset.lib.AbstractDataset;
+import co.cask.cdap.api.dataset.lib.KeyValueTable;
+import co.cask.cdap.api.dataset.lib.PartitionConsumerResult;
+import co.cask.cdap.api.dataset.lib.PartitionConsumerState;
+import co.cask.cdap.api.dataset.lib.PartitionKey;
+import co.cask.cdap.api.dataset.lib.PartitionOutput;
+import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
+import co.cask.cdap.api.dataset.lib.PartitionedFileSetArguments;
+import co.cask.cdap.api.dataset.lib.PartitionedFileSetProperties;
+import co.cask.cdap.api.dataset.lib.Partitioning;
+import co.cask.cdap.api.dataset.module.EmbeddedDataset;
+import co.cask.cdap.api.mapreduce.AbstractMapReduce;
+import co.cask.cdap.api.mapreduce.MapReduceContext;
+import co.cask.cdap.api.service.AbstractService;
+import co.cask.cdap.api.service.http.AbstractHttpServiceHandler;
+import co.cask.cdap.api.service.http.HttpServiceRequest;
+import co.cask.cdap.api.service.http.HttpServiceResponder;
+import com.google.common.collect.Maps;
+import org.apache.hadoop.io.IntWritable;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.Mapper;
+import org.apache.hadoop.mapreduce.Reducer;
+import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
+import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
+import org.apache.twill.filesystem.Location;
+
+import java.io.IOException;
+import java.nio.channels.Channels;
+import java.nio.channels.WritableByteChannel;
+import java.util.Map;
+import javax.annotation.Nullable;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+
+/**
+ * App used to test that MapReduce can incrementally consume partitions.
+ */
+public class AppWithMapReduceConsumingPartitions extends AbstractApplication {
+
+  @Override
+  public void configure() {
+    setName("AppWithMapReduceConsumingPartitions");
+    setDescription("Application with MapReduce job consuming partitions of a PartitionedFileSet Dataset");
+    createDataset("consumingState", KeyValueTable.class);
+    createDataset("counts", IncrementingKeyValueTable.class);
+    addMapReduce(new WordCount());
+    addService(new DatasetService());
+
+    // Create the "lines" partitioned file set, configure it to work with MapReduce
+    createDataset("lines", PartitionedFileSet.class, PartitionedFileSetProperties.builder()
+      // Properties for partitioning
+      .setPartitioning(Partitioning.builder().addLongField("time").build())
+        // Properties for file set
+      .setInputFormat(TextInputFormat.class)
+      .setOutputFormat(TextOutputFormat.class)
+      .setOutputProperty(TextOutputFormat.SEPERATOR, ",")
+      .build());
+  }
+
+  // BatchWritable which increments the values of the underlying KeyValue table, upon each write from the batch job.
+  public static class IncrementingKeyValueTable extends AbstractDataset implements BatchWritable<byte[], Long> {
+
+    private final KeyValueTable keyValueTable;
+
+    public IncrementingKeyValueTable(DatasetSpecification spec,
+                                     @EmbeddedDataset("store") KeyValueTable keyValueTable) {
+      super(spec.getName(), keyValueTable);
+      this.keyValueTable = keyValueTable;
+    }
+
+    @Override
+    public void write(byte[] key, Long value) {
+      keyValueTable.increment(key, value);
+    }
+
+    @Nullable
+    public Long read(String key) {
+      byte[] read = keyValueTable.read(key);
+      return read == null ? null : Bytes.toLong(read);
+    }
+  }
+
+  public static class WordCount extends AbstractMapReduce {
+    private static final String STATE_KEY = "state.key";
+    private PartitionConsumerState finalPartitionConsumerState;
+
+    @Override
+    public void configure() {
+      setOutputDataset("counts");
+      setMapperResources(new Resources(1024));
+      setReducerResources(new Resources(1024));
+    }
+
+    @Override
+    public void beforeSubmit(MapReduceContext context) throws Exception {
+      KeyValueTable keyValueTable = context.getDataset("consumingState");
+      byte[] state = keyValueTable.read(STATE_KEY);
+      PartitionConsumerState initialPartitionConsumerState;
+      if (state == null) {
+        initialPartitionConsumerState = PartitionConsumerState.FROM_BEGINNING;
+      } else {
+        initialPartitionConsumerState = PartitionConsumerState.fromBytes(state);
+      }
+
+      setInputPartitions(context, "lines", initialPartitionConsumerState);
+
+      Job job = context.getHadoopJob();
+      job.setMapperClass(Tokenizer.class);
+      job.setReducerClass(Counter.class);
+      job.setNumReduceTasks(1);
+    }
+
+    private void setInputPartitions(MapReduceContext mapReduceContext, String partitionedFileSetName,
+                                    PartitionConsumerState partitionConsumerState) {
+      PartitionedFileSet partitionedFileSet = mapReduceContext.getDataset(partitionedFileSetName);
+      PartitionConsumerResult partitionConsumerResult = partitionedFileSet.consumePartitions(partitionConsumerState);
+      finalPartitionConsumerState = partitionConsumerResult.getPartitionConsumerState();
+
+      Map<String, String> arguments = Maps.newHashMap();
+      PartitionedFileSetArguments.addPartitions(arguments, partitionConsumerResult.getPartitionIterator());
+
+      mapReduceContext.setInput(partitionedFileSetName, mapReduceContext.getDataset(partitionedFileSetName, arguments));
+    }
+
+    @Override
+    public void onFinish(boolean succeeded, MapReduceContext context) throws Exception {
+      if (succeeded) {
+        KeyValueTable keyValueTable = context.getDataset("consumingState");
+        keyValueTable.write(STATE_KEY, finalPartitionConsumerState.toBytes());
+      }
+      super.onFinish(succeeded, context);
+    }
+
+    /**
+     * A mapper that tokenizes each input line and emits each token with a value of 1.
+     */
+    public static class Tokenizer extends Mapper<LongWritable, Text, Text, IntWritable> {
+
+      private Text word = new Text();
+      private static final IntWritable ONE = new IntWritable(1);
+
+      @Override
+      public void map(LongWritable key, Text data, Context context)
+        throws IOException, InterruptedException {
+        for (String token : data.toString().split(" ")) {
+          word.set(token);
+          context.write(word, ONE);
+        }
+      }
+    }
+
+    /**
+     * A reducer that sums up the counts for each key.
+     */
+    public static class Counter extends Reducer<Text, IntWritable, byte[], Long> {
+
+      @Override
+      public void reduce(Text key, Iterable<IntWritable> values, Context context)
+        throws IOException, InterruptedException {
+        long sum = 0L;
+        for (IntWritable value : values) {
+          sum += value.get();
+        }
+        context.write(key.getBytes(), sum);
+      }
+    }
+  }
+
+  public static class DatasetService extends AbstractService {
+
+    @Override
+    protected void configure() {
+      setName("DatasetService");
+      addHandler(new DatasetServingHandler());
+    }
+
+    /**
+     * A handler that allows reading and writing with lines and counts Datasets.
+     */
+    public static class DatasetServingHandler extends AbstractHttpServiceHandler {
+
+      @UseDataSet("lines")
+      private PartitionedFileSet lines;
+
+      @UseDataSet("counts")
+      private IncrementingKeyValueTable keyValueTable;
+
+      @PUT
+      @Path("lines")
+      public void write(HttpServiceRequest request, HttpServiceResponder responder,
+                        @QueryParam("time") Long time) {
+
+        PartitionKey key = PartitionKey.builder().addLongField("time", time).build();
+        PartitionOutput partitionOutput = lines.getPartitionOutput(key);
+        Location location = partitionOutput.getLocation();
+
+        try {
+          try (WritableByteChannel channel = Channels.newChannel(location.getOutputStream())) {
+            channel.write(request.getContent());
+          }
+          partitionOutput.addPartition();
+        } catch (IOException e) {
+          responder.sendError(400, String.format("Unable to write path '%s'", location));
+          return;
+        }
+        responder.sendStatus(200);
+      }
+
+      @GET
+      @Path("counts")
+      public void get(HttpServiceRequest request, HttpServiceResponder responder,
+                      @QueryParam("word") String word) {
+        Long count = keyValueTable.read(word);
+        if (count == null) {
+          // if the word is missing from the table, it has a word count of 0
+          count = 0L;
+        }
+        responder.sendJson(count);
+      }
+
+    }
+  }
+}

--- a/cdap-unit-test/src/test/java/co/cask/cdap/partitioned/MapReducePartitionConsumingTest.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/partitioned/MapReducePartitionConsumingTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.partitioned;
+
+import co.cask.cdap.test.ApplicationManager;
+import co.cask.cdap.test.MapReduceManager;
+import co.cask.cdap.test.ServiceManager;
+import co.cask.cdap.test.base.TestFrameworkTestBase;
+import co.cask.common.http.HttpRequest;
+import co.cask.common.http.HttpRequests;
+import co.cask.common.http.HttpResponse;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Test that MapReduce can incrementally process partitions.
+ */
+public class MapReducePartitionConsumingTest extends TestFrameworkTestBase {
+  private static final String LINE1 = "a b a";
+  private static final String LINE2 = "b a b";
+  private static final String LINE3 = "c c c";
+
+  @Test
+  public void testWordCountOnFileSet() throws Exception {
+    ApplicationManager applicationManager = deployApplication(AppWithMapReduceConsumingPartitions.class);
+
+    ServiceManager serviceManager = applicationManager.getServiceManager("DatasetService").start();
+    serviceManager.waitForStatus(true);
+    URL serviceURL = serviceManager.getServiceURL();
+
+    // write a file to the file set using the service and run the WordCount MapReduce job on that one partition
+    createPartition(serviceURL, LINE1, "1");
+
+    MapReduceManager mapReduceManager = applicationManager.getMapReduceManager("WordCount").start();
+    mapReduceManager.waitForFinish(5, TimeUnit.MINUTES);
+
+    Assert.assertEquals(new Long(2), getCount(serviceURL, "a"));
+    Assert.assertEquals(new Long(1), getCount(serviceURL, "b"));
+    Assert.assertEquals(new Long(0), getCount(serviceURL, "c"));
+
+    // create two additional partitions
+    createPartition(serviceURL, LINE2, "2");
+    createPartition(serviceURL, LINE3, "3");
+
+    // running the MapReduce job now processes these two new partitions (LINE2 and LINE3) and updates the counts
+    // dataset accordingly
+    mapReduceManager = applicationManager.getMapReduceManager("WordCount").start();
+    mapReduceManager.waitForFinish(5, TimeUnit.MINUTES);
+
+    Assert.assertEquals(new Long(3), getCount(serviceURL, "a"));
+    Assert.assertEquals(new Long(3), getCount(serviceURL, "b"));
+    Assert.assertEquals(new Long(3), getCount(serviceURL, "c"));
+
+    // running the MapReduce job without adding new partitions does not affect the counts dataset
+    mapReduceManager = applicationManager.getMapReduceManager("WordCount").start();
+    mapReduceManager.waitForFinish(5, TimeUnit.MINUTES);
+
+    Assert.assertEquals(new Long(3), getCount(serviceURL, "a"));
+    Assert.assertEquals(new Long(3), getCount(serviceURL, "b"));
+    Assert.assertEquals(new Long(3), getCount(serviceURL, "c"));
+  }
+
+  private void createPartition(URL serviceUrl, String body, String time) throws IOException {
+    HttpResponse response =
+      HttpRequests.execute(HttpRequest.put(new URL(serviceUrl, "lines?time=" + time)).withBody(body).build());
+    Assert.assertEquals(200, response.getResponseCode());
+  }
+
+  private Long getCount(URL serviceUrl, String word) throws IOException {
+    HttpResponse response =
+      HttpRequests.execute(HttpRequest.get(new URL(serviceUrl, "counts?word=" + word)).build());
+    Assert.assertEquals(200, response.getResponseCode());
+    return Long.valueOf(response.getResponseBodyAsString());
+  }
+}

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/base/TestFrameworkTestSuite.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/base/TestFrameworkTestSuite.java
@@ -20,6 +20,7 @@ import co.cask.cdap.batch.stream.BatchStreamIntegrationTestRun;
 import co.cask.cdap.flow.stream.FlowStreamIntegrationTestRun;
 import co.cask.cdap.mapreduce.MapReduceStreamInputTestRun;
 import co.cask.cdap.mapreduce.service.MapReduceServiceIntegrationTestRun;
+import co.cask.cdap.partitioned.MapReducePartitionConsumingTest;
 import co.cask.cdap.spark.metrics.SparkMetricsIntegrationTestRun;
 import co.cask.cdap.spark.service.SparkServiceIntegrationTestRun;
 import co.cask.cdap.spark.stream.SparkStreamIntegrationTestRun;
@@ -44,6 +45,7 @@ import org.junit.runners.Suite;
   FlowStreamIntegrationTestRun.class,
   MapReduceStreamInputTestRun.class,
   MapReduceServiceIntegrationTestRun.class,
+  MapReducePartitionConsumingTest.class,
   SparkMetricsIntegrationTestRun.class,
   SparkServiceIntegrationTestRun.class,
   SparkStreamIntegrationTestRun.class,


### PR DESCRIPTION
First commit (which is small) is the method added to PartitionedFileSetArguments, to aid in adding Partitions to be processed by an input dataset, and a two line change for `PartitionedFileSetDataset#getInputFormatConfiguration` to delegate to `FileSet#getInputFormatConfiguration` in the case that output paths are specified.

Second commit (most of this PR) is simply a test case to exercise the functionality of the first commit.

http://builds.cask.co/browse/CDAP-DUT2219-1

ignore: http://builds.cask.co/browse/CDAP-DUT2214-5