### PR TITLE
make docs target paths project generic

### DIFF
--- a/cdap-docs/deploy.sh
+++ b/cdap-docs/deploy.sh
@@ -92,8 +92,8 @@ set_remote_dir () {
 DEBUG=${DEBUG:-no} #(optional)
 DEPLOY_TO_STG=${DEPLOY_TO_STG:-no}
 DEPLOY_TO_DOCS=${DEPLOY_TO_DOCS:-no}
-REMOTE_STG_BASE=${REMOTE_STG_BASE:-/var/www/html/${PROJECT}}
-REMOTE_DOCS_BASE=${REMOTE_DOCS_BASE:-/var/www/docs/${PROJECT}}
+REMOTE_STG_BASE=${REMOTE_STG_BASE:-/var/www/html/staging/}
+REMOTE_DOCS_BASE=${REMOTE_DOCS_BASE:-/var/www/docs/}
 
 ## bamboo global variables
 # DOCS_SERVER1
@@ -117,8 +117,8 @@ PROJECT_DOCS=${PROJECT}-docs
 ZIP_FILE=${PROJECT}-docs-${VERSION}-web.zip
 FILE_PATH=${BUILD_WORKING_DIR}/${PROJECT}/${PROJECT_DOCS}/build
 DOCS_SERVERS="${DOCS_SERVER1} ${DOCS_SERVER2}"
-REMOTE_STG_DIR="${REMOTE_STG_BASE}/${REMOTE_DIR}"
-REMOTE_DOCS_DIR="${REMOTE_DOCS_BASE}/${REMOTE_DIR}"
+REMOTE_STG_DIR="${REMOTE_STG_BASE}/${PROJECT}/${REMOTE_DIR}"		# e.g. /var/www/html/staging/cdap/develop
+REMOTE_DOCS_DIR="${REMOTE_DOCS_BASE}/${PROJECT}/${REMOTE_DIR}"		# e.g. /var/www/docs/cdap/release
 
 SSH_OPTS='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
 RSYNC_OPTS='-aPh'


### PR DESCRIPTION
This change allows us to remove 'cdap' from the bamboo global variable for staging and docs paths and make the paths generic (using $PROJECT which are already deriving from pom file in this script).

Note: This change will also be backported to release 3.1, 3.0 and 2.8

This CANNOT be merged until we disable all three docs build plans temporarily, backport and merge PRs for all four branches, and modify the two corresponding bamboo global variables.