### PR TITLE
CDAP-3039 Fix to make Worker program stop

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/AbstractInMemoryProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/AbstractInMemoryProgramRunner.java
@@ -157,7 +157,6 @@ public abstract class AbstractInMemoryProgramRunner implements ProgramRunner {
           @Override
           public void completed() {
             if (liveComponents.decrementAndGet()  == 0) {
-              LOG.info("Program stopped: {}", spec.getName());
               complete();
             }
           }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractProgramController.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractProgramController.java
@@ -144,6 +144,7 @@ public abstract class AbstractProgramController implements ProgramController {
       LOG.debug("Cannot transit to COMPLETED state from {} state: {} {}", state.get(), programName, runId);
       return;
     }
+    LOG.debug("Program stopped: {} {}", programName, runId);
     executor(State.COMPLETED).execute(new Runnable() {
       @Override
       public void run() {

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/GatewayTestBase.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/GatewayTestBase.java
@@ -247,14 +247,22 @@ public abstract class GatewayTestBase {
     int trials = 0;
     // it may take a while for workflow/mr to start...
     while (trials++ < 20) {
-      HttpResponse response = GatewayFastTestsSuite.doGet(String.format("/v3/namespaces/default/apps/%s/%s/%s/status",
-                                                                        appId, programType, programId));
-      JsonObject status = GSON.fromJson(EntityUtils.toString(response.getEntity()), JsonObject.class);
-      if (status != null && status.has("status") && state.equals(status.get("status").getAsString())) {
+      String status = getState(programType, appId, programId);
+      if (status != null && state.equals(status)) {
         break;
       }
       TimeUnit.SECONDS.sleep(1);
     }
     Assert.assertTrue(trials < 20);
+  }
+
+  protected static String getState(String programType, String appId, String programId) throws Exception {
+    HttpResponse response = GatewayFastTestsSuite.doGet(String.format("/v3/namespaces/default/apps/%s/%s/%s/status",
+                                                                      appId, programType, programId));
+    JsonObject status = GSON.fromJson(EntityUtils.toString(response.getEntity()), JsonObject.class);
+    if (status != null && status.has("status")) {
+      return status.get("status").getAsString();
+    }
+    return null;
   }
 }

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/run/StreamWriterTestRun.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/run/StreamWriterTestRun.java
@@ -54,7 +54,6 @@ public class StreamWriterTestRun extends GatewayTestBase {
     Assert.assertEquals(HttpResponseStatus.OK.getCode(), response.getStatusLine().getStatusCode());
 
     waitState("flows", AppWritingtoStream.APPNAME, AppWritingtoStream.FLOW, "RUNNING");
-    waitState("workers", AppWritingtoStream.APPNAME, AppWritingtoStream.WORKER, "RUNNING");
     waitState("services", AppWritingtoStream.APPNAME, AppWritingtoStream.SERVICE, "RUNNING");
 
     checkCount(AppWritingtoStream.VALUE);
@@ -64,11 +63,16 @@ public class StreamWriterTestRun extends GatewayTestBase {
                                                           AppWritingtoStream.APPNAME,
                                                           AppWritingtoStream.FLOW), null);
     Assert.assertEquals(HttpResponseStatus.OK.getCode(), response.getStatusLine().getStatusCode());
+
     //Stop Worker
-    response = GatewayFastTestsSuite.doPost(String.format("/v3/namespaces/default/apps/%s/workers/%s/stop",
-                                                          AppWritingtoStream.APPNAME,
-                                                          AppWritingtoStream.WORKER), null);
-    Assert.assertEquals(HttpResponseStatus.OK.getCode(), response.getStatusLine().getStatusCode());
+    String workerState = getState("workers", AppWritingtoStream.APPNAME, AppWritingtoStream.WORKER);
+    if (workerState != null && workerState.equals("RUNNING")) {
+      response = GatewayFastTestsSuite.doPost(String.format("/v3/namespaces/default/apps/%s/workers/%s/stop",
+                                                            AppWritingtoStream.APPNAME,
+                                                            AppWritingtoStream.WORKER), null);
+      Assert.assertEquals(HttpResponseStatus.OK.getCode(), response.getStatusLine().getStatusCode());
+    }
+
     //Stop Service
     response = GatewayFastTestsSuite.doPost(String.format("/v3/namespaces/default/apps/%s/services/%s/stop",
                                                           AppWritingtoStream.APPNAME,

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/NoOpWorkerApp.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/NoOpWorkerApp.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.test.app;
+
+import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.api.worker.AbstractWorker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * App with a no-op worker.
+ */
+public class NoOpWorkerApp extends AbstractApplication {
+
+  @Override
+  public void configure() {
+    addWorker(new NoOpWorker());
+  }
+
+  public static class NoOpWorker extends AbstractWorker {
+    private static final Logger LOG = LoggerFactory.getLogger(NoOpWorker.class);
+
+    @Override
+    public void run() {
+      LOG.info("NoOp {}", getContext().getInstanceId());
+    }
+
+    @Override
+    protected void configure() {
+      setInstances(5);
+    }
+  }
+}

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
@@ -554,6 +554,15 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     Assert.assertEquals(AppWithWorker.STOP, Bytes.toString(table.read(AppWithWorker.STOP)));
   }
 
+  @Test
+  public void testWorkerStop() throws Exception {
+    // Test to make sure the worker program's status goes to stopped after the run method finishes
+    ApplicationManager manager = deployApplication(NoOpWorkerApp.class);
+    WorkerManager workerManager = manager.getWorkerManager("NoOpWorker");
+    workerManager.start();
+    workerManager.waitForStatus(false, 5, 1);
+  }
+
   @Category(SlowTests.class)
   @Test
   public void testAppWithServices() throws Exception {

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
@@ -494,7 +494,9 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     lifecycleWorkerManager.stop();
     lifecycleWorkerManager.waitForStatus(false);
 
-    workerManager.stop();
+    if (workerManager.isRunning()) {
+      workerManager.stop();
+    }
     workerManager.waitForStatus(false);
 
     // Should be same instances after being stopped.


### PR DESCRIPTION
When the run method of the worker completes. This bug is relevant only for inmemory mode and thus no change is required for distributed mode logic

JIRA : https://issues.cask.co/browse/CDAP-3039

Build : http://builds.cask.co/browse/CDAP-RBT347-1