### PR TITLE
Change PartitionedFileSetDataset#dropPartition to recursively delete …

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetDataset.java
@@ -331,9 +331,13 @@ public class PartitionedFileSetDataset extends AbstractDataset implements Partit
     }
     if (!isExternal) {
       try {
-        partition.getLocation().delete();
+        boolean deleteSuccess = partition.getLocation().delete(true);
+        if (!deleteSuccess) {
+          throw new DataSetException(String.format("Error deleting file(s) for partition %s at path %s.",
+                                                   key, partition.getLocation().toURI().getPath()));
+        }
       } catch (IOException e) {
-        throw new DataSetException(String.format("Error deleting file(s) for partition %s at path %s: %s",
+        throw new DataSetException(String.format("Error deleting file(s) for partition %s at path %s: %s.",
                                                  key, partition.getLocation().toURI().getPath(), e.getMessage()), e);
       }
     }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetDataset.java
@@ -331,10 +331,12 @@ public class PartitionedFileSetDataset extends AbstractDataset implements Partit
     }
     if (!isExternal) {
       try {
-        boolean deleteSuccess = partition.getLocation().delete(true);
-        if (!deleteSuccess) {
-          throw new DataSetException(String.format("Error deleting file(s) for partition %s at path %s.",
-                                                   key, partition.getLocation().toURI().getPath()));
+        if (partition.getLocation().exists()) {
+          boolean deleteSuccess = partition.getLocation().delete(true);
+          if (!deleteSuccess) {
+            throw new DataSetException(String.format("Error deleting file(s) for partition %s at path %s.",
+                                                     key, partition.getLocation().toURI().getPath()));
+          }
         }
       } catch (IOException e) {
         throw new DataSetException(String.format("Error deleting file(s) for partition %s at path %s: %s.",

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetTest.java
@@ -393,7 +393,7 @@ public class PartitionedFileSetTest {
       @Override
       public void apply() throws Exception {
         PartitionOutput output = pfs.getPartitionOutput(PARTITION_KEY);
-        Location outputLocation = output.getLocation();
+        Location outputLocation = output.getLocation().append("file");
         OutputStream out = outputLocation.getOutputStream();
         out.close();
         output.addPartition();


### PR DESCRIPTION
…the partition files. Also throw dataset exception if the call to delete fails without throwing an exception.

The necessary change is passing `true` to the call to `delete`. The remainder is additional error-checking.

http://builds.cask.co/browse/CDAP-RBT309-4
https://issues.cask.co/browse/CDAP-3019