### PR TITLE
CDAP-3000 Persisting the WorkflowToken after the execution of the fork.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowDriver.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowDriver.java
@@ -398,6 +398,8 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
         }
       }
     } finally {
+      // Update the WorkflowToken after the execution of the FORK node completes.
+      store.updateWorkflowToken(workflowId, runId.getId(), token);
       executorService.shutdownNow();
       executorService.awaitTermination(Integer.MAX_VALUE, TimeUnit.NANOSECONDS);
     }

--- a/cdap-examples/WikipediaPipeline/src/test/java/co/cask/cdap/examples/wikipedia/WikipediaPipelineAppTest.java
+++ b/cdap-examples/WikipediaPipeline/src/test/java/co/cask/cdap/examples/wikipedia/WikipediaPipelineAppTest.java
@@ -155,8 +155,7 @@ public class WikipediaPipelineAppTest extends TestBase {
     assertTokenAtRawDataMRNode(workflowManager, pid, continueConditionSucceeded);
     assertTokenAtNormalizationMRNode(workflowManager, pid, continueConditionSucceeded);
     assertTokenAtSparkLDANode(workflowManager, pid, continueConditionSucceeded);
-    // TODO: Verification fails if the last node of the workflow is a fork node.
-//    assertTokenAtTopNMRNode(workflowManager, pid, continueConditionSucceeded);
+    assertTokenAtTopNMRNode(workflowManager, pid, continueConditionSucceeded);
   }
 
   private void assertTokenAtPageTitlesMRNode(WorkflowManager workflowManager, String pid) throws NotFoundException {


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-3000