### PR TITLE
Increase resources for Page Rank sample app to be successful in workflow

### DIFF
--- a/cdap-docs/examples-manual/build.sh
+++ b/cdap-docs/examples-manual/build.sh
@@ -154,7 +154,7 @@ function download_includes() {
   
   test_an_include 050cde0eb54b20803e65aae63b11143d ../../cdap-examples/SparkKMeans/src/main/java/co/cask/cdap/examples/sparkkmeans/SparkKMeansApp.java
   
-  test_an_include cbe1aa2a457ed414c77a97ab1e1ef641 ../../cdap-examples/SparkPageRank/src/main/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankApp.java
+  test_an_include 62a0d9ee7ad379265c5433095e25dd89 ../../cdap-examples/SparkPageRank/src/main/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankApp.java
 
   test_an_include afe12d26b79607a846d3eaa58958ea5f ../../cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/SportResults.java
   test_an_include 2d85727db18c3261b60d4cb278846329 ../../cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/UploadService.java

--- a/cdap-docs/examples-manual/source/examples/spark-page-rank.rst
+++ b/cdap-docs/examples-manual/source/examples/spark-page-rank.rst
@@ -58,7 +58,7 @@ This ``TotalPagesPRService`` service has a ``total`` endpoint to obtain the tota
 
 Memory Requirements
 -------------------
-When Spark program in running inside a workflow, the memory requirements configured for the Spark program may need increasing beyond the defaults:
+When a Spark program is running inside a workflow, the memory requirements configured for the Spark program may need increasing beyond the defaults:
 
 .. literalinclude:: /../../../cdap-examples/SparkPageRank/src/main/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankApp.java
    :language: java

--- a/cdap-docs/examples-manual/source/examples/spark-page-rank.rst
+++ b/cdap-docs/examples-manual/source/examples/spark-page-rank.rst
@@ -58,8 +58,7 @@ This ``TotalPagesPRService`` service has a ``total`` endpoint to obtain the tota
 
 Memory Requirements
 -------------------
-When running both a Spark and MapReduce programs in the same workflow, the memory
-requirements configured for the Spark program may need increasing beyond the defaults:
+When Spark program in running inside a workflow, the memory requirements configured for the Spark program may need increasing beyond the defaults:
 
 .. literalinclude:: /../../../cdap-examples/SparkPageRank/src/main/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankApp.java
    :language: java

--- a/cdap-docs/examples-manual/source/examples/spark-page-rank.rst
+++ b/cdap-docs/examples-manual/source/examples/spark-page-rank.rst
@@ -56,6 +56,16 @@ The ``RanksService`` and ``TotalPagesPRService`` Service
 This ``RanksService`` service has a ``rank`` endpoint to obtain the page rank of a given URL.
 This ``TotalPagesPRService`` service has a ``total`` endpoint to obtain the total number of pages with a given page rank.
 
+Memory Requirements
+-------------------
+When running both a Spark and MapReduce programs in the same workflow, the memory
+requirements configured for the Spark program may need increasing beyond the defaults:
+
+.. literalinclude:: /../../../cdap-examples/SparkPageRank/src/main/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankApp.java
+   :language: java
+   :lines: 123-124
+
+
 
 .. |example| replace:: SparkPageRank
 .. include:: building-starting-running-cdap.txt

--- a/cdap-docs/examples-manual/source/examples/spark-page-rank.rst
+++ b/cdap-docs/examples-manual/source/examples/spark-page-rank.rst
@@ -42,7 +42,7 @@ of the application are tied together by the class ``SparkPageRankApp``:
 
 .. literalinclude:: /../../../cdap-examples/SparkPageRank/src/main/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankApp.java
    :language: java
-   :lines: 49-96
+   :lines: 50-97
 
 The ``ranks`` and ``rankscount`` ObjectStore Data Storage
 ---------------------------------------------------------

--- a/cdap-examples/SparkPageRank/src/main/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankApp.java
+++ b/cdap-examples/SparkPageRank/src/main/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankApp.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.examples.sparkpagerank;
 
+import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.annotation.UseDataSet;
 import co.cask.cdap.api.app.AbstractApplication;
 import co.cask.cdap.api.common.Bytes;
@@ -119,6 +120,8 @@ public class SparkPageRankApp extends AbstractApplication {
       setName(SparkPageRankProgram.class.getSimpleName());
       setDescription("Spark Page Rank Program");
       setMainClass(SparkPageRankProgram.class);
+      setDriverResources(new Resources(1024));
+      setExecutorResources(new Resources(1024));
     }
   }
 


### PR DESCRIPTION
The SparkPageRankApp is being used in the workflow where the workflow driver need to share memory with Spark runner.

Need to add more resources to SparkPageRankSpecification to make sure it runs otherwise the container will randomly throw out of memory that restart the workflow app container.