### PR TITLE
remove call to tempDir.mkDirs() because DirUtils.createTempDir on the…

### DIFF
--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
@@ -55,7 +55,6 @@ import co.cask.cdap.notifications.feeds.guice.NotificationFeedServiceRuntimeModu
 import co.cask.cdap.notifications.guice.NotificationServiceRuntimeModule;
 import com.google.common.base.Charsets;
 import com.google.common.base.Joiner;
-import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.base.Supplier;
 import com.google.common.base.Throwables;
@@ -658,7 +657,6 @@ public class MasterServiceMain extends DaemonMain {
   private TwillPreparer prepareExploreContainer(TwillPreparer preparer) {
     File tempDir = DirUtils.createTempDir(new File(cConf.get(Constants.CFG_LOCAL_DATA_DIR),
                                                    cConf.get(Constants.AppFabric.TEMP_DIR)).getAbsoluteFile());
-    Preconditions.checkState(tempDir.mkdirs(), "Cannot create temp dir " + tempDir.getAbsolutePath());
 
     try {
       // Put jars needed by Hive in the containers classpath. Those jars are localized in the Explore


### PR DESCRIPTION
… previous line already creates it.

https://builds.cask.co/browse/CDAP-RBT393-3