### PR TITLE
Fix documentation build

### DIFF
--- a/cdap-docs/_common/_themes/cdap/static/doctools.js
+++ b/cdap-docs/_common/_themes/cdap/static/doctools.js
@@ -244,39 +244,37 @@ $(document).ready(function() {
  # Takes into account height of header bar and space between header bar and first heading.
  */
 
-function anchor_alert(msg){
-	alert('anchor_alert\n'+msg);
-}
-
 function anchor_scroll(hash){
-// 	anchor_alert('hash:'+hash);
-	var fromTop = 32 + 20 - 2; // Top bar height + space - overlap
-	var $toElement = jQuery("[id="+hash+"]");
-	var toPosition = $toElement.position().top - fromTop;
-	// Scroll to element
-	$('html, body').animate({ scrollTop: toPosition });
-	// Update URL in browser
-	if(history && "pushState" in history) {
-		history.pushState({}, document.title, window.location.pathname + "#" + hash);
-	}
+//   console.log('hash: '+hash);
+  var fromTop = 32 + 20 - 2; // Top bar height + space - overlap
+  var $toElement = jQuery("[id="+hash+"]");
+  if($toElement){
+    var toPosition = $toElement.position().top - fromTop;
+    // Scroll to element
+    $('html, body').animate({ scrollTop: toPosition });
+    // Update URL in browser
+    if(history && "pushState" in history) {
+      history.pushState({}, document.title, window.location.pathname + "#" + hash);
+    }
+  }
 }
 
 jQuery(function() {
-	// Catch all clicks on a tags
-	jQuery("a").click(function(){
-		// Check if it has a hash (i.e. if it's an anchor link)
-		if(this.hash){
-			var hash = this.hash.substr(1);
-			anchor_scroll(hash);
-			return false;
-		}
-	});
-	// Do the same with urls with hash (so on page load it will slide nicely)
-	if(location.hash){
-  		window.scroll(0,0);
- 		var hash = location.hash.substr(1);
-		anchor_scroll(hash);
-		return false;
-	}
-	return true;
+  // Catch all clicks on a tags
+  jQuery("a").click(function(){
+    // Check if it has a hash (i.e. if it's an anchor link)
+    if(this.hash){
+      var hash = this.hash.substr(1);
+      anchor_scroll(hash);
+      return false;
+    }
+  });
+  // Do the same with urls with hash (so on page load it will slide nicely)
+  if(location.hash){
+      window.scroll(0,0);
+    var hash = location.hash.substr(1);
+    anchor_scroll(hash);
+    return false;
+  }
+  return true;
 });

--- a/cdap-docs/_common/common-build.sh
+++ b/cdap-docs/_common/common-build.sh
@@ -357,7 +357,9 @@ function version() {
   local full_branch=`git rev-parse --abbrev-ref HEAD`
   IFS=/ read -a branch <<< "${full_branch}"
   GIT_BRANCH="${branch[1]}"
+  GIT_BRANCH_PARENT="develop"
   # Determine branch and branch type: one of develop, master, release, develop-feature, release-feature
+  # If unable to determine type, uses develop-feature
   if [ "${full_branch}" == "develop" -o  "${full_branch}" == "master" ]; then
     GIT_BRANCH="${full_branch}"
     GIT_BRANCH_TYPE=${GIT_BRANCH}
@@ -365,10 +367,15 @@ function version() {
     GIT_BRANCH_TYPE="release"
   else
     # We are on a feature branch: but from develop or release?
-    if [[ "x${GIT_BRANCH_PARENT}" == "x" ]]; then
-      GIT_BRANCH_PARENT=`git show-branch | grep '*' | grep -v "$(git rev-parse --abbrev-ref HEAD)" | head -n1 | sed 's/.*\[\(.*\)\].*/\1/' | sed 's/[\^~].*//'`  
+    # This is not easy to determine. This can fail very easily.
+    local git_branch_listing=`git show-branch | grep '*' | grep -v "$(git rev-parse --abbrev-ref HEAD)" | head -n1`
+    if [ "x${git_branch_listing}" == "x" ]; then 
+      echo_red_bold "Unable to determine parent branch as git_branch_listing empty; perhaps in a new branch with no commits"
+      echo_red_bold "Using default GIT_BRANCH_PARENT: ${GIT_BRANCH_PARENT}"
+    else
+      GIT_BRANCH_PARENT=`echo ${git_branch_listing} | sed 's/.*\[\(.*\)\].*/\1/' | sed 's/[\^~].*//'`
     fi
-    if [ "${GIT_BRANCH_PARENT}" == "release" ]; then
+    if [ "${GIT_BRANCH_PARENT:0:7}" == "release" ]; then
       GIT_BRANCH_TYPE="release-feature"
     else
       GIT_BRANCH_TYPE="develop-feature"
@@ -380,7 +387,6 @@ function version() {
 
 function display_version() {
   version
-  echo
   echo "PROJECT_PATH: ${PROJECT_PATH}"
   echo "PROJECT_VERSION: ${PROJECT_VERSION}"
   echo "PROJECT_LONG_VERSION: ${PROJECT_LONG_VERSION}"

--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -286,6 +286,7 @@ function _build_docs() {
   copy_docs_lower_level
   build_zip ${3}
   zip_extras ${4}
+  echo ""
   display_version
   display_messages_file
   local warnings="$?"


### PR DESCRIPTION
This attempts to fix the documentation build by improving the determination of the parent branch.

However, the real problem with the documentation build is that there is no 3.1-compatible branch in the CDAP-Apps repository.(This has been addressed directly in the CDAP-Apps repo.)

It moves an echo statement from a method into the place where the method is called, cleaning up the method.

This also fixes https://issues.cask.co/browse/CDAP-3072, a documentation Javascript error.