### PR TITLE
[CDAP-3086] Fixes browser resize to re-draw DAG in adapter create view

### DIFF
--- a/cdap-ui/app/directives/plumb/my-plumb-ctrl.js
+++ b/cdap-ui/app/directives/plumb/my-plumb-ctrl.js
@@ -1,5 +1,5 @@
 angular.module(PKG.name + '.commons')
-  .controller('MyPlumbController', function MyPlumbController(jsPlumb, $scope, $timeout, MyPlumbService, myHelpers, MyPlumbFactory) {
+  .controller('MyPlumbController', function MyPlumbController(jsPlumb, $scope, $timeout, MyPlumbService, myHelpers, MyPlumbFactory, $window) {
     this.plugins = $scope.config || [];
     this.instance = null;
 
@@ -157,6 +157,10 @@ angular.module(PKG.name + '.commons')
     jsPlumb.ready(function() {
       jsPlumb.setContainer('plumb-container');
       this.instance = jsPlumb.getInstance();
+
+      angular.element($window).on('resize', function() {
+        this.instance.repaintEverything();
+      }.bind(this));
 
       this.instance.importDefaults(MyPlumbFactory.getSettings().default);
 


### PR DESCRIPTION
Fixes redrawing DAG when window resized. 

![resize](https://cloud.githubusercontent.com/assets/1452845/8886056/08d3ca12-321a-11e5-8b56-495b5b5dabb8.gif)
