### PR TITLE
CDAP-2341 Shorten the cleanup thread for invalid records to make sure store quickly updated.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramLifecycleService.java
@@ -77,7 +77,7 @@ public class ProgramLifecycleService extends AbstractIdleService {
     LOG.info("Starting ProgramLifecycleService");
 
     scheduledExecutorService.scheduleWithFixedDelay(new RunRecordsCorrectorRunnable(this),
-                                                    2L, 600L, TimeUnit.SECONDS);
+                                                    2L, 6L, TimeUnit.SECONDS);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramLifecycleService.java
@@ -82,7 +82,8 @@ public class ProgramLifecycleService extends AbstractIdleService {
 
     long interval = configuration.getLong(Constants.AppFabric.PROGRAM_RUNID_CORRECTOR_INTERVAL_SECONDS);
     if (interval <= 0) {
-      interval = 300L;
+      LOG.debug("Invalid run id corrector interval {}. Setting it to 180 seconds.", interval);
+      interval = 180L;
     }
     scheduledExecutorService.scheduleWithFixedDelay(new RunRecordsCorrectorRunnable(this),
                                                     2L, interval, TimeUnit.SECONDS);

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -97,6 +97,7 @@ public final class Constants {
     public static final String APP_SCHEDULER_QUEUE = "apps.scheduler.queue";
     public static final String MAPREDUCE_JOB_CLIENT_CONNECT_MAX_RETRIES = "mapreduce.jobclient.connect.max.retries";
     public static final String MAPREDUCE_INCLUDE_CUSTOM_CLASSES = "mapreduce.include.custom.format.classes";
+    public static final String PROGRAM_RUNID_CORRECTOR_INTERVAL_SECONDS = "app.program.runid.corrector.interval";
 
     /**
      * Guice named bindings.

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -646,6 +646,15 @@
         <description>Java options for all program containers</description>
     </property>
 
+    <property>
+        <name>app.program.runid.corrector.interval</name>
+        <value>300</value>
+        <description>
+            The interval of how often the run id corrector thread will run in seconds.
+            This value should be greater than 0.
+        </description>
+    </property>
+
   <!-- Used for MapReduce Info endpoint -->
     <property>
       <name>mapreduce.jobclient.connect.max.retries</name>

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -648,7 +648,7 @@
 
     <property>
         <name>app.program.runid.corrector.interval</name>
-        <value>300</value>
+        <value>180</value>
         <description>
             The interval of how often the run id corrector thread will run in seconds.
             This value should be greater than 0.


### PR DESCRIPTION
Some of programs like Spark, MR, and workflow may die quickly due to memory error so we want
to make sure the runs status updated quickly.