### PR TITLE
update hbase-compat modules, add 1.0, 1.0-cdh, remove 0.94

### DIFF
--- a/cdap-distributions/bin/build_parcel.sh
+++ b/cdap-distributions/bin/build_parcel.sh
@@ -20,7 +20,7 @@ PARCEL_SUFFIX=${PARCEL_SUFFIX:-el6}
 PARCEL_ITERATION=${PARCEL_ITERATION:-1}
 
 # Components should map to top-level directories: "cdap-${COMPONENT}"
-COMPONENTS="cli gateway hbase-compat-0.94 hbase-compat-0.96 hbase-compat-0.98 kafka master security ui"
+COMPONENTS="cli gateway hbase-compat-0.96 hbase-compat-0.98 hbase-compat-1.0 hbase-compate-1.0-cdh kafka master security ui"
 
 # Find our location and base repo directory
 # Resolve links: $0 may be a link


### PR DESCRIPTION
parcel buildscript needs updated to include the new hbase-compat modules, and drop the 0.94 module.