### PR TITLE
Make cli output consistent and more human readable (in same format as…

### DIFF
--- a/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
+++ b/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
@@ -221,7 +221,7 @@ public class CLIMainTest {
     testCommandOutputNotContains(cli, "get stream " + streamId, "helloworld");
     testCommandOutputContains(cli, "set stream ttl " + streamId + " 100000", "Successfully set TTL of stream");
     testCommandOutputContains(cli, "set stream notification-threshold " + streamId + " 1",
-                              "Successfully set notification threshold of Stream");
+                              "Successfully set notification threshold of stream");
     testCommandOutputContains(cli, "describe stream " + streamId, "100000");
 
     File file = new File(TMP_FOLDER.newFolder(), "test.txt");
@@ -242,9 +242,9 @@ public class CLIMainTest {
                               "Successfully sent stream event to stream");
     testCommandOutputContains(cli, "get stream " + streamId, "9, Event 9");
     testCommandOutputContains(cli, "get stream-stats " + streamId,
-                              String.format("No schema found for %s", stream));
+                              String.format("No schema found for stream '%s'", streamId));
     testCommandOutputContains(cli, "set stream format " + streamId + " csv 'body string'",
-                              String.format("Successfully set format of %s", stream));
+                              String.format("Successfully set format of stream '%s'", streamId));
     testCommandOutputContains(cli, "execute 'show tables'", String.format("stream_%s", streamId));
     testCommandOutputContains(cli, "get stream-stats " + streamId,
                               "Analyzed 10 Stream events in the time range [0, 9223372036854775807]");
@@ -267,7 +267,6 @@ public class CLIMainTest {
   @Test
   public void testDataset() throws Exception {
     String datasetName = PREFIX + "sdf123lkj";
-    Id.DatasetInstance dataset = Id.DatasetInstance.from(Id.Namespace.DEFAULT, datasetName);
 
     DatasetTypeClient datasetTypeClient = new DatasetTypeClient(cliConfig.getClientConfig());
     DatasetTypeMeta datasetType = datasetTypeClient.list(Id.Namespace.DEFAULT).get(0);

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeleteAppCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeleteAppCommand.java
@@ -34,7 +34,6 @@ import java.io.PrintStream;
  */
 public class DeleteAppCommand extends AbstractAuthCommand {
 
-  public static final String SUCCESS_MSG = "Successfully deleted application '%s'";
   private final ApplicationClient appClient;
 
   @Inject
@@ -49,7 +48,7 @@ public class DeleteAppCommand extends AbstractAuthCommand {
                                                arguments.get(ArgumentName.APP.toString()));
 
     appClient.delete(appId);
-    output.printf(SUCCESS_MSG + "\n", appId);
+    output.printf("Successfully deleted application '%s'\n", appId.getId());
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeleteDatasetInstanceCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeleteDatasetInstanceCommand.java
@@ -48,7 +48,7 @@ public class DeleteDatasetInstanceCommand extends AbstractAuthCommand {
                                                          arguments.get(ArgumentName.DATASET.toString()));
 
     datasetClient.delete(dataset);
-    output.printf("Successfully deleted %s\n", dataset);
+    output.printf("Successfully deleted dataset instance '%s'\n", dataset.getId());
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeleteDatasetModuleCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeleteDatasetModuleCommand.java
@@ -48,7 +48,7 @@ public class DeleteDatasetModuleCommand extends AbstractAuthCommand {
                                                     arguments.get(ArgumentName.DATASET_MODULE.toString()));
 
     datasetClient.delete(module);
-    output.printf("Successfully deleted %s\n", module);
+    output.printf("Successfully deleted dataset module '%s'\n", module.getId());
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeleteStreamCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeleteStreamCommand.java
@@ -47,7 +47,7 @@ public class DeleteStreamCommand extends AbstractAuthCommand {
     Id.Stream streamId = Id.Stream.from(cliConfig.getCurrentNamespace(),
                                         arguments.get(ArgumentName.STREAM.toString()));
     streamClient.delete(streamId);
-    output.printf("Successfully deleted stream '%s'\n", streamId);
+    output.printf("Successfully deleted stream '%s'\n", streamId.getId());
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetStreamEventsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetStreamEventsCommand.java
@@ -73,7 +73,7 @@ public class GetStreamEventsCommand extends AbstractCommand {
       }).build();
     cliConfig.getTableRenderer().render(cliConfig, output, table);
 
-    output.printf("Fetched %d events from stream %s", events.size(), streamId);
+    output.printf("Fetched %d events from stream '%s'", events.size(), streamId.getId());
     output.println();
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetStreamStatsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetStreamStatsCommand.java
@@ -83,7 +83,7 @@ public class GetStreamStatsCommand extends AbstractCommand {
     // hack to validate streamId
     StreamProperties config = streamClient.getConfig(streamId);
     if (config.getFormat().getName().equals("text")) {
-      output.printf("No schema found for %s", streamId);
+      output.printf("No schema found for stream '%s'", streamId.getId());
       output.println();
       return;
     }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/LoadStreamCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/LoadStreamCommand.java
@@ -84,7 +84,7 @@ public class LoadStreamCommand extends AbstractAuthCommand implements Categorize
     }
 
     streamClient.sendFile(streamId, contentType, file);
-    output.printf("Successfully sent stream event to stream '%s'\n", streamId);
+    output.printf("Successfully sent stream event to stream '%s'\n", streamId.getId());
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/SendStreamEventCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/SendStreamEventCommand.java
@@ -50,7 +50,7 @@ public class SendStreamEventCommand extends AbstractAuthCommand implements Categ
                                         arguments.get(ArgumentName.STREAM.toString()));
     String streamEvent = arguments.get(ArgumentName.STREAM_EVENT.toString());
     streamClient.sendEvent(streamId, streamEvent);
-    output.printf("Successfully sent stream event to stream '%s'\n", streamId);
+    output.printf("Successfully sent stream event to stream '%s'\n", streamId.getId());
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetDatasetInstancePropertiesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetDatasetInstancePropertiesCommand.java
@@ -54,7 +54,8 @@ public class SetDatasetInstancePropertiesCommand extends AbstractCommand {
       arguments.get(ArgumentName.DATASET_PROPERTIES.toString()));
 
     datasetClient.updateExisting(instance, properties);
-    output.printf("Successfully updated properties for %s to %s", instance, GSON.toJson(properties));
+    output.printf("Successfully updated properties for dataset instance '%s' to %s",
+                  instance.getId(), GSON.toJson(properties));
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetProgramInstancesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetProgramInstancesCommand.java
@@ -59,7 +59,7 @@ public class SetProgramInstancesCommand extends AbstractAuthCommand {
         Id.Flow.Flowlet flowletId = Id.Flow.Flowlet.from(appId, flowId, flowletName);
         programClient.setFlowletInstances(flowletId, numInstances);
         output.printf("Successfully set flowlet '%s' of flow '%s' of app '%s' to %d instances\n",
-                      flowId, flowletId, appId, numInstances);
+                      flowId, flowletId, appId.getId(), numInstances);
         break;
       case WORKER:
         if (programIdParts.length < 2) {
@@ -69,7 +69,7 @@ public class SetProgramInstancesCommand extends AbstractAuthCommand {
         Id.Worker workerId = Id.Worker.from(appId, workerName);
         programClient.setWorkerInstances(workerId, numInstances);
         output.printf("Successfully set worker '%s' of app '%s' to %d instances\n",
-                      workerId, appId, numInstances);
+                      workerName, appId.getId(), numInstances);
         break;
       case SERVICE:
         if (programIdParts.length < 2) {
@@ -78,7 +78,8 @@ public class SetProgramInstancesCommand extends AbstractAuthCommand {
         String serviceName = programIdParts[1];
         Id.Service service = Id.Service.from(appId, serviceName);
         programClient.setServiceInstances(service, numInstances);
-        output.printf("Successfully set service '%s' of app '%s' to %d instances\n", service, appId, numInstances);
+        output.printf("Successfully set service '%s' of app '%s' to %d instances\n",
+                      serviceName, appId.getId(), numInstances);
         break;
       default:
         // TODO: remove this

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetProgramRuntimeArgsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetProgramRuntimeArgsCommand.java
@@ -58,7 +58,7 @@ public class SetProgramRuntimeArgsCommand extends AbstractAuthCommand {
     Map<String, String> runtimeArgs = ArgumentParser.parseMap(runtimeArgsString);
     programClient.setRuntimeArgs(programId, runtimeArgs);
     output.printf("Successfully set runtime args of %s '%s' of application '%s' to '%s'\n",
-                  elementType.getTitleName(), programId, appId, runtimeArgsString);
+                  elementType.getTitleName(), programName, appId, runtimeArgsString);
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetStreamFormatCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetStreamFormatCommand.java
@@ -69,7 +69,7 @@ public class SetStreamFormatCommand extends AbstractAuthCommand {
                                                              formatSpecification,
                                                              currentProperties.getNotificationThresholdMB());
     streamClient.setStreamProperties(streamId, streamProperties);
-    output.printf("Successfully set format of %s\n", streamId);
+    output.printf("Successfully set format of stream '%s'\n", streamId.getId());
   }
 
   private Schema getSchema(Arguments arguments) throws IOException {

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetStreamNotificationThresholdCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetStreamNotificationThresholdCommand.java
@@ -50,8 +50,8 @@ public class SetStreamNotificationThresholdCommand extends AbstractAuthCommand {
                                         arguments.get(ArgumentName.STREAM.toString()));
     int notificationThresholdMB = arguments.getInt(ArgumentName.NOTIFICATION_THRESHOLD_MB.toString());
     streamClient.setStreamProperties(streamId, new StreamProperties(null, null, notificationThresholdMB));
-    output.printf("Successfully set notification threshold of Stream '%s' to %dMB\n",
-                  streamId, notificationThresholdMB);
+    output.printf("Successfully set notification threshold of stream '%s' to %dMB\n",
+                  streamId.getId(), notificationThresholdMB);
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetStreamPropertiesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetStreamPropertiesCommand.java
@@ -69,7 +69,7 @@ public class SetStreamPropertiesCommand extends AbstractAuthCommand {
     }
 
     streamClient.setStreamProperties(streamId, streamProperties);
-    output.printf("Successfully set properties of stream '%s'\n", streamId);
+    output.printf("Successfully set properties of stream '%s'\n", streamId.getId());
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetStreamTTLCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetStreamTTLCommand.java
@@ -48,7 +48,7 @@ public class SetStreamTTLCommand extends AbstractAuthCommand {
                                         arguments.get(ArgumentName.STREAM.toString()));
     long ttlInSeconds = arguments.getLong(ArgumentName.TTL_IN_SECONDS.toString());
     streamClient.setTTL(streamId, ttlInSeconds);
-    output.printf("Successfully set TTL of stream '%s' to %d\n", streamId, ttlInSeconds);
+    output.printf("Successfully set TTL of stream '%s' to %d\n", streamId.getId(), ttlInSeconds);
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/StartProgramCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/StartProgramCommand.java
@@ -67,13 +67,13 @@ public class StartProgramCommand extends AbstractAuthCommand {
       programClient.start(programId, isDebug);
       runtimeArgsString = GSON.toJson(programClient.getRuntimeArgs(programId));
       output.printf("Successfully started %s '%s' of application '%s' with stored runtime arguments '%s'\n",
-                    elementType.getTitleName(), programId, appId, runtimeArgsString);
+                    elementType.getTitleName(), programName, appId, runtimeArgsString);
     } else {
       // run with user-provided runtime args
       Map<String, String> runtimeArgs = ArgumentParser.parseMap(runtimeArgsString);
       programClient.start(programId, isDebug, runtimeArgs);
       output.printf("Successfully started %s '%s' of application '%s' with provided runtime arguments '%s'\n",
-                    elementType.getTitleName(), programId, appId, runtimeArgsString);
+                    elementType.getTitleName(), programName, appId, runtimeArgsString);
     }
 
   }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/StopProgramCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/StopProgramCommand.java
@@ -55,7 +55,7 @@ public class StopProgramCommand extends AbstractAuthCommand {
                                            elementType.getProgramType(), programName);
 
     programClient.stop(programId);
-    output.printf("Successfully stopped %s '%s' of application '%s'\n", elementType.getTitleName(), programId, appId);
+    output.printf("Successfully stopped %s '%s' of application '%s'\n", elementType.getTitleName(), programName, appId);
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/TruncateDatasetInstanceCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/TruncateDatasetInstanceCommand.java
@@ -47,7 +47,7 @@ public class TruncateDatasetInstanceCommand extends AbstractAuthCommand {
     Id.DatasetInstance instance = Id.DatasetInstance.from(cliConfig.getCurrentNamespace(),
                                                           arguments.get(ArgumentName.DATASET.toString()));
     datasetClient.truncate(instance);
-    output.printf("Successfully truncated %s\n", instance);
+    output.printf("Successfully truncated dataset '%s'\n", instance.getId());
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/TruncateStreamCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/TruncateStreamCommand.java
@@ -47,7 +47,7 @@ public class TruncateStreamCommand extends AbstractAuthCommand {
     Id.Stream streamId = Id.Stream.from(cliConfig.getCurrentNamespace(),
                                         arguments.get(ArgumentName.STREAM.toString()));
     streamClient.truncate(streamId);
-    output.printf("Successfully truncated stream '%s'\n", streamId);
+    output.printf("Successfully truncated stream '%s'\n", streamId.getId());
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/adapter/CreateAdapterCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/adapter/CreateAdapterCommand.java
@@ -58,13 +58,10 @@ public class CreateAdapterCommand extends AbstractAuthCommand {
     File adapterConfigFile = filePathResolver.resolvePathToFile(
       arguments.get(ArgumentName.ADAPTER_SPEC.toString()));
 
-    FileReader fileReader = new FileReader(adapterConfigFile);
-    try {
+    try (FileReader fileReader = new FileReader(adapterConfigFile)) {
       adapterClient.create(Id.Adapter.from(cliConfig.getCurrentNamespace(), adapterName),
                            GSON.fromJson(fileReader, AdapterConfig.class));
       output.printf("Successfully created adapter '%s'\n", adapterName);
-    } finally {
-      fileReader.close();
     }
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/adapter/DeleteAdapterCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/adapter/DeleteAdapterCommand.java
@@ -48,7 +48,7 @@ public class DeleteAdapterCommand extends AbstractAuthCommand {
                                          arguments.get(ArgumentName.ADAPTER.toString()));
 
     adapterClient.delete(adapter);
-    output.printf("Successfully deleted %s\n", adapter);
+    output.printf("Successfully deleted adapter '%s'\n", adapter.getId());
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/adapter/StartAdapterCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/adapter/StartAdapterCommand.java
@@ -47,7 +47,7 @@ public class StartAdapterCommand extends AbstractAuthCommand {
     Id.Adapter adapter = Id.Adapter.from(cliConfig.getCurrentNamespace(),
                                          arguments.get(ArgumentName.ADAPTER.toString()));
     adapterClient.start(adapter);
-    output.printf("Successfully started %s\n", adapter);
+    output.printf("Successfully started adapter '%s'\n", adapter.getId());
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/adapter/StopAdapterCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/adapter/StopAdapterCommand.java
@@ -47,7 +47,7 @@ public class StopAdapterCommand extends AbstractAuthCommand {
     Id.Adapter adapter = Id.Adapter.from(cliConfig.getCurrentNamespace(),
                                          arguments.get(ArgumentName.ADAPTER.toString()));
     adapterClient.stop(adapter);
-    output.printf("Successfully stopped %s\n", adapter);
+    output.printf("Successfully stopped adapter '%s'\n", adapter.getId());
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/commandset/ScheduleCommands.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/commandset/ScheduleCommands.java
@@ -128,7 +128,7 @@ public class ScheduleCommands extends CommandSet<Command> implements Categorized
       Id.Schedule scheduleId = Id.Schedule.from(cliConfig.getCurrentNamespace(), appId, scheduleName);
 
       scheduleClient.suspend(scheduleId);
-      printStream.printf("Successfully suspended schedule '%s'", scheduleId);
+      printStream.printf("Successfully suspended schedule '%s' in app '%s'\n", scheduleName, appId);
     }
 
     @Override
@@ -167,7 +167,7 @@ public class ScheduleCommands extends CommandSet<Command> implements Categorized
       Id.Schedule schedule = Id.Schedule.from(cliConfig.getCurrentNamespace(), appId, scheduleName);
 
       scheduleClient.resume(schedule);
-      printStream.printf("Successfully resumed schedule '%s'", schedule);
+      printStream.printf("Successfully resumed schedule '%s' in app '%s'\n", scheduleName, appId);
     }
 
     @Override


### PR DESCRIPTION
Aim of this PR is to make cli output consistent and more human readable (in same format as it was in previous release - 3.0).

In an older PR, the output of the CLI was changed to something less human readable.
https://github.com/caskdata/cdap/pull/2960

For instance, the output became (and currently is on release/3.1):
```
cdap (http://Alis-MacBook-Pro.local:10000/default)> delete app PurchaseHistory
Successfully deleted application 'namespace:default/application:PurchaseHistory'
```
```
cdap (http://Alis-MacBook-Pro.local:10000/default)> stop service PurchaseHistory.UserProfileService
Successfully stopped Service 'namespace:default/application:PurchaseHistory/program:services:UserProfileService' of application 'PurchaseHistory'
```

This PR changes the cli output back to how it was in previous release.
For example:
```
cdap (http://Alis-MacBook-Pro.local:10000/default)> stop service PurchaseHistory.UserProfileService
Successfully stopped Service 'UserProfileService' of application 'PurchaseHistory'
```

Additional example:
Schedule command (currently on release/3.1 branch):
```
cdap (http://Alis-MacBook-Pro.local:10000/default)> suspend schedule PurchaseHistory.DailySchedule
Successfully suspended schedule 'Schedule{application=namespace:default/application:PurchaseHistory, id=DailySchedule}'
```
As suggested by this PR (and how it was in previous CDAP release):
```
cdap (http://Alis-MacBook-Pro.local:10000/default)> suspend schedule PurchaseHistory.DailySchedule
Successfully suspended schedule 'DailySchedule' in app 'PurchaseHistory'
```

http://builds.cask.co/browse/CDAP-RBT369-4