### PR TITLE
Bugfix/custom dataset embeddeding pfs

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/mds/DatasetTypeMDS.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/mds/DatasetTypeMDS.java
@@ -42,7 +42,7 @@ public class DatasetTypeMDS extends MetadataStoreDataset {
    * NOTE: we store in same table list of modules, with keys being <MODULES_PREFIX><module_name> and
    *       types to modules mapping with keys being <TYPE_TO_MODULE_PREFIX><type_name>
    */
-  static final String MODULES_PREFIX = "m_";
+  public static final String MODULES_PREFIX = "m_";
 
   /**
    * Prefix for rows containing type -> module mapping

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/PFSUpgrader.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/PFSUpgrader.java
@@ -200,13 +200,15 @@ public class PFSUpgrader {
   DatasetModuleMeta migrateDatasetModuleMeta(DatasetModuleMeta moduleMeta) {
     List<String> newUsesModules = new ArrayList<>();
     // ordering of the usesModules is important. They are loaded in order of the elements' indices
-    if (!moduleMeta.getUsesModules().contains("orderedTable-hbase")) {
-      newUsesModules.add("orderedTable-hbase");
+    // add the following two modules as the first two dependencies, and then simply exclude them from the existing
+    // declared dependencies to avoid duplicate declared dependencies.
+    newUsesModules.add("orderedTable-hbase");
+    newUsesModules.add("core");
+    for (String usesModule : moduleMeta.getUsesModules()) {
+      if (!"orderedTable-hbase".equals(usesModule) && !"core".equals(usesModule)) {
+        newUsesModules.add(usesModule);
+      }
     }
-    if (!moduleMeta.getUsesModules().contains("core")) {
-      newUsesModules.add("core");
-    }
-    newUsesModules.addAll(moduleMeta.getUsesModules());
     DatasetModuleMeta migratedModuleMeta = new DatasetModuleMeta(moduleMeta.getName(),
                                                                  moduleMeta.getClassName(),
                                                                  moduleMeta.getJarLocation(),

--- a/cdap-master/src/test/java/co/cask/cdap/data/tools/PFSUpgraderTest.java
+++ b/cdap-master/src/test/java/co/cask/cdap/data/tools/PFSUpgraderTest.java
@@ -39,6 +39,7 @@ import co.cask.tephra.TransactionExecutor;
 import co.cask.tephra.TransactionExecutorFactory;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
@@ -203,4 +204,20 @@ public class PFSUpgraderTest {
     return pfsBuilder.build();
   }
 
+
+  @Test
+  public void testSpecRename() {
+    DatasetSpecification outerSpec = constructOldPfsSpec("myDs", ImmutableMap.<String, String>of(),
+                                                         "partitionedFileSet");
+    DatasetSpecification embeddedSpec1 = outerSpec.getSpecification(PartitionedFileSetDefinition.FILESET_NAME);
+    DatasetSpecification embeddedSpec2 = outerSpec.getSpecification(PartitionedFileSetDefinition.PARTITION_TABLE_NAME);
+    Assert.assertEquals("myDs.files", embeddedSpec1.getName());
+    Assert.assertEquals("myDs.partitions", embeddedSpec2.getName());
+
+    DatasetSpecification renamedSpec = pfsUpgrader.changeName(outerSpec, "yourDs");
+    embeddedSpec1 = renamedSpec.getSpecification(PartitionedFileSetDefinition.FILESET_NAME);
+    embeddedSpec2 = renamedSpec.getSpecification(PartitionedFileSetDefinition.PARTITION_TABLE_NAME);
+    Assert.assertEquals("yourDs.files", embeddedSpec1.getName());
+    Assert.assertEquals("yourDs.partitions", embeddedSpec2.getName());
+  }
 }

--- a/cdap-master/src/test/java/co/cask/cdap/data/tools/PFSUpgraderTest.java
+++ b/cdap-master/src/test/java/co/cask/cdap/data/tools/PFSUpgraderTest.java
@@ -48,6 +48,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
 
@@ -163,7 +164,11 @@ public class PFSUpgraderTest {
                             null, ImmutableList.of("myType"), ImmutableList.of("partitionedFileSet"));
     Assert.assertTrue(pfsUpgrader.needsConverting(oldModuleMeta));
     DatasetModuleMeta newModuleMeta = pfsUpgrader.migrateDatasetModuleMeta(oldModuleMeta);
-    Assert.assertTrue(newModuleMeta.getUsesModules().contains("core"));
+
+    List<String> usesModules = newModuleMeta.getUsesModules();
+    Assert.assertTrue(usesModules.contains("orderedTable-hbase"));
+    Assert.assertTrue(usesModules.contains("core"));
+    Assert.assertTrue(usesModules.indexOf("orderedTable-hbase") < usesModules.indexOf("core"));
   }
 
   private void assertIsNewPartitionsTable(DatasetSpecification dsSpec) {


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-3030
http://builds.cask.co/browse/CDAP-RBT349-6

The issue described in the JIRA is that the dependencies declared by a module using the module partitionedFileSet (pfs) or the module timePartitionedfileSet (tpfs) did not (in pre-3.1 CDAP) include 'core', which the pfs and tpfs now depend on (3.1 and following).

This stage in the upgrade tool modifies any modules that depend on pfs or tpfs to also declare a dependency on 'core'.