### PR TITLE
Feature/cdap 2840 pfs upgrade

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/InMemoryDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/InMemoryDatasetFramework.java
@@ -137,8 +137,7 @@ public class InMemoryDatasetFramework implements DatasetFramework {
   }
 
   @Override
-  public void addModule(Id.DatasetModule moduleId,
-                        DatasetModule module) throws ModuleConflictException {
+  public void addModule(Id.DatasetModule moduleId, DatasetModule module) throws ModuleConflictException {
     writeLock.lock();
     try {
       if (moduleClasses.contains(moduleId.getNamespace(), moduleId)) {
@@ -198,7 +197,7 @@ public class InMemoryDatasetFramework implements DatasetFramework {
 
   @Override
   public void addInstance(String datasetType, Id.DatasetInstance datasetInstanceId,
-                                       DatasetProperties props) throws DatasetManagementException, IOException {
+                          DatasetProperties props) throws DatasetManagementException, IOException {
     writeLock.lock();
     try {
       if (!allowDatasetUncheckedUpgrade && instances.contains(datasetInstanceId.getNamespace(), datasetInstanceId)) {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetDefinition.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetDefinition.java
@@ -59,7 +59,7 @@ public class PartitionedFileSetDefinition extends AbstractDatasetDefinition<Part
   @VisibleForTesting
   public static final String FILESET_NAME = "files";
 
-  private static final String INDEXED_COLS = Bytes.toString(PartitionedFileSetDataset.WRITE_PTR_COL) + ','
+  public static final String INDEXED_COLS = Bytes.toString(PartitionedFileSetDataset.WRITE_PTR_COL) + ','
     + Bytes.toString(PartitionedFileSetDataset.CREATION_TIME_COL);
 
   protected final DatasetDefinition<? extends IndexedTable, ?> indexedTableDef;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetModule.java
@@ -32,8 +32,9 @@ public class PartitionedFileSetModule implements DatasetModule {
   @Override
   public void register(DatasetDefinitionRegistry registry) {
 
-    DatasetDefinition<FileSet, FileSetAdmin> fileSetDef = registry.get("fileSet");
-    DatasetDefinition<IndexedTable, ? extends DatasetAdmin> indexedTableDef = registry.get("indexedTable");
+    DatasetDefinition<FileSet, FileSetAdmin> fileSetDef = registry.get(FileSet.class.getName());
+    DatasetDefinition<IndexedTable, ? extends DatasetAdmin> indexedTableDef =
+      registry.get(IndexedTable.class.getName());
 
     // file dataset
     registry.add(new PartitionedFileSetDefinition(PartitionedFileSet.class.getName(), fileSetDef, indexedTableDef));

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetTableMigrator.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetTableMigrator.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.dataset2.lib.partitioned;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.DatasetSpecification;
+import co.cask.cdap.api.dataset.lib.IndexedTable;
+import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.dataset2.lib.table.hbase.HBaseTableAdmin;
+import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
+import co.cask.cdap.data2.util.hbase.ScanBuilder;
+import co.cask.cdap.proto.Id;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.HBaseAdmin;
+import org.apache.hadoop.hbase.client.HTable;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.ResultScanner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.NavigableMap;
+
+/**
+ * Migrates the tables of a PartitionedFileSet.
+ */
+public class PartitionedFileSetTableMigrator {
+  private static final Logger LOG = LoggerFactory.getLogger(PartitionedFileSetTableMigrator.class);
+
+  // copied from IndexedTable.java. This upgrade is only needed from 3.0 -> 3.1, so this code will be removed
+  // after 3.1 release. This is done to avoid publicizing the fields on IndexedTable.
+  private static final byte[] IDX_COL = {'r'};
+  private static final byte DELIMITER_BYTE = 0;
+  private static final byte[] KEY_DELIMITER = new byte[] { DELIMITER_BYTE };
+
+  private static final long MILLION = 1000 * 1000;
+  protected final HBaseTableUtil tableUtil;
+  protected final Configuration conf;
+  private final DatasetFramework dsFramework;
+
+  @Inject
+  public PartitionedFileSetTableMigrator(HBaseTableUtil tableUtil, Configuration conf, DatasetFramework dsFramework) {
+    this.tableUtil = tableUtil;
+    this.conf = conf;
+    this.dsFramework = dsFramework;
+  }
+
+  /**
+   * Given a specification of a PartitionedFileSet, creates an IndexedTable for the new embedded partitions Dataset
+   * and migrates the data from the old partitions table to the new partitions table.
+   *
+   * @param namespaceId the namespace that contains the PartitionedFileSet
+   * @param dsSpec the specification of the PartitionedFileSet that needs migrating
+   * @throws Exception
+   */
+  public void upgrade(Id.Namespace namespaceId, DatasetSpecification dsSpec) throws Exception {
+    DatasetSpecification newPartitionsSpec = dsSpec.getSpecification(PartitionedFileSetDefinition.PARTITION_TABLE_NAME);
+    TableId oldPartitionsTableId = TableId.from(namespaceId, newPartitionsSpec.getName());
+    TableId indexTableId = TableId.from(namespaceId, newPartitionsSpec.getName() + ".i");
+    TableId dataTableId = TableId.from(namespaceId, newPartitionsSpec.getName() + ".d");
+
+    byte[] columnFamily = HBaseTableAdmin.getColumnFamily(newPartitionsSpec);
+
+    HBaseAdmin hBaseAdmin = new HBaseAdmin(conf);
+    if (!tableUtil.tableExists(hBaseAdmin, oldPartitionsTableId)) {
+      LOG.info("Old Partitions table does not exist: {}. Nothing to migrate from.", oldPartitionsTableId);
+      return;
+    }
+
+    DatasetsUtil.createIfNotExists(dsFramework, Id.DatasetInstance.from(namespaceId, newPartitionsSpec.getName()),
+                                   IndexedTable.class.getName(),
+                                   DatasetProperties.builder().addAll(newPartitionsSpec.getProperties()).build());
+
+    HTable oldTable = tableUtil.createHTable(conf, oldPartitionsTableId);
+    HTable newIndexTable = tableUtil.createHTable(conf, indexTableId);
+    HTable newDataTable = tableUtil.createHTable(conf, dataTableId);
+
+    LOG.info("Starting upgrade for table {}", Bytes.toString(oldTable.getTableName()));
+    try {
+      ScanBuilder scan = tableUtil.buildScan();
+      scan.setTimeRange(0, HConstants.LATEST_TIMESTAMP);
+      // migrate all versions. Since we write the same versions in the new table, transactional semantics should carry
+      // across (invalid transactions' data remains invalid, etc). There shouldn't be too many versions of a given row
+      // of the partitions table anyways.
+      scan.setMaxVersions();
+      try (ResultScanner resultScanner = oldTable.getScanner(scan.build())) {
+        Result result;
+        while ((result = resultScanner.next()) != null) {
+          Put put = new Put(result.getRow());
+
+          Long writeVersion = null;
+          for (Map.Entry<byte[], NavigableMap<byte[], NavigableMap<Long, byte[]>>> familyMap :
+            result.getMap().entrySet()) {
+            for (Map.Entry<byte[], NavigableMap<Long, byte[]>> columnMap : familyMap.getValue().entrySet()) {
+              for (Map.Entry<Long, byte[]> columnEntry : columnMap.getValue().entrySet()) {
+                Long timeStamp = columnEntry.getKey();
+                byte[] colVal = columnEntry.getValue();
+                put.add(familyMap.getKey(), columnMap.getKey(), timeStamp, colVal);
+                LOG.debug("Migrating row. family: '{}', column: '{}', ts: '{}', colVal: '{}'",
+                          familyMap.getKey(), columnMap.getKey(), timeStamp, colVal);
+
+                // the hbase version for all the columns are equal since every column of a row corresponds to one
+                // partition and a partition is created entirely within a single transaction.
+                writeVersion = timeStamp;
+              }
+            }
+          }
+
+          Preconditions.checkNotNull(writeVersion,
+                                     "There should have been at least one column in the scan. Table: {}, Rowkey: {}",
+                                     oldPartitionsTableId, result.getRow());
+
+          // additionally since 3.1.0, we keep two addition columns for each partition: creation time of the partition
+          // and the transaction write pointer of the transaction in which the partition was added
+          byte[] hbaseVersionBytes = Bytes.toBytes(writeVersion);
+          put.add(columnFamily, PartitionedFileSetDataset.WRITE_PTR_COL,
+                  writeVersion, hbaseVersionBytes);
+          // here, we make the assumption that dropping the six right-most digits of the transaction write pointer
+          // yields the timestamp at which it started
+          byte[] creationTimeBytes = Bytes.toBytes(writeVersion / MILLION);
+          put.add(columnFamily, PartitionedFileSetDataset.CREATION_TIME_COL,
+                  writeVersion, creationTimeBytes);
+
+          newDataTable.put(put);
+
+          // index the data table on the two columns
+          Put indexWritePointerPut = new Put(createIndexKey(result.getRow(),
+                                                            PartitionedFileSetDataset.WRITE_PTR_COL,
+                                                            hbaseVersionBytes));
+          indexWritePointerPut.add(columnFamily, IDX_COL, writeVersion, result.getRow());
+
+          Put indexCreationTimePut = new Put(createIndexKey(result.getRow(),
+                                                            PartitionedFileSetDataset.CREATION_TIME_COL,
+                                                            creationTimeBytes));
+          indexCreationTimePut.add(columnFamily, IDX_COL, writeVersion, result.getRow());
+
+          newIndexTable.put(ImmutableList.of(indexCreationTimePut, indexWritePointerPut));
+
+          LOG.debug("Deleting old key {}.", Bytes.toString(result.getRow()));
+          oldTable.delete(new Delete(result.getRow()));
+        }
+      } finally {
+        oldTable.close();
+        newIndexTable.close();
+        newDataTable.close();
+      }
+      LOG.info("Successfully migrated data from table {} Now deleting it.", Bytes.toString(oldTable.getTableName()));
+      tableUtil.dropTable(hBaseAdmin, oldPartitionsTableId);
+      LOG.info("Succsefully deleted old data table {}", Bytes.toString(oldTable.getTableName()));
+    } catch (Exception e) {
+      LOG.error("Error while migrating data from table: {}", oldPartitionsTableId, e);
+      throw Throwables.propagate(e);
+    } finally {
+      oldTable.close();
+    }
+  }
+
+  private byte[] createIndexKey(byte[] row, byte[] column, byte[] value) {
+    return Bytes.concat(column, KEY_DELIMITER, value, KEY_DELIMITER, row);
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetModule.java
@@ -33,8 +33,9 @@ public class TimePartitionedFileSetModule implements DatasetModule {
   @Override
   public void register(DatasetDefinitionRegistry registry) {
 
-    DatasetDefinition<FileSet, FileSetAdmin> fileSetDef = registry.get("fileSet");
-    DatasetDefinition<IndexedTable, ? extends DatasetAdmin> indexedTableDef = registry.get("indexedTable");
+    DatasetDefinition<FileSet, FileSetAdmin> fileSetDef = registry.get(FileSet.class.getName());
+    DatasetDefinition<IndexedTable, ? extends DatasetAdmin> indexedTableDef =
+      registry.get(IndexedTable.class.getName());
 
     // file dataset
     registry.add(new TimePartitionedFileSetDefinition(TimePartitionedFileSet.class.getName(), fileSetDef,

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/AbstractQueueUpgrader.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/AbstractQueueUpgrader.java
@@ -104,8 +104,8 @@ public abstract class AbstractQueueUpgrader extends AbstractUpgrader {
               LOG.debug("Adding entry {} -> {} for upgrade",
                         Bytes.toString(entry.getKey()), Bytes.toString(entry.getValue()));
               put.add(QueueEntryRow.COLUMN_FAMILY, entry.getKey(), entry.getValue());
-              mutations.add(put);
             }
+            mutations.add(put);
             LOG.debug("Marking old key {} for deletion", rowKeyString);
             mutations.add(tableUtil.buildDelete(row).build());
           }

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/DatasetUpgrader.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/DatasetUpgrader.java
@@ -152,7 +152,7 @@ public class DatasetUpgrader extends AbstractUpgrader {
   /**
    * Upgrades all file sets and all datasets that contain an embedded file set: If the properties contain
    * an absolute base path, convert that into a relative base path. This is because since 2.8, with the
-   * introduction of namespaces, absolute paths have incorrectly been treated the same as realtive paths,
+   * introduction of namespaces, absolute paths have incorrectly been treated the same as relative paths,
    * that is, relative to the namespace's data path. This was fixed in 3.1, but that means that existing
    * file set with absolute paths now do not point to their data anymore. Therefore the upgrade turns all
    * absolute paths into relative paths by removing the leading "/", which is equivalent under the new

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/PFSUpgrader.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/PFSUpgrader.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data.tools;
+
+import co.cask.cdap.api.dataset.DatasetSpecification;
+import co.cask.cdap.api.dataset.lib.FileSet;
+import co.cask.cdap.api.dataset.lib.IndexedTable;
+import co.cask.cdap.api.dataset.lib.IndexedTableDefinition;
+import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
+import co.cask.cdap.api.dataset.lib.TimePartitionedFileSet;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.data2.datafabric.dataset.DatasetMetaTableUtil;
+import co.cask.cdap.data2.datafabric.dataset.service.mds.DatasetInstanceMDS;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.dataset2.lib.partitioned.PartitionedFileSetDefinition;
+import co.cask.cdap.data2.dataset2.lib.partitioned.PartitionedFileSetTableMigrator;
+import co.cask.cdap.data2.dataset2.lib.table.MDSKey;
+import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
+import co.cask.cdap.proto.Id;
+import co.cask.tephra.TransactionAware;
+import co.cask.tephra.TransactionExecutor;
+import co.cask.tephra.TransactionExecutorFactory;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import com.google.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Migrates all dataset specifications that are for PartitionedFileSet or have an embedded PartitionedFileSet,
+ * from the pre-3.1.0 format to the 3.1.0 format. The main change is that the embedded partitions table is now an
+ * IndexedTable.
+ */
+public class PFSUpgrader {
+  private static final Logger LOG = LoggerFactory.getLogger(PFSUpgrader.class);
+  protected final HBaseTableUtil tableUtil;
+  private final PartitionedFileSetTableMigrator pfsTableMigrator;
+  private final TransactionExecutorFactory executorFactory;
+  private final DatasetFramework dsFramework;
+
+  @Inject
+  protected PFSUpgrader(HBaseTableUtil tableUtil, PartitionedFileSetTableMigrator pfsTableMigrator,
+                        final TransactionExecutorFactory executorFactory, final DatasetFramework dsFramework) {
+    this.tableUtil = tableUtil;
+    this.pfsTableMigrator = pfsTableMigrator;
+    this.executorFactory = executorFactory;
+    this.dsFramework = dsFramework;
+  }
+
+  public void upgrade() throws Exception {
+    LOG.info("Begin upgrade of PartitionedFileSets.");
+    upgradePartitionedFileSets();
+    LOG.info("Completed upgrade of PartitionedFileSets.");
+  }
+
+  @VisibleForTesting
+  DatasetSpecification convertSpec(String dsName, DatasetSpecification dsSpec) {
+    Preconditions.checkArgument(isPartitionedFileSet(dsSpec));
+
+    DatasetSpecification oldPartitionsSpec = dsSpec.getSpecification(PartitionedFileSetDefinition.PARTITION_TABLE_NAME);
+    DatasetSpecification oldFileSetSpec = dsSpec.getSpecification(PartitionedFileSetDefinition.FILESET_NAME);
+
+    Map<String, String> partitionsTableProperties = oldPartitionsSpec.getProperties();
+    Map<String, String> newPartitionsTableProperties = Maps.newHashMap(partitionsTableProperties);
+    newPartitionsTableProperties.put(IndexedTableDefinition.INDEX_COLUMNS_CONF_KEY,
+                                     PartitionedFileSetDefinition.INDEXED_COLS);
+
+    DatasetSpecification dataTable = DatasetSpecification.builder("d", Table.class.getName())
+      .properties(newPartitionsTableProperties)
+      .build();
+
+    DatasetSpecification indexTable = DatasetSpecification.builder("i", Table.class.getName())
+      .properties(newPartitionsTableProperties)
+      .build();
+
+    DatasetSpecification newPartitionsSpec =
+      DatasetSpecification.builder(PartitionedFileSetDefinition.PARTITION_TABLE_NAME, IndexedTable.class.getName())
+        .properties(newPartitionsTableProperties)
+        .datasets(dataTable, indexTable)
+        .build();
+
+    // we need to do this to effectively "un-namespace" the name of the embedded fileset.
+    DatasetSpecification newFileSetSpec =
+      DatasetSpecification.builder(PartitionedFileSetDefinition.FILESET_NAME, FileSet.class.getName())
+        .properties(oldFileSetSpec.getProperties())
+        .build();
+
+
+    return DatasetSpecification.builder(dsName, dsSpec.getType())
+      .properties(dsSpec.getProperties())
+      .datasets(newPartitionsSpec, newFileSetSpec)
+      .build();
+  }
+
+  private void upgradePartitionedFileSets() throws Exception {
+    final DatasetInstanceMDS dsInstancesMDS;
+    try {
+      dsInstancesMDS = new DatasetMetaTableUtil(dsFramework).getInstanceMetaTable();
+    } catch (Exception e) {
+      LOG.error("Failed to access Datasets instances meta table.");
+      throw e;
+    }
+
+    TransactionExecutor executor = executorFactory.createExecutor(ImmutableList.of((TransactionAware) dsInstancesMDS));
+    executor.execute(new TransactionExecutor.Subroutine() {
+      @Override
+      public void apply() throws Exception {
+        MDSKey key = new MDSKey.Builder().add(DatasetInstanceMDS.INSTANCE_PREFIX).build();
+        Map<MDSKey, DatasetSpecification> dsSpecs = dsInstancesMDS.listKV(key, DatasetSpecification.class);
+
+        // first, upgrade all the specifications, while keeping track of the tables that need migrating
+        Multimap<Id.Namespace, DatasetSpecification> partitionDatasetsToMigrate = HashMultimap.create();
+        for (Map.Entry<MDSKey, DatasetSpecification> entry : dsSpecs.entrySet()) {
+          DatasetSpecification dsSpec = entry.getValue();
+          if (!needsConverting(dsSpec)) {
+            continue;
+          }
+          DatasetSpecification migratedSpec = recursivelyMigrateSpec(extractNamespace(entry.getKey()), dsSpec.getName(),
+                                                                     dsSpec, partitionDatasetsToMigrate);
+          dsInstancesMDS.write(entry.getKey(), migratedSpec);
+        }
+
+        // migrate the necessary tables
+        LOG.info("Tables to migrate: {}", partitionDatasetsToMigrate);
+        for (Map.Entry<Id.Namespace, DatasetSpecification> entry : partitionDatasetsToMigrate.entries()) {
+          pfsTableMigrator.upgrade(entry.getKey(), entry.getValue());
+        }
+      }
+    });
+
+
+  }
+
+  @VisibleForTesting
+  boolean needsConverting(DatasetSpecification dsSpec) {
+    if (isPartitionedFileSet(dsSpec) && !alreadyUpgraded(dsSpec)) {
+      return true;
+    }
+    for (DatasetSpecification datasetSpecification : dsSpec.getSpecifications().values()) {
+      if (needsConverting(datasetSpecification)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Recursively search the datasets of a Dataset for {@link PartitionedFileSet}s. Return the migrated dataset spec,
+   * and add the DatasetInstances of the partitions table that require data migration to the given list.
+   *
+   * @return recursively migrated dsSpec
+   */
+  DatasetSpecification recursivelyMigrateSpec(Id.Namespace namespaceId, String dsName, DatasetSpecification dsSpec,
+                                              Multimap<Id.Namespace, DatasetSpecification> addTo) throws Exception {
+    if (isPartitionedFileSet(dsSpec)) {
+      if (alreadyUpgraded(dsSpec)) {
+        LOG.info("The partitions table of Dataset '{}' has already been upgraded to an IndexedTable.",
+                 dsSpec.getName());
+        return dsSpec;
+      }
+      DatasetSpecification convertedSpec = convertSpec(dsName, dsSpec);
+      addTo.put(namespaceId, convertedSpec);
+      return convertedSpec;
+    }
+
+    List<DatasetSpecification> newSpecs = Lists.newArrayList();
+    for (Map.Entry<String, DatasetSpecification> entry : dsSpec.getSpecifications().entrySet()) {
+      newSpecs.add(recursivelyMigrateSpec(namespaceId, entry.getKey(), entry.getValue(), addTo));
+    }
+
+    DatasetSpecification.Builder builder = DatasetSpecification.builder(dsName, dsSpec.getType());
+    builder.properties(dsSpec.getProperties());
+    builder.datasets(newSpecs);
+    return builder.build();
+  }
+
+  private static Id.Namespace extractNamespace(MDSKey key) {
+    MDSKey.Splitter splitter = key.split();
+    splitter.skipString();
+    return Id.Namespace.from(splitter.getString());
+  }
+
+  boolean alreadyUpgraded(DatasetSpecification dsSpec) {
+    DatasetSpecification partitionsSpec = dsSpec.getSpecification(PartitionedFileSetDefinition.PARTITION_TABLE_NAME);
+    // the partitions table is now an IndexedTable (was Table in < v3.1.0 CDAP)
+    return isIndexedTable(partitionsSpec);
+  }
+
+  boolean isPartitionedFileSet(DatasetSpecification dsSpec) {
+    String dsType = dsSpec.getType();
+    return PartitionedFileSet.class.getName().equals(dsType) || "partitionedFileSet".equals(dsType)
+      || TimePartitionedFileSet.class.getName().equals(dsType) || "timePartitionedFileSet".equals(dsType);
+  }
+
+  boolean isIndexedTable(DatasetSpecification dsSpec) {
+    String dsType = dsSpec.getType();
+    return (IndexedTable.class.getName().equals(dsType) || "indexedTable".equals(dsType));
+  }
+}

--- a/cdap-master/src/test/java/co/cask/cdap/data/tools/PFSUpgraderTest.java
+++ b/cdap-master/src/test/java/co/cask/cdap/data/tools/PFSUpgraderTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data.tools;
+
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.DatasetSpecification;
+import co.cask.cdap.api.dataset.lib.FileSet;
+import co.cask.cdap.api.dataset.lib.FileSetProperties;
+import co.cask.cdap.api.dataset.lib.IndexedTable;
+import co.cask.cdap.api.dataset.lib.IndexedTableDefinition;
+import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
+import co.cask.cdap.api.dataset.lib.PartitionedFileSetProperties;
+import co.cask.cdap.api.dataset.lib.Partitioning;
+import co.cask.cdap.api.dataset.lib.TimePartitionedFileSet;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.dataset2.DatasetFrameworkTestUtil;
+import co.cask.cdap.data2.dataset2.lib.partitioned.PartitionedFileSetDefinition;
+import co.cask.cdap.data2.dataset2.lib.partitioned.PartitionedFileSetTableMigrator;
+import co.cask.cdap.proto.Id;
+import co.cask.tephra.TransactionAware;
+import co.cask.tephra.TransactionExecutor;
+import co.cask.tephra.TransactionExecutorFactory;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Multimap;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.SortedMap;
+
+public class PFSUpgraderTest {
+
+  @ClassRule
+  public static DatasetFrameworkTestUtil dsFrameworkUtil = new DatasetFrameworkTestUtil();
+
+  private static DatasetFramework framework;
+  private static PFSUpgrader pfsUpgrader;
+
+  private static DatasetProperties dsProps = PartitionedFileSetProperties.builder()
+    .setPartitioning(Partitioning.builder().addStringField("league").addIntField("season").build())
+    .setBasePath("/temp/fs2")
+    .build();
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    framework = dsFrameworkUtil.getFramework();
+    pfsUpgrader = new PFSUpgrader(
+      // we can pass null for HBaseAdmin in test case, since we do not test it
+      null,
+      new PartitionedFileSetTableMigrator(null, null, framework),
+      new TransactionExecutorFactory() {
+        @Override
+        public TransactionExecutor createExecutor(Iterable<TransactionAware> txAwares) {
+          return dsFrameworkUtil.newTransactionExecutor(Iterables.toArray(txAwares, TransactionAware.class));
+        }
+      },
+      framework
+    );
+  }
+
+
+  @Test
+  public void testSimplePFSUpgrade() throws Exception {
+    Id.DatasetInstance ds1 = Id.DatasetInstance.from("test", "fs1");
+    framework.addInstance(PartitionedFileSet.class.getName(), ds1,
+                          FileSetProperties.builder().setBasePath("/temp/fs1").build());
+    // PFS specs created by the current DSFramework already use an IndexedTable for the partitions dataset
+    Assert.assertTrue(pfsUpgrader.alreadyUpgraded(framework.getDatasetSpec(ds1)));
+
+
+    // test conversion from old PartitionedFileSet spec to current spec
+    DatasetSpecification oldResultsSpec = constructOldPfsSpec("results", dsProps.getProperties(),
+                                                              PartitionedFileSet.class.getName());
+    testPFSUpgrade(oldResultsSpec);
+  }
+
+  @Test
+  public void testSimpleTPFSUpgrade() throws Exception {
+    Id.DatasetInstance ds1 = Id.DatasetInstance.from("test", "tfs1");
+    framework.addInstance(TimePartitionedFileSet.class.getName(), ds1,
+                          FileSetProperties.builder().setBasePath("/temp/fs1").build());
+    // TPFS specs created by the current DSFramework already use an IndexedTable for the partitions dataset
+    Assert.assertTrue(pfsUpgrader.alreadyUpgraded(framework.getDatasetSpec(ds1)));
+
+
+    // test conversion from old TimePartitionedFileSet spec to current spec
+    DatasetSpecification oldResultsSpec = constructOldPfsSpec("results", Collections.<String, String>emptyMap(),
+                                                              TimePartitionedFileSet.class.getName());
+    testPFSUpgrade(oldResultsSpec);
+
+  }
+
+  // does the conversion and assertions for the PFS and TPFS specifications
+  private void testPFSUpgrade(DatasetSpecification oldPFSSpec) throws Exception {
+    Assert.assertTrue(pfsUpgrader.needsConverting(oldPFSSpec));
+    DatasetSpecification newResultsSpec = pfsUpgrader.convertSpec(oldPFSSpec.getName(), oldPFSSpec);
+
+    // the files Dataset shouldn't be changed
+    Assert.assertEquals(oldPFSSpec.getSpecification(PartitionedFileSetDefinition.FILESET_NAME),
+                        newResultsSpec.getSpecification(PartitionedFileSetDefinition.FILESET_NAME));
+
+    DatasetSpecification newPartitionsSpec =
+      newResultsSpec.getSpecification(PartitionedFileSetDefinition.PARTITION_TABLE_NAME);
+
+    assertIsNewPartitionsTable(newPartitionsSpec);
+  }
+
+  @Test
+  public void testEmbeddedPfsUpgrade() throws Exception {
+    DatasetSpecification pfsSpec = constructOldPfsSpec("results", dsProps.getProperties(),
+                                                       PartitionedFileSet.class.getName());
+
+    DatasetSpecification embeddingDsSpec = DatasetSpecification.builder("outerDataset", "customDs")
+      .datasets(pfsSpec)
+      .build();
+
+    Assert.assertTrue(pfsUpgrader.needsConverting(embeddingDsSpec));
+
+    Multimap<Id.Namespace, DatasetSpecification> datasetInstances = HashMultimap.create();
+    DatasetSpecification convertedSpec =
+      pfsUpgrader.recursivelyMigrateSpec(Constants.DEFAULT_NAMESPACE_ID, embeddingDsSpec.getName(),
+                                         embeddingDsSpec, datasetInstances);
+    DatasetSpecification migratedEmbeddedPfsSpec = convertedSpec.getSpecification("results");
+    DatasetSpecification newPartitionsSpec =
+      migratedEmbeddedPfsSpec.getSpecification(PartitionedFileSetDefinition.PARTITION_TABLE_NAME);
+    assertIsNewPartitionsTable(newPartitionsSpec);
+  }
+
+  private void assertIsNewPartitionsTable(DatasetSpecification dsSpec) {
+    // the new partitions should be an IndexedTable and should be set to index appropriately
+    Assert.assertEquals(IndexedTable.class.getName(), dsSpec.getType());
+    Assert.assertEquals(PartitionedFileSetDefinition.INDEXED_COLS,
+                        dsSpec.getProperty(IndexedTableDefinition.INDEX_COLUMNS_CONF_KEY));
+
+    // the embedded tables of Indexed Table should be named 'i' and 'd', and be of type Table
+    SortedMap<String, DatasetSpecification> indexedTableEmbeddedTables = dsSpec.getSpecifications();
+    Assert.assertEquals(ImmutableSet.of("i", "d"), indexedTableEmbeddedTables.keySet());
+    for (DatasetSpecification datasetSpecification : indexedTableEmbeddedTables.values()) {
+      Assert.assertEquals(Table.class.getName(), datasetSpecification.getType());
+    }
+  }
+
+  private DatasetSpecification constructOldPfsSpec(String name, Map<String, String> properties, String typeName) {
+    DatasetSpecification.Builder pfsBuilder = DatasetSpecification.builder(name, typeName);
+    pfsBuilder.properties(properties);
+
+    DatasetSpecification filesSpec =
+      DatasetSpecification.builder(PartitionedFileSetDefinition.FILESET_NAME, FileSet.class.getName())
+        .properties(properties)
+        .build();
+
+    DatasetSpecification partitionsSpec =
+      DatasetSpecification.builder(PartitionedFileSetDefinition.PARTITION_TABLE_NAME, Table.class.getName())
+        .properties(properties)
+        .build();
+
+    pfsBuilder.datasets(filesSpec, partitionsSpec);
+    return pfsBuilder.build();
+  }
+
+}


### PR DESCRIPTION
PartitionedFileSet's partitions table used to be `Table`. It is now an `IndexedTable`, indexed on two fields: creation time and transaction write pointer. Both of these fields are columns on the rows that did not exist before 3.1.0.

https://issues.cask.co/browse/CDAP-2840
http://builds.cask.co/browse/CDAP-RBT311-3