### PR TITLE
CDAP-2967 inspect artifacts for application classes

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ApplicationClass.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ApplicationClass.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.artifact;
+
+import co.cask.cdap.api.annotation.Beta;
+import co.cask.cdap.api.data.schema.Schema;
+
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+/**
+ * Contains information about an Application class.
+ */
+@Beta
+public class ApplicationClass {
+
+  private final String className;
+  private final String description;
+  private final Schema configSchema;
+
+  public ApplicationClass(String className, String description, @Nullable Schema configSchema) {
+    if (description == null) {
+      throw new IllegalArgumentException("Application class description cannot be null");
+    }
+    if (className == null) {
+      throw new IllegalArgumentException("Application class className cannot be null");
+    }
+    this.className = className;
+    this.description = description;
+    this.configSchema = configSchema;
+  }
+
+  /**
+   * Returns description of the Application Class.
+   */
+  public String getDescription() {
+    return description;
+  }
+
+  /**
+   * Returns the fully qualified class name of the Application Class.
+   */
+  public String getClassName() {
+    return className;
+  }
+
+  /**
+   * Returns the schema of the Application config, or null if the Application does not use config
+   */
+  @Nullable
+  public Schema getConfigSchema() {
+    return configSchema;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    ApplicationClass that = (ApplicationClass) o;
+
+    return description.equals(that.description)
+      && className.equals(that.className)
+      && configSchema.equals(that.configSchema);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(className, description, configSchema);
+  }
+
+  @Override
+  public String toString() {
+    return "ApplicationClass{" +
+      "className='" + className + '\'' +
+      ", description='" + description + '\'' +
+      ", configSchema=" + configSchema +
+      '}';
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactClassLoaderFactory.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactClassLoaderFactory.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.artifact;
+
+import co.cask.cdap.common.lang.ProgramClassLoader;
+import co.cask.cdap.common.lang.jar.BundleJarUtil;
+import co.cask.cdap.common.utils.DirUtils;
+import com.google.common.io.Closeables;
+import org.apache.twill.filesystem.Location;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Given an artifact, creates a {@link CloseableClassLoader} from it. Takes care of unpacking the artifact and
+ * cleaning up the directory when the classloader is closed.
+ */
+class ArtifactClassLoaderFactory {
+  private static final Logger LOG = LoggerFactory.getLogger(ArtifactClassLoaderFactory.class);
+  private final File baseUnpackDir;
+
+  ArtifactClassLoaderFactory(File baseUnpackDir) {
+    this.baseUnpackDir = baseUnpackDir;
+  }
+
+  CloseableClassLoader createClassLoader(Location artifactLocation) throws IOException {
+    final File unpackDir = DirUtils.createTempDir(baseUnpackDir);
+    BundleJarUtil.unpackProgramJar(artifactLocation, unpackDir);
+    final ProgramClassLoader programClassLoader = ProgramClassLoader.create(unpackDir, getClass().getClassLoader());
+    return new CloseableClassLoader(programClassLoader, new Closeable() {
+      @Override
+      public void close() {
+        try {
+          Closeables.closeQuietly(programClassLoader);
+          DirUtils.deleteDirectoryContents(unpackDir);
+        } catch (IOException e) {
+          LOG.warn("Failed to delete directory {}", unpackDir, e);
+        }
+      }
+    });
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactClasses.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactClasses.java
@@ -17,20 +17,110 @@
 package co.cask.cdap.internal.app.runtime.artifact;
 
 import co.cask.cdap.api.templates.plugins.PluginClass;
+import com.google.common.collect.ImmutableSet;
 
-import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 
 /**
  * Classes contained in an artifact, such as plugin classes and application classes.
  */
 public class ArtifactClasses {
-  private final List<PluginClass> plugins;
+  private final Set<ApplicationClass> apps;
+  private final Set<PluginClass> plugins;
 
-  public ArtifactClasses(List<PluginClass> plugins) {
+  private ArtifactClasses(Set<ApplicationClass> apps, Set<PluginClass> plugins) {
+    this.apps = apps;
     this.plugins = plugins;
   }
 
-  public List<PluginClass> getPlugins() {
+  public Set<ApplicationClass> getApps() {
+    return apps;
+  }
+
+  public Set<PluginClass> getPlugins() {
     return plugins;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    ArtifactClasses that = (ArtifactClasses) o;
+
+    return Objects.equals(apps, that.apps) && Objects.equals(plugins, that.plugins);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(apps, plugins);
+  }
+
+  @Override
+  public String toString() {
+    return "ArtifactClasses{" +
+      "apps=" + apps +
+      ", plugins=" + plugins +
+      '}';
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Builder to more easily add application and plugin classes, and in the future, program and dataset classes.
+   */
+  public static class Builder {
+    private final ImmutableSet.Builder<ApplicationClass> appsBuilder;
+    private final ImmutableSet.Builder<PluginClass> pluginsBuilder;
+
+    private Builder() {
+      appsBuilder = ImmutableSet.builder();
+      pluginsBuilder = ImmutableSet.builder();
+    }
+
+    public Builder addApps(ApplicationClass... apps) {
+      for (ApplicationClass app : apps) {
+        appsBuilder.add(app);
+      }
+      return this;
+    }
+
+    public Builder addApps(Iterable<ApplicationClass> apps) {
+      appsBuilder.addAll(apps);
+      return this;
+    }
+
+    public Builder addApp(ApplicationClass app) {
+      appsBuilder.add(app);
+      return this;
+    }
+
+    public Builder addPlugins(PluginClass... plugins) {
+      for (PluginClass plugin : plugins) {
+        pluginsBuilder.add(plugin);
+      }
+      return this;
+    }
+
+    public Builder addPlugins(Iterable<PluginClass> plugins) {
+      pluginsBuilder.addAll(plugins);
+      return this;
+    }
+
+    public Builder addPlugin(PluginClass plugin) {
+      pluginsBuilder.add(plugin);
+      return this;
+    }
+
+    public ArtifactClasses build() {
+      return new ArtifactClasses(appsBuilder.build(), pluginsBuilder.build());
+    }
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactMeta.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactMeta.java
@@ -16,12 +16,8 @@
 
 package co.cask.cdap.internal.app.runtime.artifact;
 
-import co.cask.cdap.api.templates.plugins.PluginClass;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
-import java.util.Collections;
-import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
@@ -33,21 +29,21 @@ import java.util.Set;
  * as information about which versions of the etl-batch artifact can use the plugins it contains.
  */
 public class ArtifactMeta {
-  private final List<PluginClass> plugins;
+  private final ArtifactClasses classes;
   // can't call this 'extends' since that's a reserved keyword
   private final Set<ArtifactRange> usableBy;
 
-  public ArtifactMeta(List<PluginClass> plugins) {
-    this(plugins, ImmutableSet.<ArtifactRange>of());
+  public ArtifactMeta(ArtifactClasses classes) {
+    this(classes, ImmutableSet.<ArtifactRange>of());
   }
 
-  public ArtifactMeta(List<PluginClass> plugins, Set<ArtifactRange> usableBy) {
-    this.plugins = ImmutableList.copyOf(plugins);
-    this.usableBy = ImmutableSet.copyOf(usableBy);
+  public ArtifactMeta(ArtifactClasses classes, Set<ArtifactRange> usableBy) {
+    this.classes = classes;
+    this.usableBy = usableBy;
   }
 
-  public List<PluginClass> getPlugins() {
-    return plugins;
+  public ArtifactClasses getClasses() {
+    return classes;
   }
 
   public Set<ArtifactRange> getUsableBy() {
@@ -65,18 +61,18 @@ public class ArtifactMeta {
 
     ArtifactMeta that = (ArtifactMeta) o;
 
-    return Objects.equals(plugins, that.plugins) && Objects.equals(usableBy, that.usableBy);
+    return Objects.equals(classes, that.classes) && Objects.equals(usableBy, that.usableBy);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(plugins, usableBy);
+    return Objects.hash(classes, usableBy);
   }
 
   @Override
   public String toString() {
     return "ArtifactMeta{" +
-      "plugins=" + plugins +
+      "classes=" + classes +
       ", usableBy=" + usableBy +
       '}';
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStore.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.internal.app.runtime.artifact;
 
 import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.dataset.DatasetDefinition;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.table.ConflictDetection;
@@ -34,6 +35,7 @@ import co.cask.cdap.data2.dataset2.tx.DatasetContext;
 import co.cask.cdap.data2.dataset2.tx.Transactional;
 import co.cask.cdap.internal.artifact.ArtifactVersion;
 import co.cask.cdap.internal.filesystem.LocationCodec;
+import co.cask.cdap.internal.io.SchemaTypeAdapter;
 import co.cask.cdap.proto.Id;
 import co.cask.tephra.TransactionConflictException;
 import co.cask.tephra.TransactionExecutor;
@@ -134,6 +136,7 @@ public class ArtifactStore {
     this.locationFactory = namespacedLocationFactory;
     this.gson = new GsonBuilder()
       .registerTypeAdapter(Location.class, new LocationCodec(locationFactory))
+      .registerTypeAdapter(Schema.class, new SchemaTypeAdapter())
       .create();
     this.metaTable = Transactional.of(txExecutorFactory, new Supplier<DatasetContext<Table>>() {
       @Override
@@ -490,7 +493,7 @@ public class ArtifactStore {
     ArtifactColumn artifactColumn = new ArtifactColumn(artifactId);
 
     // write pluginClass metadata
-    for (PluginClass pluginClass : data.meta.getPlugins()) {
+    for (PluginClass pluginClass : data.meta.getClasses().getPlugins()) {
       // write metadata for each artifact this plugin extends
       for (ArtifactRange artifactRange : data.meta.getUsableBy()) {
         // p:{namespace}:{type}:{name}
@@ -516,7 +519,7 @@ public class ArtifactStore {
     ArtifactData oldMeta = gson.fromJson(Bytes.toString(oldData), ArtifactData.class);
     ArtifactColumn artifactColumn = new ArtifactColumn(artifactId);
 
-    for (PluginClass pluginClass : oldMeta.meta.getPlugins()) {
+    for (PluginClass pluginClass : oldMeta.meta.getClasses().getPlugins()) {
       // write metadata for each artifact this plugin extends
       for (ArtifactRange artifactRange : oldMeta.meta.getUsableBy()) {
         // p:{namespace}:{type}:{name}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/CloseableClassLoader.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/CloseableClassLoader.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.artifact;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+/**
+ * A {@link ClassLoader} that implements {@link Closeable} for resource cleanup. All classloading is done
+ * by the delegate {@link ClassLoader}.
+ */
+class CloseableClassLoader extends ClassLoader implements Closeable {
+
+  private final Closeable closeable;
+
+  public CloseableClassLoader(ClassLoader delegate, Closeable closeable) {
+    super(delegate);
+    this.closeable = closeable;
+  }
+
+  @Override
+  public void close() throws IOException {
+    closeable.close();
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/InvalidArtifactException.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/InvalidArtifactException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.artifact;
+
+/**
+ * Thrown when an artifact is invalid.
+ */
+public class InvalidArtifactException extends Exception {
+
+  public InvalidArtifactException(String message) {
+    super(message);
+  }
+
+  public InvalidArtifactException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactInspectorTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactInspectorTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.artifact;
+
+import co.cask.cdap.api.templates.plugins.PluginClass;
+import co.cask.cdap.api.templates.plugins.PluginPropertyField;
+import co.cask.cdap.app.program.ManifestFields;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.io.Locations;
+import co.cask.cdap.common.utils.DirUtils;
+import co.cask.cdap.internal.app.runtime.artifact.app.InspectionApp;
+import co.cask.cdap.internal.io.ReflectionSchemaGenerator;
+import co.cask.cdap.internal.test.AppJarHelper;
+import co.cask.cdap.proto.Id;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.io.Files;
+import org.apache.twill.filesystem.LocalLocationFactory;
+import org.apache.twill.filesystem.Location;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Set;
+import java.util.jar.Manifest;
+
+/**
+ */
+public class ArtifactInspectorTest {
+  @ClassRule
+  public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
+
+  private static ArtifactClassLoaderFactory classLoaderFactory;
+  private static ArtifactInspector artifactInspector;
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    CConfiguration cConf = CConfiguration.create();
+    cConf.set(Constants.CFG_LOCAL_DATA_DIR, TMP_FOLDER.newFolder().getAbsolutePath());
+    cConf.set(Constants.AppFabric.APP_TEMPLATE_DIR, TMP_FOLDER.newFolder().getAbsolutePath());
+
+    classLoaderFactory = new ArtifactClassLoaderFactory(TMP_FOLDER.newFolder());
+    artifactInspector = new ArtifactInspector(cConf, classLoaderFactory);
+  }
+
+  @Test
+  public void inspectAppsAndPlugins() throws Exception {
+    Manifest manifest = new Manifest();
+    manifest.getMainAttributes().put(ManifestFields.EXPORT_PACKAGE, InspectionApp.class.getPackage().getName());
+    File appFile =
+      createJar(InspectionApp.class, new File(TMP_FOLDER.newFolder(), "InspectionApp-1.0.0.jar"), manifest);
+
+    Id.Artifact artifactId = Id.Artifact.from(Constants.DEFAULT_NAMESPACE_ID, "InspectionApp", "1.0.0");
+    Location artifactLocation = Locations.toLocation(appFile);
+    try (CloseableClassLoader artifactClassLoader = classLoaderFactory.createClassLoader(artifactLocation)) {
+
+      ArtifactClasses classes = artifactInspector.inspectArtifact(artifactId, appFile, artifactClassLoader);
+
+      // check app classes
+      Set<ApplicationClass> expectedApps = ImmutableSet.of(new ApplicationClass(
+        InspectionApp.class.getName(), "", new ReflectionSchemaGenerator().generate(InspectionApp.AConfig.class)));
+      Assert.assertEquals(expectedApps, classes.getApps());
+
+      // check plugin classes
+      PluginClass expectedPlugin = new PluginClass(
+        InspectionApp.PLUGIN_TYPE, InspectionApp.PLUGIN_NAME, InspectionApp.PLUGIN_DESCRIPTION,
+        InspectionApp.AppPlugin.class.getName(), "pluginConf",
+        ImmutableMap.of(
+          "y", new PluginPropertyField("y", "", "double", true),
+          "isSomething", new PluginPropertyField("isSomething", "", "boolean", true)));
+      Assert.assertEquals(ImmutableSet.of(expectedPlugin), classes.getPlugins());
+    }
+  }
+
+  @Test(expected = InvalidArtifactException.class)
+  public void badAppMainClassThrowsException() throws Exception {
+    File appFile = createJar(InspectionApp.AppPlugin.class,
+      new File(TMP_FOLDER.newFolder(), "InspectionApp-1.0.0.jar"), new Manifest());
+    Id.Artifact artifactId = Id.Artifact.from(Constants.DEFAULT_NAMESPACE_ID, "InspectionApp", "1.0.0");
+    Location artifactLocation = Locations.toLocation(appFile);
+    try (CloseableClassLoader artifactClassLoader = classLoaderFactory.createClassLoader(artifactLocation)) {
+      artifactInspector.inspectArtifact(artifactId, appFile, artifactClassLoader);
+    }
+  }
+
+  private static File createJar(Class<?> cls, File destFile, Manifest manifest) throws IOException {
+    Location deploymentJar = AppJarHelper.createDeploymentJar(new LocalLocationFactory(TMP_FOLDER.newFolder()),
+      cls, manifest);
+    DirUtils.mkdirs(destFile.getParentFile());
+    Files.copy(Locations.newInputSupplier(deploymentJar), destFile);
+    return destFile;
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/app/InspectionApp.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/app/InspectionApp.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.artifact.app;
+
+import co.cask.cdap.api.Config;
+import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.api.templates.plugins.PluginConfig;
+
+/**
+ * App used in artifact inspector tests
+ */
+public class InspectionApp extends AbstractApplication<InspectionApp.AConfig> {
+  public static final String PLUGIN_DESCRIPTION = "some plugin";
+  public static final String PLUGIN_NAME = "pluginA";
+  public static final String PLUGIN_TYPE = "A";
+
+  public static class AConfig extends Config {
+    private int x;
+    private String str;
+  }
+
+  public static class PConfig extends PluginConfig {
+    private double y;
+    private boolean isSomething;
+  }
+
+  @Override
+  public void configure() {
+    // nothing since its not a real app
+  }
+
+  @Plugin(type = PLUGIN_TYPE)
+  @Name(PLUGIN_NAME)
+  @Description(PLUGIN_DESCRIPTION)
+  public static class AppPlugin {
+    private PConfig pluginConf;
+
+    public double doSomething() {
+      return pluginConf.y;
+    }
+  }
+}


### PR DESCRIPTION
Enhance the ArtifactInspector to inspect the artifact for
Application Classes. For now, using the current application
requirement of having the application main class contained
in the artifact manifest.