### PR TITLE
Add new HTTP status for system service instances restart to separate between 503 Service unavailable and 403 Service is disabled.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AbstractMonitorHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AbstractMonitorHandler.java
@@ -226,12 +226,12 @@ public class AbstractMonitorHandler extends AbstractAppFabricHttpHandler {
 
     try {
       if (!masterServiceManager.isServiceEnabled()) {
-        LOG.debug(String.format("Fail restart instances because service %s is not enabled.", serviceName));
+        String message = String.format("Failed to restart instance for % because the service is not enabled.",
+                                       serviceName);
+        LOG.debug(message);
 
         isSuccess = false;
-        responder.sendString(HttpResponseStatus.FORBIDDEN,
-                             String.format("Fail to restart instance for % because the service is not enabled.",
-                                           serviceName));
+        responder.sendString(HttpResponseStatus.FORBIDDEN, message);
         return;
       }
 
@@ -245,20 +245,19 @@ public class AbstractMonitorHandler extends AbstractAppFabricHttpHandler {
       }
       responder.sendStatus(HttpResponseStatus.OK);
     } catch (IllegalStateException ise) {
-      LOG.debug(String.format("IllegalStateException when trying to restart instances for service %s", serviceName));
+      String message = String.format("Failed to restart instance for % because the service may not be ready yet",
+                                 serviceName);
+      LOG.debug(message, ise);
 
       isSuccess = false;
-      responder.sendString(HttpResponseStatus.SERVICE_UNAVAILABLE,
-                           String.format("Fail to restart instance for % because the service may not be ready yet",
-                                         serviceName));
+      responder.sendString(HttpResponseStatus.SERVICE_UNAVAILABLE, message);
     } catch (IllegalArgumentException iex) {
-      LOG.debug(String.format("IllegalArgumentException when trying to restart instances for service %s", serviceName),
-               iex);
+      String message = String.format("Failed to restart instance %d for service: %s because invalid instance id",
+                                     instanceId, serviceName);
+      LOG.debug(message, iex);
 
       isSuccess = false;
-      responder.sendString(HttpResponseStatus.BAD_REQUEST,
-                           String.format("Fail to restart instance %d for service: %s because invalid instance id",
-                                         instanceId, serviceName));
+      responder.sendString(HttpResponseStatus.BAD_REQUEST, message);
     } catch (Exception ex) {
       LOG.warn(String.format("Exception when trying to restart instances for service %s", serviceName), ex);
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AbstractMonitorHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AbstractMonitorHandler.java
@@ -226,7 +226,13 @@ public class AbstractMonitorHandler extends AbstractAppFabricHttpHandler {
 
     try {
       if (!masterServiceManager.isServiceEnabled()) {
-        throw new IllegalStateException();
+        LOG.debug(String.format("Fail restart instances because service %s is not enabled.", serviceName));
+
+        isSuccess = false;
+        responder.sendString(HttpResponseStatus.FORBIDDEN,
+                             String.format("Fail to restart instance for % because the service is not enabled.",
+                                           serviceName));
+        return;
       }
 
       if (restartAll) {
@@ -242,9 +248,9 @@ public class AbstractMonitorHandler extends AbstractAppFabricHttpHandler {
       LOG.debug(String.format("IllegalStateException when trying to restart instances for service %s", serviceName));
 
       isSuccess = false;
-      responder.sendString(HttpResponseStatus.FORBIDDEN,
-                           String.format("Fail to restart instance for % because the service may not be enabled or " +
-                                           "not ready yet", serviceName));
+      responder.sendString(HttpResponseStatus.SERVICE_UNAVAILABLE,
+                           String.format("Fail to restart instance for % because the service may not be ready yet",
+                                         serviceName));
     } catch (IllegalArgumentException iex) {
       LOG.debug(String.format("IllegalArgumentException when trying to restart instances for service %s", serviceName),
                iex);


### PR DESCRIPTION
Following basic HTTP status rule of thumb: 
5XX code is our fault, and 4XX code is caller fault.