### PR TITLE
Feature/ui styling adapter tooltip redesign

### DIFF
--- a/cdap-ui/app/directives/flow-graph/flow.js
+++ b/cdap-ui/app/directives/flow-graph/flow.js
@@ -191,7 +191,7 @@ module.directive('myFlowGraph', function ($filter, $state, $alert, myStreamServi
       scope.handleTooltip = function(tip, nodeId) {
         tip
           .html(function() {
-            return '<strong>' + nodeId + '</strong>';
+            return '<span>' + nodeId + '</span>';
           })
           .show();
       };
@@ -425,7 +425,7 @@ module.directive('myWorkflowGraph', function ($filter, $location) {
         if (['Start', 'End'].indexOf(nodeId) === -1) {
           tip
             .html(function() {
-              return '<strong>'+ scope.instanceMap[nodeId].nodeId + ' : ' + scope.instanceMap[nodeId].program.programName +'</strong>';
+              return '<span>'+ scope.instanceMap[nodeId].nodeId + ' : ' + scope.instanceMap[nodeId].program.programName +'</span>';
             })
             .show();
         }

--- a/cdap-ui/app/directives/flow-graph/flow.less
+++ b/cdap-ui/app/directives/flow-graph/flow.less
@@ -1,4 +1,5 @@
 @import "../../styles/variables.less";
+@import "../../styles/themes/cdap/mixins.less";
 
 my-flow-graph {
 
@@ -200,12 +201,13 @@ my-workflow-graph {
 
 .d3-tip {
   line-height: 1;
-  font-weight: bold;
-  padding: 12px;
-  background: rgba(0, 0, 0, 0.8);
+  font-size: 11px;
+  padding: 7px;
+  background: @cdap-header;
+  border: 1px solid @cdap-header;
   color: white;
-  border-radius: 2px;
   pointer-events: none;
+  .border-radius(3px);
 }
 
 /* Creates a small triangle extender for the tooltip */
@@ -215,7 +217,7 @@ my-workflow-graph {
   font-size: 10px;
   width: 100%;
   line-height: 1;
-  color: rgba(0, 0, 0, 0.8);
+  color: @cdap-header;
   position: absolute;
   pointer-events: none;
 }
@@ -223,7 +225,7 @@ my-workflow-graph {
 /* Style northward tooltips differently */
 .d3-tip.n:after {
   content: "\25BC";
-  margin: -1px 0 0 0;
+  margin: -3px 0 0 0;
   top: 100%;
   left: 0;
   text-align: center;

--- a/cdap-ui/app/directives/group-side-panel/group-side-panel.less
+++ b/cdap-ui/app/directives/group-side-panel/group-side-panel.less
@@ -182,12 +182,13 @@ my-side-panel {
   }
 }
 
-.tooltip-error {
+.tooltip.tooltip-error {
   z-index: 1020; // lower z-index than modal
 
   .tooltip-inner {
     background-color: @brand-danger;
     color: white;
+    border: 0;
   }
 
   &.tooltip.right .tooltip-arrow {

--- a/cdap-ui/app/features/adapters/templates/create/tabs/plugin-edit-form.html
+++ b/cdap-ui/app/features/adapters/templates/create/tabs/plugin-edit-form.html
@@ -116,7 +116,7 @@
                             <span>{{PluginEditController.groups[group].fields[field].label}}</span>
                             <span class="fa fa-info-circle"
                                   tooltip="{{description}}"
-                                  tooltip-placement="top"
+                                  tooltip-placement="right"
                                   tooltip-append-to-body="true">
                             </span>
                             <span class="fa fa-asterisk" ng-if="plugin._backendProperties[name].required"></span>
@@ -184,7 +184,7 @@
                               <span>{{name}}</span>
                               <span class="fa fa-info-circle"
                                     tooltip="{{description}}"
-                                    tooltip-placement="top"
+                                    tooltip-placement="right"
                                     tooltip-append-to-body="true">
                               </span>
                               <span class="fa fa-asterisk" ng-if="plugin._backendProperties[name].required"></span>
@@ -210,7 +210,7 @@
                                   <span>{{PluginEditController.groups[group].fields[field].label}}</span>
                                   <span class="fa fa-info-circle"
                                         tooltip="{{description}}"
-                                        tooltip-placement="top"
+                                        tooltip-placement="right"
                                         tooltip-append-to-body="true">
                                   </span>
                                   <span class="fa fa-asterisk" ng-if="plugin._backendProperties[name].required"></span>
@@ -286,7 +286,7 @@
                       <span>{{name}}</span>
                       <span class="fa fa-info-circle"
                             tooltip="{{description}}"
-                            tooltip-placement="top"
+                            tooltip-placement="right"
                             tooltip-append-to-body="true">
                       </span>
                       <span class="fa fa-asterisk" ng-if="plugin._backendProperties[name].required"></span>

--- a/cdap-ui/app/features/dashboard/templates/partials/wdgt-dd.html
+++ b/cdap-ui/app/features/dashboard/templates/partials/wdgt-dd.html
@@ -5,8 +5,7 @@
        tabindex="-1"
        href=""
        ng-click="caskPrompt('Widget name', wdgt.title)"
-       cask-promptable="currentBoard.renameWidget(wdgt, $value)"
-       title="rename widget">
+       cask-promptable="currentBoard.renameWidget(wdgt, $value)">
       <span class="fa fa-fw fa-pencil pull-right"></span>
       Edit
     </a>

--- a/cdap-ui/app/features/dashboard/templates/partials/wdgt-head.html
+++ b/cdap-ui/app/features/dashboard/templates/partials/wdgt-head.html
@@ -6,4 +6,4 @@
     <span class="fa fa-ellipsis-h"></span>
   </a>
 </div>
-<span ng-bind="wdgt.title | myEllipsis: 36 " tooltip="{{wdgt.title}}"></span>
+<span ng-bind="wdgt.title | myEllipsis: 36 "></span>

--- a/cdap-ui/app/features/dashboard/templates/staticdashboard.html
+++ b/cdap-ui/app/features/dashboard/templates/staticdashboard.html
@@ -5,7 +5,7 @@
       <div class="panel panel-default" style="margin:0;">
         <div class="panel-heading">
           <div class="btn-group btn-group-xs" role="toolbar"></div>
-          <span ng-bind="wdgt.title | myEllipsis: 25" tooltip="{{wdgt.title}}"></span>
+          <span ng-bind="wdgt.title | myEllipsis: 25"></span>
         </div>
         <div class="panel-body" ng-include="wdgt.getPartial()"></div>
       </div>

--- a/cdap-ui/app/styles/themes/cdap/theme.less
+++ b/cdap-ui/app/styles/themes/cdap/theme.less
@@ -427,5 +427,47 @@ body.theme-cdap {
   //
   // Tooltips
   // --------------------------------------------------
-  .tooltip-inner { padding: 5px; }
+  .tooltip {
+    font-size: 11px;
+    &.top {
+      margin-top: -2px;
+      .tooltip-arrow {
+        bottom: 0;
+        left: 50%;
+        margin-left: -5px;
+        border-left: 5px solid transparent;
+        border-right: 5px solid transparent;
+        border-top: 5px solid @cdap-header;
+      }
+    }
+    &.right {
+      margin-left: 2px;
+      .tooltip-arrow {
+        top: 50%;
+        left: 0;
+        margin-top: -5px;
+        border-top: 5px solid transparent;
+        border-bottom: 5px solid transparent;
+        border-right: 5px solid @cdap-header;
+      }
+    }
+    &.left {
+      margin-left: -2px;
+      .tooltip-arrow {
+        top: 50%;
+        right: 0;
+        margin-top: -5px;
+        border-top: 5px solid transparent;
+        border-bottom: 5px solid transparent;
+        border-left: 5px solid @cdap-header;
+      }
+    }
+  }
+  .tooltip-inner {
+    background-color: @cdap-header;
+    border: 1px solid @cdap-header;
+    color: white;
+    padding: 7px;
+    .border-radius(3px);
+  }
 }


### PR DESCRIPTION
*  Adds custom styling to tooltips
*  Changes tooltip placement in adapter modals
*  Removes tooltip-like title attributes from user dashboard widget headers
*  Removes tooltips from static dashboard widget headers
*  Wraps d3-tip inside a \<span>

For the purposes of this PR, the GIF below reflects the updated tooltip styling in adapter create alone:
![tooltips](https://cloud.githubusercontent.com/assets/5335210/8969989/ae93b702-35fb-11e5-8518-250d1f1e5379.gif)
