### PR TITLE
Feature/expose history on all program managers

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/DataSetInputFormat.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/DataSetInputFormat.java
@@ -75,7 +75,7 @@ public final class DataSetInputFormat<KEY, VALUE> extends InputFormat<KEY, VALUE
     BasicMapReduceContext mrContext = contextProvider.get();
     mrContext.getMetricsCollectionService().startAndWait();
     String dataSetName = getInputName(conf);
-    BatchReadable<KEY, VALUE> inputDataset = (BatchReadable<KEY, VALUE>) mrContext.getDataset(dataSetName);
+    BatchReadable<KEY, VALUE> inputDataset = mrContext.getDataset(dataSetName);
     SplitReader<KEY, VALUE> splitReader = inputDataset.createSplitReader(inputSplit.getSplit());
 
     // the record reader now owns the context and will close it

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/DataSetOutputFormat.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/DataSetOutputFormat.java
@@ -56,7 +56,7 @@ public final class DataSetOutputFormat<KEY, VALUE> extends OutputFormat<KEY, VAL
     BasicMapReduceContext mrContext = contextProvider.get();
     mrContext.getMetricsCollectionService().startAndWait();
     @SuppressWarnings("unchecked")
-    BatchWritable<KEY, VALUE> dataset = (BatchWritable<KEY, VALUE>) mrContext.getDataset(getOutputDataSet(conf));
+    BatchWritable<KEY, VALUE> dataset = mrContext.getDataset(getOutputDataSet(conf));
 
     // the record writer now owns the context and will close it
     return new DataSetRecordWriter<>(dataset, mrContext);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/security/ApplicationPermissionCollection.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/security/ApplicationPermissionCollection.java
@@ -73,7 +73,7 @@ class ApplicationPermissionCollection extends PermissionCollection {
   public boolean implies(Permission p) {
     Iterator<Permission> i = perms.iterator();
     while (i.hasNext()) {
-      Permission p1 = ((Permission) i.next());
+      Permission p1 = i.next();
       if (p.getClass().isAssignableFrom(p1.getClass()) && p1.implies(p)) {
         return true;
       }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricClient.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricClient.java
@@ -283,13 +283,18 @@ public class AppFabricClient {
     return workflowTokenDetail;
   }
 
-  public List<RunRecord> getHistory(String namespaceId, String appId, String wflowId) {
+  public List<RunRecord> getHistory(Id.Program programId) {
+    String namespaceId = programId.getNamespaceId();
+    String appId = programId.getApplicationId();
+    String programName = programId.getId();
+    String categoryName = programId.getType().getCategoryName();
+
     MockResponder responder = new MockResponder();
-    String uri = String.format("%s/apps/%s/workflows/%s/runs?status=completed",
-                               getNamespacePath(namespaceId), appId, wflowId);
+    String uri = String.format("%s/apps/%s/%s/%s/runs",
+                               getNamespacePath(namespaceId), appId, categoryName, programName);
     HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
     programLifecycleHttpHandler.programHistory(request, responder, namespaceId, appId,
-                                               "workflows", wflowId, null, null, null, 100);
+                                               categoryName, programName, null, null, null, 100);
     verifyResponse(HttpResponseStatus.OK, responder.getStatus(), "Getting workflow history failed");
 
     return responder.decodeResponseContent(RUN_RECORDS_TYPE);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricClient.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricClient.java
@@ -32,6 +32,7 @@ import co.cask.cdap.proto.AdapterConfig;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.Instances;
 import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.RunRecord;
 import co.cask.cdap.proto.ServiceInstances;
@@ -283,18 +284,18 @@ public class AppFabricClient {
     return workflowTokenDetail;
   }
 
-  public List<RunRecord> getHistory(Id.Program programId) {
+  public List<RunRecord> getHistory(Id.Program programId, ProgramRunStatus status) {
     String namespaceId = programId.getNamespaceId();
     String appId = programId.getApplicationId();
     String programName = programId.getId();
     String categoryName = programId.getType().getCategoryName();
 
     MockResponder responder = new MockResponder();
-    String uri = String.format("%s/apps/%s/%s/%s/runs",
+    String uri = String.format("%s/apps/%s/%s/%s/runs?status=" + status.name(),
                                getNamespacePath(namespaceId), appId, categoryName, programName);
     HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
     programLifecycleHttpHandler.programHistory(request, responder, namespaceId, appId,
-                                               categoryName, programName, null, null, null, 100);
+                                               categoryName, programName, status.name(), null, null, 100);
     verifyResponse(HttpResponseStatus.OK, responder.getStatus(), "Getting workflow history failed");
 
     return responder.decodeResponseContent(RUN_RECORDS_TYPE);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunnerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunnerTest.java
@@ -421,7 +421,7 @@ public class MapReduceProgramRunnerTest {
                                                                                          TEMP_FOLDER_SUPPLIER);
 
     // we need to do a "get" on all datasets we use so that they are in dataSetInstantiator.getTransactionAware()
-    final TimeseriesTable table = (TimeseriesTable) datasetInstantiator.getDataset("timeSeries");
+    final TimeseriesTable table = datasetInstantiator.getDataset("timeSeries");
     final KeyValueTable beforeSubmitTable = datasetInstantiator.getDataset("beforeSubmit");
     final KeyValueTable onFinishTable = datasetInstantiator.getDataset("onFinish");
     final Table counters = datasetInstantiator.getDataset("counters");

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/cube/MetricsTableOnTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/cube/MetricsTableOnTableTest.java
@@ -47,7 +47,7 @@ public class MetricsTableOnTableTest extends MetricsTableTest {
     if (dsFrameworkUtil.getInstance(id) == null) {
       dsFrameworkUtil.createInstance(Table.class.getName(), id, DatasetProperties.EMPTY);
     }
-    Table table = (Table) dsFrameworkUtil.getInstance(id);
+    Table table = dsFrameworkUtil.getInstance(id);
     return new MetricsTableTxnlWrapper(new MetricsTableOnTable(table), table);
   }
 

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/BufferingTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/BufferingTableTest.java
@@ -342,7 +342,7 @@ public abstract class BufferingTableTest<T extends BufferingTable>
       Assert.assertEquals(1, counters.size());
       byte[] colFromInc = counters.keySet().iterator().next();
       Assert.assertArrayEquals(new byte[] {2}, colFromInc);
-      Assert.assertEquals(3, (long) Bytes.toLong(counters.get(colFromInc)));
+      Assert.assertEquals(3, Bytes.toLong(counters.get(colFromInc)));
       counters.remove(new byte[] {2});
       colFromInc[0]++;
 

--- a/cdap-explore-jdbc/src/main/java/co/cask/cdap/explore/jdbc/BaseExploreResultSet.java
+++ b/cdap-explore-jdbc/src/main/java/co/cask/cdap/explore/jdbc/BaseExploreResultSet.java
@@ -186,7 +186,7 @@ abstract class BaseExploreResultSet implements ResultSet {
     } else if (Number.class.isInstance(obj)) {
       return ((Number) obj).intValue() != 0;
     } else if (String.class.isInstance(obj)) {
-      return !((String) obj).equals("0");
+      return !obj.equals("0");
     }
     throw new SQLException("Cannot convert column " + columnIndex + " to boolean");
   }

--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteApplicationManager.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteApplicationManager.java
@@ -23,6 +23,7 @@ import co.cask.cdap.client.util.RESTClient;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramRecord;
 import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.RunRecord;
 import co.cask.cdap.test.AbstractApplicationManager;
 import co.cask.cdap.test.DataSetManager;
 import co.cask.cdap.test.DefaultMapReduceManager;
@@ -37,6 +38,7 @@ import co.cask.cdap.test.WorkflowManager;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -52,8 +54,8 @@ public class RemoteApplicationManager extends AbstractApplicationManager {
     super(application);
 
     this.clientConfig = clientConfig;
-    this.programClient = new ProgramClient(clientConfig);
-    this.applicationClient = new ApplicationClient(clientConfig);
+    this.programClient = new ProgramClient(clientConfig, restClient);
+    this.applicationClient = new ApplicationClient(clientConfig, restClient);
     this.restClient = restClient;
   }
 
@@ -146,6 +148,15 @@ public class RemoteApplicationManager extends AbstractApplicationManager {
       String status = programClient.getStatus(programId);
       // comparing to hardcoded string is ugly, but this is how appFabricServer works now to support legacy UI
       return "STARTING".equals(status) || "RUNNING".equals(status);
+    } catch (Exception e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  @Override
+  public List<RunRecord> getHistory(Id.Program programId) {
+    try {
+      return programClient.getProgramRuns(programId, "ALL", 0, Long.MAX_VALUE, Integer.MAX_VALUE);
     } catch (Exception e) {
       throw Throwables.propagate(e);
     }

--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteApplicationManager.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteApplicationManager.java
@@ -22,6 +22,7 @@ import co.cask.cdap.client.config.ClientConfig;
 import co.cask.cdap.client.util.RESTClient;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramRecord;
+import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.RunRecord;
 import co.cask.cdap.test.AbstractApplicationManager;
@@ -154,9 +155,9 @@ public class RemoteApplicationManager extends AbstractApplicationManager {
   }
 
   @Override
-  public List<RunRecord> getHistory(Id.Program programId) {
+  public List<RunRecord> getHistory(Id.Program programId, ProgramRunStatus status) {
     try {
-      return programClient.getProgramRuns(programId, "ALL", 0, Long.MAX_VALUE, Integer.MAX_VALUE);
+      return programClient.getProgramRuns(programId, status.name(), 0, Long.MAX_VALUE, Integer.MAX_VALUE);
     } catch (Exception e) {
       throw Throwables.propagate(e);
     }

--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteWorkflowManager.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteWorkflowManager.java
@@ -26,7 +26,6 @@ import co.cask.cdap.client.util.RESTClient;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.UnauthorizedException;
 import co.cask.cdap.proto.Id;
-import co.cask.cdap.proto.RunRecord;
 import co.cask.cdap.proto.WorkflowTokenDetail;
 import co.cask.cdap.proto.WorkflowTokenNodeDetail;
 import co.cask.cdap.test.AbstractProgramManager;
@@ -61,15 +60,6 @@ public class RemoteWorkflowManager extends AbstractProgramManager<WorkflowManage
   public List<ScheduleSpecification> getSchedules() {
     try {
       return scheduleClient.list(workflowId);
-    } catch (Exception e) {
-      throw Throwables.propagate(e);
-    }
-  }
-
-  @Override
-  public List<RunRecord> getHistory() {
-    try {
-      return programClient.getProgramRuns(workflowId, "ALL", 0, Long.MAX_VALUE, Integer.MAX_VALUE);
     } catch (Exception e) {
       throw Throwables.propagate(e);
     }

--- a/cdap-security/src/main/java/co/cask/cdap/security/server/JAASLoginService.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/server/JAASLoginService.java
@@ -187,7 +187,7 @@ public class JAASLoginService extends AbstractLifeCycle implements LoginService 
               if (callback instanceof NameCallback) {
                 ((NameCallback) callback).setName(username);
               } else if (callback instanceof PasswordCallback) {
-                ((PasswordCallback) callback).setPassword((char[]) credentials.toString().toCharArray());
+                ((PasswordCallback) callback).setPassword(credentials.toString().toCharArray());
               } else if (callback instanceof ObjectCallback) {
                 ((ObjectCallback) callback).setObject(credentials);
               } else if (callback instanceof RequestParameterCallback) {

--- a/cdap-test/src/main/java/co/cask/cdap/test/AbstractProgramManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/AbstractProgramManager.java
@@ -17,8 +17,10 @@
 package co.cask.cdap.test;
 
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.RunRecord;
 import com.google.common.collect.ImmutableMap;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -101,5 +103,10 @@ public abstract class AbstractProgramManager<T extends ProgramManager> implement
     if (!statusMatched) {
       throw new IllegalStateException("Program state not as expected. Expected " + status);
     }
+  }
+
+  @Override
+  public List<RunRecord> getHistory() {
+    return applicationManager.getHistory(programId);
   }
 }

--- a/cdap-test/src/main/java/co/cask/cdap/test/AbstractProgramManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/AbstractProgramManager.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.test;
 
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.RunRecord;
 import com.google.common.collect.ImmutableMap;
 
@@ -107,6 +108,11 @@ public abstract class AbstractProgramManager<T extends ProgramManager> implement
 
   @Override
   public List<RunRecord> getHistory() {
-    return applicationManager.getHistory(programId);
+    return getHistory(ProgramRunStatus.ALL);
+  }
+
+  @Override
+  public List<RunRecord> getHistory(ProgramRunStatus status) {
+    return applicationManager.getHistory(programId, status);
   }
 }

--- a/cdap-test/src/main/java/co/cask/cdap/test/ApplicationManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/ApplicationManager.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.test;
 
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.RunRecord;
 
 import java.util.List;
@@ -242,5 +243,5 @@ public interface ApplicationManager {
    * Gets the history of the program
    * @return list of {@link RunRecord} history
    */
-  List<RunRecord> getHistory(Id.Program programId);
+  List<RunRecord> getHistory(Id.Program programId, ProgramRunStatus status);
 }

--- a/cdap-test/src/main/java/co/cask/cdap/test/ApplicationManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/ApplicationManager.java
@@ -17,7 +17,9 @@
 package co.cask.cdap.test;
 
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.RunRecord;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -235,4 +237,10 @@ public interface ApplicationManager {
    * @return true if the program is running; false otherwise.
    */
   boolean isRunning(Id.Program programId);
+
+  /**
+   * Gets the history of the program
+   * @return list of {@link RunRecord} history
+   */
+  List<RunRecord> getHistory(Id.Program programId);
 }

--- a/cdap-test/src/main/java/co/cask/cdap/test/ProgramManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/ProgramManager.java
@@ -17,7 +17,9 @@
 package co.cask.cdap.test;
 
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.RunRecord;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -76,4 +78,10 @@ public interface ProgramManager<T extends ProgramManager> {
    * @throws InterruptedException if the method is interrupted while waiting for the status.
    */
   void waitForStatus(boolean status, int retries, int timeout) throws InterruptedException;
+
+  /**
+   * Gets the history of the program
+   * @return list of {@link RunRecord} history
+   */
+  List<RunRecord> getHistory();
 }

--- a/cdap-test/src/main/java/co/cask/cdap/test/ProgramManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/ProgramManager.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.test;
 
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.RunRecord;
 
 import java.util.List;
@@ -84,4 +85,10 @@ public interface ProgramManager<T extends ProgramManager> {
    * @return list of {@link RunRecord} history
    */
   List<RunRecord> getHistory();
+
+  /**
+   * Gets the history of the program
+   * @return list of {@link RunRecord} history
+   */
+  List<RunRecord> getHistory(ProgramRunStatus status);
 }

--- a/cdap-test/src/main/java/co/cask/cdap/test/WorkflowManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/WorkflowManager.java
@@ -19,7 +19,6 @@ package co.cask.cdap.test;
 import co.cask.cdap.api.schedule.ScheduleSpecification;
 import co.cask.cdap.api.workflow.WorkflowToken;
 import co.cask.cdap.common.NotFoundException;
-import co.cask.cdap.proto.RunRecord;
 import co.cask.cdap.proto.WorkflowTokenDetail;
 import co.cask.cdap.proto.WorkflowTokenNodeDetail;
 
@@ -43,12 +42,6 @@ public interface WorkflowManager extends ProgramManager<WorkflowManager> {
    * @return {@link ScheduleManager} instance to manage the schedule identified by scheduleId
    */
   ScheduleManager getSchedule(String scheduleId);
-
-  /**
-   * Get the history of the workflow
-   * @return list of {@link RunRecord} workflow history
-   */
-  List<RunRecord> getHistory();
 
   /**
    * Get the {@link WorkflowTokenDetail} for the specified workflow run.

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/UnitTestManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/UnitTestManager.java
@@ -276,10 +276,9 @@ public class UnitTestManager implements TestManager {
   @Beta
   @Override
   public final <T> DataSetManager<T> getDataset(Id.Namespace namespace, String datasetInstanceName) throws Exception {
-    //TODO: Expose namespaces later. Hardcoding to default right now.
     Id.DatasetInstance datasetInstanceId = Id.DatasetInstance.from(namespace, datasetInstanceName);
     @SuppressWarnings("unchecked")
-    final T dataSet = (T) datasetFramework.getDataset(datasetInstanceId, new HashMap<String, String>(), null);
+    final T dataSet = datasetFramework.getDataset(datasetInstanceId, new HashMap<String, String>(), null);
     try {
       final TransactionContext txContext;
       // not every dataset is TransactionAware. FileSets for example, are not transactional.

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultApplicationManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultApplicationManager.java
@@ -22,6 +22,7 @@ import co.cask.cdap.data.dataset.DatasetInstantiator;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.internal.AppFabricClient;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.RunRecord;
 import co.cask.cdap.test.AbstractApplicationManager;
@@ -243,7 +244,7 @@ public class DefaultApplicationManager extends AbstractApplicationManager {
   }
 
   @Override
-  public List<RunRecord> getHistory(Id.Program programId) {
-    return appFabricClient.getHistory(programId);
+  public List<RunRecord> getHistory(Id.Program programId, ProgramRunStatus status) {
+    return appFabricClient.getHistory(programId, status);
   }
 }

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultApplicationManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultApplicationManager.java
@@ -23,6 +23,7 @@ import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.internal.AppFabricClient;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.RunRecord;
 import co.cask.cdap.test.AbstractApplicationManager;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.DataSetManager;
@@ -52,6 +53,7 @@ import org.junit.rules.TemporaryFolder;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -238,5 +240,10 @@ public class DefaultApplicationManager extends AbstractApplicationManager {
     } catch (Exception e) {
       throw Throwables.propagate(e);
     }
+  }
+
+  @Override
+  public List<RunRecord> getHistory(Id.Program programId) {
+    return appFabricClient.getHistory(programId.getNamespaceId(), programId.getApplicationId(), programId.getId());
   }
 }

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultApplicationManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultApplicationManager.java
@@ -244,6 +244,6 @@ public class DefaultApplicationManager extends AbstractApplicationManager {
 
   @Override
   public List<RunRecord> getHistory(Id.Program programId) {
-    return appFabricClient.getHistory(programId.getNamespaceId(), programId.getApplicationId(), programId.getId());
+    return appFabricClient.getHistory(programId);
   }
 }

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultApplicationManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultApplicationManager.java
@@ -158,7 +158,7 @@ public class DefaultApplicationManager extends AbstractApplicationManager {
   @Override
   public <T> DataSetManager<T> getDataSet(String dataSetName) {
     @SuppressWarnings("unchecked")
-    final T dataSet = (T) datasetInstantiator.getDataset(dataSetName);
+    final T dataSet = datasetInstantiator.getDataset(dataSetName);
 
     try {
       final TransactionContext txContext =

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultWorkflowManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultWorkflowManager.java
@@ -21,7 +21,6 @@ import co.cask.cdap.api.workflow.WorkflowToken;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.internal.AppFabricClient;
 import co.cask.cdap.proto.Id;
-import co.cask.cdap.proto.RunRecord;
 import co.cask.cdap.proto.WorkflowTokenDetail;
 import co.cask.cdap.proto.WorkflowTokenNodeDetail;
 import co.cask.cdap.test.AbstractProgramManager;
@@ -48,11 +47,6 @@ public class DefaultWorkflowManager extends AbstractProgramManager<WorkflowManag
   @Override
   public List<ScheduleSpecification> getSchedules() {
     return appFabricClient.getSchedules(programId.getNamespaceId(), programId.getApplicationId(), programId.getId());
-  }
-
-  @Override
-  public List<RunRecord> getHistory() {
-    return appFabricClient.getHistory(programId.getNamespaceId(), programId.getApplicationId(), programId.getId());
   }
 
   @Override

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/AppsWithDataset.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/AppsWithDataset.java
@@ -23,7 +23,6 @@ import co.cask.cdap.api.data.batch.RecordScannable;
 import co.cask.cdap.api.data.batch.RecordScanner;
 import co.cask.cdap.api.data.batch.Scannables;
 import co.cask.cdap.api.data.batch.Split;
-import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.dataset.DatasetAdmin;
 import co.cask.cdap.api.dataset.DatasetContext;
 import co.cask.cdap.api.dataset.DatasetDefinition;
@@ -203,7 +202,7 @@ public class AppsWithDataset {
 
       public KeyValueTable(DatasetSpecification spec,
                            @EmbeddedDataset("data") Table table) {
-        super(spec.getName(), (Dataset) table);
+        super(spec.getName(), table);
         this.table = table;
       }
 

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
@@ -167,7 +167,16 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     Assert.assertTrue(countService.isRunning());
     Assert.assertEquals(2, countService.getProvisionedInstances());
 
-    history = countService.getHistory();
+    // requesting with ProgramRunStatus.KILLED returns empty list
+    history = countService.getHistory(ProgramRunStatus.KILLED);
+    Assert.assertEquals(0, history.size());
+
+    // requesting with either RUNNING or ALL will return one record
+    history = countService.getHistory(ProgramRunStatus.RUNNING);
+    Assert.assertEquals(1, history.size());
+    Assert.assertEquals(ProgramRunStatus.RUNNING, history.get(0).getStatus());
+
+    history = countService.getHistory(ProgramRunStatus.ALL);
     Assert.assertEquals(1, history.size());
     Assert.assertEquals(ProgramRunStatus.RUNNING, history.get(0).getStatus());
   }

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
@@ -159,9 +159,17 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     Assert.assertEquals(0, countService.getProvisionedInstances());
     Assert.assertEquals(2, countService.getRequestedInstances());
     Assert.assertFalse(countService.isRunning());
+
+    List<RunRecord> history = countService.getHistory();
+    Assert.assertEquals(0, history.size());
+
     countService.start();
     Assert.assertTrue(countService.isRunning());
     Assert.assertEquals(2, countService.getProvisionedInstances());
+
+    history = countService.getHistory();
+    Assert.assertEquals(1, history.size());
+    Assert.assertEquals(ProgramRunStatus.RUNNING, history.get(0).getStatus());
   }
 
   @Test


### PR DESCRIPTION
First commit moves the implementation from WorkflowManager to AbstractProgramManager to enable that functionality for all program types.
Second commit simply cleans up redundant castings.

http://builds.cask.co/browse/CDAP-DUT2456-3