### PR TITLE
CDAP-2768 filter out system.queue from list of datasets

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandler.java
@@ -19,11 +19,13 @@ package co.cask.cdap.data2.datafabric.dataset.service;
 import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.common.DatasetAlreadyExistsException;
+import co.cask.cdap.common.DatasetNotFoundException;
 import co.cask.cdap.common.DatasetTypeNotFoundException;
 import co.cask.cdap.common.HandlerException;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetAdminOpResponse;
+import co.cask.cdap.data2.transaction.queue.QueueConstants;
 import co.cask.cdap.proto.DatasetInstanceConfiguration;
 import co.cask.cdap.proto.DatasetMeta;
 import co.cask.cdap.proto.DatasetSpecificationSummary;
@@ -240,6 +242,12 @@ public class DatasetInstanceHandler extends AbstractHttpHandler {
   private Collection<DatasetSpecificationSummary> spec2Summary(Collection<DatasetSpecification> specs) {
     List<DatasetSpecificationSummary> datasetSummaries = Lists.newArrayList();
     for (DatasetSpecification spec : specs) {
+      // TODO: (CDAP-3097) handle system datasets specially within a namespace instead of filtering them out
+      // by the handler. This filter is only in the list endpoint because the other endpoints are used by
+      // HBaseQueueAdmin through DatasetFramework.
+      if (QueueConstants.STATE_STORE_NAME.equals(spec.getName())) {
+        continue;
+      }
       datasetSummaries.add(new DatasetSpecificationSummary(spec.getName(), spec.getType(), spec.getProperties()));
     }
     return datasetSummaries;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/QueueConstants.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/QueueConstants.java
@@ -15,6 +15,8 @@
  */
 package co.cask.cdap.data2.transaction.queue;
 
+import co.cask.cdap.common.conf.Constants;
+
 /**
  * Constants for queue implementation in HBase.
  */
@@ -43,6 +45,7 @@ public final class QueueConstants {
 
   // Key for HBase table meta that records the value of number of queue table buckets
   public static final String DISTRIBUTOR_BUCKETS = "cdap.distributor.buckets";
+  public static final String STATE_STORE_NAME = Constants.SYSTEM_NAMESPACE + "." + QueueType.QUEUE;
 
   /**
    * whether a queue is a queue or a stream.

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueAdmin.java
@@ -124,7 +124,7 @@ public class HBaseQueueAdmin extends AbstractQueueAdmin {
   }
 
   public static TableId getConfigTableId(String namespace) {
-    return TableId.from(namespace, HBaseQueueDatasetModule.STATE_STORE_NAME + "."
+    return TableId.from(namespace, QueueConstants.STATE_STORE_NAME + "."
                                   + HBaseQueueDatasetModule.STATE_STORE_EMBEDDED_TABLE_NAME);
   }
 
@@ -259,7 +259,7 @@ public class HBaseQueueAdmin extends AbstractQueueAdmin {
   }
 
   private Id.DatasetInstance getStateStoreId(String namespaceId) {
-    return Id.DatasetInstance.from(namespaceId, HBaseQueueDatasetModule.STATE_STORE_NAME);
+    return Id.DatasetInstance.from(namespaceId, QueueConstants.STATE_STORE_NAME);
   }
 
   private Id.DatasetInstance createStateStoreDataset(String namespace) throws IOException {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueDatasetModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueDatasetModule.java
@@ -25,9 +25,7 @@ import co.cask.cdap.api.dataset.lib.AbstractDatasetDefinition;
 import co.cask.cdap.api.dataset.module.DatasetDefinitionRegistry;
 import co.cask.cdap.api.dataset.module.DatasetModule;
 import co.cask.cdap.api.dataset.table.Table;
-import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.queue.QueueName;
-import co.cask.cdap.data2.transaction.queue.QueueConstants;
 
 import java.io.IOException;
 import java.net.URI;
@@ -45,8 +43,6 @@ public class HBaseQueueDatasetModule implements DatasetModule {
   // State store table name is system.queue.
   // The embedded table used in HBaseConsumerStateStore has the name "config", hence it will
   // map to "system.queue.config" for backward compatibility
-  static final String STATE_STORE_NAME
-    = Constants.SYSTEM_NAMESPACE + "." + QueueConstants.QueueType.QUEUE.toString();
   // The name of the embedded table dataset for the state store. It has to be "config".
   static final String STATE_STORE_EMBEDDED_TABLE_NAME = "config";
 


### PR DESCRIPTION
system.queue is a system dataset, but it exists in each namespace
once a flow has been started in the namespace. It should not be
visible via the get datasets rest call. This is a short term
fix, with the longer term fix to have support for system datasets
in namespaces other than the system namespace.