### PR TITLE
Added back removed exceptions so that we remain backward compatible f…

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/AdapterNotFoundException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/AdapterNotFoundException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.exception;
+
+import co.cask.cdap.proto.Id;
+
+/**
+ * Thrown when an adapter was not found.
+ * @deprecated Use {@link co.cask.cdap.common.AdapterNotFoundException} instead
+ */
+@Deprecated
+public class AdapterNotFoundException extends NotFoundException {
+
+  private final Id.Adapter id;
+
+  public AdapterNotFoundException(Id.Adapter id) {
+    super(id);
+    this.id = id;
+  }
+
+  public Id.Adapter getId() {
+    return id;
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/AlreadyExistsException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/AlreadyExistsException.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.exception;
+
+import co.cask.cdap.proto.Id;
+
+/**
+ * Thrown when an element already exists.
+ * @deprecated Use {@link co.cask.cdap.common.AlreadyExistsException} instead
+ */
+@Deprecated
+public class AlreadyExistsException extends ConflictException {
+
+  private final Id objectId;
+
+  public AlreadyExistsException(Id id) {
+    super(String.format("'%s' already exists", id.getIdRep()));
+    this.objectId = id;
+  }
+
+  public Id getObjectId() {
+    return objectId;
+  }
+
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/ApplicationNotFoundException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/ApplicationNotFoundException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.exception;
+
+import co.cask.cdap.proto.Id;
+
+/**
+ * Thrown when an application is not found.
+ * @deprecated Use {@link co.cask.cdap.common.ApplicationNotFoundException} instead
+ */
+@Deprecated
+public class ApplicationNotFoundException extends NotFoundException {
+
+  private final Id.Application id;
+
+  public ApplicationNotFoundException(Id.Application id) {
+    super(id);
+    this.id = id;
+  }
+
+  public Id.Application getId() {
+    return id;
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/ApplicationTemplateNotFoundException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/ApplicationTemplateNotFoundException.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.exception;
+
+import co.cask.cdap.proto.Id;
+
+/**
+ * Thrown when an ApplicationTemplate is not found
+ * @deprecated Use {@link co.cask.cdap.common.ApplicationTemplateNotFoundException} instead
+ */
+@Deprecated
+public class ApplicationTemplateNotFoundException extends NotFoundException {
+
+  private final Id.ApplicationTemplate template;
+
+  public ApplicationTemplateNotFoundException(Id.ApplicationTemplate template) {
+    super(template);
+    this.template = template;
+  }
+
+  /**
+   * @return the template that was not found
+   */
+  public Id.ApplicationTemplate getTemplate() {
+    return template;
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/BadRequestException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/BadRequestException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.exception;
+
+/**
+ * Thrown when the input was bad.
+ * @deprecated Use {@link co.cask.cdap.common.BadRequestException} instead
+ */
+@Deprecated
+public class BadRequestException extends Exception {
+
+  public BadRequestException(String message) {
+    super(message);
+  }
+
+  public BadRequestException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/CannotBeCreatedException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/CannotBeCreatedException.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.exception;
+
+import co.cask.cdap.proto.Id;
+
+/**
+ * Thrown when an element cannot be created.
+ * @deprecated Use {@link co.cask.cdap.common.CannotBeCreatedException} instead
+ */
+@Deprecated
+public class CannotBeCreatedException extends Exception {
+
+  private final Id objectId;
+  private final String reason;
+
+  public CannotBeCreatedException(Id objectId, String reason) {
+    super(String.format("'%s' cannot be created. Reason: %s", objectId.getIdRep(), reason));
+    this.objectId = objectId;
+    this.reason = reason;
+  }
+
+  public CannotBeCreatedException(Id objectId, Throwable cause) {
+    super(String.format("'%s' cannot be created. Reason: %s", objectId.getIdRep(), cause.getMessage()), cause);
+    this.objectId = objectId;
+    this.reason = cause.getMessage();
+  }
+
+  public Id getObjectId() {
+    return objectId;
+  }
+
+  public String getReason() {
+    return reason;
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/CannotBeDeletedException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/CannotBeDeletedException.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.exception;
+
+import co.cask.cdap.proto.Id;
+
+/**
+ * Thrown when an element cannot be deleted.
+ * @deprecated Use {@link co.cask.cdap.common.CannotBeDeletedException} instead
+ */
+@Deprecated
+public class CannotBeDeletedException extends ConflictException {
+
+  private final Id objectId;
+  private final String reason;
+
+  public CannotBeDeletedException(Id id) {
+    super(String.format("'%s' could not be deleted", id.getIdRep()));
+    this.objectId = id;
+    this.reason = null;
+  }
+
+  public CannotBeDeletedException(Id id, String reason) {
+    super(String.format("'%s' could not be deleted. Reason: %s", id.getIdRep(), reason));
+    this.objectId = id;
+    this.reason = reason;
+  }
+
+  public CannotBeDeletedException(Id id, Throwable cause) {
+    super(String.format("'%s' could not be deleted. Reason: %s", id.getIdRep(), cause.getMessage()), cause);
+    this.objectId = id;
+    this.reason = cause.getMessage();
+  }
+
+  public Id getObjectId() {
+    return objectId;
+  }
+
+  public String getReason() {
+    return reason;
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/ConflictException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/ConflictException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.exception;
+
+/**
+ * Thrown when there was a conflict.
+ * @deprecated Use {@link co.cask.cdap.common.ConflictException} instead
+ */
+@Deprecated
+public class ConflictException extends Exception {
+
+  public ConflictException() {
+    super();
+  }
+
+  public ConflictException(String message) {
+    super(message);
+  }
+
+  public ConflictException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/DatasetAlreadyExistsException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/DatasetAlreadyExistsException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.exception;
+
+import co.cask.cdap.proto.Id;
+
+/**
+ * Thrown when the user tries to create a dataset, but a dataset already exists by that name.
+ * @deprecated Use {@link co.cask.cdap.common.DatasetAlreadyExistsException} instead
+ */
+@Deprecated
+public class DatasetAlreadyExistsException extends AlreadyExistsException {
+
+  private final Id.DatasetInstance id;
+
+  public DatasetAlreadyExistsException(Id.DatasetInstance id) {
+    super(id);
+    this.id = id;
+  }
+
+  public Id.DatasetInstance getId() {
+    return id;
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/DatasetModuleAlreadyExistsException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/DatasetModuleAlreadyExistsException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.exception;
+
+import co.cask.cdap.proto.Id;
+
+/**
+ * Thrown when the user tried to add a dataset module, but a dataset module by that name already exists.
+ * @deprecated Use {@link co.cask.cdap.common.DatasetModuleAlreadyExistsException} instead
+ */
+@Deprecated
+public class DatasetModuleAlreadyExistsException extends AlreadyExistsException {
+
+  private final Id.DatasetModule id;
+
+  public DatasetModuleAlreadyExistsException(Id.DatasetModule id) {
+    super(id);
+    this.id = id;
+  }
+
+  public Id.DatasetModule getId() {
+    return id;
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/DatasetModuleCannotBeDeletedException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/DatasetModuleCannotBeDeletedException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.exception;
+
+import co.cask.cdap.proto.Id;
+
+/**
+ * Thrown when a dataset module cannot be deleted.
+ * @deprecated Use {@link co.cask.cdap.common.DatasetModuleCannotBeDeletedException} instead
+ */
+@Deprecated
+public class DatasetModuleCannotBeDeletedException extends CannotBeDeletedException {
+
+  private final Id.DatasetModule id;
+
+  public DatasetModuleCannotBeDeletedException(Id.DatasetModule id) {
+    super(id);
+    this.id = id;
+  }
+
+  public Id.DatasetModule getId() {
+    return id;
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/DatasetModuleNotFoundException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/DatasetModuleNotFoundException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.exception;
+
+import co.cask.cdap.proto.Id;
+
+/**
+ * Thrown when a dataset module could not be found.
+ * @deprecated {@link co.cask.cdap.common.DatasetModuleNotFoundException} instead
+ */
+@Deprecated
+public class DatasetModuleNotFoundException extends NotFoundException {
+
+  private final Id.DatasetModule id;
+
+  public DatasetModuleNotFoundException(Id.DatasetModule id) {
+    super(id);
+    this.id = id;
+  }
+
+  public Id.DatasetModule getId() {
+    return id;
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/DatasetNotFoundException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/DatasetNotFoundException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.exception;
+
+import co.cask.cdap.proto.Id;
+
+/**
+ * Thrown when a dataset was not found.
+ * @deprecated Use {@link co.cask.cdap.common.DatasetNotFoundException} instead
+ */
+@Deprecated
+public class DatasetNotFoundException extends NotFoundException {
+
+  private final Id.DatasetInstance dataset;
+
+  public DatasetNotFoundException(Id.DatasetInstance dataset) {
+    super(dataset);
+    this.dataset = dataset;
+  }
+
+  public Id.DatasetInstance getId() {
+    return dataset;
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/DatasetTypeNotFoundException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/DatasetTypeNotFoundException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.exception;
+
+import co.cask.cdap.proto.Id;
+
+/**
+ * Thrown when a dataset type is not found
+ * @deprecated Use {@link co.cask.cdap.common.DatasetTypeNotFoundException} instead
+ */
+@Deprecated
+public class DatasetTypeNotFoundException extends NotFoundException {
+
+  private final Id.DatasetType id;
+
+  public DatasetTypeNotFoundException(Id.DatasetType id) {
+    super(id);
+    this.id = id;
+  }
+
+  public Id.DatasetType getId() {
+    return id;
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/HandlerException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/HandlerException.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.exception;
+
+import com.google.common.base.Charsets;
+import org.jboss.netty.buffer.ChannelBuffers;
+import org.jboss.netty.handler.codec.http.DefaultHttpResponse;
+import org.jboss.netty.handler.codec.http.HttpResponse;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+import org.jboss.netty.handler.codec.http.HttpVersion;
+
+/**
+ * Exception handling for failures in netty pipeline.
+ * @deprecated Use {@link co.cask.cdap.common.HandlerException} instead
+ */
+@Deprecated
+public final class HandlerException extends RuntimeException {
+
+  private final HttpResponseStatus failureStatus;
+  private String message;
+
+  public HandlerException(HttpResponseStatus failureStatus, String message) {
+    super(message);
+    this.failureStatus = failureStatus;
+    this.message = message;
+  }
+
+  public HandlerException(HttpResponseStatus failureStatus, String message, Throwable cause) {
+    super(message, cause);
+    this.failureStatus = failureStatus;
+    this.message = message;
+  }
+
+  public HttpResponse createFailureResponse() {
+    HttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, failureStatus);
+    response.setContent(ChannelBuffers.copiedBuffer(message, Charsets.UTF_8));
+    return response;
+  }
+
+  public HttpResponseStatus getFailureStatus() {
+    return failureStatus;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/HttpExceptionHandler.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/HttpExceptionHandler.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.exception;
+
+import co.cask.cdap.common.http.SecurityRequestContext;
+import co.cask.http.ExceptionHandler;
+import co.cask.http.HttpResponder;
+import org.jboss.netty.handler.codec.http.HttpRequest;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Common logic to handle exceptions in handler methods.
+ * @deprecated Use {@link co.cask.cdap.common.HttpExceptionHandler} instead
+ */
+@Deprecated
+public class HttpExceptionHandler extends ExceptionHandler {
+
+  private static final Logger LOG = LoggerFactory.getLogger(HttpExceptionHandler.class);
+
+  @Override
+  public void handle(Throwable t, HttpRequest request, HttpResponder responder) {
+    if (t instanceof BadRequestException) {
+      responder.sendString(HttpResponseStatus.BAD_REQUEST, t.getMessage());
+    } else if (t instanceof ConflictException) {
+      responder.sendString(HttpResponseStatus.CONFLICT, t.getMessage());
+    } else if (t instanceof NotFoundException) {
+      responder.sendString(HttpResponseStatus.NOT_FOUND, t.getMessage());
+    } else if (t instanceof UnauthorizedException) {
+      responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);
+    } else {
+      LOG.error("Unexpected error: request={} {} user={}:",
+                request.getMethod().getName(), request.getUri(),
+                SecurityRequestContext.getUserId().or("<null>"), t);
+      responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/NamespaceAlreadyExistsException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/NamespaceAlreadyExistsException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.exception;
+
+import co.cask.cdap.proto.Id;
+
+/**
+ * Thrown when a namespace already exists.
+ * @deprecated Use {@link co.cask.cdap.common.NamespaceAlreadyExistsException} instead
+ */
+@Deprecated
+public class NamespaceAlreadyExistsException extends AlreadyExistsException {
+
+  private final Id.Namespace id;
+
+  public NamespaceAlreadyExistsException(Id.Namespace id) {
+    super(id);
+    this.id = id;
+  }
+
+  public Id.Namespace getId() {
+    return id;
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/NamespaceCannotBeCreatedException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/NamespaceCannotBeCreatedException.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.exception;
+
+import co.cask.cdap.proto.Id;
+
+/**
+ * Thrown when a namespace cannot be created due to errors.
+ * @deprecated Use {@link co.cask.cdap.common.NamespaceCannotBeCreatedException} instead
+ */
+@Deprecated
+public class NamespaceCannotBeCreatedException extends CannotBeCreatedException {
+
+  private final Id.Namespace namespaceId;
+
+  public NamespaceCannotBeCreatedException(Id.Namespace namespaceId, String reason) {
+    super(namespaceId, reason);
+    this.namespaceId = namespaceId;
+  }
+
+  public NamespaceCannotBeCreatedException(Id.Namespace namespaceId, Throwable cause) {
+    super(namespaceId, cause);
+    this.namespaceId = namespaceId;
+  }
+
+  public Id.Namespace getNamespaceId() {
+    return namespaceId;
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/NamespaceCannotBeDeletedException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/NamespaceCannotBeDeletedException.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.exception;
+
+import co.cask.cdap.proto.Id;
+
+/**
+ * Thrown when a namespace cannot be deleted.
+ * @deprecated Use {@link co.cask.cdap.common.NamespaceCannotBeCreatedException} instead
+ */
+@Deprecated
+public class NamespaceCannotBeDeletedException extends CannotBeDeletedException {
+
+  private final Id.Namespace namespace;
+
+  public NamespaceCannotBeDeletedException(Id.Namespace id) {
+    super(id);
+    this.namespace = id;
+  }
+
+  public NamespaceCannotBeDeletedException(Id.Namespace id, String reason) {
+    super(id, reason);
+    this.namespace = id;
+  }
+
+  public NamespaceCannotBeDeletedException(Id.Namespace id, Throwable cause) {
+    super(id, cause);
+    this.namespace = id;
+  }
+
+  public Id.Namespace getNamespace() {
+    return namespace;
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/NamespaceNotFoundException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/NamespaceNotFoundException.java
@@ -16,12 +16,23 @@
 
 package co.cask.cdap.common.exception;
 
-/**
- * Thrown when there was an error in resetting the CDAP instance.
- */
-public class ResetFailureException extends Exception {
+import co.cask.cdap.proto.Id;
 
-  public ResetFailureException(String message) {
-    super(message);
+/**
+ * Thrown when a namespace is not found in CDAP.
+ * @deprecated Use {@link co.cask.cdap.common.NamespaceNotFoundException} instead
+ */
+@Deprecated
+public class NamespaceNotFoundException extends NotFoundException {
+
+  private final Id.Namespace namespace;
+
+  public NamespaceNotFoundException(Id.Namespace id) {
+    super(id);
+    this.namespace = id;
+  }
+
+  public Id.Namespace getId() {
+    return namespace;
   }
 }

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/NotFoundException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/NotFoundException.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.exception;
+
+import co.cask.cdap.proto.Id;
+
+/**
+ * Thrown when an element is not found
+ * @deprecated Use {@link co.cask.cdap.common.NotFoundException} instead
+ */
+@Deprecated
+public class NotFoundException extends Exception {
+
+  private final Object object;
+
+  public NotFoundException(Object object, String objectString) {
+    super(String.format("'%s' was not found", objectString));
+    this.object = object;
+  }
+
+  public NotFoundException(Object object) {
+    this(object, object.toString());
+  }
+
+  public NotFoundException(Id id) {
+    this(id, id.getIdRep());
+  }
+
+  public Object getObject() {
+    return object;
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/NotImplementedException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/NotImplementedException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.exception;
+
+/**
+ * Thrown when some operation is not implemented.
+ * @deprecated Use {@link co.cask.cdap.common.NotImplementedException} instead
+ */
+@Deprecated
+public class NotImplementedException extends Exception {
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/ProgramNotFoundException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/ProgramNotFoundException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.exception;
+
+import co.cask.cdap.proto.Id;
+
+/**
+ * Thrown when a program is not found
+ * @deprecated Use {@link co.cask.cdap.common.ProgramNotFoundException} instead
+ */
+@Deprecated
+public class ProgramNotFoundException extends NotFoundException {
+
+  private final Id.Program id;
+
+  public ProgramNotFoundException(Id.Program id) {
+    super(id);
+    this.id = id;
+  }
+
+  public Id.Program getId() {
+    return id;
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/QueryNotFoundException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/QueryNotFoundException.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.exception;
+
+import co.cask.cdap.proto.Id;
+
+/**
+ * Thrown when a query was not found by its handle.
+ * @deprecated Use {@link co.cask.cdap.common.QueryNotFoundException} instead
+ */
+@Deprecated
+public class QueryNotFoundException extends NotFoundException {
+
+  private final Id.QueryHandle id;
+
+  // TODO: namespace?
+  public QueryNotFoundException(Id.QueryHandle id) {
+    super(id);
+    this.id = id;
+  }
+
+  public Id.QueryHandle getId() {
+    return id;
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/ScheduleAlreadyExistsException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/ScheduleAlreadyExistsException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.exception;
+
+import co.cask.cdap.proto.Id;
+
+/**
+ * Thrown when the user tries to create a schedule that already exists.
+ * @deprecated Use {@link co.cask.cdap.common.ScheduleAlreadyExistsException} instead
+ */
+@Deprecated
+public class ScheduleAlreadyExistsException extends AlreadyExistsException {
+
+  private final Id.Schedule schedule;
+
+  public ScheduleAlreadyExistsException(Id.Schedule schedule) {
+    super(schedule);
+    this.schedule = schedule;
+  }
+
+  public Id.Schedule getSchedule() {
+    return schedule;
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/ScheduleNotFoundException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/ScheduleNotFoundException.java
@@ -16,9 +16,16 @@
 
 package co.cask.cdap.common.exception;
 
-/**
- * Thrown when reset is not enabled for the CDAP instance.
- */
-public class ResetNotEnabledException extends Exception {
+import co.cask.cdap.proto.Id;
 
+/**
+ * Thrown when a schedule is not found.
+ * @deprecated Use {@link co.cask.cdap.common.ScheduleNotFoundException} instead
+ */
+@Deprecated
+public class ScheduleNotFoundException extends NotFoundException {
+
+  public ScheduleNotFoundException(Id.Schedule schedule) {
+    super(schedule);
+  }
 }

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/ServiceNotEnabledException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/ServiceNotEnabledException.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.exception;
+
+/**
+ * Thrown when the user tried to execute some service operation, but the service was not enabled.
+ * @deprecated Use {@link co.cask.cdap.common.ServiceNotEnabledException} instead
+ */
+@Deprecated
+public class ServiceNotEnabledException extends Exception {
+
+  private final String serviceName;
+
+  public ServiceNotEnabledException(String serviceName) {
+    super("Service '" + serviceName + "' was not enabled");
+    this.serviceName = serviceName;
+  }
+
+  public String getServiceName() {
+    return serviceName;
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/ServiceNotFoundException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/ServiceNotFoundException.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.exception;
+
+import co.cask.cdap.proto.Id;
+
+/**
+ * Thrown when a stream is not found
+ * @deprecated Use {@link co.cask.cdap.common.ServiceNotFoundException} instead
+ */
+@Deprecated
+public class ServiceNotFoundException extends NotFoundException {
+
+  private final Id.Service id;
+
+
+  public ServiceNotFoundException(Id.Service id) {
+    super(id);
+    this.id = id;
+  }
+
+  public Id.Service getId() {
+    return id;
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/StreamNotFoundException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/StreamNotFoundException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.exception;
+
+import co.cask.cdap.proto.Id;
+
+/**
+ * Thrown when a stream is not found
+ * @deprecated Use {@link co.cask.cdap.common.StreamNotFoundException} instead
+ */
+@Deprecated
+public class StreamNotFoundException extends NotFoundException {
+
+  private final Id.Stream id;
+
+  public StreamNotFoundException(Id.Stream id) {
+    super(id);
+    this.id = id;
+  }
+
+  public Id.Stream getId() {
+    return id;
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/UnauthorizedException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/UnauthorizedException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.exception;
+
+/**
+ * Thrown when a user is not authorized to perform an operation.
+ * @deprecated Use {@link co.cask.cdap.common.UnauthorizedException} instead
+ */
+@Deprecated
+public class UnauthorizedException extends Exception {
+
+  public UnauthorizedException() {
+    super();
+  }
+
+  public UnauthorizedException(String msg, Throwable throwable) {
+    super(msg, throwable);
+  }
+
+  public UnauthorizedException(String message) {
+    super(message);
+  }
+
+}


### PR DESCRIPTION
…or the purposes of integration tests/app unit tests etc. Removed ``ResetException``s since they are not used anymore.

Build: http://builds.cask.co/browse/CDAP-RBT378
Jira to remove Deprecated Exceptions in 3.2: [CDAP-3124](https://issues.cask.co/browse/CDAP-3124)