### PR TITLE
CDAP 2892 : Deploy schedule triggers in paused state and get rid of lazyStart() scheduler hack

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/AbstractSchedulerService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/AbstractSchedulerService.java
@@ -23,8 +23,6 @@ import co.cask.cdap.api.schedule.ScheduleSpecification;
 import co.cask.cdap.app.store.Store;
 import co.cask.cdap.common.ApplicationNotFoundException;
 import co.cask.cdap.common.NotFoundException;
-import co.cask.cdap.common.conf.CConfiguration;
-import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.internal.schedule.StreamSizeSchedule;
 import co.cask.cdap.internal.schedule.TimeSchedule;
 import co.cask.cdap.proto.Id;
@@ -51,31 +49,21 @@ public abstract class AbstractSchedulerService extends AbstractIdleService imple
   private static final Logger LOG = LoggerFactory.getLogger(AbstractSchedulerService.class);
   private final TimeScheduler timeScheduler;
   private final StreamSizeScheduler streamSizeScheduler;
-  private final CConfiguration cConf;
   private final Store store;
 
-  public AbstractSchedulerService(TimeScheduler timeScheduler, StreamSizeScheduler streamSizeScheduler,
-                                  CConfiguration cConf, Store store) {
+  public AbstractSchedulerService(TimeScheduler timeScheduler, StreamSizeScheduler streamSizeScheduler, Store store) {
     this.timeScheduler = timeScheduler;
     this.streamSizeScheduler = streamSizeScheduler;
-    this.cConf = cConf;
     this.store = store;
-  }
-
-  private boolean isLazyStart() {
-    return cConf.getBoolean(Constants.Scheduler.SCHEDULERS_LAZY_START, false);
   }
 
   /**
    * Start the scheduler services, by initializing them and starting them
-   * right away if lazy start is not active.
    */
   protected final void startSchedulers() throws SchedulerException {
     try {
       timeScheduler.init();
-      if (!isLazyStart()) {
-        timeScheduler.lazyStart();
-      }
+      timeScheduler.start();
       LOG.info("Started time scheduler");
     } catch (Throwable t) {
       Throwables.propagateIfInstanceOf(t, SchedulerException.class);
@@ -84,31 +72,11 @@ public abstract class AbstractSchedulerService extends AbstractIdleService imple
 
     try {
       streamSizeScheduler.init();
-      if (!isLazyStart()) {
-        streamSizeScheduler.lazyStart();
-      }
+      streamSizeScheduler.start();
       LOG.info("Started stream size scheduler");
     } catch (Throwable t) {
       Throwables.propagateIfInstanceOf(t, SchedulerException.class);
       throw new SchedulerException(t);
-    }
-  }
-
-  private void lazyStart(Scheduler scheduler) throws SchedulerException {
-    if (scheduler instanceof TimeScheduler) {
-      try {
-        timeScheduler.lazyStart();
-      } catch (Throwable t) {
-        Throwables.propagateIfInstanceOf(t, SchedulerException.class);
-        throw new SchedulerException(t);
-      }
-    } else if (scheduler instanceof StreamSizeScheduler) {
-      try {
-        streamSizeScheduler.lazyStart();
-      } catch (Throwable t) {
-        Throwables.propagateIfInstanceOf(t, SchedulerException.class);
-        throw new SchedulerException(t);
-      }
     }
   }
 
@@ -157,30 +125,6 @@ public abstract class AbstractSchedulerService extends AbstractIdleService imple
     scheduler = getScheduler(schedule);
 
     scheduler.schedule(programId, programType, schedule, properties);
-    doLazyStart(programId, programType, schedule, properties);
-  }
-
-  private void doLazyStart(Id.Program programId, SchedulableProgramType programType, Schedule schedule,
-                           Map<String, String> properties) throws SchedulerException {
-    Scheduler scheduler = getScheduler(schedule);
-    if (isLazyStart()) {
-      // TODO: CDAP-2281 figure out a better way to handle schedules in unit tests
-      String ignoreLazy = properties.get(Constants.Scheduler.IGNORE_LAZY_START);
-      boolean shouldNotSuspend = ignoreLazy != null && Boolean.valueOf(ignoreLazy);
-      if (shouldNotSuspend) {
-        // normally in lazy mode, the scheduler is started on calls to resume.
-        // If this schedule should be active right now instead of requiring a call to resume,
-        // we need to start the scheduler here.
-        lazyStart(scheduler);
-      } else {
-        try {
-          scheduler.suspendSchedule(programId, programType, schedule.getName());
-        } catch (NotFoundException e) {
-          // Should not happen - we just created it. Could have been deleted just in between
-          LOG.info("Schedule could not be suspended - it did not exist: {}", schedule.getName());
-        }
-      }
-    }
   }
 
   @Override
@@ -229,9 +173,6 @@ public abstract class AbstractSchedulerService extends AbstractIdleService imple
   public void resumeSchedule(Id.Program program, SchedulableProgramType programType, String scheduleName)
     throws NotFoundException, SchedulerException {
     Scheduler scheduler = getSchedulerForSchedule(program, scheduleName);
-    if (!isStarted(scheduler) && isLazyStart()) {
-      lazyStart(scheduler);
-    }
     scheduler.resumeSchedule(program, programType, scheduleName);
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/DistributedSchedulerService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/DistributedSchedulerService.java
@@ -17,7 +17,6 @@
 package co.cask.cdap.internal.app.runtime.schedule;
 
 import co.cask.cdap.app.store.Store;
-import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.service.RetryOnStartFailureService;
 import co.cask.cdap.common.service.RetryStrategies;
 import com.google.common.base.Supplier;
@@ -39,8 +38,8 @@ public final class DistributedSchedulerService extends AbstractSchedulerService 
 
   @Inject
   public DistributedSchedulerService(TimeScheduler timeScheduler, StreamSizeScheduler streamSizeScheduler,
-                                     CConfiguration cConf, Store store) {
-    super(timeScheduler, streamSizeScheduler, cConf, store);
+                                     Store store) {
+    super(timeScheduler, streamSizeScheduler, store);
     this.serviceDelegate = new RetryOnStartFailureService(new Supplier<Service>() {
       @Override
       public Service get() {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/LocalSchedulerService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/LocalSchedulerService.java
@@ -17,7 +17,6 @@
 package co.cask.cdap.internal.app.runtime.schedule;
 
 import co.cask.cdap.app.store.Store;
-import co.cask.cdap.common.conf.CConfiguration;
 import com.google.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,9 +29,8 @@ public final class LocalSchedulerService extends AbstractSchedulerService {
   private static final Logger LOG = LoggerFactory.getLogger(LocalSchedulerService.class);
 
   @Inject
-  public LocalSchedulerService(TimeScheduler timeScheduler, StreamSizeScheduler streamSizeScheduler,
-                               CConfiguration cConf, Store store) {
-    super(timeScheduler, streamSizeScheduler, cConf, store);
+  public LocalSchedulerService(TimeScheduler timeScheduler, StreamSizeScheduler streamSizeScheduler, Store store) {
+    super(timeScheduler, streamSizeScheduler, store);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/StreamSizeScheduler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/StreamSizeScheduler.java
@@ -140,7 +140,7 @@ public class StreamSizeScheduler implements Scheduler {
     initializeScheduleStore();
   }
 
-  void lazyStart() throws SchedulerException {
+  void start() throws SchedulerException {
     schedulerStarted = true;
   }
 
@@ -229,8 +229,7 @@ public class StreamSizeScheduler implements Scheduler {
 
     // Add the scheduleTask to the StreamSubscriber
     streamSubscriber.createScheduleTask(program, programType, streamSizeSchedule, properties);
-    scheduleSubscribers.put(AbstractSchedulerService.scheduleIdFor(program, programType,
-                                                                   streamSizeSchedule.getName()),
+    scheduleSubscribers.put(AbstractSchedulerService.scheduleIdFor(program, programType, streamSizeSchedule.getName()),
                             streamSubscriber);
   }
 
@@ -262,8 +261,7 @@ public class StreamSizeScheduler implements Scheduler {
     // Add the scheduleTask to the StreamSubscriber
     streamSubscriber.restoreScheduleFromStore(program, programType, streamSizeSchedule, properties, active,
                                               basePollSize, basePollTs, lastRunSize, lastRunTs);
-    scheduleSubscribers.put(AbstractSchedulerService.scheduleIdFor(program, programType,
-                                                                   streamSizeSchedule.getName()),
+    scheduleSubscribers.put(AbstractSchedulerService.scheduleIdFor(program, programType, streamSizeSchedule.getName()),
                             streamSubscriber);
   }
 
@@ -650,15 +648,11 @@ public class StreamSizeScheduler implements Scheduler {
                                                                     properties);
 
         // First time that we create this schedule, it has to be initialized with the latest polling info
-        newTask.startNewSchedule(streamSize.getSize(), streamSize.getTimestamp());
+        newTask.storeNewSchedule(streamSize.getSize(), streamSize.getTimestamp());
 
         // We only modify the scheduleTasks if the persistence in startSchedule() did not throw any exception
         scheduleTasks.put(scheduleId, newTask);
-
-        activeTasks.incrementAndGet();
       }
-
-      sendPollingInfoToActiveTasks(streamSize);
     }
 
     /**
@@ -921,20 +915,19 @@ public class StreamSizeScheduler implements Scheduler {
     }
 
     /**
-     * Start a new stream size schedule task. The task is set as active, and its last run information
+     * Store a new stream size schedule task. The task is set as active, and its last run information
      * set to -1.
      *
      * @param basePollSize base size of the stream to start counting from. This info comes from polling the stream
      * @param basePollTs time at which the {@code basePollSize} was obtained
      */
-    public void startNewSchedule(long basePollSize, long basePollTs) throws SchedulerException {
+    public void storeNewSchedule(long basePollSize, long basePollTs) throws SchedulerException {
       LOG.debug("Starting new schedule {} with basePollSize {}, basePollTs {}",
                 streamSizeSchedule.getName(), basePollSize, basePollTs);
       this.basePollSize = basePollSize;
       this.basePollTs = basePollTs;
       this.lastRunSize = -1;
       this.lastRunTs = -1;
-      this.active.set(true);
 
       try {
         scheduleStore.persist(programId, programType, streamSizeSchedule, properties,

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/TimeScheduler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/TimeScheduler.java
@@ -41,12 +41,17 @@ import org.quartz.CronScheduleBuilder;
 import org.quartz.Job;
 import org.quartz.JobBuilder;
 import org.quartz.JobDetail;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
 import org.quartz.JobKey;
+import org.quartz.ObjectAlreadyExistsException;
 import org.quartz.Trigger;
 import org.quartz.TriggerBuilder;
 import org.quartz.TriggerKey;
+import org.quartz.impl.matchers.GroupMatcher;
 import org.quartz.spi.JobFactory;
 import org.quartz.spi.TriggerFiredBundle;
+import org.quartz.utils.Key;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,6 +65,7 @@ import java.util.concurrent.Executors;
  */
 final class TimeScheduler implements Scheduler {
   private static final Logger LOG = LoggerFactory.getLogger(TimeScheduler.class);
+  private static final String PAUSED_NEW_TRIGGERS_GROUP = "NewPausedTriggers";
 
   private org.quartz.Scheduler scheduler;
   private final Supplier<org.quartz.Scheduler> schedulerSupplier;
@@ -91,10 +97,31 @@ final class TimeScheduler implements Scheduler {
     }
   }
 
-  void lazyStart() throws SchedulerException {
+  /**
+   * Creates a paused group TimeScheduler#PAUSED_NEW_TRIGGERS_GROUP by adding a dummy job to it if it does not exists
+   * already. This is needed so that we can add new triggers to this paused group and they will be paused too.
+   *
+   * @throws org.quartz.SchedulerException
+   */
+  private void initNewPausedTriggersGroup() throws org.quartz.SchedulerException {
+    // if the dummy job does not already exists in the TimeScheduler#PAUSED_NEW_TRIGGERS_GROUP then create a dummy job
+    // which will create the TimeScheduler#PAUSED_NEW_TRIGGERS_GROUP
+    if (!scheduler.checkExists(new JobKey(EmptyJob.class.getSimpleName(), PAUSED_NEW_TRIGGERS_GROUP))) {
+      JobDetail job = JobBuilder.newJob(EmptyJob.class)
+        .withIdentity(EmptyJob.class.getSimpleName(), PAUSED_NEW_TRIGGERS_GROUP)
+        .storeDurably(true)
+        .build();
+      scheduler.addJob(job, true);
+    }
+    // call pause on this group this ensures that all the new triggers added to this group will also be paused
+    scheduler.pauseTriggers(GroupMatcher.triggerGroupEquals(PAUSED_NEW_TRIGGERS_GROUP));
+  }
+
+  void start() throws SchedulerException {
     try {
       scheduler.start();
       schedulerStarted = true;
+      initNewPausedTriggersGroup();
     } catch (org.quartz.SchedulerException e) {
       throw new SchedulerException(e);
     }
@@ -136,10 +163,15 @@ final class TimeScheduler implements Scheduler {
   }
 
   @Override
-  public void schedule(Id.Program program, SchedulableProgramType programType, Iterable<Schedule> schedules,
-                       Map<String, String> properties) throws SchedulerException {
+  public synchronized void schedule(Id.Program program, SchedulableProgramType programType,
+                                    Iterable<Schedule> schedules,
+                                    Map<String, String> properties) throws SchedulerException {
     checkInitialized();
-    Preconditions.checkNotNull(schedules);
+    try {
+      validateSchedules(program, programType, schedules);
+    } catch (org.quartz.SchedulerException e) {
+      throw new SchedulerException(e);
+    }
 
     String jobKey = jobKeyFor(program, programType).getName();
     JobDetail job = JobBuilder.newJob(DefaultSchedulerService.ScheduledJob.class)
@@ -152,25 +184,43 @@ final class TimeScheduler implements Scheduler {
       throw new SchedulerException(e);
     }
     for (Schedule schedule : schedules) {
-      Preconditions.checkArgument(schedule instanceof TimeSchedule);
       TimeSchedule timeSchedule = (TimeSchedule) schedule;
       String scheduleName = timeSchedule.getName();
       String cronEntry = timeSchedule.getCronEntry();
-      String triggerKey = AbstractSchedulerService.scheduleIdFor(program, programType, scheduleName);
-
-      LOG.debug("Scheduling job {} with cron {}", scheduleName, cronEntry);
-
-      TriggerBuilder trigger = TriggerBuilder.newTrigger()
-        .withIdentity(triggerKey)
-        .forJob(job)
-        .withSchedule(CronScheduleBuilder
-                        .cronSchedule(getQuartzCronExpression(cronEntry))
-                        .withMisfireHandlingInstructionDoNothing());
-      addProperties(trigger, properties);
       try {
+        TriggerKey triggerKey = getGroupedTriggerKey(program, programType, timeSchedule.getName());
+
+        LOG.debug("Scheduling job {} with cron {}", scheduleName, cronEntry);
+
+        TriggerBuilder trigger = TriggerBuilder.newTrigger()
+          // all new triggers are added to the paused group which will ensure that the triggers are paused too
+          .withIdentity(triggerKey.getName(), PAUSED_NEW_TRIGGERS_GROUP)
+          .forJob(job)
+          .withSchedule(CronScheduleBuilder
+                          .cronSchedule(getQuartzCronExpression(cronEntry))
+                          .withMisfireHandlingInstructionDoNothing());
+        addProperties(trigger, properties);
+
         scheduler.scheduleJob(trigger.build());
       } catch (org.quartz.SchedulerException e) {
         throw new SchedulerException(e);
+      }
+    }
+  }
+
+  private void validateSchedules(Id.Program program, SchedulableProgramType programType,
+                                 Iterable<Schedule> schedules) throws org.quartz.SchedulerException {
+    Preconditions.checkNotNull(schedules);
+    for (Schedule schedule : schedules) {
+      Preconditions.checkArgument(schedule instanceof TimeSchedule);
+      TimeSchedule timeSchedule = (TimeSchedule) schedule;
+      TriggerKey triggerKey = getGroupedTriggerKey(program, programType, timeSchedule.getName());
+      // Once the schedule is resumed we move the trigger from TimeScheduler#PAUSED_NEW_TRIGGERS_GROUP to
+      // Key#DEFAULT_GROUP so before adding check if this schedule does not exist.
+      // We do not need to check for same schedule in the current list as its already checked in app configuration stage
+      if (scheduler.checkExists(triggerKey)) {
+        throw new ObjectAlreadyExistsException("Unable to store Trigger with name " + triggerKey.getName() +
+                                                 "because one already exists with this identification.");
       }
     }
   }
@@ -232,24 +282,34 @@ final class TimeScheduler implements Scheduler {
 
 
   @Override
-  public void suspendSchedule(Id.Program program, SchedulableProgramType programType, String scheduleName)
+  public synchronized void suspendSchedule(Id.Program program, SchedulableProgramType programType, String scheduleName)
     throws NotFoundException, SchedulerException {
     checkInitialized();
     try {
-      scheduler.pauseTrigger(new TriggerKey(AbstractSchedulerService.scheduleIdFor(program, programType,
-                                                                                   scheduleName)));
+      scheduler.pauseTrigger(getGroupedTriggerKey(program, programType, scheduleName));
     } catch (org.quartz.SchedulerException e) {
       throw new SchedulerException(e);
     }
   }
 
   @Override
-  public void resumeSchedule(Id.Program program, SchedulableProgramType programType, String scheduleName)
+  public synchronized void resumeSchedule(Id.Program program, SchedulableProgramType programType, String scheduleName)
     throws NotFoundException, SchedulerException {
+
     checkInitialized();
+
     try {
-      scheduler.resumeTrigger(new TriggerKey(AbstractSchedulerService.scheduleIdFor(program, programType,
-                                                                                    scheduleName)));
+      TriggerKey triggerKey = getGroupedTriggerKey(program, programType, scheduleName);
+      if (triggerKey.getGroup().equals(PAUSED_NEW_TRIGGERS_GROUP)) {
+        Trigger neverScheduledTrigger = scheduler.getTrigger(triggerKey);
+        TriggerBuilder<? extends Trigger> triggerBuilder = neverScheduledTrigger.getTriggerBuilder();
+        // move this key from TimeScheduler#PAUSED_NEW_TRIGGERS_GROUP to the Key#DEFAULT_GROUP group
+        // (when no group name is provided default is used)
+        Trigger resumedTrigger = triggerBuilder.withIdentity(triggerKey.getName()).build();
+        scheduler.rescheduleJob(neverScheduledTrigger.getKey(), resumedTrigger);
+        triggerKey = resumedTrigger.getKey();
+      }
+      scheduler.resumeTrigger(triggerKey);
     } catch (org.quartz.SchedulerException e) {
       throw new SchedulerException(e);
     }
@@ -262,7 +322,7 @@ final class TimeScheduler implements Scheduler {
   }
 
   @Override
-  public void updateSchedule(Id.Program program, SchedulableProgramType programType, Schedule schedule,
+  public synchronized void updateSchedule(Id.Program program, SchedulableProgramType programType, Schedule schedule,
                              Map<String, String> properties) throws NotFoundException, SchedulerException {
     checkInitialized();
     try {
@@ -282,12 +342,11 @@ final class TimeScheduler implements Scheduler {
   }
 
   @Override
-  public void deleteSchedule(Id.Program program, SchedulableProgramType programType, String scheduleName)
+  public synchronized void deleteSchedule(Id.Program program, SchedulableProgramType programType, String scheduleName)
     throws NotFoundException, SchedulerException {
     checkInitialized();
     try {
       Trigger trigger = getTrigger(program, programType, scheduleName);
-
       scheduler.unscheduleJob(trigger.getKey());
 
       JobKey jobKey = trigger.getJobKey();
@@ -328,12 +387,12 @@ final class TimeScheduler implements Scheduler {
   }
 
   @Override
-  public ScheduleState scheduleState(Id.Program program, SchedulableProgramType programType, String scheduleName)
+  public synchronized ScheduleState scheduleState(Id.Program program, SchedulableProgramType programType,
+                                                  String scheduleName)
     throws SchedulerException {
     checkInitialized();
     try {
-      Trigger.TriggerState state = scheduler.getTriggerState(
-        new TriggerKey(AbstractSchedulerService.scheduleIdFor(program, programType, scheduleName)));
+      Trigger.TriggerState state = scheduler.getTriggerState(getGroupedTriggerKey(program, programType, scheduleName));
       // Map trigger state to schedule state.
       // This method is only interested in returning if the scheduler is
       // Paused, Scheduled or NotFound.
@@ -401,12 +460,30 @@ final class TimeScheduler implements Scheduler {
   }
 
   /**
+   * @return Trigger key created from program, programType and scheduleName and TimeScheuler#PAUSED_NEW_TRIGGERS_GROUP
+   * if it exists in this group else returns the {@link TriggerKey} prepared with null which gets it with
+   * {@link Key#DEFAULT_GROUP}
+   * @throws org.quartz.SchedulerException
+   */
+  private synchronized TriggerKey getGroupedTriggerKey(Id.Program program, SchedulableProgramType programType,
+                                                       String scheduleName)
+    throws org.quartz.SchedulerException {
+
+    TriggerKey neverResumedTriggerKey = new TriggerKey(AbstractSchedulerService.scheduleIdFor(program, programType,
+                                                                                              scheduleName),
+                                                       PAUSED_NEW_TRIGGERS_GROUP);
+    if (scheduler.checkExists(neverResumedTriggerKey)) {
+      return neverResumedTriggerKey;
+    }
+    return new TriggerKey(AbstractSchedulerService.scheduleIdFor(program, programType, scheduleName));
+  }
+
+  /**
    * Gets a {@link Trigger} associated with this program name, type and schedule name
    */
-  private Trigger getTrigger(Id.Program program, SchedulableProgramType programType,
+  private synchronized Trigger getTrigger(Id.Program program, SchedulableProgramType programType,
                              String scheduleName) throws org.quartz.SchedulerException, ScheduleNotFoundException {
-    Trigger trigger = scheduler.getTrigger(
-      new TriggerKey(AbstractSchedulerService.scheduleIdFor(program, programType, scheduleName)));
+    Trigger trigger = scheduler.getTrigger(getGroupedTriggerKey(program, programType, scheduleName));
     if (trigger == null) {
       throw new ScheduleNotFoundException(Id.Schedule.from(program.getApplication(), scheduleName));
     }
@@ -421,6 +498,15 @@ final class TimeScheduler implements Scheduler {
       for (Map.Entry<String, String> entry : properties.entrySet()) {
         trigger.usingJobData(entry.getKey(), entry.getValue());
       }
+    }
+  }
+
+  /**
+   * An empty {@link Job} to create a group in the scheduler
+   */
+  private final class EmptyJob implements Job {
+    public void execute(JobExecutionContext context) throws JobExecutionException {
+      // no-op
     }
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AdapterService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AdapterService.java
@@ -500,12 +500,11 @@ public class AdapterService extends AbstractIdleService {
     scheduler.schedule(workflowId, scheduleSpec.getProgram().getProgramType(), scheduleSpec.getSchedule(),
                        ImmutableMap.of(
                          ProgramOptionConstants.ADAPTER_NAME, adapterSpec.getName(),
-                         ProgramOptionConstants.ADAPTER_SPEC, GSON.toJson(adapterSpec),
-                         // hack for scheduler weirdness in unit tests, remove once CDAP-2281 is done
-                         Constants.Scheduler.IGNORE_LAZY_START, String.valueOf(true)
-                       ));
+                         ProgramOptionConstants.ADAPTER_SPEC, GSON.toJson(adapterSpec)));
     //TODO: Scheduler API should also manage the MDS.
     store.addSchedule(workflowId, scheduleSpec);
+    scheduler.resumeSchedule(workflowId, scheduleSpec.getProgram().getProgramType(),
+                             scheduleSpec.getSchedule().getName());
   }
 
   private void stopWorkflowAdapter(Id.Namespace namespace, AdapterDefinition adapterSpec)

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricTestHelper.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricTestHelper.java
@@ -79,7 +79,6 @@ public class AppFabricTestHelper {
       configuration = conf;
       configuration.set(Constants.CFG_LOCAL_DATA_DIR, TEMP_FOLDER.newFolder("data").getAbsolutePath());
       configuration.set(Constants.AppFabric.REST_PORT, Integer.toString(Networks.getRandomPort()));
-      configuration.setBoolean(Constants.Scheduler.SCHEDULERS_LAZY_START, true);
       configuration.setBoolean(Constants.Dangerous.UNRECOVERABLE_RESET, true);
       injector = Guice.createInjector(new AppFabricTestModule(configuration));
       injector.getInstance(TransactionManager.class).startAndWait();

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AppFabricTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AppFabricTestBase.java
@@ -164,7 +164,6 @@ public abstract class AppFabricTestBase {
     conf.set(Constants.CFG_LOCAL_DATA_DIR, tmpFolder.newFolder("data").getAbsolutePath());
     conf.set(Constants.AppFabric.OUTPUT_DIR, System.getProperty("java.io.tmpdir"));
     conf.set(Constants.AppFabric.TEMP_DIR, System.getProperty("java.io.tmpdir"));
-    conf.setBoolean(Constants.Scheduler.SCHEDULERS_LAZY_START, true);
     conf.set(Constants.AppFabric.APP_TEMPLATE_DIR, tmpFolder.newFolder("templates").getAbsolutePath());
     conf.setBoolean(Constants.Dangerous.UNRECOVERABLE_RESET, true);
 

--- a/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
+++ b/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
@@ -255,11 +255,11 @@ public class CLIMainTest {
   public void testSchedule() throws Exception {
     String scheduleId = FakeApp.NAME + "." + FakeApp.SCHEDULE_NAME;
     String workflowId = FakeApp.NAME + "." + FakeWorkflow.NAME;
-    testCommandOutputContains(cli, "get schedule status " + scheduleId, "SCHEDULED");
-    testCommandOutputContains(cli, "suspend schedule " + scheduleId, "Successfully suspended");
     testCommandOutputContains(cli, "get schedule status " + scheduleId, "SUSPENDED");
     testCommandOutputContains(cli, "resume schedule " + scheduleId, "Successfully resumed");
     testCommandOutputContains(cli, "get schedule status " + scheduleId, "SCHEDULED");
+    testCommandOutputContains(cli, "suspend schedule " + scheduleId, "Successfully suspended");
+    testCommandOutputContains(cli, "get schedule status " + scheduleId, "SUSPENDED");
     testCommandOutputContains(cli, "get workflow schedules " + workflowId, FakeApp.SCHEDULE_NAME);
   }
 

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/ScheduleClientTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/ScheduleClientTestRun.java
@@ -82,14 +82,14 @@ public class ScheduleClientTestRun extends ClientTestBase {
     Assert.assertEquals(FakeApp.STREAM_TRIGGER_MB, streamSchedule.getDataTriggerMB());
 
     String status = scheduleClient.getStatus(schedule);
-    Assert.assertEquals("SCHEDULED", status);
-
-    scheduleClient.suspend(schedule);
-    status = scheduleClient.getStatus(schedule);
     Assert.assertEquals("SUSPENDED", status);
 
     scheduleClient.resume(schedule);
     status = scheduleClient.getStatus(schedule);
     Assert.assertEquals("SCHEDULED", status);
+
+    scheduleClient.suspend(schedule);
+    status = scheduleClient.getStatus(schedule);
+    Assert.assertEquals("SUSPENDED", status);
   }
 }

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -149,12 +149,6 @@ public final class Constants {
   public class Scheduler {
     public static final String CFG_SCHEDULER_MAX_THREAD_POOL_SIZE = "scheduler.max.thread.pool.size";
     public static final int DEFAULT_THREAD_POOL_SIZE = 30;
-    public static final String SCHEDULERS_LAZY_START = "schedulers.lazy.start";
-    // TODO: CDAP-2281 remove once unit tests have a better way to handle schedules
-    // lazy start is set in some unit tests so that schedules are suspended right away when created.
-    // including this key with a true value as a schedule property will ignore the suspend behavior and schedules
-    // will be created normally.
-    public static final String IGNORE_LAZY_START = "scheduler.ignore.lazy.start";
   }
 
   /**

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
@@ -130,7 +130,6 @@ public class UpgradeTool {
 
   public UpgradeTool() throws Exception {
     this.cConf = CConfiguration.create();
-    this.cConf.setBoolean(Constants.Scheduler.SCHEDULERS_LAZY_START, true);
     this.hConf = HBaseConfiguration.create();
     this.injector = init();
     this.txService = injector.getInstance(TransactionService.class);

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/ConfigurableTestBase.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/ConfigurableTestBase.java
@@ -339,7 +339,6 @@ public class ConfigurableTestBase {
 
     cConf.set(Constants.CFG_LOCAL_DATA_DIR, localDataDir.getAbsolutePath());
     cConf.setBoolean(Constants.Dangerous.UNRECOVERABLE_RESET, true);
-    cConf.setBoolean(Constants.Scheduler.SCHEDULERS_LAZY_START, true);
     cConf.set(Constants.Explore.LOCAL_DATA_DIR,
               tmpFolder.newFolder("hive").getAbsolutePath());
     cConf.set(Constants.AppFabric.APP_TEMPLATE_DIR, tmpFolder.newFolder("templates").getAbsolutePath());


### PR DESCRIPTION
This PR does the following: 
- CDAP 2892 : When a new app is deployed with workflow its schedules are in disabled state unless resumed by the user manually. This is true for both time and stream size based schedule.
- Gets rid of lazyStart() hack which was required to deploy schedules with a stopped scheduler to ensure that they are in paused state.

Approach:
The way achieve paused triggers in Quartz scheduler is through groups. [More Details] (https://issues.cask.co/browse/CDAP-2892?focusedCommentId=17594&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-17594)
- During initialization of scheduler we create add an empty job within a group. This is needed as I was not able to find any direct way to create a group.
- This group is then paused which guarantees that any new triggers added to this group will also be added with paused state. We add all our new triggers to this paused group.
- When resume is called on a schedule we move the trigger to default group and resume it. This ensure that when cdap restarts again and scheduler gets initialized it will not pause the triggers which are resumed. 
- Any operation which needs TriggerKey use getGroupedTriggerKey() to get the appropriate TriggerKey as the key will be different depending on which group it belong to.

StreamSizeScheduler: The scheduler of this scheduler does not set activeState to  true anymore. They get activated when resume is called on them.

Build: http://builds.cask.co/browse/CDAP-DUT2386-4

***
Tasks pending for these changes 
- [x] Unit tests: The way we pause trigger according to groups changed to handle cdap restarts and my earlier unit tests are not valid anymore. Working on updating them now.
- [x] Testing on cluster with CDAP restart. 
- [x] Schedules need to be resumed in cdap-integration tests. 
- [ ] Test for HA

***
Testing: 
Following steps were followed to test the schedules across cdap restart to check that resumed schedules does not get paused when cdap  starts again. It was done on standalone and singlenode cluster and works well on both.
1. Deployed Purchase app with two schedules one being run every  3 minutes.
2. Made sure  that  the status of the schedule is suspended and the workflow does not start even if the schedule time of these paused schedule is reached.
3. Resume the 3 minute schedule and make sure the other (every day one) is still paused. 
4. Made sure that the workflow runs every 3 minutes. 
5. Stop cdap services. (I did it when the workflow was not running)
6. Restart cdap
7. Checked that the 3 min schedule is in scheduled state and every day one is paused. 
8. Redeploy the app again and this time it has one more schedule which (run every 2 minutes) - Apparently this is the only way too add schedules for now.
9. Made sure that after redeploy every 3 min is still scheduled and keeps running the workflow and every 2 min is suspended state
10. Resume every 2 min schedule and made sure it starts workflow.
11. Suspend the every 3 min schedule and made sure it does not start workflow. 
