### PR TITLE
Adding ZK dependency as it is required by KafkaSource; 

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/pom.xml
@@ -166,6 +166,10 @@
     <!-- End for JMS Source -->
     <!-- Start for Kafka Source -->
     <dependency>
+      <groupId>org.apache.zookeeper</groupId>
+      <artifactId>zookeeper</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.twill</groupId>
       <artifactId>twill-core</artifactId>
       <exclusions>


### PR DESCRIPTION
Since the ZK dependency in the cdap was turned into provided scope

Tested in standalone and cluster.

Build : http://builds.cask.co/browse/CDAP-RBT352-1