### PR TITLE
Update the system services restart endpoints to be more RESTful

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/MonitorHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/MonitorHandler.java
@@ -116,7 +116,7 @@ public class MonitorHandler extends AbstractMonitorHandler {
   /**
    * Send request to get the status of latest restart instances request for a CDAP system service.
    */
-  @Path("/system/services/{service-name}/lastrestartstatus")
+  @Path("/system/services/{service-name}/latest-restart")
   @GET
   public void getLatestRestartServiceInstanceStatus(HttpRequest request, HttpResponder responder,
                                                     @PathParam("service-name") String serviceName) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/MonitorHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/MonitorHandler.java
@@ -95,7 +95,7 @@ public class MonitorHandler extends AbstractMonitorHandler {
   /**
    * Send request to restart all instances for a CDAP system service.
    */
-  @Path("/system/services/{service-name}/instances/restart")
+  @Path("/system/services/{service-name}/restart")
   @PUT
   public void restartAllServiceInstances(HttpRequest request, HttpResponder responder,
                                          @PathParam("service-name") String serviceName) {
@@ -105,7 +105,7 @@ public class MonitorHandler extends AbstractMonitorHandler {
   /**
    * Send request to restart single instance identified by <instance-id>
    */
-  @Path("/system/services/{service-name}/instances/{instance-id}/restart")
+  @Path("/system/services/{service-name}/restart/{instance-id}")
   @PUT
   public void restartServiceInstance(HttpRequest request, HttpResponder responder,
                                      @PathParam("service-name") String serviceName,
@@ -116,7 +116,7 @@ public class MonitorHandler extends AbstractMonitorHandler {
   /**
    * Send request to get the status of latest restart instances request for a CDAP system service.
    */
-  @Path("/system/services/{service-name}/instances/restart")
+  @Path("/system/services/{service-name}/lastrestartstatus")
   @GET
   public void getLatestRestartServiceInstanceStatus(HttpRequest request, HttpResponder responder,
                                                     @PathParam("service-name") String serviceName) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/MonitorHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/MonitorHandler.java
@@ -25,6 +25,7 @@ import org.jboss.netty.handler.codec.http.HttpRequest;
 
 import java.util.Map;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -96,7 +97,7 @@ public class MonitorHandler extends AbstractMonitorHandler {
    * Send request to restart all instances for a CDAP system service.
    */
   @Path("/system/services/{service-name}/restart")
-  @PUT
+  @POST
   public void restartAllServiceInstances(HttpRequest request, HttpResponder responder,
                                          @PathParam("service-name") String serviceName) {
     super.restartAllServiceInstances(request, responder, serviceName);
@@ -105,8 +106,8 @@ public class MonitorHandler extends AbstractMonitorHandler {
   /**
    * Send request to restart single instance identified by <instance-id>
    */
-  @Path("/system/services/{service-name}/restart/{instance-id}")
-  @PUT
+  @Path("/system/services/{service-name}/instances/{instance-id}/restart")
+  @POST
   public void restartServiceInstance(HttpRequest request, HttpResponder responder,
                                      @PathParam("service-name") String serviceName,
                                      @PathParam("instance-id") int instanceId) {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/MonitorHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/MonitorHandlerTest.java
@@ -108,7 +108,7 @@ public class MonitorHandlerTest extends AppFabricTestBase {
 
     Assert.assertEquals(HttpResponseStatus.OK.getCode(), response.getStatusLine().getStatusCode());
 
-    path = String.format("%s/system/services/%s/lastrestartstatus", Constants.Gateway.API_VERSION_3,
+    path = String.format("%s/system/services/%s/latest-restart", Constants.Gateway.API_VERSION_3,
                          Constants.Service.APP_FABRIC_HTTP);
     response = doGet(path);
 
@@ -131,7 +131,7 @@ public class MonitorHandlerTest extends AppFabricTestBase {
 
     Assert.assertEquals(HttpResponseStatus.BAD_REQUEST.getCode(), response.getStatusLine().getStatusCode());
 
-    path = String.format("%s/system/services/%s/lastrestartstatus", Constants.Gateway.API_VERSION_3,
+    path = String.format("%s/system/services/%s/latest-restart", Constants.Gateway.API_VERSION_3,
                          Constants.Service.APP_FABRIC_HTTP);
     response = doGet(path);
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/MonitorHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/MonitorHandlerTest.java
@@ -102,22 +102,21 @@ public class MonitorHandlerTest extends AppFabricTestBase {
 
   @Test
   public void testRestartInstances() throws Exception {
-    String path = String.format("system/services/%s/instances/restart", Constants.Service.APP_FABRIC_HTTP);
-    HttpURLConnection urlConn = openURL(path, HttpMethod.PUT);
+    String path = String.format("%s/system/services/%s/restart", Constants.Gateway.API_VERSION_3,
+                                Constants.Service.APP_FABRIC_HTTP);
+    HttpResponse response = doPut(path);
 
-    Assert.assertEquals(HttpResponseStatus.OK.getCode(), urlConn.getResponseCode());
+    Assert.assertEquals(HttpResponseStatus.OK.getCode(), response.getStatusLine().getStatusCode());
 
-    urlConn.disconnect();
+    path = String.format("%s/system/services/%s/lastrestartstatus", Constants.Gateway.API_VERSION_3,
+                         Constants.Service.APP_FABRIC_HTTP);
+    response = doGet(path);
 
-    urlConn = openURL(path, HttpMethod.GET);
-
-    Assert.assertEquals(HttpResponseStatus.OK.getCode(), urlConn.getResponseCode());
+    Assert.assertEquals(HttpResponseStatus.OK.getCode(), response.getStatusLine().getStatusCode());
 
     RestartServiceInstancesStatus result =
-      GSON.fromJson(new String(ByteStreams.toByteArray(urlConn.getInputStream()), Charsets.UTF_8),
+      GSON.fromJson(new String(ByteStreams.toByteArray(response.getEntity().getContent()), Charsets.UTF_8),
                     RestartServiceInstancesStatus.class);
-
-    urlConn.disconnect();
 
     Assert.assertNotNull(result);
     Assert.assertEquals(Constants.Service.APP_FABRIC_HTTP, result.getServiceName());
@@ -126,13 +125,13 @@ public class MonitorHandlerTest extends AppFabricTestBase {
 
   @Test
   public void testInvalidIdRestartInstances() throws Exception {
-    String path = String.format("%s/system/services/%s/instances/1000/restart", Constants.Gateway.API_VERSION_3,
+    String path = String.format("%s/system/services/%s/restart/1000", Constants.Gateway.API_VERSION_3,
                                 Constants.Service.APP_FABRIC_HTTP);
     HttpResponse response = doPut(path);
 
     Assert.assertEquals(HttpResponseStatus.BAD_REQUEST.getCode(), response.getStatusLine().getStatusCode());
 
-    path = String.format("%s/system/services/%s/instances/restart", Constants.Gateway.API_VERSION_3,
+    path = String.format("%s/system/services/%s/lastrestartstatus", Constants.Gateway.API_VERSION_3,
                          Constants.Service.APP_FABRIC_HTTP);
     response = doGet(path);
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/MonitorHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/MonitorHandlerTest.java
@@ -104,7 +104,7 @@ public class MonitorHandlerTest extends AppFabricTestBase {
   public void testRestartInstances() throws Exception {
     String path = String.format("%s/system/services/%s/restart", Constants.Gateway.API_VERSION_3,
                                 Constants.Service.APP_FABRIC_HTTP);
-    HttpResponse response = doPut(path);
+    HttpResponse response = doPost(path);
 
     Assert.assertEquals(HttpResponseStatus.OK.getCode(), response.getStatusLine().getStatusCode());
 
@@ -125,9 +125,9 @@ public class MonitorHandlerTest extends AppFabricTestBase {
 
   @Test
   public void testInvalidIdRestartInstances() throws Exception {
-    String path = String.format("%s/system/services/%s/restart/1000", Constants.Gateway.API_VERSION_3,
+    String path = String.format("%s/system/services/%s/instances/1000/restart", Constants.Gateway.API_VERSION_3,
                                 Constants.Service.APP_FABRIC_HTTP);
-    HttpResponse response = doPut(path);
+    HttpResponse response = doPost(path);
 
     Assert.assertEquals(HttpResponseStatus.BAD_REQUEST.getCode(), response.getStatusLine().getStatusCode());
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/MonitorHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/MonitorHandlerTest.java
@@ -124,6 +124,29 @@ public class MonitorHandlerTest extends AppFabricTestBase {
   }
 
   @Test
+  public void testSingleIdRestartInstances() throws Exception {
+    String path = String.format("%s/system/services/%s/instances/0/restart", Constants.Gateway.API_VERSION_3,
+                                Constants.Service.APP_FABRIC_HTTP);
+    HttpResponse response = doPost(path);
+
+    Assert.assertEquals(HttpResponseStatus.OK.getCode(), response.getStatusLine().getStatusCode());
+
+    path = String.format("%s/system/services/%s/latest-restart", Constants.Gateway.API_VERSION_3,
+                         Constants.Service.APP_FABRIC_HTTP);
+    response = doGet(path);
+
+    Assert.assertEquals(HttpResponseStatus.OK.getCode(), response.getStatusLine().getStatusCode());
+
+    RestartServiceInstancesStatus result =
+      GSON.fromJson(new String(ByteStreams.toByteArray(response.getEntity().getContent()), Charsets.UTF_8),
+                    RestartServiceInstancesStatus.class);
+
+    Assert.assertNotNull(result);
+    Assert.assertEquals(Constants.Service.APP_FABRIC_HTTP, result.getServiceName());
+    Assert.assertEquals(RestartServiceInstancesStatus.RestartStatus.SUCCESS, result.getStatus());
+  }
+
+  @Test
   public void testInvalidIdRestartInstances() throws Exception {
     String path = String.format("%s/system/services/%s/instances/1000/restart", Constants.Gateway.API_VERSION_3,
                                 Constants.Service.APP_FABRIC_HTTP);


### PR DESCRIPTION
Follow up on endpoint for system service restart instances comments after demo.

Adding concept of "restart" resource to the /system/services/{service-name} endpoint.
The restart path represent a request to restart instances on the system services.

So to restart all instances of a system service need to send request to:
PUT /system/services/{service-name}/restart

and to restart particular instance id via:
PUT /system/services/{service-name}/restart/{instance-id}

Modify the GET endpoint for latest restart status by adding concept of latest-restart resource:
GET /system/services/{service-name}/latest-restart