### PR TITLE
Feature/r3.1 doc content fixes

### DIFF
--- a/cdap-docs/developers-manual/source/building-blocks/datasets/fileset.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/datasets/fileset.rst
@@ -66,15 +66,16 @@ specifications.
 
 If you do not specify a base path, the dataset framework will generate a path based on the dataset name.
 This path |---| and any relative base path you specify |---| is relative to the data directory of the CDAP namespace
-in which the FileSet is created. You can also specify an absolute base path (one that begins with the letter ``/``).
+in which the FileSet is created. You can also specify an absolute base path (one that begins with the character ``/``).
 This path is interpreted as an absolute path in the file system. Beware that if you create two FileSets with the
-same base path |---| be it two FileSets in the same namespace with the same relative base path, or be it in different
-namespaces with the same absolute base path |---| then these two FileSets will use the same directory and possibly
+same base path |---| be it multiple FileSets in the same namespace with the same relative base path, or in different
+namespaces with the same absolute base path |---| then these multiple FileSets will use the same directory and possibly
 obstruct each other's operations.
 
-You can configure a FileSet as "external". This means that the data (the actual files) in the FileSet are
-managed by an external process. This allows you to use FileSets with existing locations outside of CDAP. In this
-case the FileSet will not allow writing or deleting files: It treats the contents of the base path as read-only::
+You can configure a FileSet as "external". This means that the data (the actual files) in
+the FileSet are managed by an external process. This allows you to use FileSets with
+existing locations outside of CDAP. In that case, the FileSet will not allow the writing
+or deleting of files: it treats the contents of the base path as read-only::
 
       createDataset("lines", FileSet.class, FileSetProperties.builder()
         .setBasePath("/existing/path")
@@ -82,8 +83,8 @@ case the FileSet will not allow writing or deleting files: It treats the content
         .setInputFormat(TextInputFormat.class)
         ...
 
-If you do not specify an input format, you will not be able
-to use this as the input for a MapReduce program; similarly, for the output format.
+If you do not specify an input format, you will not be able to use this as the input for a
+MapReduce program; similarly for the output format.
 
 
 Using a FileSet in MapReduce

--- a/cdap-docs/developers-manual/source/building-blocks/datasets/fileset.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/datasets/fileset.rst
@@ -65,11 +65,11 @@ and
 specifications.
 
 If you do not specify a base path, the dataset framework will generate a path based on the dataset name.
-This path|---|and any relative base path you specify|---|is relative to the data directory of the CDAP namespace
+This path |---| and any relative base path you specify |---| is relative to the data directory of the CDAP namespace
 in which the FileSet is created. You can also specify an absolute base path (one that begins with the letter ``/``).
 This path is interpreted as an absolute path in the file system. Beware that if you create two FileSets with the
-same base path|---|be it two FileSets in the same namespace with the same relative base path, or be it in different
-namespaces with the same absolute base path|---|then these two FileSets will use the same directory and possibly
+same base path |---| be it two FileSets in the same namespace with the same relative base path, or be it in different
+namespaces with the same absolute base path |---| then these two FileSets will use the same directory and possibly
 obstruct each other's operations.
 
 You can configure a FileSet as "external". This means that the data (the actual files) in the FileSet are

--- a/cdap-docs/developers-manual/source/building-blocks/spark-programs.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/spark-programs.rst
@@ -219,9 +219,15 @@ Spark in Workflows
 ------------------
 Spark programs in CDAP can also be added to a :ref:`workflow <workflows>`, similar to a :ref:`MapReduce <mapreduce>`.
 
-.. rubric::  Examples of Using Spark Programs
+
+Examples of Using Spark Programs
+--------------------------------
 
 - For an example of **a Spark program,** see the :ref:`Spark K-Means <examples-spark-k-means>`
   and :ref:`Spark Page Rank <examples-spark-page-rank>` examples.
 
 - For a longer example, the how-to guide :ref:`cdap-spark-guide` gives another demonstration.
+
+- If you have problems with resolving methods when developing Spark problems in an IDE 
+  or running Spark programs, see :ref:`these hints <development-troubleshooting-spark>`.
+  

--- a/cdap-docs/developers-manual/source/testing/testing.rst
+++ b/cdap-docs/developers-manual/source/testing/testing.rst
@@ -293,5 +293,5 @@ instance. For example::
   public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false,
                                                                        "data.tx.timeout", 60);
 
-Refer to the :ref:`cdap-site.xml <appendix-cdap-site.xml:>` for the available set of configurations used by CDAP.
+Refer to the :ref:`cdap-site.xml <appendix-cdap-site.xml>` for the available set of configurations used by CDAP.
 

--- a/cdap-docs/developers-manual/source/testing/troubleshooting.rst
+++ b/cdap-docs/developers-manual/source/testing/troubleshooting.rst
@@ -40,3 +40,27 @@ A collection of tips and hints on solving problems encountered during developmen
     config.setClassLoader(Thread.currentThread().getContextClassLoader());
   
   before passing it (``config``) to the SequenceFile.Reader constructor.
+
+
+.. _development-troubleshooting-spark:
+
+.. rubric:: Spark's MLlib Dependencies
+
+Spark's MLlib (Machine Learning Library) has various dependencies; please make sure you
+have the appropriate dependencies according to your installation:
+
+- Spark 1.2: https://spark.apache.org/docs/1.2.0/mllib-guide.html#dependencies
+- Spark 1.3: https://spark.apache.org/docs/1.3.0/mllib-guide.html#dependencies
+- Spark 1.4: https://spark.apache.org/docs/1.4.0/mllib-guide.html#dependencies
+
+.. rubric:: Spark and IDEs Unable to Resolve Methods Imported Implicitly
+
+Your IDE might fail to resolve methods which are imported implicitly while writing Spark
+programs. The method ``reduceByKey`` in the class ``PairRDDFunctions`` is an example of
+such a method. If you are using either Spark 1.2 or 1.3 to write your application, you can
+resolve this issue by adding an explicit import::
+
+  import org.apache.spark.SparkContext
+
+**Note:** This issue has been resolved in Spark 1.4; in that version and later you will
+not need this explicit import.

--- a/cdap-docs/reference-manual/source/http-restful-api/lifecycle.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/lifecycle.rst
@@ -621,17 +621,29 @@ For workflows, you can retrieve:
 
 - the information about the currently running node(s) in the workflow:
 
-  .. topic::  **Note: Workflow Current Node(s) RESTful API Deprecated**
+  .. container:: table-block-example
 
-    As of *CDAP v3.1.0*, the *Workflow Current Node(s) RESTful API* has been deprecated, pending removal in a later
-    version. Replace all use of this *Workflow Current Node(s) RESTful API*  ::
+    .. list-table::
+       :widths: 99 1
+       :stub-columns: 1
 
-      GET <base-url>/namespaces/<namespace>/apps/<app-id>/workflows/<workflow-id>/<run-id>/current
+       * - Note: Workflow Current Node(s) RESTful API Deprecated
+         - 
 
-    with the revised API shown below for the *currently running node(s) of the workflow*.
-    Note the addition of a ``/runs/`` component in the path::
+    .. list-table::
+       :widths: 100
+       :class: triple-table
 
-      GET <base-url>/namespaces/<namespace>/apps/<app-id>/workflows/<workflow-id>/runs/<run-id>/current
+       * - As of **CDAP v3.1.0**, the *Workflow Current Node(s) RESTful API* has been
+           deprecated, pending removal in a later version.
+       * - Replace all use of the *Workflow Current Node(s) RESTful API*::
+           
+             GET <base-url>/namespaces/<namespace>/apps/<app-id>/workflows/<workflow-id>/<run-id>/current
+
+           with the revised API shown below for the *currently running node(s) of the workflow.*
+           Note the addition of a ``/runs/`` component in the path::
+
+             GET <base-url>/namespaces/<namespace>/apps/<app-id>/workflows/<workflow-id>/runs/<run-id>/current
 
 - the schedules defined for a workflow (using the parameter ``schedules``)::
 


### PR DESCRIPTION
Fixes minor issues that were breaking the HTML formatting.
Adds Spark documentation to address issues 2821 and 2949 (replaces https://github.com/caskdata/cdap/pull/3126):

- https://issues.cask.co/browse/CDAP-2821
- https://issues.cask.co/browse/CDAP-2949

Staged at:
http://docs-staging.cask.co/cdap/3.1.0-SNAPSHOT-feature-r3.1_doc_content_fixes/en/index.html

**Filesets**
- [developers-manual/source/building-blocks/datasets/fileset.rst](http://docs-staging.cask.co/cdap/3.1.0-SNAPSHOT-feature-r3.1_doc_content_fixes/en/developers-manual/building-blocks/datasets/fileset.html)

**Spark**
- [developers-manual/source/building-blocks/spark-programs.rst](http://docs-staging.cask.co/cdap/3.1.0-SNAPSHOT-feature-r3.1_doc_content_fixes/en/developers-manual/building-blocks/spark-programs.html#examples-of-using-spark-programs)
- [developers-manual/source/testing/troubleshooting.rst](http://docs-staging.cask.co/cdap/3.1.0-SNAPSHOT-feature-r3.1_doc_content_fixes/en/developers-manual/testing/troubleshooting.html)

**Testing**
- [developers-manual/source/testing/testing.rst](http://docs-staging.cask.co/cdap/3.1.0-SNAPSHOT-feature-r3.1_doc_content_fixes/en/developers-manual/testing/testing.html#configuring-cdap-runtime-for-test-framework)

**Lifecycle**
- [http-restful-api/lifecycle.html#retrieving-specific-run-information](http://docs-staging.cask.co/cdap/3.1.0-SNAPSHOT-feature-r3.1_doc_content_fixes/en/reference-manual/http-restful-api/lifecycle.html#retrieving-specific-run-information)

