### PR TITLE
Default AbstractFlowlet constructor should not be deprecated

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/flow/flowlet/AbstractFlowlet.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/flow/flowlet/AbstractFlowlet.java
@@ -130,9 +130,7 @@ public abstract class AbstractFlowlet implements Flowlet, Callback {
   /**
    * Default constructor that uses {@link #getClass()}.{@link Class#getSimpleName() getSimpleName} as the
    * flowlet name.
-   * @deprecated not required if you are using {@link AbstractFlowlet#configure} method.
    */
-  @Deprecated
   protected AbstractFlowlet() {
     this.name = getClass().getSimpleName();
   }


### PR DESCRIPTION
JIRA : https://issues.cask.co/browse/CDAP-3175

Build : http://builds.cask.co/browse/CDAP-RBT397-1