### PR TITLE
Remove unnecessary sleep for 2 seconds in various places in MR.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapperWrapper.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapperWrapper.java
@@ -110,9 +110,6 @@ public class MapperWrapper extends Mapper {
         ClassLoaders.setContextClassLoader(oldClassLoader);
       }
 
-      // sleep to allow metrics to be written
-      TimeUnit.SECONDS.sleep(2L);
-
       // transaction is not finished, but we want all operations to be dispatched (some could be buffered in
       // memory by tx agent
       try {
@@ -135,8 +132,11 @@ public class MapperWrapper extends Mapper {
       }
 
     } finally {
-      basicMapReduceContext.close();
-      basicMapReduceContext.getMetricsCollectionService().stop();
+      try {
+        basicMapReduceContext.close();
+      } finally {
+        basicMapReduceContext.getMetricsCollectionService().stop();
+      }
     }
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/ReducerWrapper.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/ReducerWrapper.java
@@ -109,9 +109,6 @@ public class ReducerWrapper extends Reducer {
         ClassLoaders.setContextClassLoader(oldClassLoader);
       }
 
-      // sleep to allow metrics to be written
-      TimeUnit.SECONDS.sleep(2L);
-
       // transaction is not finished, but we want all operations to be dispatched (some could be buffered in
       // memory by tx agent
       try {
@@ -135,8 +132,11 @@ public class ReducerWrapper extends Reducer {
       }
 
     } finally {
-      basicMapReduceContext.close(); // closes all datasets
-      basicMapReduceContext.getMetricsCollectionService().stop();
+      try {
+        basicMapReduceContext.close(); // closes all datasets
+      } finally {
+        basicMapReduceContext.getMetricsCollectionService().stop();
+      }
     }
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/DataSetRecordReader.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/DataSetRecordReader.java
@@ -26,7 +26,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.concurrent.TimeUnit;
 
 final class DataSetRecordReader<KEY, VALUE> extends RecordReader<KEY, VALUE> {
   private static final Logger LOG = LoggerFactory.getLogger(DataSetRecordReader.class);
@@ -73,12 +72,8 @@ final class DataSetRecordReader<KEY, VALUE> extends RecordReader<KEY, VALUE> {
     try {
       splitReader.close();
     } finally {
-      context.close();
-      // sleep to allow metrics to be emitted
       try {
-        TimeUnit.SECONDS.sleep(2L);
-      } catch (InterruptedException e) {
-        LOG.info("sleep interrupted while waiting for final metrics to be emitted", e);
+        context.close();
       } finally {
         context.getMetricsCollectionService().stop();
       }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/DataSetRecordWriter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/DataSetRecordWriter.java
@@ -56,10 +56,11 @@ final class DataSetRecordWriter<KEY, VALUE> extends RecordWriter<KEY, VALUE> {
       LOG.error("Failed to flush operations at the end of reducer of " + mrContext.toString());
       throw Throwables.propagate(e);
     } finally {
-      mrContext.close();
-      // sleep to allow metrics to be emitted
-      TimeUnit.SECONDS.sleep(2L);
-      mrContext.getMetricsCollectionService().stop();
+      try {
+        mrContext.close();
+      } finally {
+        mrContext.getMetricsCollectionService().stop();
+      }
     }
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/inmemory/InMemoryMapReduceContextBuilder.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/inmemory/InMemoryMapReduceContextBuilder.java
@@ -75,7 +75,7 @@ public class InMemoryMapReduceContextBuilder extends AbstractMapReduceContextBui
       new DiscoveryRuntimeModule().getInMemoryModules(),
       new DataFabricModules().getInMemoryModules(),
       new DataSetsModules().getStandaloneModules(),
-      new MetricsClientRuntimeModule().getNoopModules(),
+      new MetricsClientRuntimeModule().getInMemoryModules(),
       new LoggingModules().getInMemoryModules(),
       new StreamAdminModules().getInMemoryModules(),
       new ExploreClientModule(),


### PR DESCRIPTION
- The sleep was there for waiting metrics be published. However, on
  stopping the metrics collection service, metrics are being force pushed,
  hence the sleep is unnecessary