### PR TITLE
Dataset TTL correction

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/Table.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/Table.java
@@ -35,7 +35,7 @@ public interface Table extends BatchReadable<byte[], Row>, BatchWritable<byte[],
   Dataset, RecordScannable<StructuredRecord> {
 
   /**
-   * Property set to configure time-to-live on data within this dataset. The value given is in milliseconds.
+   * Property set to configure time-to-live on data within this dataset. The value given is in seconds.
    * Once a cell's data has surpassed the given value in age,
    * the cell's data will no longer be visible and may be garbage collected.
    */

--- a/cdap-docs/developers-manual/source/building-blocks/datasets/index.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/datasets/index.rst
@@ -89,14 +89,14 @@ For more details, refer to :ref:`custom datasets. <custom-datasets>`
 
 Datasets, like :ref:`streams <streams>`, can have a Time-To-Live (TTL) property that
 governs how long data will be persisted in a specific dataset. TTL is configured as the
-maximum age (in milliseconds) that data should be retained.
+maximum age (in seconds) that data should be retained.
 
 When you create a dataset, you can configure its TTL as part of the creation::
 
   public void configure() {
       createDataset("myCounters", Table.class, 
                     DatasetProperties.builder().add(Table.PROPERTY_TTL, 
-                                                    "<age in milliseconds>").build());
+                                                    "<age in seconds>").build());
       ...
   }
 

--- a/cdap-docs/developers-manual/source/building-blocks/datasets/system-custom.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/datasets/system-custom.rst
@@ -110,7 +110,7 @@ Passing Properties
 You can also pass ``DatasetProperties`` as a third parameter to the ``createDataset`` method.
 These properties will be used by embedded datasets during creation and will be available via the
 ``DatasetSpecification`` passed to the dataset constructor. For example, to create a dataset with
-a TTL (time-to-live) property, you can use::
+a TTL (time-to-live, specified in seconds) property, you can use::
 
   createDataset("frequentCustomers", KeyValueTable.class,
     DatasetProperties.builder()


### PR DESCRIPTION
Fix for https://issues.cask.co/browse/CDAP-3084

Corrects usage to show that TTL is (in these cases) specified in seconds, not milliseconds.

Related issue: https://issues.cask.co/browse/CDAP-2878

Passes local checkstyle.