### PR TITLE
CDAP-3187 metrics should be unique even if name is equal

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/template/etl/batch/ETLMapReduce.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/template/etl/batch/ETLMapReduce.java
@@ -31,6 +31,7 @@ import co.cask.cdap.template.etl.batch.config.ETLBatchConfig;
 import co.cask.cdap.template.etl.common.Constants;
 import co.cask.cdap.template.etl.common.Destroyables;
 import co.cask.cdap.template.etl.common.ETLStage;
+import co.cask.cdap.template.etl.common.PluginID;
 import co.cask.cdap.template.etl.common.StageMetrics;
 import co.cask.cdap.template.etl.common.TransformExecutor;
 import com.google.common.base.Preconditions;
@@ -165,7 +166,7 @@ public class ETLMapReduce extends AbstractMapReduce {
       BatchSourceContext batchSourceContext = new MapReduceSourceContext(context, mapperMetrics, sourcePluginId);
       source.initialize(batchSourceContext);
       pipeline.add(source);
-      stageMetrics.add(new StageMetrics(mapperMetrics, StageMetrics.Type.SOURCE, etlConfig.getSource().getName()));
+      stageMetrics.add(new StageMetrics(mapperMetrics, PluginID.from(sourcePluginId)));
 
       addTransforms(stageList, pipeline, stageMetrics, transformIds, context);
 
@@ -173,7 +174,7 @@ public class ETLMapReduce extends AbstractMapReduce {
       BatchSinkContext batchSinkContext = new MapReduceSinkContext(context, mapperMetrics, sinkPluginId);
       sink.initialize(batchSinkContext);
       pipeline.add(sink);
-      stageMetrics.add(new StageMetrics(mapperMetrics, StageMetrics.Type.SINK, etlConfig.getSink().getName()));
+      stageMetrics.add(new StageMetrics(mapperMetrics, PluginID.from(sinkPluginId)));
 
       transformExecutor = new TransformExecutor<>(pipeline, stageMetrics);
     }
@@ -193,7 +194,7 @@ public class ETLMapReduce extends AbstractMapReduce {
         transform.initialize(transformContext);
         pipeline.add(transform);
         transforms.add(transform);
-        stageMetrics.add(new StageMetrics(mapperMetrics, StageMetrics.Type.TRANSFORM, stageConfig.getName()));
+        stageMetrics.add(new StageMetrics(mapperMetrics, PluginID.from(transformId)));
       }
     }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/common/ETLTemplate.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/common/ETLTemplate.java
@@ -74,6 +74,7 @@ public abstract class ETLTemplate<T extends ETLConfig> extends ApplicationTempla
     ETLStage sinkConfig = etlConfig.getSink();
     List<ETLStage> transformConfigs = etlConfig.getTransforms();
     String sourcePluginId = PluginID.from(Constants.Source.PLUGINTYPE, sourceConfig.getName(), 1).getID();
+    // 2 + since we start at 1, and there is always a source.  For example, if there are 0 transforms, sink is stage 2.
     String sinkPluginId =
       PluginID.from(Constants.Sink.PLUGINTYPE,  sinkConfig.getName(), 2 + transformConfigs.size()).getID();
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/common/ETLTemplate.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/common/ETLTemplate.java
@@ -73,10 +73,9 @@ public abstract class ETLTemplate<T extends ETLConfig> extends ApplicationTempla
     ETLStage sourceConfig = etlConfig.getSource();
     ETLStage sinkConfig = etlConfig.getSink();
     List<ETLStage> transformConfigs = etlConfig.getTransforms();
-    String sourcePluginId = String.format("%s%s%s", Constants.Source.PLUGINTYPE, Constants.ID_SEPARATOR,
-                                          sourceConfig.getName());
-    String sinkPluginId = String.format("%s%s%s", Constants.Sink.PLUGINTYPE, Constants.ID_SEPARATOR,
-                                        sinkConfig.getName());
+    String sourcePluginId = PluginID.from(Constants.Source.PLUGINTYPE, sourceConfig.getName(), 1).getID();
+    String sinkPluginId =
+      PluginID.from(Constants.Sink.PLUGINTYPE,  sinkConfig.getName(), 2 + transformConfigs.size()).getID();
 
     // Instantiate Source, Transforms, Sink stages.
     // Use the plugin name as the plugin id for source and sink stages since there can be only one source and one sink.
@@ -89,8 +88,8 @@ public abstract class ETLTemplate<T extends ETLConfig> extends ApplicationTempla
     }
 
     PluginProperties sinkProperties = getPluginProperties(sinkConfig);
-    PipelineConfigurable sink = configurer.usePlugin(Constants.Sink.PLUGINTYPE, sinkConfig.getName(), sinkPluginId,
-                                                     sinkProperties);
+    PipelineConfigurable sink = configurer.usePlugin(Constants.Sink.PLUGINTYPE, sinkConfig.getName(),
+                                                     sinkPluginId, sinkProperties);
     if (sink == null) {
       throw new IllegalArgumentException(String.format("No Plugin of type '%s' named '%s' was found",
                                                        Constants.Sink.PLUGINTYPE, sinkConfig.getName()));
@@ -104,7 +103,8 @@ public abstract class ETLTemplate<T extends ETLConfig> extends ApplicationTempla
 
       // Generate a transformId based on transform name and the array index (since there could
       // multiple transforms - ex, N filter transforms in the same pipeline)
-      String transformId = String.format("%s%s%d", transformConfig.getName(), Constants.ID_SEPARATOR, i);
+      // stage number starts from 1, plus source is always #1, so add 2 for stage number.
+      String transformId = PluginID.from(Constants.Transform.PLUGINTYPE, transformConfig.getName(), 2 + i).getID();
       PluginProperties transformProperties = getPluginProperties(transformConfig);
       Transform transformObj = configurer.usePlugin(Constants.Transform.PLUGINTYPE, transformConfig.getName(),
                                                     transformId, transformProperties);

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/common/PluginID.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/common/PluginID.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.template.etl.common;
+
+import com.google.common.base.Splitter;
+
+import java.util.Iterator;
+import java.util.Objects;
+
+/**
+ * Id of a plugin. For example, transform.script.4 means it is a script transform that is the 4th stage in the pipeline.
+ * Stage number is actually enough to be an id but it is not human readable.
+ */
+public class PluginID {
+  private final String type;
+  private final String name;
+  private final int stage;
+
+  public static PluginID from(String idStr) {
+    Iterator<String> parts = Splitter.on(':').split(idStr).iterator();
+    return new PluginID(parts.next(), parts.next(), Integer.valueOf(parts.next()));
+  }
+
+  public static PluginID from(String type, String name, int stage) {
+    return new PluginID(type, name, stage);
+  }
+
+  private PluginID(String type, String name, int stage) {
+    this.type = type;
+    this.name = name;
+    this.stage = stage;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public int getStage() {
+    return stage;
+  }
+
+  public String getMetricsContext() {
+    return String.format("%s.%s.%d", type, name, stage);
+  }
+
+  public String getID() {
+    return String.format("%s:%s:%d", type, name, stage);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    PluginID that = (PluginID) o;
+
+    return Objects.equals(type, that.type) &&
+      Objects.equals(name, that.name) &&
+      stage == that.stage;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(type, name, stage);
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/common/StageMetrics.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/common/StageMetrics.java
@@ -26,23 +26,9 @@ public class StageMetrics implements Metrics {
   private final Metrics metrics;
   private final String prefix;
 
-  /**
-   * Types of ETL stages.
-   */
-  public enum Type {
-    SOURCE,
-    SINK,
-    TRANSFORM;
-
-    @Override
-    public String toString() {
-      return name().toLowerCase();
-    }
-  }
-
-  public StageMetrics(Metrics metrics, Type stageType, String name) {
+  public StageMetrics(Metrics metrics, PluginID id) {
     this.metrics = metrics;
-    this.prefix = stageType.toString() + "." + name + ".";
+    this.prefix = id.getMetricsContext() + ".";
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/template/etl/common/TransformExecutorTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/template/etl/common/TransformExecutorTest.java
@@ -44,32 +44,32 @@ public class TransformExecutorTest {
     List<Transformation> transforms = Lists.<Transformation>newArrayList(
       new IntToDouble(), new Filter(100d), new DoubleToString());
     List<StageMetrics> stageMetrics = Lists.newArrayList(
-      new StageMetrics(mockMetrics, StageMetrics.Type.SOURCE, "first"),
-      new StageMetrics(mockMetrics, StageMetrics.Type.TRANSFORM, "second"),
-      new StageMetrics(mockMetrics, StageMetrics.Type.SINK, "third")
+      new StageMetrics(mockMetrics, PluginID.from(Constants.Source.PLUGINTYPE, "first", 1)),
+      new StageMetrics(mockMetrics, PluginID.from(Constants.Transform.PLUGINTYPE, "second", 2)),
+      new StageMetrics(mockMetrics, PluginID.from(Constants.Sink.PLUGINTYPE, "third", 3))
     );
     TransformExecutor<Integer, String> executor = new TransformExecutor<>(transforms, stageMetrics);
 
     List<String> results = Lists.newArrayList(executor.runOneIteration(1));
     Assert.assertTrue(results.isEmpty());
-    Assert.assertEquals(3, mockMetrics.getCount("source.first.records.out"));
-    Assert.assertEquals(0, mockMetrics.getCount("transform.second.records.out"));
-    Assert.assertEquals(0, mockMetrics.getCount("sink.third.records.out"));
+    Assert.assertEquals(3, mockMetrics.getCount("source.first.1.records.out"));
+    Assert.assertEquals(0, mockMetrics.getCount("transform.second.2.records.out"));
+    Assert.assertEquals(0, mockMetrics.getCount("sink.third.3.records.out"));
 
     results = Lists.newArrayList(executor.runOneIteration(10));
     Assert.assertEquals(1, results.size());
     Assert.assertEquals("1000.0", results.get(0));
-    Assert.assertEquals(6, mockMetrics.getCount("source.first.records.out"));
-    Assert.assertEquals(1, mockMetrics.getCount("transform.second.records.out"));
-    Assert.assertEquals(1, mockMetrics.getCount("sink.third.records.out"));
+    Assert.assertEquals(6, mockMetrics.getCount("source.first.1.records.out"));
+    Assert.assertEquals(1, mockMetrics.getCount("transform.second.2.records.out"));
+    Assert.assertEquals(1, mockMetrics.getCount("sink.third.3.records.out"));
 
     results = Lists.newArrayList(executor.runOneIteration(100));
     Assert.assertEquals(2, results.size());
     Assert.assertEquals("1000.0", results.get(0));
     Assert.assertEquals("10000.0", results.get(1));
-    Assert.assertEquals(9, mockMetrics.getCount("source.first.records.out"));
-    Assert.assertEquals(3, mockMetrics.getCount("transform.second.records.out"));
-    Assert.assertEquals(3, mockMetrics.getCount("sink.third.records.out"));
+    Assert.assertEquals(9, mockMetrics.getCount("source.first.1.records.out"));
+    Assert.assertEquals(3, mockMetrics.getCount("transform.second.2.records.out"));
+    Assert.assertEquals(3, mockMetrics.getCount("sink.third.3.records.out"));
   }
 
   private static class IntToDouble extends Transform<Integer, Double> {

--- a/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/main/java/co/cask/cdap/template/etl/realtime/ETLWorker.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/main/java/co/cask/cdap/template/etl/realtime/ETLWorker.java
@@ -35,6 +35,7 @@ import co.cask.cdap.template.etl.common.Constants;
 import co.cask.cdap.template.etl.common.DefaultEmitter;
 import co.cask.cdap.template.etl.common.Destroyables;
 import co.cask.cdap.template.etl.common.ETLStage;
+import co.cask.cdap.template.etl.common.PluginID;
 import co.cask.cdap.template.etl.common.StageMetrics;
 import co.cask.cdap.template.etl.common.TransformExecutor;
 import co.cask.cdap.template.etl.realtime.config.ETLRealtimeConfig;
@@ -131,7 +132,7 @@ public class ETLWorker extends AbstractWorker {
     LOG.debug("Source Stage : {}", stage.getName());
     LOG.debug("Source Class : {}", source.getClass().getName());
     source.initialize(sourceContext);
-    sourceEmitter = new DefaultEmitter(new StageMetrics(metrics, StageMetrics.Type.SOURCE, stage.getName()));
+    sourceEmitter = new DefaultEmitter(new StageMetrics(metrics, PluginID.from(sourcePluginId)));
   }
 
   @SuppressWarnings("unchecked")
@@ -142,7 +143,7 @@ public class ETLWorker extends AbstractWorker {
     LOG.debug("Sink Stage : {}", stage.getName());
     LOG.debug("Sink Class : {}", sink.getClass().getName());
     sink.initialize(sinkContext);
-    sink = new TrackedRealtimeSink(sink, metrics, stage.getName());
+    sink = new TrackedRealtimeSink(sink, metrics, PluginID.from(sinkPluginId));
   }
 
   private List<Transformation> initializeTransforms(WorkerContext context, List<ETLStage> stages) throws Exception {
@@ -163,7 +164,7 @@ public class ETLWorker extends AbstractWorker {
         LOG.debug("Transform Class : {}", transform.getClass().getName());
         transform.initialize(transformContext);
         transforms.add(transform);
-        transformMetrics.add(new StageMetrics(metrics, StageMetrics.Type.TRANSFORM, stage.getName()));
+        transformMetrics.add(new StageMetrics(metrics, PluginID.from(transformId)));
       } catch (InstantiationException e) {
         LOG.error("Unable to instantiate Transform : {}", stage.getName(), e);
         Throwables.propagate(e);

--- a/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/main/java/co/cask/cdap/template/etl/realtime/TrackedRealtimeSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/main/java/co/cask/cdap/template/etl/realtime/TrackedRealtimeSink.java
@@ -19,6 +19,7 @@ package co.cask.cdap.template.etl.realtime;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.template.etl.api.realtime.DataWriter;
 import co.cask.cdap.template.etl.api.realtime.RealtimeSink;
+import co.cask.cdap.template.etl.common.PluginID;
 import co.cask.cdap.template.etl.common.StageMetrics;
 
 /**
@@ -30,9 +31,9 @@ public class TrackedRealtimeSink<T> extends RealtimeSink<T> {
   private final RealtimeSink<T> sink;
   private final Metrics metrics;
 
-  public TrackedRealtimeSink(RealtimeSink<T> sink, Metrics metrics, String name) {
+  public TrackedRealtimeSink(RealtimeSink<T> sink, Metrics metrics, PluginID id) {
     this.sink = sink;
-    this.metrics = new StageMetrics(metrics, StageMetrics.Type.SINK, name);
+    this.metrics = new StageMetrics(metrics, id);
   }
 
   @Override


### PR DESCRIPTION
Adding the stage number to the metrics context so that two filters
in the same pipeline will emit different metrics.