### PR TITLE
[CDAP-2922] adds metrics to datasets obtained through DynamicDatasetContext

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/DynamicMapReduceContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/DynamicMapReduceContext.java
@@ -110,7 +110,7 @@ public class DynamicMapReduceContext extends BasicMapReduceContext implements Da
       });
     this.txContext = new TransactionContext(txClient);
     this.dynamicDatasetContext = new DynamicDatasetContext(getProgram().getId().getNamespace(),
-                                                           txContext, dsFramework,
+                                                           txContext, getProgramMetrics(), dsFramework,
                                                            program.getClassLoader(),
                                                            runtimeArguments.asMap(), null, getOwners()) {
       @Nullable

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/ClientSparkContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/ClientSparkContext.java
@@ -32,7 +32,6 @@ import org.apache.twill.api.RunId;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -61,9 +60,10 @@ public final class ClientSparkContext extends AbstractSparkContext {
 
     this.datasets = new ArrayList<>();
     this.transactionContext = transactionContext;
-    this.datasetContext = new DynamicDatasetContext(program.getId().getNamespace(), transactionContext,
-                                                    datasetFramework, program.getClassLoader(), runtimeArguments,
-                                                    null, getOwners());
+    this.datasetContext = new DynamicDatasetContext(program.getId().getNamespace(),
+                                                    transactionContext, getMetricsContext(),
+                                                    datasetFramework, program.getClassLoader(),
+                                                    runtimeArguments, null, getOwners());
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/BasicWorkerContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/BasicWorkerContext.java
@@ -189,7 +189,7 @@ public class BasicWorkerContext extends AbstractContext implements WorkerContext
     try {
       context.start();
       runnable.run(new DynamicDatasetContext(Id.Namespace.from(program.getNamespaceId()),
-                                             context, datasetFramework,
+                                             context, getProgramMetrics(), datasetFramework,
                                              getProgram().getClassLoader(), runtimeArgs, null, getOwners()) {
         @Override
         protected LoadingCache<Long, Map<DatasetCacheKey, Dataset>> getDatasetsCache() {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/AppWithWorker.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/AppWithWorker.java
@@ -46,12 +46,13 @@ public class AppWithWorker extends AbstractApplication {
     createDataset(DATASET, KeyValueTable.class);
   }
 
-  private static class TableWriter extends AbstractWorker {
+  public class TableWriter extends AbstractWorker {
 
     private volatile boolean running;
 
     @Override
     public void configure() {
+      setName(WORKER);
       setDescription(DESCRIPTION);
     }
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithMapReduceUsingRuntimeDatasets.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithMapReduceUsingRuntimeDatasets.java
@@ -19,6 +19,8 @@ package co.cask.cdap.internal.app.runtime.batch;
 import co.cask.cdap.api.app.AbstractApplication;
 import co.cask.cdap.api.dataset.lib.FileSet;
 import co.cask.cdap.api.dataset.lib.FileSetArguments;
+import co.cask.cdap.api.dataset.table.Put;
+import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.api.mapreduce.AbstractMapReduce;
 import co.cask.cdap.api.mapreduce.MapReduceContext;
 import com.google.common.collect.Maps;
@@ -34,23 +36,32 @@ import java.util.Map;
 /**
  * App used to test whether M/R can read from file datasets referenced at runtime.
  */
-public class AppWithMapReduceUsingRuntimeFileSet extends AbstractApplication {
+public class AppWithMapReduceUsingRuntimeDatasets extends AbstractApplication {
   public static final String INPUT_NAME = "input.name";
   public static final String INPUT_PATHS = "input.paths";
   public static final String OUTPUT_NAME = "output.name";
   public static final String OUTPUT_PATH = "output.path";
 
+  public static final String APP_NAME = "appWithRuntimeDS";
+  public static final String MR_NAME = "computeSum";
+
   @Override
   public void configure() {
-    setName("AppWithMapReduceUsingFile");
+    setName(APP_NAME);
     setDescription("Application with MapReduce job using file as dataset");
     addMapReduce(new ComputeSum());
+    createDataset("rtt", Table.class.getName());
   }
 
   /**
    *
    */
   public static final class ComputeSum extends AbstractMapReduce {
+
+    @Override
+    protected void configure() {
+      setName(MR_NAME);
+    }
 
     @Override
     public void beforeSubmit(MapReduceContext context) throws Exception {
@@ -83,6 +94,9 @@ public class AppWithMapReduceUsingRuntimeFileSet extends AbstractApplication {
 
       context.setInput(inputName, input);
       context.setOutput(outputName, output);
+
+      Table table = context.getDataset("rtt");
+      table.put(new Put("a").add("b", "c"));
     }
   }
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunnerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunnerTest.java
@@ -25,14 +25,19 @@ import co.cask.cdap.api.dataset.lib.FileSetProperties;
 import co.cask.cdap.api.dataset.lib.KeyValueTable;
 import co.cask.cdap.api.dataset.lib.ObjectStore;
 import co.cask.cdap.api.dataset.lib.TimeseriesTable;
+import co.cask.cdap.api.dataset.lib.cube.AggregationFunction;
 import co.cask.cdap.api.dataset.table.Get;
 import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.api.metrics.MetricDataQuery;
+import co.cask.cdap.api.metrics.MetricStore;
+import co.cask.cdap.api.metrics.MetricTimeSeries;
 import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.runtime.Arguments;
 import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.app.runtime.ProgramRunner;
 import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.io.Locations;
 import co.cask.cdap.data.dataset.DatasetInstantiator;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
@@ -80,6 +85,8 @@ import java.io.FileWriter;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -98,6 +105,7 @@ public class MapReduceProgramRunnerTest {
   private static TransactionManager txService;
   private static DatasetFramework dsFramework;
   private static DatasetInstantiator datasetInstantiator;
+  private static MetricStore metricStore;
 
   @ClassRule
   public static TemporaryFolder tmpFolder = new TemporaryFolder();
@@ -127,6 +135,7 @@ public class MapReduceProgramRunnerTest {
     datasetInstantiator = new DatasetInstantiator(DefaultId.NAMESPACE, dsFramework,
                                                   MapReduceProgramRunnerTest.class.getClassLoader(),
                                                   null, null);
+    metricStore = injector.getInstance(MetricStore.class);
 
     txService.startAndWait();
 
@@ -194,7 +203,7 @@ public class MapReduceProgramRunnerTest {
   }
 
   @Test
-  public void testMapreduceWithDynamicFileSet() throws Exception {
+  public void testMapreduceWithDynamicDatasets() throws Exception {
     Id.DatasetInstance rtInput1 = Id.DatasetInstance.from(DefaultId.NAMESPACE, "rtInput1");
     Id.DatasetInstance rtInput2 = Id.DatasetInstance.from(DefaultId.NAMESPACE, "rtInput2");
     Id.DatasetInstance rtOutput1 = Id.DatasetInstance.from(DefaultId.NAMESPACE, "rtOutput1");
@@ -213,15 +222,33 @@ public class MapReduceProgramRunnerTest {
       .build());
     // build runtime args for app
     Map<String, String> runtimeArguments = Maps.newHashMap();
-    runtimeArguments.put(AppWithMapReduceUsingRuntimeFileSet.INPUT_NAME, "rtInput1");
-    runtimeArguments.put(AppWithMapReduceUsingRuntimeFileSet.INPUT_PATHS, "abc, xyz");
-    runtimeArguments.put(AppWithMapReduceUsingRuntimeFileSet.OUTPUT_NAME, "rtOutput1");
-    runtimeArguments.put(AppWithMapReduceUsingRuntimeFileSet.OUTPUT_PATH, "a001");
+    runtimeArguments.put(AppWithMapReduceUsingRuntimeDatasets.INPUT_NAME, "rtInput1");
+    runtimeArguments.put(AppWithMapReduceUsingRuntimeDatasets.INPUT_PATHS, "abc, xyz");
+    runtimeArguments.put(AppWithMapReduceUsingRuntimeDatasets.OUTPUT_NAME, "rtOutput1");
+    runtimeArguments.put(AppWithMapReduceUsingRuntimeDatasets.OUTPUT_PATH, "a001");
     // test reading and writing distinct datasets, reading more than one path
     testMapreduceWithFile("rtInput1", "abc, xyz", "rtOutput1", "a001",
-                          AppWithMapReduceUsingRuntimeFileSet.class,
-                          AppWithMapReduceUsingRuntimeFileSet.ComputeSum.class,
+                          AppWithMapReduceUsingRuntimeDatasets.class,
+                          AppWithMapReduceUsingRuntimeDatasets.ComputeSum.class,
                           new BasicArguments(runtimeArguments));
+
+    // validate that the table emitted metrics
+    Collection<MetricTimeSeries> metrics =
+      metricStore.query(new MetricDataQuery(
+        0,
+        System.currentTimeMillis() / 1000L,
+        60,
+        "system." + Constants.Metrics.Name.Dataset.OP_COUNT,
+        AggregationFunction.SUM,
+        ImmutableMap.of(Constants.Metrics.Tag.NAMESPACE, DefaultId.NAMESPACE.getId(),
+                        Constants.Metrics.Tag.APP, AppWithMapReduceUsingRuntimeDatasets.APP_NAME,
+                        Constants.Metrics.Tag.MAPREDUCE, AppWithMapReduceUsingRuntimeDatasets.MR_NAME,
+                        Constants.Metrics.Tag.DATASET, "rtt"),
+        Collections.<String>emptyList()));
+    Assert.assertEquals(1, metrics.size());
+    MetricTimeSeries ts = metrics.iterator().next();
+    Assert.assertEquals(1, ts.getTimeValues().size());
+    Assert.assertEquals(1, ts.getTimeValues().get(0).getValue());
 
     // test reading and writing same dataset
     dsFramework.addInstance("fileSet", rtInput2, FileSetProperties.builder()
@@ -231,13 +258,13 @@ public class MapReduceProgramRunnerTest {
       .setOutputProperty(TextOutputFormat.SEPERATOR, ":")
       .build());
     runtimeArguments = Maps.newHashMap();
-    runtimeArguments.put(AppWithMapReduceUsingRuntimeFileSet.INPUT_NAME, "rtInput2");
-    runtimeArguments.put(AppWithMapReduceUsingRuntimeFileSet.INPUT_PATHS, "zzz");
-    runtimeArguments.put(AppWithMapReduceUsingRuntimeFileSet.OUTPUT_NAME, "rtInput2");
-    runtimeArguments.put(AppWithMapReduceUsingRuntimeFileSet.OUTPUT_PATH, "f123");
+    runtimeArguments.put(AppWithMapReduceUsingRuntimeDatasets.INPUT_NAME, "rtInput2");
+    runtimeArguments.put(AppWithMapReduceUsingRuntimeDatasets.INPUT_PATHS, "zzz");
+    runtimeArguments.put(AppWithMapReduceUsingRuntimeDatasets.OUTPUT_NAME, "rtInput2");
+    runtimeArguments.put(AppWithMapReduceUsingRuntimeDatasets.OUTPUT_PATH, "f123");
     testMapreduceWithFile("rtInput2", "zzz", "rtInput2", "f123",
-                          AppWithMapReduceUsingRuntimeFileSet.class,
-                          AppWithMapReduceUsingRuntimeFileSet.ComputeSum.class,
+                          AppWithMapReduceUsingRuntimeDatasets.class,
+                          AppWithMapReduceUsingRuntimeDatasets.ComputeSum.class,
                           new BasicArguments(runtimeArguments));
   }
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/worker/WorkerProgramRunnerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/worker/WorkerProgramRunnerTest.java
@@ -1,0 +1,298 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.worker;
+
+import co.cask.cdap.AppWithWorker;
+import co.cask.cdap.api.common.RuntimeArguments;
+import co.cask.cdap.api.dataset.lib.KeyValueTable;
+import co.cask.cdap.api.dataset.lib.cube.AggregationFunction;
+import co.cask.cdap.api.metrics.MetricDataQuery;
+import co.cask.cdap.api.metrics.MetricStore;
+import co.cask.cdap.api.metrics.MetricTimeSeries;
+import co.cask.cdap.app.program.Program;
+import co.cask.cdap.app.runtime.ProgramController;
+import co.cask.cdap.app.runtime.ProgramRunner;
+import co.cask.cdap.common.app.RunIds;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.data.dataset.DatasetInstantiator;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.internal.AppFabricTestHelper;
+import co.cask.cdap.internal.DefaultId;
+import co.cask.cdap.internal.TempFolder;
+import co.cask.cdap.internal.app.deploy.pipeline.ApplicationWithPrograms;
+import co.cask.cdap.internal.app.runtime.AbstractListener;
+import co.cask.cdap.internal.app.runtime.BasicArguments;
+import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
+import co.cask.cdap.internal.app.runtime.ProgramRunnerFactory;
+import co.cask.cdap.internal.app.runtime.SimpleProgramOptions;
+import co.cask.cdap.proto.DatasetSpecificationSummary;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.test.SlowTests;
+import co.cask.tephra.TransactionAware;
+import co.cask.tephra.TransactionExecutor;
+import co.cask.tephra.TransactionExecutorFactory;
+import co.cask.tephra.TransactionManager;
+import co.cask.tephra.TxConstants;
+import com.google.common.base.Supplier;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Injector;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.twill.common.Threads;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Tests running worker programs.
+ */
+@Category(SlowTests.class)
+public class WorkerProgramRunnerTest {
+
+  private static final TempFolder TEMP_FOLDER = new TempFolder();
+
+  private static Injector injector;
+  private static TransactionExecutorFactory txExecutorFactory;
+
+  private static TransactionManager txService;
+  private static DatasetFramework dsFramework;
+  private static DatasetInstantiator datasetInstantiator;
+  private static MetricStore metricStore;
+
+  private static Collection<ProgramController> runningPrograms = new HashSet<>();
+
+  @ClassRule
+  public static TemporaryFolder tmpFolder = new TemporaryFolder();
+
+  private static final Supplier<File> TEMP_FOLDER_SUPPLIER = new Supplier<File>() {
+    @Override
+    public File get() {
+      try {
+        return tmpFolder.newFolder();
+      } catch (IOException e) {
+        throw Throwables.propagate(e);
+      }
+    }
+  };
+
+  @BeforeClass
+  public static void beforeClass() {
+    // we are only gonna do long-running transactions here. Set the tx timeout to a ridiculously low value.
+    // that will test that the long-running transactions actually bypass that timeout.
+    CConfiguration conf = CConfiguration.create();
+    conf.set(Constants.CFG_LOCAL_DATA_DIR, TEMP_FOLDER.newFolder("data").getAbsolutePath());
+    conf.setInt(TxConstants.Manager.CFG_TX_TIMEOUT, 1);
+    conf.setInt(TxConstants.Manager.CFG_TX_CLEANUP_INTERVAL, 2);
+    injector = AppFabricTestHelper.getInjector(conf);
+    txService = injector.getInstance(TransactionManager.class);
+    txExecutorFactory = injector.getInstance(TransactionExecutorFactory.class);
+    dsFramework = injector.getInstance(DatasetFramework.class);
+    datasetInstantiator = new DatasetInstantiator(DefaultId.NAMESPACE, dsFramework,
+                                                  WorkerProgramRunnerTest.class.getClassLoader(),
+                                                  null, null);
+    metricStore = injector.getInstance(MetricStore.class);
+
+    txService.startAndWait();
+  }
+
+  @AfterClass
+  public static void afterClass() throws Exception {
+    txService.stopAndWait();
+  }
+
+  @After
+  public void after() throws Throwable {
+    // stop all running programs
+    for (ProgramController controller : runningPrograms) {
+        stopProgram(controller);
+    }
+    // cleanup user data (only user datasets)
+    for (DatasetSpecificationSummary spec : dsFramework.getInstances(DefaultId.NAMESPACE)) {
+      dsFramework.deleteInstance(Id.DatasetInstance.from(DefaultId.NAMESPACE, spec.getName()));
+    }
+  }
+
+  @Test
+  public void testWorkerDatasetWithMetrics() throws Throwable {
+    final ApplicationWithPrograms app =
+      AppFabricTestHelper.deployApplicationWithManager(AppWithWorker.class, TEMP_FOLDER_SUPPLIER);
+
+    ProgramController controller = startProgram(app, AppWithWorker.TableWriter.class);
+
+    // validate worker wrote the "initialize" and "run" rows
+    final KeyValueTable kvTable = datasetInstantiator.getDataset(AppWithWorker.DATASET);
+    TransactionExecutor executor = txExecutorFactory.createExecutor(Collections.singleton((TransactionAware) kvTable));
+    // wait at most 5 seconds
+    long timeout = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(5);
+    boolean done = false;
+    while (System.currentTimeMillis() < timeout) {
+      done = executor.execute(
+        new Callable<Boolean>() {
+          @Override
+          public Boolean call() throws Exception {
+            return AppWithWorker.RUN.equals(Bytes.toString(kvTable.read(AppWithWorker.RUN)));
+          }
+        });
+    }
+    if (!done) {
+      Assert.fail("timeout waiting for worker to start.");
+    }
+
+    stopProgram(controller);
+
+    txExecutorFactory.createExecutor(Collections.singleton((TransactionAware) kvTable)).execute(
+      new TransactionExecutor.Subroutine() {
+        @Override
+        public void apply() throws Exception {
+          Assert.assertEquals(AppWithWorker.RUN, Bytes.toString(kvTable.read(AppWithWorker.RUN)));
+          Assert.assertEquals(AppWithWorker.INITIALIZE, Bytes.toString(kvTable.read(AppWithWorker.INITIALIZE)));
+          Assert.assertEquals(AppWithWorker.STOP, Bytes.toString(kvTable.read(AppWithWorker.STOP)));
+        }
+      });
+
+    // validate that the table emitted metrics
+    timeout = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(2);
+    long metricValue = 0L;
+    while (System.currentTimeMillis() < timeout) {
+      Collection<MetricTimeSeries> metrics =
+        metricStore.query(new MetricDataQuery(
+          0,
+          System.currentTimeMillis() / 1000L,
+          60,
+          "system." + Constants.Metrics.Name.Dataset.OP_COUNT,
+          AggregationFunction.SUM,
+          ImmutableMap.of(Constants.Metrics.Tag.NAMESPACE, DefaultId.NAMESPACE.getId(),
+                          Constants.Metrics.Tag.APP, AppWithWorker.NAME,
+                          Constants.Metrics.Tag.WORKER, AppWithWorker.WORKER,
+                          Constants.Metrics.Tag.DATASET, AppWithWorker.DATASET),
+          Collections.<String>emptyList()));
+      if (!metrics.isEmpty()) {
+        Assert.assertEquals(1, metrics.size());
+        MetricTimeSeries ts = metrics.iterator().next();
+        Assert.assertEquals(1, ts.getTimeValues().size());
+        metricValue = ts.getTimeValues().get(0).getValue();
+        if (metricValue >= 3L) {
+          break;
+        }
+      }
+      TimeUnit.MILLISECONDS.sleep(50);
+    }
+    Assert.assertEquals(3L, metricValue);
+  }
+
+  private ProgramController startProgram(ApplicationWithPrograms app, Class<?> programClass)
+    throws Throwable {
+    final AtomicReference<Throwable> errorCause = new AtomicReference<>();
+    ProgramController controller = submit(app, programClass, RuntimeArguments.NO_ARGUMENTS);
+    runningPrograms.add(controller);
+    controller.addListener(new AbstractListener() {
+      @Override
+      public void error(Throwable cause) {
+        errorCause.set(cause);
+      }
+
+      @Override
+      public void killed() {
+        errorCause.set(new RuntimeException("Killed"));
+      }
+    }, Threads.SAME_THREAD_EXECUTOR);
+    long timeout = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(30);
+    while (System.currentTimeMillis() < timeout) {
+      if (controller.getState() == ProgramController.State.ALIVE) {
+        return controller;
+      }
+    }
+    //noinspection ThrowableResultOfMethodCallIgnored
+    if (errorCause.get() != null) {
+      throw errorCause.get();
+    } else {
+      throw new RuntimeException("Timeout");
+    }
+  }
+
+  private void stopProgram(ProgramController controller) throws Throwable {
+    final AtomicReference<Throwable> errorCause = new AtomicReference<>();
+    final CountDownLatch complete = new CountDownLatch(1);
+    controller.addListener(new AbstractListener() {
+      @Override
+      public void error(Throwable cause) {
+        complete.countDown();
+        errorCause.set(cause);
+      }
+
+      @Override
+      public void completed() {
+        complete.countDown();
+      }
+
+      @Override
+      public void killed() {
+        complete.countDown();
+      }
+    }, Threads.SAME_THREAD_EXECUTOR);
+    controller.stop();
+    complete.await(30, TimeUnit.SECONDS);
+    runningPrograms.remove(controller);
+    //noinspection ThrowableResultOfMethodCallIgnored
+    if (errorCause.get() != null) {
+      throw errorCause.get();
+    }
+  }
+
+  private ProgramController submit(ApplicationWithPrograms app,
+                                   Class<?> programClass,
+                                   Map<String, String> userArgs) throws ClassNotFoundException {
+
+    ProgramRunnerFactory runnerFactory = injector.getInstance(ProgramRunnerFactory.class);
+    Program program = getProgram(app, programClass);
+    Assert.assertNotNull(program);
+    ProgramRunner runner = runnerFactory.create(ProgramRunnerFactory.Type.valueOf(program.getType().name()));
+
+    BasicArguments systemArgs = new BasicArguments(ImmutableMap.of(ProgramOptionConstants.RUN_ID,
+                                                                   RunIds.generate().getId()));
+
+    return runner.run(program, new SimpleProgramOptions(program.getName(), systemArgs, new BasicArguments(userArgs)));
+  }
+
+  private Program getProgram(ApplicationWithPrograms app, Class<?> programClass) throws ClassNotFoundException {
+    for (Program p : app.getPrograms()) {
+      if (programClass.getCanonicalName().equals(p.getMainClass().getCanonicalName())) {
+        return p;
+      }
+    }
+    return null;
+  }
+
+
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DynamicDatasetContext.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DynamicDatasetContext.java
@@ -84,7 +84,9 @@ public class DynamicDatasetContext implements DatasetContext {
   }
 
   /**
-   * @param namespace the {@link Id.Namespace} in which the transaction context is created
+   * Create a dynamic dataset context that will get datasets and add them to the transaction context.
+   *
+   * @param namespace the {@link Id.Namespace} in which all datasets are instantiated
    * @param context the transaction context
    * @param metricsContext if non-null, this context is used as the context for dataset metrics,
    *                       with an additional tag for the dataset name.
@@ -103,7 +105,7 @@ public class DynamicDatasetContext implements DatasetContext {
   /**
    * Create a dynamic dataset context that will get datasets and add them to the transaction context.
    *
-   * @param namespace the {@link Id.Namespace} in which the transaction context is created
+   * @param namespace the {@link Id.Namespace} in which all datasets are instantiated
    * @param context the transaction context
    * @param metricsContext if non-null, this context is used as the context for dataset metrics,
    *                       with an additional tag for the dataset name.

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DynamicDatasetContext.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DynamicDatasetContext.java
@@ -22,6 +22,9 @@ import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.data.DatasetInstantiationException;
 import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.dataset.DatasetDefinition;
+import co.cask.cdap.api.dataset.metrics.MeteredDataset;
+import co.cask.cdap.api.metrics.MetricsContext;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.proto.Id;
 import co.cask.tephra.TransactionAware;
 import co.cask.tephra.TransactionContext;
@@ -45,6 +48,7 @@ import javax.annotation.Nullable;
 public class DynamicDatasetContext implements DatasetContext {
 
   private final TransactionContext context;
+  private final MetricsContext metricsContext;
   private final Set<String> allowedDatasets;
   private final DatasetFramework datasetFramework;
   private final ClassLoader classLoader;
@@ -72,16 +76,28 @@ public class DynamicDatasetContext implements DatasetContext {
    * arguments.
    *
    * @param name the name of the dataset
+   *
    * @return runtime arguments for the given dataset
    */
   protected Map<String, String> getRuntimeArguments(String name) {
     return RuntimeArguments.extractScope(Scope.DATASET, name, runtimeArguments);
   }
 
+  /**
+   * @param namespace the {@link Id.Namespace} in which the transaction context is created
+   * @param context the transaction context
+   * @param metricsContext if non-null, this context is used as the context for dataset metrics,
+   *                       with an additional tag for the dataset name.
+   * @param datasetFramework the dataset framework for creating dataset instances
+   * @param classLoader the classloader to use when creating dataset instances
+   */
   public DynamicDatasetContext(Id.Namespace namespace,
-                               TransactionContext context, DatasetFramework datasetFramework,
+                               TransactionContext context,
+                               @Nullable MetricsContext metricsContext,
+                               DatasetFramework datasetFramework,
                                ClassLoader classLoader) {
-    this(namespace, context, datasetFramework, classLoader, ImmutableMap.<String, String>of(), null, null);
+    this(namespace, context, metricsContext, datasetFramework,
+         classLoader, ImmutableMap.<String, String>of(), null, null);
   }
 
   /**
@@ -89,6 +105,8 @@ public class DynamicDatasetContext implements DatasetContext {
    *
    * @param namespace the {@link Id.Namespace} in which the transaction context is created
    * @param context the transaction context
+   * @param metricsContext if non-null, this context is used as the context for dataset metrics,
+   *                       with an additional tag for the dataset name.
    * @param datasetFramework the dataset framework for creating dataset instances
    * @param classLoader the classloader to use when creating dataset instances
    * @param runtimeArguments all runtime arguments that are available to datasets in the context. Runtime arguments
@@ -96,7 +114,9 @@ public class DynamicDatasetContext implements DatasetContext {
    * @param datasets the set of datasets that are allowed to be created. If null, any dataset can be created
    * @param owners the {@link Id}s which own this context
    */
-  public DynamicDatasetContext(Id.Namespace namespace, TransactionContext context,
+  public DynamicDatasetContext(Id.Namespace namespace,
+                               TransactionContext context,
+                               @Nullable MetricsContext metricsContext,
                                DatasetFramework datasetFramework,
                                ClassLoader classLoader,
                                Map<String, String> runtimeArguments,
@@ -105,6 +125,7 @@ public class DynamicDatasetContext implements DatasetContext {
     this.namespace = namespace;
     this.owners = owners == null ? ImmutableList.<Id>of() : ImmutableList.copyOf(owners);
     this.context = context;
+    this.metricsContext = metricsContext;
     this.allowedDatasets = datasets == null ? null : ImmutableSet.copyOf(datasets);
     this.datasetFramework = datasetFramework;
     this.classLoader = classLoader;
@@ -190,6 +211,11 @@ public class DynamicDatasetContext implements DatasetContext {
         context.addTransactionAware((TransactionAware) dataset);
         txnInProgressDatasets.add(datasetCacheKey);
       }
+
+      if (dataset instanceof MeteredDataset && metricsContext != null) {
+        ((MeteredDataset) dataset).setMetricsCollector(getMetricsContext(metricsContext, name));
+      }
+
       @SuppressWarnings("unchecked")
       T t = (T) dataset;
       return t;
@@ -200,5 +226,10 @@ public class DynamicDatasetContext implements DatasetContext {
       throw new DatasetInstantiationException(String.format("Could not instantiate dataset '%s'", name), t);
     }
   }
+
+  private static MetricsContext getMetricsContext(MetricsContext metricsContext, String datasetName) {
+    return metricsContext.childContext(Constants.Metrics.Tag.DATASET, datasetName);
+  }
+
 }
 

--- a/cdap-notifications/src/main/java/co/cask/cdap/notifications/service/BasicNotificationContext.java
+++ b/cdap-notifications/src/main/java/co/cask/cdap/notifications/service/BasicNotificationContext.java
@@ -51,7 +51,7 @@ public final class BasicNotificationContext implements NotificationContext {
         final TransactionContext context = new TransactionContext(transactionSystemClient);
         try {
           context.start();
-          runnable.run(new DynamicDatasetContext(namespaceId, context, dsFramework,
+          runnable.run(new DynamicDatasetContext(namespaceId, context, null, dsFramework,
                                                  context.getClass().getClassLoader()));
           context.finish();
           return true;

--- a/cdap-notifications/src/main/java/co/cask/cdap/notifications/service/BasicNotificationContext.java
+++ b/cdap-notifications/src/main/java/co/cask/cdap/notifications/service/BasicNotificationContext.java
@@ -51,6 +51,7 @@ public final class BasicNotificationContext implements NotificationContext {
         final TransactionContext context = new TransactionContext(transactionSystemClient);
         try {
           context.start();
+          // TODO this dataset context needs a metrics context [CDAP-3114]
           runnable.run(new DynamicDatasetContext(namespaceId, context, null, dsFramework,
                                                  context.getClass().getClassLoader()));
           context.finish();


### PR DESCRIPTION
This affects: workers, mapreduce, spark (driver side). 
- adds a metrics context to the DynamicDatasetContext
- changes to program contexts to pass in the metrics context
- additions to some test cases to validate that the metrics are emitted with correct context
- new test case WorkerProgramRunnerTest - we did not have a test case for workers before
