### PR TITLE
Explicitly set list of Eclipse plugins to install and set HDP 2.1

### DIFF
--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu12.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu12.json
@@ -1,6 +1,6 @@
 {
   "variables": {
-    "sdk_version": "3.0.0"
+    "sdk_version": "3.1.0"
   },
   "builders": [
     {
@@ -78,10 +78,18 @@
         "eclipse": {
           "version": "Luna",
           "release_code": "SR2",
+          "plugins": [
+            { "http://download.eclipse.org/releases/luna": "org.eclipse.egit.feature.group" },
+            { "http://download.eclipse.org/technology/m2e/releases": "org.eclipse.m2e.feature.feature.group" }
+          ],
           "url": "http://mirrors.ibiblio.org/pub/mirrors/eclipse/technology/epp/downloads/release/luna/SR2/eclipse-jee-luna-SR2-linux-gtk-x86_64.tar.gz"
         },
         "idea": {
           "setup_dir": "/opt"
+        },
+        "hadoop": {
+          "distribution": "hdp",
+          "distribution_version": "2.1.7.0"
         },
         "java": {
           "install_flavor": "oracle",


### PR DESCRIPTION
This fixes the VM build for release.

- Using a known-good version of HDP to get Flume Agent
- Set `sdk_version` default to `3.1.0`
- Set explicit list of Eclipse plugins to install