### PR TITLE
updates dropdown options for no app template

### DIFF
--- a/cdap-ui/app/features/admin/templates/namespace/apps.html
+++ b/cdap-ui/app/features/admin/templates/namespace/apps.html
@@ -85,18 +85,24 @@
       <ul class="dropdown-menu dropdown-menu-right" role="menu">
         <li>
           <my-file-select dropdown="true"
-                          data-button-label="Add App"
+                          data-button-label="Custom App"
                           on-file-select="onFileSelected($files)">
           </my-file-select>
         </li>
         <li>
-          <a ui-sref="adapters.create({namespace: $stateParams.nsadmin, type: 'ETLBatch'})"> Add ETL Batch App </a>
+          <a ui-sref="adapters.create({namespace: $stateParams.nsadmin, type: 'ETLBatch'})">
+            ETL Batch App
+            <i class="icon-app pull-right"></i>
+          </a>
         </li>
         <li>
-          <a ui-sref="adapters.create({namespace: $stateParams.nsadmin, type: 'ETLRealtime'})"> Add ETL Realtime App </a>
+          <a ui-sref="adapters.create({namespace: $stateParams.nsadmin, type: 'ETLRealtime'})">
+            ETL Realtime App
+            <i class="icon-app pull-right"></i>
+          </a>
         </li>
         <li>
-          <a ui-sref="adapters.list({namespace: $stateParams.nsadmin})"> Un-Published Adapters </a>
+          <a ui-sref="adapters.list({namespace: $stateParams.nsadmin})"> Drafts </a>
         </li>
       </ul>
     </div>

--- a/cdap-ui/app/features/overview/overview.less
+++ b/cdap-ui/app/features/overview/overview.less
@@ -214,7 +214,7 @@ body.state-overview {
       h3 {
         margin-bottom: 18px;
       }
-      .btn-group .btn {
+      .btn {
         padding-top: 3px;
         padding-bottom: 3px;
         font-size: 12px;
@@ -338,10 +338,8 @@ body.state-overview {
             color: #5F6674;
           }
         }
-        .col-sm-9 {
-          .btn-group.open button.dropdown-toggle {
-            .box-shadow(none);
-          }
+        button.white-dropdown {
+          .box-shadow(none);
         }
         li.list-group-item {
           background-color: white;

--- a/cdap-ui/app/features/overview/templates/data-apps.html
+++ b/cdap-ui/app/features/overview/templates/data-apps.html
@@ -143,18 +143,24 @@
         <ul class="dropdown-menu dropdown-menu-right" role="menu">
           <li>
             <my-file-select dropdown="true"
-                            data-button-label="Add App"
+                            data-button-label="Custom App"
                             on-file-select="AppsSectionCtrl.onFileSelected($files)">
             </my-file-select>
           </li>
           <li>
-            <a ui-sref="adapters.create({ type: 'ETLBatch'})"> Add ETL Batch App </a>
+            <a ui-sref="adapters.create({type: 'ETLBatch'})">
+              ETL Batch App
+              <i class="icon-app pull-right"></i>
+            </a>
           </li>
           <li>
-            <a ui-sref="adapters.create({ type: 'ETLRealtime'})"> Add ETL Realtime App </a>
+            <a ui-sref="adapters.create({type: 'ETLRealtime'})">
+              ETL Realtime App
+              <i class="icon-app pull-right"></i>
+            </a>
           </li>
           <li>
-            <a ui-sref="adapters.list"> Un-Published Adapters </a>
+            <a ui-sref="adapters.list"> Drafts </a>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
*  Adds correct dropdown menu text + icons to no apps template (dev start + admin)
*  Removes box shadow in dropdown menu open state
*  Adds consistent padding to buttons in data apps template (dev start)

![apps](https://cloud.githubusercontent.com/assets/5335210/8940285/f2ffe214-351d-11e5-88a7-7579eec38203.gif)

