### PR TITLE
CDAP-2735 shouldn't have removed table name since the sink uses it

### DIFF
--- a/cdap-ui/templates/common/Database.json
+++ b/cdap-ui/templates/common/Database.json
@@ -4,17 +4,21 @@
     "position": [ "group1", "group2", "group3" ],
     "group1": {
        "display" : "General",
-       "position" : [ "user", "password" ],
+       "position" : [ "user", "password", "tableName" ],
        "fields" : {
           "user" : {
              "widget": "textbox",
-             "label": "Username",
-             "description" : "Username to connect to dashboard"
+             "label": "Username"
           },
 
           "password" : {
              "widget": "password",
              "label": "Password"
+          },
+
+          "tableName" : {
+             "widget": "textbox",
+             "label" : "Table Name"
           }
        }
     },
@@ -49,14 +53,12 @@
        "fields" : {
           "importQuery" : {
              "widget": "textbox",
-             "label": "Import SQL",
-             "description" : "SQL query used to import the rows from the RDBMS"
+             "label": "Import SQL"
           },
 
           "countQuery" : {
              "widget": "textbox",
-             "label": "Count SQL",
-             "description" : "SQL query specifying how the counts need to be computed. This information is used in determining the degree of parallelism."
+             "label": "Count SQL"
           }
        }
     }


### PR DESCRIPTION
Also removing descriptions since the descriptions from the backend
should be used.