### PR TITLE
port changes to release_3_0

### DIFF
--- a/cdap-distributions/bin/build_artifact_upload.sh
+++ b/cdap-distributions/bin/build_artifact_upload.sh
@@ -116,7 +116,11 @@ function sync_build_artifacts_to_server () {
     decho "version stub=${_version_stub}"
     _version=`echo ${_version_stub} | awk -F - '{ print $1 }' | awk -F . '{ print $1"."$2"."$3 }'`
     decho "version = ${_version}"
-    _snapshot_time=`echo ${_version_stub} | awk -F - '{ print $1 }' | sed 's/\([0-9]\.[0-9]\.[0-9]\)\.\([0-9]*\)/\2/'`
+    _snapshot_time=`echo ${_version_stub} | awk -F - '{ print $1 }' | sed 's/[0-9]\.[0-9]\.[0-9][\.]*\([0-9]*\)/\1/'`
+    if [ "${_version}" == ${_snapshot_time} ]; then
+      _snapshot_time=''
+    fi
+    decho "snapshot time = ${_snapshot_time}"
 
     # identify and create remote incoming directory
     if [ "${_snapshot_time}" == '' ]; then
@@ -128,8 +132,8 @@ function sync_build_artifacts_to_server () {
     ssh -l ${REMOTE_USER} ${REMOTE_HOST} "mkdir -p ${REMOTE_INCOMING_DIR}/${OUTGOING_DIR}" || die "could not create remote directory"
 
     # sync package(s) to remote server
-    decho "rsyncing with rsync -av -e \"ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null\" ${RSYNC_QUIET} ${i} ${REMOTE_BASE_DIR}/${OUTGOING_DIR} ${DRY_RUN} 2>&1"
-    rsync -av -e "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" ${RSYNC_QUIET} ${i} ${REMOTE_BASE_DIR}/${OUTGOING_DIR} ${DRY_RUN} 2>&1 || die "could not rsync ${_package} as ${REMOTE_USER} to ${REMOTE_HOST}: ${!}"
+    decho "rsyncing with rsync -av -e \"ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null\" ${RSYNC_QUIET} ${i} ${REMOTE_BASE_DIR}/${OUTGOING_DIR}/ ${DRY_RUN} 2>&1"
+    rsync -av -e "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" ${RSYNC_QUIET} ${i} ${REMOTE_BASE_DIR}/${OUTGOING_DIR}/ ${DRY_RUN} 2>&1 || die "could not rsync ${_package} as ${REMOTE_USER} to ${REMOTE_HOST}: ${!}"
     decho ""
   done
 }


### PR DESCRIPTION
Port over build_artifact_upload script changes to release 3.0.
This fixes the following issues:
* artifacts erroneously going to snapshot incoming directory on docs
* sync to remote should copy to blah/ not blah (risking creating a file, not adding to directory)

Note: this last thing should be ported back to 2.8 as well.