### PR TITLE
temporarily remove dependency on hbase-compat-1.0, until it actually …

### DIFF
--- a/cdap-master/pom.xml
+++ b/cdap-master/pom.xml
@@ -163,7 +163,7 @@
       <id>dist</id>
       <properties>
         <package.depends>--depends cdap --depends cdap-hbase-compat-0.96 --depends cdap-hbase-compat-0.98
-        --depends cdap-hbase-compat-1.0 --depends cdap-hbase-compat-1.0-cdh</package.depends>
+        --depends cdap-hbase-compat-1.0-cdh</package.depends>
       </properties>
       <build>
         <plugins>


### PR DESCRIPTION
…be built

This will fix our internal auto-build process for the time-being, until the ``cdap-hbase-compat-1.0`` package can be built.  At that time, this change will be reverted.  ETA 1-2 days.