### PR TITLE
CDAP-3042 fix bug where buffered operations weren't seen in multiget

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/Table.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/Table.java
@@ -133,7 +133,6 @@ public interface Table extends BatchReadable<byte[], Row>, BatchWritable<byte[],
    */
   Row get(Get get);
 
-
   /**
    * Reads values for the rows and columns defined by the {@link Get} parameters.  When running in distributed mode,
    * and retrieving multiple rows at the same time, this method should be preferred to multiple {@link Table#get(Get)}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/BufferingTable.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/BufferingTable.java
@@ -395,11 +395,6 @@ public abstract class BufferingTable extends AbstractTable implements MeteredDat
     reportRead(1);
     // checking if the row was deleted inside this tx
     NavigableMap<byte[], Update> buffCols = buff.get(row);
-    boolean rowDeleted = buffCols == null && buff.containsKey(row);
-    // ANDREAS: can this ever happen?
-    if (rowDeleted) {
-      return new Result(row, Collections.<byte[], byte[]>emptyMap());
-    }
 
     // NOTE: since we cannot tell the exact column set, we always have to go to persisted store.
     //       potential improvement: do not fetch columns available in in-mem buffer (we know them at this point)
@@ -450,11 +445,6 @@ public abstract class BufferingTable extends AbstractTable implements MeteredDat
 
         byte[] row = get.getRow();
         NavigableMap<byte[], Update> buffCols = buff.get(row);
-        // if the row was deleted in the buffer, add an empty row to the results
-        if (buffCols == null && buff.containsKey(row)) {
-          result.add(new Result(row, Collections.<byte[], byte[]>emptyMap()));
-          continue;
-        }
 
         // merge what was in the buffer and what was persisted
         if (buffCols != null) {
@@ -734,10 +724,6 @@ public abstract class BufferingTable extends AbstractTable implements MeteredDat
     NavigableMap<byte[], byte[]> result = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
     // checking if the row was deleted inside this tx
     NavigableMap<byte[], Update> buffCols = buff.get(row);
-    boolean rowDeleted = buffCols == null && buff.containsKey(row);
-    if (rowDeleted) {
-      return Collections.emptyMap();
-    }
 
     // if nothing locally, return all from server
     if (buffCols == null) {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/BufferingTable.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/BufferingTable.java
@@ -23,6 +23,7 @@ import co.cask.cdap.api.dataset.DataSetException;
 import co.cask.cdap.api.dataset.metrics.MeteredDataset;
 import co.cask.cdap.api.dataset.table.ConflictDetection;
 import co.cask.cdap.api.dataset.table.Filter;
+import co.cask.cdap.api.dataset.table.Get;
 import co.cask.cdap.api.dataset.table.Result;
 import co.cask.cdap.api.dataset.table.Row;
 import co.cask.cdap.api.dataset.table.Scan;
@@ -224,7 +225,26 @@ public abstract class BufferingTable extends AbstractTable implements MeteredDat
    * @return instance of {@link Scanner}, never null
    * @throws Exception
    */
-  protected abstract  Scanner scanPersisted(Scan scan) throws Exception;
+  protected abstract Scanner scanPersisted(Scan scan) throws Exception;
+
+  /**
+   * Fetches a list of rows from persistent store. Subclasses should override this if they can batch multiple
+   * gets into a single request, as the default implementation simply loops through the gets and calls
+   * {@link #getPersisted(byte[], byte[][])} on each get.
+   * NOTE: persisted store can also be in-memory, it is called "persisted" to distinguish from in-memory buffer.
+   * @param gets list of gets to perform
+   * @return list of rows, one for each get
+   * @throws Exception
+   */
+  protected List<Map<byte[], byte[]>> getPersisted(List<Get> gets) throws Exception {
+    List<Map<byte[], byte[]>> results = Lists.newArrayListWithCapacity(gets.size());
+    for (Get get : gets) {
+      List<byte[]> getColumns = get.getColumns();
+      byte[][] columns = getColumns.isEmpty() ? null : getColumns.toArray(new byte[getColumns.size()][]);
+      results.add(getPersisted(get.getRow(), columns));
+    }
+    return results;
+  }
 
   @Override
   public void setMetricsCollector(MetricsCollector metricsCollector) {
@@ -403,6 +423,52 @@ public abstract class BufferingTable extends AbstractTable implements MeteredDat
     } catch (Exception e) {
       LOG.debug("get failed for table: " + getTransactionAwareName() + ", row: " + Bytes.toStringBinary(row), e);
       throw new DataSetException("get failed", e);
+    }
+  }
+
+  @Override
+  public List<Row> get(List<Get> gets) {
+    try {
+      // get persisted, then overwrite with whats buffered
+      List<Map<byte[], byte[]>> persistedRows = getPersisted(gets);
+      // gets and rows lists are always of the same size
+      Preconditions.checkArgument(gets.size() == persistedRows.size(),
+        "Invalid number of rows fetched when performing multi-get. There must be one row for each get.");
+
+      List<Row> result = Lists.newArrayListWithCapacity(persistedRows.size());
+
+      Iterator<Map<byte[], byte[]>> persistedRowsIter = persistedRows.iterator();
+      Iterator<Get> getIter = gets.iterator();
+      while (persistedRowsIter.hasNext() && getIter.hasNext()) {
+        Get get = getIter.next();
+        Map<byte[], byte[]> persistedRow = persistedRowsIter.next();
+
+        // navigable copy of the persisted data. Implementation may return immutable or unmodifiable maps,
+        // so we make a copy here.
+        NavigableMap<byte[], byte[]> rowColumns = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
+        rowColumns.putAll(persistedRow);
+
+        byte[] row = get.getRow();
+        NavigableMap<byte[], Update> buffCols = buff.get(row);
+        // if the row was deleted in the buffer, add an empty row to the results
+        if (buffCols == null && buff.containsKey(row)) {
+          result.add(new Result(row, Collections.<byte[], byte[]>emptyMap()));
+          continue;
+        }
+
+        // merge what was in the buffer and what was persisted
+        if (buffCols != null) {
+          List<byte[]> getColumns = get.getColumns();
+          byte[][] columns = getColumns.isEmpty() ? null : getColumns.toArray(new byte[getColumns.size()][]);
+          mergeToPersisted(rowColumns, buffCols, columns);
+        }
+
+        result.add(new Result(row, unwrapDeletes(rowColumns)));
+      }
+      return result;
+    } catch (Exception e) {
+      LOG.debug("multi-get failed for table: " + getTransactionAwareName(), e);
+      throw new DataSetException("multi-get failed", e);
     }
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTable.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTable.java
@@ -23,7 +23,6 @@ import co.cask.cdap.api.dataset.DatasetContext;
 import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.dataset.table.ConflictDetection;
 import co.cask.cdap.api.dataset.table.Filter;
-import co.cask.cdap.api.dataset.table.Row;
 import co.cask.cdap.api.dataset.table.Scanner;
 import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.common.conf.CConfiguration;
@@ -127,7 +126,7 @@ public class HBaseTable extends BufferingTable {
   }
 
   @Override
-  public List<Row> get(List<co.cask.cdap.api.dataset.table.Get> gets) {
+  public List<Map<byte[], byte[]>> getPersisted(List<co.cask.cdap.api.dataset.table.Get> gets) {
     List<Get> hbaseGets = Lists.transform(gets, new Function<co.cask.cdap.api.dataset.table.Get, Get>() {
       @Nullable
       @Override
@@ -138,13 +137,12 @@ public class HBaseTable extends BufferingTable {
     });
     try {
       Result[] results = hTable.get(hbaseGets);
-      return Lists.transform(Arrays.asList(results), new Function<Result, Row>() {
+      return Lists.transform(Arrays.asList(results), new Function<Result, Map<byte[], byte[]>>() {
         @Nullable
         @Override
-        public Row apply(Result result) {
+        public Map<byte[], byte[]> apply(Result result) {
           Map<byte[], byte[]> familyMap = result.getFamilyMap(columnFamily);
-          return new co.cask.cdap.api.dataset.table.Result(result.getRow(),
-              familyMap != null ? familyMap : ImmutableMap.<byte[], byte[]>of());
+          return familyMap != null ? familyMap : ImmutableMap.<byte[], byte[]>of();
         }
       });
     } catch (IOException ioe) {

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/BufferingTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/BufferingTableTest.java
@@ -18,6 +18,7 @@ package co.cask.cdap.data2.dataset2.lib.table;
 
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.dataset.DatasetAdmin;
+import co.cask.cdap.api.dataset.table.Get;
 import co.cask.cdap.api.dataset.table.Row;
 import co.cask.cdap.api.dataset.table.Scan;
 import co.cask.cdap.api.dataset.table.Scanner;
@@ -25,12 +26,14 @@ import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.data2.dataset2.TableAssert;
 import co.cask.tephra.Transaction;
 import co.cask.tephra.TransactionAware;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
 
@@ -423,6 +426,76 @@ public abstract class BufferingTableTest<T extends BufferingTable>
     } finally {
       admin1.drop();
       admin2.drop();
+    }
+  }
+
+  @Test
+  public void testMultiGetIncludesBuffer() throws Exception {
+    DatasetAdmin admin = getTableAdmin(CONTEXT1, MY_TABLE);
+    admin.create();
+    try {
+      // persist some data
+      BufferingTable table = getTable(CONTEXT1, MY_TABLE);
+      Transaction tx1 = txClient.startShort();
+      table.startTx(tx1);
+      // writing a couple rows
+      // table should look like the following, with everything in the buffer
+      //          c1    c2    c3    c4
+      // r1       1     2     3     -
+      // r2       -     3     2     1
+      table.put(R1, a(C1, C2, C3), lb(1, 2, 3));
+      table.put(R2, a(C2, C3, C4), lb(3, 2, 1));
+      // check that multi-get can see buffered writes
+      List<Row> rows = table.get(Lists.newArrayList(new Get(R1), new Get(R2)));
+      Assert.assertEquals(2, rows.size());
+      TableAssert.assertRow(rows.get(0), R1, a(C1, C2, C3), lb(1, 2, 3));
+      TableAssert.assertRow(rows.get(1), R2, a(C2, C3, C4), lb(3, 2, 1));
+      // check multi-get with gets that specify columns, and one get that should return an empty row
+      rows = table.get(Lists.newArrayList(new Get(R1, C2, C3), new Get(R2, C2, C3), new Get(R3)));
+      Assert.assertEquals(3, rows.size());
+      TableAssert.assertRow(rows.get(0), R1, a(C2, C3), lb(2, 3));
+      TableAssert.assertRow(rows.get(1), R2, a(C2, C3), lb(3, 2));
+      Assert.assertTrue(rows.get(2).isEmpty());
+
+      // persist changes
+      Collection<byte []> txChanges = table.getTxChanges();
+      Assert.assertTrue(txClient.canCommit(tx1, txChanges));
+      Assert.assertTrue(table.commitTx());
+      Assert.assertTrue(txClient.commit(tx1));
+      table.postTxCommit();
+
+      // start another transaction
+      Transaction tx2 = txClient.startShort();
+      table.startTx(tx2);
+      // now add another row, delete a row, and change some column values
+      // table should look like the following
+      //         c1    c2    c3    c4    c5
+      // r1      -     -     3     2     -
+      // r3      -     -     -     -     1
+      table.put(R1, a(C2, C3, C4), lb(4, 3, 2));
+      table.delete(R1, a(C1, C2));
+      table.delete(R2);
+      table.put(R3, C5, L1);
+      // verify multi-get sees persisted data with buffer applied on top
+      rows = table.get(Lists.newArrayList(new Get(R1), new Get(R2), new Get(R3)));
+      Assert.assertEquals(3, rows.size());
+      TableAssert.assertRow(rows.get(0), R1, a(C3, C4), lb(3, 2));
+      Assert.assertTrue(rows.get(1).isEmpty());
+      TableAssert.assertRow(rows.get(2), R3, a(C5), lb(1));
+
+      // pretend there was a write conflict and rollback changes
+      Assert.assertTrue(table.rollbackTx());
+      txClient.abort(tx2);
+
+      // start another transaction and make sure it can't see what was done before
+      Transaction tx3 = txClient.startShort();
+      table.startTx(tx3);
+      rows = table.get(Lists.newArrayList(new Get(R1), new Get(R2)));
+      Assert.assertEquals(2, rows.size());
+      TableAssert.assertRow(rows.get(0), R1, a(C1, C2, C3), lb(1, 2, 3));
+      TableAssert.assertRow(rows.get(1), R2, a(C2, C3, C4), lb(3, 2, 1));
+    } finally {
+      admin.drop();
     }
   }
 

--- a/cdap-examples/UserProfiles/src/main/java/co/cask/cdap/examples/profiles/UserProfileService.java
+++ b/cdap-examples/UserProfiles/src/main/java/co/cask/cdap/examples/profiles/UserProfileService.java
@@ -100,11 +100,15 @@ public class UserProfileService extends AbstractService {
       } else {
         // otherwise, scan the entire table
         Scanner scanner = profiles.scan(null, null);
-        Row row;
-        int profilesAdded = 0;
-        while (profilesAdded < limit && (row = scanner.next()) != null) {
-          profilesList.add(toProfile(row));
-          profilesAdded++;
+        try {
+          Row row;
+          int profilesAdded = 0;
+          while (profilesAdded < limit && (row = scanner.next()) != null) {
+            profilesList.add(toProfile(row));
+            profilesAdded++;
+          }
+        } finally {
+          scanner.close();
         }
       }
 


### PR DESCRIPTION
Fixes a bug in BufferingTable where multiget calls for HBase were
only returning persisted data and could not see changes made in the
same transaction. In order to fix this, BufferingTable now has a
getPersisted(List<Get> gets) method for subclasses to override.
BufferingTable will then apply buffered changes on top of the
persisted changes.

Also adding a service endpoint to the UserProfiles example app to
demonstrate usage of multi-get on a Table.