### PR TITLE
CDAP-3001 fix classloading for getting user dataset admins

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/dataset/SystemDatasetInstantiator.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/dataset/SystemDatasetInstantiator.java
@@ -18,10 +18,12 @@ package co.cask.cdap.data.dataset;
 
 import co.cask.cdap.api.data.DatasetInstantiationException;
 import co.cask.cdap.api.dataset.Dataset;
+import co.cask.cdap.api.dataset.DatasetAdmin;
 import co.cask.cdap.api.dataset.DatasetDefinition;
 import co.cask.cdap.data2.datafabric.dataset.type.DatasetClassLoaderProvider;
 import co.cask.cdap.data2.datafabric.dataset.type.DirectoryClassLoaderProvider;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.dataset2.DatasetManagementException;
 import co.cask.cdap.proto.Id;
 import com.google.common.base.Objects;
 
@@ -54,6 +56,12 @@ public class SystemDatasetInstantiator implements Closeable {
     this.parentClassLoader = parentClassLoader == null ?
       Objects.firstNonNull(Thread.currentThread().getContextClassLoader(), getClass().getClassLoader()) :
       parentClassLoader;
+  }
+
+  @Nullable
+  public <T extends DatasetAdmin> T getDatasetAdmin(Id.DatasetInstance datasetId)
+    throws DatasetManagementException, IOException {
+    return datasetFramework.getAdmin(datasetId, parentClassLoader, classLoaderProvider);
   }
 
   public <T extends Dataset> T getDataset(Id.DatasetInstance datasetId)

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/dataset/SystemDatasetInstantiatorFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/dataset/SystemDatasetInstantiatorFactory.java
@@ -37,9 +37,9 @@ public class SystemDatasetInstantiatorFactory {
   private final CConfiguration cConf;
 
   @Inject
-  private SystemDatasetInstantiatorFactory(LocationFactory locationFactory,
-                                           DatasetFramework datasetFramework,
-                                           CConfiguration cConf) {
+  public SystemDatasetInstantiatorFactory(LocationFactory locationFactory,
+                                          DatasetFramework datasetFramework,
+                                          CConfiguration cConf) {
     this.locationFactory = locationFactory;
     this.datasetFramework = datasetFramework;
     this.cConf = cConf;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFramework.java
@@ -177,6 +177,15 @@ public class RemoteDatasetFramework implements DatasetFramework {
   @Override
   public <T extends DatasetAdmin> T getAdmin(Id.DatasetInstance datasetInstanceId, ClassLoader classLoader)
     throws DatasetManagementException, IOException {
+    return getAdmin(datasetInstanceId, classLoader, new ConstantClassLoaderProvider(classLoader));
+  }
+
+  @Nullable
+  @Override
+  public <T extends DatasetAdmin> T getAdmin(Id.DatasetInstance datasetInstanceId,
+                                             @Nullable ClassLoader parentClassLoader,
+                                             DatasetClassLoaderProvider classLoaderProvider)
+    throws DatasetManagementException, IOException {
     DatasetMeta instanceInfo = clientCache.getUnchecked(datasetInstanceId.getNamespace())
       .getInstance(datasetInstanceId.getId());
     if (instanceInfo == null) {
@@ -184,7 +193,7 @@ public class RemoteDatasetFramework implements DatasetFramework {
     }
 
     DatasetType type =
-      getDatasetType(instanceInfo.getType(), classLoader, new ConstantClassLoaderProvider(classLoader));
+      getDatasetType(instanceInfo.getType(), parentClassLoader, classLoaderProvider);
     return (T) type.getAdmin(DatasetContext.from(datasetInstanceId.getNamespaceId()), instanceInfo.getSpec());
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DatasetFramework.java
@@ -176,7 +176,9 @@ public interface DatasetFramework {
   void deleteAllInstances(Id.Namespace namespaceId) throws DatasetManagementException, IOException;
 
   /**
-   * Gets dataset instance admin to be used to perform administrative operations.
+   * Gets dataset instance admin to be used to perform administrative operations. The given classloader must
+   * be able to load all classes needed to instantiate the dataset admin. This means if the system classloader is
+   * used, only system dataset admins can fetched.
    *
    * @param <T> dataset admin type
    * @param datasetInstanceId dataset instance name
@@ -187,6 +189,25 @@ public interface DatasetFramework {
    */
   @Nullable
   <T extends DatasetAdmin> T getAdmin(Id.DatasetInstance datasetInstanceId, @Nullable ClassLoader classLoader)
+    throws DatasetManagementException, IOException;
+
+  /**
+   * Gets dataset instance admin to be used to perform administrative operations. The class loader provider
+   * is used get classloaders for any dataset modules used by the specified dataset admin. This is because
+   * the classloader(s) for a dataset admin may create some resources that need to be cleaned up on close.
+   *
+   * @param <T> dataset admin type
+   * @param datasetInstanceId dataset instance name
+   * @param classLoader parent classLoader to be used to load classes or {@code null} to use system classLoader
+   * @param classLoaderProvider provider to get classloaders for different dataset modules
+   * @return instance of dataset admin or {@code null} if dataset instance of this name doesn't exist.
+   * @throws DatasetManagementException when there's trouble getting dataset meta info
+   * @throws IOException when there's trouble to instantiate {@link DatasetAdmin}
+   */
+  @Nullable
+  <T extends DatasetAdmin> T getAdmin(Id.DatasetInstance datasetInstanceId,
+                                      @Nullable ClassLoader classLoader,
+                                      DatasetClassLoaderProvider classLoaderProvider)
     throws DatasetManagementException, IOException;
 
   /**

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/InMemoryDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/InMemoryDatasetFramework.java
@@ -27,6 +27,7 @@ import co.cask.cdap.api.dataset.module.DatasetModule;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.lang.ClassLoaders;
+import co.cask.cdap.data2.datafabric.dataset.type.ConstantClassLoaderProvider;
 import co.cask.cdap.data2.datafabric.dataset.type.DatasetClassLoaderProvider;
 import co.cask.cdap.data2.dataset2.module.lib.DatasetModules;
 import co.cask.cdap.proto.DatasetSpecificationSummary;
@@ -338,7 +339,15 @@ public class InMemoryDatasetFramework implements DatasetFramework {
 
   @Override
   public <T extends DatasetAdmin> T getAdmin(Id.DatasetInstance datasetInstanceId,
-                                                          @Nullable ClassLoader classLoader) throws IOException {
+                                             @Nullable ClassLoader classLoader) throws IOException {
+    return getAdmin(datasetInstanceId, classLoader, new ConstantClassLoaderProvider(classLoader));
+  }
+
+  @Nullable
+  @Override
+  public <T extends DatasetAdmin> T getAdmin(Id.DatasetInstance datasetInstanceId,
+                                             @Nullable ClassLoader classLoader,
+                                             DatasetClassLoaderProvider classLoaderProvider) throws IOException {
     readLock.lock();
     try {
       DatasetSpecification spec = instances.get(datasetInstanceId.getNamespace(), datasetInstanceId);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/StaticDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/StaticDatasetFramework.java
@@ -16,21 +16,14 @@
 
 package co.cask.cdap.data2.dataset2;
 
-import co.cask.cdap.api.dataset.Dataset;
-import co.cask.cdap.api.dataset.DatasetAdmin;
-import co.cask.cdap.api.dataset.DatasetProperties;
-import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.dataset.module.DatasetDefinitionRegistry;
 import co.cask.cdap.api.dataset.module.DatasetModule;
 import co.cask.cdap.common.conf.CConfiguration;
-import co.cask.cdap.proto.DatasetSpecificationSummary;
 import co.cask.cdap.proto.Id;
 import com.google.common.base.Throwables;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 
-import java.io.IOException;
-import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -53,46 +46,6 @@ public class StaticDatasetFramework extends InMemoryDatasetFramework implements 
                                 Map<String, DatasetModule> modules,
                                 CConfiguration configuration) {
     super(registryFactory, modules, configuration);
-  }
-
-  @Override
-  public Collection<DatasetSpecificationSummary> getInstances(Id.Namespace namespaceId) {
-    return super.getInstances(namespaceId);
-  }
-
-  @Nullable
-  @Override
-  public DatasetSpecification getDatasetSpec(Id.DatasetInstance datasetInstanceId) {
-    return super.getDatasetSpec(datasetInstanceId);
-  }
-
-  @Override
-  public boolean hasInstance(Id.DatasetInstance datasetInstanceId) {
-    return super.hasInstance(datasetInstanceId);
-  }
-
-  @Override
-  public boolean hasSystemType(String typeName) {
-    return super.hasSystemType(typeName);
-  }
-
-  @Override
-  public boolean hasType(Id.DatasetType datasetTypeId) {
-    return super.hasType(datasetTypeId);
-  }
-
-  @Nullable
-  @Override
-  public <T extends DatasetAdmin> T getAdmin(Id.DatasetInstance datasetInstanceId, @Nullable ClassLoader classLoader)
-    throws IOException {
-    return super.getAdmin(datasetInstanceId, classLoader);
-  }
-
-  @Nullable
-  @Override
-  public <T extends Dataset> T getDataset(Id.DatasetInstance datasetInstanceId, @Nullable Map<String, String> arguments,
-                                          @Nullable ClassLoader classLoader) throws IOException {
-    return super.getDataset(datasetInstanceId, arguments, classLoader);
   }
 
   @Override
@@ -126,28 +79,6 @@ public class StaticDatasetFramework extends InMemoryDatasetFramework implements 
     } catch (ExecutionException e) {
       throw Throwables.propagate(e);
     }
-  }
-
-  @Override
-  public void addInstance(String datasetTypeName, Id.DatasetInstance datasetInstanceId, DatasetProperties props)
-    throws DatasetManagementException, IOException {
-    super.addInstance(datasetTypeName, datasetInstanceId, props);
-  }
-
-  @Override
-  public void updateInstance(Id.DatasetInstance datasetInstanceId, DatasetProperties props)
-    throws DatasetManagementException, IOException {
-    super.updateInstance(datasetInstanceId, props);
-  }
-
-  @Override
-  public void deleteInstance(Id.DatasetInstance datasetInstanceId) throws DatasetManagementException, IOException {
-    super.deleteInstance(datasetInstanceId);
-  }
-
-  @Override
-  public void deleteAllInstances(Id.Namespace namespaceId) throws DatasetManagementException, IOException {
-    super.deleteAllInstances(namespaceId);
   }
 
   @Override

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
@@ -24,6 +24,7 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.metrics.NoOpMetricsCollectionService;
 import co.cask.cdap.common.namespace.DefaultNamespacedLocationFactory;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
+import co.cask.cdap.data.dataset.SystemDatasetInstantiatorFactory;
 import co.cask.cdap.data2.datafabric.dataset.instance.DatasetInstanceManager;
 import co.cask.cdap.data2.datafabric.dataset.service.DatasetInstanceService;
 import co.cask.cdap.data2.datafabric.dataset.service.DatasetService;
@@ -104,9 +105,11 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
     LocalLocationFactory locationFactory = new LocalLocationFactory(new File(cConf.get(Constants.CFG_LOCAL_DATA_DIR)));
     NamespacedLocationFactory namespacedLocationFactory = new DefaultNamespacedLocationFactory(cConf, locationFactory);
     framework = new RemoteDatasetFramework(discoveryService, registryFactory);
+    SystemDatasetInstantiatorFactory datasetInstantiatorFactory =
+      new SystemDatasetInstantiatorFactory(locationFactory, framework, cConf);
 
-    ImmutableSet<HttpHandler> handlers =
-      ImmutableSet.<HttpHandler>of(new DatasetAdminOpHTTPHandler(framework, cConf, locationFactory));
+    ImmutableSet<HttpHandler> handlers = ImmutableSet.<HttpHandler>of(
+      new DatasetAdminOpHTTPHandler(framework, cConf, locationFactory, datasetInstantiatorFactory));
     opExecutorService = new DatasetOpExecutorService(cConf, discoveryService, metricsCollectionService, handlers);
 
     opExecutorService.startAndWait();

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
@@ -28,6 +28,7 @@ import co.cask.cdap.common.io.Locations;
 import co.cask.cdap.common.metrics.NoOpMetricsCollectionService;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.common.utils.DirUtils;
+import co.cask.cdap.data.dataset.SystemDatasetInstantiatorFactory;
 import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;
 import co.cask.cdap.data2.datafabric.dataset.DatasetMetaTableUtil;
 import co.cask.cdap.data2.datafabric.dataset.RemoteDatasetFramework;
@@ -147,9 +148,11 @@ public abstract class DatasetServiceTestBase {
     locationFactory = injector.getInstance(LocationFactory.class);
     NamespacedLocationFactory namespacedLocationFactory = injector.getInstance(NamespacedLocationFactory.class);
     dsFramework = new RemoteDatasetFramework(discoveryService, registryFactory);
+    SystemDatasetInstantiatorFactory datasetInstantiatorFactory =
+      new SystemDatasetInstantiatorFactory(locationFactory, dsFramework, cConf);
 
-    ImmutableSet<HttpHandler> handlers =
-      ImmutableSet.<HttpHandler>of(new DatasetAdminOpHTTPHandler(dsFramework, cConf, locationFactory));
+    ImmutableSet<HttpHandler> handlers = ImmutableSet.<HttpHandler>of(
+      new DatasetAdminOpHTTPHandler(dsFramework, cConf, locationFactory, datasetInstantiatorFactory));
     opExecutorService = new DatasetOpExecutorService(cConf, discoveryService, metricsCollectionService, handlers);
 
     opExecutorService.startAndWait();


### PR DESCRIPTION
Fixing a bug introduced by the fix to CDAP-2564. The previous
change changed DatasetFramework to just use the classloader it
is given instead of trying to unpack dataset jars to create
classloaders. Since the CDAP system does not have access to
user dataset jars in its classpath, it needs to pass a
DatasetClassLoaderProvider to DatasetFramework, which is
responsible for unpacking user dataset jars to create the
classloaders needed to instantiate a dataset.

That refactoring was done for dataset instantiation, but not for
dataset admin instantiation. This fix adds a corresponding
method for instantiating a DatasetAdmin, which must be used when
the CDAP system needs to instantiate a DatasetAdmin for a user
dataset.