### PR TITLE
CDAP-2992: CLI broken for secure CDAP

### DIFF
--- a/cdap-cli/src/main/java/co/cask/cdap/cli/CLIConfig.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/CLIConfig.java
@@ -156,6 +156,7 @@ public class CLIConfig implements TableRendererConfig {
       }
       checkConnection(clientConfig, connectionConfig, accessToken);
       setConnectionConfig(connectionConfig);
+      clientConfig.setAccessToken(accessToken);
       output.printf("Successfully connected to CDAP instance at %s", connectionConfig.getURI().toString());
       output.println();
     } catch (IOException e) {


### PR DESCRIPTION
- Made CLIConfig.tryConnect also set access token upon successful
  connection

https://issues.cask.co/browse/CDAP-2992
http://builds.cask.co/browse/CDAP-DUT2236