### PR TITLE
CDAP-2986: spark takes dataset arguments when reading writing

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/spark/SparkContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/spark/SparkContext.java
@@ -29,6 +29,7 @@ import co.cask.cdap.api.workflow.Workflow;
 import co.cask.cdap.api.workflow.WorkflowToken;
 
 import java.io.Serializable;
+import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
@@ -72,6 +73,19 @@ public interface SparkContext extends RuntimeContext, DatasetContext {
   <T> T readFromDataset(String datasetName, Class<?> kClass, Class<?> vClass);
 
   /**
+   * Create a Spark RDD that uses {@link Dataset} instantiated using the provided arguments as an input source
+   *
+   * @param datasetName the name of the {@link Dataset} to be read as an RDD
+   * @param kClass      the key class
+   * @param vClass      the value class
+   * @param datasetArgs arguments for the dataset
+   * @param <T>         type of RDD
+   * @return the RDD created from Dataset
+   * @throws UnsupportedOperationException if the SparkContext is not yet initialized
+   */
+  <T> T readFromDataset(String datasetName, Class<?> kClass, Class<?> vClass, Map<String, String> datasetArgs);
+
+  /**
    * Writes a Spark RDD to {@link Dataset}
    *
    * @param rdd         the rdd to be stored
@@ -82,6 +96,19 @@ public interface SparkContext extends RuntimeContext, DatasetContext {
    * @throws UnsupportedOperationException if the SparkContext is not yet initialized
    */
   <T> void writeToDataset(T rdd, String datasetName, Class<?> kClass, Class<?> vClass);
+
+  /**
+   * Writes a Spark RDD to {@link Dataset} instantiated using the provided arguments
+   *
+   * @param rdd         the rdd to be stored
+   * @param datasetName the name of the {@link Dataset} where the RDD should be stored
+   * @param kClass      the key class
+   * @param vClass      the value class
+   * @param datasetArgs arguments for the dataset
+   * @param <T>         type of RDD
+   * @throws UnsupportedOperationException if the SparkContext is not yet initialized
+   */
+  <T> void writeToDataset(T rdd, String datasetName, Class<?> kClass, Class<?> vClass, Map<String, String> datasetArgs);
 
   /**
    * Create a Spark RDD that uses complete {@link Stream} as input source

--- a/cdap-api/src/main/java/co/cask/cdap/api/spark/SparkContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/spark/SparkContext.java
@@ -73,7 +73,7 @@ public interface SparkContext extends RuntimeContext, DatasetContext {
   <T> T readFromDataset(String datasetName, Class<?> kClass, Class<?> vClass);
 
   /**
-   * Create a Spark RDD that uses {@link Dataset} instantiated using the provided arguments as an input source
+   * Create a Spark RDD that uses {@link Dataset} instantiated using the provided arguments as an input source.
    *
    * @param datasetName the name of the {@link Dataset} to be read as an RDD
    * @param kClass      the key class
@@ -98,7 +98,7 @@ public interface SparkContext extends RuntimeContext, DatasetContext {
   <T> void writeToDataset(T rdd, String datasetName, Class<?> kClass, Class<?> vClass);
 
   /**
-   * Writes a Spark RDD to {@link Dataset} instantiated using the provided arguments
+   * Writes a Spark RDD to {@link Dataset} instantiated using the provided arguments.
    *
    * @param rdd         the rdd to be stored
    * @param datasetName the name of the {@link Dataset} where the RDD should be stored

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/AbstractSparkContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/AbstractSparkContext.java
@@ -47,6 +47,7 @@ import org.apache.twill.api.RunId;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 
 import java.io.Closeable;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -113,6 +114,16 @@ public abstract class AbstractSparkContext implements SparkContext, Closeable {
   @Override
   public Metrics getMetrics() {
     return new SparkUserMetrics(metricsContext);
+  }
+
+  @Override
+  public <T> T readFromDataset(String datasetName, Class<?> kClass, Class<?> vClass) {
+    return readFromDataset(datasetName, kClass, vClass, Collections.<String, String>emptyMap());
+  }
+
+  @Override
+  public <T> void writeToDataset(T rdd, String datasetName, Class<?> kClass, Class<?> vClass) {
+    writeToDataset(rdd, datasetName, kClass, vClass, Collections.<String, String>emptyMap());
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/ClientSparkContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/ClientSparkContext.java
@@ -67,18 +67,8 @@ public final class ClientSparkContext extends AbstractSparkContext {
   }
 
   @Override
-  public <T> T readFromDataset(String datasetName, Class<?> kClass, Class<?> vClass) {
-    return readFromDataset(datasetName, kClass, vClass, Collections.<String, String>emptyMap());
-  }
-
-  @Override
   public <T> T readFromDataset(String datasetName, Class<?> kClass, Class<?> vClass, Map<String, String> datasetArgs) {
     throw new UnsupportedOperationException("Only supported in SparkProgram.run() execution context");
-  }
-
-  @Override
-  public <T> void writeToDataset(T rdd, String datasetName, Class<?> kClass, Class<?> vClass) {
-    writeToDataset(rdd, datasetName, kClass, vClass, Collections.<String, String>emptyMap());
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/ClientSparkContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/ClientSparkContext.java
@@ -32,6 +32,7 @@ import org.apache.twill.api.RunId;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -67,11 +68,22 @@ public final class ClientSparkContext extends AbstractSparkContext {
 
   @Override
   public <T> T readFromDataset(String datasetName, Class<?> kClass, Class<?> vClass) {
+    return readFromDataset(datasetName, kClass, vClass, Collections.<String, String>emptyMap());
+  }
+
+  @Override
+  public <T> T readFromDataset(String datasetName, Class<?> kClass, Class<?> vClass, Map<String, String> datasetArgs) {
     throw new UnsupportedOperationException("Only supported in SparkProgram.run() execution context");
   }
 
   @Override
   public <T> void writeToDataset(T rdd, String datasetName, Class<?> kClass, Class<?> vClass) {
+    writeToDataset(rdd, datasetName, kClass, vClass, Collections.<String, String>emptyMap());
+  }
+
+  @Override
+  public <T> void writeToDataset(T rdd, String datasetName, Class<?> kClass, Class<?> vClass,
+                                 Map<String, String> datasetArgs) {
     throw new UnsupportedOperationException("Only supported in SparkProgram.run() execution context");
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/ExecutionSparkContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/ExecutionSparkContext.java
@@ -122,20 +122,14 @@ public class ExecutionSparkContext extends AbstractSparkContext {
   }
 
   @Override
-  public <T> T readFromDataset(String datasetName, Class<?> kClass, Class<?> vClass) {
-    return readFromDataset(datasetName, kClass, vClass, Collections.<String, String>emptyMap());
-  }
-
-  @Override
   public <T> T readFromDataset(String datasetName, Class<?> kClass, Class<?> vClass, Map<String, String> userDsArgs) {
     // Clone the configuration since it's dataset specification and shouldn't affect the global hConf
     Configuration configuration = new Configuration(hConf);
 
     // first try if it is InputFormatProvider
-    Map<String, String> runtimeDsArgs = RuntimeArguments.extractScope(Scope.DATASET, datasetName,
-                                                                      getRuntimeArguments());
-    runtimeDsArgs.putAll(userDsArgs);
-    Dataset dataset = instantiateDataset(datasetName, runtimeDsArgs);
+    Map<String, String> dsArgs = RuntimeArguments.extractScope(Scope.DATASET, datasetName, getRuntimeArguments());
+    dsArgs.putAll(userDsArgs);
+    Dataset dataset = instantiateDataset(datasetName, dsArgs);
     try {
       if (dataset instanceof InputFormatProvider) {
         // get the input format and its configuration from the dataset
@@ -171,13 +165,8 @@ public class ExecutionSparkContext extends AbstractSparkContext {
     }
 
     // it must be supported by SparkDatasetInputFormat
-    SparkDatasetInputFormat.setDataset(configuration, datasetName, runtimeDsArgs);
+    SparkDatasetInputFormat.setDataset(configuration, datasetName, dsArgs);
     return getSparkFacade().createRDD(SparkDatasetInputFormat.class, kClass, vClass, configuration);
-  }
-
-  @Override
-  public <T> void writeToDataset(T rdd, String datasetName, Class<?> kClass, Class<?> vClass) {
-    writeToDataset(rdd, datasetName, kClass, vClass, Collections.<String, String>emptyMap());
   }
 
   @Override
@@ -187,10 +176,9 @@ public class ExecutionSparkContext extends AbstractSparkContext {
     Configuration configuration = new Configuration(hConf);
 
     // first try if it is OutputFormatProvider
-    Map<String, String> runtimeDsArgs = RuntimeArguments.extractScope(Scope.DATASET, datasetName,
-                                                                      getRuntimeArguments());
-    runtimeDsArgs.putAll(userDsArgs);
-    Dataset dataset = instantiateDataset(datasetName, runtimeDsArgs);
+    Map<String, String> dsArgs = RuntimeArguments.extractScope(Scope.DATASET, datasetName, getRuntimeArguments());
+    dsArgs.putAll(userDsArgs);
+    Dataset dataset = instantiateDataset(datasetName, dsArgs);
     try {
       if (dataset instanceof OutputFormatProvider) {
         // get the output format and its configuration from the dataset
@@ -238,7 +226,7 @@ public class ExecutionSparkContext extends AbstractSparkContext {
     }
 
     // it must be supported by SparkDatasetOutputFormat
-    SparkDatasetOutputFormat.setDataset(hConf, datasetName, runtimeDsArgs);
+    SparkDatasetOutputFormat.setDataset(hConf, datasetName, dsArgs);
     getSparkFacade().saveAsDataset(rdd, SparkDatasetOutputFormat.class, kClass, vClass, new Configuration(hConf));
   }
 


### PR DESCRIPTION
- Add new API in SparkContext to take take arguments while reading and writing dataset.
- Unit test for the above

- Fix : Earlier testSparkWithTimePartitionedFileSet was calling testSparkWithPartitionedFileSet() rather than testSparkWithTimePartitionedFileSet()

Build: http://builds.cask.co/browse/CDAP-RBT319-1