### PR TITLE
Fix error checking in VM build scripts

### DIFF
--- a/cdap-distributions/src/packer/scripts/cookbook-dir.sh
+++ b/cdap-distributions/src/packer/scripts/cookbook-dir.sh
@@ -25,7 +25,7 @@ cd /var/chef/cookbooks
 # Initialize Git repository
 touch .gitignore
 
-which git || echo "Cannot locate git" && exit 1
+which git || (echo "Cannot locate git" && exit 1)
 git init
 git add .gitignore
 git commit -m 'Initial commit'

--- a/cdap-distributions/src/packer/scripts/cookbook-setup.sh
+++ b/cdap-distributions/src/packer/scripts/cookbook-setup.sh
@@ -20,7 +20,7 @@
 
 # Grab cookbooks using knife
 for cb in hadoop idea maven nodejs cdap ; do
-  knife cookbook site install $cb || echo "Cannot fetch cookbook $cb" && exit 1
+  knife cookbook site install $cb || (echo "Cannot fetch cookbook $cb" && exit 1)
 done
 
 # Do not change HOME for cdap user

--- a/cdap-distributions/src/packer/scripts/eclipse-cookbook.sh
+++ b/cdap-distributions/src/packer/scripts/eclipse-cookbook.sh
@@ -18,11 +18,11 @@
 # Download Eclipse cookbook for Chef from https://github.com/geocent-cookbooks/eclipse
 #
 
-cd /var/chef/cookbooks || echo "Cannot change to cookbook directory" && exit 1
+cd /var/chef/cookbooks || (echo "Cannot change to cookbook directory" && exit 1)
 
 # Check out the cookbook from GitHub
-which git || echo "Cannot locate git" && exit 1
-git clone https://github.com/geocent-cookbooks/eclipse.git || echo "Cannot checkout eclipse cookbook" && exit 1
+which git || (echo "Cannot locate git" && exit 1)
+git clone https://github.com/geocent-cookbooks/eclipse.git || (echo "Cannot checkout eclipse cookbook" && exit 1)
 
 # Remove .git, so it's no longer tracked by git
 rm -rf eclipse/.git

--- a/cdap-distributions/src/packer/scripts/lxde.sh
+++ b/cdap-distributions/src/packer/scripts/lxde.sh
@@ -22,7 +22,7 @@
 apt-get install -y lxde
 
 # Symlink idea
-ln -sf /opt/idea* /opt/idea || echo "Unable to symlink IDEA" && exit 1
+ln -sf /opt/idea* /opt/idea || (echo "Unable to symlink IDEA" && exit 1)
 # Copy icons
 cp -f /opt/idea/bin/idea.png /usr/share/pixmaps
 cp -f /usr/local/eclipse/icon.xpm /usr/share/pixmaps/eclipse.xpm

--- a/cdap-distributions/src/packer/scripts/vbox-guest-additions.sh
+++ b/cdap-distributions/src/packer/scripts/vbox-guest-additions.sh
@@ -19,10 +19,10 @@
 #
 
 # Mount ISO
-mount -o ro,loop /root/VBoxGuestAdditions.iso /mnt || echo "Cannot mount VirtualBox Guest Additions ISO" && exit 1
+mount -o ro,loop /root/VBoxGuestAdditions.iso /mnt || (echo "Cannot mount VirtualBox Guest Additions ISO" && exit 1)
 
 # Run installer
-/mnt/VBoxLinuxAdditions.run || echo "Failed installing VirtualBox Guest Additions" && exit 1
+/mnt/VBoxLinuxAdditions.run || (echo "Failed installing VirtualBox Guest Additions" && exit 1)
 
 # Unmount and remove ISO
 umount /mnt

--- a/cdap-distributions/src/packer/scripts/zero-disk.sh
+++ b/cdap-distributions/src/packer/scripts/zero-disk.sh
@@ -22,6 +22,6 @@
 dd if=/dev/zero of=/deleteme bs=1M
 
 # Remove file to free space
-rm -f /deleteme || echo "Unable to delete zero-filled /deleteme" && exit 1
+rm -f /deleteme || (echo "Unable to delete zero-filled /deleteme" && exit 1)
 
 exit 0


### PR DESCRIPTION
Bash evaluates && before || so wrap invocations in parentheses.