### PR TITLE
CDAP-3043: Javadoc Building and Formatting

### DIFF
--- a/BUILD.rst
+++ b/BUILD.rst
@@ -58,7 +58,7 @@ Standalone and Distributed CDAP
     
 - Build the limited set of Javadocs, including the App Templates, used in documentation::
 
-    MAVEN_OPTS="-Xmx1024m" mvn clean install -P examples,templates,release -DskipTests -Dgpg.skip=true && mvn clean site -DskipTests -P templates -DisOffline=false
+    MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=128m" mvn clean install -P examples,templates,release -DskipTests -Dgpg.skip=true && mvn clean site -DskipTests -P templates -DisOffline=false
 
 - Build the complete set of Javadocs, for all modules (currently incomplete)::
 

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/AbstractCloseableIterator.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/AbstractCloseableIterator.java
@@ -20,8 +20,9 @@ import com.google.common.collect.AbstractIterator;
 
 /**
  * Iterator that extends {@link com.google.common.collect.AbstractIterator} and implements
- * {@link co.cask.cdap.api.dataset.lib.CloseableIterator}
- * @param <T>
+ * {@link co.cask.cdap.api.dataset.lib.CloseableIterator}.
+ * 
+ * @param <T> Type of elements returned by this iterator
  */
 public abstract class AbstractCloseableIterator<T> extends AbstractIterator<T> implements CloseableIterator<T> {
 

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/CloseableIterator.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/CloseableIterator.java
@@ -19,9 +19,10 @@ package co.cask.cdap.api.dataset.lib;
 import java.util.Iterator;
 
 /**
- * Iterator that can be closed
- * @param <T>
+ * Iterator that can be closed.
+ *
+ * @param <T> Type of elements returned by this iterator
  */
 public interface CloseableIterator<T> extends Iterator<T> {
- void close();
+  void close();
 }

--- a/cdap-docs/_common/common-build.sh
+++ b/cdap-docs/_common/common-build.sh
@@ -120,7 +120,7 @@ GITHUB="github"
 
 # BUILD.rst
 BUILD_RST="BUILD.rst"
-BUILD_RST_HASH="0d41d293a6e11c0461bf3ff3be03c242"
+BUILD_RST_HASH="f54ae74bb72f9ad894766b6c0bd2d2df"
 
 
 function usage() {
@@ -183,7 +183,7 @@ function build_javadocs_api() {
   cd ${PROJECT_PATH}
   set_mvn_environment
   check_build_for_changes
-  MAVEN_OPTS="-Xmx1024m" mvn clean install -P examples,templates,release -DskipTests -Dgpg.skip=true && mvn clean site -DskipTests -P templates -DisOffline=false
+  MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=128m" mvn clean install -P examples,templates,release -DskipTests -Dgpg.skip=true && mvn clean site -DskipTests -P templates -DisOffline=false
 }
 
 function build_javadocs_sdk() {


### PR DESCRIPTION
Fixes minor issues with two sets of Javadocs, and updates the build script and BUILD.rst with increased memory requirements for building the Javadocs.