### PR TITLE
Remove the unnecessary field

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/SparkTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/SparkTwillRunnable.java
@@ -18,17 +18,11 @@ package co.cask.cdap.internal.app.runtime.distributed;
 
 import co.cask.cdap.internal.app.runtime.spark.SparkProgramRunner;
 import org.apache.twill.api.TwillRunnable;
-import org.spark_project.protobuf.GeneratedMessage;
 
 /**
  * A {@link TwillRunnable} wrapper for {@link SparkProgramRunner}.
  */
 public class SparkTwillRunnable extends AbstractProgramTwillRunnable<SparkProgramRunner> {
-
-  // Don't remove. This dummy variable is needed for dependency tracing
-  // by Twill to pick the jar containing the GeneratedMessage class.
-  @SuppressWarnings("unused")
-  private GeneratedMessage gm;
 
   SparkTwillRunnable(String name, String hConfName, String cConfName) {
     super(name, hConfName, cConfName);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/WorkflowTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/WorkflowTwillRunnable.java
@@ -31,7 +31,6 @@ import com.google.inject.multibindings.MapBinder;
 import com.google.inject.util.Modules;
 import org.apache.hadoop.mapred.YarnClientProtocolProvider;
 import org.apache.twill.api.TwillContext;
-import org.spark_project.protobuf.GeneratedMessage;
 
 import java.util.Map;
 
@@ -43,12 +42,6 @@ final class WorkflowTwillRunnable extends AbstractProgramTwillRunnable<WorkflowP
   // NOTE: DO NOT REMOVE.  Though it is unused, the dependency is needed when submitting the mapred job.
   @SuppressWarnings("unused")
   private YarnClientProtocolProvider provider;
-
-  // Don't remove. This dummy variable is needed for dependency tracing
-  // by Twill to pick the jar containing the GeneratedMessage class.
-  @SuppressWarnings("unused")
-  private GeneratedMessage gm;
-
 
   WorkflowTwillRunnable(String name, String hConfName, String cConfName) {
     super(name, hConfName, cConfName);


### PR DESCRIPTION
- We no longer need those fields since we always ship the spark-assembly.jar to the spark containers, which contains everything spark needs.