### PR TITLE
Correct supported versions in FAQ.

### DIFF
--- a/cdap-docs/reference-manual/source/faq.rst
+++ b/cdap-docs/reference-manual/source/faq.rst
@@ -96,8 +96,8 @@ Yes. You can install CDAP on your Hadoop cluster. See :ref:`install`.
 
 .. rubric:: What Hadoop distributions can CDAP run on?
 
-CDAP has been tested on and supports CDH 4.2.x through 5.3.x, HDP 2.0 through 2.1, and
-Apache Bigtop 0.8.0. 
+CDAP |version| has been tested on and supports CDH 5.0.0 through 5.4.4; HDP 2.0, 2.0, and 2.1; 
+MapR 4.1, and Apache Bigtop 0.8.0. 
 
 
 .. _faq-cdap-user-groups:

--- a/cdap-docs/reference-manual/source/faq.rst
+++ b/cdap-docs/reference-manual/source/faq.rst
@@ -96,7 +96,7 @@ Yes. You can install CDAP on your Hadoop cluster. See :ref:`install`.
 
 .. rubric:: What Hadoop distributions can CDAP run on?
 
-CDAP |version| has been tested on and supports CDH 5.0.0 through 5.4.4; HDP 2.0, 2.0, and 2.1; 
+CDAP |version| has been tested on and supports CDH 5.0.0 through 5.4.4; HDP 2.0, 2.1, and 2.2; 
 MapR 4.1, and Apache Bigtop 0.8.0. 
 
 


### PR DESCRIPTION
Updates the supported versions to match the versions in the installation instructions.

"|version|" in the code is replaced with the CDAP version, "3.1.0".

Staged at: [FAQ: Hadoop](http://docs-staging.cask.co/staging/cdap/3.1.0-feature-r3.1_fix_faq/en/reference-manual/faq.html#hadoop) 

Built.