### PR TITLE
Fixes broken doc build 

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/source/TimePartitionedFileSetDatasetAvroSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/source/TimePartitionedFileSetDatasetAvroSource.java
@@ -66,8 +66,8 @@ public class TimePartitionedFileSetDatasetAvroSource extends
     "the pipeline will read 5 minutes of events from the TPFS source.";
   private static final String DELAY_DESC = "Optional delay for reading from TPFS source. The value must be " +
     "of the same format as the duration value. For example, a duration of '5m' and a delay of '10m' means each run " +
-    "of the pipeline will read 5 minutes of data from 15 minutes before its logical start time to 10 minutes before its " +
-    "logical start time. The default value is 0.";
+    "of the pipeline will read 5 minutes of data from 15 minutes before its logical start time to 10 minutes " +
+    "before its logical start time. The default value is 0.";
 
   private final AvroToStructuredTransformer recordTransformer = new AvroToStructuredTransformer();
 

--- a/cdap-docs/application-templates/source/etl/templates/sources/real-time/amazonsqs.rst
+++ b/cdap-docs/application-templates/source/etl/templates/sources/real-time/amazonsqs.rst
@@ -1,0 +1,31 @@
+.. meta::
+    :author: Cask Data, Inc.
+    :copyright: Copyright © 2015 Cask Data, Inc.
+
+=======================
+Sources: Real-time: SQS
+=======================
+
+.. rubric:: Description
+
+Amazon SQS (Simple Queue Service) Real-time Source that emits a record with a field 'body' of type String.
+
+.. rubric:: Use Case
+
+TODO: Fill me out
+
+.. rubric:: Properties
+
+**region:** Region where the queue is located.
+
+**accessKey:** Access Key of the AWS (Amazon Web Services) account to use.
+
+**accessID:** Access ID of the AWS account to use.
+  
+**queueName:** Name of the queue.
+  
+**endpoint:** Endpoint of the SQS server to connect to. Omit this field to connect to AWS.
+
+.. rubric:: Example
+
+TODO: Fill me out

--- a/cdap-docs/application-templates/source/etl/templates/sources/real-time/amazonsqs.rst
+++ b/cdap-docs/application-templates/source/etl/templates/sources/real-time/amazonsqs.rst
@@ -2,9 +2,9 @@
     :author: Cask Data, Inc.
     :copyright: Copyright © 2015 Cask Data, Inc.
 
-=======================
-Sources: Real-time: SQS
-=======================
+==============================
+Sources: Real-time: Amazon SQS
+==============================
 
 .. rubric:: Description
 

--- a/cdap-docs/application-templates/source/etl/templates/sources/real-time/index.rst
+++ b/cdap-docs/application-templates/source/etl/templates/sources/real-time/index.rst
@@ -9,8 +9,8 @@ Sources: Real-time
 .. toctree::
    :maxdepth: 1
 
+    AmazonSQS <amazonsqs>
     JMS <jms>
     Kafka <kafka>
-    AmazonSQS <amazonsqs>
     Test <test>
     Twitter <twitter>

--- a/cdap-docs/application-templates/source/etl/templates/sources/real-time/index.rst
+++ b/cdap-docs/application-templates/source/etl/templates/sources/real-time/index.rst
@@ -11,5 +11,6 @@ Sources: Real-time
 
     JMS <jms>
     Kafka <kafka>
+    AmazonSQS <amazonsqs>
     Test <test>
     Twitter <twitter>

--- a/cdap-docs/application-templates/source/etl/templates/sources/real-time/index.rst
+++ b/cdap-docs/application-templates/source/etl/templates/sources/real-time/index.rst
@@ -11,6 +11,5 @@ Sources: Real-time
 
     JMS <jms>
     Kafka <kafka>
-    SQS <sqs>
     Test <test>
     Twitter <twitter>

--- a/cdap-docs/developers-manual/source/building-blocks/workflows.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/workflows.rst
@@ -104,7 +104,7 @@ you use  multiple instances of the same program in the same workflow.
 These unique names can be set when the Workflow is first configured, passed to the
 instance of the program, and then be used when the program performs its own configuration.
 
-An example of this is the :ref:`Wikipedia Pipeline<wikipedia-data-pipeline>` example, and
+An example of this is the :ref:`Wikipedia Pipeline <examples-wikipedia-data-pipeline>` example, and
 its use of the *StreamToDataset* MapReduce program multiple times::
 
   public class StreamToDataset extends AbstractMapReduce {
@@ -219,7 +219,7 @@ object passed to those methods is a Hadoop class that is unaware of CDAP and its
 tokens.
 
 Here is an example, taken from the
-:ref:`Wikipedia Pipeline<wikipedia-data-pipeline>` example's ``TopNMapReduce.java``:
+:ref:`Wikipedia Pipeline <examples-wikipedia-data-pipeline>` example's ``TopNMapReduce.java``:
 
 .. literalinclude:: /../../../cdap-examples/WikipediaPipeline/src/main/java/co/cask/cdap/examples/wikipedia/TopNMapReduce.java
    :language: java
@@ -241,7 +241,7 @@ Spark Accumulators and Workflow Tokens
 `Spark Accumulators <https://spark.apache.org/docs/latest/programming-guide.html#accumulators-a-nameaccumlinka>`__ 
 can be accessed through the SparkContext, and used with workflow tokens. This allows the 
 values in the accumulators to be accessed through workflow tokens. An example of this is in
-the :ref:`Wikipedia Pipeline<wikipedia-data-pipeline>` example's ``ScalaSparkLDA.scala``:
+the :ref:`Wikipedia Pipeline <examples-wikipedia-data-pipeline>` example's ``ScalaSparkLDA.scala``:
 
 .. literalinclude:: /../../../cdap-examples/WikipediaPipeline/src/main/scala/co/cask/cdap/examples/wikipedia/ScalaSparkLDA.scala
    :language: scala
@@ -585,4 +585,4 @@ Example of Using a Workflow
 
 - For an example of the use of **a workflow,** see the :ref:`Purchase
   <examples-purchase>` example.
-- The :ref:`Wikipedia Pipeline<wikipedia-data-pipeline>` example is another workflow example.
+- The :ref:`Wikipedia Pipeline <examples-wikipedia-data-pipeline>` example is another workflow example.

--- a/cdap-docs/examples-manual/build.sh
+++ b/cdap-docs/examples-manual/build.sh
@@ -129,12 +129,18 @@ function download_includes() {
   guide_rewrite_sed $1 cdap-workflow-guide
   
   echo_red_bold "Check included example files for changes"
+  
+  # Group alphabetically each example separately, files from each example together
+  
   test_an_include 55738256b6c668914e0dde5c0ec44bd5 ../../cdap-examples/CountRandom/src/main/java/co/cask/cdap/examples/countrandom/CountRandom.java
   test_an_include 964869077820198813af338ae7220e34 ../../cdap-examples/CountRandom/src/main/java/co/cask/cdap/examples/countrandom/CountRandomFlow.java
   test_an_include 288c590e1a9b010e1cd7e29a431e9071 ../../cdap-examples/CountRandom/src/main/java/co/cask/cdap/examples/countrandom/RandomSource.java
   test_an_include 77d244f968d508d9ea2d91e463065b68 ../../cdap-examples/CountRandom/src/main/java/co/cask/cdap/examples/countrandom/NumberSplitter.java
   test_an_include 9f963a17090976d2c15a4d092bd9e8de ../../cdap-examples/CountRandom/src/main/java/co/cask/cdap/examples/countrandom/NumberCounter.java
   
+  test_an_include 15ea5c523a9079762007b877ac980a7c ../../cdap-examples/DataCleansing/src/main/java/co/cask/cdap/examples/datacleansing/DataCleansing.java
+  test_an_include cda3c92d74d6bf44a536ea72fad5b976 ../../cdap-examples/DataCleansing/src/main/java/co/cask/cdap/examples/datacleansing/DataCleansingMapReduce.java
+
   test_an_include 8a7b4aacee88800cd82d96b07280cc64 ../../cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetExample.java
   test_an_include 2ad024c8093bea2b3cb9b5fa14f1224b ../../cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetService.java
   test_an_include 31c9d6fd543a48ce5e3f2b9cdc630b6d ../../cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/WordCount.java
@@ -147,6 +153,7 @@ function download_includes() {
   test_an_include d9c7f594204f42adaac7ad866c11ed7a ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseStore.java
   
   test_an_include 050cde0eb54b20803e65aae63b11143d ../../cdap-examples/SparkKMeans/src/main/java/co/cask/cdap/examples/sparkkmeans/SparkKMeansApp.java
+  
   test_an_include cbe1aa2a457ed414c77a97ab1e1ef641 ../../cdap-examples/SparkPageRank/src/main/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankApp.java
 
   test_an_include afe12d26b79607a846d3eaa58958ea5f ../../cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/SportResults.java
@@ -161,11 +168,10 @@ function download_includes() {
   test_an_include 75aee2ce7b34eb125d41a295d5f3122d ../../cdap-examples/WebAnalytics/src/main/java/co/cask/cdap/examples/webanalytics/UniqueVisitor.java
   test_an_include 936d007286f0d6d59967c1b421850e37 ../../cdap-examples/WebAnalytics/src/main/java/co/cask/cdap/examples/webanalytics/UniqueVisitCount.java
   test_an_include 1656c8e7158e10175cb750aeafeea58f ../../cdap-examples/WebAnalytics/src/main/java/co/cask/cdap/examples/webanalytics/WebAnalyticsFlow.java
-  test_an_include 333dc3ee2fd7b5ae36b640a5e34ba3c9 ../../cdap-examples/WikipediaPipeline/src/main/java/co/cask/cdap/examples/wikipedia/WikipediaPipelineApp.java
+  
+  test_an_include 2ad87b92766a879a6664a9f231993409 ../../cdap-examples/WikipediaPipeline/src/main/java/co/cask/cdap/examples/wikipedia/WikipediaPipelineApp.java
+  
   test_an_include 23d3a5c9f8cbe1a41fe706c6f95bad73 ../../cdap-examples/WordCount/src/main/java/co/cask/cdap/examples/wordcount/WordCount.java
-
-  test_an_include 35c07a43a7e3b53b3788e0b1b25019ec ../../cdap-examples/DataCleansing/src/main/java/co/cask/cdap/examples/datacleansing/DataCleansing.java
-  test_an_include 0e5e114dd2fda00eabcc302f9dd46e98 ../../cdap-examples/DataCleansing/src/main/java/co/cask/cdap/examples/datacleansing/DataCleansingMapReduce.java
 }
 
 run_command ${1}

--- a/cdap-docs/examples-manual/source/examples/data-cleansing.rst
+++ b/cdap-docs/examples-manual/source/examples/data-cleansing.rst
@@ -3,7 +3,7 @@
     :description: Cask Data Application Platform Data Cleansing Application
     :copyright: Copyright © 2015 Cask Data, Inc.
 
-.. _examples-word-count:
+.. _examples-data-cleansing:
 
 ==============
 Data Cleansing
@@ -60,19 +60,8 @@ the ``cleanRecords`` PartitionedFileSet. The ``beforeSubmit`` method prepares th
 - It specifies the output partition that is written to, based upon the supplied runtime arguments.
 
 
-Building and Starting
-=====================
-
-.. include:: building-starting-running-cdap.txt
-
-
-Running CDAP Applications
-=========================
-
 .. |example| replace:: DataCleansing
-
-.. include:: /../../developers-manual/source/getting-started/building-apps.rst
-   :start-line: 11
+.. include:: building-starting-running-cdap.txt
 
 
 Running the Example
@@ -113,15 +102,16 @@ the ``cleanRecords`` dataset to write to. In this example, we'll simply use ``1`
 
     $ cdap-cli.sh start mapreduce DataCleansing.DataCleansingMapReduce output.partition.key=1
 
-    Successfully started mapreduce 'DataCleansingMapReduce' of application 'DataCleansing' with provided runtime arguments 'output.partition.key=1'
+    Successfully started mapreduce 'DataCleansingMapReduce' of application 'DataCleansing'
+    with provided runtime arguments 'output.partition.key=1'
 
 Optionally, to specify a custom schema to match records against, the JSON of the schema can be
 specified as an additional runtime argument to the MapReduce with the key 'schema.key'.
 Otherwise, the default schema that is matched against the records:
 
 .. literalinclude:: /../../../cdap-examples/DataCleansing/src/main/java/co/cask/cdap/examples/datacleansing/DataCleansingMapReduce.java
-:language: java
-     :lines: 112-117
+    :language: java
+    :lines: 108-112
 
 Querying the Results
 --------------------

--- a/cdap-docs/examples-manual/source/examples/index.rst
+++ b/cdap-docs/examples-manual/source/examples/index.rst
@@ -17,6 +17,7 @@ Examples
 
    Hello World <hello-world>
    Count Random <count-random>
+   Data Cleansing <data-cleansing>
    File Sets <fileset>
    Log Analysis <log-analysis>
    Purchase <purchase>
@@ -26,6 +27,7 @@ Examples
    Stream Conversion <stream-conversion>
    User Profiles <user-profiles>
    Web Analytics <web-analytics>
+   Wikipedia Pipeline <wikipedia-data-pipeline>
    Word Count <word-count>
 
 In addition to the :ref:`Getting Started's <getting-started-index>` 
@@ -37,22 +39,22 @@ In addition to the :ref:`Getting Started's <getting-started-index>`
 
   * - Example Name
     - Description
-  * - :doc:`Hello World<hello-world>`
+  * - :doc:`Hello World <hello-world>`
     - A simple HelloWorld App that's written using CDAP. It introduces how the components stream, flow, dataset,
       and service are used in a CDAP application.
-  * - :doc:`Count Random<count-random>`
+  * - :doc:`Count Random <count-random>`
     - An application that demonstrates the ``@Tick`` feature of flows. It uses a tick method to generate random
       numbers which are then counted by downstream flowlets.
-  * - :doc:`Data Cleansing<data-cleansing>`
+  * - :doc:`Data Cleansing <data-cleansing>`
     - A Cask Data Application Platform (CDAP) example demonstrating incrementally consuming partitions of a
       partitioned fileset using MapReduce.
-  * - :doc:`File Sets<fileset>`
+  * - :doc:`File Sets <fileset>`
     - A variation of the *WordCount* example that operates on files. It demonstrates the usage of the FileSet
       dataset, including a service to upload and download files, and a MapReduce that operates over these files.
   * - :doc:`Log Analysis <log-analysis>`
     - An example demonstrating Spark and MapReduce running in parallel inside a workflow, showing the use of
       forks within workflows.
-  * - :doc:`Purchase<purchase>`
+  * - :doc:`Purchase <purchase>`
     - This example demonstrates use of many of the CDAP components |---| streams, flows, flowlets, datasets, queries,
       MapReduce programs, workflows, and services |---| in a single application.
 
@@ -60,28 +62,28 @@ In addition to the :ref:`Getting Started's <getting-started-index>`
       the flow processes the events and stores them in a dataset. A MapReduce program reads the dataset, compiles
       the purchases for each customer into a purchase history and stores the histories in a second dataset.
       The purchase histories can then be queried either through a service or an ad-hoc SQL query.
-  * - :doc:`Spark K-Means<spark-k-means>`
+  * - :doc:`Spark K-Means <spark-k-means>`
     - An application that demonstrates streaming text analysis using a Spark program. It calculates the centers
       of points from an input stream using the K-Means clustering method.
-  * - :doc:`Spark Page Rank<spark-page-rank>`
+  * - :doc:`Spark Page Rank <spark-page-rank>`
     - An application that demonstrates text analysis using Spark and MapReduce programs. It computes the page rank
       of URLs from an input stream.
-  * - :doc:`Sport Results<sport-results>`
+  * - :doc:`Sport Results <sport-results>`
     - An application that illustrates the use of partitioned file sets.
       It loads game results into a file set partitioned by league and season, and processes them with MapReduce.
-  * - :doc:`Stream Conversion<stream-conversion>`
+  * - :doc:`Stream Conversion <stream-conversion>`
     - An application that demonstrates the use of time-partitioned File sets.
       It periodically converts a stream into partitions of a File set, which can be read by SQL queries.
-  * - :doc:`User Profiles<user-profiles>`
+  * - :doc:`User Profiles <user-profiles>`
     - An application that demonstrates column-level conflict detection using the example of updating of
       user profiles in a dataset.
-  * - :doc:`Web Analytics<web-analytics>`
+  * - :doc:`Web Analytics <web-analytics>`
     - An application to generate statistics and to provide insights about web usage through the analysis
       of web traffic.
-  * - :doc:`Wikipedia Pipeline<wikipedia-data-pipeline>`
+  * - :doc:`Wikipedia Pipeline <wikipedia-data-pipeline>`
     - An application that performs analysis on Wikipedia data using MapReduce and Spark programs
       running within a CDAP Workflow: *WikipediaPipelineWorkflow*.
-  * - :doc:`Word Count<word-count>`
+  * - :doc:`Word Count <word-count>`
     - A simple application that counts words, and tracks word associations and unique words seen on the stream.
       It demonstrates the power of using datasets and how they can be employed to simplify storing complex data.
       It uses a configuration class to configure the application at deployment time.

--- a/cdap-docs/examples-manual/source/examples/log-analysis.rst
+++ b/cdap-docs/examples-manual/source/examples/log-analysis.rst
@@ -3,7 +3,7 @@
     :description: Cask Data Application Platform SparkPageRank Application
     :copyright: Copyright © 2015 Cask Data, Inc.
 
-.. _examples-spark-page-rank:
+.. _examples-log-analysis:
 
 ====================
 Log Analysis Example
@@ -73,23 +73,13 @@ The ``HitCounterService``, ``ResponseCounterService`` and ``RequestCounterServic
 These services provide convenient endpoints:
 
 - ``HitCounterService:`` ``hitcount`` endpoint to obtain the total number of hits for a given URL;
-- ``ResponseCounterService:`` ``rescount `` endpoint to obtain the total number of responses for a given response code;
-- ``RequestCounterService:`` ``reqcount `` endpoint to obtain a set of all the available partitions in the TimePartitionedFileSet; and
-- ``RequestCounterService:`` ``reqfile `` endpoint to retrieve data from a particular partition.
+- ``ResponseCounterService:`` ``rescount`` endpoint to obtain the total number of responses for a given response code;
+- ``RequestCounterService:`` ``reqcount`` endpoint to obtain a set of all the available partitions in the TimePartitionedFileSet; and
+- ``RequestCounterService:`` ``reqfile`` endpoint to retrieve data from a particular partition.
 
-Building and Starting
-=====================
-
-.. include:: building-and-starting.txt
-
-
-Running CDAP Applications
-=========================
 
 .. |example| replace:: LogAnalysisApp
-
-.. include:: /../../developers-manual/source/getting-started/building-apps.rst
-:start-line: 11
+.. include:: building-starting-running-cdap.txt
 
 
 Running the Example

--- a/cdap-docs/examples-manual/source/examples/wikipedia-data-pipeline.rst
+++ b/cdap-docs/examples-manual/source/examples/wikipedia-data-pipeline.rst
@@ -17,13 +17,15 @@ Overview
 This example demonstrates a CDAP application performing analysis on Wikipedia data using MapReduce and Spark programs
 running within a CDAP Workflow: *WikipediaPipelineWorkflow*.
 
-This example can be run in both online and offline modes.
+This example can be run in both online and offline modes:
+
 - In the online mode, the custom action *DownloadWikiDataAction* reads the stream *pageTitleStream*, each event of which
   is an element from the output of the
   `Facebook "Likes" API <https://developers.facebook.com/docs/graph-api/reference/v2.4/object/likes>`__.
   For each event, it tries to download Wikipedia data for the page using the
   `MediaWiki Wikipedia API <https://www.mediawiki.org/wiki/API:Main_page>`__. It stores the downloaded data in the
   KeyValueTable dataset *wikiData*.
+  
 - In the offline mode, it expects Wikipedia data formatted per the output of the MediaWiki API in the stream *wikiStream*.
 
 The MapReduce program *wikiDataToDataset* consumes this stream and stores it in the same KeyValueTable dataset
@@ -51,16 +53,22 @@ of the application are tied together by the class ``WikipediaPipelineApp``:
    :language: java
    :lines: 24-55
 
-Among other things, this application demonstrates:
+This application demonstrates:
+
 - The use of assigning unique names, as the same MapReduce (*StreamToDataset*) is used twice in the workflow
   (*WikipediaPipelineWorkflow*) with two different names.
+  
 - The use of Workflow Tokens in:
+
     - Condition Predicates
     - Setting MapReduce program configuration (setting it based on values in the token)
     - ``map()``/``reduce()`` functions (read-only, no updates)
     - Spark Programs (reading from/writing to workflow token, adding Spark Accumulators to workflow token)
     - Assertions in application unit tests
 
+
+.. |example| replace:: WikipediaPipeline
+.. include:: building-starting-running-cdap.txt
 
 Running the Example
 ===================

--- a/cdap-docs/examples-manual/source/examples/word-count.rst
+++ b/cdap-docs/examples-manual/source/examples/word-count.rst
@@ -66,7 +66,6 @@ It exposes these endpoints:
 - ``/assoc/{word1}/{word2}`` returns the top associated words (those with the highest counts).
 
 
-
 .. |example| replace:: WordCount
 .. include:: building-starting-running-cdap.txt
 


### PR DESCRIPTION
and fixes check style error in documentation strings.

Running Doc Build: http://builds.cask.co/browse/CDAP-DDBD540-1/log

Results staged at: [Examples](http://docs-staging.cask.co/cdap/3.1.0-SNAPSHOT-feature-r3.1-fix_broken_doc_build/en/examples-manual/examples/index.html)

Passes checkstyle (locally).