### PR TITLE
CDAP-3232 fix stream writer to persist headers

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/stream/DefaultStreamWriter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/stream/DefaultStreamWriter.java
@@ -119,8 +119,11 @@ public class DefaultStreamWriter implements StreamWriter {
 
   private void write(String stream, ByteBuffer data, Map<String, String> headers) throws IOException {
     URL streamURL = getStreamURL(stream);
-    HttpRequest request = HttpRequest.post(streamURL).withBody(data).addHeaders(headers).build();
-    writeToStream(Id.Stream.from(namespace, stream), request);
+    HttpRequest.Builder requestBuilder = HttpRequest.post(streamURL).withBody(data);
+    for (Map.Entry<String, String> header : headers.entrySet()) {
+      requestBuilder.addHeader(stream + "." + header.getKey(), header.getValue());
+    }
+    writeToStream(Id.Stream.from(namespace, stream), requestBuilder.build());
   }
 
   @Override

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/apps/AppWritingtoStream.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/apps/AppWritingtoStream.java
@@ -42,8 +42,10 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Map;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 
 /**
  * Application writing to Stream.
@@ -55,6 +57,7 @@ public class AppWritingtoStream extends AbstractApplication {
   public static final String FLOW = "flow";
   public static final String WORKER = "worker";
   public static final String DATASET = "kvTable";
+  public static final String HEADER_DATASET = "headers";
   public static final String SERVICE = "srv";
   public static final String KEY = "key";
   public static final String ENDPOINT = "count";
@@ -68,6 +71,7 @@ public class AppWritingtoStream extends AbstractApplication {
     addFlow(new SimpleFlow());
     addService(SERVICE, new MyServiceHandler());
     createDataset(DATASET, KeyValueTable.class);
+    createDataset(HEADER_DATASET, KeyValueTable.class);
   }
 
   public static final class MyServiceHandler extends AbstractHttpServiceHandler {
@@ -75,10 +79,20 @@ public class AppWritingtoStream extends AbstractApplication {
     @UseDataSet(DATASET)
     private KeyValueTable table;
 
+    @UseDataSet(HEADER_DATASET)
+    private KeyValueTable headers;
+
     @GET
     @Path(ENDPOINT)
     public void process(HttpServiceRequest request, HttpServiceResponder responder) {
       responder.sendString(String.valueOf(Bytes.toLong(table.read(Bytes.toBytes(KEY)))));
+    }
+
+    @GET
+    @Path("/headers/{header}")
+    public void getHeader(HttpServiceRequest request, HttpServiceResponder responder,
+                          @PathParam("header") String header) {
+      responder.sendString(Bytes.toString(headers.read(header)));
     }
   }
 
@@ -94,7 +108,7 @@ public class AppWritingtoStream extends AbstractApplication {
     public void run() {
       try {
         getContext().write(STREAM, ByteBuffer.wrap(Bytes.toBytes("Event 0")));
-        getContext().write(STREAM, new StreamEventData(ImmutableMap.<String, String>of(),
+        getContext().write(STREAM, new StreamEventData(ImmutableMap.of("Event", "1"),
                                                        ByteBuffer.wrap(Bytes.toBytes("Event 1"))));
 
         File tempDir = Files.createTempDir();
@@ -154,9 +168,15 @@ public class AppWritingtoStream extends AbstractApplication {
     @UseDataSet(DATASET)
     private KeyValueTable table;
 
+    @UseDataSet(HEADER_DATASET)
+    private KeyValueTable headers;
+
     @ProcessInput
     public void receive(StreamEvent data) {
       table.increment(Bytes.toBytes(KEY), 1L);
+      for (Map.Entry<String, String> header : data.getHeaders().entrySet()) {
+        headers.write(header.getKey(), header.getValue());
+      }
     }
   }
 }

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/run/StreamWriterTestRun.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/run/StreamWriterTestRun.java
@@ -57,6 +57,7 @@ public class StreamWriterTestRun extends GatewayTestBase {
     waitState("services", AppWritingtoStream.APPNAME, AppWritingtoStream.SERVICE, "RUNNING");
 
     checkCount(AppWritingtoStream.VALUE);
+    checkHeader("Event", "1");
 
     //Stop Flow
     response = GatewayFastTestsSuite.doPost(String.format("/v3/namespaces/default/apps/%s/flows/%s/stop",
@@ -86,6 +87,8 @@ public class StreamWriterTestRun extends GatewayTestBase {
     response = GatewayFastTestsSuite.doDelete(String.format("/v3/namespaces/default/apps/%s",
                                                             AppWritingtoStream.APPNAME));
     Assert.assertEquals(HttpResponseStatus.OK.getCode(), response.getStatusLine().getStatusCode());
+
+
   }
 
   private void checkCount(int expected) throws Exception {
@@ -99,6 +102,25 @@ public class StreamWriterTestRun extends GatewayTestBase {
       if (response.getStatusLine().getStatusCode() == HttpResponseStatus.OK.getCode()) {
         String count = EntityUtils.toString(response.getEntity());
         if (expected == Integer.valueOf(count)) {
+          break;
+        }
+      }
+      TimeUnit.MILLISECONDS.sleep(250);
+    }
+    Assert.assertTrue(trials < 5);
+  }
+
+  private void checkHeader(String key, String expected) throws Exception {
+    int trials = 0;
+    while (trials++ < 5) {
+      HttpResponse response = GatewayFastTestsSuite.doGet(
+        String.format("/v3/namespaces/default/apps/%s/services/%s/methods/headers/%s",
+          AppWritingtoStream.APPNAME,
+          AppWritingtoStream.SERVICE,
+          key));
+      if (response.getStatusLine().getStatusCode() == HttpResponseStatus.OK.getCode()) {
+        String val = EntityUtils.toString(response.getEntity());
+        if (expected.equals(val)) {
           break;
         }
       }


### PR DESCRIPTION
prefix headers with the stream name so that they are interpreted
as stream headers instead of request headers.