### PR TITLE
CDAP-3223 filebatchsource should just be named file

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/co/cask/cdap/template/etl/batch/ETLMapReduceTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/co/cask/cdap/template/etl/batch/ETLMapReduceTest.java
@@ -239,7 +239,7 @@ public class ETLMapReduceTest extends BaseETLBatchTest {
     writeData.flush();
     writeData.close();
 
-    ETLStage source = new ETLStage("FileBatchSource", ImmutableMap.<String, String>builder()
+    ETLStage source = new ETLStage("File", ImmutableMap.<String, String>builder()
       .put(Properties.File.FILESYSTEM, "Text")
       .put(Properties.File.PATH, filePath)
       .build());

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/source/FileBatchSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/source/FileBatchSource.java
@@ -58,7 +58,7 @@ import javax.annotation.Nullable;
  * A {@link BatchSource} to use any distributed file system as a Source.
  */
 @Plugin(type = "source")
-@Name("FileBatchSource")
+@Name("File")
 @Description("Batch source for File Systems")
 public class FileBatchSource extends BatchSource<LongWritable, Object, StructuredRecord> {
 

--- a/cdap-ui/templates/ETLBatch/FileBatchSource.json
+++ b/cdap-ui/templates/ETLBatch/FileBatchSource.json
@@ -1,5 +1,5 @@
 {
-  "id": "FileBatchSource",
+  "id": "File",
   "groups" : {
     "position": [ "group1" ],
     "group1": {


### PR DESCRIPTION
this makes is consistent with all the other plugins. batch and
source are both redundant information.