### PR TITLE
CDAP-2765 Remove CLI security warnings

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -1080,14 +1080,8 @@
     </property>
 
     <property>
-      <name>security.auth.server.address</name>
-      <value></value>
-      <description>Deprecated. Use security.auth.server.bind.address instead.</description>
-    </property>
-
-    <property>
-      <name>security.auth.server.bind.address</name>
-      <value>0.0.0.0</value>
+        <name>security.auth.server.bind.address</name>
+        <value>0.0.0.0</value>
     </property>
 
     <property>


### PR DESCRIPTION
This is the same as #3353 but against `release/3.1`