### PR TITLE
CDAP-2376: Make sure Mapper/Reducer Logs are flushed 

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextProvider.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextProvider.java
@@ -90,6 +90,12 @@ public final class MapReduceContextProvider {
     return context;
   }
 
+  public synchronized void stop() {
+    if (contextBuilder != null) {
+      contextBuilder.finish();
+    }
+  }
+
   private synchronized AbstractMapReduceContextBuilder getBuilder(CConfiguration conf) {
     if (contextBuilder != null) {
       return contextBuilder;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextProvider.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextProvider.java
@@ -90,6 +90,8 @@ public final class MapReduceContextProvider {
     return context;
   }
 
+  // TODO: CDAP-3160 : Refactor to remove the need for the stop method below. Provider/Builder classes should not have
+  // methods like stop(), finish() or close().
   public synchronized void stop() {
     if (contextBuilder != null) {
       contextBuilder.finish();

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
@@ -97,6 +97,7 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
@@ -773,8 +774,19 @@ final class MapReduceRuntimeService extends AbstractExecutionThreadService {
       LOG.warn("Not including HBaseTableUtil classes in submitted Job Jar since they are not available");
     }
 
+    // Add the logback.xml as a resource while creating the MapReduce Job JAR
+    Set<URI> logbackURI = Sets.newHashSet();
+    try {
+      URL logback = getClass().getResource("logback.xml");
+      if (logback != null) {
+        logbackURI.add(logback.toURI());
+      }
+    } catch (URISyntaxException e) {
+      LOG.warn("Could not find logback.xml during building MapReduce Job JAR", e);
+    }
+
     ClassLoader oldCLassLoader = ClassLoaders.setContextClassLoader(job.getConfiguration().getClassLoader());
-    appBundler.createBundle(new LocalLocationFactory().create(jobJar.toURI()), classes);
+    appBundler.createBundle(new LocalLocationFactory().create(jobJar.toURI()), classes, logbackURI);
     ClassLoaders.setContextClassLoader(oldCLassLoader);
 
     LOG.info("Built MapReduce Job Jar at {}", jobJar.toURI());

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
@@ -706,7 +706,7 @@ final class MapReduceRuntimeService extends AbstractExecutionThreadService {
    *
    * @return a new {@link File} containing the job jar
    */
-  private File buildJobJar(Job job, File tempDir) throws IOException {
+  private File buildJobJar(Job job, File tempDir) throws IOException, URISyntaxException {
     File jobJar = new File(tempDir, "job.jar");
     LOG.debug("Creating Job jar: {}", jobJar);
 
@@ -776,13 +776,11 @@ final class MapReduceRuntimeService extends AbstractExecutionThreadService {
 
     // Add the logback.xml as a resource while creating the MapReduce Job JAR
     Set<URI> logbackURI = Sets.newHashSet();
-    try {
-      URL logback = getClass().getResource("logback.xml");
-      if (logback != null) {
-        logbackURI.add(logback.toURI());
-      }
-    } catch (URISyntaxException e) {
-      LOG.warn("Could not find logback.xml during building MapReduce Job JAR", e);
+    URL logback = getClass().getResource("/logback.xml");
+    if (logback != null) {
+      logbackURI.add(logback.toURI());
+    } else {
+      LOG.warn("Could not find logback.xml while building MapReduce Job JAR!");
     }
 
     ClassLoader oldCLassLoader = ClassLoaders.setContextClassLoader(job.getConfiguration().getClassLoader());

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/ReducerWrapper.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/ReducerWrapper.java
@@ -65,6 +65,7 @@ public class ReducerWrapper extends Reducer {
     MapReduceContextProvider mrContextProvider =
       new MapReduceContextProvider(context, MapReduceMetrics.TaskType.Reducer);
     final BasicMapReduceContext basicMapReduceContext = mrContextProvider.get();
+    LoggingContextAccessor.setLoggingContext(basicMapReduceContext.getLoggingContext());
     basicMapReduceContext.getMetricsCollectionService().startAndWait();
 
     try {
@@ -82,8 +83,6 @@ public class ReducerWrapper extends Reducer {
         LOG.error("Failed to inject fields to {}.", delegate.getClass(), t);
         throw Throwables.propagate(t);
       }
-
-      LoggingContextAccessor.setLoggingContext(basicMapReduceContext.getLoggingContext());
 
       // this is a hook for periodic flushing of changes buffered by datasets (to avoid OOME)
       WrappedReducer.Context flushingContext = createAutoFlushingContext(context, basicMapReduceContext);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/ReducerWrapper.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/ReducerWrapper.java
@@ -36,7 +36,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Wraps user-defined implementation of {@link Reducer} class which allows perform extra configuration.
@@ -135,7 +134,7 @@ public class ReducerWrapper extends Reducer {
       try {
         basicMapReduceContext.close(); // closes all datasets
       } finally {
-        basicMapReduceContext.getMetricsCollectionService().stop();
+        mrContextProvider.stop();
       }
     }
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/DataSetInputFormat.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/DataSetInputFormat.java
@@ -75,11 +75,11 @@ public final class DataSetInputFormat<KEY, VALUE> extends InputFormat<KEY, VALUE
     BasicMapReduceContext mrContext = contextProvider.get();
     mrContext.getMetricsCollectionService().startAndWait();
     String dataSetName = getInputName(conf);
-    BatchReadable<KEY, VALUE> inputDataset = (BatchReadable<KEY, VALUE>) mrContext.getDataset(dataSetName);
+    BatchReadable<KEY, VALUE> inputDataset = mrContext.getDataset(dataSetName);
     SplitReader<KEY, VALUE> splitReader = inputDataset.createSplitReader(inputSplit.getSplit());
 
     // the record reader now owns the context and will close it
-    return new DataSetRecordReader<>(splitReader, mrContext);
+    return new DataSetRecordReader<>(splitReader, contextProvider);
   }
 
   private String getInputName(Configuration conf) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/DataSetOutputFormat.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/DataSetOutputFormat.java
@@ -56,10 +56,10 @@ public final class DataSetOutputFormat<KEY, VALUE> extends OutputFormat<KEY, VAL
     BasicMapReduceContext mrContext = contextProvider.get();
     mrContext.getMetricsCollectionService().startAndWait();
     @SuppressWarnings("unchecked")
-    BatchWritable<KEY, VALUE> dataset = (BatchWritable<KEY, VALUE>) mrContext.getDataset(getOutputDataSet(conf));
+    BatchWritable<KEY, VALUE> dataset = mrContext.getDataset(getOutputDataSet(conf));
 
     // the record writer now owns the context and will close it
-    return new DataSetRecordWriter<>(dataset, mrContext);
+    return new DataSetRecordWriter<>(dataset, contextProvider);
   }
 
   private String getOutputDataSet(Configuration conf) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/DataSetRecordReader.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/DataSetRecordReader.java
@@ -19,6 +19,7 @@ package co.cask.cdap.internal.app.runtime.batch.dataset;
 import co.cask.cdap.api.data.batch.SplitReader;
 import co.cask.cdap.common.logging.LoggingContextAccessor;
 import co.cask.cdap.internal.app.runtime.batch.BasicMapReduceContext;
+import co.cask.cdap.internal.app.runtime.batch.MapReduceContextProvider;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
@@ -30,12 +31,14 @@ import java.io.IOException;
 final class DataSetRecordReader<KEY, VALUE> extends RecordReader<KEY, VALUE> {
   private static final Logger LOG = LoggerFactory.getLogger(DataSetRecordReader.class);
   private final SplitReader<KEY, VALUE> splitReader;
+  private final MapReduceContextProvider mrContextProvider;
   private final BasicMapReduceContext context;
 
   public DataSetRecordReader(final SplitReader<KEY, VALUE> splitReader,
-                             BasicMapReduceContext context) {
+                             final MapReduceContextProvider mrContextProvider) {
     this.splitReader = splitReader;
-    this.context = context;
+    this.mrContextProvider = mrContextProvider;
+    this.context = mrContextProvider.get();
   }
 
   @Override
@@ -75,7 +78,7 @@ final class DataSetRecordReader<KEY, VALUE> extends RecordReader<KEY, VALUE> {
       try {
         context.close();
       } finally {
-        context.getMetricsCollectionService().stop();
+        mrContextProvider.stop();
       }
     }
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/distributed/DistributedMapReduceContextBuilder.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/distributed/DistributedMapReduceContextBuilder.java
@@ -50,6 +50,7 @@ public class DistributedMapReduceContextBuilder extends AbstractMapReduceContext
   private ZKClientService zkClientService;
   private KafkaClientService kafkaClientService;
   private MetricsCollectionService metricsCollectionService;
+  private LogAppenderInitializer logAppenderInitializer;
 
   public DistributedMapReduceContextBuilder(CConfiguration cConf, Configuration hConf) {
     this.cConf = cConf;
@@ -90,7 +91,7 @@ public class DistributedMapReduceContextBuilder extends AbstractMapReduceContext
 
     // Initialize log appender in distributed mode.
     // In single node the log appender is initialized during process startup.
-    LogAppenderInitializer logAppenderInitializer = injector.getInstance(LogAppenderInitializer.class);
+    logAppenderInitializer = injector.getInstance(LogAppenderInitializer.class);
     logAppenderInitializer.initialize();
 
     return injector;
@@ -98,6 +99,7 @@ public class DistributedMapReduceContextBuilder extends AbstractMapReduceContext
 
   @Override
   protected void finish() {
+    logAppenderInitializer.close();
     metricsCollectionService.stop();
     kafkaClientService.stop();
     zkClientService.stop();


### PR DESCRIPTION
For very short running MapReduce jobs, the logs were not collected. The issue was that the KakfaLogAppender was not getting closed and thus the messages were not getting flushed. PR makes sure that LogAppenderInititalizer is closed in MapperWrapper, ReducerWrapper and in DatasetInputFormat, DatasetOutputFormat (by closing MapReduceContextProvider). Also had to package logback.xml when building the MapReduce Job JAR so that messages are formatted in the expected format.

JIRA : https://issues.cask.co/browse/CDAP-2376

Build : http://builds.cask.co/browse/CDAP-RBT388-1