### PR TITLE
CDH upgrade instructions

### DIFF
--- a/cdap-docs/admin-manual/source/installation/installation.rst
+++ b/cdap-docs/admin-manual/source/installation/installation.rst
@@ -733,8 +733,6 @@ These steps will upgrade from CDAP 3.0.3 to 3.1.0. If you are on an earlier vers
 please follow the upgrade instructions for the earlier versions and upgrade first to 3.0.3 before proceeding.
 (**Note:** Some apps need to be both recompiled and re-deployed, see below.)
 
-.. _install-upgrade-stop:
-
 .. highlight:: console
 
 1. Stop all flows, services, and other programs in all your applications.

--- a/cdap-docs/admin-manual/source/installation/installation.rst
+++ b/cdap-docs/admin-manual/source/installation/installation.rst
@@ -401,7 +401,7 @@ Depending on your installation, you may want to set these properties:
 
 - If you want to use **a different HDFS user** than ``yarn``:
 
-  1. Check that there is—and create if necessary—a corresponding user on all machines
+  1. Check that there is |--—| and create if necessary —--| a corresponding user on all machines
      in the cluster on which YARN is running (typically, all of the machines).
   #. Create an ``hdfs.user`` property for that user in ``conf/cdap-site.xml``::
 
@@ -776,7 +776,7 @@ please follow the upgrade instructions for the earlier versions and upgrade firs
 
      $ kinit -kt <keytab> <principal>
 
-#. Run the upgrade tool as the user that runs CDAP Master::
+#. Run the upgrade tool, as the user that runs CDAP Master (the CDAP user)::
 
      $ /opt/cdap/master/bin/svc-master run co.cask.cdap.data.tools.UpgradeTool upgrade
 

--- a/cdap-docs/admin-manual/source/installation/installation.rst
+++ b/cdap-docs/admin-manual/source/installation/installation.rst
@@ -401,7 +401,7 @@ Depending on your installation, you may want to set these properties:
 
 - If you want to use **a different HDFS user** than ``yarn``:
 
-  1. Check that there is |--—| and create if necessary —--| a corresponding user on all machines
+  1. Check that there is |---| and create if necessary |---| a corresponding user on all machines
      in the cluster on which YARN is running (typically, all of the machines).
   #. Create an ``hdfs.user`` property for that user in ``conf/cdap-site.xml``::
 

--- a/cdap-docs/admin-manual/source/installation/installation.rst
+++ b/cdap-docs/admin-manual/source/installation/installation.rst
@@ -733,6 +733,8 @@ These steps will upgrade from CDAP 3.0.3 to 3.1.0. If you are on an earlier vers
 please follow the upgrade instructions for the earlier versions and upgrade first to 3.0.3 before proceeding.
 (**Note:** Some apps need to be both recompiled and re-deployed, see below.)
 
+.. _install-upgrade-stop:
+
 .. highlight:: console
 
 1. Stop all flows, services, and other programs in all your applications.

--- a/cdap-docs/integrations/source/partners/cloudera/configuring.rst
+++ b/cdap-docs/integrations/source/partners/cloudera/configuring.rst
@@ -191,7 +191,7 @@ The following is the generic procedure for Major/Minor version upgrades:
 **Background:** CDH 5.3 ships with Hbase 0.98 while CDH 5.4 supports HBase 1.0. We support
 CDH 5.4 as of CDAP 3.1.0. Upgrading from CDH 5.3 to CDH 5.4 entails an HBase upgrade in
 addition to a CDAP upgrade. **It is important to perform these steps as described, otherwise
-you can end up with a unworkable system.**
+you can end up with an unusable system.**
 
 **Upgrade Steps**
 

--- a/cdap-docs/integrations/source/partners/cloudera/configuring.rst
+++ b/cdap-docs/integrations/source/partners/cloudera/configuring.rst
@@ -247,18 +247,16 @@ see these troubleshooting instructions for :ref:`problems while upgrading CDH
     
 #. Start CDAP
 
-
-.. rubric:: Upgrading CDAP 3.0 to 3.1
-
-**Note:** An app need to be both recompiled and re-deployed if it uses either a PartitionedFileSet or a TimePartitionedFileSet.
+**Note:** Any apps will need to be both recompiled and re-deployed if they use either a
+PartitionedFileSet or a TimePartitionedFileSet.
 
 
 .. rubric:: Upgrading CDAP 2.8 to 3.0
 
 **Note:** Apps need to be both recompiled and re-deployed.
 
-When upgrading from 2.8.0 to 3.0.0, the CDAP Web-App role has been replaced by the CDAP-UI role.  After starting the 3.0 services 
-for the first time:
+When upgrading from 2.8.0 to 3.0.0, the CDAP Web-App role has been replaced by the CDAP-UI
+role.  After starting the 3.0 services for the first time:
 
    - From the CDAP Instances page, select "Add Role Instances", and choose a host for the CDAP-UI role.
 
@@ -331,7 +329,8 @@ state where the tables can be disabled again and complete the process.
 
 In that case, set this configuration property in ``hbase-site.xml``::
 
-  hbase.coprocessor.abortonerror = false
+  hbase.coprocessor.abortonerror
+  false
 
 and restart the HBase regionservers. This will allow the regionservers to start up
 despite the coprocessor version mismatch. At this point, you should be able to run through

--- a/cdap-docs/integrations/source/partners/cloudera/configuring.rst
+++ b/cdap-docs/integrations/source/partners/cloudera/configuring.rst
@@ -8,6 +8,8 @@ Configuring and Installing CDAP using Cloudera Manager
 Overview
 =======================================
 
+.. highlight:: console
+
 You can use `Cloudera Manager
 <http://www.cloudera.com/content/cloudera/en/products-and-services/cloudera-enterprise/cloudera-manager.html>`__ 
 to integrate CDAP into a Hadoop cluster by downloading and installing a CDAP CSD (Custom
@@ -58,7 +60,7 @@ Prerequisites
    - The 'cdap' user needs to be granted HBase permissions to create tables.
      In an HBase shell, enter::
      
-      grant 'cdap', 'ACRW'
+      > grant 'cdap', 'ACRW'
 
    - The 'cdap' user must be able to launch YARN containers, either by adding it to the YARN
      ``allowed.system.users`` or by adjusting ``min.user.id``.
@@ -188,8 +190,8 @@ The following is the generic procedure for Major/Minor version upgrades:
 
 .. rubric:: Upgrading CDAP 3.0 to 3.1 and Upgrading CDH 5.3 to 5.4
 
-**Background:** CDH 5.3 ships with Hbase 0.98 while CDH 5.4 ships with HBase 1.0. We support
-CDH 5.4 as of CDAP 3.1.0. Upgrading from CDH 5.3 to CDH 5.4 entails an HBase upgrade in
+**Background:** CDH 5.3 ships with HBase 0.98 while CDH 5.4 ships with HBase 1.0. We support
+CDH 5.4 as of CDAP 3.1.0. Upgrading from CDH 5.3 to CDH 5.4 includes an HBase upgrade in
 addition to a CDAP upgrade. **It is important to perform these steps as described, otherwise
 you can end up with an unusable system.**
 
@@ -204,8 +206,11 @@ you can end up with an unusable system.**
 #. Upgrade to CDH 5.4
 #. :ref:`Stop CDAP application and services <install-upgrade>`, as CDH will have auto-started CDAP
 #. Upgrade to CDAP 3.1
-#. Run the CDAP Upgrade Tool, as the user that runs CDAP Master (the CDAP user)
-#. Check if the co-processor JARs for these tables have been upgraded to ``cdh-1.0``:
+#. Run the CDAP Upgrade Tool, as the user that runs CDAP Master (the CDAP user)::
+
+    $ /opt/cdap/master/bin/svc-master run co.cask.cdap.data.tools.UpgradeTool upgrade
+    
+#. Check if the coprocessor JARs for these tables have been upgraded to ``cdh-1.0``:
 
     - ``cdap_system:app.meta``
     - ``cdap_system:datasets.instance``
@@ -233,7 +238,11 @@ you can end up with an unusable system.**
     > enable 'cdap_system:datasets.type'
 
 #. Run the CDAP Upgrade Tool (again), as the user that runs CDAP Master (the CDAP user)
-#. Before starting CDAP, check that all tables have co-processors upgraded, as described above
+#. Before starting CDAP, check that all tables have coprocessors upgraded, as described above
+#. Enable all CDAP tables; from an HBase shell, run this command::
+
+    > enable_all 'cdap.*'
+    
 #. Start CDAP
 
 

--- a/cdap-docs/integrations/source/partners/cloudera/configuring.rst
+++ b/cdap-docs/integrations/source/partners/cloudera/configuring.rst
@@ -192,10 +192,17 @@ The following is the generic procedure for Major/Minor version upgrades:
 
 **Background:** CDH 5.3 ships with HBase 0.98 while CDH 5.4 ships with HBase 1.0. We support
 CDH 5.4 as of CDAP 3.1.0. Upgrading from CDH 5.3 to CDH 5.4 includes an HBase upgrade in
-addition to a CDAP upgrade. **It is important to perform these steps as described,
-otherwise you can end up with an unusable system.** If you make a mistake and get stuck,
-see these troubleshooting instructions for :ref:`problems while upgrading CDH
-<cloudera-troubleshooting-upgrade-cdh>`.
+addition to a CDAP upgrade. 
+
+**It is important to perform these steps as described, otherwise you can end up with an
+unusable system.** The coprocessors may not get upgraded correctly, and HBase
+regionservers may crash.
+
+If you make a mistake and get stuck, see these troubleshooting instructions for
+:ref:`problems while upgrading CDH <cloudera-troubleshooting-upgrade-cdh>`.
+
+In the future, we intend to automate all these steps. The issue that tracks that work is
+`CDAP-3179 <https://issues.cask.co/browse/CDAP-3179>`__.
 
 **Upgrade Steps**
 

--- a/cdap-docs/integrations/source/partners/cloudera/configuring.rst
+++ b/cdap-docs/integrations/source/partners/cloudera/configuring.rst
@@ -211,14 +211,14 @@ you can end up with an unusable system.**
     - ``cdap_system:datasets.instance``
     - ``cdap_system:datasets.type``
     
-  by checking that the coprocessor classnames are using the ``base10cdh`` package |---|
-  for example, ``co.cask.cdap.data2.transaction.coprocessor.hbase10cdh.DefaultTransactionProcessor``
+   by checking that the coprocessor classnames are using the ``base10cdh`` package |---|
+   for example, ``co.cask.cdap.data2.transaction.coprocessor.hbase10cdh.DefaultTransactionProcessor``
   
-  Running this command in an HBase shell will give you table attributes::
+   Running this command in an HBase shell will give you table attributes::
   
     > describe 'cdap_system:app.meta'
     
-  The result output will show the coprocessor classname::
+   The resulting output will show the coprocessor classname::
   
     'cdap_system:app.meta', {TABLE_ATTRIBUTES => {coprocessor$1 =>
     'hdfs://server.example.com/cdap/cdap/lib/

--- a/cdap-docs/integrations/source/partners/cloudera/configuring.rst
+++ b/cdap-docs/integrations/source/partners/cloudera/configuring.rst
@@ -232,8 +232,6 @@ you can end up with an unusable system.**
     > enable 'cdap_system:datasets.instance'
     > enable 'cdap_system:datasets.type'
 
-#. Run the CDAP Upgrade Tool, as the user that runs CDAP Master (the CDAP user)
-#. Before starting CDAP, check that all tables have co-processors upgraded
 #. Start CDAP
 
 

--- a/cdap-docs/integrations/source/partners/cloudera/configuring.rst
+++ b/cdap-docs/integrations/source/partners/cloudera/configuring.rst
@@ -186,9 +186,45 @@ The following is the generic procedure for Major/Minor version upgrades:
 
 .. _cloudera-release-specific-upgrade-notes:
 
+.. rubric:: Upgrading CDAP 3.0 to 3.1 and Upgrading CDH 5.3 to 5.4
+
+**Background:** CDH 5.3 ships with Hbase 0.98 while CDH 5.4 supports HBase 1.0. We support
+CDH 5.4 as of CDAP 3.1.0. Upgrading from CDH 5.3 to CDH 5.4 entails an HBase upgrade in
+addition to a CDAP upgrade. **It is important to perform these steps as described, otherwise
+you can end up with a unworkable system.**
+
+**Upgrade Steps**
+
+1. Stop CDAP applications and services
+#. Disable all CDAP tables; from an HBase shell, run this command::
+
+    > disable_all 'cdap.*'
+    
+#. Upgrade to CDH 5.4
+#. Stop CDAP application and services, as CDH will have auto-started CDAP
+#. Upgrade to CDAP 3.1
+#. Run the CDAP Upgrade Tool 
+#. Check if the co-processor JARs for these tables have been upgraded to ``cdh-1.0``:
+
+    - ``cdap_system:app.meta``
+    - ``cdap_system:datasets.instance``
+    - ``cdap_system:datasets.type``
+
+#. Enable these tables; from an HBase shell, run these commands::
+   
+    > enable 'cdap_system:app.meta'
+    > enable 'cdap_system:datasets.instance'
+    > enable 'cdap_system:datasets.type'
+
+#. Run the CDAP Upgrade Tool
+#. Before starting CDAP, check that all tables have co-processors upgraded
+#. Start CDAP
+
+
 .. rubric:: Upgrading CDAP 3.0 to 3.1
 
 **Note:** An app need to be both recompiled and re-deployed if it uses either a PartitionedFileSet or a TimePartitionedFileSet.
+
 
 .. rubric:: Upgrading CDAP 2.8 to 3.0
 

--- a/cdap-docs/integrations/source/partners/cloudera/configuring.rst
+++ b/cdap-docs/integrations/source/partners/cloudera/configuring.rst
@@ -194,11 +194,12 @@ The following is the generic procedure for Major/Minor version upgrades:
 CDH 5.4 as of CDAP 3.1.0. Upgrading from CDH 5.3 to CDH 5.4 includes an HBase upgrade in
 addition to a CDAP upgrade. 
 
-**It is important to perform these steps as described, otherwise you can end up with an
-unusable system.** The coprocessors may not get upgraded correctly, and HBase
+**It is important to perform these steps as described, otherwise you can end up with a
+problematic system.** The coprocessors may not get upgraded correctly, and HBase
 regionservers may crash.
 
-If you make a mistake and get stuck, see these troubleshooting instructions for
+In the case where goes wrong with the upgrade, and you end up with a dead HBase
+regionserver see these troubleshooting instructions for
 :ref:`problems while upgrading CDH <cloudera-troubleshooting-upgrade-cdh>`.
 
 In the future, we intend to automate all these steps. The issue that tracks that work is

--- a/cdap-docs/integrations/source/partners/cloudera/configuring.rst
+++ b/cdap-docs/integrations/source/partners/cloudera/configuring.rst
@@ -334,10 +334,14 @@ tables will get re-enabled before the coprocessors are upgraded. This could caus
 regionservers to abort and may make it very difficult to get the cluster back to a stable
 state where the tables can be disabled again and complete the process.
 
+.. highlight:: xml
+
 In that case, set this configuration property in ``hbase-site.xml``::
 
-  hbase.coprocessor.abortonerror
-  false
+  <property>
+    <name>hbase.coprocessor.abortonerror</name>
+    <value>false</value>
+  </property>
 
 and restart the HBase regionservers. This will allow the regionservers to start up
 despite the coprocessor version mismatch. At this point, you should be able to run through

--- a/cdap-docs/integrations/source/partners/cloudera/configuring.rst
+++ b/cdap-docs/integrations/source/partners/cloudera/configuring.rst
@@ -194,12 +194,12 @@ The following is the generic procedure for Major/Minor version upgrades:
 CDH 5.4 as of CDAP 3.1.0. Upgrading from CDH 5.3 to CDH 5.4 includes an HBase upgrade in
 addition to a CDAP upgrade. 
 
-**It is important to perform these steps as described, otherwise you can end up with a
-problematic system.** The coprocessors may not get upgraded correctly, and HBase
-regionservers may crash.
+**It is important to perform these steps as described, otherwise you can end up with a you
+may end up with a dead HBase regionserver.** The coprocessors may not get upgraded
+correctly and HBase regionservers may crash.
 
-In the case where goes wrong with the upgrade, and you end up with a dead HBase
-regionserver see these troubleshooting instructions for
+In the case where something goes wrong with the upgrade, and you end up with a dead HBase
+regionserver, see these troubleshooting instructions for
 :ref:`problems while upgrading CDH <cloudera-troubleshooting-upgrade-cdh>`.
 
 In the future, we intend to automate all these steps. The issue that tracks that work is

--- a/cdap-docs/integrations/source/partners/cloudera/configuring.rst
+++ b/cdap-docs/integrations/source/partners/cloudera/configuring.rst
@@ -220,7 +220,7 @@ In the future, we intend to automate all these steps. The issue that tracks that
    If using Cloudera Manager, this can be done by selecting ``Run CDAP Upgrade Tool`` from
    the *CDAP Service Actions* menu
     
-#. Check if the coprocessor JARs for these tables have been upgraded to ``cdh-1.0``:
+#. Check if the coprocessor JARs for these tables have been upgraded to CDH HBase 1.0:
 
     - ``cdap_system:app.meta``
     - ``cdap_system:datasets.instance``
@@ -333,7 +333,7 @@ Previously released parcels can also be accessed from their version-specific URL
 If you miss a step in the upgrade process and something goes wrong, it's possible that the
 tables will get re-enabled before the coprocessors are upgraded. This could cause the
 regionservers to abort and may make it very difficult to get the cluster back to a stable
-state where the tables can be disabled again and complete the process.
+state where the tables can be disabled again and complete the upgrade process.
 
 .. highlight:: xml
 
@@ -348,10 +348,5 @@ and restart the HBase regionservers. This will allow the regionservers to start 
 despite the coprocessor version mismatch. At this point, you should be able to run through
 the upgrade steps successfully. 
 
-At the end, set the entry for ``hbase.coprocessor.abortonerror`` to ``true`` in order to
-ensure that data correctness is maintained::
-
-  <property>
-    <name>hbase.coprocessor.abortonerror</name>
-    <value>true</value>
-  </property>
+At the end, remove the entry for ``hbase.coprocessor.abortonerror`` in order to ensure
+that data correctness is maintained.

--- a/cdap-docs/integrations/source/partners/cloudera/configuring.rst
+++ b/cdap-docs/integrations/source/partners/cloudera/configuring.rst
@@ -188,20 +188,21 @@ The following is the generic procedure for Major/Minor version upgrades:
 
 .. rubric:: Upgrading CDAP 3.0 to 3.1 and Upgrading CDH 5.3 to 5.4
 
-**Background:** CDH 5.3 ships with Hbase 0.98 while CDH 5.4 supports HBase 1.0. We support
+**Background:** CDH 5.3 ships with Hbase 0.98 while CDH 5.4 ships with HBase 1.0. We support
 CDH 5.4 as of CDAP 3.1.0. Upgrading from CDH 5.3 to CDH 5.4 entails an HBase upgrade in
 addition to a CDAP upgrade. **It is important to perform these steps as described, otherwise
 you can end up with an unusable system.**
 
 **Upgrade Steps**
 
-1. Stop CDAP applications and services
+1. If using Cloudera Manager, :ref:`stop all CDAP application and services
+   <install-upgrade-stop>`, as Cloudera Manager will have auto-started CDAP
 #. Disable all CDAP tables; from an HBase shell, run this command::
 
     > disable_all 'cdap.*'
     
 #. Upgrade to CDH 5.4
-#. Stop CDAP application and services, as CDH will have auto-started CDAP
+#. :ref:`Stop CDAP application and services <install-upgrade-stop>, as CDH will have auto-started CDAP
 #. Upgrade to CDAP 3.1
 #. Run the CDAP Upgrade Tool, as the user that runs CDAP Master (the CDAP user)
 #. Check if the co-processor JARs for these tables have been upgraded to ``cdh-1.0``:
@@ -209,6 +210,9 @@ you can end up with an unusable system.**
     - ``cdap_system:app.meta``
     - ``cdap_system:datasets.instance``
     - ``cdap_system:datasets.type``
+    
+  by checking that the coprocessor classnames are using the ``base10cdh`` package |---|
+  for example, ``co.cask.cdap.data2.transaction.coprocessor.hbase10cdh.DefaultTransactionProcessor``
 
 #. Enable these tables; from an HBase shell, run these commands::
    

--- a/cdap-docs/integrations/source/partners/cloudera/configuring.rst
+++ b/cdap-docs/integrations/source/partners/cloudera/configuring.rst
@@ -194,13 +194,10 @@ The following is the generic procedure for Major/Minor version upgrades:
 CDH 5.4 as of CDAP 3.1.0. Upgrading from CDH 5.3 to CDH 5.4 includes an HBase upgrade in
 addition to a CDAP upgrade. 
 
-**It is important to perform these steps as described, otherwise you can end up with a you
-may end up with a dead HBase regionserver.** The coprocessors may not get upgraded
-correctly and HBase regionservers may crash.
-
-In the case where something goes wrong with the upgrade, and you end up with a dead HBase
-regionserver, see these troubleshooting instructions for
-:ref:`problems while upgrading CDH <cloudera-troubleshooting-upgrade-cdh>`.
+**It is important to perform these steps as described, otherwise you can end up with a
+dead HBase regionserver.** The coprocessors may not get upgraded correctly and HBase
+regionservers may crash. In the case where something goes wrong, see these troubleshooting
+instructions for :ref:`problems while upgrading CDH <cloudera-troubleshooting-upgrade-cdh>`.
 
 In the future, we intend to automate all these steps. The issue that tracks that work is
 `CDAP-3179 <https://issues.cask.co/browse/CDAP-3179>`__.

--- a/cdap-docs/integrations/source/partners/cloudera/configuring.rst
+++ b/cdap-docs/integrations/source/partners/cloudera/configuring.rst
@@ -351,5 +351,10 @@ and restart the HBase regionservers. This will allow the regionservers to start 
 despite the coprocessor version mismatch. At this point, you should be able to run through
 the upgrade steps successfully. 
 
-At the end, remove the entry for ``hbase.coprocessor.abortonerror`` in order to ensure
-that data correctness is maintained.
+At the end, set the entry for ``hbase.coprocessor.abortonerror`` to ``true`` in order to
+ensure that data correctness is maintained::
+
+  <property>
+    <name>hbase.coprocessor.abortonerror</name>
+    <value>true</value>
+  </property>

--- a/cdap-docs/integrations/source/partners/cloudera/configuring.rst
+++ b/cdap-docs/integrations/source/partners/cloudera/configuring.rst
@@ -218,7 +218,7 @@ you can end up with an unusable system.**
   
     > describe 'cdap_system:app.meta'
     
-  The result output will look something like, and show the coprocessor classname::
+  The result output will show the coprocessor classname::
   
     'cdap_system:app.meta', {TABLE_ATTRIBUTES => {coprocessor$1 =>
     'hdfs://server.example.com/cdap/cdap/lib/

--- a/cdap-docs/integrations/source/partners/cloudera/configuring.rst
+++ b/cdap-docs/integrations/source/partners/cloudera/configuring.rst
@@ -203,7 +203,7 @@ you can end up with a unworkable system.**
 #. Upgrade to CDH 5.4
 #. Stop CDAP application and services, as CDH will have auto-started CDAP
 #. Upgrade to CDAP 3.1
-#. Run the CDAP Upgrade Tool 
+#. Run the CDAP Upgrade Tool, as the user that runs CDAP Master (the CDAP user)
 #. Check if the co-processor JARs for these tables have been upgraded to ``cdh-1.0``:
 
     - ``cdap_system:app.meta``
@@ -216,7 +216,7 @@ you can end up with a unworkable system.**
     > enable 'cdap_system:datasets.instance'
     > enable 'cdap_system:datasets.type'
 
-#. Run the CDAP Upgrade Tool
+#. Run the CDAP Upgrade Tool, as the user that runs CDAP Master (the CDAP user)
 #. Before starting CDAP, check that all tables have co-processors upgraded
 #. Start CDAP
 

--- a/cdap-docs/integrations/source/partners/cloudera/configuring.rst
+++ b/cdap-docs/integrations/source/partners/cloudera/configuring.rst
@@ -194,10 +194,10 @@ The following is the generic procedure for Major/Minor version upgrades:
 CDH 5.4 as of CDAP 3.1.0. Upgrading from CDH 5.3 to CDH 5.4 includes an HBase upgrade in
 addition to a CDAP upgrade. 
 
-**It is important to perform these steps as described, otherwise you can end up with a
-dead HBase regionserver.** The coprocessors may not get upgraded correctly and HBase
-regionservers may crash. In the case where something goes wrong, see these troubleshooting
-instructions for :ref:`problems while upgrading CDH <cloudera-troubleshooting-upgrade-cdh>`.
+**It is important to perform these steps as described, otherwise the coprocessors may not
+get upgraded correctly and HBase regionservers may crash.** In the case where something
+goes wrong, see these troubleshooting instructions for :ref:`problems while upgrading CDH
+<cloudera-troubleshooting-upgrade-cdh>`.
 
 In the future, we intend to automate all these steps. The issue that tracks that work is
 `CDAP-3179 <https://issues.cask.co/browse/CDAP-3179>`__.

--- a/cdap-docs/integrations/source/partners/cloudera/configuring.rst
+++ b/cdap-docs/integrations/source/partners/cloudera/configuring.rst
@@ -192,8 +192,10 @@ The following is the generic procedure for Major/Minor version upgrades:
 
 **Background:** CDH 5.3 ships with HBase 0.98 while CDH 5.4 ships with HBase 1.0. We support
 CDH 5.4 as of CDAP 3.1.0. Upgrading from CDH 5.3 to CDH 5.4 includes an HBase upgrade in
-addition to a CDAP upgrade. **It is important to perform these steps as described, otherwise
-you can end up with an unusable system.**
+addition to a CDAP upgrade. **It is important to perform these steps as described,
+otherwise you can end up with an unusable system.** If you make a mistake and get stuck,
+see these troubleshooting instructions for :ref:`problems while upgrading CDH
+<cloudera-troubleshooting-upgrade-cdh>`.
 
 **Upgrade Steps**
 
@@ -316,3 +318,24 @@ Previously released parcels can also be accessed from their version-specific URL
   |http:|//repository.cask.co/parcels/cdap/2.8/CDAP-2.8.0-1-precise.parcel
   |http:|//repository.cask.co/parcels/cdap/2.8/CDAP-2.8.0-1-trusty.parcel
   |http:|//repository.cask.co/parcels/cdap/2.8/CDAP-2.8.0-1-wheezy.parcel
+  
+
+.. _cloudera-troubleshooting-upgrade-cdh:
+
+.. rubric:: Problems While Upgrading CDH
+
+If you miss a step in the upgrade process and something goes wrong, it's possible that the
+tables will get re-enabled before the coprocessors are upgraded. This could cause the
+regionservers to abort and may make it very difficult to get the cluster back to a stable
+state where the tables can be disabled again and complete the process.
+
+In that case, set this configuration property in ``hbase-site.xml``::
+
+  hbase.coprocessor.abortonerror = false
+
+and restart the HBase regionservers. This will allow the regionservers to start up
+despite the coprocessor version mismatch. At this point, you should be able to run through
+the upgrade steps successfully. 
+
+At the end, remove the entry for ``hbase.coprocessor.abortonerror`` in order to ensure
+that data correctness is maintained.

--- a/cdap-docs/integrations/source/partners/cloudera/configuring.rst
+++ b/cdap-docs/integrations/source/partners/cloudera/configuring.rst
@@ -220,6 +220,9 @@ In the future, we intend to automate all these steps. The issue that tracks that
 
     $ /opt/cdap/master/bin/svc-master run co.cask.cdap.data.tools.UpgradeTool upgrade
     
+   If using Cloudera Manager, this can be done by selecting ``Run CDAP Upgrade Tool`` from
+   the *CDAP Service Actions* menu
+    
 #. Check if the coprocessor JARs for these tables have been upgraded to ``cdh-1.0``:
 
     - ``cdap_system:app.meta``

--- a/cdap-docs/integrations/source/partners/cloudera/configuring.rst
+++ b/cdap-docs/integrations/source/partners/cloudera/configuring.rst
@@ -232,6 +232,8 @@ you can end up with an unusable system.**
     > enable 'cdap_system:datasets.instance'
     > enable 'cdap_system:datasets.type'
 
+#. Run the CDAP Upgrade Tool (again), as the user that runs CDAP Master (the CDAP user)
+#. Before starting CDAP, check that all tables have co-processors upgraded, as described above
 #. Start CDAP
 
 

--- a/cdap-docs/integrations/source/partners/cloudera/configuring.rst
+++ b/cdap-docs/integrations/source/partners/cloudera/configuring.rst
@@ -226,7 +226,7 @@ In the future, we intend to automate all these steps. The issue that tracks that
     - ``cdap_system:datasets.instance``
     - ``cdap_system:datasets.type``
     
-   by checking that the coprocessor classnames are using the ``base10cdh`` package |---|
+   by checking that the coprocessor classnames are using the ``hbase10cdh`` package |---|
    for example, ``co.cask.cdap.data2.transaction.coprocessor.hbase10cdh.DefaultTransactionProcessor``
   
    Running this command in an HBase shell will give you table attributes::

--- a/cdap-docs/integrations/source/partners/cloudera/configuring.rst
+++ b/cdap-docs/integrations/source/partners/cloudera/configuring.rst
@@ -196,13 +196,13 @@ you can end up with an unusable system.**
 **Upgrade Steps**
 
 1. If using Cloudera Manager, :ref:`stop all CDAP application and services
-   <install-upgrade-stop>`, as Cloudera Manager will have auto-started CDAP
+   <install-upgrade>`, as Cloudera Manager will have auto-started CDAP
 #. Disable all CDAP tables; from an HBase shell, run this command::
 
     > disable_all 'cdap.*'
     
 #. Upgrade to CDH 5.4
-#. :ref:`Stop CDAP application and services <install-upgrade-stop>, as CDH will have auto-started CDAP
+#. :ref:`Stop CDAP application and services <install-upgrade>`, as CDH will have auto-started CDAP
 #. Upgrade to CDAP 3.1
 #. Run the CDAP Upgrade Tool, as the user that runs CDAP Master (the CDAP user)
 #. Check if the co-processor JARs for these tables have been upgraded to ``cdh-1.0``:
@@ -213,6 +213,18 @@ you can end up with an unusable system.**
     
   by checking that the coprocessor classnames are using the ``base10cdh`` package |---|
   for example, ``co.cask.cdap.data2.transaction.coprocessor.hbase10cdh.DefaultTransactionProcessor``
+  
+  Running this command in an HBase shell will give you table attributes::
+  
+    > describe 'cdap_system:app.meta'
+    
+  The result output will look something like, and show the coprocessor classname::
+  
+    'cdap_system:app.meta', {TABLE_ATTRIBUTES => {coprocessor$1 =>
+    'hdfs://server.example.com/cdap/cdap/lib/
+    coprocessorb5cb1b69834de686a84d513dff009908.jar|co.cask.cdap.data2.transaction.
+    coprocessor.hbase10cdh.DefaultTransactionProcessor|1073741823|', METADATA =>
+    {'cdap.version' => '3.1.0...
 
 #. Enable these tables; from an HBase shell, run these commands::
    

--- a/cdap-docs/reference-manual/source/release-notes.rst
+++ b/cdap-docs/reference-manual/source/release-notes.rst
@@ -1163,10 +1163,10 @@ Bug Fixes
 
 
 
-.. Deprecated and Removed Features
-.. -------------------------------
+Deprecated and Removed Features
+-------------------------------
 
-
+- See the :ref:`CDAP 3.1.0 Javadocs <javadocs>` for a list of deprecated and removed APIs.
 
 .. _known-issues-310:
 


### PR DESCRIPTION
Added a link to the Javadocs in the release notes for 3.1.0 under "deprecated APIs".
Staged at: 
- [Cloudera: Configuring and Installing](http://docs-staging.cask.co/staging/cdap/3.1.0-feature-r3.1_CDH/en/integrations/partners/cloudera/configuring.html#upgrading-an-existing-version)
- [Upgrading An Existing Version](http://docs-staging.cask.co/staging/cdap/3.1.0-feature-r3.1_CDH/en/admin-manual/installation/installation.html#upgrading-an-existing-version)

Building...