### PR TITLE
(CDAP-2836) Add support for restart specific CDAP system services instances

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/ServiceStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/ServiceStore.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.app.store;
 
+import co.cask.cdap.proto.RestartServiceInstancesStatus;
 import com.google.common.util.concurrent.Service;
 
 import javax.annotation.Nullable;
@@ -39,4 +40,35 @@ public interface ServiceStore extends Service {
    * @param instances Instance Count.
    */
   void setServiceInstance(String serviceName, int instances);
+
+  /**
+   * Update the service instances restart request.
+   *
+   * @param serviceName Service name to be restarted.
+   * @param startTime Start time in Ms from Epoch.
+   * @param endTime End time in Ms from Epoch.
+   * @param isSuccess Whether or not the operation successful.
+   * @param instanceId The instance Id to be restarted.
+   */
+  void setRestartInstanceRequest(String serviceName, long startTime, long endTime, boolean isSuccess,
+                                  int instanceId);
+
+  /**
+   * Update the service instances restart request.
+   *
+   * @param serviceName Service name to be restarted.
+   * @param startTime Start time in Ms from Epoch.
+   * @param endTime End time in Ms from Epoch.
+   * @param isSuccess Whether or not the operation successful.
+   */
+  void setRestartAllInstancesRequest(String serviceName, long startTime, long endTime, boolean isSuccess);
+
+  /**
+   * Get the latest service instances restart as JSON String.
+   *
+   * @param serviceName Service name for the restart record.
+   * @return JSON string representation of latest restart instances for the service.
+   * @throws IllegalStateException when restart request can not be found for the service name.
+   */
+  RestartServiceInstancesStatus getLatestRestartInstancesRequest(String serviceName) throws IllegalStateException;
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/MonitorHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/MonitorHandler.java
@@ -91,4 +91,36 @@ public class MonitorHandler extends AbstractMonitorHandler {
   public void getServiceSpec(HttpRequest request, HttpResponder responder) throws Exception {
     super.getServiceSpec(request, responder);
   }
+
+  /**
+   * Send request to restart all instances for a CDAP system service.
+   */
+  @Path("/system/services/{service-name}/instances/restart")
+  @PUT
+  public void restartAllServiceInstances(HttpRequest request, HttpResponder responder,
+                                         @PathParam("service-name") String serviceName) {
+    super.restartAllServiceInstances(request, responder, serviceName);
+  }
+
+  /**
+   * Send request to restart single instance identified by <instance-id>
+   */
+  @Path("/system/services/{service-name}/instances/{instance-id}/restart")
+  @PUT
+  public void restartServiceInstance(HttpRequest request, HttpResponder responder,
+                                     @PathParam("service-name") String serviceName,
+                                     @PathParam("instance-id") int instanceId) {
+    super.restartServiceInstance(request, responder, serviceName, instanceId);
+  }
+
+  /**
+   * Send request to get the status of latest restart instances request for a CDAP system service.
+   */
+  @Path("/system/services/{service-name}/instances/restart")
+  @GET
+  public void getLatestRestartServiceInstanceStatus(HttpRequest request, HttpResponder responder,
+                                                    @PathParam("service-name") String serviceName) {
+    super.getLatestRestartServiceInstanceStatus(request, responder, serviceName);
+  }
+
 }

--- a/cdap-common/src/main/java/co/cask/cdap/common/twill/AbstractDistributedMasterServiceManager.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/twill/AbstractDistributedMasterServiceManager.java
@@ -179,4 +179,31 @@ public abstract class AbstractDistributedMasterServiceManager implements MasterS
       }
     }
   }
+
+  @Override
+  public void restartAllInstances() {
+    try {
+      Iterable<TwillController> twillControllers = twillRunnerService.lookup(Constants.Service.MASTER_SERVICES);
+      for (TwillController twillController : twillControllers) {
+        // Call restart instances
+        twillController.restartAllInstances(serviceName).get();
+      }
+    } catch (Throwable t) {
+      throw new RuntimeException(String.format("Could not change service instances of %s", serviceName), t);
+    }
+  }
+
+  @Override
+  public void restartInstances(int instanceId, int... moreInstanceIds) {
+    // Get Twill controller for the service
+    try {
+      Iterable<TwillController> twillControllers = twillRunnerService.lookup(Constants.Service.MASTER_SERVICES);
+      for (TwillController twillController : twillControllers) {
+        // Call restart instances
+        twillController.restartInstances(serviceName, instanceId, moreInstanceIds).get();
+      }
+    } catch (Throwable t) {
+      throw new RuntimeException(String.format("Could not change service instances of %s", serviceName), t);
+    }
+  }
 }

--- a/cdap-common/src/main/java/co/cask/cdap/common/twill/AbstractInMemoryMasterServiceManager.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/twill/AbstractInMemoryMasterServiceManager.java
@@ -69,4 +69,14 @@ public abstract class AbstractInMemoryMasterServiceManager implements MasterServ
   public boolean isServiceEnabled() {
     return true;
   }
+
+  @Override
+  public void restartAllInstances() {
+    // No operation for in memory manager.
+  }
+
+  @Override
+  public void restartInstances(int instanceId, int... moreInstanceIds) {
+    // No operation for in memory manager.
+  }
 }

--- a/cdap-common/src/main/java/co/cask/cdap/common/twill/MasterServiceManager.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/twill/MasterServiceManager.java
@@ -87,4 +87,17 @@ public interface MasterServiceManager {
   SystemServiceLiveInfo getLiveInfo();
 
   //TODO: Add method to get the metrics name to get event rate on UI
+
+  /**
+   * Restart all instances of this service.
+   */
+  void restartAllInstances();
+
+  /**
+   * Restart some instances of this service.
+   *
+   * @param instanceId the instance id to be restarted.
+   * @param moreInstanceIds optional additional instance ids to be restarted.
+   */
+   void restartInstances(int instanceId, int... moreInstanceIds);
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/RestartServiceInstancesStatus.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/RestartServiceInstancesStatus.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.proto;
+
+import java.util.Set;
+
+/**
+ * Class to describe status of restart instances of service request.
+ */
+public class RestartServiceInstancesStatus {
+  private final Set<Integer> instanceIds;
+  private final String serviceName;
+  private final long startTimeInMs;
+  private final long endTimeInMs;
+  private final RestartStatus status;
+
+  public RestartServiceInstancesStatus(String serviceName, long startMs, long endMs, RestartStatus status,
+                                       Set<Integer> instanceIds) {
+    this.serviceName = serviceName;
+    this.startTimeInMs = startMs;
+    this.endTimeInMs = endMs;
+    this.status = status;
+    this.instanceIds = instanceIds;
+  }
+
+  public Set<Integer> getInstanceIds() {
+    return instanceIds;
+  }
+
+  public String getServiceName() {
+    return serviceName;
+  }
+
+  public long getStartTimeInMs() {
+    return startTimeInMs;
+  }
+
+  public long getEndTimeInMs() {
+    return endTimeInMs;
+  }
+
+  public RestartStatus getStatus() {
+    return status;
+  }
+
+  /**
+   * Defining the status of the restart instances request.
+   */
+  public enum RestartStatus {
+    SUCCESS, FAILURE;
+  }
+}


### PR DESCRIPTION
Add support for restart for CDAP system services instances. Need to be able to send restart commands to individual instances in System Services for CDAP Master.

Currently, to restart one of the CDAP master services (data-fabric, explore, metrics, etc.), you have to restart them all. It should be possible to just stop/start/restart a specific one.