### PR TITLE
CDAP-1618: Do schedule updates in proper way

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/TimeScheduler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/TimeScheduler.java
@@ -262,7 +262,6 @@ final class TimeScheduler implements Scheduler {
   }
 
   @Override
-
   public void updateSchedule(Id.Program program, SchedulableProgramType programType, Schedule schedule,
                              Map<String, String> properties) throws NotFoundException, SchedulerException {
     checkInitialized();

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/TimeScheduler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/TimeScheduler.java
@@ -267,8 +267,7 @@ final class TimeScheduler implements Scheduler {
     checkInitialized();
     try {
       Trigger trigger = getTrigger(program, programType, schedule.getName());
-      @SuppressWarnings("unchecked")
-      TriggerBuilder<Trigger> triggerBuilder = (TriggerBuilder<Trigger>) trigger.getTriggerBuilder();
+      TriggerBuilder triggerBuilder = trigger.getTriggerBuilder();
       String cronEntry =  ((TimeSchedule) schedule).getCronEntry();
 
       // create the new trigger with the new schedule schedule all other fields will remain unmodified

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/TimeScheduler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/TimeScheduler.java
@@ -166,11 +166,7 @@ final class TimeScheduler implements Scheduler {
         .withSchedule(CronScheduleBuilder
                         .cronSchedule(getQuartzCronExpression(cronEntry))
                         .withMisfireHandlingInstructionDoNothing());
-      if (properties != null) {
-        for (Map.Entry<String, String> entry : properties.entrySet()) {
-          trigger.usingJobData(entry.getKey(), entry.getValue());
-        }
-      }
+      addProperties(trigger, properties);
       try {
         scheduler.scheduleJob(trigger.build());
       } catch (org.quartz.SchedulerException e) {
@@ -266,11 +262,25 @@ final class TimeScheduler implements Scheduler {
   }
 
   @Override
+
   public void updateSchedule(Id.Program program, SchedulableProgramType programType, Schedule schedule,
                              Map<String, String> properties) throws NotFoundException, SchedulerException {
-    // TODO modify the update flow [CDAP-1618]
-    deleteSchedule(program, programType, schedule.getName());
-    schedule(program, programType, schedule, properties);
+    checkInitialized();
+    try {
+      Trigger trigger = getTrigger(program, programType, schedule.getName());
+      @SuppressWarnings("unchecked")
+      TriggerBuilder<Trigger> triggerBuilder = (TriggerBuilder<Trigger>) trigger.getTriggerBuilder();
+      String cronEntry =  ((TimeSchedule) schedule).getCronEntry();
+
+      // create the new trigger with the new schedule schedule all other fields will remain unmodified
+      triggerBuilder.withSchedule(CronScheduleBuilder
+                                    .cronSchedule(getQuartzCronExpression(cronEntry))
+                                    .withMisfireHandlingInstructionDoNothing());
+      addProperties(triggerBuilder, properties);
+      scheduler.rescheduleJob(trigger.getKey(), triggerBuilder.build());
+    } catch (org.quartz.SchedulerException e) {
+      throw new SchedulerException(e);
+    }
   }
 
   @Override
@@ -278,11 +288,7 @@ final class TimeScheduler implements Scheduler {
     throws NotFoundException, SchedulerException {
     checkInitialized();
     try {
-      Trigger trigger = scheduler.getTrigger(
-        new TriggerKey(AbstractSchedulerService.scheduleIdFor(program, programType, scheduleName)));
-      if (trigger == null) {
-        throw new ScheduleNotFoundException(Id.Schedule.from(program.getApplication(), scheduleName));
-      }
+      Trigger trigger = getTrigger(program, programType, scheduleName);
 
       scheduler.unscheduleJob(trigger.getKey());
 
@@ -394,5 +400,29 @@ final class TimeScheduler implements Scheduler {
         }
       }
     };
+  }
+
+  /**
+   * Gets a {@link Trigger} associated with this program name, type and schedule name
+   */
+  private Trigger getTrigger(Id.Program program, SchedulableProgramType programType,
+                             String scheduleName) throws org.quartz.SchedulerException, ScheduleNotFoundException {
+    Trigger trigger = scheduler.getTrigger(
+      new TriggerKey(AbstractSchedulerService.scheduleIdFor(program, programType, scheduleName)));
+    if (trigger == null) {
+      throw new ScheduleNotFoundException(Id.Schedule.from(program.getApplication(), scheduleName));
+    }
+    return  trigger;
+  }
+
+  /**
+   * Adds properties to a {@link TriggerBuilder} to used by the {@link Trigger}
+   */
+  private void addProperties(TriggerBuilder trigger, Map<String, String> properties) {
+    if (properties != null) {
+      for (Map.Entry<String, String> entry : properties.entrySet()) {
+        trigger.usingJobData(entry.getKey(), entry.getValue());
+      }
+    }
   }
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/SchedulerServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/SchedulerServiceTest.java
@@ -180,17 +180,22 @@ public class SchedulerServiceTest {
     Assert.assertEquals(1, scheduleIds.size());
     checkState(Scheduler.ScheduleState.SUSPENDED, scheduleIds);
 
+    List<ScheduledRuntime> oldScheduledRuntimes = schedulerService.nextScheduledRuntime(program, programType);
+
     schedulerService.updateSchedule(program, programType, updatedTimeSchedule1);
 
     schedulerService.resumeSchedule(program, programType, "Schedule1");
     checkState(Scheduler.ScheduleState.SCHEDULED, scheduleIds);
 
-    List<ScheduledRuntime> scheduledRuntimes = schedulerService.nextScheduledRuntime(program, programType);
+    List<ScheduledRuntime> updatedScheduledRuntimes = schedulerService.nextScheduledRuntime(program, programType);
 
     // the next schedule runtime should be in next 10 minutes from resume
-    Assert.assertTrue(scheduledRuntimes.get(0).getTime() > System.currentTimeMillis() &&
-                        scheduledRuntimes.get(0).getTime() < System.currentTimeMillis() +
+    Assert.assertTrue(updatedScheduledRuntimes.get(0).getTime() > System.currentTimeMillis() &&
+                        updatedScheduledRuntimes.get(0).getTime() < System.currentTimeMillis() +
                           TimeUnit.MINUTES.toMillis(12));
+
+    // the updated next schedule runtime must be less than the old one
+    Assert.assertTrue(updatedScheduledRuntimes.get(0).getTime() < oldScheduledRuntimes.get(0).getTime());
 
     schedulerService.deleteSchedules(program, programType);
     Assert.assertEquals(0, schedulerService.getScheduleIds(program, programType).size());

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/SchedulerServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/SchedulerServiceTest.java
@@ -29,6 +29,7 @@ import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.internal.AppFabricTestHelper;
 import co.cask.cdap.internal.app.DefaultApplicationSpecification;
 import co.cask.cdap.internal.app.namespace.NamespaceAdmin;
+import co.cask.cdap.internal.schedule.TimeSchedule;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.ProgramType;
@@ -44,6 +45,7 @@ import org.junit.Test;
 import java.util.Calendar;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 
 public class SchedulerServiceTest {
   private static SchedulerService schedulerService;
@@ -56,16 +58,18 @@ public class SchedulerServiceTest {
                                                            AppWithWorkflow.SampleWorkflow.NAME);
   private static final SchedulableProgramType programType = SchedulableProgramType.WORKFLOW;
   private static final Id.Stream STREAM_ID = Id.Stream.from(namespace, "stream");
-  private static final Schedule timeSchedule1 =
+  private static final Schedule TIME_SCHEDULE_1 =
     Schedules.createTimeSchedule("Schedule1", "Next hour", getCron(1, TimeUnit.HOURS));
-  private static final Schedule timeSchedule2 =
+  private static final Schedule TIME_SCHEDULE_2 =
     Schedules.createTimeSchedule("Schedule2", "Next day", getCron(1, TimeUnit.DAYS));
-  private static final Schedule dataSchedule1 =
+  private static final Schedule DATA_SCHEDULE_1 =
     Schedules.createDataSchedule("Schedule3", "Every 1M", Schedules.Source.STREAM, STREAM_ID.getId(), 1);
-  private static final Schedule dataSchedule2 =
+  private static final Schedule DATA_SCHEDULE_2 =
     Schedules.createDataSchedule("Schedule4", "Every 10M", Schedules.Source.STREAM, STREAM_ID.getId(), 10);
-  private static final Schedule  updatedTimeSchedule1 =
+  private static final Schedule UPDATED_TIME_SCHEDULE_1 =
     Schedules.createTimeSchedule("Schedule1", "Next 10 Minutes", getCron(10, TimeUnit.MINUTES));
+  private static final Schedule UPDATED_DATA_SCHEDULE_2 =
+    Schedules.createDataSchedule("Schedule4", "Every 5M", Schedules.Source.STREAM, STREAM_ID.getId(), 5);
 
   @BeforeClass
   public static void set() throws Exception {
@@ -89,8 +93,8 @@ public class SchedulerServiceTest {
     AppFabricTestHelper.deployApplication(namespace, AppWithWorkflow.class);
     ApplicationSpecification applicationSpecification = store.getApplication(appId);
 
-    schedulerService.schedule(program, programType, ImmutableList.of(timeSchedule1));
-    store.addApplication(appId, createNewSpecification(applicationSpecification, program, programType, timeSchedule1),
+    schedulerService.schedule(program, programType, ImmutableList.of(TIME_SCHEDULE_1));
+    store.addApplication(appId, createNewSpecification(applicationSpecification, program, programType, TIME_SCHEDULE_1),
                          locationFactory.create("app"));
 
     Id.Program programInOtherNamespace =
@@ -103,9 +107,9 @@ public class SchedulerServiceTest {
     List<String> scheduleIdsOtherNamespace = schedulerService.getScheduleIds(programInOtherNamespace, programType);
     Assert.assertEquals(0, scheduleIdsOtherNamespace.size());
 
-    schedulerService.schedule(programInOtherNamespace, programType, ImmutableList.of(timeSchedule2));
+    schedulerService.schedule(programInOtherNamespace, programType, ImmutableList.of(TIME_SCHEDULE_2));
     store.addApplication(appId, createNewSpecification(applicationSpecification, programInOtherNamespace, programType,
-                                                       timeSchedule2),
+                                                       TIME_SCHEDULE_2),
                          locationFactory.create("app"));
 
     scheduleIdsOtherNamespace = schedulerService.getScheduleIds(programInOtherNamespace, programType);
@@ -120,8 +124,8 @@ public class SchedulerServiceTest {
     AppFabricTestHelper.deployApplication(namespace, AppWithWorkflow.class);
     ApplicationSpecification applicationSpecification = store.getApplication(appId);
 
-    schedulerService.schedule(program, programType, ImmutableList.of(timeSchedule1));
-    applicationSpecification = createNewSpecification(applicationSpecification, program, programType, timeSchedule1);
+    schedulerService.schedule(program, programType, ImmutableList.of(TIME_SCHEDULE_1));
+    applicationSpecification = createNewSpecification(applicationSpecification, program, programType, TIME_SCHEDULE_1);
     store.addApplication(appId, applicationSpecification, locationFactory.create("app"));
     List<String> scheduleIds = schedulerService.getScheduleIds(program, programType);
     Assert.assertEquals(1, scheduleIds.size());
@@ -129,17 +133,17 @@ public class SchedulerServiceTest {
     schedulerService.resumeSchedule(program, programType, "Schedule1");
     checkState(Scheduler.ScheduleState.SCHEDULED, scheduleIds);
 
-    schedulerService.schedule(program, programType, timeSchedule2);
-    applicationSpecification = createNewSpecification(applicationSpecification, program, programType, timeSchedule2);
+    schedulerService.schedule(program, programType, TIME_SCHEDULE_2);
+    applicationSpecification = createNewSpecification(applicationSpecification, program, programType, TIME_SCHEDULE_2);
     store.addApplication(appId, applicationSpecification, locationFactory.create("app"));
     scheduleIds = schedulerService.getScheduleIds(program, programType);
     Assert.assertEquals(2, scheduleIds.size());
     schedulerService.resumeSchedule(program, programType, "Schedule2");
     checkState(Scheduler.ScheduleState.SCHEDULED, scheduleIds);
 
-    schedulerService.schedule(program, programType, ImmutableList.of(dataSchedule1, dataSchedule2));
-    applicationSpecification = createNewSpecification(applicationSpecification, program, programType, dataSchedule1);
-    applicationSpecification = createNewSpecification(applicationSpecification, program, programType, dataSchedule2);
+    schedulerService.schedule(program, programType, ImmutableList.of(DATA_SCHEDULE_1, DATA_SCHEDULE_2));
+    applicationSpecification = createNewSpecification(applicationSpecification, program, programType, DATA_SCHEDULE_1);
+    applicationSpecification = createNewSpecification(applicationSpecification, program, programType, DATA_SCHEDULE_2);
     store.addApplication(appId, applicationSpecification, locationFactory.create("app"));
     scheduleIds = schedulerService.getScheduleIds(program, programType);
     Assert.assertEquals(4, scheduleIds.size());
@@ -170,37 +174,66 @@ public class SchedulerServiceTest {
 
   @Test
   public void testScheduleUpdate() throws Exception {
+    // test time schedule update
+    testScheduleUpdate(TIME_SCHEDULE_1, UPDATED_TIME_SCHEDULE_1, TimeUnit.MINUTES.toMillis(10));
+    // test stream size schedule update
+    testScheduleUpdate(DATA_SCHEDULE_2, UPDATED_DATA_SCHEDULE_2, null);
+  }
+
+  private void testScheduleUpdate(Schedule oldSchedule, Schedule newSchedule, @Nullable Long durationInMillis)
+    throws Exception {
     AppFabricTestHelper.deployApplication(namespace, AppWithWorkflow.class);
     ApplicationSpecification applicationSpecification = store.getApplication(appId);
 
-    schedulerService.schedule(program, programType, ImmutableList.of(timeSchedule1));
-    applicationSpecification = createNewSpecification(applicationSpecification, program, programType, timeSchedule1);
+    schedulerService.schedule(program, programType, ImmutableList.of(oldSchedule));
+    applicationSpecification = createNewSpecification(applicationSpecification, program, programType, oldSchedule);
     store.addApplication(appId, applicationSpecification, locationFactory.create("app"));
     List<String> scheduleIds = schedulerService.getScheduleIds(program, programType);
+
+    // schedule should be deployed in suspended state
     Assert.assertEquals(1, scheduleIds.size());
     checkState(Scheduler.ScheduleState.SUSPENDED, scheduleIds);
 
     List<ScheduledRuntime> oldScheduledRuntimes = schedulerService.nextScheduledRuntime(program, programType);
 
-    schedulerService.updateSchedule(program, programType, updatedTimeSchedule1);
+    // update an newly created schedule whih is in suspended state
+    schedulerService.updateSchedule(program, programType, newSchedule);
 
-    schedulerService.resumeSchedule(program, programType, "Schedule1");
+    scheduleIds = schedulerService.getScheduleIds(program, programType);
+    // there should be only one schedule for this program
+    Assert.assertEquals(1, scheduleIds.size());
+    // schedules should still be in suspended state after update
+    checkState(Scheduler.ScheduleState.SUSPENDED, scheduleIds);
+
+    // time schedules will have nextRuntime associated with it so verify that they are correct after update
+    if (oldSchedule instanceof TimeSchedule && newSchedule instanceof TimeSchedule) {
+      verifyUpdatedNextRuntime(oldScheduledRuntimes, durationInMillis);
+    }
+
+    // the state of an resumed schedule should remain resumed even after update
+    schedulerService.resumeSchedule(program, programType, newSchedule.getName());
+    schedulerService.updateSchedule(program, programType, oldSchedule);
+    scheduleIds = schedulerService.getScheduleIds(program, programType);
     checkState(Scheduler.ScheduleState.SCHEDULED, scheduleIds);
-
-    List<ScheduledRuntime> updatedScheduledRuntimes = schedulerService.nextScheduledRuntime(program, programType);
-
-    // the next schedule runtime should be in next 10 minutes from resume
-    Assert.assertTrue(updatedScheduledRuntimes.get(0).getTime() > System.currentTimeMillis() &&
-                        updatedScheduledRuntimes.get(0).getTime() < System.currentTimeMillis() +
-                          TimeUnit.MINUTES.toMillis(12));
-
-    // the updated next schedule runtime must be less than the old one
-    Assert.assertTrue(updatedScheduledRuntimes.get(0).getTime() < oldScheduledRuntimes.get(0).getTime());
 
     schedulerService.deleteSchedules(program, programType);
     Assert.assertEquals(0, schedulerService.getScheduleIds(program, programType).size());
     applicationSpecification = deleteSchedulesFromSpec(applicationSpecification);
     store.addApplication(appId, applicationSpecification, locationFactory.create("app"));
+  }
+
+  private void verifyUpdatedNextRuntime(List<ScheduledRuntime> oldScheduledRuntimes, Long durationInMillis)
+    throws SchedulerException {
+    Assert.assertNotNull("Expected nextScheduleRuntime duration must be given for time schedules", durationInMillis);
+    List<ScheduledRuntime> updatedScheduledRuntimes = schedulerService.nextScheduledRuntime(program, programType);
+
+    // after update the next schedule runtime should be in next 10 minutes from resume
+    Assert.assertTrue(updatedScheduledRuntimes.get(0).getTime() > System.currentTimeMillis() &&
+                        updatedScheduledRuntimes.get(0).getTime() < System.currentTimeMillis() +
+                          durationInMillis);
+
+    // the updated next schedule runtime must be less than the old one
+    Assert.assertTrue(updatedScheduledRuntimes.get(0).getTime() < oldScheduledRuntimes.get(0).getTime());
   }
 
   /**


### PR DESCRIPTION
- Uses rescheduleJob() from Scheduler to update schedules
- Earlier approach of deleting the schedule and creating new one was not safe for concurrency. For example, thread A calls updateSchedule() and deletes the schedule() and before new one is added thread B calls checkStatus() or some other function which will fail to find the trigger even though the key is valid and exists.
- The rescheduleJob() function perform the reschedule synchronously which guarantees that while the schedule is being updated all other threads have to wait and hence will not lead to any concurrent access issues.
- Added a unit tests in SchedulerService to test updateSchedule.

Issue: https://issues.cask.co/browse/CDAP-1618
Build: http://builds.cask.co/browse/CDAP-DUT2449-1

