### PR TITLE
[CDAP-3077] Added another config parameter in Table Sink to allow cas…

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/data/schema/Schema.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/data/schema/Schema.java
@@ -116,6 +116,11 @@ public final class Schema {
     public Schema getSchema() {
       return schema;
     }
+
+    @Override
+    public String toString() {
+      return String.format("{name: %s, schema: %s}", name, schema);
+    }
   }
 
   /**

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricClient.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricClient.java
@@ -458,4 +458,12 @@ public class AppFabricClient {
       throw Throwables.propagate(e);
     }
   }
+
+  public void deleteAdapter(Id.Adapter adapterId) throws Exception {
+    String url = String.format("%s/adapters/%s", getNamespacePath(adapterId.getNamespaceId()), adapterId.getId());
+    DefaultHttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.DELETE, url);
+    MockResponder responder = new MockResponder();
+    adapterHttpHandler.deleteAdapter(request, responder, adapterId.getNamespaceId(), adapterId.getId());
+    verifyResponse(HttpResponseStatus.valueOf(200), responder.getStatus(), "Failed to delete adapter.");
+  }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/sink/TableSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/sink/TableSink.java
@@ -23,18 +23,17 @@ import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.api.dataset.lib.KeyValue;
 import co.cask.cdap.api.dataset.table.Put;
 import co.cask.cdap.api.dataset.table.Table;
-import co.cask.cdap.api.templates.plugins.PluginConfig;
 import co.cask.cdap.template.etl.api.Emitter;
 import co.cask.cdap.template.etl.api.PipelineConfigurer;
 import co.cask.cdap.template.etl.api.batch.BatchSinkContext;
 import co.cask.cdap.template.etl.common.Properties;
 import co.cask.cdap.template.etl.common.RecordPutTransformer;
+import co.cask.cdap.template.etl.common.TableConfig;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
 
 import java.util.Map;
-import javax.annotation.Nullable;
 
 /**
  * CDAP Table Dataset Batch Sink.
@@ -43,40 +42,9 @@ import javax.annotation.Nullable;
 @Name("Table")
 @Description("CDAP Table Dataset Batch Sink")
 public class TableSink extends BatchWritableSink<StructuredRecord, byte[], Put> {
-  private static final String NAME_DESC = "Name of the table dataset. If it does not already exist, one will be " +
-    "created.";
-  private static final String PROPERTY_SCHEMA_DESC = "Optional schema of the table as a JSON Object. If the table " +
-    "does not already exist, one will be created with this schema, which will allow the table to be explored " +
-    "through Hive.";
-  private static final String PROPERTY_SCHEMA_ROW_FIELD_DESC = "The name of the record field that should be used as " +
-    "the row key when writing to the table.";
-
-  private RecordPutTransformer recordPutTransformer;
-
-  /**
-   * Config class for TableSink
-   */
-  public static class TableConfig extends PluginConfig {
-    @Description(NAME_DESC)
-    private String name;
-
-    @Name(Properties.Table.PROPERTY_SCHEMA)
-    @Description(PROPERTY_SCHEMA_DESC)
-    @Nullable
-    String schemaStr;
-
-    @Name(Properties.Table.PROPERTY_SCHEMA_ROW_FIELD)
-    @Description(PROPERTY_SCHEMA_ROW_FIELD_DESC)
-    String rowField;
-
-    public TableConfig(String name, String schemaStr, String rowField) {
-      this.name = name;
-      this.schemaStr = schemaStr;
-      this.rowField = rowField;
-    }
-  }
 
   private final TableConfig tableConfig;
+  private RecordPutTransformer recordPutTransformer;
 
   public TableSink(TableConfig tableConfig) {
     this.tableConfig = tableConfig;
@@ -85,19 +53,20 @@ public class TableSink extends BatchWritableSink<StructuredRecord, byte[], Put> 
   @Override
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
     super.configurePipeline(pipelineConfigurer);
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(tableConfig.rowField), "Row field must be given as a property.");
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(tableConfig.getRowField()),
+                                "Row field must be given as a property.");
   }
 
   @Override
   public void initialize(BatchSinkContext context) throws Exception {
     super.initialize(context);
-    recordPutTransformer = new RecordPutTransformer(tableConfig.rowField);
+    recordPutTransformer = new RecordPutTransformer(tableConfig.getRowField(), tableConfig.isRowFieldCaseInsensitive());
   }
 
   @Override
   protected Map<String, String> getProperties() {
     Map<String, String> properties = Maps.newHashMap(tableConfig.getProperties().getProperties());
-    properties.put(Properties.BatchReadableWritable.NAME, tableConfig.name);
+    properties.put(Properties.BatchReadableWritable.NAME, tableConfig.getName());
     properties.put(Properties.BatchReadableWritable.TYPE, Table.class.getName());
     return properties;
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/source/TableSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/source/TableSource.java
@@ -24,18 +24,17 @@ import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.dataset.lib.KeyValue;
 import co.cask.cdap.api.dataset.table.Row;
 import co.cask.cdap.api.dataset.table.Table;
-import co.cask.cdap.api.templates.plugins.PluginConfig;
 import co.cask.cdap.template.etl.api.Emitter;
 import co.cask.cdap.template.etl.api.PipelineConfigurer;
 import co.cask.cdap.template.etl.api.batch.BatchSourceContext;
 import co.cask.cdap.template.etl.common.Properties;
 import co.cask.cdap.template.etl.common.RowRecordTransformer;
+import co.cask.cdap.template.etl.common.TableConfig;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
 
 import java.util.Map;
-import javax.annotation.Nullable;
 
 /**
  * CDAP Table Dataset Batch Source.
@@ -46,38 +45,6 @@ import javax.annotation.Nullable;
 public class TableSource extends BatchReadableSource<byte[], Row, StructuredRecord> {
   private RowRecordTransformer rowRecordTransformer;
 
-  private static final String NAME_DESC = "Table name. If the table does not already exist, it will be created.";
-  private static final String PROPERTY_SCHEMA_DESC = "Schema of records read from the Table. Row columns map to " +
-    "record fields. For example, if the schema contains a field named 'user' of type string, " +
-    "the value of that field will be taken from the value stored in the 'user' column. " +
-    "Only simple types are allowed (boolean, int, long, float, double, bytes, string).";
-  private static final String PROPERTY_SCHEMA_ROW_FIELD_DESC = "Optional field name indicating that the field " +
-    "value should come from the row key instead of a row column. The field name specified must be present in the " +
-    "schema, and must not be nullable.";
-
-  /**
-   * Config class for TableSource
-   */
-  public static class TableConfig extends PluginConfig {
-    @Description(NAME_DESC)
-    String name;
-
-    @Name(Properties.Table.PROPERTY_SCHEMA)
-    @Description(PROPERTY_SCHEMA_DESC)
-    String schemaStr;
-
-    @Name(Properties.Table.PROPERTY_SCHEMA_ROW_FIELD)
-    @Description(PROPERTY_SCHEMA_ROW_FIELD_DESC)
-    @Nullable
-    String rowField;
-
-    public TableConfig(String name, String schemaStr, String rowField) {
-      this.name = name;
-      this.schemaStr = schemaStr;
-      this.rowField = rowField;
-    }
-  }
-
   private final TableConfig tableConfig;
 
   public TableSource(TableConfig tableConfig) {
@@ -87,7 +54,7 @@ public class TableSource extends BatchReadableSource<byte[], Row, StructuredReco
   @Override
   protected Map<String, String> getProperties() {
     Map<String, String> properties = Maps.newHashMap(tableConfig.getProperties().getProperties());
-    properties.put(Properties.BatchReadableWritable.NAME, tableConfig.name);
+    properties.put(Properties.BatchReadableWritable.NAME, tableConfig.getName());
     properties.put(Properties.BatchReadableWritable.TYPE, Table.class.getName());
     return properties;
   }
@@ -95,14 +62,14 @@ public class TableSource extends BatchReadableSource<byte[], Row, StructuredReco
   @Override
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
     super.configurePipeline(pipelineConfigurer);
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(tableConfig.schemaStr), "Schema must be specified.");
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(tableConfig.getSchemaStr()), "Schema must be specified.");
   }
 
   @Override
   public void initialize(BatchSourceContext context) throws Exception {
     super.initialize(context);
-    Schema schema = Schema.parseJson(tableConfig.schemaStr);
-    rowRecordTransformer = new RowRecordTransformer(schema, tableConfig.rowField);
+    Schema schema = Schema.parseJson(tableConfig.getSchemaStr());
+    rowRecordTransformer = new RowRecordTransformer(schema, tableConfig.getRowField());
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/common/Properties.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/common/Properties.java
@@ -109,6 +109,7 @@ public final class Properties {
     public static final String PROPERTY_SCHEMA = co.cask.cdap.api.dataset.table.Table.PROPERTY_SCHEMA;
     public static final String PROPERTY_SCHEMA_ROW_FIELD =
       co.cask.cdap.api.dataset.table.Table.PROPERTY_SCHEMA_ROW_FIELD;
+    public static final String CASE_SENSITIVE_ROW_FIELD = "case.sensitive.row.field";
   }
 
   /**

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/common/TableConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/common/TableConfig.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.template.etl.common;
+
+import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.templates.plugins.PluginConfig;
+import co.cask.cdap.template.etl.batch.sink.TableSink;
+import co.cask.cdap.template.etl.realtime.sink.RealtimeTableSink;
+
+import javax.annotation.Nullable;
+
+/**
+ * {@link PluginConfig} for {@link TableSink} and {@link RealtimeTableSink}
+ */
+public class TableConfig extends PluginConfig {
+  @Name(Properties.Table.NAME)
+  @Description("Name of the table. If the table does not already exist, one will be created.")
+  private String name;
+
+  @Name(Properties.Table.PROPERTY_SCHEMA)
+  @Description("Optional schema of the table as a JSON Object. If the table does not already exist, one will be " +
+    "created with this schema, which will allow the table to be explored through Hive.")
+  @Nullable
+  private String schemaStr;
+
+  @Name(Properties.Table.PROPERTY_SCHEMA_ROW_FIELD)
+  @Description("The name of the record field that should be used as the row key when writing to the table.")
+  private String rowField;
+
+  @Name(Properties.Table.CASE_SENSITIVE_ROW_FIELD)
+  @Description("Whether or not schema.row.field is case sensitive, defaults to true.")
+  @Nullable
+  private Boolean rowFieldCaseSensitive;
+
+  public TableConfig() {
+    this.rowFieldCaseSensitive = true;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  @Nullable
+  public String getSchemaStr() {
+    return schemaStr;
+  }
+
+  public String getRowField() {
+    return rowField;
+  }
+
+  public Boolean isRowFieldCaseInsensitive() {
+    return rowFieldCaseSensitive;
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/realtime/sink/RealtimeTableSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/realtime/sink/RealtimeTableSink.java
@@ -30,6 +30,7 @@ import co.cask.cdap.template.etl.api.realtime.RealtimeContext;
 import co.cask.cdap.template.etl.api.realtime.RealtimeSink;
 import co.cask.cdap.template.etl.common.Properties;
 import co.cask.cdap.template.etl.common.RecordPutTransformer;
+import co.cask.cdap.template.etl.common.TableConfig;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 
@@ -44,39 +45,7 @@ import javax.annotation.Nullable;
 @Description("Real Time Sink for CDAP Table dataset")
 public class RealtimeTableSink extends RealtimeSink<StructuredRecord> {
 
-  private static final String NAME_DESC = "Name of the table. If the table does not already exist, one will be " +
-    "created.";
-  private static final String PROPERTY_SCHEMA_DESC = "Optional schema of the table as a JSON Object. If the table " +
-    "does not already exist, one will be created with this schema, which will allow the table to be explored " +
-    "through Hive.\"";
-  private static final String PROPERTY_SCHEMA_ROW_FIELD_DESC = "The name of the record field that should be used as " +
-    "the row key when writing to the table.";
-
   private RecordPutTransformer recordPutTransformer;
-
-  /**
-   * Config class for RealtimeTableSink
-   */
-  public static class TableConfig extends PluginConfig {
-    @Name(Properties.Table.NAME)
-    @Description(NAME_DESC)
-    private String name;
-
-    @Name(Properties.Table.PROPERTY_SCHEMA)
-    @Description(PROPERTY_SCHEMA_DESC)
-    @Nullable
-    String schemaStr;
-
-    @Name(Properties.Table.PROPERTY_SCHEMA_ROW_FIELD)
-    @Description(PROPERTY_SCHEMA_ROW_FIELD_DESC)
-    String rowField;
-
-    public TableConfig(String name, String schemaStr, String rowField) {
-      this.name = name;
-      this.schemaStr = schemaStr;
-      this.rowField = rowField;
-    }
-  }
 
   private final TableConfig tableConfig;
 
@@ -87,10 +56,10 @@ public class RealtimeTableSink extends RealtimeSink<StructuredRecord> {
   @Override
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
     Map<String, String> properties = tableConfig.getProperties().getProperties();
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(tableConfig.name), "Dataset name must be given.");
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(tableConfig.rowField),
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(tableConfig.getName()), "Dataset name must be given.");
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(tableConfig.getRowField()),
                                 "Field to be used as rowkey must be given.");
-    pipelineConfigurer.createDataset(tableConfig.name, Table.class.getName(), DatasetProperties.builder()
+    pipelineConfigurer.createDataset(tableConfig.getName(), Table.class.getName(), DatasetProperties.builder()
       .addAll(properties)
       .build());
   }
@@ -98,12 +67,12 @@ public class RealtimeTableSink extends RealtimeSink<StructuredRecord> {
   @Override
   public void initialize(RealtimeContext context) throws Exception {
     super.initialize(context);
-    recordPutTransformer = new RecordPutTransformer(tableConfig.rowField);
+    recordPutTransformer = new RecordPutTransformer(tableConfig.getRowField(), tableConfig.isRowFieldCaseInsensitive());
   }
 
   @Override
   public int write(Iterable<StructuredRecord> records, DataWriter writer) throws Exception {
-    Table table = writer.getDataset(tableConfig.name);
+    Table table = writer.getDataset(tableConfig.getName());
     int numRecords = 0;
     for (StructuredRecord record : records) {
       Put put = recordPutTransformer.toPut(record);

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/template/etl/common/RecordPutTransformerTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/template/etl/common/RecordPutTransformerTest.java
@@ -29,7 +29,7 @@ import java.util.Map;
  */
 @SuppressWarnings("unchecked")
 public class RecordPutTransformerTest {
-  
+
   @Test(expected = IllegalArgumentException.class)
   public void testNullRowkeyThrowsException() throws Exception {
     RecordPutTransformer transformer = new RecordPutTransformer("key");
@@ -100,5 +100,32 @@ public class RecordPutTransformerTest {
     Assert.assertTrue(Math.abs(3.14f - Bytes.toFloat(values.get(Bytes.toBytes("floatField")))) < 0.000001);
     Assert.assertTrue(Math.abs(3.14 - Bytes.toDouble(values.get(Bytes.toBytes("doubleField")))) < 0.000001);
     Assert.assertArrayEquals(Bytes.toBytes("foo"), values.get(Bytes.toBytes("bytesField")));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testCaseSensitiveRowKey() {
+    RecordPutTransformer transformer = new RecordPutTransformer("key");
+    Schema schema = Schema.recordOf("record", Schema.Field.of("KEY", Schema.of(Schema.Type.STRING)));
+    StructuredRecord record = StructuredRecord.builder(schema).set("KEY", "someKey").build();
+    transformer.toPut(record);
+  }
+
+  @Test
+  public void testCaseInsensitiveRowKeyValid() {
+    RecordPutTransformer transformer = new RecordPutTransformer("key", false);
+    Schema schema = Schema.recordOf("record", Schema.Field.of("KEY", Schema.of(Schema.Type.STRING)));
+    StructuredRecord record = StructuredRecord.builder(schema).set("KEY", "someKey").build();
+    Put put = transformer.toPut(record);
+    Assert.assertEquals("someKey", Bytes.toString(put.getRow()));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testCaseInsensitiveRowKeyInvalid() {
+    RecordPutTransformer transformer = new RecordPutTransformer("key", false);
+    Schema schema = Schema.recordOf("record",
+                                    Schema.Field.of("KEY", Schema.of(Schema.Type.STRING)),
+                                    Schema.Field.of("Key", Schema.nullableOf(Schema.of(Schema.Type.BYTES))));
+    StructuredRecord record = StructuredRecord.builder(schema).set("KEY", "someKey").set("Key", "someOtherKey").build();
+    transformer.toPut(record);
   }
 }

--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteAdapterManager.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteAdapterManager.java
@@ -60,4 +60,9 @@ public class RemoteAdapterManager extends AbstractAdapterManager {
     // TODO: implement
     return null;
   }
+
+  @Override
+  public void delete() throws Exception {
+    // TODO: implement
+  }
 }

--- a/cdap-test/src/main/java/co/cask/cdap/test/AdapterManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/AdapterManager.java
@@ -90,4 +90,9 @@ public interface AdapterManager {
    */
   void waitForRunsToFinish(int numRuns, long timeout,
                            TimeUnit timeoutUnit) throws TimeoutException, InterruptedException;
+
+  /**
+   * Deletes the adapter.
+   */
+  void delete() throws Exception;
 }

--- a/cdap-ui/templates/common/Table.json
+++ b/cdap-ui/templates/common/Table.json
@@ -24,6 +24,16 @@
              "widget": "textbox",
              "label" : "Row Field",
              "description" : "Specify the field from the record above that should be used as key"
+          },
+
+          "case.sensitive.row.field" : {
+             "widget": "select",
+             "label" : "Case-Sensitive Row Field",
+             "properties" : {
+               "values" : [ "true", "false" ],
+               "default" : "true"
+             },
+             "description" : "Specify whether the row field specified in schema.row.field is case sensitive"
           }
        }
     }

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultAdapterManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultAdapterManager.java
@@ -58,4 +58,10 @@ public class DefaultAdapterManager extends AbstractAdapterManager {
     return appFabricClient.getAdapterRun(adapterId, runId);
   }
 
+  @Override
+  public void delete() throws Exception {
+    appFabricClient.deleteAdapter(adapterId);
+  }
+
+
 }


### PR DESCRIPTION
…e-insensitive find for row key field in the incoming record's schema.

Also:
- Refactored TableSink, RealtimeTableSink and TableSource to share their PluginConfig class.
- Added a delete() method to AdapterManager for cleanup in tests. Still not implemented in RemoteAdapterManager.

re-use table config in TableSource


This was wrongly merged to develop. Creating against release/3.1. Already reviewed in #3366 