### PR TITLE
Do not quote OPTS

### DIFF
--- a/cdap-common/bin/service
+++ b/cdap-common/bin/service
@@ -137,7 +137,7 @@ start() {
 
       nohup nice -n $NICENESS "$JAVA" -Dcdap.service=$APP "$JAVA_HEAPMAX" \
         -Dexplore.conf.files=$EXPLORE_CONF_FILES \
-        -Dexplore.classpath=$EXPLORE_CLASSPATH "$OPTS" \
+        -Dexplore.classpath=$EXPLORE_CLASSPATH $OPTS \
         -Duser.dir=$LOCAL_DIR \
         -cp $CLASSPATH $MAIN_CLASS $MAIN_CLASS_ARGS </dev/null >>$loglog 2>&1 &
       echo $! >$pid
@@ -234,7 +234,7 @@ run() {
     check_or_create_master_local_dir
 
     echo "Running class $classname"
-    "$JAVA" "$JAVA_HEAPMAX" -Dhive.classpath=$HIVE_CLASSPATH -Duser.dir=$LOCAL_DIR "$OPTS" -cp $CLASSPATH $classname $@
+    "$JAVA" "$JAVA_HEAPMAX" -Dhive.classpath=$HIVE_CLASSPATH -Duser.dir=$LOCAL_DIR $OPTS -cp $CLASSPATH $classname $@
 }
 
 case "$1" in


### PR DESCRIPTION
Quoting OPTS only allows a single Java property to be set. This is
fine with the default configuration of CDAP, but fails quite
spectacularly if the user specifies their own variables in the
cdap-env.sh file:

export OPTS="${OPTS} -Dhdp.version=2.2.4.2-2"

Our scripts interpret OPTS as a single parameter, and pass it to
the "java" binary as such, causing Java to not recognise this now
combined parameter. Removing the quotes allows them to be interpreted
correctly by Bash, and passed correctly to Java.