### PR TITLE
CDAP-2530 making RecordScannable<StructuredRecord> explorable

### DIFF
--- a/cdap-docs/developers-manual/source/data-exploration/custom-datasets.rst
+++ b/cdap-docs/developers-manual/source/data-exploration/custom-datasets.rst
@@ -132,6 +132,48 @@ The SQL schema of the dataset would be::
 
 Refer to the Hive language manual for more details on schema and data types.
 
+StructuredRecord Type
+---------------------
+There are times when your record type cannot be expressed as a plain old Java object. For example, you may want to write
+a custom dataset whose schema may change depending on the properties it is given. In these situations, you can implement
+a record-scannable dataset that uses ``StructuredRecord`` as the record type::
+
+  class MyStructuredDataset ... implements RecordScannable<StructuredRecord> {
+    ...
+    public Type getRecordType() {
+      return StructuredRecord.class;
+    }
+
+The ``StructuredRecord`` class is essentially a map of fields to values, with a ``Schema`` describing the fields and values::
+
+  public class StructuredRecord {
+    ...
+    public Schema getSchema() { ... }
+
+    public <T> T get(String fieldName) { ... }
+
+Datasets that use ``StructuredRecord`` as the record type must also set the schema dataset property when they are created::
+
+  @Override
+  public void configure() {
+    Schema schema = Schema.recordOf("mySchema",
+      Schema.Field.of("id", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("name", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("age", Schema.of(Schema.Type.INT)),
+      Schema.Field.of("email", Schema.of(Schema.Type.STRING))
+    );
+    createDataset("users", MyStructuredDataset.class,
+                  DatasetProperties.builder()
+                    .add(DatasetProperties.SCHEMA, schema.toString())
+                    .build());
+
+Failure to set the schema property will result in errors when enabling exploration on the dataset. The dataset will still
+be created, but it will not be explorable until the schema property is set correctly and another call to enable exploration
+on the dataset is made. In addition, it is up to the user to ensure that the schema set in the dataset properties
+matches the schema of records returned by the dataset. Schema mismatches will result in runtime errors.
+
+The CDAP ``Table`` and ``ObjectMappedTable`` datasets implement ``RecordScannable`` in this way and can be used as references.
+
 .. _sql-scanning-records:
 
 Scanning Records

--- a/cdap-docs/developers-manual/source/data-exploration/custom-datasets.rst
+++ b/cdap-docs/developers-manual/source/data-exploration/custom-datasets.rst
@@ -168,8 +168,8 @@ Datasets that use ``StructuredRecord`` as the record type must also set the sche
                     .build());
 
 Failure to set the schema property will result in errors when enabling exploration on the dataset. The dataset will still
-be created, but it will not be explorable until the schema property is set correctly and another call to enable exploration
-on the dataset is made. In addition, it is up to the user to ensure that the schema set in the dataset properties
+be created, but it will not be explorable until the schema property is set correctly through the RESTful API.
+In addition, it is up to the user to ensure that the schema set in the dataset properties
 matches the schema of records returned by the dataset. Schema mismatches will result in runtime errors.
 
 The CDAP ``Table`` and ``ObjectMappedTable`` datasets implement ``RecordScannable`` in this way and can be used as references.

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/executor/ExploreExecutorHttpHandler.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/executor/ExploreExecutorHttpHandler.java
@@ -174,7 +174,7 @@ public class ExploreExecutorHttpHandler extends AbstractHttpHandler {
                            "SQL exception while trying to enable explore on dataset " + datasetID);
     } catch (UnsupportedTypeException e) {
       responder.sendString(HttpResponseStatus.BAD_REQUEST,
-                           "Schema for dataset " + datasetID + " is not supported for exploration");
+                           "Schema for dataset " + datasetID + " is not supported for exploration: " + e.getMessage());
     } catch (Throwable e) {
       LOG.error("Got exception:", e);
       responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, e.getMessage());

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/ExploreTableManager.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/ExploreTableManager.java
@@ -186,7 +186,8 @@ public class ExploreTableManager {
 
         // if the type is a structured record, use the schema property to create the table
         if (StructuredRecord.class.equals(recordType)) {
-          if (isRecordWritable) {
+          // TODO: CDAP-3079 remove this check once RecordWritable<StructuredRecord> is supported
+          if (isRecordWritable && !isRecordScannable) {
             throw new UnsupportedTypeException("StructuredRecord is not supported as a type for RecordWritable.");
           }
           return createFromSchemaProperty(spec, datasetID, serdeProperties);

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreServiceTestsSuite.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreServiceTestsSuite.java
@@ -33,7 +33,8 @@ import org.junit.runners.Suite;
   HiveExploreServiceTestRun.class,
   WritableDatasetTestRun.class,
   HiveExploreObjectMappedTableTestRun.class,
-  HiveExploreServiceFileSetTestRun.class
+  HiveExploreServiceFileSetTestRun.class,
+  HiveExploreStructuredRecordTestRun.class
 })
 public class ExploreServiceTestsSuite {
 

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreStructuredRecordTestRun.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreStructuredRecordTestRun.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.explore.service;
+
+import co.cask.cdap.api.dataset.DatasetDefinition;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.explore.client.ExploreExecutionResult;
+import co.cask.cdap.explore.service.datasets.EmailTableDefinition;
+import co.cask.cdap.explore.service.datasets.KeyStructValueTableDefinition;
+import co.cask.cdap.explore.service.datasets.Record;
+import co.cask.cdap.proto.ColumnDesc;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.QueryResult;
+import co.cask.cdap.test.SlowTests;
+import co.cask.tephra.Transaction;
+import com.google.common.collect.Lists;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TemporaryFolder;
+
+import java.util.List;
+
+/**
+ * Tests exploration of record scannables that are scannables of StructuredRecord.
+ */
+@Category(SlowTests.class)
+public class HiveExploreStructuredRecordTestRun extends BaseHiveExploreServiceTest {
+  @ClassRule
+  public static TemporaryFolder tmpFolder = new TemporaryFolder();
+
+  @BeforeClass
+  public static void start() throws Exception {
+    initialize(tmpFolder);
+
+    Id.DatasetModule moduleId = Id.DatasetModule.from(NAMESPACE_ID, "email");
+    datasetFramework.addModule(moduleId, new EmailTableDefinition.EmailTableModule());
+    datasetFramework.addInstance("email", MY_TABLE, DatasetProperties.EMPTY);
+
+    // Accessing dataset instance to perform data operations
+    EmailTableDefinition.EmailTable table = datasetFramework.getDataset(MY_TABLE, DatasetDefinition.NO_ARGUMENTS, null);
+    Assert.assertNotNull(table);
+
+    Transaction tx1 = transactionManager.startShort(100);
+    table.startTx(tx1);
+
+    table.writeEmail("email1", "this is the subject", "this is the body", "sljackson@boss.com");
+
+    Assert.assertTrue(table.commitTx());
+
+    transactionManager.canCommit(tx1, table.getTxChanges());
+    transactionManager.commit(tx1);
+
+    table.postTxCommit();
+
+    Transaction tx2 = transactionManager.startShort(100);
+    table.startTx(tx2);
+  }
+
+  @AfterClass
+  public static void stop() throws Exception {
+    datasetFramework.deleteInstance(MY_TABLE);
+  }
+
+  @Test
+  public void testSchema() throws Exception {
+    runCommand(NAMESPACE_ID, "describe " + MY_TABLE_NAME,
+               true,
+               Lists.newArrayList(
+                 new ColumnDesc("col_name", "STRING", 1, "from deserializer"),
+                 new ColumnDesc("data_type", "STRING", 2, "from deserializer"),
+                 new ColumnDesc("comment", "STRING", 3, "from deserializer")
+               ),
+               Lists.newArrayList(
+                 new QueryResult(Lists.<Object>newArrayList("id", "string", "from deserializer")),
+                 new QueryResult(Lists.<Object>newArrayList("subject", "string", "from deserializer")),
+                 new QueryResult(Lists.<Object>newArrayList("body", "string", "from deserializer")),
+                 new QueryResult(Lists.<Object>newArrayList("sender", "string", "from deserializer"))
+               )
+    );
+  }
+
+  @Test
+  public void testSelectStar() throws Exception {
+    List<ColumnDesc> expectedSchema = Lists.newArrayList(
+      new ColumnDesc(MY_TABLE_NAME + ".id", "STRING", 1, null),
+      new ColumnDesc(MY_TABLE_NAME + ".subject", "STRING", 2, null),
+      new ColumnDesc(MY_TABLE_NAME + ".body", "STRING", 3, null),
+      new ColumnDesc(MY_TABLE_NAME + ".sender", "STRING", 4, null)
+    );
+    ExploreExecutionResult results = exploreClient.submit(NAMESPACE_ID, "select * from " + MY_TABLE_NAME).get();
+    // check schema
+    Assert.assertEquals(expectedSchema, results.getResultSchema());
+    List<Object> columns = results.next().getColumns();
+    // check results
+    Assert.assertEquals("email1", columns.get(0));
+    Assert.assertEquals("this is the subject", columns.get(1));
+    Assert.assertEquals("this is the body", columns.get(2));
+    Assert.assertEquals("sljackson@boss.com", columns.get(3));
+    // should not be any more
+    Assert.assertFalse(results.hasNext());
+  }
+
+  @Test
+  public void testSelect() throws Exception {
+    String command = String.format("select sender from %s where body='this is the body'", MY_TABLE_NAME);
+    runCommand(NAMESPACE_ID, command,
+               true,
+               Lists.newArrayList(new ColumnDesc("sender", "STRING", 1, null)),
+               Lists.newArrayList(new QueryResult(Lists.<Object>newArrayList("sljackson@boss.com")))
+    );
+  }
+}

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/datasets/EmailTableDefinition.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/datasets/EmailTableDefinition.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.explore.service.datasets;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.data.batch.RecordScannable;
+import co.cask.cdap.api.data.batch.RecordScanner;
+import co.cask.cdap.api.data.batch.Split;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.dataset.DatasetAdmin;
+import co.cask.cdap.api.dataset.DatasetContext;
+import co.cask.cdap.api.dataset.DatasetDefinition;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.DatasetSpecification;
+import co.cask.cdap.api.dataset.lib.AbstractDataset;
+import co.cask.cdap.api.dataset.lib.AbstractDatasetDefinition;
+import co.cask.cdap.api.dataset.module.DatasetDefinitionRegistry;
+import co.cask.cdap.api.dataset.module.DatasetModule;
+import co.cask.cdap.api.dataset.table.Put;
+import co.cask.cdap.api.dataset.table.Table;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Dataset definition with a record scannable table, containing an extensive schema. Used for testing.
+ */
+public class EmailTableDefinition extends AbstractDatasetDefinition<EmailTableDefinition.EmailTable, DatasetAdmin> {
+  private static final Schema SCHEMA = Schema.recordOf("email",
+    Schema.Field.of("id", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("subject", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("body", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("sender", Schema.of(Schema.Type.STRING))
+  );
+  private final DatasetDefinition<? extends Table, ?> tableDef;
+
+  public EmailTableDefinition(String name, DatasetDefinition<? extends Table, ?> orderedTableDefinition) {
+    super(name);
+    this.tableDef = orderedTableDefinition;
+  }
+
+  @Override
+  public DatasetSpecification configure(String instanceName, DatasetProperties properties) {
+    DatasetProperties propertiesWithSchema = DatasetProperties.builder()
+      .addAll(properties.getProperties())
+      .add(DatasetProperties.SCHEMA, SCHEMA.toString())
+      .add(Table.PROPERTY_SCHEMA_ROW_FIELD, "id")
+      .build();
+    return DatasetSpecification.builder(instanceName, getName())
+      .properties(propertiesWithSchema.getProperties())
+      .datasets(tableDef.configure("email-table", propertiesWithSchema))
+      .build();
+  }
+
+  @Override
+  public DatasetAdmin getAdmin(DatasetContext datasetContext, DatasetSpecification spec,
+                               ClassLoader classLoader) throws IOException {
+    return tableDef.getAdmin(datasetContext, spec.getSpecification("email-table"), classLoader);
+  }
+
+  @Override
+  public EmailTable getDataset(DatasetContext datasetContext, DatasetSpecification spec,
+                                         Map<String, String> arguments, ClassLoader classLoader) throws IOException {
+    Table table = tableDef.getDataset(datasetContext, spec.getSpecification("email-table"), arguments,
+                                      classLoader);
+    return new EmailTable(spec.getName(), table);
+  }
+
+  /**
+   * Table that writes emails.
+   */
+  public static class EmailTable extends AbstractDataset implements RecordScannable<StructuredRecord> {
+    private final Table table;
+
+    public EmailTable(String instanceName, Table table) {
+      super(instanceName, table);
+      this.table = table;
+    }
+
+    public void writeEmail(String id, String subject, String body, String sender) {
+      Put put = new Put(Bytes.toBytes(id));
+      put.add("subject", subject);
+      put.add("body", body);
+      put.add("sender", sender);
+      table.put(put);
+    }
+
+    @Override
+    public Type getRecordType() {
+      return StructuredRecord.class;
+    }
+
+    @Override
+    public List<Split> getSplits() {
+      return table.getSplits();
+    }
+
+    @Override
+    public RecordScanner<StructuredRecord> createSplitRecordScanner(Split split) {
+      return table.createSplitRecordScanner(split);
+    }
+  }
+
+  /**
+   * EmailTable Module
+   */
+  public static class EmailTableModule implements DatasetModule {
+    @Override
+    public void register(DatasetDefinitionRegistry registry) {
+      DatasetDefinition<Table, DatasetAdmin> table = registry.get("table");
+      EmailTableDefinition emailTable = new EmailTableDefinition("email", table);
+      registry.add(emailTable);
+    }
+  }
+}

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/datasets/StructuredWritableDefinition.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/datasets/StructuredWritableDefinition.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.explore.service.datasets;
+
+import co.cask.cdap.api.data.batch.RecordWritable;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.dataset.DatasetAdmin;
+import co.cask.cdap.api.dataset.DatasetContext;
+import co.cask.cdap.api.dataset.DatasetDefinition;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.DatasetSpecification;
+import co.cask.cdap.api.dataset.lib.AbstractDataset;
+import co.cask.cdap.api.dataset.lib.AbstractDatasetDefinition;
+import co.cask.cdap.api.dataset.module.DatasetDefinitionRegistry;
+import co.cask.cdap.api.dataset.module.DatasetModule;
+import co.cask.cdap.api.dataset.table.Table;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.Map;
+
+/**
+ * Simple definition for a dataset that implements RecordWritable with type StructuredRecord, which is not allowed.
+ */
+public class StructuredWritableDefinition extends
+  AbstractDatasetDefinition<StructuredWritableDefinition.SWritable, DatasetAdmin> {
+
+  private final DatasetDefinition<? extends Table, ?> tableDef;
+
+  public StructuredWritableDefinition(String name,
+                                      DatasetDefinition<? extends Table, ?> orderedTableDefinition) {
+    super(name);
+    this.tableDef = orderedTableDefinition;
+  }
+
+  @Override
+  public DatasetSpecification configure(String instanceName, DatasetProperties properties) {
+    return DatasetSpecification.builder(instanceName, getName())
+      .properties(properties.getProperties())
+     .datasets(tableDef.configure("table", properties))
+     .build();
+  }
+
+  @Override
+  public DatasetAdmin getAdmin(DatasetContext datasetContext, DatasetSpecification spec,
+                               ClassLoader classLoader) throws IOException {
+    return tableDef.getAdmin(datasetContext, spec.getSpecification("table"), classLoader);
+  }
+
+  @Override
+  public SWritable getDataset(DatasetContext datasetContext, DatasetSpecification spec,
+                                        Map<String, String> arguments, ClassLoader classLoader) throws IOException {
+    Table table = tableDef.getDataset(datasetContext, spec.getSpecification("table"), arguments, classLoader);
+    return new SWritable(spec.getName(), table);
+  }
+
+  /**
+   */
+  public static class SWritable extends AbstractDataset implements RecordWritable<StructuredRecord> {
+
+    public SWritable(String instanceName, Table table) {
+      super(instanceName, table);
+    }
+
+    @Override
+    public Type getRecordType() {
+      return StructuredRecord.class;
+    }
+
+    @Override
+    public void write(StructuredRecord structuredRecord) throws IOException {
+
+    }
+  }
+
+  /**
+   */
+  public static class Module implements DatasetModule {
+    @Override
+    public void register(DatasetDefinitionRegistry registry) {
+      DatasetDefinition<Table, DatasetAdmin> tableDef = registry.get("table");
+      registry.add(new StructuredWritableDefinition("StructuredWritable", tableDef));
+    }
+  }
+
+}
+

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/datasets/TableWrapperDefinition.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/datasets/TableWrapperDefinition.java
@@ -18,6 +18,7 @@ package co.cask.cdap.explore.service.datasets;
 
 import co.cask.cdap.api.data.batch.RecordScannable;
 import co.cask.cdap.api.data.batch.RecordScanner;
+import co.cask.cdap.api.data.batch.RecordWritable;
 import co.cask.cdap.api.data.batch.Split;
 import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.api.dataset.DatasetAdmin;
@@ -72,8 +73,10 @@ public class TableWrapperDefinition extends
   }
 
   /**
+   * Doesn't actually do anything, only used to test hive table creation.
    */
-  public static class TableWrapper extends AbstractDataset implements RecordScannable<StructuredRecord> {
+  public static class TableWrapper extends AbstractDataset
+    implements RecordScannable<StructuredRecord>, RecordWritable<StructuredRecord> {
 
     public TableWrapper(String instanceName, Table table) {
       super(instanceName, table);
@@ -82,6 +85,11 @@ public class TableWrapperDefinition extends
     @Override
     public Type getRecordType() {
       return StructuredRecord.class;
+    }
+
+    @Override
+    public void write(StructuredRecord structuredRecord) throws IOException {
+
     }
 
     @Override

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/datasets/TableWrapperDefinition.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/datasets/TableWrapperDefinition.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.explore.service.datasets;
+
+import co.cask.cdap.api.data.batch.RecordScannable;
+import co.cask.cdap.api.data.batch.RecordScanner;
+import co.cask.cdap.api.data.batch.Split;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.dataset.DatasetAdmin;
+import co.cask.cdap.api.dataset.DatasetContext;
+import co.cask.cdap.api.dataset.DatasetDefinition;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.DatasetSpecification;
+import co.cask.cdap.api.dataset.lib.AbstractDataset;
+import co.cask.cdap.api.dataset.lib.AbstractDatasetDefinition;
+import co.cask.cdap.api.dataset.module.DatasetDefinitionRegistry;
+import co.cask.cdap.api.dataset.module.DatasetModule;
+import co.cask.cdap.api.dataset.table.Table;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A wrapper around the Table dataset. You wouldn't actually do this, purely for testing purposes.
+ */
+public class TableWrapperDefinition extends
+  AbstractDatasetDefinition<TableWrapperDefinition.TableWrapper, DatasetAdmin> {
+
+  private final DatasetDefinition<? extends Table, ?> tableDef;
+
+  public TableWrapperDefinition(String name,
+                                DatasetDefinition<? extends Table, ?> orderedTableDefinition) {
+    super(name);
+    this.tableDef = orderedTableDefinition;
+  }
+
+  @Override
+  public DatasetSpecification configure(String instanceName, DatasetProperties properties) {
+    return DatasetSpecification.builder(instanceName, getName())
+      .properties(properties.getProperties())
+     .datasets(tableDef.configure("table", properties))
+     .build();
+  }
+
+  @Override
+  public DatasetAdmin getAdmin(DatasetContext datasetContext, DatasetSpecification spec,
+                               ClassLoader classLoader) throws IOException {
+    return tableDef.getAdmin(datasetContext, spec.getSpecification("table"), classLoader);
+  }
+
+  @Override
+  public TableWrapper getDataset(DatasetContext datasetContext, DatasetSpecification spec,
+                                        Map<String, String> arguments, ClassLoader classLoader) throws IOException {
+    Table table = tableDef.getDataset(datasetContext, spec.getSpecification("table"), arguments, classLoader);
+    return new TableWrapper(spec.getName(), table);
+  }
+
+  /**
+   */
+  public static class TableWrapper extends AbstractDataset implements RecordScannable<StructuredRecord> {
+
+    public TableWrapper(String instanceName, Table table) {
+      super(instanceName, table);
+    }
+
+    @Override
+    public Type getRecordType() {
+      return StructuredRecord.class;
+    }
+
+    @Override
+    public List<Split> getSplits() {
+      return null;
+    }
+
+    @Override
+    public RecordScanner<StructuredRecord> createSplitRecordScanner(Split split) {
+      return null;
+    }
+  }
+
+  /**
+   */
+  public static class Module implements DatasetModule {
+    @Override
+    public void register(DatasetDefinitionRegistry registry) {
+      DatasetDefinition<Table, DatasetAdmin> tableDef = registry.get("table");
+      registry.add(new TableWrapperDefinition("TableWrapper", tableDef));
+    }
+  }
+
+}
+


### PR DESCRIPTION
There was a bug where Table and ObjectMappedTable are
explorable because they are ```RecordScannable<StructureRecord>```,
but custom datasets were not explorable in the same way. So
somebody could create a custom dataset that uses an explorable
table, but would not be able to use that to make their custom
dataset explorable.

This fix will create a Hive table for custom datasets that are
```RecordScannable<StructuredRecord>```, assuming the schema dataset
property is set. If the schema property is not set, enabling
exploration will fail with a message that the schema property
is required.