### PR TITLE
CDAP-2498: Test Source has three modes - stream, table, default. 

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/realtime/source/TestSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/realtime/source/TestSource.java
@@ -78,12 +78,12 @@ public class TestSource extends RealtimeSource<StructuredRecord> {
     }
 
     LOG.info("Emitting data! {}", prevCount);
-    if (config.type == null) {
-      writeDefaultRecords(writer);
-    } else if (STREAM_TYPE.equals(config.type)) {
+    if (STREAM_TYPE.equalsIgnoreCase(config.type)) {
       writeRecordsForStreamConsumption(writer);
-    } else if (TABLE_TYPE.equals(config.type)) {
+    } else if (TABLE_TYPE.equalsIgnoreCase(config.type)) {
       writeRecordsForTableConsumption(writer);
+    } else {
+      writeDefaultRecords(writer);
     }
     return currentState;
   }


### PR DESCRIPTION
Logic should go to default mode if the type is not set to stream or table

Build : http://builds.cask.co/browse/CDAP-RBT376-1

JIRA : https://issues.cask.co/browse/CDAP-2498