### PR TITLE
Fixes DAG traversal to construct config based on connections in random order

### DIFF
--- a/cdap-ui/app/directives/plumb/my-plumb-ctrl.js
+++ b/cdap-ui/app/directives/plumb/my-plumb-ctrl.js
@@ -200,8 +200,6 @@ angular.module(PKG.name + '.commons')
 
     $scope.$watch('reloaddag', function (value) {
       if (value) {
-        this.instance.reset();
-        this.instance = jsPlumb.getInstance();
         this.instance.importDefaults(MyPlumbFactory.getSettings().default);
         this.plugins = $scope.config;
         $timeout(this.drawGraph.bind(this));

--- a/cdap-ui/app/directives/plumb/my-plumb-factory.js
+++ b/cdap-ui/app/directives/plumb/my-plumb-factory.js
@@ -13,7 +13,7 @@ angular.module(PKG.name + '.commons')
 
     var commonSettings = {
       endpoint:'Dot',
-      maxConnections: -1,
+      maxConnections: 1,
       paintStyle: {
         strokeStyle: 'white',
         fillStyle: '#666e82',

--- a/cdap-ui/app/features/adapters/controllers/create/canvas-ctrl.js
+++ b/cdap-ui/app/features/adapters/controllers/create/canvas-ctrl.js
@@ -3,6 +3,7 @@ angular.module(PKG.name + '.feature.adapters')
     this.nodes = [];
     this.reloadDAG = false;
     if ($scope.AdapterCreateController.data) {
+      this.reloadDAG = true;
       setNodesAndConnectionsFromDraft.call(this, $scope.AdapterCreateController.data);
     }
 

--- a/cdap-ui/app/features/adapters/controllers/create/canvas-ctrl.js
+++ b/cdap-ui/app/features/adapters/controllers/create/canvas-ctrl.js
@@ -67,7 +67,7 @@ angular.module(PKG.name + '.feature.adapters')
         if (result.template !== MyPlumbService.metadata.template.type) {
           $alert({
             type: 'danger',
-            content: 'Template imported is for ' + config.template + '. Please switch to ' + config.template + ' creation to import.'
+            content: 'Template imported is for ' + result.template + '. Please switch to ' + result.template + ' creation to import.'
           });
           return;
         }


### PR DESCRIPTION
- Add nodes in any random order.
- Form connections with/without source and sink.
- Re-order/change connections in anyway.

The above conditions should all be supported in UI and final config formed should be correct. There should be no restriction in the order in which we add nodes nor the order in which we make connections. The final connection should be the way we represent in UI.


