### PR TITLE
Misc log fixes

### DIFF
--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/LogHandler.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/LogHandler.java
@@ -208,7 +208,9 @@ public class LogHandler extends AbstractHttpHandler {
         toTimeMillis = runStopMillis;
       }
     }
-    return new ReadRange(fromTimeMillis, toTimeMillis, readRange.getKafkaOffset());
+    ReadRange adjusted = new ReadRange(fromTimeMillis, toTimeMillis, readRange.getKafkaOffset());
+    LOG.trace("Original read range: {}. Adjusted read range: {}", readRange, adjusted);
+    return adjusted;
   }
 
   @GET

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/read/DistributedLogReader.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/read/DistributedLogReader.java
@@ -62,6 +62,7 @@ public final class DistributedLogReader implements LogReader {
         fileLogReader.getLogNext(loggingContext, readRange, maxEvents, filter, callback);
         // If there are events from fileLogReader, return. Otherwise try in kafkaLogReader.
         if (callback.getCount() != 0) {
+          LOG.trace("Got {} log entries from file", callback.getCount());
           return;
         }
       }
@@ -76,9 +77,10 @@ public final class DistributedLogReader implements LogReader {
     // If latest logs are not requested, try reading from file.
     if (readRange != ReadRange.LATEST) {
       long checkpointTime = getCheckpointTime(loggingContext);
-      // Read from file only if logs are saved for the loggingContext until fromTime
+      // Read from file only if logs are saved for the loggingContext until toTime
       if (readRange.getToMillis() < checkpointTime) {
         fileLogReader.getLogPrev(loggingContext, readRange, maxEvents, filter, callback);
+        LOG.trace("Got {} log entries from file", callback.getCount());
         return;
       }
     }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/read/DistributedLogReader.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/read/DistributedLogReader.java
@@ -69,6 +69,15 @@ public final class DistributedLogReader implements LogReader {
     }
 
     kafkaLogReader.getLogNext(loggingContext, readRange, maxEvents, filter, callback);
+    LOG.trace("Got {} log entries from kafka", callback.getCount());
+
+    // No logs in Kafka. This can happen for the latest run of a program, where the logs have been saved and
+    // are expired in Kafka, but the checkpoint time is less than run end time - as this is the latest run.
+    // In this case, return whatever you can find in saved logs.
+    if (callback.getCount() == 0) {
+      fileLogReader.getLogNext(loggingContext, readRange, maxEvents, filter, callback);
+      LOG.trace("Got {} log entries from file", callback.getCount());
+    }
   }
 
   @Override
@@ -86,6 +95,15 @@ public final class DistributedLogReader implements LogReader {
     }
 
     kafkaLogReader.getLogPrev(loggingContext, readRange, maxEvents, filter, callback);
+    LOG.trace("Got {} log entries from kafka", callback.getCount());
+
+    // No logs in Kafka. This can happen for the latest run of a program, where the logs have been saved and
+    // are expired in Kafka, but the checkpoint time is less than run end time - as this is the latest run.
+    // In this case, return whatever you can find in saved logs.
+    if (callback.getCount() == 0) {
+      fileLogReader.getLogPrev(loggingContext, readRange, maxEvents, filter, callback);
+      LOG.trace("Got {} log entries from file", callback.getCount());
+    }
   }
 
   @Override

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/read/KafkaLogReader.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/read/KafkaLogReader.java
@@ -81,6 +81,7 @@ public class KafkaLogReader implements LogReader {
     }
 
     int partition = partitioner.partition(loggingContext.getLogPartition(), -1);
+    LOG.trace("Reading from kafka partiton {}", partition);
 
     callback.init();
 
@@ -99,6 +100,7 @@ public class KafkaLogReader implements LogReader {
       long latestOffset = kafkaConsumer.fetchOffsetBefore(KafkaConsumer.LATEST_OFFSET);
       long startOffset = readRange.getKafkaOffset() + 1;
 
+      LOG.trace("Using startOffset={}, latestOffset={}, readRange={}", startOffset, latestOffset, readRange);
       if (startOffset >= latestOffset) {
         // At end of events, nothing to return
         return;
@@ -126,6 +128,7 @@ public class KafkaLogReader implements LogReader {
     }
 
     int partition = partitioner.partition(loggingContext.getLogPartition(), -1);
+    LOG.trace("Reading from kafka partiton {}", partition);
 
     callback.init();
 
@@ -150,6 +153,7 @@ public class KafkaLogReader implements LogReader {
         startOffset = earliestOffset;
       }
 
+      LOG.trace("Using startOffset={}, latestOffset={}, readRange={}", startOffset, latestOffset, readRange);
       if (startOffset >= stopOffset || startOffset >= latestOffset) {
         // At end of kafka events, nothing to return
         return;

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/read/FileLogReaderTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/read/FileLogReaderTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.logging.read;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSortedMap;
+import org.apache.twill.filesystem.LocalLocationFactory;
+import org.apache.twill.filesystem.Location;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.util.Collections;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+
+public class FileLogReaderTest {
+  @Rule
+  public TemporaryFolder tempFolder = new TemporaryFolder();
+
+  @Test
+  public void testGetFilesInRange() throws Exception {
+    Location base = new LocalLocationFactory().create(tempFolder.newFolder().toURI());
+    NavigableMap<Long, Location> sortedFiles = new TreeMap<>(ImmutableSortedMap.of(10L, base.append("10"),
+                                                                                   15L, base.append("15"),
+                                                                                   20L, base.append("20"),
+                                                                                   28L, base.append("28"),
+                                                                                   35L, base.append("35")));
+
+    Assert.assertEquals(Collections.<Location>emptyList(), FileLogReader.getFilesInRange(sortedFiles, 1, 10));
+
+    Assert.assertEquals(ImmutableList.of(base.append("10")), FileLogReader.getFilesInRange(sortedFiles, 1, 11));
+
+    // Since we don't know the last log entry in 35, we need to return 35 for query with [46, 50)
+    Assert.assertEquals(ImmutableList.of(base.append("35")), FileLogReader.getFilesInRange(sortedFiles, 46, 50));
+
+    Assert.assertEquals(ImmutableList.of(base.append("15"),
+                                         base.append("20")),
+                        FileLogReader.getFilesInRange(sortedFiles, 15, 28));
+
+    Assert.assertEquals(ImmutableList.of(base.append("10"),
+                                         base.append("15"),
+                                         base.append("20"),
+                                         base.append("28")),
+                        FileLogReader.getFilesInRange(sortedFiles, 13, 30));
+
+    Assert.assertEquals(ImmutableList.of(base.append("10"),
+                                         base.append("15"),
+                                         base.append("20"),
+                                         base.append("28")),
+                        FileLogReader.getFilesInRange(sortedFiles, 10, 34));
+
+    Assert.assertEquals(ImmutableList.of(base.append("10"),
+                                         base.append("15"),
+                                         base.append("20"),
+                                         base.append("28")),
+                        FileLogReader.getFilesInRange(sortedFiles, 11, 35));
+
+    Assert.assertEquals(ImmutableList.of(base.append("10"),
+                                         base.append("15"),
+                                         base.append("20"),
+                                         base.append("28"),
+                                         base.append("35")),
+                        FileLogReader.getFilesInRange(sortedFiles, 11, 36));
+
+    Assert.assertEquals(ImmutableList.of(base.append("20"),
+                                         base.append("28")),
+                        FileLogReader.getFilesInRange(sortedFiles, 25, 32));
+  }
+}


### PR DESCRIPTION
This contains the following fixes -
1. Simplify log file range calculation, also fixes a bug in rage calculation.
2. Handle a case where no logs were returned when logs in Kafka were expired for the latest run.

It would be easier to review commit by commit.

JIRA - https://issues.cask.co/browse/CDAP-2935