### PR TITLE
Add support to access tpfs through service in LogAnalysisApp

### DIFF
--- a/cdap-examples/LogAnalysis/pom.xml
+++ b/cdap-examples/LogAnalysis/pom.xml
@@ -58,11 +58,6 @@
       <artifactId>spark-core_2.10</artifactId>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>co.cask.cdap</groupId>
-      <artifactId>cdap-common</artifactId>
-      <version>${project.version}</version>
-    </dependency>
   </dependencies>
 
   <build>

--- a/cdap-examples/LogAnalysis/pom.xml
+++ b/cdap-examples/LogAnalysis/pom.xml
@@ -58,6 +58,11 @@
       <artifactId>spark-core_2.10</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/cdap-examples/LogAnalysis/src/main/java/co/cask/cdap/examples/loganalysis/LogAnalysisApp.java
+++ b/cdap-examples/LogAnalysis/src/main/java/co/cask/cdap/examples/loganalysis/LogAnalysisApp.java
@@ -190,7 +190,7 @@ public class LogAnalysisApp extends AbstractApplication {
     static final String REQUEST_COUNTER_PARTITIONS_PATH = "reqcount";
     static final String REQUEST_FILE_CONTENT_PATH = "reqfile";
     static final String REQUEST_FILE_PATH_HANDLER_KEY = "time";
-    public static final DateFormat SHORT_DATE_FORMAT = DateFormat.getDateTimeInstance(DateFormat.SHORT,
+    private static final DateFormat SHORT_DATE_FORMAT = DateFormat.getDateTimeInstance(DateFormat.SHORT,
                                                                                       DateFormat.SHORT);
 
     @UseDataSet(REQ_COUNT_STORE)
@@ -245,21 +245,18 @@ public class LogAnalysisApp extends AbstractApplication {
       try {
         for (Location file : location.list()) {
           if (file.getName().startsWith("part")) {
-            String line;
             try (BufferedReader reader = new BufferedReader(new InputStreamReader(file.getInputStream(),
                                                                                   Charsets.UTF_8))) {
+              String line;
               while ((line = reader.readLine()) != null) {
                 int idx = line.indexOf(":");
                 requestCountsMap.put(line.substring(0, idx), Integer.parseInt(line.substring(idx + 1)));
               }
-            } catch (IOException e) {
-              responder.sendError(HttpURLConnection.HTTP_INTERNAL_ERROR, "Failed to read file.");
-              return;
             }
           }
         }
       } catch (IOException e) {
-        responder.sendError(HttpURLConnection.HTTP_INTERNAL_ERROR, "Failed to access files.");
+        responder.sendError(HttpURLConnection.HTTP_INTERNAL_ERROR, e.getMessage());
         return;
       }
       responder.sendJson(HttpURLConnection.HTTP_OK, requestCountsMap);

--- a/cdap-examples/LogAnalysis/src/main/scala/co/cask/cdap/examples/loganalysis/ResponseCounterProgram.scala
+++ b/cdap-examples/LogAnalysis/src/main/scala/co/cask/cdap/examples/loganalysis/ResponseCounterProgram.scala
@@ -23,7 +23,7 @@ import co.cask.cdap.api.common.Bytes
 import co.cask.cdap.api.dataset.lib.TimePartitionedFileSetArguments
 import co.cask.cdap.api.spark.{ScalaSparkProgram, SparkContext}
 import org.apache.hadoop.io.{LongWritable, Text}
-import org.apache.spark.rdd.{NewHadoopRDD, RDD}
+import org.apache.spark.rdd.NewHadoopRDD
 import org.slf4j.{Logger, LoggerFactory}
 import org.apache.spark.SparkContext._
 
@@ -51,9 +51,9 @@ class ResponseCounterProgram extends ScalaSparkProgram {
     val ipCounts = logsData.map(x => (ApacheAccessLog.
       parseFromLogLine(x._2.toString).getIpAddress, 1L)).reduceByKey(_ + _)
 
-    val outputArgs: util.HashMap[String, String] = new util.HashMap[String, String]
+    val outputArgs = new util.HashMap[String, String]
     TimePartitionedFileSetArguments.setOutputPartitionTime(outputArgs, endTime)
     context.writeToDataset(ipCounts, LogAnalysisApp.REQ_COUNT_STORE,
-      classOf[String], classOf[java.lang.Long], outputArgs)
+      classOf[String], classOf[Long], outputArgs)
   }
 }

--- a/cdap-examples/LogAnalysis/src/test/java/co/cask/cdap/examples/loganalysis/LogAnalysisAppTest.java
+++ b/cdap-examples/LogAnalysis/src/test/java/co/cask/cdap/examples/loganalysis/LogAnalysisAppTest.java
@@ -16,13 +16,7 @@
 
 package co.cask.cdap.examples.loganalysis;
 
-import co.cask.cdap.api.common.RuntimeArguments;
-import co.cask.cdap.api.common.Scope;
-import co.cask.cdap.api.dataset.lib.TimePartitionDetail;
-import co.cask.cdap.api.dataset.lib.TimePartitionedFileSet;
-import co.cask.cdap.api.dataset.lib.TimePartitionedFileSetArguments;
 import co.cask.cdap.test.ApplicationManager;
-import co.cask.cdap.test.DataSetManager;
 import co.cask.cdap.test.MapReduceManager;
 import co.cask.cdap.test.ServiceManager;
 import co.cask.cdap.test.SparkManager;
@@ -32,24 +26,23 @@ import co.cask.cdap.test.TestConfiguration;
 import co.cask.common.http.HttpRequest;
 import co.cask.common.http.HttpRequests;
 import co.cask.common.http.HttpResponse;
-import com.google.common.base.Charsets;
-import org.apache.twill.filesystem.Location;
+import com.google.common.reflect.TypeToken;
+import com.google.gson.Gson;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 /**
  * Unit test for {@link LogAnalysisApp}
  */
 public class LogAnalysisAppTest extends TestBase {
+
+  private static final Gson GSON = new Gson();
   private static final String LOG_1 = "127.0.0.1 - - [21/Jul/2014:9:55:27 -0800] \"GET /home.html HTTP/1.1\" 200 2048";
   private static final String LOG_2 = "127.0.1.1 - - [21/Jul/2014:9:55:27 -0800] \"GET /home.html HTTP/1.1\" 400 2048";
   private static final String LOG_3 = "127.0.0.1 - - [21/Jul/2014:9:55:27 -0800] \"GET /index.html HTTP/1.1\" 200 2048";
@@ -57,7 +50,7 @@ public class LogAnalysisAppTest extends TestBase {
   private static final String TOTAL_HITS_VALUE = "2";
   private static final String TOTAL_RESPONSE_VALUE = "2";
   private static final String RESPONSE_CODE = "200";
-  private static final String TPFS_RESULT = "127.0.0.1:2";
+  private static final String TPFS_RESULT = "127.0.1.1:1\n127.0.0.1:2\n";
 
   @ClassRule
   public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
@@ -76,15 +69,9 @@ public class LogAnalysisAppTest extends TestBase {
     streamManager.send(LOG_2);
     streamManager.send(LOG_3);
 
-    Map<String, String> outputArgs = new HashMap<>();
-    TimePartitionedFileSetArguments.setOutputPartitionTime(outputArgs, outputTime);
-    Map<String, String> args = new HashMap<>();
-    args.putAll(RuntimeArguments.addScope(Scope.DATASET, LogAnalysisApp.IP_COUNT_STORE, outputArgs));
-    args.put("output", LogAnalysisApp.IP_COUNT_STORE);
-
     // run the spark program
     SparkManager sparkManager = appManager.getSparkManager(
-      LogAnalysisApp.ResponseCounterSpark.class.getSimpleName()).start(args);
+      LogAnalysisApp.ResponseCounterSpark.class.getSimpleName()).start();
     sparkManager.waitForFinish(60, TimeUnit.SECONDS);
 
     // run the mapreduce job
@@ -95,6 +82,8 @@ public class LogAnalysisAppTest extends TestBase {
     ServiceManager hitCounterServiceManager = getServiceManager(appManager, LogAnalysisApp.HIT_COUNTER_SERVICE);
     ServiceManager responseCounterServiceManager = getServiceManager(appManager,
                                                                      LogAnalysisApp.RESPONSE_COUNTER_SERVICE);
+    ServiceManager requestCounterServiceManager = getServiceManager(appManager,
+                                                                    LogAnalysisApp.REQUEST_COUNTER_SERVICE);
 
     //Query for hit counts and verify it
     URL totalHitsURL = new URL(hitCounterServiceManager.getServiceURL(15, TimeUnit.SECONDS),
@@ -114,27 +103,29 @@ public class LogAnalysisAppTest extends TestBase {
     response = HttpRequests.execute(request);
     Assert.assertEquals(TOTAL_RESPONSE_VALUE, response.getResponseBodyAsString());
 
-    // validate the output by reading directly from the tpfs
-    DataSetManager<TimePartitionedFileSet> dataSetManager = getDataset(LogAnalysisApp.IP_COUNT_STORE);
-    TimePartitionedFileSet tpfs = dataSetManager.get();
-    TimePartitionDetail partitionDetail = tpfs.getPartitionByTime(outputTime);
+    // query to get partitions in the request count tpfs
+    URL requestCountFilsetsURL = new URL(requestCounterServiceManager.getServiceURL(15, TimeUnit.SECONDS),
+                                         LogAnalysisApp.RequestCounterHanlder.REQUEST_COUNTER_PARTITIONS_HANDLER);
+    request = HttpRequest.get(requestCountFilsetsURL).build();
+    response = HttpRequests.execute(request);
+    Set<String> partitions = GSON.fromJson(response.getResponseBodyAsString(),
+                                           new TypeToken<Set<String>>() {
+                                           }.getType());
+    Assert.assertEquals(1, partitions.size());
+    String partition = partitions.iterator().next();
 
-    Assert.assertNotNull(partitionDetail);
-    Location location = partitionDetail.getLocation();
+    //Query for the contents of the files in this partition and verify
+    URL requestFilesetContentURL = new URL(requestCounterServiceManager.getServiceURL(15, TimeUnit.SECONDS),
+                                           LogAnalysisApp.RequestCounterHanlder.REQUEST_FILE_CONTENT_HANDLER);
 
-    // find the part file that has the actual results
-    Assert.assertTrue(location.isDirectory());
-    for (Location file : location.list()) {
-      if (file.getName().startsWith("part")) {
-        location = file;
-      }
-    }
-    try (BufferedReader reader = new BufferedReader(new InputStreamReader(location.getInputStream(), Charsets.UTF_8))) {
-      Assert.assertEquals(TPFS_RESULT, reader.readLine());
-    }
+    response = HttpRequests.execute(HttpRequest.post(requestFilesetContentURL)
+                                      .withBody("{\"" + LogAnalysisApp.RequestCounterHanlder.REQUEST_FILE_PATH_HANDLER_KEY + "\":\""
+                                                  + partition + "\"}")
+                                      .build());
+    Assert.assertEquals(HttpURLConnection.HTTP_OK, response.getResponseCode());
+    Assert.assertEquals(TPFS_RESULT, response.getResponseBodyAsString());
   }
-
-
+  
   private ServiceManager getServiceManager(ApplicationManager appManager, String serviceName)
     throws InterruptedException {
     // Start the service


### PR DESCRIPTION
- Spark program now writes the TPFS with partition key as the logicalStartTime by passing it as arguments while calling writeToDataset rather than requiring the user user to provide the partition time as a dataset argument. https://github.com/caskdata/cdap/pull/3215
- Exposes to handlers: One to get a list of all partitions and another to get contents of a partition as a string.
- Update the unit test for the same.

Build: http://builds.cask.co/browse/CDAP-RBT333-1
