### PR TITLE
reset flowlet metrics data on scope destroy

### DIFF
--- a/cdap-ui/app/features/flows/controllers/tabs/runs/tabs/status-ctrl.js
+++ b/cdap-ui/app/features/flows/controllers/tabs/runs/tabs/status-ctrl.js
@@ -67,4 +67,8 @@ angular.module(PKG.name + '.feature.flows')
     this.flowletClick = function(node) {
       $scope.RunsController.selectTab($scope.RunsController.tabs[1], node);
     };
+
+    $scope.$on('$destroy', function () {
+      FlowDiagramData.reset();
+    });
   });

--- a/cdap-ui/app/features/flows/service/flow-graph-data.js
+++ b/cdap-ui/app/features/flows/service/flow-graph-data.js
@@ -48,4 +48,8 @@ angular.module(PKG.name + '.feature.flows')
       return defer.promise;
     };
 
+    this.reset = function() {
+      this.data = {};
+    };
+
   });


### PR DESCRIPTION
Use case: When there are 2 namespaces with identical programs, run a flow and it will generate metrics. When you switch to a different namespace and go to the identical flow, the metrics from the other namespace will show up. It disappears on refresh.

Solution: Adding a reset function on FlowDiagramData service which is called on $scope $destroy event of the status-ctrl. 