### PR TITLE
Fixes json error validation to skip properties that are added in imported json & not from backend

### DIFF
--- a/cdap-ui/app/features/adapters/services/adapter-error-factory.js
+++ b/cdap-ui/app/features/adapters/services/adapter-error-factory.js
@@ -114,7 +114,7 @@ angular.module(PKG.name + '.feature.adapters')
       plugin.valid = true;
       for (i=0; i< keys.length; i++) {
         var property = plugin.properties[keys[i]];
-        if (plugin._backendProperties[keys[i]].required && (!property || property === '')) {
+        if (plugin._backendProperties[keys[i]] && plugin._backendProperties[keys[i]].required && (!property || property === '')) {
           plugin.valid = false;
           break;
         }


### PR DESCRIPTION
- When importing json in UI the user might construct the json by hand and they may add a property that is not in the backend. In that case the UI should not fail and should skip in sending that property to the backend.
- Minor js error to fix when we check if a property is required when it is not from the backend (in the malformed json being imported)