### PR TITLE
Fixes bower component (lodash) path from dist/lodash.js to just lodash.js

### DIFF
--- a/cdap-ui/Gulpfile.js
+++ b/cdap-ui/Gulpfile.js
@@ -114,9 +114,9 @@ gulp.task('js:lib', function() {
 
       './bower_components/d3/d3.min.js',
       './bower_components/d3-tip/index.js',
-      './bower_components/epoch/epoch.min.js',
 
-      './bower_components/lodash/dist/lodash.js',
+      './bower_components/epoch/epoch.min.js',
+      './bower_components/lodash/lodash.js',
       './bower_components/graphlib/dist/graphlib.core.js',
       './bower_components/dagre/dist/dagre.core.js',
       './bower_components/dagre-d3/dist/dagre-d3.core.js',


### PR DESCRIPTION
Merging this change https://github.com/caskdata/cdap/pull/3117 to release/3.0

Cluster: http://release3-01996-1000.dev.continuuity.net:9999/ns/default