### PR TITLE
[CDAP-3092] Mapper reads in multiple files

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/source/FileBatchSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/source/FileBatchSource.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.lib.input.CombineTextInputFormat;
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -86,12 +87,15 @@ public class FileBatchSource extends BatchSource<LongWritable, Object, Structure
   private static final String TABLE_DESCRIPTION = "Name of the Table that keeps track of the last time files " +
     "were read in.";
   private static final String INPUT_FORMAT_CLASS_DESCRIPTION = "Name of the input format class, which must be a " +
-    "subclass of FileInputFormat. Defaults to TextInputFormat";
+    "subclass of FileInputFormat. Defaults to CombineTextInputFormat";
   private static final String FILESYSTEM_DESCRIPTION = "Distributed file system to read in from.";
+  private static final String MAX_SPLIT_SIZE_DESCRIPTION = "Max split size for each mapper in the MapReduce Job. " +
+    "Defaults to 128MB.";
   private static final Gson GSON = new Gson();
   private static final Logger LOG = LoggerFactory.getLogger(FileBatchSource.class);
   private static final Type ARRAYLIST_DATE_TYPE  = new TypeToken<ArrayList<Date>>() { }.getType();
   private static final Type MAP_STRING_STRING_TYPE = new TypeToken<Map<String, String>>() { }.getType();
+  private static final int DEFAULT_SPLIT_SIZE = 134217728;
 
   private final FileBatchConfig config;
   private KeyValueTable table;
@@ -158,9 +162,18 @@ public class FileBatchSource extends BatchSource<LongWritable, Object, Structure
       Class<? extends FileInputFormat> classType = (Class<? extends FileInputFormat>)
         classLoader.loadClass(config.inputFormatClass);
       job.setInputFormatClass(classType);
+    } else {
+      job.setInputFormatClass(CombineTextInputFormat.class);
     }
     FileInputFormat.setInputPathFilter(job, BatchFileFilter.class);
     FileInputFormat.addInputPath(job, new Path(config.path));
+    long maxSplitSize;
+    try {
+      maxSplitSize = Long.parseLong(config.maxSplitSize);
+    } catch (NumberFormatException e) {
+      maxSplitSize = DEFAULT_SPLIT_SIZE;
+    }
+    CombineTextInputFormat.setMaxInputSplitSize(job, maxSplitSize);
   }
 
   @Override
@@ -216,14 +229,21 @@ public class FileBatchSource extends BatchSource<LongWritable, Object, Structure
     @Description(INPUT_FORMAT_CLASS_DESCRIPTION)
     private String inputFormatClass;
 
+    @Name("maxSplitSize")
+    @Nullable
+    @Description(MAX_SPLIT_SIZE_DESCRIPTION)
+    private String maxSplitSize;
+
     public FileBatchConfig(String fileSystem, String path, @Nullable String regex, @Nullable String timeTable,
-                           @Nullable String inputFormatClass, @Nullable String fileSystemProperties) {
+                           @Nullable String inputFormatClass, @Nullable String fileSystemProperties,
+                           @Nullable String maxSplitSize) {
       this.fileSystem = fileSystem;
       this.fileSystemProperties = fileSystemProperties;
       this.path = path;
       this.fileRegex = regex;
       this.timeTable = timeTable;
       this.inputFormatClass = inputFormatClass;
+      this.maxSplitSize = maxSplitSize;
     }
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/common/Properties.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/common/Properties.java
@@ -37,7 +37,7 @@ public final class Properties {
   }
 
   /**
-   * Class to hold properties for S3BatchSource
+   * Class to hold properties for FileBatchSource
    */
   public static class File {
     public static final String FILESYSTEM = "fileSystem";
@@ -46,6 +46,7 @@ public final class Properties {
     public static final String FILE_REGEX = "fileRegex";
     public static final String TIME_TABLE = "timeTable";
     public static final String INPUT_FORMAT_CLASS = "inputFormatClass";
+    public static final String MAX_SPLIT_SIZE = "maxSplitSize";
   }
 
   /**

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/realtime/source/SqsSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/realtime/source/SqsSource.java
@@ -44,8 +44,8 @@ import javax.jms.TextMessage;
  * TODO: CDAP-2978: Extend JMS source so this class can be deleted.
  */
 @Plugin(type = "source")
-@Name("Sqs")
-@Description("Sqs Realtime Source - Emits a record with a field 'body' of string type")
+@Name("AmazonSQS")
+@Description("Amazon Simple Queue Service realtime source - Emits a record with a field 'body' of string type")
 public class SqsSource extends RealtimeSource<StructuredRecord> {
   private static final Logger LOG = LoggerFactory.getLogger(SqsSource.class);
   private static final String REGION_DESCRIPTION = "Region where the queue is located.";

--- a/cdap-ui/templates/ETLBatch/FileBatchSource.json
+++ b/cdap-ui/templates/ETLBatch/FileBatchSource.json
@@ -4,7 +4,7 @@
     "position": [ "group1" ],
     "group1": {
       "display" : "File Batch Source",
-      "position" : [ "fileSystem", "fileSystemProperties", "path", "fileRegex", "timeTable", "inputFormatClass"],
+      "position" : [ "fileSystem", "fileSystemProperties", "path", "fileRegex", "timeTable", "inputFormatClass", "maxSplitSize" ],
       "fields" : {
         "fileSystem" : {
           "widget": "textbox",
@@ -34,6 +34,11 @@
         "inputFormatClass" : {
           "widget": "textbox",
           "label": "Input Format Class"
+        },
+
+        "maxSplitSize" : {
+          "widget": "textbox",
+          "label": "Max Split Size"
         }
       }
     }

--- a/cdap-ui/templates/ETLRealtime/AmazonSQS.json
+++ b/cdap-ui/templates/ETLRealtime/AmazonSQS.json
@@ -1,5 +1,5 @@
 {
-  "id": "Sqs",
+  "id": "AmazonSQS",
   "groups" : {
     "position": [ "group1" ],
     "group1": {


### PR DESCRIPTION
JIRA - https://issues.cask.co/browse/CDAP-3092
BUILD - http://builds.cask.co/browse/CDAP-DUT2333-1

Allows each mapper in FileBatchSource to read in multiple files. Previous behavior would generate at least one mapper per file. This solves the many small files problem, in which a large number of mappers would cause slow runtime and eventually OOM issues.