### PR TITLE
CDAP-2868 Added hbase-compat-1.0 module and abstract out changed APIs

### DIFF
--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/util/hbase/ConfigurationTableTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/util/hbase/ConfigurationTableTest.java
@@ -62,7 +62,7 @@ public class ConfigurationTableTest {
 
     String configTableQualifier = "configuration";
     TableId configTableId = TableId.from(Constants.SYSTEM_NAMESPACE_ID, configTableQualifier);
-    String configTableName = tableUtil.createHTableDescriptor(configTableId).getNameAsString();
+    String configTableName = tableUtil.createHTableDescriptor(configTableId).build().getNameAsString();
     // the config table name minus the qualifier ('configuration'). Example: 'cdap.system.'
     String configTablePrefix = configTableName.substring(0, configTableName.length()  - configTableQualifier.length());
 

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/util/hbase/ConfigurationTableTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/util/hbase/ConfigurationTableTest.java
@@ -62,7 +62,7 @@ public class ConfigurationTableTest {
 
     String configTableQualifier = "configuration";
     TableId configTableId = TableId.from(Constants.SYSTEM_NAMESPACE_ID, configTableQualifier);
-    String configTableName = tableUtil.createHTableDescriptor(configTableId).build().getNameAsString();
+    String configTableName = tableUtil.buildHTableDescriptor(configTableId).build().getNameAsString();
     // the config table name minus the qualifier ('configuration'). Example: 'cdap.system.'
     String configTablePrefix = configTableName.substring(0, configTableName.length()  - configTableQualifier.length());
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/hbase/AbstractHBaseDataSetAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/hbase/AbstractHBaseDataSetAdmin.java
@@ -19,6 +19,7 @@ import co.cask.cdap.api.dataset.DatasetAdmin;
 import co.cask.cdap.common.utils.ProjectInfo;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
+import co.cask.cdap.data2.util.hbase.HTableDescriptorBuilder;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -119,6 +120,9 @@ public abstract class AbstractHBaseDataSetAdmin implements DatasetAdmin {
       return;
     }
 
+    // create a new descriptor for the table upgrade
+    HTableDescriptorBuilder newDescriptor = tableUtil.createHTableDescriptor(tableDescriptor);
+
     // Generate the coprocessor jar
     CoprocessorJar coprocessorJar = createCoprocessorJar();
     Location jarLocation = coprocessorJar.getJarLocation();
@@ -134,13 +138,13 @@ public abstract class AbstractHBaseDataSetAdmin implements DatasetAdmin {
         if (!jarLocation.getName().equals(info.getPath().getName())) {
           needUpgrade = true;
           // Remove old one and add the new one.
-          tableDescriptor.removeCoprocessor(info.getClassName());
-          addCoprocessor(tableDescriptor, coprocessor, jarLocation, coprocessorJar.getPriority(coprocessor));
+          newDescriptor.removeCoprocessor(info.getClassName());
+          addCoprocessor(newDescriptor, coprocessor, jarLocation, coprocessorJar.getPriority(coprocessor));
         }
       } else {
         // The coprocessor is missing from the table, add it.
         needUpgrade = true;
-        addCoprocessor(tableDescriptor, coprocessor, jarLocation, coprocessorJar.getPriority(coprocessor));
+        addCoprocessor(newDescriptor, coprocessor, jarLocation, coprocessorJar.getPriority(coprocessor));
       }
     }
 
@@ -148,7 +152,7 @@ public abstract class AbstractHBaseDataSetAdmin implements DatasetAdmin {
     Set<String> coprocessorNames = ImmutableSet.copyOf(Iterables.transform(coprocessorJar.coprocessors, CLASS_TO_NAME));
     for (String remove : Sets.difference(coprocessorInfo.keySet(), coprocessorNames)) {
       needUpgrade = true;
-      tableDescriptor.removeCoprocessor(remove);
+      newDescriptor.removeCoprocessor(remove);
     }
 
     if (!needUpgrade) {
@@ -156,7 +160,7 @@ public abstract class AbstractHBaseDataSetAdmin implements DatasetAdmin {
       return;
     }
 
-    setVersion(tableDescriptor);
+    setVersion(newDescriptor);
 
     LOG.info("Upgrading table '{}'...", tableId);
     boolean enableTable = false;
@@ -167,7 +171,7 @@ public abstract class AbstractHBaseDataSetAdmin implements DatasetAdmin {
       LOG.debug("Table '{}' not enabled when try to disable it.", tableId);
     }
 
-    tableUtil.modifyTable(getAdmin(), tableDescriptor);
+    tableUtil.modifyTable(getAdmin(), newDescriptor.build());
     if (enableTable) {
       tableUtil.enableTable(getAdmin(), tableId);
     }
@@ -175,7 +179,7 @@ public abstract class AbstractHBaseDataSetAdmin implements DatasetAdmin {
     LOG.info("Table '{}' upgrade completed.", tableId);
   }
 
-  public static void setVersion(HTableDescriptor tableDescriptor) {
+  public static void setVersion(HTableDescriptorBuilder tableDescriptor) {
     tableDescriptor.setValue(CDAP_VERSION, ProjectInfo.getVersion().toString());
   }
 
@@ -184,7 +188,7 @@ public abstract class AbstractHBaseDataSetAdmin implements DatasetAdmin {
     return new ProjectInfo.Version(value);
   }
 
-  protected void addCoprocessor(HTableDescriptor tableDescriptor, Class<? extends Coprocessor> coprocessor,
+  protected void addCoprocessor(HTableDescriptorBuilder tableDescriptor, Class<? extends Coprocessor> coprocessor,
                                 Location jarFile, Integer priority) throws IOException {
     if (priority == null) {
       priority = Coprocessor.PRIORITY_USER;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/hbase/AbstractHBaseDataSetAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/hbase/AbstractHBaseDataSetAdmin.java
@@ -121,7 +121,7 @@ public abstract class AbstractHBaseDataSetAdmin implements DatasetAdmin {
     }
 
     // create a new descriptor for the table upgrade
-    HTableDescriptorBuilder newDescriptor = tableUtil.createHTableDescriptor(tableDescriptor);
+    HTableDescriptorBuilder newDescriptor = tableUtil.buildHTableDescriptor(tableDescriptor);
 
     // Generate the coprocessor jar
     CoprocessorJar coprocessorJar = createCoprocessorJar();

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/kv/HBaseKVTableDefinition.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/kv/HBaseKVTableDefinition.java
@@ -32,7 +32,6 @@ import com.google.common.base.Throwables;
 import com.google.inject.Inject;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HColumnDescriptor;
-import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.client.HBaseAdmin;
 import org.apache.hadoop.hbase.client.HTable;
 import org.apache.hadoop.hbase.client.Put;
@@ -101,7 +100,7 @@ public class HBaseKVTableDefinition extends AbstractDatasetDefinition<NoTxKeyVal
       columnDescriptor.setMaxVersions(1);
       tableUtil.setBloomFilter(columnDescriptor, HBaseTableUtil.BloomType.ROW);
 
-      HTableDescriptorBuilder tableDescriptor = tableUtil.createHTableDescriptor(tableId);
+      HTableDescriptorBuilder tableDescriptor = tableUtil.buildHTableDescriptor(tableId);
       tableDescriptor.addFamily(columnDescriptor);
       tableUtil.createTableIfNotExists(admin, tableId, tableDescriptor.build());
     }
@@ -144,11 +143,11 @@ public class HBaseKVTableDefinition extends AbstractDatasetDefinition<NoTxKeyVal
     public void put(byte[] key, @Nullable byte[] value) {
       try {
         if (value == null) {
-          table.delete(tableUtil.buildDelete(key).create());
+          table.delete(tableUtil.buildDelete(key).build());
         } else {
           Put put = tableUtil.buildPut(key)
             .add(DATA_COLUMN_FAMILY, DEFAULT_COLUMN, value)
-            .create();
+            .build();
           table.put(put);
         }
       } catch (IOException e) {
@@ -160,7 +159,7 @@ public class HBaseKVTableDefinition extends AbstractDatasetDefinition<NoTxKeyVal
     @Override
     public byte[] get(byte[] key) {
       try {
-        Result result = table.get(tableUtil.buildGet(key).create());
+        Result result = table.get(tableUtil.buildGet(key).build());
         return result.isEmpty() ? null : result.getValue(DATA_COLUMN_FAMILY, DEFAULT_COLUMN);
       } catch (IOException e) {
         throw Throwables.propagate(e);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/kv/HBaseKVTableDefinition.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/kv/HBaseKVTableDefinition.java
@@ -27,13 +27,12 @@ import co.cask.cdap.api.dataset.module.DatasetModule;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
+import co.cask.cdap.data2.util.hbase.HTableDescriptorBuilder;
 import com.google.common.base.Throwables;
 import com.google.inject.Inject;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
-import org.apache.hadoop.hbase.client.Delete;
-import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.HBaseAdmin;
 import org.apache.hadoop.hbase.client.HTable;
 import org.apache.hadoop.hbase.client.Put;
@@ -102,9 +101,9 @@ public class HBaseKVTableDefinition extends AbstractDatasetDefinition<NoTxKeyVal
       columnDescriptor.setMaxVersions(1);
       tableUtil.setBloomFilter(columnDescriptor, HBaseTableUtil.BloomType.ROW);
 
-      HTableDescriptor tableDescriptor = tableUtil.createHTableDescriptor(tableId);
+      HTableDescriptorBuilder tableDescriptor = tableUtil.createHTableDescriptor(tableId);
       tableDescriptor.addFamily(columnDescriptor);
-      tableUtil.createTableIfNotExists(admin, tableId, tableDescriptor);
+      tableUtil.createTableIfNotExists(admin, tableId, tableDescriptor.build());
     }
 
     @Override
@@ -145,10 +144,11 @@ public class HBaseKVTableDefinition extends AbstractDatasetDefinition<NoTxKeyVal
     public void put(byte[] key, @Nullable byte[] value) {
       try {
         if (value == null) {
-          table.delete(new Delete(key));
+          table.delete(tableUtil.buildDelete(key).create());
         } else {
-          Put put = new Put(key);
-          put.add(DATA_COLUMN_FAMILY, DEFAULT_COLUMN, value);
+          Put put = tableUtil.buildPut(key)
+            .add(DATA_COLUMN_FAMILY, DEFAULT_COLUMN, value)
+            .create();
           table.put(put);
         }
       } catch (IOException e) {
@@ -160,7 +160,7 @@ public class HBaseKVTableDefinition extends AbstractDatasetDefinition<NoTxKeyVal
     @Override
     public byte[] get(byte[] key) {
       try {
-        Result result = table.get(new Get(key));
+        Result result = table.get(tableUtil.buildGet(key).create());
         return result.isEmpty() ? null : result.getValue(DATA_COLUMN_FAMILY, DEFAULT_COLUMN);
       } catch (IOException e) {
         throw Throwables.propagate(e);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/BufferingTable.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/BufferingTable.java
@@ -39,6 +39,7 @@ import com.google.common.collect.Maps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -231,7 +232,7 @@ public abstract class BufferingTable extends AbstractTable implements MeteredDat
   }
 
   @Override
-  public void close() {
+  public void close() throws IOException {
     // releasing resources
     buff = null;
     toUndo = null;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseMetricsTable.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseMetricsTable.java
@@ -25,7 +25,10 @@ import co.cask.cdap.common.utils.ImmutablePair;
 import co.cask.cdap.data2.dataset2.lib.table.FuzzyRowFilter;
 import co.cask.cdap.data2.dataset2.lib.table.MetricsTable;
 import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.data2.util.hbase.DeleteBuilder;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
+import co.cask.cdap.data2.util.hbase.PutBuilder;
+import co.cask.cdap.data2.util.hbase.ScanBuilder;
 import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.client.Delete;
@@ -35,7 +38,6 @@ import org.apache.hadoop.hbase.client.Increment;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
-import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.util.Pair;
 
 import java.io.IOException;
@@ -48,12 +50,15 @@ import javax.annotation.Nullable;
  * An HBase metrics table client.
  */
 public class HBaseMetricsTable implements MetricsTable {
+
+  private final HBaseTableUtil tableUtil;
   private final TableId tableId;
   private final HTable hTable;
   private final byte[] columnFamily;
 
   public HBaseMetricsTable(DatasetContext datasetContext, DatasetSpecification spec,
                            Configuration hConf, HBaseTableUtil tableUtil) throws IOException {
+    this.tableUtil = tableUtil;
     this.tableId = TableId.from(datasetContext.getNamespaceId(), spec.getName());
     HTable hTable = tableUtil.createHTable(hConf, tableId);
     // todo: make configurable
@@ -67,9 +72,10 @@ public class HBaseMetricsTable implements MetricsTable {
   @Nullable
   public byte[] get(byte[] row, byte[] column) {
     try {
-      Get get = new Get(row);
-      get.addColumn(columnFamily, column);
-      get.setMaxVersions(1);
+      Get get = tableUtil.buildGet(row)
+        .addColumn(columnFamily, column)
+        .setMaxVersions(1)
+        .create();
       Result getResult = hTable.get(get);
       if (!getResult.isEmpty()) {
         return getResult.getValue(columnFamily, column);
@@ -84,11 +90,11 @@ public class HBaseMetricsTable implements MetricsTable {
   public void put(NavigableMap<byte[], NavigableMap<byte[], Long>> updates) {
     List<Put> puts = Lists.newArrayList();
     for (Map.Entry<byte[], NavigableMap<byte[], Long>> row : updates.entrySet()) {
-      Put put = new Put(row.getKey());
+      PutBuilder put = tableUtil.buildPut(row.getKey());
       for (Map.Entry<byte[], Long> column : row.getValue().entrySet()) {
         put.add(columnFamily, column.getKey(), Bytes.toBytes(column.getValue()));
       }
-      puts.add(put);
+      puts.add(put.create());
     }
     try {
       hTable.put(puts);
@@ -102,13 +108,15 @@ public class HBaseMetricsTable implements MetricsTable {
   public boolean swap(byte[] row, byte[] column, byte[] oldValue, byte[] newValue) {
     try {
       if (newValue == null) {
-        Delete delete = new Delete(row);
         // HBase API weirdness: we must use deleteColumns() because deleteColumn() deletes only the last version.
-        delete.deleteColumns(columnFamily, column);
+        Delete delete = tableUtil.buildDelete(row)
+          .deleteColumns(columnFamily, column)
+          .create();
         return hTable.checkAndDelete(row, columnFamily, column, oldValue, delete);
       } else {
-        Put put = new Put(row);
-        put.add(columnFamily, column, newValue);
+        Put put = tableUtil.buildPut(row)
+          .add(columnFamily, column, newValue)
+          .create();
         return hTable.checkAndPut(row, columnFamily, column, oldValue, put);
       }
     } catch (IOException e) {
@@ -145,9 +153,9 @@ public class HBaseMetricsTable implements MetricsTable {
   }
 
   private Put getIncrementalPut(byte[] row) {
-    Put put = new Put(row);
-    put.setAttribute(HBaseTable.DELTA_WRITE, Bytes.toBytes(true));
-    return put;
+    return tableUtil.buildPut(row)
+      .setAttribute(HBaseTable.DELTA_WRITE, Bytes.toBytes(true))
+      .create();
   }
 
   @Override
@@ -192,12 +200,12 @@ public class HBaseMetricsTable implements MetricsTable {
 
   @Override
   public void delete(byte[] row, byte[][] columns) {
-    Delete delete = new Delete(row);
+    DeleteBuilder delete = tableUtil.buildDelete(row);
     for (byte[] column : columns) {
       delete.deleteColumns(columnFamily, column);
     }
     try {
-      hTable.delete(delete);
+      hTable.delete(delete.create());
     } catch (IOException e) {
       throw new DataSetException("Delete failed on table " + tableId, e);
     }
@@ -206,18 +214,18 @@ public class HBaseMetricsTable implements MetricsTable {
   @Override
   public Scanner scan(@Nullable byte[] startRow, @Nullable byte[] stopRow,
                       @Nullable FuzzyRowFilter filter) {
-    Scan scan = new Scan();
-    configureRangeScan(scan, startRow, stopRow, filter);
+    ScanBuilder scanBuilder = tableUtil.buildScan();
+    configureRangeScan(scanBuilder, startRow, stopRow, filter);
     try {
-      ResultScanner resultScanner = hTable.getScanner(scan);
+      ResultScanner resultScanner = hTable.getScanner(scanBuilder.build());
       return new HBaseScanner(resultScanner, columnFamily);
     } catch (IOException e) {
       throw new DataSetException("Scan failed on table " + tableId, e);
     }
   }
 
-  private Scan configureRangeScan(Scan scan, @Nullable byte[] startRow, @Nullable byte[] stopRow,
-                                  @Nullable FuzzyRowFilter filter) {
+  private ScanBuilder configureRangeScan(ScanBuilder scan, @Nullable byte[] startRow, @Nullable byte[] stopRow,
+                                         @Nullable FuzzyRowFilter filter) {
     // todo: should be configurable
     scan.setCaching(1000);
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseMetricsTable.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseMetricsTable.java
@@ -75,7 +75,7 @@ public class HBaseMetricsTable implements MetricsTable {
       Get get = tableUtil.buildGet(row)
         .addColumn(columnFamily, column)
         .setMaxVersions(1)
-        .create();
+        .build();
       Result getResult = hTable.get(get);
       if (!getResult.isEmpty()) {
         return getResult.getValue(columnFamily, column);
@@ -94,7 +94,7 @@ public class HBaseMetricsTable implements MetricsTable {
       for (Map.Entry<byte[], Long> column : row.getValue().entrySet()) {
         put.add(columnFamily, column.getKey(), Bytes.toBytes(column.getValue()));
       }
-      puts.add(put.create());
+      puts.add(put.build());
     }
     try {
       hTable.put(puts);
@@ -111,12 +111,12 @@ public class HBaseMetricsTable implements MetricsTable {
         // HBase API weirdness: we must use deleteColumns() because deleteColumn() deletes only the last version.
         Delete delete = tableUtil.buildDelete(row)
           .deleteColumns(columnFamily, column)
-          .create();
+          .build();
         return hTable.checkAndDelete(row, columnFamily, column, oldValue, delete);
       } else {
         Put put = tableUtil.buildPut(row)
           .add(columnFamily, column, newValue)
-          .create();
+          .build();
         return hTable.checkAndPut(row, columnFamily, column, oldValue, put);
       }
     } catch (IOException e) {
@@ -155,7 +155,7 @@ public class HBaseMetricsTable implements MetricsTable {
   private Put getIncrementalPut(byte[] row) {
     return tableUtil.buildPut(row)
       .setAttribute(HBaseTable.DELTA_WRITE, Bytes.toBytes(true))
-      .create();
+      .build();
   }
 
   @Override
@@ -205,7 +205,7 @@ public class HBaseMetricsTable implements MetricsTable {
       delete.deleteColumns(columnFamily, column);
     }
     try {
-      hTable.delete(delete.create());
+      hTable.delete(delete.build());
     } catch (IOException e) {
       throw new DataSetException("Delete failed on table " + tableId, e);
     }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTable.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTable.java
@@ -158,6 +158,15 @@ public class HBaseTable extends BufferingTable {
   }
 
   @Override
+  public void close() throws IOException {
+    try {
+      super.close();
+    } finally {
+      hTable.close();
+    }
+  }
+
+  @Override
   protected void persist(NavigableMap<byte[], NavigableMap<byte[], Update>> buff) throws Exception {
     List<Put> puts = Lists.newArrayList();
     for (Map.Entry<byte[], NavigableMap<byte[], Update>> row : buff.entrySet()) {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTable.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTable.java
@@ -35,7 +35,11 @@ import co.cask.cdap.data2.dataset2.lib.table.PutValue;
 import co.cask.cdap.data2.dataset2.lib.table.Update;
 import co.cask.cdap.data2.dataset2.lib.table.inmemory.PrefixedNamespaces;
 import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.data2.util.hbase.DeleteBuilder;
+import co.cask.cdap.data2.util.hbase.GetBuilder;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
+import co.cask.cdap.data2.util.hbase.PutBuilder;
+import co.cask.cdap.data2.util.hbase.ScanBuilder;
 import co.cask.tephra.Transaction;
 import co.cask.tephra.TransactionCodec;
 import co.cask.tephra.TxConstants;
@@ -49,11 +53,9 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.HTable;
-import org.apache.hadoop.hbase.client.OperationWithAttributes;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
-import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.util.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -76,6 +78,7 @@ public class HBaseTable extends BufferingTable {
 
   public static final String DELTA_WRITE = "d";
 
+  private final HBaseTableUtil tableUtil;
   private final HTable hTable;
   private final String hTableName;
   private final byte[] columnFamily;
@@ -98,6 +101,7 @@ public class HBaseTable extends BufferingTable {
     // todo: make configurable
     hTable.setWriteBufferSize(HBaseTableUtil.DEFAULT_WRITE_BUFFER_SIZE);
     hTable.setAutoFlush(false);
+    this.tableUtil = tableUtil;
     this.hTable = hTable;
     this.hTableName = Bytes.toStringBinary(hTable.getTableName());
     this.columnFamily = HBaseTableAdmin.getColumnFamily(spec);
@@ -157,7 +161,7 @@ public class HBaseTable extends BufferingTable {
   protected void persist(NavigableMap<byte[], NavigableMap<byte[], Update>> buff) throws Exception {
     List<Put> puts = Lists.newArrayList();
     for (Map.Entry<byte[], NavigableMap<byte[], Update>> row : buff.entrySet()) {
-      Put put = new Put(row.getKey());
+      PutBuilder put = tableUtil.buildPut(row.getKey());
       Put incrementPut = null;
       for (Map.Entry<byte[], Update> column : row.getValue().entrySet()) {
         // we want support tx and non-tx modes
@@ -187,7 +191,7 @@ public class HBaseTable extends BufferingTable {
         puts.add(incrementPut);
       }
       if (!put.isEmpty()) {
-        puts.add(put);
+        puts.add(put.create());
       }
     }
     if (!puts.isEmpty()) {
@@ -202,9 +206,9 @@ public class HBaseTable extends BufferingTable {
     if (existing != null) {
       return existing;
     }
-    Put put = new Put(row);
-    put.setAttribute(DELTA_WRITE, Bytes.toBytes(true));
-    return put;
+    return tableUtil.buildPut(row)
+      .setAttribute(DELTA_WRITE, Bytes.toBytes(true))
+      .create();
   }
 
   @Override
@@ -212,7 +216,7 @@ public class HBaseTable extends BufferingTable {
     // NOTE: we use Delete with the write pointer as the specific version to delete.
     List<Delete> deletes = Lists.newArrayList();
     for (Map.Entry<byte[], NavigableMap<byte[], Update>> row : persisted.entrySet()) {
-      Delete delete = new Delete(row.getKey());
+      DeleteBuilder delete = tableUtil.buildDelete(row.getKey());
       for (Map.Entry<byte[], Update> column : row.getValue().entrySet()) {
         // we want support tx and non-tx modes
         if (tx != null) {
@@ -223,7 +227,7 @@ public class HBaseTable extends BufferingTable {
           delete.deleteColumns(columnFamily, column.getKey());
         }
       }
-      deletes.add(delete);
+      deletes.add(delete.create());
     }
     hTable.delete(deletes);
     hTable.flushCommits();
@@ -244,7 +248,7 @@ public class HBaseTable extends BufferingTable {
 
   @Override
   protected Scanner scanPersisted(co.cask.cdap.api.dataset.table.Scan scan) throws Exception {
-    Scan hScan = new Scan();
+    ScanBuilder hScan = tableUtil.buildScan();
     hScan.addFamily(columnFamily);
     // todo: should be configurable
     // NOTE: by default we assume scanner is used in mapreduce job, hence no cache blocks
@@ -261,14 +265,13 @@ public class HBaseTable extends BufferingTable {
     }
 
     setFilterIfNeeded(hScan, scan.getFilter());
+    hScan.setAttribute(TxConstants.TX_OPERATION_ATTRIBUTE_KEY, txCodec.encode(tx));
 
-    addToOperation(hScan, tx);
-
-    ResultScanner resultScanner = hTable.getScanner(hScan);
+    ResultScanner resultScanner = hTable.getScanner(hScan.build());
     return new HBaseScanner(resultScanner, columnFamily);
   }
 
-  private void setFilterIfNeeded(Scan scan, @Nullable Filter filter) {
+  private void setFilterIfNeeded(ScanBuilder scan, @Nullable Filter filter) {
     if (filter == null) {
       return;
     }
@@ -287,7 +290,7 @@ public class HBaseTable extends BufferingTable {
   }
 
   private Get createGet(byte[] row, @Nullable byte[][] columns) {
-    Get get = new Get(row);
+    GetBuilder get = tableUtil.buildGet(row);
     get.addFamily(columnFamily);
     if (columns != null && columns.length > 0) {
       for (byte[] column : columns) {
@@ -302,27 +305,24 @@ public class HBaseTable extends BufferingTable {
       if (tx == null) {
         get.setMaxVersions(1);
       } else {
-        addToOperation(get, tx);
+        get.setAttribute(TxConstants.TX_OPERATION_ATTRIBUTE_KEY, txCodec.encode(tx));
       }
     } catch (IOException ioe) {
       throw Throwables.propagate(ioe);
     }
-    return get;
+    return get.create();
   }
 
   private NavigableMap<byte[], byte[]> getInternal(byte[] row, @Nullable byte[][] columns) throws IOException {
     Get get = createGet(row, columns);
 
+    Result result = hTable.get(get);
+
     // no tx logic needed
     if (tx == null) {
-      get.setMaxVersions(1);
-      Result result = hTable.get(get);
       return result.isEmpty() ? EMPTY_ROW_MAP : result.getFamilyMap(columnFamily);
     }
 
-    addToOperation(get, tx);
-
-    Result result = hTable.get(get);
     return getRowMap(result, columnFamily);
   }
 
@@ -341,9 +341,5 @@ public class HBaseTable extends BufferingTable {
     }
 
     return unwrapDeletes(rowMap);
-  }
-
-  private void addToOperation(OperationWithAttributes op, Transaction tx) throws IOException {
-    op.setAttribute(TxConstants.TX_OPERATION_ATTRIBUTE_KEY, txCodec.encode(tx));
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTable.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTable.java
@@ -191,7 +191,7 @@ public class HBaseTable extends BufferingTable {
         puts.add(incrementPut);
       }
       if (!put.isEmpty()) {
-        puts.add(put.create());
+        puts.add(put.build());
       }
     }
     if (!puts.isEmpty()) {
@@ -208,7 +208,7 @@ public class HBaseTable extends BufferingTable {
     }
     return tableUtil.buildPut(row)
       .setAttribute(DELTA_WRITE, Bytes.toBytes(true))
-      .create();
+      .build();
   }
 
   @Override
@@ -227,7 +227,7 @@ public class HBaseTable extends BufferingTable {
           delete.deleteColumns(columnFamily, column.getKey());
         }
       }
-      deletes.add(delete.create());
+      deletes.add(delete.build());
     }
     hTable.delete(deletes);
     hTable.flushCommits();
@@ -310,7 +310,7 @@ public class HBaseTable extends BufferingTable {
     } catch (IOException ioe) {
       throw Throwables.propagate(ioe);
     }
-    return get.create();
+    return get.build();
   }
 
   private NavigableMap<byte[], byte[]> getInternal(byte[] row, @Nullable byte[][] columns) throws IOException {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableAdmin.java
@@ -88,7 +88,7 @@ public class HBaseTableAdmin extends AbstractHBaseDataSetAdmin {
       }
     }
 
-    final HTableDescriptorBuilder tableDescriptor = tableUtil.createHTableDescriptor(tableId);
+    final HTableDescriptorBuilder tableDescriptor = tableUtil.buildHTableDescriptor(tableId);
     setVersion(tableDescriptor);
     tableDescriptor.addFamily(columnDescriptor);
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableAdmin.java
@@ -25,6 +25,7 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.dataset2.lib.hbase.AbstractHBaseDataSetAdmin;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
+import co.cask.cdap.data2.util.hbase.HTableDescriptorBuilder;
 import co.cask.tephra.TxConstants;
 import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
@@ -87,7 +88,7 @@ public class HBaseTableAdmin extends AbstractHBaseDataSetAdmin {
       }
     }
 
-    final HTableDescriptor tableDescriptor = tableUtil.createHTableDescriptor(tableId);
+    final HTableDescriptorBuilder tableDescriptor = tableUtil.createHTableDescriptor(tableId);
     setVersion(tableDescriptor);
     tableDescriptor.addFamily(columnDescriptor);
 
@@ -119,7 +120,7 @@ public class HBaseTableAdmin extends AbstractHBaseDataSetAdmin {
       splits = GSON.fromJson(splitsProperty, byte[][].class);
     }
 
-    tableUtil.createTableIfNotExists(getAdmin(), tableId, tableDescriptor, splits);
+    tableUtil.createTableIfNotExists(getAdmin(), tableId, tableDescriptor.build(), splits);
   }
 
   @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/DequeueScanAttributes.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/DequeueScanAttributes.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.io.WritableUtils;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
@@ -38,24 +39,20 @@ public class DequeueScanAttributes {
   private static final String ATTR_CONSUMER_CONFIG = "cdap.queue.dequeue.consumerConfig";
   private static final String ATTR_TX = "cdap.queue.dequeue.transaction";
 
-  /**
-   * Deprecated. It is maintained for old queue table only.
-   */
-  @Deprecated
-  private static final String ATTR_QUEUE_ROW_PREFIX = "cdap.queue.dequeue.queueRowPrefix";
-
-  public static void set(Scan scan, ConsumerConfig consumerConfig) {
+  public static Map<String, byte[]> addAttribute(ConsumerConfig consumerConfig, Map<String, byte[]> attributes) {
     try {
-      scan.setAttribute(ATTR_CONSUMER_CONFIG, toBytes(consumerConfig));
+      attributes.put(ATTR_CONSUMER_CONFIG, toBytes(consumerConfig));
+      return attributes;
     } catch (IOException e) {
       // SHOULD NEVER happen
       throw new RuntimeException(e);
     }
   }
 
-  public static void set(Scan scan, Transaction transaction) {
+  public static Map<String, byte[]> addAttribute(Transaction transaction, Map<String, byte[]> attributes) {
     try {
-      scan.setAttribute(ATTR_TX, toBytes(transaction));
+      attributes.put(ATTR_TX, toBytes(transaction));
+      return attributes;
     } catch (IOException e) {
       // SHOULD NEVER happen
       throw new RuntimeException(e);
@@ -82,14 +79,6 @@ public class DequeueScanAttributes {
       // SHOULD NEVER happen
       throw new RuntimeException(e);
     }
-  }
-
-  /**
-   * TODO: Remove when {@link #ATTR_QUEUE_ROW_PREFIX} is removed.
-   */
-  @Deprecated
-  public static void setQueueRowPrefix(Scan scan, byte[] queueNamePrefix) {
-    scan.setAttribute(ATTR_QUEUE_ROW_PREFIX, queueNamePrefix);
   }
 
   private static byte[] toBytes(ConsumerConfig consumerConfig) throws IOException {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueAdmin.java
@@ -35,6 +35,7 @@ import co.cask.cdap.data2.transaction.queue.QueueConstants;
 import co.cask.cdap.data2.transaction.queue.QueueEntryRow;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
+import co.cask.cdap.data2.util.hbase.HTableDescriptorBuilder;
 import co.cask.cdap.hbase.wd.AbstractRowKeyDistributor;
 import co.cask.cdap.hbase.wd.RowKeyDistributorByHashPrefix;
 import co.cask.cdap.proto.Id;
@@ -476,7 +477,7 @@ public class HBaseQueueAdmin extends AbstractQueueAdmin {
     @Override
     public void create() throws IOException {
       // Create the queue table
-      HTableDescriptor htd = tableUtil.createHTableDescriptor(tableId);
+      HTableDescriptorBuilder htd = tableUtil.createHTableDescriptor(tableId);
       for (String key : properties.stringPropertyNames()) {
         htd.setValue(key, properties.getProperty(key));
       }
@@ -501,12 +502,12 @@ public class HBaseQueueAdmin extends AbstractQueueAdmin {
       createQueueTable(tableId, htd, splitKeys);
     }
 
-    private void createQueueTable(TableId tableId, HTableDescriptor htd, byte[][] splitKeys) throws IOException {
+    private void createQueueTable(TableId tableId, HTableDescriptorBuilder htd, byte[][] splitKeys) throws IOException {
       int prefixBytes = (type == QueueConstants.QueueType.SHARDED_QUEUE) ? ShardedHBaseQueueStrategy.PREFIX_BYTES
                                                                          : SaltedHBaseQueueStrategy.SALT_BYTES;
       htd.setValue(HBaseQueueAdmin.PROPERTY_PREFIX_BYTES, Integer.toString(prefixBytes));
       LOG.info("Create queue table with prefix bytes {}", htd.getValue(HBaseQueueAdmin.PROPERTY_PREFIX_BYTES));
-      tableUtil.createTableIfNotExists(getHBaseAdmin(), tableId, htd, splitKeys);
+      tableUtil.createTableIfNotExists(getHBaseAdmin(), tableId, htd.build(), splitKeys);
     }
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueAdmin.java
@@ -477,7 +477,7 @@ public class HBaseQueueAdmin extends AbstractQueueAdmin {
     @Override
     public void create() throws IOException {
       // Create the queue table
-      HTableDescriptorBuilder htd = tableUtil.createHTableDescriptor(tableId);
+      HTableDescriptorBuilder htd = tableUtil.buildHTableDescriptor(tableId);
       for (String key : properties.stringPropertyNames()) {
         htd.setValue(key, properties.getProperty(key));
       }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueAdmin.java
@@ -297,7 +297,8 @@ public class HBaseQueueAdmin extends AbstractQueueAdmin {
       return;
     }
     try (final HBaseConsumerStateStore stateStore = getConsumerStateStore(queueName)) {
-      Transactions.createTransactionExecutor(txExecutorFactory, stateStore).execute(new TransactionExecutor.Subroutine() {
+      Transactions.createTransactionExecutor(txExecutorFactory, stateStore)
+        .execute(new TransactionExecutor.Subroutine() {
         @Override
         public void apply() throws Exception {
           stateStore.clear();

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueClientFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueClientFactory.java
@@ -105,7 +105,7 @@ public class HBaseQueueClientFactory implements QueueClientFactory {
       HTable hTable = createHTable(admin.getDataTableId(queueName, queueAdmin.getType()));
       int distributorBuckets = getDistributorBuckets(hTable.getTableDescriptor());
       return createProducer(hTable, queueName, queueMetrics,
-                            new ShardedHBaseQueueStrategy(distributorBuckets), groupConfigs);
+                            new ShardedHBaseQueueStrategy(hBaseTableUtil, distributorBuckets), groupConfigs);
     } catch (Exception e) {
       Throwables.propagateIfPossible(e);
       throw new IOException(e);
@@ -174,8 +174,8 @@ public class HBaseQueueClientFactory implements QueueClientFactory {
             int distributorBuckets = getDistributorBuckets(hTable.getTableDescriptor());
 
             HBaseQueueStrategy strategy = (state.getPreviousBarrier() == null)
-                                          ? new SaltedHBaseQueueStrategy(distributorBuckets)
-                                          : new ShardedHBaseQueueStrategy(distributorBuckets);
+                                          ? new SaltedHBaseQueueStrategy(hBaseTableUtil, distributorBuckets)
+                                          : new ShardedHBaseQueueStrategy(hBaseTableUtil, distributorBuckets);
             consumers.add(queueUtil.getQueueConsumer(cConf, hTable, queueName, state,
                                                      admin.getConsumerStateStore(queueName),
                                                      strategy));

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseStreamConsumerStateStoreFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseStreamConsumerStateStoreFactory.java
@@ -24,6 +24,7 @@ import co.cask.cdap.data2.transaction.stream.StreamConsumerStateStore;
 import co.cask.cdap.data2.transaction.stream.StreamConsumerStateStoreFactory;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
+import co.cask.cdap.data2.util.hbase.HTableDescriptorBuilder;
 import co.cask.cdap.proto.Id;
 import com.google.inject.Inject;
 import org.apache.hadoop.conf.Configuration;
@@ -55,13 +56,13 @@ public final class HBaseStreamConsumerStateStoreFactory implements StreamConsume
     try (HBaseAdmin admin = new HBaseAdmin(hConf)) {
       if (!tableUtil.tableExists(admin, streamStateStoreTableId)) {
 
-        HTableDescriptor htd = tableUtil.createHTableDescriptor(streamStateStoreTableId);
+        HTableDescriptorBuilder htd = tableUtil.createHTableDescriptor(streamStateStoreTableId);
 
         HColumnDescriptor hcd = new HColumnDescriptor(QueueEntryRow.COLUMN_FAMILY);
         htd.addFamily(hcd);
         hcd.setMaxVersions(1);
 
-        tableUtil.createTableIfNotExists(admin, streamStateStoreTableId, htd, null,
+        tableUtil.createTableIfNotExists(admin, streamStateStoreTableId, htd.build(), null,
                                          QueueConstants.MAX_CREATE_TABLE_WAIT, TimeUnit.MILLISECONDS);
       }
     }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseStreamConsumerStateStoreFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseStreamConsumerStateStoreFactory.java
@@ -29,7 +29,6 @@ import co.cask.cdap.proto.Id;
 import com.google.inject.Inject;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HColumnDescriptor;
-import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.client.HBaseAdmin;
 import org.apache.hadoop.hbase.client.HTable;
 
@@ -56,7 +55,7 @@ public final class HBaseStreamConsumerStateStoreFactory implements StreamConsume
     try (HBaseAdmin admin = new HBaseAdmin(hConf)) {
       if (!tableUtil.tableExists(admin, streamStateStoreTableId)) {
 
-        HTableDescriptorBuilder htd = tableUtil.createHTableDescriptor(streamStateStoreTableId);
+        HTableDescriptorBuilder htd = tableUtil.buildHTableDescriptor(streamStateStoreTableId);
 
         HColumnDescriptor hcd = new HColumnDescriptor(QueueEntryRow.COLUMN_FAMILY);
         htd.addFamily(hcd);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseStreamFileConsumerFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseStreamFileConsumerFactory.java
@@ -33,6 +33,7 @@ import co.cask.cdap.data2.transaction.stream.StreamConsumerStateStore;
 import co.cask.cdap.data2.transaction.stream.StreamConsumerStateStoreFactory;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
+import co.cask.cdap.data2.util.hbase.HTableDescriptorBuilder;
 import co.cask.cdap.hbase.wd.AbstractRowKeyDistributor;
 import co.cask.cdap.hbase.wd.RowKeyDistributorByHashPrefix;
 import com.google.inject.Inject;
@@ -78,7 +79,7 @@ public final class HBaseStreamFileConsumerFactory extends AbstractStreamFileCons
 
     byte[][] splitKeys = HBaseTableUtil.getSplitKeys(splits, splits, distributor);
 
-    HTableDescriptor htd = tableUtil.createHTableDescriptor(tableId);
+    HTableDescriptorBuilder htd = tableUtil.createHTableDescriptor(tableId);
 
     HColumnDescriptor hcd = new HColumnDescriptor(QueueEntryRow.COLUMN_FAMILY);
     hcd.setMaxVersions(1);
@@ -86,14 +87,14 @@ public final class HBaseStreamFileConsumerFactory extends AbstractStreamFileCons
     htd.addFamily(hcd);
     htd.setValue(QueueConstants.DISTRIBUTOR_BUCKETS, Integer.toString(splits));
 
-    tableUtil.createTableIfNotExists(getAdmin(), tableId, htd, splitKeys,
+    tableUtil.createTableIfNotExists(getAdmin(), tableId, htd.build(), splitKeys,
                                      QueueConstants.MAX_CREATE_TABLE_WAIT, TimeUnit.MILLISECONDS);
 
     HTable hTable = tableUtil.createHTable(hConf, tableId);
     hTable.setWriteBufferSize(Constants.Stream.HBASE_WRITE_BUFFER_SIZE);
     hTable.setAutoFlush(false);
 
-    return new HBaseStreamFileConsumer(cConf, streamConfig, consumerConfig, hTable, reader,
+    return new HBaseStreamFileConsumer(cConf, streamConfig, consumerConfig, tableUtil, hTable, reader,
                                        stateStore, beginConsumerState, extraFilter,
                                        createKeyDistributor(hTable.getTableDescriptor()));
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseStreamFileConsumerFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseStreamFileConsumerFactory.java
@@ -79,7 +79,7 @@ public final class HBaseStreamFileConsumerFactory extends AbstractStreamFileCons
 
     byte[][] splitKeys = HBaseTableUtil.getSplitKeys(splits, splits, distributor);
 
-    HTableDescriptorBuilder htd = tableUtil.createHTableDescriptor(tableId);
+    HTableDescriptorBuilder htd = tableUtil.buildHTableDescriptor(tableId);
 
     HColumnDescriptor hcd = new HColumnDescriptor(QueueEntryRow.COLUMN_FAMILY);
     hcd.setMaxVersions(1);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/ConfigurationTable.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/ConfigurationTable.java
@@ -24,7 +24,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HColumnDescriptor;
-import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.TableNotFoundException;
 import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.Get;
@@ -76,7 +75,7 @@ public class ConfigurationTable {
     HTable table = null;
     try {
       HBaseTableUtil tableUtil = new HBaseTableUtilFactory(cConf).get();
-      HTableDescriptorBuilder htd = tableUtil.createHTableDescriptor(tableId);
+      HTableDescriptorBuilder htd = tableUtil.buildHTableDescriptor(tableId);
       htd.addFamily(new HColumnDescriptor(FAMILY));
       tableUtil.createTableIfNotExists(admin, tableId, htd.build());
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/ConfigurationTable.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/ConfigurationTable.java
@@ -76,9 +76,9 @@ public class ConfigurationTable {
     HTable table = null;
     try {
       HBaseTableUtil tableUtil = new HBaseTableUtilFactory(cConf).get();
-      HTableDescriptor htd = tableUtil.createHTableDescriptor(tableId);
+      HTableDescriptorBuilder htd = tableUtil.createHTableDescriptor(tableId);
       htd.addFamily(new HColumnDescriptor(FAMILY));
-      tableUtil.createTableIfNotExists(admin, tableId, htd);
+      tableUtil.createTableIfNotExists(admin, tableId, htd.build());
 
       long now = System.currentTimeMillis();
       long previous = now - 1;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/DefaultDeleteBuilder.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/DefaultDeleteBuilder.java
@@ -99,7 +99,7 @@ class DefaultDeleteBuilder implements DeleteBuilder {
   }
 
   @Override
-  public Delete create() {
+  public Delete build() {
     return delete;
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/DefaultDeleteBuilder.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/DefaultDeleteBuilder.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import org.apache.hadoop.hbase.client.Delete;
+
+/**
+ * Default implementation of {@link DeleteBuilder}. Specific HBase compat module can extends and override methods.
+ */
+class DefaultDeleteBuilder implements DeleteBuilder {
+
+  protected final Delete delete;
+
+  DefaultDeleteBuilder(byte[] row) {
+    delete = new Delete(row);
+  }
+
+  DefaultDeleteBuilder(Delete delete) {
+    this.delete = new Delete(delete);
+  }
+
+  @Override
+  public DeleteBuilder deleteFamily(byte[] family) {
+    delete.deleteFamily(family);
+    return this;
+  }
+
+  @Override
+  public DeleteBuilder deleteFamily(byte[] family, long timestamp) {
+    delete.deleteFamily(family, timestamp);
+    return this;
+  }
+
+  @Override
+  public DeleteBuilder deleteFamilyVersion(byte[] family, long timestamp) {
+    delete.deleteFamilyVersion(family, timestamp);
+    return this;
+  }
+
+  @Override
+  public DeleteBuilder deleteColumns(byte[] family, byte[] qualifier) {
+    delete.deleteColumns(family, qualifier);
+    return this;
+  }
+
+  @Override
+  public DeleteBuilder deleteColumns(byte[] family, byte[] qualifier, long timestamp) {
+    delete.deleteColumns(family, qualifier, timestamp);
+    return this;
+  }
+
+  @Override
+  public DeleteBuilder deleteColumn(byte[] family, byte[] qualifier) {
+    delete.deleteColumn(family, qualifier);
+    return this;
+  }
+
+  @Override
+  public DeleteBuilder deleteColumn(byte[] family, byte[] qualifier, long timestamp) {
+    delete.deleteColumn(family, qualifier, timestamp);
+    return this;
+  }
+
+  @Override
+  public DeleteBuilder setTimestamp(long timestamp) {
+    delete.setTimestamp(timestamp);
+    return this;
+  }
+
+  @Override
+  public DeleteBuilder setAttribute(String name, byte[] value) {
+    delete.setAttribute(name, value);
+    return this;
+  }
+
+  @Override
+  public DeleteBuilder setId(String id) {
+    delete.setId(id);
+    return this;
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return delete.isEmpty();
+  }
+
+  @Override
+  public Delete create() {
+    return delete;
+  }
+
+  @Override
+  public String toString() {
+    return delete.toString();
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/DefaultGetBuilder.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/DefaultGetBuilder.java
@@ -121,7 +121,7 @@ class DefaultGetBuilder implements GetBuilder {
   }
 
   @Override
-  public Get create() {
+  public Get build() {
     return get;
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/DefaultGetBuilder.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/DefaultGetBuilder.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.filter.Filter;
+
+import java.io.IOException;
+
+/**
+ * Default implementation of {@link GetBuilder}. Specific HBase compat module can extends and override methods.
+ */
+class DefaultGetBuilder implements GetBuilder {
+
+  protected final Get get;
+
+  DefaultGetBuilder(byte[] row) {
+    this.get = new Get(row);
+  }
+
+  DefaultGetBuilder(Get get) {
+    this.get = new Get(get);
+  }
+
+  @Override
+  public GetBuilder addFamily(byte[] family) {
+    get.addFamily(family);
+    return this;
+  }
+
+  @Override
+  public GetBuilder addColumn(byte[] family, byte[] qualifier) {
+    get.addColumn(family, qualifier);
+    return this;
+  }
+
+  @Override
+  public GetBuilder setTimeRange(long minStamp, long maxStamp) throws IOException {
+    get.setTimeRange(minStamp, maxStamp);
+    return this;
+  }
+
+  @Override
+  public GetBuilder setTimeStamp(long timestamp) throws IOException {
+    get.setTimeStamp(timestamp);
+    return this;
+  }
+
+  @Override
+  public GetBuilder setMaxVersions() {
+    get.setMaxVersions();
+    return this;
+  }
+
+  @Override
+  public GetBuilder setMaxVersions(int maxVersions) throws IOException {
+    get.setMaxVersions(maxVersions);
+    return this;
+  }
+
+  @Override
+  public GetBuilder setMaxResultsPerColumnFamily(int limit) {
+    get.setMaxResultsPerColumnFamily(limit);
+    return this;
+  }
+
+  @Override
+  public GetBuilder setRowOffsetPerColumnFamily(int offset) {
+    get.setRowOffsetPerColumnFamily(offset);
+    return this;
+  }
+
+  @Override
+  public GetBuilder setFilter(Filter filter) {
+    get.setFilter(filter);
+    return this;
+  }
+
+  @Override
+  public GetBuilder setCheckExistenceOnly(boolean checkExistenceOnly) {
+    get.setCheckExistenceOnly(checkExistenceOnly);
+    return this;
+  }
+
+  @Override
+  public GetBuilder setClosestRowBefore(boolean closestRowBefore) {
+    get.setClosestRowBefore(closestRowBefore);
+    return this;
+  }
+
+  @Override
+  public GetBuilder setAttribute(String name, byte[] value) {
+    get.setAttribute(name, value);
+    return this;
+  }
+
+  @Override
+  public GetBuilder setId(String id) {
+    get.setId(id);
+    return this;
+  }
+
+  @Override
+  public GetBuilder setCacheBlocks(boolean cacheBlocks) {
+    get.setCacheBlocks(cacheBlocks);
+    return this;
+  }
+
+  @Override
+  public Get create() {
+    return get;
+  }
+
+  @Override
+  public String toString() {
+    return get.toString();
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/DefaultPutBuilder.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/DefaultPutBuilder.java
@@ -89,7 +89,7 @@ class DefaultPutBuilder implements PutBuilder {
   }
 
   @Override
-  public Put create() {
+  public Put build() {
     return put;
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/DefaultPutBuilder.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/DefaultPutBuilder.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import org.apache.hadoop.hbase.client.Put;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Default implementation of {@link PutBuilder}. Specific HBase compat module can extends and override methods.
+ */
+class DefaultPutBuilder implements PutBuilder {
+
+  protected final Put put;
+
+  DefaultPutBuilder(byte[] row) {
+    this.put = new Put(row);
+  }
+  
+  DefaultPutBuilder(Put put) {
+    this.put = new Put(put);
+  }
+
+  @Override
+  public PutBuilder add(byte[] family, byte[] qualifier, byte[] value) {
+    put.add(family, qualifier, value);
+    return this;
+  }
+
+  @Override
+  public PutBuilder addImmutable(byte[] family, byte[] qualifier, byte[] value) {
+    put.addImmutable(family, qualifier, value);
+    return this;
+  }
+
+  @Override
+  public PutBuilder add(byte[] family, byte[] qualifier, long ts, byte[] value) {
+    put.add(family, qualifier, ts, value);
+    return this;
+  }
+
+  @Override
+  public PutBuilder addImmutable(byte[] family, byte[] qualifier, long ts, byte[] value) {
+    put.addImmutable(family, qualifier, ts, value);
+    return this;
+  }
+
+  @Override
+  public PutBuilder add(byte[] family, ByteBuffer qualifier, long ts, ByteBuffer value) {
+    put.add(family, qualifier, ts, value);
+    return this;
+  }
+
+  @Override
+  public PutBuilder addImmutable(byte[] family, ByteBuffer qualifier, long ts, ByteBuffer value) {
+    put.addImmutable(family, qualifier, ts, value);
+    return this;
+  }
+
+  @Override
+  public PutBuilder setAttribute(String name, byte[] value) {
+    put.setAttribute(name, value);
+    return this;
+  }
+
+  @Override
+  public PutBuilder setId(String id) {
+    put.setId(id);
+    return this;
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return put.isEmpty();
+  }
+
+  @Override
+  public Put create() {
+    return put;
+  }
+
+  @Override
+  public String toString() {
+    return put.toString();
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/DefaultScanBuilder.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/DefaultScanBuilder.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import org.apache.hadoop.hbase.client.IsolationLevel;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.filter.Filter;
+import org.apache.hadoop.hbase.security.access.Permission;
+import org.apache.hadoop.hbase.security.visibility.Authorizations;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.NavigableSet;
+
+/**
+ * Default implementation for {@link ScanBuilder}. Specific HBase compat module can extends and override methods.
+ */
+class DefaultScanBuilder implements ScanBuilder {
+
+  protected final Scan scan;
+
+  DefaultScanBuilder() {
+    this.scan = new Scan();
+  }
+
+  DefaultScanBuilder(Scan other) throws IOException {
+    this.scan = new Scan(other);
+  }
+
+  @Override
+  public ScanBuilder addFamily(byte[] family) {
+    scan.addFamily(family);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder addColumn(byte[] family, byte[] qualifier) {
+    scan.addColumn(family, qualifier);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setTimeRange(long minStamp, long maxStamp) throws IOException {
+    scan.setTimeRange(minStamp, maxStamp);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setTimeStamp(long timestamp) throws IOException {
+    scan.setTimeStamp(timestamp);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setStartRow(byte[] startRow) {
+    scan.setStartRow(startRow);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setStopRow(byte[] stopRow) {
+    scan.setStopRow(stopRow);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setMaxVersions() {
+    scan.setMaxVersions();
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setMaxVersions(int maxVersions) {
+    scan.setMaxVersions(maxVersions);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setFilter(Filter filter) {
+    scan.setFilter(filter);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setFamilyMap(Map<byte[], NavigableSet<byte[]>> familyMap) {
+    scan.setFamilyMap(familyMap);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setAttribute(String name, byte[] value) {
+    scan.setAttribute(name, value);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setId(String id) {
+    scan.setId(id);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setAuthorizations(Authorizations authorizations) {
+    scan.setAuthorizations(authorizations);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setACL(String user, Permission perms) {
+    scan.setACL(user, perms);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setACL(Map<String, Permission> perms) {
+    scan.setACL(perms);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setBatch(int batch) {
+    scan.setBatch(batch);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setMaxResultsPerColumnFamily(int limit) {
+    scan.setMaxResultsPerColumnFamily(limit);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setRowOffsetPerColumnFamily(int offset) {
+    scan.setRowOffsetPerColumnFamily(offset);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setCaching(int caching) {
+    scan.setCaching(caching);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setMaxResultSize(long maxResultSize) {
+    scan.setMaxResultSize(maxResultSize);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setCacheBlocks(boolean cacheBlocks) {
+    scan.setCacheBlocks(cacheBlocks);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setLoadColumnFamiliesOnDemand(boolean value) {
+    scan.setLoadColumnFamiliesOnDemand(value);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setRaw(boolean raw) {
+    scan.setRaw(raw);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setIsolationLevel(IsolationLevel level) {
+    scan.setIsolationLevel(level);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setSmall(boolean small) {
+    scan.setSmall(small);
+    return this;
+  }
+
+  @Override
+  public Scan build() {
+    return scan;
+  }
+
+  @Override
+  public String toString() {
+    return scan.toString();
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/DeleteBuilder.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/DeleteBuilder.java
@@ -46,5 +46,5 @@ public interface DeleteBuilder {
 
   boolean isEmpty();
 
-  Delete create();
+  Delete build();
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/DeleteBuilder.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/DeleteBuilder.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import org.apache.hadoop.hbase.client.Delete;
+
+/**
+ * Builder for creating {@link Delete}. This builder should be used for cross HBase versions compatibility.
+ * All methods on this class are just delegating to calls to {@link Delete} object.
+ */
+public interface DeleteBuilder {
+
+  DeleteBuilder deleteFamily(byte [] family);
+
+  DeleteBuilder deleteFamily(byte [] family, long timestamp);
+
+  DeleteBuilder deleteFamilyVersion(byte [] family, long timestamp);
+
+  DeleteBuilder deleteColumns(byte [] family, byte [] qualifier);
+
+  DeleteBuilder deleteColumns(byte [] family, byte [] qualifier, long timestamp);
+
+  DeleteBuilder deleteColumn(byte [] family, byte [] qualifier);
+
+  DeleteBuilder deleteColumn(byte [] family, byte [] qualifier, long timestamp);
+
+  DeleteBuilder setTimestamp(long timestamp);
+
+  DeleteBuilder setAttribute(String name, byte[] value);
+
+  DeleteBuilder setId(String id);
+
+  boolean isEmpty();
+
+  Delete create();
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/GetBuilder.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/GetBuilder.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.filter.Filter;
+
+import java.io.IOException;
+
+/**
+ * Builder for creating {@link Get}. This builder should be used for cross HBase versions compatibility.
+ * All methods on this class are just delegating to calls to {@link Get} object.
+ */
+public interface GetBuilder {
+
+  GetBuilder addFamily(byte [] family);
+
+  GetBuilder addColumn(byte [] family, byte [] qualifier);
+
+  GetBuilder setTimeRange(long minStamp, long maxStamp) throws IOException;
+
+  GetBuilder setTimeStamp(long timestamp) throws IOException;
+
+  GetBuilder setMaxVersions();
+
+  GetBuilder setMaxVersions(int maxVersions) throws IOException;
+
+  GetBuilder setMaxResultsPerColumnFamily(int limit);
+
+  GetBuilder setRowOffsetPerColumnFamily(int offset);
+
+  GetBuilder setFilter(Filter filter);
+
+  GetBuilder setCheckExistenceOnly(boolean checkExistenceOnly);
+
+  GetBuilder setClosestRowBefore(boolean closestRowBefore);
+
+  GetBuilder setAttribute(String name, byte[] value);
+
+  GetBuilder setId(String id);
+
+  GetBuilder setCacheBlocks(boolean cacheBlocks);
+
+  Get create();
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/GetBuilder.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/GetBuilder.java
@@ -55,5 +55,5 @@ public interface GetBuilder {
 
   GetBuilder setCacheBlocks(boolean cacheBlocks);
 
-  Get create();
+  Get build();
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseTableUtil.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseTableUtil.java
@@ -41,8 +41,12 @@ import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.HRegionInfo;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.TableExistsException;
+import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.HBaseAdmin;
 import org.apache.hadoop.hbase.client.HTable;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 import org.apache.twill.api.ClassAcceptor;
 import org.apache.twill.filesystem.Location;
@@ -388,12 +392,20 @@ public abstract class HBaseTableUtil {
   public abstract HTable createHTable(Configuration conf, TableId tableId) throws IOException;
 
   /**
-   * Creates a new {@link HTableDescriptor} which may contain an HBase namespace depending on the HBase version
+   * Creates a new {@link HTableDescriptorBuilder} which may contain an HBase namespace depending on the HBase version
    *
    * @param tableId the {@link TableId} to create an {@link HTableDescriptor} for
-   * @return an {@link HTableDescriptor} for the table
+   * @return an {@link HTableDescriptorBuilder} for the table
    */
-  public abstract HTableDescriptor createHTableDescriptor(TableId tableId);
+  public abstract HTableDescriptorBuilder createHTableDescriptor(TableId tableId);
+
+  /**
+   * Creates a new {@link HTableDescriptorBuilder} which may contain an HBase namespace depending on the HBase version
+   *
+   * @param tableDescriptor the {@link HTableDescriptor} whose values should be copied
+   * @return an {@link HTableDescriptorBuilder} for the table
+   */
+  public abstract HTableDescriptorBuilder createHTableDescriptor(HTableDescriptor tableDescriptor);
 
   /**
    * Constructs a {@link HTableDescriptor} which may contain an HBase namespace for an existing table
@@ -551,6 +563,62 @@ public abstract class HBaseTableUtil {
     HTableDescriptor tableDescriptor = getHTableDescriptor(admin, tableId);
     dropTable(admin, tableId);
     createTableIfNotExists(admin, tableId, tableDescriptor);
+  }
+
+  /**
+   * Creates a {@link ScanBuilder}.
+   */
+  public ScanBuilder buildScan() {
+    return new DefaultScanBuilder();
+  }
+
+  /**
+   * Creates a {@link ScanBuilder} by copying from another {@link Scan} instance.
+   */
+  public ScanBuilder buildScan(Scan scan) throws IOException {
+    return new DefaultScanBuilder(scan);
+  }
+
+  /**
+   * Creates a {@link PutBuilder} for the given row.
+   */
+  public PutBuilder buildPut(byte[] row) {
+    return new DefaultPutBuilder(row);
+  }
+
+  /**
+   * Creates a {@link PutBuilder} by copying from another {@link Put} instance.
+   */
+  public PutBuilder buildPut(Put put) {
+    return new DefaultPutBuilder(put);
+  }
+
+  /**
+   * Creates a {@link GetBuilder} for the given row.
+   */
+  public GetBuilder buildGet(byte[] row) {
+    return new DefaultGetBuilder(row);
+  }
+
+  /**
+   * Creates a {@link GetBuilder} by copying from another {@link Get} instance.
+   */
+  public GetBuilder buildGet(Get get) {
+    return new DefaultGetBuilder(get);
+  }
+
+  /**
+   * Creates a {@link DeleteBuilder} for the given row.
+   */
+  public DeleteBuilder buildDelete(byte[] row) {
+    return new DefaultDeleteBuilder(row);
+  }
+
+  /**
+   * Creates a {@link DeleteBuilder} by copying from another {@link Delete} instance.
+   */
+  public DeleteBuilder buildDelete(Delete delete) {
+    return new DefaultDeleteBuilder(delete);
   }
 
   public abstract void setCompression(HColumnDescriptor columnDescriptor, CompressionType type);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseTableUtil.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseTableUtil.java
@@ -397,7 +397,7 @@ public abstract class HBaseTableUtil {
    * @param tableId the {@link TableId} to create an {@link HTableDescriptor} for
    * @return an {@link HTableDescriptorBuilder} for the table
    */
-  public abstract HTableDescriptorBuilder createHTableDescriptor(TableId tableId);
+  public abstract HTableDescriptorBuilder buildHTableDescriptor(TableId tableId);
 
   /**
    * Creates a new {@link HTableDescriptorBuilder} which may contain an HBase namespace depending on the HBase version
@@ -405,7 +405,7 @@ public abstract class HBaseTableUtil {
    * @param tableDescriptor the {@link HTableDescriptor} whose values should be copied
    * @return an {@link HTableDescriptorBuilder} for the table
    */
-  public abstract HTableDescriptorBuilder createHTableDescriptor(HTableDescriptor tableDescriptor);
+  public abstract HTableDescriptorBuilder buildHTableDescriptor(HTableDescriptor tableDescriptor);
 
   /**
    * Constructs a {@link HTableDescriptor} which may contain an HBase namespace for an existing table

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseVersionSpecificFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseVersionSpecificFactory.java
@@ -42,10 +42,8 @@ public abstract class HBaseVersionSpecificFactory<T> implements Provider<T> {
           instance = createInstance(getHBase98Classname());
           break;
         case HBASE_10:
-          // TODO: remove exception and uncomment when CDAP-2868 is in place
-          throw new ProvisionException("Apache HBase 1.0 is not yet supported.");
-          // instance = createInstance(getHBase10Classname());
-          // break;
+          instance = createInstance(getHBase10Classname());
+          break;
         case HBASE_10_CDH:
           instance = createInstance(getHBase10CDHClassname());
           break;
@@ -59,8 +57,9 @@ public abstract class HBaseVersionSpecificFactory<T> implements Provider<T> {
   }
 
   protected T createInstance(String className) throws ClassNotFoundException {
-    Class clz = Class.forName(className);
-    return (T) Instances.newInstance(clz);
+    @SuppressWarnings("unchecked")
+    Class<T> clz = (Class<T>) Class.forName(className);
+    return Instances.newInstance(clz);
   }
 
   protected abstract String getHBase96Classname();

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HTableDescriptorBuilder.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HTableDescriptorBuilder.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.TableName;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Builder for creating an HBase {@code HTableDescriptor} object.  This should be used instead of creating an
+ * {@code HTableDescriptor} directly in order to avoid
+ */
+public class HTableDescriptorBuilder {
+  protected final HTableDescriptor instance;
+
+  HTableDescriptorBuilder(TableName tableName) {
+    this.instance = new HTableDescriptor(tableName);
+  }
+
+  HTableDescriptorBuilder(HTableDescriptor toCopy) {
+    this.instance = new HTableDescriptor(toCopy);
+  }
+
+  /* Common methods shared by all HBase versions */
+  public HTableDescriptorBuilder removeCoprocessor(String className) {
+    instance.removeCoprocessor(className);
+    return this;
+  }
+
+  public byte[] getValue(byte[] key) {
+    return instance.getValue(key);
+  }
+
+  public String getValue(String key) {
+    return instance.getValue(key);
+  }
+
+  /* Methods whose signature changed in HBase 1.0 due to HBASE-10841 */
+  public HTableDescriptorBuilder setValue(byte[] key, byte[] value) {
+    instance.setValue(key, value);
+    return this;
+  }
+
+  public HTableDescriptorBuilder setValue(String key, String value) {
+    instance.setValue(key, value);
+    return this;
+  }
+
+  public HTableDescriptorBuilder addFamily(HColumnDescriptor columnDescriptor) {
+    instance.addFamily(columnDescriptor);
+    return this;
+  }
+
+  public HTableDescriptorBuilder addCoprocessor(String className) throws IOException {
+    instance.addCoprocessor(className);
+    return this;
+  }
+  public HTableDescriptorBuilder addCoprocessor(String className, Path jarFilePath, int priority,
+                                                Map<String, String> keyValues) throws IOException {
+    instance.addCoprocessor(className, jarFilePath, priority, keyValues);
+    return this;
+  }
+
+  public HTableDescriptor build() {
+    return instance;
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HTableDescriptorBuilder.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HTableDescriptorBuilder.java
@@ -26,7 +26,7 @@ import java.util.Map;
 
 /**
  * Builder for creating an HBase {@code HTableDescriptor} object.  This should be used instead of creating an
- * {@code HTableDescriptor} directly in order to avoid
+ * {@code HTableDescriptor} directly in order to avoid API incompatibilities between HBase versions.
  */
 public class HTableDescriptorBuilder {
   protected final HTableDescriptor instance;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/PutBuilder.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/PutBuilder.java
@@ -44,5 +44,5 @@ public interface PutBuilder {
 
   boolean isEmpty();
 
-  Put create();
+  Put build();
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/PutBuilder.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/PutBuilder.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import org.apache.hadoop.hbase.client.Put;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Builder for creating {@link Put}. This builder should be used for cross HBase versions compatibility.
+ * All methods on this class are just delegating to calls to {@link Put} object.
+ */
+public interface PutBuilder {
+
+  PutBuilder add(byte [] family, byte [] qualifier, byte [] value);
+
+  PutBuilder addImmutable(byte [] family, byte [] qualifier, byte [] value);
+
+  PutBuilder add(byte [] family, byte [] qualifier, long ts, byte [] value);
+
+  PutBuilder addImmutable(byte [] family, byte [] qualifier, long ts, byte [] value);
+
+  PutBuilder add(byte[] family, ByteBuffer qualifier, long ts, ByteBuffer value);
+
+  PutBuilder addImmutable(byte[] family, ByteBuffer qualifier, long ts, ByteBuffer value);
+
+  PutBuilder setAttribute(String name, byte[] value);
+
+  PutBuilder setId(String id);
+
+  boolean isEmpty();
+
+  Put create();
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/ScanBuilder.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/ScanBuilder.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2014-2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import org.apache.hadoop.hbase.client.IsolationLevel;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.filter.Filter;
+import org.apache.hadoop.hbase.security.access.Permission;
+import org.apache.hadoop.hbase.security.visibility.Authorizations;
+import org.apache.hadoop.hbase.util.Bytes;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.NavigableSet;
+
+/**
+ * Builder for creating {@link Scan}. This builder should be used for cross HBase versions compatibility.
+ * All methods on this class are just delegating to calls to {@link Scan} object.
+ */
+public interface ScanBuilder {
+
+  ScanBuilder addFamily(byte[] family);
+
+  ScanBuilder addColumn(byte[] family, byte[] qualifier);
+
+  ScanBuilder setTimeRange(long minStamp, long maxStamp) throws IOException;
+
+  ScanBuilder setTimeStamp(long timestamp) throws IOException;
+
+  ScanBuilder setStartRow(byte[] startRow);
+
+  ScanBuilder setStopRow(byte[] stopRow);
+
+  ScanBuilder setMaxVersions();
+
+  ScanBuilder setMaxVersions(int maxVersions);
+
+  ScanBuilder setFilter(Filter filter);
+
+  ScanBuilder setFamilyMap(Map<byte[], NavigableSet<byte[]>> familyMap);
+
+  ScanBuilder setAttribute(String name, byte[] value);
+
+  ScanBuilder setId(String id);
+
+  ScanBuilder setAuthorizations(Authorizations authorizations);
+
+  ScanBuilder setACL(String user, Permission perms);
+
+  ScanBuilder setACL(Map<String, Permission> perms);
+
+  ScanBuilder setBatch(int batch);
+
+  ScanBuilder setMaxResultsPerColumnFamily(int limit);
+
+  ScanBuilder setRowOffsetPerColumnFamily(int offset);
+
+  ScanBuilder setCaching(int caching);
+
+  ScanBuilder setMaxResultSize(long maxResultSize);
+
+  ScanBuilder setCacheBlocks(boolean cacheBlocks);
+
+  ScanBuilder setLoadColumnFamiliesOnDemand(boolean value);
+
+  ScanBuilder setRaw(boolean raw);
+
+  ScanBuilder setIsolationLevel(IsolationLevel level);
+
+  ScanBuilder setSmall(boolean small);
+
+  Scan build();
+}

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/increment/hbase/AbstractIncrementHandlerTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/increment/hbase/AbstractIncrementHandlerTest.java
@@ -22,6 +22,7 @@ import co.cask.cdap.data.hbase.HBaseTestBase;
 import co.cask.cdap.data.hbase.HBaseTestFactory;
 import co.cask.cdap.data2.dataset2.lib.table.hbase.HBaseTable;
 import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
 import co.cask.tephra.TxConstants;
 import com.google.common.collect.ImmutableMap;
@@ -61,6 +62,7 @@ public abstract class AbstractIncrementHandlerTest {
   protected static HBaseTestBase testUtil;
   protected static Configuration conf;
   protected static CConfiguration cConf;
+  protected static HBaseTableUtil tableUtil;
 
   protected long ts = 1;
 
@@ -70,6 +72,7 @@ public abstract class AbstractIncrementHandlerTest {
     testUtil.startHBase();
     conf = testUtil.getConfiguration();
     cConf = CConfiguration.create();
+    tableUtil = new HBaseTableUtilFactory(cConf).get();
   }
 
   @AfterClass
@@ -95,9 +98,7 @@ public abstract class AbstractIncrementHandlerTest {
       assertColumn(table, row1, colA, 3);
 
       // test intermixed increments and puts
-      Put putA = new Put(row1);
-      putA.add(FAMILY, colA, ts++, Bytes.toBytes(5L));
-      table.put(putA);
+      table.put(tableUtil.buildPut(row1).add(FAMILY, colA, ts++, Bytes.toBytes(5L)).create());
 
       assertColumn(table, row1, colA, 5);
 
@@ -118,12 +119,10 @@ public abstract class AbstractIncrementHandlerTest {
       // increment A once more
       table.put(newIncrement(row2, colA, 1));
 
-      assertColumns(table, row2, new byte[][]{ colA, colB }, new long[]{ 3, 2 });
+      assertColumns(table, row2, new byte[][]{colA, colB}, new long[]{3, 2});
 
       // overwrite B with a new put
-      Put p = new Put(row2);
-      p.add(FAMILY, colB, ts++, Bytes.toBytes(10L));
-      table.put(p);
+      table.put(tableUtil.buildPut(row2).add(FAMILY, colB, ts++, Bytes.toBytes(10L)).create());
 
       assertColumns(table, row2, new byte[][]{ colA, colB }, new long[]{ 3, 10 });
     } finally {
@@ -265,19 +264,18 @@ public abstract class AbstractIncrementHandlerTest {
       assertColumn(table, row1, col, 100);
 
       // do a new put on the column
-      Put put = new Put(row1);
-      put.add(FAMILY, col, Bytes.toBytes(11L));
-      table.put(put);
+      table.put(tableUtil.buildPut(row1).add(FAMILY, col, Bytes.toBytes(11L)).create());
 
       assertColumn(table, row1, col, 11);
 
       // perform a delete on the column
-      Delete delete = new Delete(row1);
-      delete.deleteColumns(FAMILY, col);
+      Delete delete = tableUtil.buildDelete(row1)
+        .deleteColumns(FAMILY, col)
+        .create();
       // use batch to work around a bug in delete coprocessor hooks on HBase 0.94
       table.batch(Lists.newArrayList(delete));
 
-      Get get = new Get(row1);
+      Get get = tableUtil.buildGet(row1).create();
       Result result = table.get(get);
       LOG.info("Get after delete returned " + result);
       assertTrue(result.isEmpty());
@@ -290,12 +288,13 @@ public abstract class AbstractIncrementHandlerTest {
       assertColumn(table, row1, col, 100);
 
       // perform a family delete
-      delete = new Delete(row1);
-      delete.deleteFamily(FAMILY);
+      delete = tableUtil.buildDelete(row1)
+        .deleteFamily(FAMILY)
+        .create();
       // use batch to work around a bug in delete coprocessor hooks on HBase 0.94
       table.batch(Lists.newArrayList(delete));
 
-      get = new Get(row1);
+      get = tableUtil.buildGet(row1).create();
       result = table.get(get);
       LOG.info("Get after delete returned " + result);
       assertTrue(result.isEmpty());
@@ -308,11 +307,11 @@ public abstract class AbstractIncrementHandlerTest {
       assertColumn(table, row1, col, 100);
 
       // perform a row delete
-      delete = new Delete(row1);
+      delete = tableUtil.buildDelete(row1).create();
       // use batch to work around a bug in delete coprocessor hooks on HBase 0.94
       table.batch(Lists.newArrayList(delete));
 
-      get = new Get(row1);
+      get = tableUtil.buildGet(row1).create();
       result = table.get(get);
       LOG.info("Get after delete returned " + result);
       assertTrue(result.isEmpty());
@@ -390,9 +389,7 @@ public abstract class AbstractIncrementHandlerTest {
       // test that we do not apply TTL to a put terminating a set of increments
       byte[] row2 = Bytes.toBytes("r2");
       // first add a full put
-      Put p = new Put(row2);
-      p.add(FAMILY, col, Bytes.toBytes(50L));
-      region.put(p);
+      region.put(tableUtil.buildPut(row2).add(FAMILY, col, Bytes.toBytes(50L)).create());
 
       // move 51 msec into the future, so that the previous put is behind the TTL
       now = now + 51;
@@ -438,9 +435,7 @@ public abstract class AbstractIncrementHandlerTest {
       timeOracle.setCurrentTime(now * IncrementHandlerState.MAX_TS_PER_MS);
 
       // do another full put
-      p = new Put(row2);
-      p.add(FAMILY, col, Bytes.toBytes(99L));
-      region.put(p);
+      region.put(tableUtil.buildPut(row2).add(FAMILY, col, Bytes.toBytes(99L)).create());
 
       // run a compaction to apply TTL
       region.compact(true);
@@ -453,9 +448,7 @@ public abstract class AbstractIncrementHandlerTest {
 
       // test that we apply TTL to a standalone put
       byte[] row3 = Bytes.toBytes("r3");
-      p = new Put(row3);
-      p.add(FAMILY, col, Bytes.toBytes(11L));
-      region.put(p);
+      region.put(tableUtil.buildPut(row3).add(FAMILY, col, Bytes.toBytes(11L)).create());
 
       results.clear();
       assertFalse(region.scanRegion(results, row3));
@@ -482,10 +475,10 @@ public abstract class AbstractIncrementHandlerTest {
   }
 
   public Put newIncrement(byte[] row, byte[] column, long timestamp, long value) {
-    Put p = new Put(row);
-    p.add(FAMILY, column, timestamp, Bytes.toBytes(value));
-    p.setAttribute(HBaseTable.DELTA_WRITE, EMPTY_BYTES);
-    return p;
+    return tableUtil.buildPut(row)
+      .add(FAMILY, column, timestamp, Bytes.toBytes(value))
+      .setAttribute(HBaseTable.DELTA_WRITE, EMPTY_BYTES)
+      .create();
   }
 
   public abstract void assertColumn(HTable table, byte[] row, byte[] col, long expected) throws Exception;

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/increment/hbase/AbstractIncrementHandlerTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/increment/hbase/AbstractIncrementHandlerTest.java
@@ -98,7 +98,7 @@ public abstract class AbstractIncrementHandlerTest {
       assertColumn(table, row1, colA, 3);
 
       // test intermixed increments and puts
-      table.put(tableUtil.buildPut(row1).add(FAMILY, colA, ts++, Bytes.toBytes(5L)).create());
+      table.put(tableUtil.buildPut(row1).add(FAMILY, colA, ts++, Bytes.toBytes(5L)).build());
 
       assertColumn(table, row1, colA, 5);
 
@@ -122,7 +122,7 @@ public abstract class AbstractIncrementHandlerTest {
       assertColumns(table, row2, new byte[][]{colA, colB}, new long[]{3, 2});
 
       // overwrite B with a new put
-      table.put(tableUtil.buildPut(row2).add(FAMILY, colB, ts++, Bytes.toBytes(10L)).create());
+      table.put(tableUtil.buildPut(row2).add(FAMILY, colB, ts++, Bytes.toBytes(10L)).build());
 
       assertColumns(table, row2, new byte[][]{ colA, colB }, new long[]{ 3, 10 });
     } finally {
@@ -264,18 +264,18 @@ public abstract class AbstractIncrementHandlerTest {
       assertColumn(table, row1, col, 100);
 
       // do a new put on the column
-      table.put(tableUtil.buildPut(row1).add(FAMILY, col, Bytes.toBytes(11L)).create());
+      table.put(tableUtil.buildPut(row1).add(FAMILY, col, Bytes.toBytes(11L)).build());
 
       assertColumn(table, row1, col, 11);
 
       // perform a delete on the column
       Delete delete = tableUtil.buildDelete(row1)
         .deleteColumns(FAMILY, col)
-        .create();
+        .build();
       // use batch to work around a bug in delete coprocessor hooks on HBase 0.94
       table.batch(Lists.newArrayList(delete));
 
-      Get get = tableUtil.buildGet(row1).create();
+      Get get = tableUtil.buildGet(row1).build();
       Result result = table.get(get);
       LOG.info("Get after delete returned " + result);
       assertTrue(result.isEmpty());
@@ -290,11 +290,11 @@ public abstract class AbstractIncrementHandlerTest {
       // perform a family delete
       delete = tableUtil.buildDelete(row1)
         .deleteFamily(FAMILY)
-        .create();
+        .build();
       // use batch to work around a bug in delete coprocessor hooks on HBase 0.94
       table.batch(Lists.newArrayList(delete));
 
-      get = tableUtil.buildGet(row1).create();
+      get = tableUtil.buildGet(row1).build();
       result = table.get(get);
       LOG.info("Get after delete returned " + result);
       assertTrue(result.isEmpty());
@@ -307,11 +307,11 @@ public abstract class AbstractIncrementHandlerTest {
       assertColumn(table, row1, col, 100);
 
       // perform a row delete
-      delete = tableUtil.buildDelete(row1).create();
+      delete = tableUtil.buildDelete(row1).build();
       // use batch to work around a bug in delete coprocessor hooks on HBase 0.94
       table.batch(Lists.newArrayList(delete));
 
-      get = tableUtil.buildGet(row1).create();
+      get = tableUtil.buildGet(row1).build();
       result = table.get(get);
       LOG.info("Get after delete returned " + result);
       assertTrue(result.isEmpty());
@@ -389,7 +389,7 @@ public abstract class AbstractIncrementHandlerTest {
       // test that we do not apply TTL to a put terminating a set of increments
       byte[] row2 = Bytes.toBytes("r2");
       // first add a full put
-      region.put(tableUtil.buildPut(row2).add(FAMILY, col, Bytes.toBytes(50L)).create());
+      region.put(tableUtil.buildPut(row2).add(FAMILY, col, Bytes.toBytes(50L)).build());
 
       // move 51 msec into the future, so that the previous put is behind the TTL
       now = now + 51;
@@ -435,7 +435,7 @@ public abstract class AbstractIncrementHandlerTest {
       timeOracle.setCurrentTime(now * IncrementHandlerState.MAX_TS_PER_MS);
 
       // do another full put
-      region.put(tableUtil.buildPut(row2).add(FAMILY, col, Bytes.toBytes(99L)).create());
+      region.put(tableUtil.buildPut(row2).add(FAMILY, col, Bytes.toBytes(99L)).build());
 
       // run a compaction to apply TTL
       region.compact(true);
@@ -448,7 +448,7 @@ public abstract class AbstractIncrementHandlerTest {
 
       // test that we apply TTL to a standalone put
       byte[] row3 = Bytes.toBytes("r3");
-      region.put(tableUtil.buildPut(row3).add(FAMILY, col, Bytes.toBytes(11L)).create());
+      region.put(tableUtil.buildPut(row3).add(FAMILY, col, Bytes.toBytes(11L)).build());
 
       results.clear();
       assertFalse(region.scanRegion(results, row3));
@@ -478,7 +478,7 @@ public abstract class AbstractIncrementHandlerTest {
     return tableUtil.buildPut(row)
       .add(FAMILY, column, timestamp, Bytes.toBytes(value))
       .setAttribute(HBaseTable.DELTA_WRITE, EMPTY_BYTES)
-      .create();
+      .build();
   }
 
   public abstract void assertColumn(HTable table, byte[] row, byte[] col, long expected) throws Exception;

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueTest.java
@@ -196,7 +196,7 @@ public abstract class HBaseQueueTest extends QueueTest {
     TableId tableId = hbaseQueueAdmin.getDataTableId(queueName);
     Assert.assertEquals(Constants.DEFAULT_NAMESPACE_ID, tableId.getNamespace());
     Assert.assertEquals("system." + hbaseQueueAdmin.getType() + ".application1.flow1", tableId.getTableName());
-    String tableName = tableUtil.createHTableDescriptor(tableId).build().getNameAsString();
+    String tableName = tableUtil.buildHTableDescriptor(tableId).build().getNameAsString();
     Assert.assertEquals("application1", HBaseQueueAdmin.getApplicationName(tableName));
     Assert.assertEquals("flow1", HBaseQueueAdmin.getFlowName(tableName));
 
@@ -204,7 +204,7 @@ public abstract class HBaseQueueTest extends QueueTest {
     tableId = hbaseQueueAdmin.getDataTableId(queueName);
     Assert.assertEquals(Id.Namespace.from("testNamespace"), tableId.getNamespace());
     Assert.assertEquals("system." + hbaseQueueAdmin.getType() + ".application1.flow1", tableId.getTableName());
-    tableName = tableUtil.createHTableDescriptor(tableId).build().getNameAsString();
+    tableName = tableUtil.buildHTableDescriptor(tableId).build().getNameAsString();
     Assert.assertEquals("application1", HBaseQueueAdmin.getApplicationName(tableName));
     Assert.assertEquals("flow1", HBaseQueueAdmin.getFlowName(tableName));
   }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueTest.java
@@ -193,7 +193,7 @@ public abstract class HBaseQueueTest extends QueueTest {
     TableId tableId = hbaseQueueAdmin.getDataTableId(queueName);
     Assert.assertEquals(Constants.DEFAULT_NAMESPACE_ID, tableId.getNamespace());
     Assert.assertEquals("system." + hbaseQueueAdmin.getType() + ".application1.flow1", tableId.getTableName());
-    String tableName = tableUtil.createHTableDescriptor(tableId).getNameAsString();
+    String tableName = tableUtil.createHTableDescriptor(tableId).build().getNameAsString();
     Assert.assertEquals("application1", HBaseQueueAdmin.getApplicationName(tableName));
     Assert.assertEquals("flow1", HBaseQueueAdmin.getFlowName(tableName));
 
@@ -201,7 +201,7 @@ public abstract class HBaseQueueTest extends QueueTest {
     tableId = hbaseQueueAdmin.getDataTableId(queueName);
     Assert.assertEquals(Id.Namespace.from("testNamespace"), tableId.getNamespace());
     Assert.assertEquals("system." + hbaseQueueAdmin.getType() + ".application1.flow1", tableId.getTableName());
-    tableName = tableUtil.createHTableDescriptor(tableId).getNameAsString();
+    tableName = tableUtil.createHTableDescriptor(tableId).build().getNameAsString();
     Assert.assertEquals("application1", HBaseQueueAdmin.getApplicationName(tableName));
     Assert.assertEquals("flow1", HBaseQueueAdmin.getFlowName(tableName));
   }
@@ -418,7 +418,8 @@ public abstract class HBaseQueueTest extends QueueTest {
     try (
       final HBaseQueueProducer oldProducer = hBaseQueueClientFactory.createProducer(
         oldQueueAdmin, queueName, QueueConstants.QueueType.QUEUE,
-        QueueMetrics.NOOP_QUEUE_METRICS, new SaltedHBaseQueueStrategy(buckets), new ArrayList<ConsumerGroupConfig>());
+        QueueMetrics.NOOP_QUEUE_METRICS, new SaltedHBaseQueueStrategy(tableUtil, buckets),
+        new ArrayList<ConsumerGroupConfig>());
     ) {
       // Enqueue 10 items to old queue table
       Transactions.createTransactionExecutor(executorFactory, oldProducer)

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/util/hbase/AbstractHBaseTableUtilTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/util/hbase/AbstractHBaseTableUtilTest.java
@@ -141,7 +141,7 @@ public abstract class AbstractHBaseTableUtilTest {
 
     // modify
     HTableDescriptor desc = getTableDescriptor("namespace2", "table1");
-    HTableDescriptorBuilder newDesc = getTableUtil().createHTableDescriptor(desc);
+    HTableDescriptorBuilder newDesc = getTableUtil().buildHTableDescriptor(desc);
     newDesc.setValue("mykey", "myvalue");
     disable("namespace2", "table1");
     getTableUtil().modifyTable(hAdmin, newDesc.build());
@@ -328,7 +328,7 @@ public abstract class AbstractHBaseTableUtilTest {
 
   private void create(TableId tableId) throws IOException {
     HBaseTableUtil tableUtil = getTableUtil();
-    HTableDescriptorBuilder desc = tableUtil.createHTableDescriptor(tableId);
+    HTableDescriptorBuilder desc = tableUtil.buildHTableDescriptor(tableId);
     desc.addFamily(new HColumnDescriptor("d"));
     tableUtil.createTableIfNotExists(hAdmin, tableId, desc.build());
   }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/util/hbase/AbstractHBaseTableUtilTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/util/hbase/AbstractHBaseTableUtilTest.java
@@ -141,9 +141,10 @@ public abstract class AbstractHBaseTableUtilTest {
 
     // modify
     HTableDescriptor desc = getTableDescriptor("namespace2", "table1");
-    desc.setValue("mykey", "myvalue");
+    HTableDescriptorBuilder newDesc = getTableUtil().createHTableDescriptor(desc);
+    newDesc.setValue("mykey", "myvalue");
     disable("namespace2", "table1");
-    getTableUtil().modifyTable(hAdmin, desc);
+    getTableUtil().modifyTable(hAdmin, newDesc.build());
     desc = getTableDescriptor("namespace2", "table1");
     Assert.assertTrue(desc.getValue("mykey").equals("myvalue"));
     enable("namespace2", "table1");
@@ -302,16 +303,13 @@ public abstract class AbstractHBaseTableUtilTest {
   }
 
   private void writeSome(String namespace, String tableName) throws IOException {
-    HTable table = getTableUtil().createHTable(testHBase.getConfiguration(), TableId.from(namespace, tableName));
-    try {
+    try (HTable table = getTableUtil().createHTable(testHBase.getConfiguration(), TableId.from(namespace, tableName))) {
       // writing at least couple megs to reflect in "megabyte"-based metrics
       for (int i = 0; i < 8; i++) {
         Put put = new Put(Bytes.toBytes("row" + i));
         put.add(Bytes.toBytes("d"), Bytes.toBytes("col" + i), new byte[1024 * 1024]);
         table.put(put);
       }
-    } finally {
-      table.close();
     }
   }
 
@@ -330,9 +328,9 @@ public abstract class AbstractHBaseTableUtilTest {
 
   private void create(TableId tableId) throws IOException {
     HBaseTableUtil tableUtil = getTableUtil();
-    HTableDescriptor desc = tableUtil.createHTableDescriptor(tableId);
+    HTableDescriptorBuilder desc = tableUtil.createHTableDescriptor(tableId);
     desc.addFamily(new HColumnDescriptor("d"));
-    tableUtil.createTableIfNotExists(hAdmin, tableId, desc);
+    tableUtil.createTableIfNotExists(hAdmin, tableId, desc.build());
   }
 
   private boolean exists(String namespace, String tableName) throws IOException {

--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase96/HBaseQueueRegionObserver.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase96/HBaseQueueRegionObserver.java
@@ -30,6 +30,7 @@ import co.cask.cdap.data2.util.hbase.HTable96NameConverter;
 import co.cask.tephra.coprocessor.TransactionStateCache;
 import co.cask.tephra.persist.TransactionSnapshot;
 import com.google.common.base.Supplier;
+import com.google.common.io.InputSupplier;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -37,6 +38,8 @@ import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CoprocessorEnvironment;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.HTableInterface;
 import org.apache.hadoop.hbase.coprocessor.BaseRegionObserver;
 import org.apache.hadoop.hbase.coprocessor.ObserverContext;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
@@ -62,8 +65,7 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
 
   private static final Log LOG = LogFactory.getLog(HBaseQueueRegionObserver.class);
 
-  private Configuration conf;
-  private byte[] configTableNameBytes;
+  private TableName configTableName;
   private CConfigurationReader cConfReader;
   private TransactionStateCache txStateCache;
   private Supplier<TransactionSnapshot> txSnapshotSupplier;
@@ -96,7 +98,7 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
       appName = HBaseQueueAdmin.getApplicationName(hTableName);
       flowName = HBaseQueueAdmin.getFlowName(hTableName);
 
-      conf = env.getConfiguration();
+      Configuration conf = env.getConfiguration();
       String hbaseNamespacePrefix = nameConverter.getNamespacePrefix(tableDesc);
       TableId queueConfigTableId = HBaseQueueAdmin.getConfigTableId(namespaceId);
       final String sysConfigTablePrefix = nameConverter.getSysConfigTablePrefix(tableDesc);
@@ -107,9 +109,9 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
           return txStateCache.getLatestState();
         }
       };
-      configTableNameBytes = nameConverter.toTableName(hbaseNamespacePrefix, queueConfigTableId).getName();
+      configTableName = nameConverter.toTableName(hbaseNamespacePrefix, queueConfigTableId);
       cConfReader = new CConfigurationReader(conf, sysConfigTablePrefix);
-      configCache = ConsumerConfigCache.getInstance(conf, configTableNameBytes, cConfReader, txSnapshotSupplier);
+      configCache = createConfigCache(env);
     }
   }
 
@@ -137,11 +139,29 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
   }
 
   // needed for queue unit-test
-  private ConsumerConfigCache getConfigCache() {
+  @SuppressWarnings("unused")
+  private void updateCache() throws IOException {
+    ConsumerConfigCache configCache = this.configCache;
+    if (configCache != null) {
+      configCache.updateCache();
+    }
+  }
+
+  private ConsumerConfigCache getConfigCache(CoprocessorEnvironment env) {
     if (!configCache.isAlive()) {
-      configCache = ConsumerConfigCache.getInstance(conf, configTableNameBytes, cConfReader, txSnapshotSupplier);
+      configCache = createConfigCache(env);
     }
     return configCache;
+  }
+
+  private ConsumerConfigCache createConfigCache(final CoprocessorEnvironment env) {
+    return ConsumerConfigCache.getInstance(configTableName, cConfReader,
+                                           txSnapshotSupplier, new InputSupplier<HTableInterface>() {
+      @Override
+      public HTableInterface getInput() throws IOException {
+        return env.getTable(configTableName);
+      }
+    });
   }
 
   // need for queue unit-test
@@ -204,7 +224,7 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
                                                            cell.getRowLength());
           currentQueue = queueName.toBytes();
           currentQueueRowPrefix = QueueEntryRow.getQueueRowPrefix(queueName);
-          consumerConfig = getConfigCache().getConsumerConfig(currentQueue);
+          consumerConfig = getConfigCache(env).getConsumerConfig(currentQueue);
         }
 
         if (consumerConfig == null) {

--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBase96QueueConsumer.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBase96QueueConsumer.java
@@ -31,6 +31,8 @@ import org.apache.hadoop.hbase.filter.Filter;
 import org.apache.hadoop.hbase.filter.FilterList;
 import org.apache.hadoop.hbase.filter.SingleColumnValueFilter;
 
+import java.util.Map;
+
 /**
  * HBase 0.96 implementation of {@link HBaseQueueConsumer}.
  */
@@ -45,7 +47,7 @@ final class HBase96QueueConsumer extends HBaseQueueConsumer {
   }
 
   @Override
-  protected Scan createScan(byte[] startRow, byte[] stopRow, int numRows) {
+  protected Scan createScan(byte[] startRow, byte[] stopRow, int numRows, Map<String, byte[]> attributes) {
     // Scan the table for queue entries.
     Scan scan = new Scan();
     scan.setStartRow(startRow);
@@ -55,6 +57,11 @@ final class HBase96QueueConsumer extends HBaseQueueConsumer {
     scan.addColumn(QueueEntryRow.COLUMN_FAMILY, stateColumnName);
     scan.setFilter(createFilter());
     scan.setMaxVersions(1);
+
+    for (Map.Entry<String, byte[]> entry : attributes.entrySet()) {
+      scan.setAttribute(entry.getKey(), entry.getValue());
+    }
+
     return scan;
   }
 

--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/util/hbase/HBase96TableUtil.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/util/hbase/HBase96TableUtil.java
@@ -58,9 +58,15 @@ public class HBase96TableUtil extends HBaseTableUtil {
   }
 
   @Override
-  public HTableDescriptor createHTableDescriptor(TableId tableId) {
+  public HTableDescriptorBuilder createHTableDescriptor(TableId tableId) {
     Preconditions.checkArgument(tableId != null, "Table id should not be null");
-    return new HTableDescriptor(nameConverter.toTableName(tablePrefix, tableId));
+    return new HTableDescriptorBuilder(nameConverter.toTableName(tablePrefix, tableId));
+  }
+
+  @Override
+  public HTableDescriptorBuilder createHTableDescriptor(HTableDescriptor tableDescriptorToCopy) {
+    Preconditions.checkArgument(tableDescriptorToCopy != null, "Table descriptor should not be null");
+    return new HTableDescriptorBuilder(tableDescriptorToCopy);
   }
 
   @Override

--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/util/hbase/HBase96TableUtil.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/util/hbase/HBase96TableUtil.java
@@ -58,13 +58,13 @@ public class HBase96TableUtil extends HBaseTableUtil {
   }
 
   @Override
-  public HTableDescriptorBuilder createHTableDescriptor(TableId tableId) {
+  public HTableDescriptorBuilder buildHTableDescriptor(TableId tableId) {
     Preconditions.checkArgument(tableId != null, "Table id should not be null");
     return new HTableDescriptorBuilder(nameConverter.toTableName(tablePrefix, tableId));
   }
 
   @Override
-  public HTableDescriptorBuilder createHTableDescriptor(HTableDescriptor tableDescriptorToCopy) {
+  public HTableDescriptorBuilder buildHTableDescriptor(HTableDescriptor tableDescriptorToCopy) {
     Preconditions.checkArgument(tableDescriptorToCopy != null, "Table descriptor should not be null");
     return new HTableDescriptorBuilder(tableDescriptorToCopy);
   }

--- a/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data2/increment/hbase96/IncrementHandlerTest.java
+++ b/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data2/increment/hbase96/IncrementHandlerTest.java
@@ -22,6 +22,7 @@ import co.cask.cdap.data2.increment.hbase.TimestampOracle;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
+import co.cask.cdap.data2.util.hbase.HTableDescriptorBuilder;
 import co.cask.cdap.test.SlowTests;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
@@ -112,14 +113,15 @@ public class IncrementHandlerTest extends AbstractIncrementHandlerTest {
   @Override
   public HTable createTable(TableId tableId) throws Exception {
     HBaseTableUtil tableUtil = new HBaseTableUtilFactory(cConf).get();
-    HTableDescriptor tableDesc = tableUtil.createHTableDescriptor(tableId);
+    HTableDescriptorBuilder tableDesc = tableUtil.createHTableDescriptor(tableId);
     HColumnDescriptor columnDesc = new HColumnDescriptor(FAMILY);
     columnDesc.setMaxVersions(Integer.MAX_VALUE);
     columnDesc.setValue(IncrementHandlerState.PROPERTY_TRANSACTIONAL, "false");
     tableDesc.addFamily(columnDesc);
     tableDesc.addCoprocessor(IncrementHandler.class.getName());
-    testUtil.getHBaseAdmin().createTable(tableDesc);
-    testUtil.waitUntilTableAvailable(tableDesc.getName(), 5000);
+    HTableDescriptor htd = tableDesc.build();
+    testUtil.getHBaseAdmin().createTable(htd);
+    testUtil.waitUntilTableAvailable(htd.getName(), 5000);
     return tableUtil.createHTable(conf, tableId);
   }
 

--- a/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data2/increment/hbase96/IncrementHandlerTest.java
+++ b/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data2/increment/hbase96/IncrementHandlerTest.java
@@ -113,7 +113,7 @@ public class IncrementHandlerTest extends AbstractIncrementHandlerTest {
   @Override
   public HTable createTable(TableId tableId) throws Exception {
     HBaseTableUtil tableUtil = new HBaseTableUtilFactory(cConf).get();
-    HTableDescriptorBuilder tableDesc = tableUtil.createHTableDescriptor(tableId);
+    HTableDescriptorBuilder tableDesc = tableUtil.buildHTableDescriptor(tableId);
     HColumnDescriptor columnDesc = new HColumnDescriptor(FAMILY);
     columnDesc.setMaxVersions(Integer.MAX_VALUE);
     columnDesc.setValue(IncrementHandlerState.PROPERTY_TRANSACTIONAL, "false");

--- a/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data2/increment/hbase96/IncrementSummingScannerTest.java
+++ b/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data2/increment/hbase96/IncrementSummingScannerTest.java
@@ -434,7 +434,7 @@ public class IncrementSummingScannerTest {
   static HRegion createRegion(Configuration hConf, CConfiguration cConf, TableId tableId,
                               HColumnDescriptor cfd) throws Exception {
     HBaseTableUtil tableUtil = new HBaseTableUtilFactory(cConf).get();
-    HTableDescriptorBuilder htd = tableUtil.createHTableDescriptor(tableId);
+    HTableDescriptorBuilder htd = tableUtil.buildHTableDescriptor(tableId);
     cfd.setMaxVersions(Integer.MAX_VALUE);
     cfd.setKeepDeletedCells(true);
     htd.addFamily(cfd);

--- a/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data2/util/hbase/HTable96NameConverterTest.java
+++ b/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data2/util/hbase/HTable96NameConverterTest.java
@@ -32,9 +32,9 @@ public class HTable96NameConverterTest {
     HBaseTableUtil tableUtil = new HBaseTableUtilFactory(cConf).get();
     HTableNameConverter hBaseNameConversionUtil = new HTableNameConverterFactory().get();
 
-    HTableDescriptor htd = tableUtil.createHTableDescriptor(TableId.from("user", "some_table"));
-    Assert.assertEquals(tablePrefix + "_system:", hBaseNameConversionUtil.getSysConfigTablePrefix(htd));
+    HTableDescriptorBuilder htd = tableUtil.createHTableDescriptor(TableId.from("user", "some_table"));
+    Assert.assertEquals(tablePrefix + "_system:", hBaseNameConversionUtil.getSysConfigTablePrefix(htd.build()));
     htd = tableUtil.createHTableDescriptor(TableId.from(Constants.DEFAULT_NAMESPACE_ID, "table_in_default_ns"));
-    Assert.assertEquals(tablePrefix + "_system:", hBaseNameConversionUtil.getSysConfigTablePrefix(htd));
+    Assert.assertEquals(tablePrefix + "_system:", hBaseNameConversionUtil.getSysConfigTablePrefix(htd.build()));
   }
 }

--- a/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data2/util/hbase/HTable96NameConverterTest.java
+++ b/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data2/util/hbase/HTable96NameConverterTest.java
@@ -19,7 +19,6 @@ package co.cask.cdap.data2.util.hbase;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.util.TableId;
-import org.apache.hadoop.hbase.HTableDescriptor;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -32,9 +31,9 @@ public class HTable96NameConverterTest {
     HBaseTableUtil tableUtil = new HBaseTableUtilFactory(cConf).get();
     HTableNameConverter hBaseNameConversionUtil = new HTableNameConverterFactory().get();
 
-    HTableDescriptorBuilder htd = tableUtil.createHTableDescriptor(TableId.from("user", "some_table"));
+    HTableDescriptorBuilder htd = tableUtil.buildHTableDescriptor(TableId.from("user", "some_table"));
     Assert.assertEquals(tablePrefix + "_system:", hBaseNameConversionUtil.getSysConfigTablePrefix(htd.build()));
-    htd = tableUtil.createHTableDescriptor(TableId.from(Constants.DEFAULT_NAMESPACE_ID, "table_in_default_ns"));
+    htd = tableUtil.buildHTableDescriptor(TableId.from(Constants.DEFAULT_NAMESPACE_ID, "table_in_default_ns"));
     Assert.assertEquals(tablePrefix + "_system:", hBaseNameConversionUtil.getSysConfigTablePrefix(htd.build()));
   }
 }

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase98/HBaseQueueRegionObserver.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase98/HBaseQueueRegionObserver.java
@@ -30,6 +30,7 @@ import co.cask.cdap.data2.util.hbase.HTable98NameConverter;
 import co.cask.tephra.coprocessor.TransactionStateCache;
 import co.cask.tephra.persist.TransactionSnapshot;
 import com.google.common.base.Supplier;
+import com.google.common.io.InputSupplier;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -37,6 +38,8 @@ import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CoprocessorEnvironment;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.HTableInterface;
 import org.apache.hadoop.hbase.coprocessor.BaseRegionObserver;
 import org.apache.hadoop.hbase.coprocessor.ObserverContext;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
@@ -62,8 +65,7 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
 
   private static final Log LOG = LogFactory.getLog(HBaseQueueRegionObserver.class);
 
-  private Configuration conf;
-  private byte[] configTableNameBytes;
+  private TableName configTableName;
   private CConfigurationReader cConfReader;
   TransactionStateCache txStateCache;
   private Supplier<TransactionSnapshot> txSnapshotSupplier;
@@ -96,7 +98,7 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
       appName = HBaseQueueAdmin.getApplicationName(hTableName);
       flowName = HBaseQueueAdmin.getFlowName(hTableName);
 
-      conf = env.getConfiguration();
+      Configuration conf = env.getConfiguration();
       String hbaseNamespacePrefix = nameConverter.getNamespacePrefix(tableDesc);
       TableId queueConfigTableId = HBaseQueueAdmin.getConfigTableId(namespaceId);
       final String sysConfigTablePrefix = nameConverter.getSysConfigTablePrefix(tableDesc);
@@ -107,9 +109,9 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
           return txStateCache.getLatestState();
         }
       };
-      configTableNameBytes = nameConverter.toTableName(hbaseNamespacePrefix, queueConfigTableId).getName();
+      configTableName = nameConverter.toTableName(hbaseNamespacePrefix, queueConfigTableId);
       cConfReader = new CConfigurationReader(conf, sysConfigTablePrefix);
-      configCache = ConsumerConfigCache.getInstance(conf, configTableNameBytes, cConfReader, txSnapshotSupplier);
+      configCache = createConfigCache(env);
     }
   }
 
@@ -137,11 +139,29 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
   }
 
   // needed for queue unit-test
-  private ConsumerConfigCache getConfigCache() {
+  @SuppressWarnings("unused")
+  private void updateCache() throws IOException {
+    ConsumerConfigCache configCache = this.configCache;
+    if (configCache != null) {
+      configCache.updateCache();
+    }
+  }
+
+  private ConsumerConfigCache getConfigCache(CoprocessorEnvironment env) {
     if (!configCache.isAlive()) {
-      configCache = ConsumerConfigCache.getInstance(conf, configTableNameBytes, cConfReader, txSnapshotSupplier);
+      configCache = createConfigCache(env);
     }
     return configCache;
+  }
+
+  private ConsumerConfigCache createConfigCache(final CoprocessorEnvironment env) {
+    return ConsumerConfigCache.getInstance(configTableName, cConfReader,
+                                           txSnapshotSupplier, new InputSupplier<HTableInterface>() {
+      @Override
+      public HTableInterface getInput() throws IOException {
+        return env.getTable(configTableName);
+      }
+    });
   }
 
   // need for queue unit-test
@@ -204,7 +224,7 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
                                                            cell.getRowLength());
           currentQueue = queueName.toBytes();
           currentQueueRowPrefix = QueueEntryRow.getQueueRowPrefix(queueName);
-          consumerConfig = getConfigCache().getConsumerConfig(currentQueue);
+          consumerConfig = getConfigCache(env).getConsumerConfig(currentQueue);
         }
 
         if (consumerConfig == null) {

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBase98QueueConsumer.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBase98QueueConsumer.java
@@ -31,6 +31,8 @@ import org.apache.hadoop.hbase.filter.Filter;
 import org.apache.hadoop.hbase.filter.FilterList;
 import org.apache.hadoop.hbase.filter.SingleColumnValueFilter;
 
+import java.util.Map;
+
 /**
  * HBase 0.98 implementation of {@link HBaseQueueConsumer}.
  */
@@ -45,7 +47,7 @@ final class HBase98QueueConsumer extends HBaseQueueConsumer {
   }
 
   @Override
-  protected Scan createScan(byte[] startRow, byte[] stopRow, int numRows) {
+  protected Scan createScan(byte[] startRow, byte[] stopRow, int numRows, Map<String, byte[]> attributes) {
     // Scan the table for queue entries.
     Scan scan = new Scan();
     scan.setStartRow(startRow);
@@ -55,6 +57,10 @@ final class HBase98QueueConsumer extends HBaseQueueConsumer {
     scan.addColumn(QueueEntryRow.COLUMN_FAMILY, stateColumnName);
     scan.setFilter(createFilter());
     scan.setMaxVersions(1);
+
+    for (Map.Entry<String, byte[]> entry : attributes.entrySet()) {
+      scan.setAttribute(entry.getKey(), entry.getValue());
+    }
     return scan;
   }
 

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/util/hbase/HBase98TableUtil.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/util/hbase/HBase98TableUtil.java
@@ -58,9 +58,15 @@ public class HBase98TableUtil extends HBaseTableUtil {
   }
 
   @Override
-  public HTableDescriptor createHTableDescriptor(TableId tableId) {
+  public HTableDescriptorBuilder createHTableDescriptor(TableId tableId) {
     Preconditions.checkArgument(tableId != null, "Table id should not be null");
-    return new HTableDescriptor(nameConverter.toTableName(tablePrefix, tableId));
+    return new HTableDescriptorBuilder(nameConverter.toTableName(tablePrefix, tableId));
+  }
+
+  @Override
+  public HTableDescriptorBuilder createHTableDescriptor(HTableDescriptor tableDescriptorToCopy) {
+    Preconditions.checkArgument(tableDescriptorToCopy != null, "Table descriptor should not be null");
+    return new HTableDescriptorBuilder(tableDescriptorToCopy);
   }
 
   @Override

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/util/hbase/HBase98TableUtil.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/util/hbase/HBase98TableUtil.java
@@ -58,13 +58,13 @@ public class HBase98TableUtil extends HBaseTableUtil {
   }
 
   @Override
-  public HTableDescriptorBuilder createHTableDescriptor(TableId tableId) {
+  public HTableDescriptorBuilder buildHTableDescriptor(TableId tableId) {
     Preconditions.checkArgument(tableId != null, "Table id should not be null");
     return new HTableDescriptorBuilder(nameConverter.toTableName(tablePrefix, tableId));
   }
 
   @Override
-  public HTableDescriptorBuilder createHTableDescriptor(HTableDescriptor tableDescriptorToCopy) {
+  public HTableDescriptorBuilder buildHTableDescriptor(HTableDescriptor tableDescriptorToCopy) {
     Preconditions.checkArgument(tableDescriptorToCopy != null, "Table descriptor should not be null");
     return new HTableDescriptorBuilder(tableDescriptorToCopy);
   }

--- a/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data2/increment/hbase98/IncrementHandlerTest.java
+++ b/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data2/increment/hbase98/IncrementHandlerTest.java
@@ -22,6 +22,7 @@ import co.cask.cdap.data2.increment.hbase.TimestampOracle;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
+import co.cask.cdap.data2.util.hbase.HTableDescriptorBuilder;
 import co.cask.cdap.test.SlowTests;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
@@ -108,14 +109,15 @@ public class IncrementHandlerTest extends AbstractIncrementHandlerTest {
   @Override
   public HTable createTable(TableId tableId) throws Exception {
     HBaseTableUtil tableUtil = new HBaseTableUtilFactory(cConf).get();
-    HTableDescriptor tableDesc = tableUtil.createHTableDescriptor(tableId);
+    HTableDescriptorBuilder tableDesc = tableUtil.createHTableDescriptor(tableId);
     HColumnDescriptor columnDesc = new HColumnDescriptor(FAMILY);
     columnDesc.setMaxVersions(Integer.MAX_VALUE);
     columnDesc.setValue(IncrementHandlerState.PROPERTY_TRANSACTIONAL, "false");
     tableDesc.addFamily(columnDesc);
     tableDesc.addCoprocessor(IncrementHandler.class.getName());
-    testUtil.getHBaseAdmin().createTable(tableDesc);
-    testUtil.waitUntilTableAvailable(tableDesc.getName(), 5000);
+    HTableDescriptor htd = tableDesc.build();
+    testUtil.getHBaseAdmin().createTable(htd);
+    testUtil.waitUntilTableAvailable(htd.getName(), 5000);
     return tableUtil.createHTable(conf, tableId);
   }
 

--- a/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data2/increment/hbase98/IncrementHandlerTest.java
+++ b/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data2/increment/hbase98/IncrementHandlerTest.java
@@ -109,7 +109,7 @@ public class IncrementHandlerTest extends AbstractIncrementHandlerTest {
   @Override
   public HTable createTable(TableId tableId) throws Exception {
     HBaseTableUtil tableUtil = new HBaseTableUtilFactory(cConf).get();
-    HTableDescriptorBuilder tableDesc = tableUtil.createHTableDescriptor(tableId);
+    HTableDescriptorBuilder tableDesc = tableUtil.buildHTableDescriptor(tableId);
     HColumnDescriptor columnDesc = new HColumnDescriptor(FAMILY);
     columnDesc.setMaxVersions(Integer.MAX_VALUE);
     columnDesc.setValue(IncrementHandlerState.PROPERTY_TRANSACTIONAL, "false");

--- a/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data2/increment/hbase98/IncrementSummingScannerTest.java
+++ b/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data2/increment/hbase98/IncrementSummingScannerTest.java
@@ -434,7 +434,7 @@ public class IncrementSummingScannerTest {
   static HRegion createRegion(Configuration hConf, CConfiguration cConf, TableId tableId,
                               HColumnDescriptor cfd) throws Exception {
     HBaseTableUtil tableUtil = new HBaseTableUtilFactory(cConf).get();
-    HTableDescriptorBuilder htd = tableUtil.createHTableDescriptor(tableId);
+    HTableDescriptorBuilder htd = tableUtil.buildHTableDescriptor(tableId);
     cfd.setMaxVersions(Integer.MAX_VALUE);
     cfd.setKeepDeletedCells(true);
     htd.addFamily(cfd);

--- a/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data2/util/hbase/HTable98NameConverterTest.java
+++ b/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data2/util/hbase/HTable98NameConverterTest.java
@@ -32,9 +32,9 @@ public class HTable98NameConverterTest {
     HBaseTableUtil tableUtil = new HBaseTableUtilFactory(cConf).get();
     HTableNameConverter hBaseNameConversionUtil = new HTableNameConverterFactory().get();
 
-    HTableDescriptor htd = tableUtil.createHTableDescriptor(TableId.from("user", "some_table"));
-    Assert.assertEquals(tablePrefix + "_system:", hBaseNameConversionUtil.getSysConfigTablePrefix(htd));
+    HTableDescriptorBuilder htd = tableUtil.createHTableDescriptor(TableId.from("user", "some_table"));
+    Assert.assertEquals(tablePrefix + "_system:", hBaseNameConversionUtil.getSysConfigTablePrefix(htd.build()));
     htd = tableUtil.createHTableDescriptor(TableId.from(Constants.DEFAULT_NAMESPACE_ID, "table_in_default_ns"));
-    Assert.assertEquals(tablePrefix + "_system:", hBaseNameConversionUtil.getSysConfigTablePrefix(htd));
+    Assert.assertEquals(tablePrefix + "_system:", hBaseNameConversionUtil.getSysConfigTablePrefix(htd.build()));
   }
 }

--- a/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data2/util/hbase/HTable98NameConverterTest.java
+++ b/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data2/util/hbase/HTable98NameConverterTest.java
@@ -19,7 +19,6 @@ package co.cask.cdap.data2.util.hbase;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.util.TableId;
-import org.apache.hadoop.hbase.HTableDescriptor;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -32,9 +31,9 @@ public class HTable98NameConverterTest {
     HBaseTableUtil tableUtil = new HBaseTableUtilFactory(cConf).get();
     HTableNameConverter hBaseNameConversionUtil = new HTableNameConverterFactory().get();
 
-    HTableDescriptorBuilder htd = tableUtil.createHTableDescriptor(TableId.from("user", "some_table"));
+    HTableDescriptorBuilder htd = tableUtil.buildHTableDescriptor(TableId.from("user", "some_table"));
     Assert.assertEquals(tablePrefix + "_system:", hBaseNameConversionUtil.getSysConfigTablePrefix(htd.build()));
-    htd = tableUtil.createHTableDescriptor(TableId.from(Constants.DEFAULT_NAMESPACE_ID, "table_in_default_ns"));
+    htd = tableUtil.buildHTableDescriptor(TableId.from(Constants.DEFAULT_NAMESPACE_ID, "table_in_default_ns"));
     Assert.assertEquals(tablePrefix + "_system:", hBaseNameConversionUtil.getSysConfigTablePrefix(htd.build()));
   }
 }

--- a/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBase10CDHQueueConsumer.java
+++ b/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBase10CDHQueueConsumer.java
@@ -31,6 +31,8 @@ import org.apache.hadoop.hbase.filter.Filter;
 import org.apache.hadoop.hbase.filter.FilterList;
 import org.apache.hadoop.hbase.filter.SingleColumnValueFilter;
 
+import java.util.Map;
+
 /**
  * HBase 1.0 (CDH) implementation of {@link HBaseQueueConsumer}.
  */
@@ -45,7 +47,7 @@ final class HBase10CDHQueueConsumer extends HBaseQueueConsumer {
   }
 
   @Override
-  protected Scan createScan(byte[] startRow, byte[] stopRow, int numRows) {
+  protected Scan createScan(byte[] startRow, byte[] stopRow, int numRows, Map<String, byte[]> attributes) {
     // Scan the table for queue entries.
     Scan scan = new Scan();
     scan.setStartRow(startRow);
@@ -55,6 +57,11 @@ final class HBase10CDHQueueConsumer extends HBaseQueueConsumer {
     scan.addColumn(QueueEntryRow.COLUMN_FAMILY, stateColumnName);
     scan.setFilter(createFilter());
     scan.setMaxVersions(1);
+
+    for (Map.Entry<String, byte[]> entry : attributes.entrySet()) {
+      scan.setAttribute(entry.getKey(), entry.getValue());
+    }
+
     return scan;
   }
 

--- a/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/util/hbase/HBase10CDHTableUtil.java
+++ b/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/util/hbase/HBase10CDHTableUtil.java
@@ -58,13 +58,13 @@ public class HBase10CDHTableUtil extends HBaseTableUtil {
   }
 
   @Override
-  public HTableDescriptorBuilder createHTableDescriptor(TableId tableId) {
+  public HTableDescriptorBuilder buildHTableDescriptor(TableId tableId) {
     Preconditions.checkArgument(tableId != null, "Table id should not be null");
     return new HTableDescriptorBuilder(nameConverter.toTableName(tablePrefix, tableId));
   }
 
   @Override
-  public HTableDescriptorBuilder createHTableDescriptor(HTableDescriptor tableDescriptorToCopy) {
+  public HTableDescriptorBuilder buildHTableDescriptor(HTableDescriptor tableDescriptorToCopy) {
     Preconditions.checkArgument(tableDescriptorToCopy != null, "Table descriptor should not be null");
     return new HTableDescriptorBuilder(tableDescriptorToCopy);
   }

--- a/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/util/hbase/HBase10CDHTableUtil.java
+++ b/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/util/hbase/HBase10CDHTableUtil.java
@@ -58,9 +58,15 @@ public class HBase10CDHTableUtil extends HBaseTableUtil {
   }
 
   @Override
-  public HTableDescriptor createHTableDescriptor(TableId tableId) {
+  public HTableDescriptorBuilder createHTableDescriptor(TableId tableId) {
     Preconditions.checkArgument(tableId != null, "Table id should not be null");
-    return new HTableDescriptor(nameConverter.toTableName(tablePrefix, tableId));
+    return new HTableDescriptorBuilder(nameConverter.toTableName(tablePrefix, tableId));
+  }
+
+  @Override
+  public HTableDescriptorBuilder createHTableDescriptor(HTableDescriptor tableDescriptorToCopy) {
+    Preconditions.checkArgument(tableDescriptorToCopy != null, "Table descriptor should not be null");
+    return new HTableDescriptorBuilder(tableDescriptorToCopy);
   }
 
   @Override

--- a/cdap-hbase-compat-1.0-cdh/src/test/java/co/cask/cdap/data2/increment/hbase10cdh/IncrementHandlerTest.java
+++ b/cdap-hbase-compat-1.0-cdh/src/test/java/co/cask/cdap/data2/increment/hbase10cdh/IncrementHandlerTest.java
@@ -22,6 +22,7 @@ import co.cask.cdap.data2.increment.hbase.TimestampOracle;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
+import co.cask.cdap.data2.util.hbase.HTableDescriptorBuilder;
 import co.cask.cdap.test.SlowTests;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
@@ -108,14 +109,15 @@ public class IncrementHandlerTest extends AbstractIncrementHandlerTest {
   @Override
   public HTable createTable(TableId tableId) throws Exception {
     HBaseTableUtil tableUtil = new HBaseTableUtilFactory(cConf).get();
-    HTableDescriptor tableDesc = tableUtil.createHTableDescriptor(tableId);
+    HTableDescriptorBuilder tableDesc = tableUtil.createHTableDescriptor(tableId);
     HColumnDescriptor columnDesc = new HColumnDescriptor(FAMILY);
     columnDesc.setMaxVersions(Integer.MAX_VALUE);
     columnDesc.setValue(IncrementHandlerState.PROPERTY_TRANSACTIONAL, "false");
     tableDesc.addFamily(columnDesc);
     tableDesc.addCoprocessor(IncrementHandler.class.getName());
-    testUtil.getHBaseAdmin().createTable(tableDesc);
-    testUtil.waitUntilTableAvailable(tableDesc.getName(), 5000);
+    HTableDescriptor htd = tableDesc.build();
+    testUtil.getHBaseAdmin().createTable(htd);
+    testUtil.waitUntilTableAvailable(htd.getName(), 5000);
     return tableUtil.createHTable(conf, tableId);
   }
 

--- a/cdap-hbase-compat-1.0-cdh/src/test/java/co/cask/cdap/data2/increment/hbase10cdh/IncrementHandlerTest.java
+++ b/cdap-hbase-compat-1.0-cdh/src/test/java/co/cask/cdap/data2/increment/hbase10cdh/IncrementHandlerTest.java
@@ -109,7 +109,7 @@ public class IncrementHandlerTest extends AbstractIncrementHandlerTest {
   @Override
   public HTable createTable(TableId tableId) throws Exception {
     HBaseTableUtil tableUtil = new HBaseTableUtilFactory(cConf).get();
-    HTableDescriptorBuilder tableDesc = tableUtil.createHTableDescriptor(tableId);
+    HTableDescriptorBuilder tableDesc = tableUtil.buildHTableDescriptor(tableId);
     HColumnDescriptor columnDesc = new HColumnDescriptor(FAMILY);
     columnDesc.setMaxVersions(Integer.MAX_VALUE);
     columnDesc.setValue(IncrementHandlerState.PROPERTY_TRANSACTIONAL, "false");

--- a/cdap-hbase-compat-1.0-cdh/src/test/java/co/cask/cdap/data2/increment/hbase10cdh/IncrementSummingScannerTest.java
+++ b/cdap-hbase-compat-1.0-cdh/src/test/java/co/cask/cdap/data2/increment/hbase10cdh/IncrementSummingScannerTest.java
@@ -436,7 +436,7 @@ public class IncrementSummingScannerTest {
   static HRegion createRegion(Configuration hConf, CConfiguration cConf, TableId tableId,
                               HColumnDescriptor cfd) throws Exception {
     HBaseTableUtil tableUtil = new HBaseTableUtilFactory(cConf).get();
-    HTableDescriptorBuilder htd = tableUtil.createHTableDescriptor(tableId);
+    HTableDescriptorBuilder htd = tableUtil.buildHTableDescriptor(tableId);
     cfd.setMaxVersions(Integer.MAX_VALUE);
     cfd.setKeepDeletedCells(true);
     htd.addFamily(cfd);

--- a/cdap-hbase-compat-1.0-cdh/src/test/java/co/cask/cdap/data2/increment/hbase10cdh/IncrementSummingScannerTest.java
+++ b/cdap-hbase-compat-1.0-cdh/src/test/java/co/cask/cdap/data2/increment/hbase10cdh/IncrementSummingScannerTest.java
@@ -23,6 +23,7 @@ import co.cask.cdap.data2.increment.hbase.IncrementHandlerState;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
+import co.cask.cdap.data2.util.hbase.HTableDescriptorBuilder;
 import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -435,22 +436,23 @@ public class IncrementSummingScannerTest {
   static HRegion createRegion(Configuration hConf, CConfiguration cConf, TableId tableId,
                               HColumnDescriptor cfd) throws Exception {
     HBaseTableUtil tableUtil = new HBaseTableUtilFactory(cConf).get();
-    HTableDescriptor htd = tableUtil.createHTableDescriptor(tableId);
+    HTableDescriptorBuilder htd = tableUtil.createHTableDescriptor(tableId);
     cfd.setMaxVersions(Integer.MAX_VALUE);
     cfd.setKeepDeletedCells(true);
     htd.addFamily(cfd);
     htd.addCoprocessor(IncrementHandler.class.getName());
 
-    String tableName = htd.getNameAsString();
+    HTableDescriptor desc = htd.build();
+    String tableName = desc.getNameAsString();
     Path tablePath = new Path("/tmp/" + tableName);
     Path hlogPath = new Path("/tmp/hlog-" + tableName);
     FileSystem fs = FileSystem.get(hConf);
     assertTrue(fs.mkdirs(tablePath));
     WALFactory walFactory = new WALFactory(hConf, null, hlogPath.toString());
     WAL hLog = walFactory.getWAL(new byte[]{1});
-    HRegionInfo regionInfo = new HRegionInfo(htd.getTableName());
+    HRegionInfo regionInfo = new HRegionInfo(desc.getTableName());
     HRegionFileSystem regionFS = HRegionFileSystem.createRegionOnFileSystem(hConf, fs, tablePath, regionInfo);
-    return new HRegion(regionFS, hLog, hConf, htd,
+    return new HRegion(regionFS, hLog, hConf, desc,
                        new LocalRegionServerServices(hConf, ServerName.valueOf(
                            InetAddress.getLocalHost().getHostName(), 0, System.currentTimeMillis())));
   }

--- a/cdap-hbase-compat-1.0-cdh/src/test/java/co/cask/cdap/data2/util/hbase/HTable10CDHNameConverterTest.java
+++ b/cdap-hbase-compat-1.0-cdh/src/test/java/co/cask/cdap/data2/util/hbase/HTable10CDHNameConverterTest.java
@@ -19,7 +19,6 @@ package co.cask.cdap.data2.util.hbase;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.util.TableId;
-import org.apache.hadoop.hbase.HTableDescriptor;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -32,9 +31,9 @@ public class HTable10CDHNameConverterTest {
     HBaseTableUtil tableUtil = new HBaseTableUtilFactory(cConf).get();
     HTableNameConverter hBaseNameConversionUtil = new HTableNameConverterFactory().get();
 
-    HTableDescriptorBuilder htd = tableUtil.createHTableDescriptor(TableId.from("user", "some_table"));
+    HTableDescriptorBuilder htd = tableUtil.buildHTableDescriptor(TableId.from("user", "some_table"));
     Assert.assertEquals(tablePrefix + "_system:", hBaseNameConversionUtil.getSysConfigTablePrefix(htd.build()));
-    htd = tableUtil.createHTableDescriptor(TableId.from(Constants.DEFAULT_NAMESPACE_ID, "table_in_default_ns"));
+    htd = tableUtil.buildHTableDescriptor(TableId.from(Constants.DEFAULT_NAMESPACE_ID, "table_in_default_ns"));
     Assert.assertEquals(tablePrefix + "_system:", hBaseNameConversionUtil.getSysConfigTablePrefix(htd.build()));
   }
 }

--- a/cdap-hbase-compat-1.0-cdh/src/test/java/co/cask/cdap/data2/util/hbase/HTable10CDHNameConverterTest.java
+++ b/cdap-hbase-compat-1.0-cdh/src/test/java/co/cask/cdap/data2/util/hbase/HTable10CDHNameConverterTest.java
@@ -32,9 +32,9 @@ public class HTable10CDHNameConverterTest {
     HBaseTableUtil tableUtil = new HBaseTableUtilFactory(cConf).get();
     HTableNameConverter hBaseNameConversionUtil = new HTableNameConverterFactory().get();
 
-    HTableDescriptor htd = tableUtil.createHTableDescriptor(TableId.from("user", "some_table"));
-    Assert.assertEquals(tablePrefix + "_system:", hBaseNameConversionUtil.getSysConfigTablePrefix(htd));
+    HTableDescriptorBuilder htd = tableUtil.createHTableDescriptor(TableId.from("user", "some_table"));
+    Assert.assertEquals(tablePrefix + "_system:", hBaseNameConversionUtil.getSysConfigTablePrefix(htd.build()));
     htd = tableUtil.createHTableDescriptor(TableId.from(Constants.DEFAULT_NAMESPACE_ID, "table_in_default_ns"));
-    Assert.assertEquals(tablePrefix + "_system:", hBaseNameConversionUtil.getSysConfigTablePrefix(htd));
+    Assert.assertEquals(tablePrefix + "_system:", hBaseNameConversionUtil.getSysConfigTablePrefix(htd.build()));
   }
 }

--- a/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase10/HBaseQueueRegionObserver.java
+++ b/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase10/HBaseQueueRegionObserver.java
@@ -30,6 +30,7 @@ import co.cask.cdap.data2.util.hbase.HTable10NameConverter;
 import co.cask.tephra.coprocessor.TransactionStateCache;
 import co.cask.tephra.persist.TransactionSnapshot;
 import com.google.common.base.Supplier;
+import com.google.common.io.InputSupplier;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -37,6 +38,8 @@ import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CoprocessorEnvironment;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.HTableInterface;
 import org.apache.hadoop.hbase.coprocessor.BaseRegionObserver;
 import org.apache.hadoop.hbase.coprocessor.ObserverContext;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
@@ -62,8 +65,7 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
 
   private static final Log LOG = LogFactory.getLog(HBaseQueueRegionObserver.class);
 
-  private Configuration conf;
-  private byte[] configTableNameBytes;
+  private TableName configTableName;
   private CConfigurationReader cConfReader;
   TransactionStateCache txStateCache;
   private Supplier<TransactionSnapshot> txSnapshotSupplier;
@@ -96,7 +98,7 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
       appName = HBaseQueueAdmin.getApplicationName(hTableName);
       flowName = HBaseQueueAdmin.getFlowName(hTableName);
 
-      conf = env.getConfiguration();
+      Configuration conf = env.getConfiguration();
       String hbaseNamespacePrefix = nameConverter.getNamespacePrefix(tableDesc);
       TableId queueConfigTableId = HBaseQueueAdmin.getConfigTableId(namespaceId);
       final String sysConfigTablePrefix = nameConverter.getSysConfigTablePrefix(tableDesc);
@@ -107,9 +109,9 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
           return txStateCache.getLatestState();
         }
       };
-      configTableNameBytes = nameConverter.toTableName(hbaseNamespacePrefix, queueConfigTableId).getName();
+      configTableName = nameConverter.toTableName(hbaseNamespacePrefix, queueConfigTableId);
       cConfReader = new CConfigurationReader(conf, sysConfigTablePrefix);
-      configCache = ConsumerConfigCache.getInstance(conf, configTableNameBytes, cConfReader, txSnapshotSupplier);
+      configCache = createConfigCache(env);
     }
   }
 
@@ -137,11 +139,29 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
   }
 
   // needed for queue unit-test
-  private ConsumerConfigCache getConfigCache() {
+  @SuppressWarnings("unused")
+  private void updateCache() throws IOException {
+    ConsumerConfigCache configCache = this.configCache;
+    if (configCache != null) {
+      configCache.updateCache();
+    }
+  }
+
+  private ConsumerConfigCache getConfigCache(CoprocessorEnvironment env) {
     if (!configCache.isAlive()) {
-      configCache = ConsumerConfigCache.getInstance(conf, configTableNameBytes, cConfReader, txSnapshotSupplier);
+      configCache = createConfigCache(env);
     }
     return configCache;
+  }
+
+  private ConsumerConfigCache createConfigCache(final CoprocessorEnvironment env) {
+    return ConsumerConfigCache.getInstance(configTableName, cConfReader,
+                                           txSnapshotSupplier, new InputSupplier<HTableInterface>() {
+      @Override
+      public HTableInterface getInput() throws IOException {
+        return env.getTable(configTableName);
+      }
+    });
   }
 
   // need for queue unit-test
@@ -204,7 +224,7 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
                                                            cell.getRowLength());
           currentQueue = queueName.toBytes();
           currentQueueRowPrefix = QueueEntryRow.getQueueRowPrefix(queueName);
-          consumerConfig = getConfigCache().getConsumerConfig(currentQueue);
+          consumerConfig = getConfigCache(env).getConsumerConfig(currentQueue);
         }
 
         if (consumerConfig == null) {

--- a/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBase10QueueConsumer.java
+++ b/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBase10QueueConsumer.java
@@ -31,8 +31,10 @@ import org.apache.hadoop.hbase.filter.Filter;
 import org.apache.hadoop.hbase.filter.FilterList;
 import org.apache.hadoop.hbase.filter.SingleColumnValueFilter;
 
+import java.util.Map;
+
 /**
- * HBase 0.98 implementation of {@link HBaseQueueConsumer}.
+ * HBase 1.0 implementation of {@link HBaseQueueConsumer}.
  */
 final class HBase10QueueConsumer extends HBaseQueueConsumer {
   private final Filter processedStateFilter;
@@ -45,7 +47,7 @@ final class HBase10QueueConsumer extends HBaseQueueConsumer {
   }
 
   @Override
-  protected Scan createScan(byte[] startRow, byte[] stopRow, int numRows) {
+  protected Scan createScan(byte[] startRow, byte[] stopRow, int numRows, Map<String, byte[]> attributes) {
     // Scan the table for queue entries.
     Scan scan = new Scan();
     scan.setStartRow(startRow);
@@ -55,6 +57,11 @@ final class HBase10QueueConsumer extends HBaseQueueConsumer {
     scan.addColumn(QueueEntryRow.COLUMN_FAMILY, stateColumnName);
     scan.setFilter(createFilter());
     scan.setMaxVersions(1);
+
+    for (Map.Entry<String, byte[]> entry : attributes.entrySet()) {
+      scan.setAttribute(entry.getKey(), entry.getValue());
+    }
+
     return scan;
   }
 

--- a/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBase10QueueUtil.java
+++ b/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBase10QueueUtil.java
@@ -21,7 +21,7 @@ import co.cask.cdap.common.queue.QueueName;
 import org.apache.hadoop.hbase.client.HTable;
 
 /**
- * HBase 0.98 implementation of {@link HBaseQueueUtil}.
+ * HBase 1.0 implementation of {@link HBaseQueueUtil}.
  */
 public class HBase10QueueUtil extends HBaseQueueUtil {
   @Override

--- a/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase10DeleteBuilder.java
+++ b/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase10DeleteBuilder.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import org.apache.hadoop.hbase.client.Delete;
+
+/**
+ * HBase 1.0 specific implementation for {@link DeleteBuilder}.
+ */
+class HBase10DeleteBuilder extends DefaultDeleteBuilder {
+
+  HBase10DeleteBuilder(byte[] row) {
+    super(row);
+  }
+
+  HBase10DeleteBuilder(Delete delete) {
+    super(delete);
+  }
+
+  @Override
+  public DeleteBuilder setAttribute(String name, byte[] value) {
+    delete.setAttribute(name, value);
+    return this;
+  }
+
+  @Override
+  public DeleteBuilder setId(String id) {
+    delete.setId(id);
+    return this;
+  }
+
+  @Override
+  public DeleteBuilder setTimestamp(long timestamp) {
+    delete.setTimestamp(timestamp);
+    return this;
+  }
+}

--- a/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase10GetBuilder.java
+++ b/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase10GetBuilder.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import org.apache.hadoop.hbase.client.Get;
+
+/**
+ * HBase 1.0 specific implementation for {@link GetBuilder}.
+ */
+class HBase10GetBuilder extends DefaultGetBuilder {
+
+  HBase10GetBuilder(byte[] row) {
+    super(row);
+  }
+
+  HBase10GetBuilder(Get get) {
+    super(get);
+  }
+
+  @Override
+  public GetBuilder setCheckExistenceOnly(boolean checkExistenceOnly) {
+    get.setCheckExistenceOnly(checkExistenceOnly);
+    return this;
+  }
+
+  @Override
+  public GetBuilder setClosestRowBefore(boolean closestRowBefore) {
+    get.setClosestRowBefore(closestRowBefore);
+    return this;
+  }
+
+  @Override
+  public GetBuilder setAttribute(String name, byte[] value) {
+    get.setAttribute(name, value);
+    return this;
+  }
+
+  @Override
+  public GetBuilder setCacheBlocks(boolean cacheBlocks) {
+    get.setCacheBlocks(cacheBlocks);
+    return this;
+  }
+
+  @Override
+  public GetBuilder setId(String id) {
+    get.setId(id);
+    return this;
+  }
+}

--- a/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase10HTableDescriptorBuilder.java
+++ b/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase10HTableDescriptorBuilder.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.TableName;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * HBase 1.0 specific implementation for {@link HTableDescriptorBuilder}.
+ */
+public class HBase10HTableDescriptorBuilder extends HTableDescriptorBuilder {
+  HBase10HTableDescriptorBuilder(TableName tableName) {
+    super(tableName);
+  }
+
+  HBase10HTableDescriptorBuilder(HTableDescriptor descriptorToCopy) {
+    super(descriptorToCopy);
+  }
+
+  /* Methods whose signature changed in HBase 1.0 due to HBASE-10841 */
+  @Override
+  public HTableDescriptorBuilder setValue(byte[] key, byte[] value) {
+    instance.setValue(key, value);
+    return this;
+  }
+
+  @Override
+  public HTableDescriptorBuilder setValue(String key, String value) {
+    instance.setValue(key, value);
+    return this;
+  }
+
+  @Override
+  public HTableDescriptorBuilder addFamily(HColumnDescriptor columnDescriptor) {
+    instance.addFamily(columnDescriptor);
+    return this;
+  }
+
+  @Override
+  public HTableDescriptorBuilder addCoprocessor(String className) throws IOException {
+    instance.addCoprocessor(className);
+    return this;
+  }
+
+  @Override
+  public HTableDescriptorBuilder addCoprocessor(String className, Path jarFilePath, int priority,
+                                                Map<String, String> keyValues) throws IOException {
+    instance.addCoprocessor(className, jarFilePath, priority, keyValues);
+    return this;
+  }
+}

--- a/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase10PutBuilder.java
+++ b/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase10PutBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,15 +14,32 @@
  * the License.
  */
 
-package co.cask.cdap.data2.transaction.queue.hbase;
+package co.cask.cdap.data2.util.hbase;
 
-import co.cask.cdap.test.XSlowTests;
-import org.junit.experimental.categories.Category;
+import org.apache.hadoop.hbase.client.Put;
 
 /**
- * Queue test implementation running on HBase 1.0.
+ * HBase 1.0 specific implementation for {@link PutBuilder}.
  */
-@Category(XSlowTests.class)
-public class HBase10QueueTest extends HBaseQueueTest {
-  // nothing to override
+class HBase10PutBuilder extends DefaultPutBuilder {
+
+  HBase10PutBuilder(Put put) {
+    super(put);
+  }
+
+  HBase10PutBuilder(byte[] row) {
+    super(row);
+  }
+
+  @Override
+  public PutBuilder setAttribute(String name, byte[] value) {
+    put.setAttribute(name, value);
+    return this;
+  }
+
+  @Override
+  public PutBuilder setId(String id) {
+    put.setId(id);
+    return this;
+  }
 }

--- a/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase10ScanBuilder.java
+++ b/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase10ScanBuilder.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import org.apache.hadoop.hbase.client.IsolationLevel;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.security.access.Permission;
+import org.apache.hadoop.hbase.security.visibility.Authorizations;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * HBase 1.0 specific implementation for {@link ScanBuilder}.
+ */
+class HBase10ScanBuilder extends DefaultScanBuilder {
+
+  HBase10ScanBuilder() {
+    super();
+  }
+
+  HBase10ScanBuilder(Scan other) throws IOException {
+    super(other);
+  }
+
+  @Override
+  public ScanBuilder setAttribute(String name, byte[] value) {
+    scan.setAttribute(name, value);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setId(String id) {
+    scan.setId(id);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setAuthorizations(Authorizations authorizations) {
+    scan.setAuthorizations(authorizations);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setACL(String user, Permission perms) {
+    scan.setACL(user, perms);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setACL(Map<String, Permission> perms) {
+    scan.setACL(perms);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setBatch(int batch) {
+    scan.setBatch(batch);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setCacheBlocks(boolean cacheBlocks) {
+    scan.setCacheBlocks(cacheBlocks);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setCaching(int caching) {
+    scan.setCaching(caching);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setIsolationLevel(IsolationLevel level) {
+    scan.setIsolationLevel(level);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setLoadColumnFamiliesOnDemand(boolean value) {
+    scan.setLoadColumnFamiliesOnDemand(value);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setMaxResultSize(long maxResultSize) {
+    scan.setMaxResultSize(maxResultSize);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setMaxResultsPerColumnFamily(int limit) {
+    scan.setMaxResultsPerColumnFamily(limit);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setRaw(boolean raw) {
+    scan.setRaw(raw);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setRowOffsetPerColumnFamily(int offset) {
+    scan.setRowOffsetPerColumnFamily(offset);
+    return this;
+  }
+
+  @Override
+  public ScanBuilder setSmall(boolean small) {
+    scan.setSmall(small);
+    return this;
+  }
+}

--- a/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase10TableUtil.java
+++ b/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase10TableUtil.java
@@ -62,13 +62,13 @@ public class HBase10TableUtil extends HBaseTableUtil {
   }
 
   @Override
-  public HTableDescriptorBuilder createHTableDescriptor(TableId tableId) {
+  public HTableDescriptorBuilder buildHTableDescriptor(TableId tableId) {
     Preconditions.checkArgument(tableId != null, "Table id should not be null");
     return new HBase10HTableDescriptorBuilder(nameConverter.toTableName(tablePrefix, tableId));
   }
 
   @Override
-  public HTableDescriptorBuilder createHTableDescriptor(HTableDescriptor descriptorToCopy) {
+  public HTableDescriptorBuilder buildHTableDescriptor(HTableDescriptor descriptorToCopy) {
     Preconditions.checkArgument(descriptorToCopy != null, "Table descriptor should not be null");
     return new HBase10HTableDescriptorBuilder(descriptorToCopy);
   }

--- a/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase10TableUtil.java
+++ b/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase10TableUtil.java
@@ -36,8 +36,12 @@ import org.apache.hadoop.hbase.NamespaceNotFoundException;
 import org.apache.hadoop.hbase.RegionLoad;
 import org.apache.hadoop.hbase.ServerName;
 import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.HBaseAdmin;
 import org.apache.hadoop.hbase.client.HTable;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.io.compress.Compression;
 
 import java.io.IOException;
@@ -58,9 +62,15 @@ public class HBase10TableUtil extends HBaseTableUtil {
   }
 
   @Override
-  public HTableDescriptor createHTableDescriptor(TableId tableId) {
+  public HTableDescriptorBuilder createHTableDescriptor(TableId tableId) {
     Preconditions.checkArgument(tableId != null, "Table id should not be null");
-    return new HTableDescriptor(nameConverter.toTableName(tablePrefix, tableId));
+    return new HBase10HTableDescriptorBuilder(nameConverter.toTableName(tablePrefix, tableId));
+  }
+
+  @Override
+  public HTableDescriptorBuilder createHTableDescriptor(HTableDescriptor descriptorToCopy) {
+    Preconditions.checkArgument(descriptorToCopy != null, "Table descriptor should not be null");
+    return new HBase10HTableDescriptorBuilder(descriptorToCopy);
   }
 
   @Override
@@ -287,5 +297,45 @@ public class HBase10TableUtil extends HBaseTableUtil {
       }
     }
     return datasetStat;
+  }
+
+  @Override
+  public ScanBuilder buildScan() {
+    return new HBase10ScanBuilder();
+  }
+
+  @Override
+  public ScanBuilder buildScan(Scan scan) throws IOException {
+    return new HBase10ScanBuilder(scan);
+  }
+
+  @Override
+  public PutBuilder buildPut(byte[] row) {
+    return new HBase10PutBuilder(row);
+  }
+
+  @Override
+  public PutBuilder buildPut(Put put) {
+    return new HBase10PutBuilder(put);
+  }
+
+  @Override
+  public GetBuilder buildGet(byte[] row) {
+    return new HBase10GetBuilder(row);
+  }
+
+  @Override
+  public GetBuilder buildGet(Get get) {
+    return new HBase10GetBuilder(get);
+  }
+
+  @Override
+  public DeleteBuilder buildDelete(byte[] row) {
+    return new HBase10DeleteBuilder(row);
+  }
+
+  @Override
+  public DeleteBuilder buildDelete(Delete delete) {
+    return new HBase10DeleteBuilder(delete);
   }
 }

--- a/cdap-hbase-compat-1.0/src/test/java/co/cask/cdap/data2/increment/hbase10/IncrementHandlerTest.java
+++ b/cdap-hbase-compat-1.0/src/test/java/co/cask/cdap/data2/increment/hbase10/IncrementHandlerTest.java
@@ -22,6 +22,7 @@ import co.cask.cdap.data2.increment.hbase.TimestampOracle;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
+import co.cask.cdap.data2.util.hbase.HTableDescriptorBuilder;
 import co.cask.cdap.test.SlowTests;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
@@ -50,7 +51,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
 /**
- * Tests for the HBase 0.98+ version of the {@link IncrementHandler} coprocessor.
+ * Tests for the HBase 1.0 version of the {@link IncrementHandler} coprocessor.
  */
 @Category(SlowTests.class)
 public class IncrementHandlerTest extends AbstractIncrementHandlerTest {
@@ -108,14 +109,15 @@ public class IncrementHandlerTest extends AbstractIncrementHandlerTest {
   @Override
   public HTable createTable(TableId tableId) throws Exception {
     HBaseTableUtil tableUtil = new HBaseTableUtilFactory(cConf).get();
-    HTableDescriptor tableDesc = tableUtil.createHTableDescriptor(tableId);
+    HTableDescriptorBuilder tableDesc = tableUtil.createHTableDescriptor(tableId);
     HColumnDescriptor columnDesc = new HColumnDescriptor(FAMILY);
     columnDesc.setMaxVersions(Integer.MAX_VALUE);
     columnDesc.setValue(IncrementHandlerState.PROPERTY_TRANSACTIONAL, "false");
     tableDesc.addFamily(columnDesc);
     tableDesc.addCoprocessor(IncrementHandler.class.getName());
-    testUtil.getHBaseAdmin().createTable(tableDesc);
-    testUtil.waitUntilTableAvailable(tableDesc.getName(), 5000);
+    HTableDescriptor htd = tableDesc.build();
+    testUtil.getHBaseAdmin().createTable(htd);
+    testUtil.waitUntilTableAvailable(htd.getName(), 5000);
     return tableUtil.createHTable(conf, tableId);
   }
 

--- a/cdap-hbase-compat-1.0/src/test/java/co/cask/cdap/data2/increment/hbase10/IncrementHandlerTest.java
+++ b/cdap-hbase-compat-1.0/src/test/java/co/cask/cdap/data2/increment/hbase10/IncrementHandlerTest.java
@@ -109,7 +109,7 @@ public class IncrementHandlerTest extends AbstractIncrementHandlerTest {
   @Override
   public HTable createTable(TableId tableId) throws Exception {
     HBaseTableUtil tableUtil = new HBaseTableUtilFactory(cConf).get();
-    HTableDescriptorBuilder tableDesc = tableUtil.createHTableDescriptor(tableId);
+    HTableDescriptorBuilder tableDesc = tableUtil.buildHTableDescriptor(tableId);
     HColumnDescriptor columnDesc = new HColumnDescriptor(FAMILY);
     columnDesc.setMaxVersions(Integer.MAX_VALUE);
     columnDesc.setValue(IncrementHandlerState.PROPERTY_TRANSACTIONAL, "false");

--- a/cdap-hbase-compat-1.0/src/test/java/co/cask/cdap/data2/increment/hbase10/IncrementSummingScannerTest.java
+++ b/cdap-hbase-compat-1.0/src/test/java/co/cask/cdap/data2/increment/hbase10/IncrementSummingScannerTest.java
@@ -436,7 +436,7 @@ public class IncrementSummingScannerTest {
   static HRegion createRegion(Configuration hConf, CConfiguration cConf, TableId tableId,
                               HColumnDescriptor cfd) throws Exception {
     HBaseTableUtil tableUtil = new HBaseTableUtilFactory(cConf).get();
-    HTableDescriptorBuilder htd = tableUtil.createHTableDescriptor(tableId);
+    HTableDescriptorBuilder htd = tableUtil.buildHTableDescriptor(tableId);
     cfd.setMaxVersions(Integer.MAX_VALUE);
     cfd.setKeepDeletedCells(true);
     htd.addFamily(cfd);

--- a/cdap-hbase-compat-1.0/src/test/java/co/cask/cdap/data2/increment/hbase10/IncrementSummingScannerTest.java
+++ b/cdap-hbase-compat-1.0/src/test/java/co/cask/cdap/data2/increment/hbase10/IncrementSummingScannerTest.java
@@ -23,6 +23,7 @@ import co.cask.cdap.data2.increment.hbase.IncrementHandlerState;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
+import co.cask.cdap.data2.util.hbase.HTableDescriptorBuilder;
 import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -435,22 +436,23 @@ public class IncrementSummingScannerTest {
   static HRegion createRegion(Configuration hConf, CConfiguration cConf, TableId tableId,
                               HColumnDescriptor cfd) throws Exception {
     HBaseTableUtil tableUtil = new HBaseTableUtilFactory(cConf).get();
-    HTableDescriptor htd = tableUtil.createHTableDescriptor(tableId);
+    HTableDescriptorBuilder htd = tableUtil.createHTableDescriptor(tableId);
     cfd.setMaxVersions(Integer.MAX_VALUE);
     cfd.setKeepDeletedCells(true);
     htd.addFamily(cfd);
     htd.addCoprocessor(IncrementHandler.class.getName());
 
-    String tableName = htd.getNameAsString();
+    HTableDescriptor desc = htd.build();
+    String tableName = desc.getNameAsString();
     Path tablePath = new Path("/tmp/" + tableName);
     Path hlogPath = new Path("/tmp/hlog-" + tableName);
     FileSystem fs = FileSystem.get(hConf);
     assertTrue(fs.mkdirs(tablePath));
     WALFactory walFactory = new WALFactory(hConf, null, hlogPath.toString());
     WAL hLog = walFactory.getWAL(new byte[]{1});
-    HRegionInfo regionInfo = new HRegionInfo(htd.getTableName());
+    HRegionInfo regionInfo = new HRegionInfo(desc.getTableName());
     HRegionFileSystem regionFS = HRegionFileSystem.createRegionOnFileSystem(hConf, fs, tablePath, regionInfo);
-    return new HRegion(regionFS, hLog, hConf, htd,
+    return new HRegion(regionFS, hLog, hConf, desc,
                        new LocalRegionServerServices(hConf, ServerName.valueOf(
                            InetAddress.getLocalHost().getHostName(), 0, System.currentTimeMillis())));
   }

--- a/cdap-hbase-compat-1.0/src/test/java/co/cask/cdap/data2/util/hbase/HTable10NameConverterTest.java
+++ b/cdap-hbase-compat-1.0/src/test/java/co/cask/cdap/data2/util/hbase/HTable10NameConverterTest.java
@@ -19,7 +19,6 @@ package co.cask.cdap.data2.util.hbase;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.util.TableId;
-import org.apache.hadoop.hbase.HTableDescriptor;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -32,9 +31,9 @@ public class HTable10NameConverterTest {
     HBaseTableUtil tableUtil = new HBaseTableUtilFactory(cConf).get();
     HTableNameConverter hBaseNameConversionUtil = new HTableNameConverterFactory().get();
 
-    HTableDescriptorBuilder htd = tableUtil.createHTableDescriptor(TableId.from("user", "some_table"));
+    HTableDescriptorBuilder htd = tableUtil.buildHTableDescriptor(TableId.from("user", "some_table"));
     Assert.assertEquals(tablePrefix + "_system:", hBaseNameConversionUtil.getSysConfigTablePrefix(htd.build()));
-    htd = tableUtil.createHTableDescriptor(TableId.from(Constants.DEFAULT_NAMESPACE_ID, "table_in_default_ns"));
+    htd = tableUtil.buildHTableDescriptor(TableId.from(Constants.DEFAULT_NAMESPACE_ID, "table_in_default_ns"));
     Assert.assertEquals(tablePrefix + "_system:", hBaseNameConversionUtil.getSysConfigTablePrefix(htd.build()));
   }
 }

--- a/cdap-hbase-compat-1.0/src/test/java/co/cask/cdap/data2/util/hbase/HTable10NameConverterTest.java
+++ b/cdap-hbase-compat-1.0/src/test/java/co/cask/cdap/data2/util/hbase/HTable10NameConverterTest.java
@@ -32,9 +32,9 @@ public class HTable10NameConverterTest {
     HBaseTableUtil tableUtil = new HBaseTableUtilFactory(cConf).get();
     HTableNameConverter hBaseNameConversionUtil = new HTableNameConverterFactory().get();
 
-    HTableDescriptor htd = tableUtil.createHTableDescriptor(TableId.from("user", "some_table"));
-    Assert.assertEquals(tablePrefix + "_system:", hBaseNameConversionUtil.getSysConfigTablePrefix(htd));
+    HTableDescriptorBuilder htd = tableUtil.createHTableDescriptor(TableId.from("user", "some_table"));
+    Assert.assertEquals(tablePrefix + "_system:", hBaseNameConversionUtil.getSysConfigTablePrefix(htd.build()));
     htd = tableUtil.createHTableDescriptor(TableId.from(Constants.DEFAULT_NAMESPACE_ID, "table_in_default_ns"));
-    Assert.assertEquals(tablePrefix + "_system:", hBaseNameConversionUtil.getSysConfigTablePrefix(htd));
+    Assert.assertEquals(tablePrefix + "_system:", hBaseNameConversionUtil.getSysConfigTablePrefix(htd.build()));
   }
 }

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/AbstractQueueUpgrader.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/AbstractQueueUpgrader.java
@@ -23,18 +23,17 @@ import co.cask.cdap.data2.dataset2.lib.hbase.AbstractHBaseDataSetAdmin;
 import co.cask.cdap.data2.transaction.queue.QueueEntryRow;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
+import co.cask.cdap.data2.util.hbase.ScanBuilder;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HConstants;
-import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.HBaseAdmin;
 import org.apache.hadoop.hbase.client.HTable;
 import org.apache.hadoop.hbase.client.Mutation;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
-import org.apache.hadoop.hbase.client.Scan;
 import org.apache.twill.filesystem.LocationFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -87,14 +86,13 @@ public abstract class AbstractQueueUpgrader extends AbstractUpgrader {
 
     LOG.info("Starting upgrade for table {}", Bytes.toString(hTable.getTableName()));
     try {
-      Scan scan = new Scan();
+      ScanBuilder scan = tableUtil.buildScan();
       scan.setTimeRange(0, HConstants.LATEST_TIMESTAMP);
       scan.addFamily(QueueEntryRow.COLUMN_FAMILY);
       scan.setMaxVersions(1); // we only need to see one version of each row
       List<Mutation> mutations = Lists.newArrayList();
       Result result;
-      ResultScanner resultScanner = hTable.getScanner(scan);
-      try {
+      try (ResultScanner resultScanner = hTable.getScanner(scan.build())) {
         while ((result = resultScanner.next()) != null) {
           byte[] row = result.getRow();
           String rowKeyString = Bytes.toString(row);
@@ -109,12 +107,10 @@ public abstract class AbstractQueueUpgrader extends AbstractUpgrader {
               mutations.add(put);
             }
             LOG.debug("Marking old key {} for deletion", rowKeyString);
-            mutations.add(new Delete(row));
+            mutations.add(tableUtil.buildDelete(row).create());
           }
           LOG.info("Finished processing row key {}", rowKeyString);
         }
-      } finally {
-        resultScanner.close();
       }
 
       hTable.batch(mutations);

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/AbstractQueueUpgrader.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/AbstractQueueUpgrader.java
@@ -107,7 +107,7 @@ public abstract class AbstractQueueUpgrader extends AbstractUpgrader {
               mutations.add(put);
             }
             LOG.debug("Marking old key {} for deletion", rowKeyString);
-            mutations.add(tableUtil.buildDelete(row).create());
+            mutations.add(tableUtil.buildDelete(row).build());
           }
           LOG.info("Finished processing row key {}", rowKeyString);
         }

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/HBaseQueueDebugger.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/HBaseQueueDebugger.java
@@ -43,6 +43,7 @@ import co.cask.cdap.data2.transaction.queue.hbase.ShardedHBaseQueueStrategy;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
+import co.cask.cdap.data2.util.hbase.ScanBuilder;
 import co.cask.cdap.internal.app.runtime.flow.FlowUtils;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramType;
@@ -67,7 +68,6 @@ import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.google.inject.Singleton;
 import org.apache.hadoop.hbase.client.HTable;
-import org.apache.hadoop.hbase.client.Scan;
 import org.apache.twill.zookeeper.ZKClientService;
 
 import java.net.URI;
@@ -81,16 +81,18 @@ import javax.annotation.Nullable;
  */
 public class HBaseQueueDebugger extends AbstractIdleService {
 
+  private final HBaseTableUtil tableUtil;
   private final HBaseQueueAdmin queueAdmin;
   private final ZKClientService zkClientService;
   private final HBaseQueueClientFactory queueClientFactory;
   private final TransactionExecutorFactory txExecutorFactory;
 
   @Inject
-  public HBaseQueueDebugger(HBaseQueueAdmin queueAdmin,
+  public HBaseQueueDebugger(HBaseTableUtil tableUtil, HBaseQueueAdmin queueAdmin,
                             HBaseQueueClientFactory queueClientFactory,
                             ZKClientService zkClientService,
                             TransactionExecutorFactory txExecutorFactory) {
+    this.tableUtil = tableUtil;
     this.queueAdmin = queueAdmin;
     this.queueClientFactory = queueClientFactory;
     this.zkClientService = zkClientService;
@@ -177,9 +179,9 @@ public class HBaseQueueDebugger extends AbstractIdleService {
                                              Bytes.toBytes(groupConfig.getGroupId()));
 
     int distributorBuckets = queueClientFactory.getDistributorBuckets(hTable.getTableDescriptor());
-    ShardedHBaseQueueStrategy queueStrategy = new ShardedHBaseQueueStrategy(distributorBuckets);
+    ShardedHBaseQueueStrategy queueStrategy = new ShardedHBaseQueueStrategy(tableUtil, distributorBuckets);
 
-    Scan scan = new Scan();
+    ScanBuilder scan = tableUtil.buildScan();
     scan.setStartRow(start.getStartRow());
     if (end != null) {
       scan.setStopRow(end.getStartRow());
@@ -209,7 +211,7 @@ public class HBaseQueueDebugger extends AbstractIdleService {
     for (final int instanceId : instanceIds) {
       System.out.printf("Processing instance %d", instanceId);
       ConsumerConfig consConfig = new ConsumerConfig(groupConfig, instanceId);
-      final QueueScanner scanner = queueStrategy.createScanner(consConfig, hTable, scan, rowsCache);
+      final QueueScanner scanner = queueStrategy.createScanner(consConfig, hTable, scan.build(), rowsCache);
 
       try {
         txExecutor.execute(new TransactionExecutor.Procedure<HBaseConsumerStateStore>() {

--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,7 @@
     <hbase96.version>0.96.2-hadoop2</hbase96.version>
     <hbase98.version>0.98.6.1-hadoop2</hbase98.version>
     <hbase10cdh.version>1.0.0-cdh5.4.4</hbase10cdh.version>
+    <hbase10.version>1.0.1.1</hbase10.version>
     <hive.version>1.1.0</hive.version>
     <hsql.version>2.2.4</hsql.version>
     <http.component.version>4.2.5</http.component.version>
@@ -222,6 +223,17 @@
       <dependency>
         <groupId>co.cask.tephra</groupId>
         <artifactId>tephra-hbase-compat-1.0-cdh</artifactId>
+        <version>${tephra.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>co.cask.tephra</groupId>
+        <artifactId>tephra-hbase-compat-1.0</artifactId>
         <version>${tephra.version}</version>
         <exclusions>
           <exclusion>
@@ -2054,13 +2066,14 @@
         <module>cdap-common-unit-test</module>
         <module>cdap-api</module>
         <module>cdap-formats</module>
+        <module>cdap-hbase-compat-0.96</module>
+        <module>cdap-hbase-compat-0.98</module>
+        <module>cdap-hbase-compat-1.0-cdh</module>
+        <module>cdap-hbase-compat-1.0</module>
         <module>cdap-common</module>
         <module>cdap-watchdog-api</module>
         <module>cdap-kafka</module>
         <module>cdap-data-fabric</module>
-        <module>cdap-hbase-compat-0.96</module>
-        <module>cdap-hbase-compat-0.98</module>
-        <module>cdap-hbase-compat-1.0-cdh</module>
         <module>cdap-watchdog</module>
         <module>cdap-app-fabric</module>
         <module>cdap-security</module>

--- a/pom.xml
+++ b/pom.xml
@@ -1134,7 +1134,7 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.14.1</version>
           <configuration>
-            <argLine>-Xmx5000m -Djava.awt.headless=true -XX:MaxPermSize=256m -XX:+UseConcMarkSweepGC -XX:OnOutOfMemoryError="kill -9 %p"</argLine>
+            <argLine>-Xmx5000m -Djava.awt.headless=true -XX:MaxPermSize=256m -XX:+UseConcMarkSweepGC -XX:OnOutOfMemoryError="kill -9 %p" -Djava.net.preferIPv4Stack=true</argLine>
             <redirectTestOutputToFile>${surefire.redirectTestOutputToFile}</redirectTestOutputToFile>
             <reuseForks>false</reuseForks>
             <reportFormat>plain</reportFormat>


### PR DESCRIPTION
This commit adds support for Apache HBase 1.0:
* enables the cdap-hbase-compat-1.0 module
* abstracts use of the methods which have changed between prior HBase versions and 1.0 in certain client classes: Scan, Get, Put, Delete, HTableDescriptor.  Here we use builder classes which override the method calls in a version-specific implementation where necessary.