### PR TITLE
CDAP-2972 use combined classloader to run program code

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkRuntimeService.java
@@ -21,6 +21,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.io.Locations;
 import co.cask.cdap.common.lang.ClassLoaders;
+import co.cask.cdap.common.lang.CombineClassLoader;
 import co.cask.cdap.common.logging.LoggingContextAccessor;
 import co.cask.cdap.common.twill.HadoopClassExcluder;
 import co.cask.cdap.common.utils.DirUtils;
@@ -247,7 +248,8 @@ final class SparkRuntimeService extends AbstractExecutionThreadService {
     Transactions.execute(txContext, spark.getClass().getName() + ".beforeSubmit()", new Callable<Void>() {
       @Override
       public Void call() throws Exception {
-        ClassLoader oldClassLoader = ClassLoaders.setContextClassLoader(spark.getClass().getClassLoader());
+        ClassLoader oldClassLoader = ClassLoaders.setContextClassLoader(new CombineClassLoader(
+          null, ImmutableList.of(spark.getClass().getClassLoader(), getClass().getClassLoader())));
         try {
           spark.beforeSubmit(sparkContextFactory.getClientContext());
           return null;
@@ -266,7 +268,8 @@ final class SparkRuntimeService extends AbstractExecutionThreadService {
     Transactions.execute(txContext, spark.getClass().getName() + ".onFinish()", new Callable<Void>() {
       @Override
       public Void call() throws Exception {
-        ClassLoader oldClassLoader = ClassLoaders.setContextClassLoader(spark.getClass().getClassLoader());
+        ClassLoader oldClassLoader = ClassLoaders.setContextClassLoader(new CombineClassLoader(
+          null, ImmutableList.of(spark.getClass().getClassLoader(), getClass().getClassLoader())));
         try {
           spark.onFinish(succeeded, sparkContextFactory.getClientContext());
           return null;


### PR DESCRIPTION
The particular bug that was observed was a getDataset() call that
eventually creates an HTable, which runs some static code
blocks that create HBaseConfiguration. HBaseConfiguration will try
and load hbase-default.xml by calling the context classloader's
getResource(), which is the ProgramClassLoader. Thus, the resource
is filtered out and the conf setting required by hbase is not
found and and exception is thrown.

This change will set the context classloader to a combined
classloader that uses the bootstrap as the parent, then uses
the program classloader, and finally the CDAP system classloader.
This means the program classes should always be loaded by the
program classloader instead of the system classloader, but also
serves as a catch all to load any classes that are needed by the
system. This is needed because programs can call methods in
cdap-api, such as getDataset(), that call system code that need
access to system classes. Rather than resetting the context
classloader to the system classloader at every api boundary,
we just make the system classloader available as a fallback.
In the particular bug mentioned earlier, this will allow the
static code block in hbase to load hbase-default.xml and find
the required config setting.