### PR TITLE
(CDAP-3016) Tune down number of HBase threads

### DIFF
--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data/hbase/HBaseTestBase.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data/hbase/HBaseTestBase.java
@@ -55,7 +55,16 @@ public abstract class HBaseTestBase {
 
   // Test startup / teardown
 
-  public abstract void startHBase() throws Exception;
+  public final void startHBase() throws Exception {
+    // Tune down the connection thread pool size
+    getConfiguration().setInt("hbase.hconnection.threads.core", 5);
+    getConfiguration().setInt("hbase.hconnection.threads.max", 10);
+    // Tunn down handler threads in regionserver
+    getConfiguration().setInt("hbase.regionserver.handler.count", 10);
+    doStartHBase();
+  }
+
+  public abstract void doStartHBase() throws Exception;
 
   public abstract void stopHBase() throws Exception;
 

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueTest.java
@@ -103,7 +103,6 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 /**
  * HBase queue tests.

--- a/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data/hbase/HBase96Test.java
+++ b/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data/hbase/HBase96Test.java
@@ -57,7 +57,7 @@ public class HBase96Test extends HBaseTestBase {
   }
 
   @Override
-  public void startHBase() throws Exception {
+  public void doStartHBase() throws Exception {
     testUtil.startMiniCluster();
   }
 

--- a/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data/hbase/HBase98Test.java
+++ b/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data/hbase/HBase98Test.java
@@ -57,7 +57,7 @@ public class HBase98Test extends HBaseTestBase {
   }
 
   @Override
-  public void startHBase() throws Exception {
+  public void doStartHBase() throws Exception {
     testUtil.startMiniCluster();
   }
 

--- a/cdap-hbase-compat-1.0-cdh/src/test/java/co/cask/cdap/data/hbase/HBase10CDHTest.java
+++ b/cdap-hbase-compat-1.0-cdh/src/test/java/co/cask/cdap/data/hbase/HBase10CDHTest.java
@@ -57,7 +57,7 @@ public class HBase10CDHTest extends HBaseTestBase {
   }
 
   @Override
-  public void startHBase() throws Exception {
+  public void doStartHBase() throws Exception {
     testUtil.startMiniCluster();
   }
 

--- a/cdap-hbase-compat-1.0/src/test/java/co/cask/cdap/data/hbase/HBase10Test.java
+++ b/cdap-hbase-compat-1.0/src/test/java/co/cask/cdap/data/hbase/HBase10Test.java
@@ -57,7 +57,7 @@ public class HBase10Test extends HBaseTestBase {
   }
 
   @Override
-  public void startHBase() throws Exception {
+  public void doStartHBase() throws Exception {
     testUtil.startMiniCluster();
   }
 


### PR DESCRIPTION
- Tune down hconnection threads and regionserver handler count.
- Refactor HBaseTestBase code so that more configurations can be set before starting mini HBase cluster for testing.