### PR TITLE
Feature/ui styling dev start spacing links

### DIFF
--- a/cdap-ui/app/features/overview/overview.html
+++ b/cdap-ui/app/features/overview/overview.html
@@ -52,10 +52,10 @@
 <section class="system-health"> <!-- ng-show="isEnterprise" -->
   <div class="divider"></div>
   <div>
-    <a ui-sref="admin.system.services">
-      <div class="row">
-        <div class="col-xs-12 col-lg-4">
-          <div>
+    <div class="row">
+      <div class="col-xs-12 col-lg-4">
+        <div>
+          <a ui-sref="admin.system.services">
             <div class="row">
               <div class="col-xs-4">
                 <div>
@@ -78,36 +78,36 @@
                 </p>
               </div>
             </div>
-          </div>
-        </div>
-
-        <div class="col-xs-12 col-lg-8">
-          <div class="row health-widgets">
-            <div class="col-xs-12">
-              <p class="text-center">
-                <span> Errors last hour </span>
-              </p>
-            </div>
-          </div>
-
-            <div ng-controller="C3WidgetTimeseriesCtrl" ng-repeat="wdgt in OverviewCtrl.wdgts" class="health-widget">
-              <span>{{wdgt.title}}</span>
-              <c3-spline
-                chart-metric="wdgt.formattedData"
-                chart-metric-alias="wdgt.metricAlias"
-                chart-settings="wdgt.settings"
-                chart-size="chartSize"
-                ></c3-spline>
-              <div class="warning-alert">
-                <div>
-                  <p> Warning </p><span class="warn"> {{wdgt.chartData.totals[1]}} </span>
-                  <p> Alert </p><span class="error"> {{wdgt.chartData.totals[0]}} </span>
-                </div>
-              </div>
-            </div>
+          </a>
         </div>
       </div>
-    </a>
+
+      <div class="col-xs-12 col-lg-8">
+        <div class="row health-widgets">
+          <div class="col-xs-12">
+            <p class="text-center">
+              <span> Errors last hour </span>
+            </p>
+          </div>
+        </div>
+
+          <div ng-controller="C3WidgetTimeseriesCtrl" ng-repeat="wdgt in OverviewCtrl.wdgts" class="health-widget">
+            <span>{{wdgt.title}}</span>
+            <c3-spline
+              chart-metric="wdgt.formattedData"
+              chart-metric-alias="wdgt.metricAlias"
+              chart-settings="wdgt.settings"
+              chart-size="chartSize"
+              ></c3-spline>
+            <div class="warning-alert">
+              <div>
+                <p> Warning </p><span class="warn"> {{wdgt.chartData.totals[1]}} </span>
+                <p> Alert </p><span class="error"> {{wdgt.chartData.totals[0]}} </span>
+              </div>
+            </div>
+          </div>
+      </div>
+    </div>
   </div>
 </section>
 

--- a/cdap-ui/app/features/overview/overview.less
+++ b/cdap-ui/app/features/overview/overview.less
@@ -5,7 +5,7 @@
 body.state-overview {
 
   .panel-message {
-    margin-bottom: 40px;
+    margin: 20px auto 40px;
     position: relative;
 
     .panel-body {
@@ -195,6 +195,7 @@ body.state-overview {
             display: inline-block;
             font-weight: 400;
             margin: 0 10px;
+            padding: 0 5px;
             text-align: center;
             vertical-align: middle;
             .border-radius(2px);

--- a/cdap-ui/app/styles/common.less
+++ b/cdap-ui/app/styles/common.less
@@ -22,7 +22,6 @@ body {
   div.progress { margin: 1px; /* by default they have just margin-bottom: 20px */ }
 
   main.container {
-    margin-top: 150px;
     padding-top: 1em;
     > div { margin-bottom: 80px; }
     .sidebar {
@@ -35,6 +34,12 @@ body {
         }
       }
     }
+  }
+  &.state-overview {
+    main.container { margin-top: 130px; }
+  }
+  &.state-dashboard {
+    main.container { margin-top: 150px; }
   }
   &.state-admin {
     main.container { margin-top: 100px; }


### PR DESCRIPTION
*  Adjusts top margin of main.container for each tab state to reduce excess spacing underneath the namespace dropdown
*  System Health: Moves Services link to just within the status circle
*  System Health: Adds left/right padding to the warning/alert text

![dev](https://cloud.githubusercontent.com/assets/5335210/8681708/ec86cbb0-2a1d-11e5-8254-035f3d97bef0.gif)
