### PR TITLE
[CDAP-2923] Added Support for Workflow Token in Spark programs run through workflows.

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/spark/SparkContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/spark/SparkContext.java
@@ -25,8 +25,11 @@ import co.cask.cdap.api.data.stream.Stream;
 import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.stream.StreamEventDecoder;
+import co.cask.cdap.api.workflow.Workflow;
+import co.cask.cdap.api.workflow.WorkflowToken;
 
 import java.io.Serializable;
+import javax.annotation.Nullable;
 
 /**
  * Spark job execution context. This context is shared between CDAP and User's Spark job.
@@ -165,4 +168,11 @@ public interface SparkContext extends RuntimeContext, DatasetContext {
    * @param <T> the SparkConf type
    */
   <T> void setSparkConf(T sparkConf);
+
+  /**
+   * @return the {@link WorkflowToken} associated with the current {@link Workflow},
+   * if the {@link Spark} program is executed as a part of the Workflow.
+   */
+  @Nullable
+  WorkflowToken getWorkflowToken();
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/NodeValue.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/NodeValue.java
@@ -16,12 +16,17 @@
 
 package co.cask.cdap.api.workflow;
 
+import java.io.Serializable;
+
 /**
  * Multiple nodes in the Workflow can add the same key to the {@link WorkflowToken}.
  * This class provides a mapping from node name to the {@link Value} which was set for the
  * specific key.
  */
-public final class NodeValue {
+public final class NodeValue implements Serializable {
+
+  private static final long serialVersionUID = 6157808964174399650L;
+
   private final String nodeName;
   private final Value value;
 

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/Value.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/Value.java
@@ -16,10 +16,15 @@
 
 package co.cask.cdap.api.workflow;
 
+import java.io.Serializable;
+
 /**
  * Class representing the value of the key in the {@link WorkflowToken}.
  */
-public class Value {
+public class Value implements Serializable {
+
+  private static final long serialVersionUID = -3420759818008526875L;
+
   private final String value;
 
   private Value(String value) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/AbstractSparkContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/AbstractSparkContext.java
@@ -29,6 +29,7 @@ import co.cask.cdap.api.spark.Spark;
 import co.cask.cdap.api.spark.SparkContext;
 import co.cask.cdap.api.spark.SparkProgram;
 import co.cask.cdap.api.spark.SparkSpecification;
+import co.cask.cdap.api.workflow.WorkflowToken;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.logging.LoggingContext;
 import co.cask.cdap.internal.app.program.ProgramTypeMetricTag;
@@ -48,6 +49,7 @@ import org.apache.twill.discovery.DiscoveryServiceClient;
 import java.io.Closeable;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * An abstract implementation of {@link SparkContext} for common functionality that spread across
@@ -61,10 +63,10 @@ public abstract class AbstractSparkContext implements SparkContext, Closeable {
   private final ClassLoader programClassLoader;
   private final long logicalStartTime;
   private final Map<String, String> runtimeArguments;
-
   private final DiscoveryServiceClient discoveryServiceClient;
   private final MetricsContext metricsContext;
   private final LoggingContext loggingContext;
+  private final WorkflowToken workflowToken;
 
   private Resources executorResources;
   private SparkConf sparkConf;
@@ -72,7 +74,8 @@ public abstract class AbstractSparkContext implements SparkContext, Closeable {
   protected AbstractSparkContext(SparkSpecification specification, Id.Program programId, RunId runId,
                                  ClassLoader programClassLoader, long logicalStartTime,
                                  Map<String, String> runtimeArguments, DiscoveryServiceClient discoveryServiceClient,
-                                 MetricsContext metricsContext, LoggingContext loggingContext) {
+                                 MetricsContext metricsContext, LoggingContext loggingContext,
+                                 @Nullable WorkflowToken workflowToken) {
     this.specification = specification;
     this.programId = programId;
     this.runId = runId;
@@ -84,6 +87,7 @@ public abstract class AbstractSparkContext implements SparkContext, Closeable {
     this.loggingContext = loggingContext;
     this.executorResources = Objects.firstNonNull(specification.getExecutorResources(), new Resources());
     this.sparkConf = new SparkConf();
+    this.workflowToken = workflowToken;
   }
 
   @Override
@@ -130,6 +134,12 @@ public abstract class AbstractSparkContext implements SparkContext, Closeable {
   public void setExecutorResources(Resources resources) {
     Preconditions.checkArgument(resources != null, "Resources must not be null");
     this.executorResources = resources;
+  }
+
+  @Nullable
+  @Override
+  public WorkflowToken getWorkflowToken() {
+    return workflowToken;
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/ClientSparkContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/ClientSparkContext.java
@@ -22,6 +22,7 @@ import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.api.spark.Spark;
 import co.cask.cdap.api.spark.SparkContext;
 import co.cask.cdap.api.stream.StreamEventDecoder;
+import co.cask.cdap.api.workflow.WorkflowToken;
 import co.cask.cdap.app.program.Program;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.DynamicDatasetContext;
@@ -33,6 +34,7 @@ import org.apache.twill.discovery.DiscoveryServiceClient;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * A {@link SparkContext} implementation that is used in {@link Spark#beforeSubmit(SparkContext)} and
@@ -49,12 +51,12 @@ public final class ClientSparkContext extends AbstractSparkContext {
   public ClientSparkContext(Program program, RunId runId, long logicalStartTime, Map<String, String> runtimeArguments,
                             TransactionContext transactionContext, DatasetFramework datasetFramework,
                             DiscoveryServiceClient discoveryServiceClient,
-                            MetricsCollectionService metricsCollectionService) {
+                            MetricsCollectionService metricsCollectionService, @Nullable WorkflowToken workflowToken) {
     super(program.getApplicationSpecification().getSpark().get(program.getName()),
          program.getId(), runId, program.getClassLoader(), logicalStartTime,
          runtimeArguments, discoveryServiceClient,
          createMetricsContext(metricsCollectionService, program.getId(), runId),
-         createLoggingContext(program.getId(), runId));
+         createLoggingContext(program.getId(), runId), workflowToken);
 
     this.datasets = new ArrayList<>();
     this.transactionContext = transactionContext;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/ExecutionSparkContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/ExecutionSparkContext.java
@@ -34,6 +34,7 @@ import co.cask.cdap.api.spark.SparkContext;
 import co.cask.cdap.api.spark.SparkProgram;
 import co.cask.cdap.api.spark.SparkSpecification;
 import co.cask.cdap.api.stream.StreamEventDecoder;
+import co.cask.cdap.api.workflow.WorkflowToken;
 import co.cask.cdap.common.logging.LoggingContext;
 import co.cask.cdap.data.dataset.DatasetInstantiator;
 import co.cask.cdap.data.stream.StreamInputFormat;
@@ -67,6 +68,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * A {@link SparkContext} implementation that is used in both {@link SparkProgram#run(SparkContext)} and
@@ -93,11 +95,11 @@ public class ExecutionSparkContext extends AbstractSparkContext {
                                Transaction transaction, DatasetFramework datasetFramework,
                                DiscoveryServiceClient discoveryServiceClient,
                                MetricsCollectionService metricsCollectionService,
-                               Configuration hConf, StreamAdmin streamAdmin) {
+                               Configuration hConf, StreamAdmin streamAdmin, @Nullable WorkflowToken workflowToken) {
     this(specification, programId, runId, programClassLoader, logicalStartTime, runtimeArguments,
          transaction, datasetFramework, discoveryServiceClient,
          createMetricsContext(metricsCollectionService, programId, runId),
-         createLoggingContext(programId, runId), hConf, streamAdmin);
+         createLoggingContext(programId, runId), hConf, streamAdmin, workflowToken);
   }
 
   public ExecutionSparkContext(SparkSpecification specification, Id.Program programId, RunId runId,
@@ -105,9 +107,10 @@ public class ExecutionSparkContext extends AbstractSparkContext {
                                Map<String, String> runtimeArguments,
                                Transaction transaction, DatasetFramework datasetFramework,
                                DiscoveryServiceClient discoveryServiceClient, MetricsContext metricsContext,
-                               LoggingContext loggingContext, Configuration hConf, StreamAdmin streamAdmin) {
+                               LoggingContext loggingContext, Configuration hConf, StreamAdmin streamAdmin,
+                               WorkflowToken workflowToken) {
     super(specification, programId, runId, programClassLoader, logicalStartTime,
-          runtimeArguments, discoveryServiceClient, metricsContext, loggingContext);
+          runtimeArguments, discoveryServiceClient, metricsContext, loggingContext, workflowToken);
 
     this.datasets = new HashMap<>();
     this.hConf = hConf;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkContextConfig.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkContextConfig.java
@@ -17,8 +17,10 @@
 package co.cask.cdap.internal.app.runtime.spark;
 
 import co.cask.cdap.api.spark.SparkSpecification;
+import co.cask.cdap.api.workflow.WorkflowToken;
 import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.internal.app.ApplicationSpecificationAdapter;
+import co.cask.cdap.internal.app.runtime.workflow.BasicWorkflowToken;
 import co.cask.cdap.proto.Id;
 import co.cask.tephra.Transaction;
 import com.google.common.reflect.TypeToken;
@@ -29,6 +31,7 @@ import org.apache.twill.api.RunId;
 
 import java.lang.reflect.Type;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Helper class for getting and setting specific config settings for a spark job context.
@@ -48,6 +51,7 @@ public class SparkContextConfig {
   private static final String HCONF_ATTR_LOGICAL_START_TIME = "hconf.program.logical.start.time";
   private static final String HCONF_ATTR_ARGS = "hconf.program.args";
   private static final String HCONF_ATTR_NEW_TX = "hconf.program.newtx.tx";
+  private static final String HCONF_ATTR_WORKFLOW_TOKEN = "hconf.program.workflow.token";
 
   private final Configuration hConf;
 
@@ -82,6 +86,7 @@ public class SparkContextConfig {
     setLogicalStartTime(context.getLogicalStartTime());
     setArguments(context.getRuntimeArguments());
     setTransaction(context.getTransaction());
+    setWorkflowToken(context.getWorkflowToken());
 
     return this;
   }
@@ -91,45 +96,53 @@ public class SparkContextConfig {
   }
 
   /**
-   * Returns the {@link SparkSpecification} stored in the configuration.
+   * @return the {@link SparkSpecification} stored in the configuration.
    */
   public SparkSpecification getSpecification() {
     return GSON.fromJson(hConf.get(HCONF_ATTR_PROGRAM_SPEC), SparkSpecification.class);
   }
 
   /**
-   * Returns the {@link Id.Program} stored in the configuration.
+   * @return the {@link Id.Program} stored in the configuration.
    */
   public Id.Program getProgramId() {
     return GSON.fromJson(hConf.get(HCONF_ATTR_PROGRAM_ID), Id.Program.class);
   }
 
   /**
-   * Returns the {@link RunId} stored in the configuration.
+   * @return the {@link RunId} stored in the configuration.
    */
   public RunId getRunId() {
     return RunIds.fromString(hConf.get(HCONF_ATTR_RUN_ID));
   }
 
   /**
-   * Returns the runtime arguments stored in the configuration.
+   * @return the runtime arguments stored in the configuration.
    */
   public Map<String, String> getArguments() {
     return GSON.fromJson(hConf.get(HCONF_ATTR_ARGS), ARGS_TYPE);
   }
 
   /**
-   * Returns the logical start time stored in the configuration.
+   * @return the logical start time stored in the configuration.
    */
   public long getLogicalStartTime() {
     return hConf.getLong(HCONF_ATTR_LOGICAL_START_TIME, System.currentTimeMillis());
   }
 
   /**
-   * Returns the transaction stored in the configuration.
+   * @return the {@link Transaction} stored in the configuration.
    */
   public Transaction getTransaction() {
     return GSON.fromJson(hConf.get(HCONF_ATTR_NEW_TX), Transaction.class);
+  }
+
+  /**
+   * @return the {@link WorkflowToken} stored in the configuration.
+   */
+  @Nullable
+  public WorkflowToken getWorkflowToken() {
+    return GSON.fromJson(hConf.get(HCONF_ATTR_WORKFLOW_TOKEN), BasicWorkflowToken.class);
   }
 
   private void setSpecification(SparkSpecification spec) {
@@ -154,5 +167,9 @@ public class SparkContextConfig {
 
   private void setTransaction(Transaction tx) {
     hConf.set(HCONF_ATTR_NEW_TX, GSON.toJson(tx));
+  }
+
+  public void setWorkflowToken(@Nullable WorkflowToken workflowToken) {
+    hConf.set(HCONF_ATTR_WORKFLOW_TOKEN, GSON.toJson(workflowToken));
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkContextFactory.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkContextFactory.java
@@ -61,7 +61,7 @@ final class SparkContextFactory {
                                      clientContext.getLogicalStartTime(), clientContext.getRuntimeArguments(),
                                      transaction, datasetFramework, clientContext.getDiscoveryServiceClient(),
                                      clientContext.getMetricsContext(), clientContext.getLoggingContext(),
-                                     hConf, streamAdmin);
+                                     hConf, streamAdmin, clientContext.getWorkflowToken());
   }
 
   private SparkSpecification updateSpecExecutorResources(SparkSpecification originalSpec, Resources executorResources) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkContextProvider.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkContextProvider.java
@@ -154,7 +154,7 @@ public final class SparkContextProvider {
         classLoader, contextConfig.getLogicalStartTime(), contextConfig.getArguments(),
         contextConfig.getTransaction(), injector.getInstance(DatasetFramework.class),
         injector.getInstance(DiscoveryServiceClient.class), metricsCollectionService, hConf,
-        injector.getInstance(StreamAdmin.class)
+        injector.getInstance(StreamAdmin.class), contextConfig.getWorkflowToken()
       );
       return sparkContext;
     } catch (Exception e) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/BasicWorkflowToken.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/BasicWorkflowToken.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 
+import java.io.Serializable;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
@@ -32,7 +33,10 @@ import java.util.Map;
 /**
  * Implementation of the {@link WorkflowToken} interface.
  */
-public class BasicWorkflowToken implements WorkflowToken {
+public class BasicWorkflowToken implements WorkflowToken, Serializable {
+
+  private static final long serialVersionUID = -1173500180640174909L;
+
   private Map<String, Map<String, Long>> mapReduceCounters;
   private final Map<Scope, Map<String, List<NodeValue>>> tokenValueMap = new EnumMap<>(Scope.class);
   private String nodeName;


### PR DESCRIPTION
Jira: [CDAP-2923](https://issues.cask.co/browse/CDAP-2923)
Build: http://builds.cask.co/browse/CDAP-DUT2240

Note: Currently, workflow token is available in ``beforeSubmit``, ``onFinish``, ``driver`` and ``executor``. However, you can only update it in ``beforeSubmit``, ``onFinish`` and ``driver``

