### PR TITLE
CDAP-2454 Remove twillrunid from proto RunRecord so not send back to client

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/Store.java
@@ -24,11 +24,11 @@ import co.cask.cdap.api.worker.Worker;
 import co.cask.cdap.api.workflow.WorkflowToken;
 import co.cask.cdap.app.ApplicationSpecification;
 import co.cask.cdap.app.program.Program;
+import co.cask.cdap.internal.app.store.RunRecordMeta;
 import co.cask.cdap.proto.AdapterStatus;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.ProgramRunStatus;
-import co.cask.cdap.proto.RunRecord;
 import co.cask.cdap.templates.AdapterDefinition;
 import com.google.common.base.Predicate;
 import org.apache.twill.filesystem.Location;
@@ -121,8 +121,8 @@ public interface Store {
    * @param adapter   name of the adapter associated with the runs
    * @return          list of logged runs
    */
-  List<RunRecord> getRuns(Id.Program id, ProgramRunStatus status, long startTime, long endTime, int limit,
-                          String adapter);
+  List<RunRecordMeta> getRuns(Id.Program id, ProgramRunStatus status, long startTime, long endTime, int limit,
+                              String adapter);
 
   /**
    * Fetches run records for particular program. Returns only finished runs.
@@ -135,7 +135,7 @@ public interface Store {
    * @param limit     max number of entries to fetch for this history call
    * @return          list of logged runs
    */
-  List<RunRecord> getRuns(Id.Program id, ProgramRunStatus status, long startTime, long endTime, int limit);
+  List<RunRecordMeta> getRuns(Id.Program id, ProgramRunStatus status, long startTime, long endTime, int limit);
 
   /**
    * Fetches the run records for the particular status.
@@ -143,7 +143,7 @@ public interface Store {
    * @param filter  predicate to be passed to filter the records
    * @return        list of logged runs
    */
-  List<RunRecord> getRuns(ProgramRunStatus status, Predicate<RunRecord> filter);
+  List<RunRecordMeta> getRuns(ProgramRunStatus status, Predicate<RunRecordMeta> filter);
 
   /**
    * Fetches the run record for particular run of a program.
@@ -153,7 +153,7 @@ public interface Store {
    * @return          run record for the specified program and runid, null if not found
    */
   @Nullable
-  RunRecord getRun(Id.Program id, String runid);
+  RunRecordMeta getRun(Id.Program id, String runid);
 
   /**
    * Creates a new stream if it does not exist.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/AdapterService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/AdapterService.java
@@ -49,6 +49,7 @@ import co.cask.cdap.internal.app.runtime.schedule.SchedulerException;
 import co.cask.cdap.internal.app.services.ApplicationLifecycleService;
 import co.cask.cdap.internal.app.services.ProgramLifecycleService;
 import co.cask.cdap.internal.app.services.PropertiesResolver;
+import co.cask.cdap.internal.app.store.RunRecordMeta;
 import co.cask.cdap.proto.AdapterConfig;
 import co.cask.cdap.proto.AdapterStatus;
 import co.cask.cdap.proto.Id;
@@ -57,6 +58,7 @@ import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.RunRecord;
 import co.cask.cdap.templates.AdapterDefinition;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
@@ -100,6 +102,15 @@ import javax.annotation.Nullable;
 public class AdapterService extends AbstractIdleService {
   private static final Logger LOG = LoggerFactory.getLogger(AdapterService.class);
   private static final Gson GSON = ApplicationSpecificationAdapter.addTypeAdapters(new GsonBuilder()).create();
+
+  private static final Function<RunRecordMeta, RunRecord> CONVERT_TO_RUN_RECORD =
+    new Function<RunRecordMeta, RunRecord>() {
+      @Override
+      public RunRecord apply(RunRecordMeta input) {
+        return new RunRecord(input);
+      }
+    };
+
   private final ManagerFactory<DeploymentInfo, ApplicationWithPrograms> templateManagerFactory;
   private final ManagerFactory<AdapterDeploymentInfo, AdapterDefinition> adapterManagerFactory;
   private final CConfiguration configuration;
@@ -444,7 +455,8 @@ public class AdapterService extends AbstractIdleService {
   public List<RunRecord> getRuns(Id.Namespace namespace, String adapterName, ProgramRunStatus status,
                                  long start, long end, int limit) throws NotFoundException {
     Id.Program program = getProgramId(namespace, adapterName);
-    return store.getRuns(program, status, start, end, limit, adapterName);
+
+    return Lists.transform(store.getRuns(program, status, start, end, limit, adapterName), CONVERT_TO_RUN_RECORD);
   }
 
   /**
@@ -458,9 +470,9 @@ public class AdapterService extends AbstractIdleService {
    */
   public RunRecord getRun(Id.Namespace namespace, String adapterName, String runId) throws NotFoundException {
     Id.Program program = getProgramId(namespace, adapterName);
-    RunRecord runRecord = store.getRun(program, runId);
-    if (runRecord != null && adapterName.equals(runRecord.getAdapterName())) {
-      return runRecord;
+    RunRecordMeta runRecordMeta = store.getRun(program, runId);
+    if (runRecordMeta != null && adapterName.equals(runRecordMeta.getAdapterName())) {
+      return CONVERT_TO_RUN_RECORD.apply(runRecordMeta);
     }
     return null;
   }
@@ -576,9 +588,9 @@ public class AdapterService extends AbstractIdleService {
   private void stopWorkerAdapter(Id.Namespace namespace, AdapterDefinition adapterSpec) throws NotFoundException,
     ExecutionException, InterruptedException {
     final Id.Program workerId = getProgramId(namespace, adapterSpec);
-    List<RunRecord> runRecords = store.getRuns(workerId, ProgramRunStatus.RUNNING, 0, Long.MAX_VALUE, Integer.MAX_VALUE,
-                                               adapterSpec.getName());
-    RunRecord adapterRun = Iterables.getFirst(runRecords, null);
+    List<RunRecordMeta> runRecords = store.getRuns(workerId, ProgramRunStatus.RUNNING, 0, Long.MAX_VALUE,
+                                                   Integer.MAX_VALUE, adapterSpec.getName());
+    RunRecordMeta adapterRun = Iterables.getFirst(runRecords, null);
     if (adapterRun != null) {
       RunId runId = RunIds.fromString(adapterRun.getPid());
       lifecycleService.stopProgram(workerId, runId);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedProgramRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedProgramRuntimeService.java
@@ -38,6 +38,7 @@ import co.cask.cdap.internal.app.runtime.AbstractResourceReporter;
 import co.cask.cdap.internal.app.runtime.ProgramRunnerFactory;
 import co.cask.cdap.internal.app.runtime.flow.FlowUtils;
 import co.cask.cdap.internal.app.runtime.service.SimpleRuntimeInfo;
+import co.cask.cdap.internal.app.store.RunRecordMeta;
 import co.cask.cdap.proto.Containers;
 import co.cask.cdap.proto.DistributedProgramLiveInfo;
 import co.cask.cdap.proto.Id;
@@ -173,7 +174,7 @@ public final class DistributedProgramRuntimeService extends AbstractProgramRunti
       }
 
       // Program matched
-      RunRecord record = store.getRun(programId, runId.getId());
+      RunRecordMeta record = store.getRun(programId, runId.getId());
       if (record == null) {
         return null;
       }
@@ -235,15 +236,15 @@ public final class DistributedProgramRuntimeService extends AbstractProgramRunti
     }
 
     final Set<RunId> twillRunIds = twillProgramInfo.columnKeySet();
-    List<RunRecord> activeRunRecords = store.getRuns(ProgramRunStatus.RUNNING, new Predicate<RunRecord>() {
+    List<RunRecordMeta> activeRunRecords = store.getRuns(ProgramRunStatus.RUNNING, new Predicate<RunRecordMeta>() {
       @Override
-      public boolean apply(RunRecord record) {
+      public boolean apply(RunRecordMeta record) {
         return record.getTwillRunId() != null
           && twillRunIds.contains(org.apache.twill.internal.RunIds.fromString(record.getTwillRunId()));
       }
     });
 
-    for (RunRecord record : activeRunRecords) {
+    for (RunRecordMeta record : activeRunRecords) {
       RunId twillRunIdFromRecord = org.apache.twill.internal.RunIds.fromString(record.getTwillRunId());
       // Get the CDAP RunId from RunRecord
       RunId runId = RunIds.fromString(record.getPid());

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/AppMetadataStore.java
@@ -34,14 +34,15 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.ProgramType;
-import co.cask.cdap.proto.RunRecord;
 import co.cask.cdap.templates.AdapterDefinition;
+
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -140,7 +141,7 @@ public class AppMetadataStore extends MetadataStoreDataset {
       .add(pid)
       .build();
 
-    write(key, new RunRecord(pid, startTs, null, ProgramRunStatus.RUNNING, adapter, twillRunId));
+    write(key, new RunRecordMeta(pid, startTs, null, ProgramRunStatus.RUNNING, adapter, null, twillRunId));
   }
 
   public void recordProgramSuspend(Id.Program program, String pid) {
@@ -170,7 +171,7 @@ public class AppMetadataStore extends MetadataStoreDataset {
       .add(program.getId())
       .add(pid)
       .build();
-    RunRecord record = get(key, RunRecord.class);
+    RunRecordMeta record = get(key, RunRecordMeta.class);
     if (record == null) {
       String msg = String.format("No meta for %s run record for namespace %s app %s program type %s " +
                                    "program %s pid %s exists", action.equals("suspend") ? "started" : "suspended",
@@ -190,7 +191,7 @@ public class AppMetadataStore extends MetadataStoreDataset {
       .add(program.getId())
       .add(pid)
       .build();
-    write(key, new RunRecord(record, null, toStatus));
+    write(key, new RunRecordMeta(record, null, toStatus));
   }
 
   public void recordProgramStop(Id.Program program, String pid, long stopTs, ProgramRunStatus runStatus) {
@@ -202,7 +203,7 @@ public class AppMetadataStore extends MetadataStoreDataset {
       .add(program.getId())
       .add(pid)
       .build();
-    RunRecord started = getFirst(key, RunRecord.class);
+    RunRecordMeta started = getFirst(key, RunRecordMeta.class);
     if (started == null) {
       String msg = String.format("No meta for started run record for namespace %s app %s program type %s " +
                                  "program %s pid %s exists",
@@ -222,10 +223,11 @@ public class AppMetadataStore extends MetadataStoreDataset {
       .add(program.getId())
       .add(getInvertedTsKeyPart(started.getStartTs()))
       .add(pid).build();
-    write(key, new RunRecord(started, stopTs, runStatus));
+
+    write(key, new RunRecordMeta(started, stopTs, runStatus));
   }
 
-  public List<RunRecord> getRuns(ProgramRunStatus status, Predicate<RunRecord> filter) {
+  public List<RunRecordMeta> getRuns(ProgramRunStatus status, Predicate<RunRecordMeta> filter) {
     return getRuns(null, status, Long.MIN_VALUE, Long.MAX_VALUE, Integer.MAX_VALUE, null, filter);
   }
 
@@ -240,11 +242,11 @@ public class AppMetadataStore extends MetadataStoreDataset {
     return builder;
   }
 
-  public List<RunRecord> getRuns(@Nullable Id.Program program, ProgramRunStatus status,
+  public List<RunRecordMeta> getRuns(@Nullable Id.Program program, ProgramRunStatus status,
                                  long startTime, long endTime, int limit, String adapter,
-                                 @Nullable Predicate<RunRecord> filter) {
+                                 @Nullable Predicate<RunRecordMeta> filter) {
     if (status.equals(ProgramRunStatus.ALL)) {
-      List<RunRecord> resultRecords = Lists.newArrayList();
+      List<RunRecordMeta> resultRecords = Lists.newArrayList();
       resultRecords.addAll(getSuspendedRuns(program, startTime, endTime, limit, adapter, filter));
       resultRecords.addAll(getActiveRuns(program, startTime, endTime, limit, adapter, filter));
       resultRecords.addAll(getHistoricalRuns(program, status, startTime, endTime, limit, adapter, filter));
@@ -258,7 +260,7 @@ public class AppMetadataStore extends MetadataStoreDataset {
     }
   }
 
-  public List<RunRecord> getRuns(@Nullable Id.Program program, ProgramRunStatus status,
+  public List<RunRecordMeta> getRuns(@Nullable Id.Program program, ProgramRunStatus status,
                                  long startTime, long endTime, int limit, String adapter) {
     return getRuns(program, status, startTime, endTime, limit, adapter, null);
   }
@@ -266,16 +268,16 @@ public class AppMetadataStore extends MetadataStoreDataset {
   // TODO: getRun is duplicated in cdap-watchdog AppMetadataStore class.
   // Any changes made here will have to be made over there too.
   // JIRA https://issues.cask.co/browse/CDAP-2172
-  public RunRecord getRun(Id.Program program, final String runid) {
+  public RunRecordMeta getRun(Id.Program program, final String runid) {
     // Query active run record first
-    RunRecord running = getUnfinishedRun(program, TYPE_RUN_RECORD_STARTED, runid);
+    RunRecordMeta running = getUnfinishedRun(program, TYPE_RUN_RECORD_STARTED, runid);
     // If program is running, this will be non-null
     if (running != null) {
       return running;
     }
 
     // If program is not running, query completed run records
-    RunRecord complete = getCompletedRun(program, runid);
+    RunRecordMeta complete = getCompletedRun(program, runid);
     if (complete != null) {
       return complete;
     }
@@ -287,7 +289,7 @@ public class AppMetadataStore extends MetadataStoreDataset {
   /**
    * @return run records for runs that do not have start time in mds key for the run record.
    */
-  private RunRecord getUnfinishedRun(Id.Program program, String recordType, String runid) {
+  private RunRecordMeta getUnfinishedRun(Id.Program program, String recordType, String runid) {
     MDSKey runningKey = new MDSKey.Builder()
       .add(recordType)
       .add(program.getNamespaceId())
@@ -297,10 +299,10 @@ public class AppMetadataStore extends MetadataStoreDataset {
       .add(runid)
       .build();
 
-    return get(runningKey, RunRecord.class);
+    return get(runningKey, RunRecordMeta.class);
   }
 
-  private RunRecord getCompletedRun(Id.Program program, final String runid) {
+  private RunRecordMeta getCompletedRun(Id.Program program, final String runid) {
     MDSKey completedKey = new MDSKey.Builder()
       .add(TYPE_RUN_RECORD_COMPLETED)
       .add(program.getNamespaceId())
@@ -318,16 +320,16 @@ public class AppMetadataStore extends MetadataStoreDataset {
         .add(runid)
         .build();
 
-      return get(key, RunRecord.class);
+      return get(key, RunRecordMeta.class);
     } else {
       // If start time is not found, scan the table (backwards compatibility when run ids were random UUIDs)
       MDSKey startKey = new MDSKey.Builder(completedKey).add(getInvertedTsScanKeyPart(Long.MAX_VALUE)).build();
       MDSKey stopKey = new MDSKey.Builder(completedKey).add(getInvertedTsScanKeyPart(0)).build();
-      List<RunRecord> runRecords =
-        list(startKey, stopKey, RunRecord.class, 1,  // Should have only one record for this runid
-             new Predicate<RunRecord>() {
+      List<RunRecordMeta> runRecords =
+        list(startKey, stopKey, RunRecordMeta.class, 1,  // Should have only one record for this runid
+             new Predicate<RunRecordMeta>() {
                @Override
-               public boolean apply(RunRecord input) {
+               public boolean apply(RunRecordMeta input) {
                  return input.getPid().equals(runid);
                }
              });
@@ -335,24 +337,24 @@ public class AppMetadataStore extends MetadataStoreDataset {
     }
   }
 
-  private List<RunRecord> getSuspendedRuns(Id.Program program, long startTime, long endTime, int limit,
-                                           final String adapter, @Nullable Predicate<RunRecord> filter) {
+  private List<RunRecordMeta> getSuspendedRuns(Id.Program program, long startTime, long endTime, int limit,
+                                           final String adapter, @Nullable Predicate<RunRecordMeta> filter) {
     return getNonCompleteRuns(program, TYPE_RUN_RECORD_SUSPENDED, startTime, endTime, limit, adapter, filter);
   }
 
-  private List<RunRecord> getActiveRuns(Id.Program program, final long startTime, final long endTime, int limit,
-                                        final String adapter, @Nullable Predicate<RunRecord> filter) {
+  private List<RunRecordMeta> getActiveRuns(Id.Program program, final long startTime, final long endTime, int limit,
+                                        final String adapter, @Nullable Predicate<RunRecordMeta> filter) {
     return getNonCompleteRuns(program, TYPE_RUN_RECORD_STARTED, startTime, endTime, limit, adapter, filter);
     }
 
-  private List<RunRecord> getNonCompleteRuns(Id.Program program, String recordType,
+  private List<RunRecordMeta> getNonCompleteRuns(Id.Program program, String recordType,
                                              final long startTime, final long endTime, int limit,
-                                             final String adapter, Predicate<RunRecord> filter) {
+                                             final String adapter, Predicate<RunRecordMeta> filter) {
     MDSKey activeKey = getProgramKeyBuilder(recordType, program).build();
 
-    return list(activeKey, null, RunRecord.class, limit, andPredicate(new Predicate<RunRecord>() {
+    return list(activeKey, null, RunRecordMeta.class, limit, andPredicate(new Predicate<RunRecordMeta>() {
                   @Override
-                  public boolean apply(RunRecord input) {
+                  public boolean apply(RunRecordMeta input) {
                     boolean normalCheck = input.getStartTs() >= startTime && input.getStartTs() < endTime;
                     // Check if RunRecord matches with passed in adapter name
                     if (normalCheck && adapter != null) {
@@ -363,18 +365,18 @@ public class AppMetadataStore extends MetadataStoreDataset {
                 }, filter));
   }
 
-  private List<RunRecord> getHistoricalRuns(Id.Program program, ProgramRunStatus status,
+  private List<RunRecordMeta> getHistoricalRuns(Id.Program program, ProgramRunStatus status,
                                             final long startTime, final long endTime, int limit, final String adapter,
-                                            @Nullable Predicate<RunRecord> filter) {
+                                            @Nullable Predicate<RunRecordMeta> filter) {
     MDSKey historyKey = getProgramKeyBuilder(TYPE_RUN_RECORD_COMPLETED, program).build();
 
     MDSKey start = new MDSKey.Builder(historyKey).add(getInvertedTsScanKeyPart(endTime)).build();
     MDSKey stop = new MDSKey.Builder(historyKey).add(getInvertedTsScanKeyPart(startTime)).build();
     if (status.equals(ProgramRunStatus.ALL)) {
       //return all records (successful and failed)
-      return list(start, stop, RunRecord.class, limit, andPredicate(new Predicate<RunRecord>() {
+      return list(start, stop, RunRecordMeta.class, limit, andPredicate(new Predicate<RunRecordMeta>() {
         @Override
-        public boolean apply(@Nullable RunRecord record) {
+        public boolean apply(@Nullable RunRecordMeta record) {
           // Check if RunRecord matches with passed in adapter name
           return (adapter == null) || (record != null && adapter.equals(record.getAdapterName()));
         }
@@ -382,21 +384,21 @@ public class AppMetadataStore extends MetadataStoreDataset {
     }
 
     if (status.equals(ProgramRunStatus.COMPLETED)) {
-      return list(start, stop, RunRecord.class, limit,
+      return list(start, stop, RunRecordMeta.class, limit,
                   andPredicate(getPredicate(ProgramController.State.COMPLETED, adapter), filter));
     }
     if (status.equals(ProgramRunStatus.KILLED)) {
-      return list(start, stop, RunRecord.class, limit,
+      return list(start, stop, RunRecordMeta.class, limit,
                   andPredicate(getPredicate(ProgramController.State.KILLED, adapter), filter));
     }
-    return list(start, stop, RunRecord.class, limit,
+    return list(start, stop, RunRecordMeta.class, limit,
                 andPredicate(getPredicate(ProgramController.State.ERROR, adapter), filter));
   }
 
-  private Predicate<RunRecord> getPredicate(final ProgramController.State state, final String adapter) {
-    return new Predicate<RunRecord>() {
+  private Predicate<RunRecordMeta> getPredicate(final ProgramController.State state, final String adapter) {
+    return new Predicate<RunRecordMeta>() {
       @Override
-      public boolean apply(RunRecord record) {
+      public boolean apply(RunRecordMeta record) {
         boolean normalCheck = record.getStatus().equals(state.getRunStatus());
         // Check if RunRecord matches with passed in adapter name
         if (normalCheck && adapter != null) {
@@ -407,7 +409,8 @@ public class AppMetadataStore extends MetadataStoreDataset {
     };
   }
 
-  private Predicate<RunRecord> andPredicate(Predicate<RunRecord> first, @Nullable Predicate<RunRecord> second) {
+  private Predicate<RunRecordMeta> andPredicate(Predicate<RunRecordMeta> first,
+                                                @Nullable Predicate<RunRecordMeta> second) {
     if (second != null) {
       return and(first, second);
     }
@@ -579,7 +582,7 @@ public class AppMetadataStore extends MetadataStoreDataset {
     // Get the run record of the Workflow which started this program
     MDSKey key = getWorkflowRunRecordKey(Id.Workflow.from(program.getApplication(), workflow), workflowRunId);
 
-    RunRecord record = get(key, RunRecord.class);
+    RunRecordMeta record = get(key, RunRecordMeta.class);
     if (record == null) {
       String msg = String.format("No meta found for associated Workflow %s run record %s, while recording run for the" +
                                    " namespace %s app %s type %s program %s runid %s", workflow, workflowRunId,
@@ -593,8 +596,8 @@ public class AppMetadataStore extends MetadataStoreDataset {
     Map<String, String> properties = record.getProperties();
     properties.put(workflowNodeId, programRunId);
 
-    write(key, new RunRecord(record.getPid(), record.getStartTs(), null, ProgramRunStatus.RUNNING,
-                             record.getAdapterName(), record.getTwillRunId(), properties));
+    write(key, new RunRecordMeta(record.getPid(), record.getStartTs(), null, ProgramRunStatus.RUNNING,
+                                 record.getAdapterName(), properties, record.getTwillRunId()));
 
     // Record the program start
     key = new MDSKey.Builder()
@@ -606,35 +609,35 @@ public class AppMetadataStore extends MetadataStoreDataset {
       .add(programRunId)
       .build();
 
-    write(key, new RunRecord(programRunId, startTimeInSeconds, null, ProgramRunStatus.RUNNING, adapter, twillRunId,
-                             ImmutableMap.of("workflowrunid", workflowRunId)));
+    write(key, new RunRecordMeta(programRunId, startTimeInSeconds, null, ProgramRunStatus.RUNNING, adapter,
+                                 ImmutableMap.of("workflowrunid", workflowRunId), twillRunId));
   }
 
   public void updateWorkflowToken(Id.Workflow workflowId, String workflowRunId,
                                   WorkflowToken workflowToken) throws NotFoundException {
-    RunRecord runRecord = getUnfinishedRun(workflowId, TYPE_RUN_RECORD_STARTED, workflowRunId);
-    if (runRecord == null) {
+    RunRecordMeta runRecordMeta = getUnfinishedRun(workflowId, TYPE_RUN_RECORD_STARTED, workflowRunId);
+    if (runRecordMeta == null) {
       // Even if a run is suspended, the currently running node runs to completion.
       // This node also updates the workflow token at the end.
       // For such a scenario, check for a suspended run record too.
-      runRecord = getUnfinishedRun(workflowId, TYPE_RUN_RECORD_SUSPENDED, workflowRunId);
-      if (runRecord == null) {
+      runRecordMeta = getUnfinishedRun(workflowId, TYPE_RUN_RECORD_SUSPENDED, workflowRunId);
+      if (runRecordMeta == null) {
         throw new NotFoundException(new Id.Run(workflowId, workflowRunId));
       }
     }
-    Map<String, String> propertiesToUpdate = runRecord.getProperties();
+    Map<String, String> propertiesToUpdate = runRecordMeta.getProperties();
     propertiesToUpdate.put(WORKFLOW_TOKEN_PROPERTY_KEY, GSON.toJson(workflowToken));
 
     write(getWorkflowRunRecordKey(workflowId, workflowRunId),
-          new RunRecord(runRecord, propertiesToUpdate));
+          new RunRecordMeta(runRecordMeta, propertiesToUpdate));
   }
 
   public WorkflowToken getWorkflowToken(Id.Workflow workflowId, String workflowRunId) throws NotFoundException {
-    RunRecord runRecord = getRun(workflowId, workflowRunId);
-    if (runRecord == null) {
+    RunRecordMeta runRecordMeta = getRun(workflowId, workflowRunId);
+    if (runRecordMeta == null) {
       throw new NotFoundException(new Id.Run(workflowId, workflowRunId));
     }
-    String workflowToken = runRecord.getProperties().get(WORKFLOW_TOKEN_PROPERTY_KEY);
+    String workflowToken = runRecordMeta.getProperties().get(WORKFLOW_TOKEN_PROPERTY_KEY);
     // For pre-3.1 run records, there won't be a workflow token. Return an empty token for such run records.
     if (workflowToken == null) {
       LOG.debug("Could not find workflowToken for workflow: {}, runId: {}", workflowId, workflowRunId);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
@@ -49,7 +49,6 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.ProgramType;
-import co.cask.cdap.proto.RunRecord;
 import co.cask.cdap.templates.AdapterDefinition;
 import co.cask.tephra.TransactionExecutor;
 import co.cask.tephra.TransactionExecutorFactory;
@@ -164,7 +163,7 @@ public class DefaultStore implements Store {
     txnl.executeUnchecked(new TransactionExecutor.Function<AppMds, Void>() {
       @Override
       public Void apply(AppMds mds) throws Exception {
-        RunRecord target = mds.apps.getRun(id, pid);
+        RunRecordMeta target = mds.apps.getRun(id, pid);
         if (target.getStatus() == expectedStatus) {
           long now = System.currentTimeMillis();
           long nowSecs = TimeUnit.MILLISECONDS.toSeconds(now);
@@ -244,26 +243,26 @@ public class DefaultStore implements Store {
   }
 
   @Override
-  public List<RunRecord> getRuns(final Id.Program id, final ProgramRunStatus status,
+  public List<RunRecordMeta> getRuns(final Id.Program id, final ProgramRunStatus status,
                                  final long startTime, final long endTime, final int limit, final String adapter) {
-    return txnl.executeUnchecked(new TransactionExecutor.Function<AppMds, List<RunRecord>>() {
+    return txnl.executeUnchecked(new TransactionExecutor.Function<AppMds, List<RunRecordMeta>>() {
       @Override
-      public List<RunRecord> apply(AppMds mds) throws Exception {
+      public List<RunRecordMeta> apply(AppMds mds) throws Exception {
         return mds.apps.getRuns(id, status, startTime, endTime, limit, adapter);
       }
     });
   }
 
   @Override
-  public List<RunRecord> getRuns(Id.Program id, ProgramRunStatus status, long startTime, long endTime, int limit) {
+  public List<RunRecordMeta> getRuns(Id.Program id, ProgramRunStatus status, long startTime, long endTime, int limit) {
     return getRuns(id, status, startTime, endTime, limit, null);
   }
 
   @Override
-  public List<RunRecord> getRuns(final ProgramRunStatus status, final Predicate<RunRecord> filter) {
-    return txnl.executeUnchecked(new TransactionExecutor.Function<AppMds, List<RunRecord>>() {
+  public List<RunRecordMeta> getRuns(final ProgramRunStatus status, final Predicate<RunRecordMeta> filter) {
+    return txnl.executeUnchecked(new TransactionExecutor.Function<AppMds, List<RunRecordMeta>>() {
       @Override
-      public List<RunRecord> apply(AppMds mds) throws Exception {
+      public List<RunRecordMeta> apply(AppMds mds) throws Exception {
         return mds.apps.getRuns(status, filter);
       }
     });
@@ -277,10 +276,10 @@ public class DefaultStore implements Store {
    * @return run record for runid
    */
   @Override
-  public RunRecord getRun(final Id.Program id, final String runid) {
-    return txnl.executeUnchecked(new TransactionExecutor.Function<AppMds, RunRecord>() {
+  public RunRecordMeta getRun(final Id.Program id, final String runid) {
+    return txnl.executeUnchecked(new TransactionExecutor.Function<AppMds, RunRecordMeta>() {
       @Override
-      public RunRecord apply(AppMds mds) throws Exception {
+      public RunRecordMeta apply(AppMds mds) throws Exception {
         return mds.apps.getRun(id, runid);
       }
     });

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/ProgramLifecycleServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/ProgramLifecycleServiceTest.java
@@ -24,6 +24,7 @@ import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.internal.app.services.http.AppFabricTestBase;
 import co.cask.cdap.internal.app.store.DefaultStore;
+import co.cask.cdap.internal.app.store.RunRecordMeta;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.ProgramType;
@@ -88,8 +89,8 @@ public class ProgramLifecycleServiceTest extends AppFabricTestBase {
     Thread.sleep(2000);
 
     // Verify that the status of that run is KILLED
-    rr = store.getRun(wordcountFlow1, rr.getPid());
-    Assert.assertEquals(ProgramRunStatus.KILLED, rr.getStatus());
+    RunRecordMeta runRecordMeta = store.getRun(wordcountFlow1, rr.getPid());
+    Assert.assertEquals(ProgramRunStatus.KILLED, runRecordMeta.getStatus());
 
     // Use the store manipulate state to be RUNNING
     long now = System.currentTimeMillis();
@@ -97,8 +98,8 @@ public class ProgramLifecycleServiceTest extends AppFabricTestBase {
     store.setStart(wordcountFlow1, rr.getPid(), nowSecs);
 
     // Now check again via Store to assume data store is wrong.
-    rr = store.getRun(wordcountFlow1, rr.getPid());
-    Assert.assertEquals(ProgramRunStatus.RUNNING, rr.getStatus());
+    runRecordMeta = store.getRun(wordcountFlow1, rr.getPid());
+    Assert.assertEquals(ProgramRunStatus.RUNNING, runRecordMeta.getStatus());
 
     // Verify there is NO FAILED run record for the application
     runRecords = getProgramRuns(wordcountFlow1, ProgramRunStatus.FAILED.toString());

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/DefaultStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/DefaultStoreTest.java
@@ -61,7 +61,6 @@ import co.cask.cdap.internal.app.namespace.NamespaceAdmin;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.ProgramType;
-import co.cask.cdap.proto.RunRecord;
 import co.cask.cdap.templates.AdapterDefinition;
 import com.google.common.base.Objects;
 import com.google.common.base.Throwables;
@@ -165,8 +164,8 @@ public class DefaultStoreTest {
     store.setStop(programId, run1.getId(), nowSecs, ProgramController.State.COMPLETED.getRunStatus());
     store.setStop(programId, run2.getId(), nowSecs, ProgramController.State.COMPLETED.getRunStatus());
 
-    List<RunRecord> history = store.getRuns(programId, ProgramRunStatus.ALL,
-                                            0, Long.MAX_VALUE, Integer.MAX_VALUE);
+    List<RunRecordMeta> history = store.getRuns(programId, ProgramRunStatus.ALL,
+                                                0, Long.MAX_VALUE, Integer.MAX_VALUE);
     Assert.assertEquals(2, history.size());
   }
 
@@ -181,30 +180,31 @@ public class DefaultStoreTest {
     // Record start through an Adapter but try to stop the run outside of an adapter.
     store.setStart(programId, run1.getId(), runIdToSecs(run1), adapter, null);
 
-    // RunRecord should be available through RunRecord query for that Program.
-    RunRecord programRun = store.getRun(programId, run1.getId());
+    // RunRecordMeta should be available through RunRecordMeta query for that Program.
+    RunRecordMeta programRun = store.getRun(programId, run1.getId());
     Assert.assertEquals(run1.getId(), programRun.getPid());
 
     store.setStop(programId, run1.getId(), nowSecs - 10, ProgramController.State.COMPLETED.getRunStatus());
 
-    RunRecord adapterRun = store.getRun(programId, run1.getId());
+    RunRecordMeta adapterRun = store.getRun(programId, run1.getId());
     Assert.assertNotNull(adapterRun);
     Assert.assertEquals(run1.getId(), adapterRun.getPid());
 
-    // RunRecords query for the Program under different Adapter name should not return anything
-    List<RunRecord> records = store.getRuns(programId, ProgramRunStatus.ALL, 0, Long.MAX_VALUE, Integer.MAX_VALUE,
-                                            "invalidAdapter");
+    // RunRecordMetas query for the Program under different Adapter name should not return anything
+    List<RunRecordMeta> records = store.getRuns(programId, ProgramRunStatus.ALL, 0, Long.MAX_VALUE, Integer.MAX_VALUE,
+                                                "invalidAdapter");
     Assert.assertTrue(records.isEmpty());
 
-    // RunRecords query for the Program should return the RunRecord
-    List<RunRecord> runRecords = store.getRuns(programId, ProgramRunStatus.ALL, 0, Long.MAX_VALUE, Integer.MAX_VALUE);
+    // RunRecordMetas query for the Program should return the RunRecordMeta
+    List<RunRecordMeta> runRecords = store.getRuns(programId, ProgramRunStatus.ALL, 0, Long.MAX_VALUE,
+                                                   Integer.MAX_VALUE);
     Assert.assertEquals(1, runRecords.size());
     Assert.assertEquals(run1.getId(), Iterables.getFirst(runRecords, null).getPid());
 
-    List<RunRecord> adapterRuns = store.getRuns(programId, ProgramRunStatus.ALL, 0, Long.MAX_VALUE, Integer.MAX_VALUE,
-                                                adapter);
-    List<RunRecord> completedRuns = store.getRuns(programId, ProgramRunStatus.COMPLETED, 0, Long.MAX_VALUE,
-                                                  Integer.MAX_VALUE, adapter);
+    List<RunRecordMeta> adapterRuns = store.getRuns(programId, ProgramRunStatus.ALL, 0, Long.MAX_VALUE,
+                                                    Integer.MAX_VALUE, adapter);
+    List<RunRecordMeta> completedRuns = store.getRuns(programId, ProgramRunStatus.COMPLETED, 0, Long.MAX_VALUE,
+                                                      Integer.MAX_VALUE, adapter);
     Assert.assertEquals(adapterRuns, completedRuns);
     Assert.assertEquals(1, adapterRuns.size());
     Assert.assertEquals(run1.getId(), Iterables.getFirst(adapterRuns, null).getPid());
@@ -235,8 +235,8 @@ public class DefaultStoreTest {
     RunId run3 = RunIds.generate(now);
     store.setStart(programId, run3.getId(), runIdToSecs(run3));
 
-    // For a RunRecord that has not yet been completed, getStopTs should return null
-    RunRecord runRecord = store.getRun(programId, run3.getId());
+    // For a RunRecordMeta that has not yet been completed, getStopTs should return null
+    RunRecordMeta runRecord = store.getRun(programId, run3.getId());
     Assert.assertNull(runRecord.getStopTs());
 
     // record run of different program
@@ -250,16 +250,16 @@ public class DefaultStoreTest {
                    run3.getId(), RunIds.getTime(run3, TimeUnit.MILLISECONDS));
 
     // we should probably be better with "get" method in DefaultStore interface to do that, but we don't have one
-    List<RunRecord> successHistory = store.getRuns(programId, ProgramRunStatus.COMPLETED,
-                                                   0, Long.MAX_VALUE, Integer.MAX_VALUE);
+    List<RunRecordMeta> successHistory = store.getRuns(programId, ProgramRunStatus.COMPLETED,
+                                                       0, Long.MAX_VALUE, Integer.MAX_VALUE);
 
-    List<RunRecord> failureHistory = store.getRuns(programId, ProgramRunStatus.FAILED,
-                                                   nowSecs - 20, nowSecs - 10, Integer.MAX_VALUE);
+    List<RunRecordMeta> failureHistory = store.getRuns(programId, ProgramRunStatus.FAILED,
+                                                       nowSecs - 20, nowSecs - 10, Integer.MAX_VALUE);
     Assert.assertEquals(failureHistory, store.getRuns(programId, ProgramRunStatus.FAILED,
                                                       0, Long.MAX_VALUE, Integer.MAX_VALUE));
 
-    List<RunRecord> suspendedHistory = store.getRuns(programId, ProgramRunStatus.SUSPENDED,
-                                                   nowSecs - 20, nowSecs, Integer.MAX_VALUE);
+    List<RunRecordMeta> suspendedHistory = store.getRuns(programId, ProgramRunStatus.SUSPENDED,
+                                                         nowSecs - 20, nowSecs, Integer.MAX_VALUE);
 
     // only finished + succeeded runs should be returned
     Assert.assertEquals(1, successHistory.size());
@@ -269,7 +269,7 @@ public class DefaultStoreTest {
     Assert.assertEquals(1, suspendedHistory.size());
 
     // records should be sorted by start time latest to earliest
-    RunRecord run = successHistory.get(0);
+    RunRecordMeta run = successHistory.get(0);
     Assert.assertEquals(nowSecs - 10, run.getStartTs());
     Assert.assertEquals(Long.valueOf(nowSecs - 5), run.getStopTs());
     Assert.assertEquals(ProgramController.State.COMPLETED.getRunStatus(), run.getStatus());
@@ -284,31 +284,31 @@ public class DefaultStoreTest {
     Assert.assertEquals(ProgramController.State.SUSPENDED.getRunStatus(), run.getStatus());
 
     // Assert all history
-    List<RunRecord> allHistory = store.getRuns(programId, ProgramRunStatus.ALL,
-                                               nowSecs - 20, nowSecs + 1, Integer.MAX_VALUE);
+    List<RunRecordMeta> allHistory = store.getRuns(programId, ProgramRunStatus.ALL,
+                                                   nowSecs - 20, nowSecs + 1, Integer.MAX_VALUE);
     Assert.assertEquals(allHistory.toString(), 4, allHistory.size());
 
     // Assert running programs
-    List<RunRecord> runningHistory = store.getRuns(programId, ProgramRunStatus.RUNNING, nowSecs, nowSecs + 1, 100);
+    List<RunRecordMeta> runningHistory = store.getRuns(programId, ProgramRunStatus.RUNNING, nowSecs, nowSecs + 1, 100);
     Assert.assertEquals(1, runningHistory.size());
     Assert.assertEquals(runningHistory, store.getRuns(programId, ProgramRunStatus.RUNNING, 0, Long.MAX_VALUE, 100));
 
     // Get a run record for running program
-    RunRecord expectedRunning = runningHistory.get(0);
+    RunRecordMeta expectedRunning = runningHistory.get(0);
     Assert.assertNotNull(expectedRunning);
-    RunRecord actualRunning = store.getRun(programId, expectedRunning.getPid());
+    RunRecordMeta actualRunning = store.getRun(programId, expectedRunning.getPid());
     Assert.assertEquals(expectedRunning, actualRunning);
 
     // Get a run record for completed run
-    RunRecord expectedCompleted = successHistory.get(0);
+    RunRecordMeta expectedCompleted = successHistory.get(0);
     Assert.assertNotNull(expectedCompleted);
-    RunRecord actualCompleted = store.getRun(programId, expectedCompleted.getPid());
+    RunRecordMeta actualCompleted = store.getRun(programId, expectedCompleted.getPid());
     Assert.assertEquals(expectedCompleted, actualCompleted);
 
     // Get a run record for suspended run
-    RunRecord expectedSuspended = suspendedHistory.get(0);
+    RunRecordMeta expectedSuspended = suspendedHistory.get(0);
     Assert.assertNotNull(expectedSuspended);
-    RunRecord actualSuspended = store.getRun(programId, expectedSuspended.getPid());
+    RunRecordMeta actualSuspended = store.getRun(programId, expectedSuspended.getPid());
     Assert.assertEquals(expectedSuspended, actualSuspended);
 
     // Backwards compatibility test with random UUIDs
@@ -322,13 +322,15 @@ public class DefaultStoreTest {
     store.setStart(programId, run6.getId(), nowSecs - 2);
 
     // Get run record for run5
-    RunRecord expectedRecord5 = new RunRecord(run5.getId(), nowSecs - 8, nowSecs - 4, ProgramRunStatus.COMPLETED);
-    RunRecord actualRecord5 = store.getRun(programId, run5.getId());
+    RunRecordMeta expectedRecord5 = new RunRecordMeta(run5.getId(), nowSecs - 8, nowSecs - 4,
+                                                      ProgramRunStatus.COMPLETED, null, null, null);
+    RunRecordMeta actualRecord5 = store.getRun(programId, run5.getId());
     Assert.assertEquals(expectedRecord5, actualRecord5);
 
     // Get run record for run6
-    RunRecord expectedRecord6 = new RunRecord(run6.getId(), nowSecs - 2, null, ProgramRunStatus.RUNNING);
-    RunRecord actualRecord6 = store.getRun(programId, run6.getId());
+    RunRecordMeta expectedRecord6 = new RunRecordMeta(run6.getId(), nowSecs - 2, null, ProgramRunStatus.RUNNING, null,
+                                                      null, null);
+    RunRecordMeta actualRecord6 = store.getRun(programId, run6.getId());
     Assert.assertEquals(expectedRecord6, actualRecord6);
 
     // Non-existent run record should give null
@@ -545,7 +547,7 @@ public class DefaultStoreTest {
 
     Id.Program programId = new Id.Program(appId, ProgramType.FLOW, "WordCountFlow");
     store.setFlowletInstances(programId, "StreamSource",
-                                                      initialInstances + 5);
+                              initialInstances + 5);
     // checking that app spec in store was adjusted
     ApplicationSpecification adjustedSpec = store.getApplication(appId);
     Assert.assertEquals(initialInstances + 5,
@@ -728,13 +730,13 @@ public class DefaultStoreTest {
   }
 
   private void verifyRunHistory(Id.Program programId, int count) {
-    List<RunRecord> history = store.getRuns(programId, ProgramRunStatus.ALL,
-                                            0, Long.MAX_VALUE, Integer.MAX_VALUE);
+    List<RunRecordMeta> history = store.getRuns(programId, ProgramRunStatus.ALL,
+                                                0, Long.MAX_VALUE, Integer.MAX_VALUE);
     Assert.assertEquals(count, history.size());
   }
 
   @Test
-  public void testCheckDeletedProgramSpecs () throws Exception {
+  public void testCheckDeletedProgramSpecs() throws Exception {
     //Deploy program with all types of programs.
     AppFabricTestHelper.deployApplication(AllProgramsApp.class);
     ApplicationSpecification spec = Specifications.from(new AllProgramsApp());
@@ -772,7 +774,7 @@ public class DefaultStoreTest {
   }
 
   @Test
-  public void testCheckDeletedWorkflow () throws Exception {
+  public void testCheckDeletedWorkflow() throws Exception {
     //Deploy program with all types of programs.
     AppFabricTestHelper.deployApplication(AllProgramsApp.class);
     ApplicationSpecification spec = Specifications.from(new AllProgramsApp());

--- a/cdap-common/src/main/java/co/cask/cdap/internal/app/store/RunRecordMeta.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/app/store/RunRecordMeta.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.internal.app.store;
+
+import co.cask.cdap.proto.ProgramRunStatus;
+import co.cask.cdap.proto.RunRecord;
+
+import com.google.common.base.Objects;
+import com.google.gson.annotations.SerializedName;
+
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Store the meta information about program runs in CDAP. Extends {@link RunRecord} with additional
+ * information about Apache Twill run id.
+ */
+public final class RunRecordMeta extends RunRecord {
+  @SerializedName("twillrunid")
+  private final String twillRunId;
+
+  public RunRecordMeta(String pid, long startTs, @Nullable Long stopTs, ProgramRunStatus status,
+                       @Nullable String adapterName, @Nullable Map<String, String> properties,
+                       @Nullable String twillRunId) {
+    super(pid, startTs, stopTs, status, adapterName, properties);
+    this.twillRunId = twillRunId;
+  }
+
+  public RunRecordMeta(String pid, long startTs, @Nullable Long stopTs, ProgramRunStatus status,
+                   @Nullable String adapterName) {
+    this(pid, startTs, stopTs, status, adapterName, null, null);
+  }
+
+  public RunRecordMeta(String pid, long startTs, @Nullable Long stopTs, ProgramRunStatus status) {
+    this(pid, startTs, stopTs, status, null, null, null);
+  }
+
+  public RunRecordMeta(RunRecordMeta started, @Nullable Long stopTs, ProgramRunStatus status) {
+    this(started.getPid(), started.getStartTs(), stopTs, status, started.getAdapterName(), started.getProperties(),
+         started.getTwillRunId());
+  }
+
+  public RunRecordMeta(RunRecordMeta existing, Map<String, String> updatedProperties) {
+    this(existing.getPid(), existing.getStartTs(), existing.getStopTs(), existing.getStatus(),
+         existing.getAdapterName(), updatedProperties, existing.getTwillRunId());
+  }
+
+  @Nullable
+  public String getTwillRunId() {
+    return twillRunId;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    RunRecordMeta that = (RunRecordMeta) o;
+    return Objects.equal(this.getPid(), that.getPid()) &&
+      Objects.equal(this.getStartTs(), that.getStartTs()) &&
+      Objects.equal(this.getStopTs(), that.getStopTs()) &&
+      Objects.equal(this.getStatus(), that.getStatus()) &&
+      Objects.equal(this.getAdapterName(), that.getAdapterName()) &&
+      Objects.equal(this.getProperties(), that.getProperties()) &&
+      Objects.equal(this.getTwillRunId(), that.getTwillRunId());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(twillRunId, getPid(), getStartTs(), getStopTs(), getStatus(), getAdapterName(),
+                            getProperties());
+  }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(this)
+      .add("pid", getPid())
+      .add("startTs", getStartTs())
+      .add("stopTs", getStopTs())
+      .add("status", getStatus())
+      .add("adapter", getAdapterName())
+      .add("twillrunid", twillRunId)
+      .add("properties", getProperties())
+      .toString();
+  }
+}

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/log/MockLogReader.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/log/MockLogReader.java
@@ -253,7 +253,7 @@ public class MockLogReader implements LogReader {
     long startTs = RunIds.getTime(runId, TimeUnit.SECONDS);
     if (id != null) {
       //noinspection ConstantConditions
-      runRecordMap.put(id, new RunRecord(runId.getId(), startTs, stopTs, runStatus));
+      runRecordMap.put(id, new RunRecord(runId.getId(), startTs, stopTs, runStatus, null, null));
       store.setStart(id, runId.getId(), startTs);
       if (stopTs != null) {
         store.setStop(id, runId.getId(), stopTs, runStatus);

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/RunRecord.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/RunRecord.java
@@ -26,12 +26,9 @@ import javax.annotation.Nullable;
 /**
  * This class records information for a particular run.
  */
-public final class RunRecord {
+public class RunRecord {
   @SerializedName("runid")
   private final String pid;
-
-  @SerializedName("twillrunid")
-  private final String twillRunId;
 
   @SerializedName("start")
   private final long startTs;
@@ -50,34 +47,18 @@ public final class RunRecord {
   private final Map<String, String> properties;
 
   public RunRecord(String pid, long startTs, @Nullable Long stopTs, ProgramRunStatus status,
-                   @Nullable String adapterName, @Nullable String twillRunId,
-                   @Nullable Map<String, String> properties) {
+                   @Nullable String adapterName, @Nullable Map<String, String> properties) {
     this.pid = pid;
     this.startTs = startTs;
     this.stopTs = stopTs;
     this.status = status;
     this.adapterName = adapterName;
-    this.twillRunId = twillRunId;
     this.properties = properties == null ? Maps.<String, String>newHashMap() : properties;
   }
 
-  public RunRecord(String pid, long startTs, @Nullable Long stopTs, ProgramRunStatus status,
-                   @Nullable String adapterName, @Nullable String twillRunId) {
-    this(pid, startTs, stopTs, status, adapterName, twillRunId, null);
-  }
-
-  public RunRecord(String pid, long startTs, @Nullable Long stopTs, ProgramRunStatus status) {
-    this(pid, startTs, stopTs, status, null, null);
-  }
-
-  public RunRecord(RunRecord started, @Nullable Long stopTs, ProgramRunStatus status) {
-    this(started.pid, started.startTs, stopTs, status, started.getAdapterName(), started.getTwillRunId(),
-         started.getProperties());
-  }
-
-  public RunRecord(RunRecord existing, Map<String, String> updatedProperties) {
-    this(existing.pid, existing.startTs, existing.stopTs, existing.status, existing.adapterName, existing.twillRunId,
-         updatedProperties);
+  public RunRecord(RunRecord otherRunRecord) {
+    this(otherRunRecord.getPid(), otherRunRecord.getStartTs(), otherRunRecord.getStopTs(), otherRunRecord.getStatus(),
+         otherRunRecord.getAdapterName(), otherRunRecord.getProperties());
   }
 
   public String getPid() {
@@ -102,11 +83,6 @@ public final class RunRecord {
     return adapterName;
   }
 
-  @Nullable
-  public String getTwillRunId() {
-    return twillRunId;
-  }
-
   public Map<String, String> getProperties() {
     return properties;
   }
@@ -127,13 +103,12 @@ public final class RunRecord {
       Objects.equal(this.stopTs, that.stopTs) &&
       Objects.equal(this.status, that.status) &&
       Objects.equal(this.adapterName, that.adapterName) &&
-      Objects.equal(this.twillRunId, that.twillRunId) &&
       Objects.equal(this.properties, that.properties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(pid, startTs, stopTs, status, adapterName, twillRunId, properties);
+    return Objects.hashCode(pid, startTs, stopTs, status, adapterName, properties);
   }
 
   @Override
@@ -144,7 +119,6 @@ public final class RunRecord {
       .add("stopTs", stopTs)
       .add("status", status)
       .add("adapter", adapterName)
-      .add("twillrunid", twillRunId)
       .add("properties", properties)
       .toString();
   }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/LogHandler.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/LogHandler.java
@@ -19,6 +19,7 @@ package co.cask.cdap.logging.gateway.handlers;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.logging.LoggingContext;
+import co.cask.cdap.internal.app.store.RunRecordMeta;
 import co.cask.cdap.logging.LoggingConfiguration;
 import co.cask.cdap.logging.context.LoggingContextHelper;
 import co.cask.cdap.logging.filter.Filter;
@@ -29,7 +30,6 @@ import co.cask.cdap.logging.read.LogReader;
 import co.cask.cdap.logging.read.ReadRange;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramType;
-import co.cask.cdap.proto.RunRecord;
 import co.cask.http.AbstractHttpHandler;
 import co.cask.http.HttpHandler;
 import co.cask.http.HttpResponder;
@@ -97,14 +97,14 @@ public class LogHandler extends AbstractHttpHandler {
       LoggingContextHelper.getLoggingContextWithRunId(namespaceId, appId, programId,
                                                       ProgramType.valueOfCategoryName(programType),
                                                       runId, adapterId);
-    RunRecord runRecord = programStore.getRun(
+    RunRecordMeta runRecord = programStore.getRun(
       Id.Program.from(namespaceId, appId, ProgramType.valueOfCategoryName(programType), programId), runId);
     doGetLogs(responder, loggingContext, fromTimeSecsParam, toTimeSecsParam, escape, filterStr, runRecord);
   }
 
   private void doGetLogs(HttpResponder responder, LoggingContext loggingContext,
                          long fromTimeSecsParam, long toTimeSecsParam, boolean escape, String filterStr,
-                         @Nullable RunRecord runRecord) {
+                         @Nullable RunRecordMeta runRecord) {
     try {
       TimeRange timeRange = parseTime(fromTimeSecsParam, toTimeSecsParam, responder);
       if (timeRange == null) {
@@ -160,13 +160,13 @@ public class LogHandler extends AbstractHttpHandler {
       LoggingContextHelper.getLoggingContextWithRunId(namespaceId, appId, programId,
                                                       ProgramType.valueOfCategoryName(programType),
                                                       runId, adapterId);
-    RunRecord runRecord = programStore.getRun(
+    RunRecordMeta runRecord = programStore.getRun(
       Id.Program.from(namespaceId, appId, ProgramType.valueOfCategoryName(programType), programId), runId);
     doNext(responder, loggingContext, maxEvents, fromOffsetStr, escape, filterStr, runRecord);
   }
 
   private void doNext(HttpResponder responder, LoggingContext loggingContext, int maxEvents,
-                      String fromOffsetStr, boolean escape, String filterStr, @Nullable RunRecord runRecord) {
+                      String fromOffsetStr, boolean escape, String filterStr, @Nullable RunRecordMeta runRecord) {
     try {
       Filter filter = FilterParser.parse(filterStr);
 
@@ -190,7 +190,7 @@ public class LogHandler extends AbstractHttpHandler {
   /**
    * If readRange is outside runRecord's range, then the readRange is adjusted to fall within runRecords range.
    */
-  private ReadRange adjustReadRange(ReadRange readRange, @Nullable RunRecord runRecord) {
+  private ReadRange adjustReadRange(ReadRange readRange, @Nullable RunRecordMeta runRecord) {
     if (runRecord == null) {
       return readRange;
     }
@@ -240,13 +240,13 @@ public class LogHandler extends AbstractHttpHandler {
       LoggingContextHelper.getLoggingContextWithRunId(namespaceId, appId, programId,
                                                       ProgramType.valueOfCategoryName(programType),
                                                       runId, adapterId);
-    RunRecord runRecord = programStore.getRun(
+    RunRecordMeta runRecord = programStore.getRun(
       Id.Program.from(namespaceId, appId, ProgramType.valueOfCategoryName(programType), programId), runId);
     doPrev(responder, loggingContext, maxEvents, fromOffsetStr, escape, filterStr, runRecord);
   }
 
   private void doPrev(HttpResponder responder, LoggingContext loggingContext, int maxEvents, String fromOffsetStr,
-                      boolean escape, String filterStr, @Nullable RunRecord runRecord) {
+                      boolean escape, String filterStr, @Nullable RunRecordMeta runRecord) {
     try {
       Filter filter = FilterParser.parse(filterStr);
 

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/store/ProgramStore.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/store/ProgramStore.java
@@ -18,8 +18,8 @@ package co.cask.cdap.logging.gateway.handlers.store;
 
 import co.cask.cdap.data2.dataset2.tx.DatasetContext;
 import co.cask.cdap.data2.dataset2.tx.Transactional;
+import co.cask.cdap.internal.app.store.RunRecordMeta;
 import co.cask.cdap.proto.Id;
-import co.cask.cdap.proto.RunRecord;
 import co.cask.tephra.TransactionExecutor;
 import co.cask.tephra.TransactionExecutorFactory;
 import com.google.common.base.Supplier;
@@ -54,10 +54,10 @@ public class ProgramStore {
    * @param runid run id
    * @return run record for runid
    */
-  public RunRecord getRun(final Id.Program id, final String runid) {
-    return txnl.executeUnchecked(new TransactionExecutor.Function<DatasetContext<AppMetadataStore>, RunRecord>() {
+  public RunRecordMeta getRun(final Id.Program id, final String runid) {
+    return txnl.executeUnchecked(new TransactionExecutor.Function<DatasetContext<AppMetadataStore>, RunRecordMeta>() {
       @Override
-      public RunRecord apply(DatasetContext<AppMetadataStore> context) throws Exception {
+      public RunRecordMeta apply(DatasetContext<AppMetadataStore> context) throws Exception {
         return context.get().getRun(id, runid);
       }
     });


### PR DESCRIPTION
Since twillrunid is internal to CDAP it should not be exposed to RunRecord proto which is wired to client:
-) Removed twillRunId field from proto RunRecord
-) Added RunRecordMeta class that extends RunRecord with twillRunId field to work with app meta store.
-) Updated handler and test classes to reflect the changes