### PR TITLE
Adding specifying in seconds to TTL references.

### DIFF
--- a/cdap-docs/developers-manual/source/building-blocks/streams.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/streams.rst
@@ -56,7 +56,7 @@ encoding of the data, such as shown in this code fragment::
 .. rubric:: Stream Time-To-Live (TTL)
 
 Streams are persisted by CDAP, and once an event has been sent to a stream, by default it
-never expires. The Time-To-Live (TTL) property governs how long an event is valid for
+never expires. The Time-To-Live (TTL, specified in seconds) property governs how long an event is valid for
 consumption since it was written to the stream. The default TTL for all streams is
 infinite, meaning that events will never expire. The TTL property of a stream can be
 changed, using the :ref:`http-restful-api-stream`, the :ref:`stream-client` of the

--- a/cdap-docs/reference-manual/source/http-restful-api/stream.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/stream.rst
@@ -343,7 +343,7 @@ A stream can be deleted with an HTTP DELETE method to the URL::
 Setting Stream Properties
 -------------------------
 There are a number of stream properties that can be specified.
-The Time-To-Live (TTL) property governs how long an event is valid for consumption since 
+The Time-To-Live (TTL, specified in seconds) property governs how long an event is valid for consumption since 
 it was written to the stream.
 The default TTL for all streams is infinite, meaning that events will never expire.
 The format property defines how stream event bodies should be read for data exploration.


### PR DESCRIPTION
Fix for https://issues.cask.co/browse/CDAP-3084. Adds "seconds" to TTL references.

Other repos (cdap-ingest) have been updated separately and will automatically be included whenever the documentation is built.