### PR TITLE
CDAP-3002: Tick initialDelay does not work properly

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowletProcessEntry.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowletProcessEntry.java
@@ -15,6 +15,7 @@
  */
 package co.cask.cdap.internal.app.runtime.flow;
 
+import com.google.common.math.LongMath;
 import com.google.common.primitives.Longs;
 
 import java.util.concurrent.TimeUnit;
@@ -42,11 +43,23 @@ final class FlowletProcessEntry<T> implements Comparable<FlowletProcessEntry> {
   private final ProcessSpecification<T> processSpec;
   private final ProcessSpecification<T> retrySpec;
   private final boolean isTick;
+
+  /**
+   * {@code System.nanoTime} when the next deque should happen.
+   */
   private long nextDeque;
   private long currentBackOff = BACKOFF_MIN;
 
   static <T> FlowletProcessEntry<T> create(ProcessSpecification<T> processSpec) {
-    return new FlowletProcessEntry<>(processSpec, null, processSpec.getInitialCallDelay());
+    long nextDeque;
+    try {
+      nextDeque = LongMath.checkedAdd(System.nanoTime(), processSpec.getInitialCallDelay());
+    } catch (ArithmeticException e) {
+      // in case System.nanoTime + initialCallDelay > MAX_VALUE, we simply set nextDeque to MAX_VALUE
+      // so that the flowlet never performs a deque instead of dequing immediately.
+      nextDeque = Long.MAX_VALUE;
+    }
+    return new FlowletProcessEntry<>(processSpec, null, nextDeque);
   }
 
   static <T> FlowletProcessEntry<T> create(ProcessSpecification<T> processSpec, ProcessSpecification<T> retrySpec) {
@@ -58,6 +71,10 @@ final class FlowletProcessEntry<T> implements Comparable<FlowletProcessEntry> {
     this.retrySpec = retrySpec;
     this.nextDeque = nextDeque;
     this.isTick = processSpec.isTick();
+  }
+
+  long getNextDeque() {
+    return nextDeque;
   }
 
   public boolean isRetry() {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/flow/FlowletProcessEntryTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/flow/FlowletProcessEntryTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.internal.app.runtime.flow;
+
+import co.cask.cdap.api.annotation.Tick;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.annotation.Annotation;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Test for {@link FlowletProcessEntry}.
+ */
+public class FlowletProcessEntryTest {
+
+  @Test
+  public void testInitialDelay() {
+    long nanoTimeStart = System.nanoTime();
+    FlowletProcessEntry entry = FlowletProcessEntry.create(
+      new ProcessSpecification<>(null, null, new TickObject(100)));
+    Assert.assertEquals(floorNanosToSec(nanoTimeStart + TimeUnit.SECONDS.toNanos(100)),
+                        floorNanosToSec(entry.getNextDeque()));
+  }
+
+  @Test
+  public void testInitialDelayOverflow() {
+    FlowletProcessEntry entry = FlowletProcessEntry.create(
+      new ProcessSpecification<>(null, null, new TickObject(Long.MAX_VALUE)));
+    Assert.assertEquals(Long.MAX_VALUE, entry.getNextDeque());
+  }
+
+  private long floorNanosToSec(long nanoseconds) {
+    return TimeUnit.SECONDS.toNanos(TimeUnit.NANOSECONDS.toSeconds(nanoseconds));
+  }
+
+  /**
+   * Convenience class to construct {@link Tick} with a specified initialDelay.
+   */
+  private static class TickObject implements Tick {
+
+    private final long initialDelaySec;
+
+    private TickObject(long initialDelaySec) {
+      this.initialDelaySec = initialDelaySec;
+    }
+
+    @Override
+    public long initialDelay() {
+      return initialDelaySec;
+    }
+
+    @Override
+    public long delay() {
+      return 0;
+    }
+
+    @Override
+    public TimeUnit unit() {
+      return TimeUnit.SECONDS;
+    }
+
+    @Override
+    public int maxRetries() {
+      return Integer.MAX_VALUE;
+    }
+
+    @Override
+    public Class<? extends Annotation> annotationType() {
+      return Tick.class;
+    }
+  }
+}


### PR DESCRIPTION
- Handle @Tick initialDelay by treating it as a delay instead of a
  timestamp relative to `System.nanoTime()`

https://issues.cask.co/browse/CDAP-3002
http://builds.cask.co/browse/CDAP-DUT2232