### PR TITLE
StructuredRecordToPutTransformer, StructuredRecordToAvro Transformer

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/sink/TableSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/sink/TableSink.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.annotation.Description;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.dataset.lib.KeyValue;
 import co.cask.cdap.api.dataset.table.Put;
 import co.cask.cdap.api.dataset.table.Table;
@@ -61,7 +62,14 @@ public class TableSink extends BatchWritableSink<StructuredRecord, byte[], Put> 
   @Override
   public void initialize(BatchSinkContext context) throws Exception {
     super.initialize(context);
-    recordPutTransformer = new RecordPutTransformer(tableSinkConfig.getRowField(),
+    Schema outputSchema = null;
+    // If a schema string is present in the properties, use that to construct the outputSchema and pass it to the
+    // recordPutTransformer
+    String schemaString = context.getPluginProperties().getProperties().get(Properties.Table.PROPERTY_SCHEMA);
+    if (schemaString != null) {
+      outputSchema = Schema.parseJson(schemaString);
+    }
+    recordPutTransformer = new RecordPutTransformer(tableSinkConfig.getRowField(), outputSchema,
                                                     tableSinkConfig.isRowFieldCaseInsensitive());
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/sink/TimePartitionedFileSetDatasetAvroSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/sink/TimePartitionedFileSetDatasetAvroSink.java
@@ -23,7 +23,6 @@ import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.api.dataset.lib.FileSetProperties;
 import co.cask.cdap.api.dataset.lib.KeyValue;
 import co.cask.cdap.api.dataset.lib.TimePartitionedFileSet;
-import co.cask.cdap.api.templates.plugins.PluginConfig;
 import co.cask.cdap.template.etl.api.Emitter;
 import co.cask.cdap.template.etl.api.PipelineConfigurer;
 import co.cask.cdap.template.etl.api.batch.BatchSink;
@@ -50,7 +49,7 @@ public class TimePartitionedFileSetDatasetAvroSink extends
   TimePartitionedFileSetSink<AvroKey<GenericRecord>, NullWritable> {
   private static final String SCHEMA_DESC = "The Avro schema of the record being written to the Sink as a JSON " +
     "Object.";
-  private final StructuredToAvroTransformer recordTransformer = new StructuredToAvroTransformer();
+  private StructuredToAvroTransformer recordTransformer;
   private final TPFSAvroSinkConfig config;
 
   public TimePartitionedFileSetDatasetAvroSink(TPFSAvroSinkConfig config) {
@@ -80,6 +79,13 @@ public class TimePartitionedFileSetDatasetAvroSink extends
     Schema avroSchema = new Schema.Parser().parse(config.schema);
     Job job = context.getHadoopJob();
     AvroJob.setOutputKeySchema(job, avroSchema);
+  }
+
+
+  @Override
+  public void initialize(BatchSinkContext context) throws Exception {
+    super.initialize(context);
+    recordTransformer = new StructuredToAvroTransformer(config.schema);
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/sink/TimePartitionedFileSetDatasetParquetSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/sink/TimePartitionedFileSetDatasetParquetSink.java
@@ -50,7 +50,7 @@ public class TimePartitionedFileSetDatasetParquetSink extends
 
   private static final String SCHEMA_DESC = "The Parquet schema of the record being written to the Sink as a JSON " +
     "Object.";
-  private final StructuredToAvroTransformer recordTransformer = new StructuredToAvroTransformer();
+  private StructuredToAvroTransformer recordTransformer;
   private final TPFSParquetSinkConfig config;
   private String hiveSchema;
 
@@ -84,6 +84,12 @@ public class TimePartitionedFileSetDatasetParquetSink extends
     org.apache.avro.Schema avroSchema = new org.apache.avro.Schema.Parser().parse(config.schema.toLowerCase());
     Job job = context.getHadoopJob();
     AvroParquetOutputFormat.setSchema(job, avroSchema);
+  }
+
+  @Override
+  public void initialize(BatchSinkContext context) throws Exception {
+    super.initialize(context);
+    recordTransformer = new StructuredToAvroTransformer(config.schema);
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/common/StructuredToAvroTransformer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/common/StructuredToAvroTransformer.java
@@ -31,7 +31,13 @@ import java.util.Map;
  */
 public class StructuredToAvroTransformer extends RecordConverter<StructuredRecord, GenericRecord> {
 
-  private final Map<Integer, Schema> schemaCache = Maps.newHashMap();
+  private final Map<Integer, Schema> schemaCache;
+  private final Schema outputAvroSchema;
+
+  public StructuredToAvroTransformer(String outputSchema) {
+    this.schemaCache = Maps.newHashMap();
+    this.outputAvroSchema = (outputSchema != null) ? new Schema.Parser().parse(outputSchema) : null;
+  }
 
   public GenericRecord transform(StructuredRecord structuredRecord) throws IOException {
     co.cask.cdap.api.data.schema.Schema structuredRecordSchema = structuredRecord.getSchema();
@@ -39,7 +45,9 @@ public class StructuredToAvroTransformer extends RecordConverter<StructuredRecor
     int hashCode = structuredRecordSchema.hashCode();
     Schema avroSchema;
 
-    if (schemaCache.containsKey(hashCode)) {
+    if (outputAvroSchema != null) {
+      avroSchema = outputAvroSchema;
+    } else if (schemaCache.containsKey(hashCode)) {
       avroSchema = schemaCache.get(hashCode);
     } else {
       avroSchema = new Schema.Parser().parse(structuredRecordSchema.toString());

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/realtime/sink/RealtimeTableSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/realtime/sink/RealtimeTableSink.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.annotation.Description;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.table.Put;
 import co.cask.cdap.api.dataset.table.Table;
@@ -27,6 +28,7 @@ import co.cask.cdap.template.etl.api.PipelineConfigurer;
 import co.cask.cdap.template.etl.api.realtime.DataWriter;
 import co.cask.cdap.template.etl.api.realtime.RealtimeContext;
 import co.cask.cdap.template.etl.api.realtime.RealtimeSink;
+import co.cask.cdap.template.etl.common.Properties;
 import co.cask.cdap.template.etl.common.RecordPutTransformer;
 import co.cask.cdap.template.etl.common.TableSinkConfig;
 import com.google.common.base.Preconditions;
@@ -64,7 +66,14 @@ public class RealtimeTableSink extends RealtimeSink<StructuredRecord> {
   @Override
   public void initialize(RealtimeContext context) throws Exception {
     super.initialize(context);
-    recordPutTransformer = new RecordPutTransformer(tableSinkConfig.getRowField(),
+    Schema outputSchema = null;
+    // If a schema string is present in the properties, use that to construct the outputSchema and pass it to the
+    // recordPutTransformer
+    String schemaString = context.getPluginProperties().getProperties().get(Properties.Table.PROPERTY_SCHEMA);
+    if (schemaString != null) {
+      outputSchema = Schema.parseJson(schemaString);
+    }
+    recordPutTransformer = new RecordPutTransformer(tableSinkConfig.getRowField(), outputSchema,
                                                     tableSinkConfig.isRowFieldCaseInsensitive());
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/transform/StructuredRecordToGenericRecordTransform.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/transform/StructuredRecordToGenericRecordTransform.java
@@ -32,7 +32,7 @@ import org.apache.avro.generic.GenericRecord;
 @Name("StructuredRecordToGenericRecord")
 @Description("Transforms a StructuredRecord into an Avro GenericRecord.")
 public class StructuredRecordToGenericRecordTransform extends Transform<StructuredRecord, GenericRecord> {
-  private final StructuredToAvroTransformer transformer = new StructuredToAvroTransformer();
+  private final StructuredToAvroTransformer transformer = new StructuredToAvroTransformer(null);
 
   @Override
   public void transform(StructuredRecord structuredRecord, Emitter<GenericRecord> emitter) throws Exception {

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/template/etl/common/RecordPutTransformerTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/template/etl/common/RecordPutTransformerTest.java
@@ -112,7 +112,7 @@ public class RecordPutTransformerTest {
 
   @Test
   public void testCaseInsensitiveRowKeyValid() {
-    RecordPutTransformer transformer = new RecordPutTransformer("key", false);
+    RecordPutTransformer transformer = new RecordPutTransformer("key", null, false);
     Schema schema = Schema.recordOf("record", Schema.Field.of("KEY", Schema.of(Schema.Type.STRING)));
     StructuredRecord record = StructuredRecord.builder(schema).set("KEY", "someKey").build();
     Put put = transformer.toPut(record);
@@ -121,11 +121,31 @@ public class RecordPutTransformerTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void testCaseInsensitiveRowKeyInvalid() {
-    RecordPutTransformer transformer = new RecordPutTransformer("key", false);
+    RecordPutTransformer transformer = new RecordPutTransformer("key", null, false);
     Schema schema = Schema.recordOf("record",
                                     Schema.Field.of("KEY", Schema.of(Schema.Type.STRING)),
                                     Schema.Field.of("Key", Schema.nullableOf(Schema.of(Schema.Type.BYTES))));
     StructuredRecord record = StructuredRecord.builder(schema).set("KEY", "someKey").set("Key", "someOtherKey").build();
     transformer.toPut(record);
+  }
+
+  @Test
+  public void testOutputSchemaUsage() {
+    Schema outputSchema = Schema.recordOf("output",
+                                          Schema.Field.of("id", Schema.of(Schema.Type.LONG)),
+                                          Schema.Field.of("name", Schema.of(Schema.Type.STRING)));
+    Schema inputSchema = Schema.recordOf("input",
+                                         Schema.Field.of("id", Schema.of(Schema.Type.LONG)),
+                                         Schema.Field.of("name", Schema.of(Schema.Type.STRING)),
+                                         Schema.Field.of("age", Schema.of(Schema.Type.INT)));
+    StructuredRecord record = StructuredRecord.builder(inputSchema)
+      .set("id", 123L).set("name", "ABC").set("age", 10).build();
+    RecordPutTransformer transformer = new RecordPutTransformer("id", outputSchema, true);
+    Put put = transformer.toPut(record);
+    Assert.assertEquals(1, put.getValues().size());
+
+    transformer = new RecordPutTransformer("id", null, true);
+    put = transformer.toPut(record);
+    Assert.assertEquals(2, put.getValues().size());
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/template/etl/transform/StructuredtoAvroTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/template/etl/transform/StructuredtoAvroTest.java
@@ -23,7 +23,7 @@ import org.apache.avro.generic.GenericRecord;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class StructuredToAvroTest {
+public class StructuredtoAvroTest {
 
   @Test
   public void testStructuredToAvroConversionForNested() throws Exception {

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/template/etl/transform/StructuredtoAvroTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/template/etl/transform/StructuredtoAvroTest.java
@@ -18,15 +18,12 @@ package co.cask.cdap.template.etl.transform;
 
 import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.api.data.schema.Schema;
-import co.cask.cdap.template.etl.common.AvroToStructuredTransformer;
 import co.cask.cdap.template.etl.common.StructuredToAvroTransformer;
-import com.google.common.collect.ImmutableList;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.avro.generic.GenericRecordBuilder;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class StructuredtoAvroTest {
+public class StructuredToAvroTest {
 
   @Test
   public void testStructuredToAvroConversionForNested() throws Exception {
@@ -48,11 +45,31 @@ public class StructuredtoAvroTest {
              .build()
       )
       .build();
-    StructuredToAvroTransformer structuredToAvroTransformer = new StructuredToAvroTransformer();
+    StructuredToAvroTransformer structuredToAvroTransformer = new StructuredToAvroTransformer(null);
     GenericRecord result = structuredToAvroTransformer.transform(record);
     Assert.assertEquals(5, result.get("intField"));
     GenericRecord innerRecord = (GenericRecord) result.get("recordField");
     Assert.assertEquals(7, innerRecord.get("innerInt"));
     Assert.assertEquals("hello world", innerRecord.get("innerString"));
   }
+
+  @Test
+  public void testOutputSchemaUsage() throws Exception {
+    Schema outputSchema = Schema.recordOf("output",
+                                          Schema.Field.of("id", Schema.of(Schema.Type.LONG)),
+                                          Schema.Field.of("name", Schema.of(Schema.Type.STRING)));
+    Schema inputSchema = Schema.recordOf("input",
+                                         Schema.Field.of("id", Schema.of(Schema.Type.LONG)),
+                                         Schema.Field.of("name", Schema.of(Schema.Type.STRING)),
+                                         Schema.Field.of("age", Schema.of(Schema.Type.INT)));
+    StructuredRecord record = StructuredRecord.builder(inputSchema)
+      .set("id", 123L).set("name", "ABC").set("age", 10).build();
+
+    StructuredToAvroTransformer avroTransformer = new StructuredToAvroTransformer(outputSchema.toString());
+    GenericRecord result = avroTransformer.transform(record);
+    Assert.assertEquals(123L, result.get("id"));
+    Assert.assertEquals("ABC", result.get("name"));
+    Assert.assertNull(result.get("age"));
+  }
+
 }


### PR DESCRIPTION
Takes in an output schema and filters out fields that are not present in it.

This allows the sink to drop fields if the schema string that it gets has fields removed compared to the previous stage. Before this change, we were converting the structured record we get directly to Put or AvroRecord without taking into consideration the output schema that was provided (output schema was used only for explore). 

Build : http://builds.cask.co/browse/CDAP-RBT413-1

JIRA : 