### PR TITLE
Introduce a ClassRule, TestConfiguration, that unit-test can use to set CDAP configs

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/co/cask/cdap/template/etl/batch/BaseETLBatchTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/co/cask/cdap/template/etl/batch/BaseETLBatchTest.java
@@ -41,6 +41,7 @@ import co.cask.cdap.template.etl.transform.StructuredRecordToGenericRecordTransf
 import co.cask.cdap.template.test.sink.MetaKVTableSink;
 import co.cask.cdap.template.test.source.MetaKVTableSource;
 import co.cask.cdap.test.TestBase;
+import co.cask.cdap.test.TestConfiguration;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.gson.Gson;
@@ -54,6 +55,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.twill.filesystem.Location;
 import org.hsqldb.jdbc.JDBCDriver;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import parquet.avro.AvroParquetOutputFormat;
 import parquet.avro.AvroParquetReader;
 
@@ -64,6 +66,10 @@ import java.util.List;
  * Base test class that sets up plugins and the batch template.
  */
 public class BaseETLBatchTest extends TestBase {
+
+  @ClassRule
+  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
+
   protected static final Id.Namespace NAMESPACE = Constants.DEFAULT_NAMESPACE_ID;
   protected static final Id.ApplicationTemplate TEMPLATE_ID = Id.ApplicationTemplate.from("ETLBatch");
   protected static final Gson GSON = new Gson();

--- a/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/test/java/co/cask/cdap/template/etl/realtime/ETLWorkerTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/test/java/co/cask/cdap/template/etl/realtime/ETLWorkerTest.java
@@ -45,6 +45,7 @@ import co.cask.cdap.test.DataSetManager;
 import co.cask.cdap.test.SlowTests;
 import co.cask.cdap.test.StreamManager;
 import co.cask.cdap.test.TestBase;
+import co.cask.cdap.test.TestConfiguration;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
@@ -87,6 +88,9 @@ public class ETLWorkerTest extends TestBase {
 
   @ClassRule
   public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
+
+  @ClassRule
+  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
 
   protected static final int PARTITIONS = 1;
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/test/java/co/cask/cdap/template/etl/realtime/RealtimeCubeSinkTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/test/java/co/cask/cdap/template/etl/realtime/RealtimeCubeSinkTest.java
@@ -43,11 +43,13 @@ import co.cask.cdap.template.etl.transform.StructuredRecordToGenericRecordTransf
 import co.cask.cdap.test.AdapterManager;
 import co.cask.cdap.test.DataSetManager;
 import co.cask.cdap.test.TestBase;
+import co.cask.cdap.test.TestConfiguration;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.gson.Gson;
 import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -60,6 +62,10 @@ import java.util.concurrent.TimeUnit;
  *
  */
 public class RealtimeCubeSinkTest extends TestBase {
+
+  @ClassRule
+  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
+
   private static final Gson GSON = new Gson();
   private static final Id.Namespace NAMESPACE = Constants.DEFAULT_NAMESPACE_ID;
   private static final Id.ApplicationTemplate TEMPLATE_ID = Id.ApplicationTemplate.from("ETLRealtime");

--- a/cdap-examples/FileSetExample/src/test/java/co/cask/cdap/examples/fileset/FileSetWordCountTest.java
+++ b/cdap-examples/FileSetExample/src/test/java/co/cask/cdap/examples/fileset/FileSetWordCountTest.java
@@ -25,10 +25,12 @@ import co.cask.cdap.test.DataSetManager;
 import co.cask.cdap.test.MapReduceManager;
 import co.cask.cdap.test.ServiceManager;
 import co.cask.cdap.test.TestBase;
+import co.cask.cdap.test.TestConfiguration;
 import com.google.common.base.Charsets;
 import com.google.common.collect.Maps;
 import org.apache.twill.filesystem.Location;
 import org.junit.Assert;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.io.BufferedReader;
@@ -45,6 +47,9 @@ import java.util.concurrent.TimeUnit;
  * A unit test for word count over file sets.
  */
 public class FileSetWordCountTest extends TestBase {
+
+  @ClassRule
+  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
 
   @Test
   public void testWordCountOnFileSet() throws Exception {

--- a/cdap-examples/HelloWorld/src/test/java/co/cask/cdap/examples/helloworld/HelloWorldTest.java
+++ b/cdap-examples/HelloWorld/src/test/java/co/cask/cdap/examples/helloworld/HelloWorldTest.java
@@ -22,9 +22,11 @@ import co.cask.cdap.test.RuntimeStats;
 import co.cask.cdap.test.ServiceManager;
 import co.cask.cdap.test.StreamManager;
 import co.cask.cdap.test.TestBase;
+import co.cask.cdap.test.TestConfiguration;
 import com.google.common.base.Charsets;
 import com.google.common.io.ByteStreams;
 import org.junit.Assert;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.net.HttpURLConnection;
@@ -35,6 +37,9 @@ import java.util.concurrent.TimeUnit;
  * Test for {@link HelloWorld}.
  */
 public class HelloWorldTest extends TestBase {
+
+  @ClassRule
+  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
 
   @Test
   public void test() throws Exception {

--- a/cdap-examples/LogAnalysis/src/test/java/co/cask/cdap/examples/loganalysis/LogAnalysisAppTest.java
+++ b/cdap-examples/LogAnalysis/src/test/java/co/cask/cdap/examples/loganalysis/LogAnalysisAppTest.java
@@ -28,14 +28,18 @@ import co.cask.cdap.test.ServiceManager;
 import co.cask.cdap.test.SparkManager;
 import co.cask.cdap.test.StreamManager;
 import co.cask.cdap.test.TestBase;
+import co.cask.cdap.test.TestConfiguration;
 import co.cask.common.http.HttpRequest;
 import co.cask.common.http.HttpRequests;
 import co.cask.common.http.HttpResponse;
+import com.google.common.base.Charsets;
 import org.apache.twill.filesystem.Location;
 import org.junit.Assert;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.io.BufferedReader;
+import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.HashMap;
@@ -53,7 +57,10 @@ public class LogAnalysisAppTest extends TestBase {
   private static final String TOTAL_HITS_VALUE = "2";
   private static final String TOTAL_RESPONSE_VALUE = "2";
   private static final String RESPONSE_CODE = "200";
-  public static final String TPFS_RESULT = "127.0.0.1:2";
+  private static final String TPFS_RESULT = "127.0.0.1:2";
+
+  @ClassRule
+  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
 
   @Test
   public void test() throws Exception {
@@ -122,8 +129,9 @@ public class LogAnalysisAppTest extends TestBase {
         location = file;
       }
     }
-    BufferedReader reader = new BufferedReader(new jline.internal.InputStreamReader(location.getInputStream()));
-    Assert.assertEquals(TPFS_RESULT, reader.readLine());
+    try (BufferedReader reader = new BufferedReader(new InputStreamReader(location.getInputStream(), Charsets.UTF_8))) {
+      Assert.assertEquals(TPFS_RESULT, reader.readLine());
+    }
   }
 
 

--- a/cdap-examples/Purchase/src/test/java/co/cask/cdap/examples/purchase/PurchaseAppTest.java
+++ b/cdap-examples/Purchase/src/test/java/co/cask/cdap/examples/purchase/PurchaseAppTest.java
@@ -24,10 +24,12 @@ import co.cask.cdap.test.RuntimeStats;
 import co.cask.cdap.test.ServiceManager;
 import co.cask.cdap.test.StreamManager;
 import co.cask.cdap.test.TestBase;
+import co.cask.cdap.test.TestConfiguration;
 import com.google.common.base.Charsets;
 import com.google.common.io.ByteStreams;
 import com.google.gson.Gson;
 import org.junit.Assert;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.net.HttpURLConnection;
@@ -38,6 +40,9 @@ import java.util.concurrent.TimeUnit;
  * Test for {@link PurchaseApp}.
  */
 public class PurchaseAppTest extends TestBase {
+
+  @ClassRule
+  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
 
   private static final Gson GSON = new Gson();
 

--- a/cdap-examples/SparkKMeans/src/test/java/co/cask/cdap/examples/sparkkmeans/SparkKMeansAppTest.java
+++ b/cdap-examples/SparkKMeans/src/test/java/co/cask/cdap/examples/sparkkmeans/SparkKMeansAppTest.java
@@ -24,9 +24,11 @@ import co.cask.cdap.test.ServiceManager;
 import co.cask.cdap.test.SparkManager;
 import co.cask.cdap.test.StreamManager;
 import co.cask.cdap.test.TestBase;
+import co.cask.cdap.test.TestConfiguration;
 import com.google.common.base.Charsets;
 import com.google.common.io.ByteStreams;
 import org.junit.Assert;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -38,6 +40,9 @@ import java.util.concurrent.TimeUnit;
  * SparkKMeansApp main tests.
  */
 public class SparkKMeansAppTest extends TestBase {
+
+  @ClassRule
+  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
 
   @Test
   public void test() throws Exception {

--- a/cdap-examples/UserProfiles/src/test/java/co/cask/cdap/examples/profiles/UserProfilesTest.java
+++ b/cdap-examples/UserProfiles/src/test/java/co/cask/cdap/examples/profiles/UserProfilesTest.java
@@ -27,10 +27,12 @@ import co.cask.cdap.test.RuntimeStats;
 import co.cask.cdap.test.ServiceManager;
 import co.cask.cdap.test.StreamManager;
 import co.cask.cdap.test.TestBase;
+import co.cask.cdap.test.TestConfiguration;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import org.junit.Assert;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.net.HttpURLConnection;
@@ -41,6 +43,9 @@ import java.util.concurrent.TimeUnit;
  * Tests the UserProfiles example app.
  */
 public class UserProfilesTest extends TestBase {
+
+  @ClassRule
+  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
 
   @Test
   public void testUserProfiles() throws Exception {

--- a/cdap-examples/WebAnalytics/src/test/java/co/cask/cdap/examples/webanalytics/WebAnalyticsTest.java
+++ b/cdap-examples/WebAnalytics/src/test/java/co/cask/cdap/examples/webanalytics/WebAnalyticsTest.java
@@ -21,7 +21,9 @@ import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.RuntimeStats;
 import co.cask.cdap.test.StreamManager;
 import co.cask.cdap.test.TestBase;
+import co.cask.cdap.test.TestConfiguration;
 import org.junit.Assert;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.io.BufferedReader;
@@ -34,6 +36,9 @@ import java.util.concurrent.TimeUnit;
  * does not assert the data has indeed been inserted.
  */
 public class WebAnalyticsTest extends TestBase {
+
+  @ClassRule
+  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
 
   @Test
   public void testWebAnalytics() throws Exception {

--- a/cdap-examples/WordCount/src/test/java/co/cask/cdap/examples/wordcount/WordCountTest.java
+++ b/cdap-examples/WordCount/src/test/java/co/cask/cdap/examples/wordcount/WordCountTest.java
@@ -22,11 +22,13 @@ import co.cask.cdap.test.RuntimeStats;
 import co.cask.cdap.test.ServiceManager;
 import co.cask.cdap.test.StreamManager;
 import co.cask.cdap.test.TestBase;
+import co.cask.cdap.test.TestConfiguration;
 import com.google.common.base.Charsets;
 import com.google.common.io.ByteStreams;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import org.junit.Assert;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -41,8 +43,11 @@ import java.util.concurrent.TimeUnit;
  */
 public class WordCountTest extends TestBase {
 
-  static Type stringMapType = new TypeToken<Map<String, String>>() { }.getType();
-  static Type objectMapType = new TypeToken<Map<String, Object>>() { }.getType();
+  @ClassRule
+  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
+
+  private static final Type STRING_MAP_TYPE = new TypeToken<Map<String, String>>() { }.getType();
+  private static final Type OBJECT_MAP_TYPE = new TypeToken<Map<String, Object>>() { }.getType();
 
   @Test
   public void testWordCount() throws Exception {
@@ -70,14 +75,14 @@ public class WordCountTest extends TestBase {
 
     // First verify global statistics
     String response = requestService(new URL(serviceManager.getServiceURL(15, TimeUnit.SECONDS), "stats"));
-    Map<String, String> map = new Gson().fromJson(response, stringMapType);
+    Map<String, String> map = new Gson().fromJson(response, STRING_MAP_TYPE);
     Assert.assertEquals("9", map.get("totalWords"));
     Assert.assertEquals("6", map.get("uniqueWords"));
     Assert.assertEquals(((double) 42) / 9, Double.valueOf(map.get("averageLength")), 0.001);
 
     // Now verify statistics for a specific word
     response = requestService(new URL(serviceManager.getServiceURL(15, TimeUnit.SECONDS), "count/world"));
-    Map<String, Object> omap = new Gson().fromJson(response, objectMapType);
+    Map<String, Object> omap = new Gson().fromJson(response, OBJECT_MAP_TYPE);
     Assert.assertEquals("world", omap.get("word"));
     Assert.assertEquals(3.0, omap.get("count"));
 

--- a/cdap-formats/pom.xml
+++ b/cdap-formats/pom.xml
@@ -26,6 +26,8 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>cdap-formats</artifactId>
+  <name>CDAP Data Format</name>
+  <packaging>jar</packaging>
 
   <dependencies>
     <dependency>

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
@@ -17,9 +17,17 @@
 package co.cask.cdap.test;
 
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 
 /**
+ * Base class to inherit from for unit-test.
+ * It provides testing functionality for {@link co.cask.cdap.api.app.Application}.
+ * To clean App Fabric state, you can use the {@link #clear} method.
+ * <p>
+ * Custom configurations for CDAP can be set by using {@link ClassRule} and {@link TestConfiguration}.
+ * </p>
  *
+ * @see TestConfiguration
  */
 public class TestBase extends ConfigurableTestBase {
 

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/TestConfiguration.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/TestConfiguration.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.test;
+
+import com.google.common.base.Preconditions;
+import org.junit.rules.ExternalResource;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This class can be used to setup CDAP configuration for unit-test.
+ * <p>
+ * Usage:
+ *
+ * <pre>{@code
+ * class MyUnitTest extends TestBase {
+ *
+ *   &#64;ClassRule
+ *   public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", "false");
+ *
+ *   ....
+ * }
+ * }</pre>
+ *
+ * </p>
+ */
+public class TestConfiguration extends ExternalResource {
+
+  public static final String PROPERTY_PREFIX = "cdap.unit.test.";
+  private final Map<String, String> configs;
+
+  /**
+   * Creates a new instance with the give list of configurations.
+   *
+   * @param configs list of configuration pairs.
+   *                The list must be in the form of {@code (key1, value1, key2, value2, ...)},
+   *                hence the length of configs must be even.
+   *                The {@link Object#toString()} method will be called to obtain the keys and values that go into
+   *                the configuration.
+   */
+  public TestConfiguration(Object... configs) {
+    Preconditions.checkArgument(configs.length % 2 == 0,
+                                "Arguments must be in pair form like (k1, v1, k2, v2): %s", Arrays.toString(configs));
+
+    this.configs = new HashMap<>();
+    for (int i = 0; i < configs.length; i += 2) {
+      this.configs.put(PROPERTY_PREFIX + configs[i].toString(), configs[i + 1].toString());
+    }
+  }
+
+  /**
+   * Creates a new instance with the given configurations.
+   *
+   * @param configs a Map of configurations
+   */
+  public TestConfiguration(Map<String, String> configs) {
+    this.configs = new HashMap<>(configs);
+  }
+
+  @Override
+  protected void before() throws Throwable {
+    // Use the system properties map as a mean to communicate unit-test specific CDAP configurations to the
+    // TestBase class, which it will use to setup the CConfiguration.
+    // All keys set into the properties are prefixed with PROPERTY_PREFIX.
+
+    // It is done using @ClassRule instead of inheritance/method override is because TestBase starts
+    // CDAP services in a @BeforeClass method, which is a static method.
+    //
+    // In JUnit, @BeforeClass methods in super-class are called before the one in the sub-class.
+    // This means the sub-class cannot use @BeforeClass method to provide configurations before CDAP initialize.
+    //
+    // Since @BeforeClass method must be static, there is no way to guarantee that the sub-class implements
+    // a particular method such that TestBase can calls to get configurations before initializing CDAP.
+    // One can rely on naming convention and static method shadowing, however, that is an anti-pattern.
+    // Using @ClassRule gives a much cleaner solution.
+    for (Map.Entry<String, String> entry : configs.entrySet()) {
+      System.setProperty(entry.getKey(), entry.getValue());
+    }
+  }
+
+  @Override
+  protected void after() {
+    for (String key : configs.keySet()) {
+      System.clearProperty(key);
+    }
+  }
+}

--- a/cdap-unit-test/src/test/java/co/cask/cdap/partitioned/MapReducePartitionConsumingTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/partitioned/MapReducePartitionConsumingTestRun.java
@@ -47,7 +47,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * Test that MapReduce can incrementally process partitions.
  */
-public class MapReducePartitionConsumingTest extends TestFrameworkTestBase {
+public class MapReducePartitionConsumingTestRun extends TestFrameworkTestBase {
   private static final String LINE1 = "a b a";
   private static final String LINE2 = "b a b";
   private static final String LINE3 = "c c c";

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/DatasetUpgradeDisabledTest.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/DatasetUpgradeDisabledTest.java
@@ -17,14 +17,13 @@
 package co.cask.cdap.test.app;
 
 import co.cask.cdap.common.conf.Constants;
-import co.cask.cdap.test.ApplicationManager;
-import co.cask.cdap.test.ConfigurableTestBase;
 import co.cask.cdap.test.DataSetManager;
 import co.cask.cdap.test.SlowTests;
+import co.cask.cdap.test.TestBase;
+import co.cask.cdap.test.TestConfiguration;
 import co.cask.cdap.test.XSlowTests;
-import com.google.common.collect.ImmutableMap;
 import org.junit.Assert;
-import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -32,17 +31,18 @@ import org.junit.experimental.categories.Category;
  *
  */
 @Category(SlowTests.class)
-public class DatasetUpgradeDisabledTest extends ConfigurableTestBase {
+public class DatasetUpgradeDisabledTest extends TestBase {
 
-  @BeforeClass
-  public static void init() throws Exception {
-    initTestBase(ImmutableMap.of(Constants.Dataset.DATASET_UNCHECKED_UPGRADE, Boolean.FALSE.toString()));
-  }
+  @ClassRule
+  public static final TestConfiguration CONFIG = new TestConfiguration(
+    Constants.Dataset.DATASET_UNCHECKED_UPGRADE, false,
+    Constants.Explore.EXPLORE_ENABLED, false
+  );
 
   @Category(XSlowTests.class)
   @Test
   public void testDatasetUncheckedUpgrade() throws Exception {
-    ApplicationManager applicationManager = deployApplication(DatasetUncheckedUpgradeApp.class);
+    deployApplication(DatasetUncheckedUpgradeApp.class);
     DataSetManager<DatasetUncheckedUpgradeApp.RecordDataset> datasetManager =
       getDataset(DatasetUncheckedUpgradeApp.DATASET_NAME);
     DatasetUncheckedUpgradeApp.Record expectedRecord = new DatasetUncheckedUpgradeApp.Record("0AXB", "john", "doe");
@@ -54,7 +54,7 @@ public class DatasetUpgradeDisabledTest extends ConfigurableTestBase {
     Assert.assertEquals(expectedRecord, actualRecord);
 
     // Test incompatible upgrade
-    applicationManager = deployApplication(IncompatibleDatasetUncheckedUpgradeApp.class);
+    deployApplication(IncompatibleDatasetUncheckedUpgradeApp.class);
     datasetManager = getDataset(DatasetUncheckedUpgradeApp.DATASET_NAME);
     // new dataset is incompatible, but because dataset upgrade is disabled, it should not have an effect
     // this would either fail in getRecord() or throw a class cast exception if the dataset had been upgraded

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/DatasetUpgradeEnabledTest.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/DatasetUpgradeEnabledTest.java
@@ -21,10 +21,11 @@ import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.ConfigurableTestBase;
 import co.cask.cdap.test.DataSetManager;
 import co.cask.cdap.test.SlowTests;
+import co.cask.cdap.test.TestBase;
+import co.cask.cdap.test.TestConfiguration;
 import co.cask.cdap.test.XSlowTests;
-import com.google.common.collect.ImmutableMap;
 import org.junit.Assert;
-import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -32,12 +33,13 @@ import org.junit.experimental.categories.Category;
  *
  */
 @Category(SlowTests.class)
-public class DatasetUpgradeEnabledTest extends ConfigurableTestBase {
+public class DatasetUpgradeEnabledTest extends TestBase {
 
-  @BeforeClass
-  public static void init() throws Exception {
-    initTestBase(ImmutableMap.of(Constants.Dataset.DATASET_UNCHECKED_UPGRADE, Boolean.TRUE.toString()));
-  }
+  @ClassRule
+  public static final TestConfiguration CONFIG = new TestConfiguration(
+    Constants.Dataset.DATASET_UNCHECKED_UPGRADE, true,
+    Constants.Explore.EXPLORE_ENABLED, false
+  );
 
   @Category(XSlowTests.class)
   @Test

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestAppWithCube.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestAppWithCube.java
@@ -24,10 +24,12 @@ import co.cask.cdap.api.dataset.lib.cube.DimensionValue;
 import co.cask.cdap.api.dataset.lib.cube.MeasureType;
 import co.cask.cdap.api.dataset.lib.cube.TimeSeries;
 import co.cask.cdap.api.dataset.lib.cube.TimeValue;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.ServiceManager;
 import co.cask.cdap.test.SlowTests;
 import co.cask.cdap.test.TestBase;
+import co.cask.cdap.test.TestConfiguration;
 import co.cask.common.http.HttpRequest;
 import co.cask.common.http.HttpRequests;
 import co.cask.common.http.HttpResponse;
@@ -36,6 +38,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import org.junit.Assert;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -51,6 +54,10 @@ import java.util.concurrent.TimeUnit;
  *
  */
 public class TestAppWithCube extends TestBase {
+
+  @ClassRule
+  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false);
+
   private static final Gson GSON = new Gson();
 
   @Category(SlowTests.class)

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
@@ -742,7 +742,7 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
 
   @Test
   public void testAppRedeployKeepsData() throws Exception {
-    ApplicationManager appManager = deployApplication(testSpace, AppWithTable.class);
+    deployApplication(testSpace, AppWithTable.class);
     DataSetManager<Table> myTableManager = getDataset(testSpace, "my_table");
     myTableManager.get().put(new Put("key1", "column1", "value1"));
     myTableManager.flush();
@@ -752,7 +752,7 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     Assert.assertEquals("value1", myTableManager2.get().get(new Get("key1", "column1")).getString("column1"));
 
     // Even after redeploy of an app: changes should be visible to other instances of datasets
-    appManager = deployApplication(AppWithTable.class);
+    deployApplication(AppWithTable.class);
     DataSetManager<Table> myTableManager3 = getDataset(testSpace, "my_table");
     Assert.assertEquals("value1", myTableManager3.get().get(new Get("key1", "column1")).getString("column1"));
 
@@ -898,20 +898,17 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     kvTable.put("c", "1");
     myTableManager.flush();
 
-    Connection connection = getQueryClient(testSpace);
-    try {
-
-      // run a query over the dataset
+    try (
+      Connection connection = getQueryClient(testSpace);
       ResultSet results = connection.prepareStatement("select first from dataset_mytable where second = '1'")
-        .executeQuery();
+                                    .executeQuery()
+    ) {
+      // run a query over the dataset
       Assert.assertTrue(results.next());
       Assert.assertEquals("a", results.getString(1));
       Assert.assertTrue(results.next());
       Assert.assertEquals("c", results.getString(1));
       Assert.assertFalse(results.next());
-
-    } finally {
-      connection.close();
     }
   }
 

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/base/TestFrameworkTestSuite.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/base/TestFrameworkTestSuite.java
@@ -20,7 +20,7 @@ import co.cask.cdap.batch.stream.BatchStreamIntegrationTestRun;
 import co.cask.cdap.flow.stream.FlowStreamIntegrationTestRun;
 import co.cask.cdap.mapreduce.MapReduceStreamInputTestRun;
 import co.cask.cdap.mapreduce.service.MapReduceServiceIntegrationTestRun;
-import co.cask.cdap.partitioned.MapReducePartitionConsumingTest;
+import co.cask.cdap.partitioned.MapReducePartitionConsumingTestRun;
 import co.cask.cdap.spark.metrics.SparkMetricsIntegrationTestRun;
 import co.cask.cdap.spark.service.SparkServiceIntegrationTestRun;
 import co.cask.cdap.spark.stream.SparkStreamIntegrationTestRun;
@@ -45,7 +45,7 @@ import org.junit.runners.Suite;
   FlowStreamIntegrationTestRun.class,
   MapReduceStreamInputTestRun.class,
   MapReduceServiceIntegrationTestRun.class,
-  MapReducePartitionConsumingTest.class,
+  MapReducePartitionConsumingTestRun.class,
   SparkMetricsIntegrationTestRun.class,
   SparkServiceIntegrationTestRun.class,
   SparkStreamIntegrationTestRun.class,

--- a/cdap-unit-test/src/test/java/net/fake/test/app/TestBundleJarApp.java
+++ b/cdap-unit-test/src/test/java/net/fake/test/app/TestBundleJarApp.java
@@ -17,6 +17,7 @@
 package net.fake.test.app;
 
 import co.cask.cdap.api.metrics.RuntimeMetrics;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.FlowManager;
 import co.cask.cdap.test.RuntimeStats;
@@ -24,10 +25,12 @@ import co.cask.cdap.test.ServiceManager;
 import co.cask.cdap.test.SlowTests;
 import co.cask.cdap.test.StreamManager;
 import co.cask.cdap.test.TestBase;
+import co.cask.cdap.test.TestConfiguration;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import org.junit.Assert;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -45,6 +48,9 @@ import java.util.concurrent.TimeUnit;
  */
 @Category(SlowTests.class)
 public class TestBundleJarApp extends TestBase {
+
+  @ClassRule
+  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false);
 
   @Test
   public void testBundleJar() throws Exception {


### PR DESCRIPTION
It can be used by unit-test classes to alter CDAP configurations easily in unit-test.

- Deprecate the ConfigurableTestBase, since it’s harder to use
- Convert all existing unit-tests to use the TestConfiguration
- Disable explore for tests that doesn’t need explore capability.
  - It cuts ~10-15 seconds from unit-tests that doesn't need explore service