### PR TITLE
Don't try to upgrade usage.registy on fresh cluster

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/instance/DatasetInstanceManager.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/instance/DatasetInstanceManager.java
@@ -24,6 +24,7 @@ import co.cask.cdap.proto.Id;
 import com.google.inject.Inject;
 
 import java.util.Collection;
+import javax.annotation.Nullable;
 
 /**
  * Manages dataset instances metadata
@@ -56,6 +57,7 @@ public class DatasetInstanceManager {
    * @param datasetInstanceId {@link Id.DatasetInstance} of the dataset instance
    * @return dataset instance's {@link DatasetSpecification}
    */
+  @Nullable
   public DatasetSpecification get(final Id.DatasetInstance datasetInstanceId) {
     return mdsDatasets.executeUnchecked(new TxCallable<MDSDatasets, DatasetSpecification>() {
       @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/UsageRegistry.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/UsageRegistry.java
@@ -332,18 +332,21 @@ public class UsageRegistry {
    */
   public void upgrade(DatasetInstanceManager datasetInstanceManager) {
     DatasetSpecification oldDatasetSpecification = datasetInstanceManager.get(USAGE_INSTANCE_ID);
-
-    if (!oldDatasetSpecification.getType().equals(UsageDataset.class.getSimpleName())) {
-      LOG.info("Upgrading {} dataset from Table to UsageDataset type", USAGE_INSTANCE_ID);
-      DatasetSpecification newDatasetSpecification = DatasetSpecification.builder(oldDatasetSpecification.getName(),
-                                                                                  UsageDataset.class.getSimpleName())
-        .properties(oldDatasetSpecification.getProperties())
-        .datasets(oldDatasetSpecification.getSpecifications().values())
-        .build();
-      datasetInstanceManager.delete(USAGE_INSTANCE_ID);
-      datasetInstanceManager.add(Constants.SYSTEM_NAMESPACE_ID, newDatasetSpecification);
-    } else {
-      LOG.info("{} dataset is of type UsageDataset. No upgrade required.", USAGE_INSTANCE_ID);
+    // the usage.registry table will only be created if something runs on a cluster and creates a usage record.
+    // on a fresh cluster the dataset will not be present and in this case no upgrade is required.
+    if (oldDatasetSpecification != null) {
+      if (!oldDatasetSpecification.getType().equals(UsageDataset.class.getSimpleName())) {
+        LOG.info("Upgrading {} dataset from Table to UsageDataset type", USAGE_INSTANCE_ID);
+        DatasetSpecification newDatasetSpecification = DatasetSpecification.builder(oldDatasetSpecification.getName(),
+                                                                                    UsageDataset.class.getSimpleName())
+          .properties(oldDatasetSpecification.getProperties())
+          .datasets(oldDatasetSpecification.getSpecifications().values())
+          .build();
+        datasetInstanceManager.delete(USAGE_INSTANCE_ID);
+        datasetInstanceManager.add(Constants.SYSTEM_NAMESPACE_ID, newDatasetSpecification);
+      } else {
+        LOG.info("{} dataset is of type UsageDataset. No upgrade required.", USAGE_INSTANCE_ID);
+      }
     }
   }
 


### PR DESCRIPTION
- usage.registry table is created when something runs on a cluster and a usage record needs to be written. On a fresh cluster the usage.registry will not exists and will not be found. No upgrade is necessary in this case. 