### PR TITLE
Fixes margin top for the entire view to be consistent (for namespace dropdown)

### DIFF
--- a/cdap-ui/app/styles/common.less
+++ b/cdap-ui/app/styles/common.less
@@ -22,6 +22,7 @@ body {
   div.progress { margin: 1px; /* by default they have just margin-bottom: 20px */ }
 
   main.container {
+    margin-top: 100px;
     padding-top: 1em;
     > div { margin-bottom: 80px; }
     .sidebar {
@@ -34,15 +35,6 @@ body {
         }
       }
     }
-  }
-  &.state-overview {
-    main.container { margin-top: 130px; }
-  }
-  &.state-dashboard {
-    main.container { margin-top: 150px; }
-  }
-  &.state-admin {
-    main.container { margin-top: 100px; }
   }
 }
 


### PR DESCRIPTION
Fixes the margin top on all view . The current style prevented user from accessing any part of UI on top of the page.
