### PR TITLE
Feature/ui adapter prototype integration 4.1

### DIFF
--- a/cdap-ui/app/directives/fileselect/fileselect.less
+++ b/cdap-ui/app/directives/fileselect/fileselect.less
@@ -22,6 +22,23 @@ body.theme-cdap {
         &:only-child my-file-select > a { .border-radius(4px 0 4px 4px); }
       }
     }
+    .dropdown-toggle.white-dropdown + .dropdown-menu.dropdown-menu-right {
+      > li {
+        my-file-select > a {
+          cursor: pointer;
+          display: block;
+          padding: 10px;
+          background-color: #ffffff;
+          color: #6a7387;
+          &:hover, &:focus {
+            background: @cdap-header;
+            color: white;
+            text-decoration: none;
+          }
+        }
+        &:only-child my-file-select > a { .border-radius(4px 0 4px 4px); }
+      }
+    }
 
   }
 }

--- a/cdap-ui/app/features/adapters/controllers/create-new-ctrl.js
+++ b/cdap-ui/app/features/adapters/controllers/create-new-ctrl.js
@@ -1,9 +1,22 @@
 angular.module(PKG.name + '.feature.adapters')
-  .controller('_AdapterCreateController', function(MyPlumbService, myAdapterApi, $bootstrapModal, $scope, rConfig) {
+  .controller('_AdapterCreateController', function(MyPlumbService, myAdapterApi, $bootstrapModal, $scope, rConfig, $stateParams, $alert) {
+    this.metadata = MyPlumbService.metadata;
     if (rConfig) {
       this.data =  rConfig;
     }
-    this.metadata = MyPlumbService.metadata;
+    if ($stateParams.name) {
+      this.metadata.name = $stateParams.name;
+    }
+    if ($stateParams.type) {
+      if (['ETLBatch', 'ETLRealtime'].indexOf($stateParams.type) !== -1) {
+        this.metadata.template.type = $stateParams.type;
+      } else {
+        $alert({
+          type: 'danger',
+          content: 'Invalid template type. Has to be either ETLBatch or ETLRealtime'
+        });
+      }
+    }
 
     myAdapterApi.fetchTemplates({
       scope: $scope

--- a/cdap-ui/app/features/adapters/controllers/create/canvas-ctrl.js
+++ b/cdap-ui/app/features/adapters/controllers/create/canvas-ctrl.js
@@ -105,13 +105,13 @@ angular.module(PKG.name + '.feature.adapters')
       var prom;
       switch(group.name) {
         case 'source':
-          prom = myAdapterApi.fetchSources({ adapterType: 'ETLBatch' }).$promise;
+          prom = myAdapterApi.fetchSources({ adapterType: MyPlumbService.metadata.template.type }).$promise;
           break;
         case 'transform':
-          prom = myAdapterApi.fetchTransforms({ adapterType: 'ETLBatch' }).$promise;
+          prom = myAdapterApi.fetchTransforms({ adapterType: MyPlumbService.metadata.template.type }).$promise;
           break;
         case 'sink':
-          prom = myAdapterApi.fetchSinks({ adapterType: 'ETLBatch' }).$promise;
+          prom = myAdapterApi.fetchSinks({ adapterType: MyPlumbService.metadata.template.type }).$promise;
           break;
       }
       prom.then(function(res) {

--- a/cdap-ui/app/features/adapters/controllers/list-ctrl.js
+++ b/cdap-ui/app/features/adapters/controllers/list-ctrl.js
@@ -1,25 +1,7 @@
 angular.module(PKG.name + '.feature.adapters')
-  .controller('AdapterListController', function($scope, mySettings, $state, $alert, $timeout, myAdapterApi, myAlert, myHelpers) {
+  .controller('AdapterListController', function($scope, mySettings, $state, $alert, $timeout, myAlert, myHelpers) {
     $scope.adapters  = [];
 
-    var params = {
-      namespace: $state.params.namespace,
-      scope: $scope
-    };
-
-    myAdapterApi.list(params)
-      .$promise
-      .then(function(res) {
-        if (!res.length) {
-          return;
-        }
-        $scope.adapters = $scope.adapters.concat(res);
-        angular.forEach($scope.adapters, function(app) {
-          if (!app.isdraft)  {
-            pollStatus(app);
-          }
-        });
-      });
     mySettings.get('adapterDrafts')
       .then(function(res) {
         if (res && Object.keys(res).length) {
@@ -34,18 +16,6 @@ angular.module(PKG.name + '.feature.adapters')
           });
         }
       });
-
-    function pollStatus(app) {
-      var statusParams = angular.extend({
-        adapter: app.name
-      }, params);
-
-      myAdapterApi.pollStatus(statusParams)
-        .$promise
-        .then(function (res) {
-          app.status = res.status;
-        });
-    }
 
     $scope.deleteAdapter = function (appName) {
       var deleteParams = angular.extend({
@@ -69,6 +39,31 @@ angular.module(PKG.name + '.feature.adapters')
           });
         });
     };
+
+    $scope.deleteDraft = function(draftName) {
+      mySettings.get('adapterDrafts')
+        .then(function(res) {
+          if (res[draftName]) {
+            delete res[draftName];
+          }
+          return mySettings.set('adapterDrafts', res);
+        })
+        .then(
+          function success() {
+            $alert({
+              type: 'success',
+              content: 'Adapter draft ' + draftName + ' delete successfully'
+            });
+            $state.reload();
+          },
+          function error() {
+            $alert({
+              type: 'danger',
+              content: 'Adapter draft ' + draftName + ' delete failed'
+            });
+            $state.reload();
+          });
+    }
 
     $scope.doAction = function(action, appName) {
       var app = $scope.adapters.filter(function(app) {

--- a/cdap-ui/app/features/adapters/routes.js
+++ b/cdap-ui/app/features/adapters/routes.js
@@ -23,20 +23,19 @@ angular.module(PKG.name + '.feature.adapters')
         })
 
         .state('adapters.create', {
-          url: '/create',
-          params: {
-            data: null
-          },
+          url: '/create?name&type',
           resolve: {
             rConfig: function($stateParams, mySettings, $q) {
               var defer = $q.defer();
-              if ($stateParams.data) {
+              if ($stateParams.name) {
                 mySettings.get('adapterDrafts')
                   .then(function(res) {
-                    var draft = res[$stateParams.data];
-                    draft.name = $stateParams.data;
-                    if (draft) {
+                    var draft = res[$stateParams.name];
+                    if (angular.isObject(draft)) {
+                      draft.name = $stateParams.name;
                       defer.resolve(draft);
+                    } else {
+                      defer.resolve(false);
                     }
                   });
               } else {

--- a/cdap-ui/app/features/adapters/templates/list.html
+++ b/cdap-ui/app/features/adapters/templates/list.html
@@ -4,49 +4,34 @@
   <div class="col-xs-6">
     <h2 class="pull-left"> All Adapters </h2>
   </div>
+  <div class="col-xs-6 text-right">
+    <div class="btn-group dropdown-right h2" dropdown>
+      <button type="button" class="btn btn-default dropdown-toggle" dropdown-toggle>
+        Add App <span class="caret"></span>
+      </button>
+      <ul class="dropdown-menu dropdown-menu-right" role="menu">
+        <li>
+          <a ui-sref="adapters.create({type: 'ETLBatch'})"> ETLBatch App </a>
+        </li>
+        <li>
+          <a ui-sref="adapters.create({type: 'ETLRealtime'})"> ETLRealtime App </a>
+        </li>
+      </ul>
+    </div>
+  </div>
 </div>
 
 <br/>
 <div class="row" adapters-list>
-  <div class="col-lg-2 col-md-3 col-sm-3 col-xs-6 text-center"
-        ng-click="$state.go('^.create')"
-        etl-add-app>
-    <div class="well well-lg">
-      <br/>
-      <h1>
-        <span class="fa fa-plus"></span>
-      </h1>
-      <br/>
-    </div>
-  </div>
   <div ng-model="adapters">
     <div class="col-lg-2 col-md-3 col-sm-3 col-xs-6"
          ng-repeat="app in adapters">
       <div>
-        <div class="label etlappcontainer" ng-if="app.isdraft">
+        <div class="label etlappcontainer">
           Draft
         </div>
-        <div class="label etlappcontainer green" ng-if="!app.isdraft">
-          Published
-        </div>
         <div class="well well-md">
-
-          <a ng-if="!app.isdraft" ui-sref="adapters.detail.runs({adapterId: app.name})" class="content-panel">
-
-            <h4 tooltip="{{::app.name}}">
-              <i class="icon-app"></i>
-              <span>{{::app.name | myEllipsis:15}}</span>
-            </h4>
-
-            <small>
-              Type: {{::app.template}}
-            </small>
-
-            <p class="description" tooltip="{{::app.description}}">
-              {{::app.description | myEllipsis: 50}}
-            </p>
-          </a>
-          <a href ng-if="app.isdraft" ng-click="$state.go('^.create', {data: app.name})"
+          <a href ng-click="$state.go('^.create', {name: app.name})"
               class="content-panel">
               <h4 tooltip="{{::app.name}}">
                 <i class="icon-app"></i>
@@ -62,31 +47,15 @@
           </a>
 
           <div class="clearfix action-panel"
-               ng-class="{'invisible': app.isdraft === true}"
+
                >
             <div class="pull-left">
-              <button class="text-success" ng-if="app.status === 'STOPPED'" ng-click="doAction('start', app.name)">
-                <span class="fa fa-play"></span>
-              </button>
-              <button class="text-danger" ng-if="app.status === 'STARTED'" ng-click="doAction('stop', app.name)">
-                <span class="fa fa-stop"></span>
-              </button>
-              <button ng-if="app.status === 'STARTING' || app.status === 'STOPPING'" class="text-default" >
-                <span class="fa fa-refresh fa-spin"></span>
-              </button>
               <button class="text-danger"
                       ng-click="caskConfirm()"
-                      ng-class="{'invisible': (app.status === 'STARTED' || app.status === 'STARTING' || app.status === 'STOPPING')}"
-                      cask-confirmable="deleteAdapter(app.name)"
-                      data-confirmable-content="Are you sure you want to delete this adapter?">
+                      cask-confirmable="deleteDraft(app.name)"
+                      data-confirmable-content="Are you sure you want to delete this adapter draft?">
                 <span class="fa fa-trash"></span>
               </button>
-            </div>
-
-
-            <div ng-class="{'running': app.status === 'Running', 'stopped': app.status === 'Stopped'}" class="pull-right" >
-              <i class="fa fa-circle"></i>
-              <span> {{app.status}} </span>
             </div>
           </div>
         </div>

--- a/cdap-ui/app/features/admin/templates/namespace/apps.html
+++ b/cdap-ui/app/features/admin/templates/namespace/apps.html
@@ -3,9 +3,28 @@
         <h2> Applications </h2>
     </div>
     <div class="col-xs-6 text-right" ng-if="apps.length > 0">
-    <!--     <button type="button" class="btn btn-default" ng-model="button.active" bs-button>Previous</button>
-        <button type="button" class="btn btn-default" ng-model="button.active" bs-button>Next</button> -->
-        <my-file-select ng-controller="NamespaceAppController" data-button-label="Add App" on-file-select="onFileSelected($files)"> </my-file-select>
+        <div class="btn-group dropdown-right" dropdown>
+          <button type="button" class="btn btn-default dropdown-toggle white-dropdown" dropdown-toggle>
+            Add App <span class="caret"></span>
+          </button>
+          <ul class="dropdown-menu dropdown-menu-right" role="menu">
+            <li>
+              <my-file-select dropdown="true"
+                              data-button-label="Add App"
+                              on-file-select="AppsSectionCtrl.onFileSelected($files)">
+              </my-file-select>
+            </li>
+            <li>
+              <a ui-sref="adapters.create({namespace: $stateParams.nsadmin, type: 'ETLBatch'})"> Add ETL Batch App </a>
+            </li>
+            <li>
+              <a ui-sref="adapters.create({namespace: $stateParams.nsadmin, type: 'ETLRealtime'})"> Add ETL Realtime App </a>
+            </li>
+            <li>
+              <a ui-sref="adapters.list({namespace: $stateParams.nsadmin})"> Un-Published Adapters </a>
+            </li>
+          </ul>
+        </div>
     </div>
 </div>
 
@@ -41,5 +60,26 @@
 
 <div class="well text-center" ng-if="apps.length === 0">
     <p> You haven't deployed any apps. </p>
-    <my-file-select ng-controller="NamespaceAppController" data-button-label="Add App" on-file-select="onFileSelected($files)"> </my-file-select>
+    <div class="btn-group dropdown-right" dropdown>
+      <button type="button" class="btn btn-default dropdown-toggle white-dropdown" dropdown-toggle>
+        Add App <span class="caret"></span>
+      </button>
+      <ul class="dropdown-menu dropdown-menu-right" role="menu">
+        <li>
+          <my-file-select dropdown="true"
+                          data-button-label="Add App"
+                          on-file-select="AppsSectionCtrl.onFileSelected($files)">
+          </my-file-select>
+        </li>
+        <li>
+          <a ui-sref="adapters.create({namespace: $stateParams.nsadmin, type: 'ETLBatch'})"> Add ETL Batch App </a>
+        </li>
+        <li>
+          <a ui-sref="adapters.create({namespace: $stateParams.nsadmin, type: 'ETLRealtime'})"> Add ETL Realtime App </a>
+        </li>
+        <li>
+          <a ui-sref="adapters.list({namespace: $stateParams.nsadmin})"> Un-Published Adapters </a>
+        </li>
+      </ul>
+    </div>
 </div>

--- a/cdap-ui/app/features/apps/controllers/list-ctrl.js
+++ b/cdap-ui/app/features/apps/controllers/list-ctrl.js
@@ -1,5 +1,5 @@
 angular.module(PKG.name + '.feature.apps')
-  .controller('AppListController', function CdapAppList($timeout, $scope, MyDataSource, myAppUploader, $alert, $state, MyOrderings) {
+  .controller('AppListController', function CdapAppList($timeout, $scope, MyDataSource, myAppUploader, $alert, $state, MyOrderings, myAdapterApi) {
     this.MyOrderings = MyOrderings;
     this.apps = [];
     this.currentPage = 1;
@@ -10,8 +10,24 @@ angular.module(PKG.name + '.feature.apps')
       _cdapNsPath: '/apps/'
     })
       .then(function(apps) {
-        this.apps = apps;
+        this.apps = this.apps.concat(apps);
       }.bind(this));
       this.onFileSelected = myAppUploader.upload;
+
+      var params = {
+        namespace: $state.params.namespace,
+        scope: $scope
+      };
+      myAdapterApi.list(params)
+        .$promise
+        .then(function(res) {
+          if (!res.length) {
+            return;
+          }
+          res.forEach(function(adapter) {
+            adapter.type = 'adapter';
+          });
+          this.apps = this.apps.concat(res);
+        }.bind(this));
 
   });

--- a/cdap-ui/app/features/apps/templates/list.html
+++ b/cdap-ui/app/features/apps/templates/list.html
@@ -58,7 +58,14 @@
     <tbody>
       <tr ng-repeat="app in ListController.filtered = (ListController.apps | filter: ListController.searchText ) | myPaginate:ListController.currentPage | orderBy:sortable.predicate:sortable.reverse">
         <td >
-          <a ui-sref="apps.detail.overview.status({ appId: app.id })" ng-click="MyOrderings.appClicked(app.id)">
+          <a ui-sref="apps.detail.overview.status({ appId: app.id })"
+              ng-if="app.type !== 'adapter'"
+              ng-click="MyOrderings.appClicked(app.id)">
+            <strong> {{ ::app.name }} </strong>
+          </a>
+          <a ui-sref="adapters.detail.runs({adapterId: app.name})"
+              ng-if="app.type === 'adapter'"
+              ng-click="MyOrderings.appClicked(app.id)">
             <strong> {{ ::app.name }} </strong>
           </a>
         </td>

--- a/cdap-ui/app/features/apps/templates/list.html
+++ b/cdap-ui/app/features/apps/templates/list.html
@@ -13,7 +13,7 @@
               dropdown-toggle=""
               aria-haspopup="true"
               aria-expanded="false">
-        Actions <span class="caret"></span>
+        Add App <span class="caret"></span>
       </button>
       <ul class="dropdown-menu dropdown-menu-right" role="menu">
         <li role="presentation">
@@ -21,6 +21,15 @@
                           data-button-label="Add App"
                           on-file-select="ListController.onFileSelected($files)">
           </my-file-select>
+        </li>
+        <li>
+          <a ui-sref="adapters.create({type: 'ETLBatch'})"> Add ETL Batch App </a>
+        </li>
+        <li>
+          <a ui-sref="adapters.create({type: 'ETLRealtime'})"> Add ETL Realtime App </a>
+        </li>
+        <li>
+          <a ui-sref="adapters.list"> Un-Published Adapters </a>
         </li>
       </ul>
     </div>

--- a/cdap-ui/app/features/overview/controllers/apps-section-ctrl.js
+++ b/cdap-ui/app/features/overview/controllers/apps-section-ctrl.js
@@ -1,5 +1,5 @@
 angular.module(PKG.name + '.feature.overview')
-  .controller('AppsSectionCtrl', function(myAppUploader, myStreamApi, myDatasetApi, MyDataSource, MyOrderings, $scope, $state) {
+  .controller('AppsSectionCtrl', function(myAppUploader, myStreamApi, myDatasetApi, MyDataSource, MyOrderings, $scope, $state, myAdapterApi) {
     var dataSrc = new MyDataSource($scope);
     this.MyOrderings = MyOrderings;
     this.apps = [];
@@ -9,13 +9,25 @@ angular.module(PKG.name + '.feature.overview')
       _cdapNsPath: '/apps'
     })
       .then(function(res) {
-        this.apps = res;
+        this.apps = this.apps.concat(res);
       }.bind(this));
 
     var params = {
       namespace: $state.params.namespace,
       scope: $scope
     };
+
+    myAdapterApi.list(params)
+      .$promise
+      .then(function(res) {
+        if (!res.length) {
+          return;
+        }
+        res.forEach(function(adapter) {
+          adapter.type = 'adapter';
+        });
+        this.apps = this.apps.concat(res);
+      }.bind(this));
 
     myDatasetApi.list(params)
       .$promise

--- a/cdap-ui/app/features/overview/templates/data-apps.html
+++ b/cdap-ui/app/features/overview/templates/data-apps.html
@@ -73,22 +73,47 @@
               <span class="fa fa-list-ul"></span>
                <span>All Apps</span>
             </a>
-            <a ui-sref="adapters.list" class="btn btn-default">
-              <span class="fa fa-list-ul"></span>
-               All Adapters
-            </a>
 
-            <my-file-select data-button-label="Add App"
-                            on-file-select="AppsSectionCtrl.onFileSelected($files)">
-            </my-file-select>
-
+            <div class="btn-group dropdown-right" dropdown>
+              <button type="button" class="btn btn-default dropdown-toggle white-dropdown" dropdown-toggle>
+                Add App <span class="caret"></span>
+              </button>
+              <ul class="dropdown-menu dropdown-menu-right" role="menu">
+                <li>
+                  <my-file-select dropdown="true"
+                                  data-button-label="Add App"
+                                  on-file-select="AppsSectionCtrl.onFileSelected($files)">
+                  </my-file-select>
+                </li>
+                <li>
+                  <a ui-sref="adapters.create({type: 'ETLBatch'})"> Add ETL Batch App </a>
+                </li>
+                <li>
+                  <a ui-sref="adapters.create({type: 'ETLRealtime'})"> Add ETL Realtime App </a>
+                </li>
+                <li>
+                  <a ui-sref="adapters.list"> Un-Published Adapters </a>
+                </li>
+              </ul>
+            </div>
           </div>
         </div>
       </div>
 
       <ul class="list-group">
         <li class="list-group-item" ng-repeat="app in AppsSectionCtrl.apps | orderBy:AppsSectionCtrl.MyOrderings.appOrdering | limitTo:5">
-          <a ui-sref="apps.detail.overview.status({appId: app.id})"  ng-click="AppsSectionCtrl.MyOrderings.appClicked(app.id)">
+          <a ui-sref="apps.detail.overview.status({appId: app.id})"
+              ng-if="app.type !== 'adapter'"
+              ng-click="AppsSectionCtrl.MyOrderings.appClicked(app.id)">
+            <p ng-bind="app.name"> </p>
+            <div class="title-type-image">
+              <span class="icon-fist"></span>
+              <span> CDAP </span>
+            </div>
+          </a>
+          <a ui-sref="adapters.detail.runs({adapterId: app.name})"
+              ng-if="app.type === 'adapter'"
+              ng-click="AppsSectionCtrl.MyOrderings.appClicked(app.id)">
             <p ng-bind="app.name"> </p>
             <div class="title-type-image">
               <span class="icon-fist"></span>

--- a/cdap-ui/app/features/overview/templates/data-apps.html
+++ b/cdap-ui/app/features/overview/templates/data-apps.html
@@ -130,15 +130,27 @@
         <p> You haven't deployed any apps. Add one. </p>
       </div>
       <hr />
-      <div class="text-left">
-        <my-file-select ng-controller="AppsSectionCtrl"
-                        data-button-label="Add App"
-                        on-file-select="AppsSectionCtrl.onFileSelected($files)">
-        </my-file-select>
-        <a ui-sref="adapters.create" class="btn btn-default">
-          <span class="fa fa-plus"></span>
-          <span>Add Adapter</span>
-        </a>
+      <div class="btn-group dropdown-right" dropdown>
+        <button type="button" class="btn btn-default dropdown-toggle white-dropdown" dropdown-toggle>
+          Add App <span class="caret"></span>
+        </button>
+        <ul class="dropdown-menu dropdown-menu-right" role="menu">
+          <li>
+            <my-file-select dropdown="true"
+                            data-button-label="Add App"
+                            on-file-select="AppsSectionCtrl.onFileSelected($files)">
+            </my-file-select>
+          </li>
+          <li>
+            <a ui-sref="adapters.create({ type: 'ETLBatch'})"> Add ETL Batch App </a>
+          </li>
+          <li>
+            <a ui-sref="adapters.create({ type: 'ETLRealtime'})"> Add ETL Realtime App </a>
+          </li>
+          <li>
+            <a ui-sref="adapters.list"> Un-Published Adapters </a>
+          </li>
+        </ul>
       </div>
     </div>
   </div>

--- a/cdap-ui/app/services/plumber/my-plumb-service.js
+++ b/cdap-ui/app/services/plumber/my-plumb-service.js
@@ -95,7 +95,7 @@ angular.module(PKG.name + '.services')
       };
       this.nodes[config.id] = config;
       if (!conf._backendProperties) {
-        fetchBackendProperties(this.nodes[config.id]);
+        fetchBackendProperties.call(this, this.nodes[config.id]);
       } else if(Object.keys(conf._backendProperties).length !== Object.keys(conf.properties).length) {
         angular.forEach(conf._backendProperties, function(value, key) {
           config.properties[key] = '';
@@ -119,7 +119,7 @@ angular.module(PKG.name + '.services')
       // This needs to pass on a scope always. Right now there is no cleanup
       // happening
       var params = {
-        adapterType: 'ETLBatch'
+        adapterType: this.metadata.template.type
       };
       if (scope) {
         params.scope = scope;
@@ -150,7 +150,7 @@ angular.module(PKG.name + '.services')
 
       var plugin = this.nodes[pluginId];
 
-      fetchBackendProperties(plugin, scope)
+      fetchBackendProperties.call(this, plugin, scope)
         .then(function(plugin) {
           $bootstrapModal.open({
             animation: false,

--- a/cdap-ui/app/styles/themes/cdap/buttons.less
+++ b/cdap-ui/app/styles/themes/cdap/buttons.less
@@ -110,6 +110,13 @@ body.theme-cdap {
     .dropdown-right();
   }
 
+  .btn-default.dropdown-toggle.white-dropdown {
+    background-color: #ffffff;
+    border: 1px solid #dfe2e9;
+    color: #6a7387;
+    .dropdown-white();
+  }
+
   .dropdown-left {
     .dropdown-left();
   }

--- a/cdap-ui/app/styles/themes/cdap/mixins.less
+++ b/cdap-ui/app/styles/themes/cdap/mixins.less
@@ -116,3 +116,18 @@
     }
   }
 }
+
+.dropdown-white() {
+  + .dropdown-menu {
+    > li {
+      > a {
+        background-color: #ffffff;
+        color: #6a7387;
+        &:hover, &:focus {
+          background-color: @cdap-header;
+          color: white;
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Unifies Adapters with Apps
  - Modifies "All Apps" to list All apps + All Published Adapters
  - Modifies "Add App" to show dropdown to Add an app, Add ETL Batch app & Add ETL Realtime app.
  - Adds a new white dropdown to be added to overview 
  - Modifies overview listings to have both apps + adapters.
  - Modifies apps list view to have both apps + adapters
- Passes adapter type or name during adapter creation view or draft edit view.
  - Passes adapter type during new adapter creation
  - Passes adapter name during adapter edit view.

![adpater apps](https://cloud.githubusercontent.com/assets/1452845/8814763/3f60a46c-2fc5-11e5-8165-7cf71799488f.gif)
