### PR TITLE
[CDAP 2945] PFS should not fail if the input partition filter matches no partitions

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceWithPartitionedTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceWithPartitionedTest.java
@@ -252,14 +252,14 @@ public class MapReduceWithPartitionedTest {
         }
       });
 
-    // now run a map/reduce that reads no partitions
+    // now run a map/reduce that reads no partitions (because the range matches nothing)
     TimePartitionedFileSetArguments.setInputStartTime(inputArgs, time - TimeUnit.MINUTES.toMillis(10));
     TimePartitionedFileSetArguments.setInputEndTime(inputArgs, time - TimeUnit.MINUTES.toMillis(9));
     runtimeArguments.putAll(RuntimeArguments.addScope(Scope.DATASET, TIME_PARTITIONED, inputArgs));
     runtimeArguments.put(AppWithTimePartitionedFileSet.ROW_TO_WRITE, "n");
     runProgram(app, AppWithTimePartitionedFileSet.PartitionReader.class, new BasicArguments(runtimeArguments));
 
-    // this should have read the first partition only - and written only x to row b
+    // this should have read no partitions - and written nothing to row n
     txExecutorFactory.createExecutor(datasetInstantiator.getTransactionAware()).execute(
       new TransactionExecutor.Subroutine() {
         @Override
@@ -397,12 +397,12 @@ public class MapReduceWithPartitionedTest {
         }
       });
 
-    // a partition filter that matches the no key
+    // a partition filter that matches no key
     PartitionFilter filterMT = PartitionFilter.builder()
       .addValueCondition("type", "nosuchthing")
       .build();
 
-    // now run a map/reduce that reads a range of the partitions, namely the first one
+    // now run a map/reduce that reads an empty range of partitions (the filter matches nothing)
     inputArgs.clear();
     PartitionedFileSetArguments.setInputPartitionFilter(inputArgs, filterMT);
     runtimeArguments.putAll(RuntimeArguments.addScope(Scope.DATASET, PARTITIONED, inputArgs));

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/file/FileSetDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/file/FileSetDataset.java
@@ -193,9 +193,7 @@ public final class FileSetDataset implements FileSet {
         return getFileSystemPath(location);
       }
     }));
-    if (!inputs.isEmpty()) {
-      config.put(FileInputFormat.INPUT_DIR, inputs);
-    }
+    config.put(FileInputFormat.INPUT_DIR, inputs);
     return config.build();
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/EmptyInputFormat.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/EmptyInputFormat.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.dataset2.lib.partitioned;
+
+import org.apache.hadoop.mapreduce.InputFormat;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * An InputFormat that returns no data.
+ * @param <K> the key class
+ * @param <V> the value class
+ */
+public class EmptyInputFormat<K, V> extends InputFormat<K, V> {
+
+  @Override
+  public List<InputSplit> getSplits(JobContext context) throws IOException, InterruptedException {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public RecordReader<K, V> createRecordReader(InputSplit split, TaskAttemptContext context) {
+    return new RecordReader<K, V>() {
+      @Override
+      public void initialize(InputSplit split, TaskAttemptContext context) {
+        // do nothing
+      }
+
+      @Override
+      public boolean nextKeyValue() {
+        return false;
+      }
+
+      @Override
+      public K getCurrentKey() {
+        return null;
+      }
+
+      @Override
+      public V getCurrentValue() {
+        return null;
+      }
+
+      @Override
+      public float getProgress() {
+        return 1.0F;
+      }
+
+      @Override
+      public void close() {
+        // nothing to do
+      }
+    };
+  }
+}


### PR DESCRIPTION
This changes partitioned file sets to use an EmptyInputFormat if the input filter does not match anything. (the actual input format, which most likely extends FileInputFormat, would throw an exception if no input paths are configured). This does not change the behavior if no input filter was given - that will still throw an exception, unless the input was specified directly using FileSetArguments, bypassing the partition filter (not a common use case, but supported). 

Similar for TimePartitionedFileSet: If an input time range was specified, and it matches no partitions, use EmptyInputFormat. If no time range was given, fall back to PartitionedFileSet's method of input selection (using partition filters).

Also changes the behavior if not output path is given for a file set. It used to write to the base location, which is wrong. I will now fail (just like FileOutputFormat would) if no output path is given.