### PR TITLE
Fix broken build

### DIFF
--- a/cdap-docs/_common/common-build.sh
+++ b/cdap-docs/_common/common-build.sh
@@ -373,6 +373,8 @@ function version() {
     if [ "x${git_branch_listing}" == "x" ]; then 
       echo_red_bold "Unable to determine parent branch as git_branch_listing empty; perhaps in a new branch with no commits"
       echo_red_bold "Using default GIT_BRANCH_PARENT: ${GIT_BRANCH_PARENT}"
+      echo "DEBUGING:"
+      git show-branch
     else
       GIT_BRANCH_PARENT=`echo ${git_branch_listing} | sed 's/.*\[\(.*\)\].*/\1/' | sed 's/[\^~].*//'`
     fi

--- a/cdap-docs/_common/common-build.sh
+++ b/cdap-docs/_common/common-build.sh
@@ -305,12 +305,13 @@ function test_an_include() {
   fi
   
   local m
+  local m_display
   
   if [[ "${new_md5_hash}" == "${NOT_FOUND_HASH}" ]]; then
-    m="${WARNING} ${RED}${BOLD}${file_name} not found!${NC}"  
+    m="${WARNING} ${RED}${BOLD}${file_name} not found!${NC} "  
     m="${m}\nfile: ${target}"  
   elif [[ "${new_md5_hash}" != "${md5_hash}" ]]; then
-    m="${WARNING} ${RED}${BOLD}${file_name} has changed! Compare files and update hash!${NC}"   
+    m="${WARNING} ${RED}${BOLD}${file_name} has changed! Compare files and update hash!${NC} "   
     m="${m}\nfile: ${target}"   
     m="${m}\nOld MD5 Hash: ${md5_hash} New MD5 Hash: ${new_md5_hash}"   
   fi
@@ -396,18 +397,14 @@ function display_version() {
   echo "GIT_BRANCH_PARENT: ${GIT_BRANCH_PARENT}"
 }
 
-function set_messages_file() {
+function clear_messages_set_messages_file() {
+  MESSAGES=
   TMP_MESSAGES_FILE="/tmp/$(basename $0).$$.tmp"
   export TMP_MESSAGES_FILE
 }
 
 function cleanup_messages_file() {
   rm -f ${TMP_MESSAGES_FILE}
-}
-
-function clear_messages() {
-  MESSAGES=
-  set_messages_file
 }
 
 function set_message() {
@@ -419,9 +416,11 @@ function set_message() {
   if [ "x${TMP_MESSAGES_FILE}" != "x" ]; then
     local clean_m=`echo_clean_colors "${*}"`
     if [ -e ${TMP_MESSAGES_FILE} ]; then
+      # As TMP_MESSAGES_FILE exists, add a blank line to start new message
       echo >> ${TMP_MESSAGES_FILE}
     fi
-    echo -e "Warning Message for \"${MANUAL}\":\n${clean_m}" >> ${TMP_MESSAGES_FILE}
+    echo "Warning Message for \"${MANUAL}\":" >> ${TMP_MESSAGES_FILE}
+    echo "${clean_m}" >> ${TMP_MESSAGES_FILE}
   fi
 }
 
@@ -451,7 +450,9 @@ function display_any_messages() {
 function display_messages_file() {
   if [[ "x${TMP_MESSAGES_FILE}" != "x" && -a ${TMP_MESSAGES_FILE} ]]; then
     echo 
-    echo "Warning Messages: ${TMP_MESSAGES_FILE}"
+    echo "--------------------------------------------------------"
+    echo_red_bold "Warning Messages: ${TMP_MESSAGES_FILE}"
+    echo "--------------------------------------------------------"
     echo 
     echo >> ${TMP_MESSAGES_FILE}
     cat ${TMP_MESSAGES_FILE} | while read line

--- a/cdap-docs/_common/common-build.sh
+++ b/cdap-docs/_common/common-build.sh
@@ -475,7 +475,7 @@ function rewrite() {
   echo "    $rewrite_source"
   if [ "x${3}" == "x" ]; then
     local sub_string=${2}
-    echo "  $sub_string"
+  echo "    $sub_string"
     if [ "$(uname)" == "Darwin" ]; then
       sed -i '.bak' "${sub_string}" ${rewrite_source}
       rm ${rewrite_source}.bak
@@ -485,7 +485,7 @@ function rewrite() {
   elif [ "x${4}" == "x" ]; then
     local sub_string=${2}
     local new_sub_string=${3}
-    echo "  ${sub_string} -> ${new_sub_string} "
+    echo "    ${sub_string} -> ${new_sub_string} "
     if [ "$(uname)" == "Darwin" ]; then
       sed -i '.bak' "s|${sub_string}|${new_sub_string}|g" ${rewrite_source}
       rm ${rewrite_source}.bak
@@ -498,7 +498,7 @@ function rewrite() {
     local new_sub_string=${4}
     echo "  to"
     echo "    ${rewrite_target}"
-    echo "  ${sub_string} -> ${new_sub_string} "
+    echo "    ${sub_string} -> ${new_sub_string} "
     sed -e "s|${sub_string}|${new_sub_string}|g" ${rewrite_source} > ${rewrite_target}
   fi
 }

--- a/cdap-docs/_common/common-build.sh
+++ b/cdap-docs/_common/common-build.sh
@@ -373,8 +373,6 @@ function version() {
     if [ "x${git_branch_listing}" == "x" ]; then 
       echo_red_bold "Unable to determine parent branch as git_branch_listing empty; perhaps in a new branch with no commits"
       echo_red_bold "Using default GIT_BRANCH_PARENT: ${GIT_BRANCH_PARENT}"
-      echo "DEBUGING:"
-      git show-branch
     else
       GIT_BRANCH_PARENT=`echo ${git_branch_listing} | sed 's/.*\[\(.*\)\].*/\1/' | sed 's/[\^~].*//'`
     fi

--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -72,8 +72,6 @@ function usage() {
   echo "    docs-web       Clean build of HTML docs and Javadocs, zipped for placing on docs.cask.co webserver"
   echo ""
   echo "    javadocs       Build Javadocs"
-  echo "    json           Build JSON file (json-versions.js)"
-  echo "    print-json     Prints what would be the JSON file (json-versions.js)"
   echo "    licenses       Clean build of License Dependency PDFs"
   echo "    sdk            Build SDK"
   echo "    version        Print the version information"
@@ -97,9 +95,7 @@ function run_command() {
     docs-web-part )     build_docs_web ${ARG_2} ${ARG_3};;
     docs-web )          build_docs_web ${ARG_2} ${ARG_3}; exit 0;;
     javadocs )          build_javadocs; exit 0;;
-    json )              build_json; exit 0;;
     licenses )          build_license_depends; exit 0;;
-    print-json )        print_json; exit 0;;
     sdk )               build_sdk; exit 0;;
     version )           print_version; exit 0;;
     test )              test; exit 0;;
@@ -236,29 +232,6 @@ function build_docs_javadocs() {
   build_docs_inner_level "build"
 }
 
-
-function build_json() {
-  version
-  if [ -d ${SCRIPT_PATH}/${BUILD}/${SOURCE} ]; then
-    cd ${SCRIPT_PATH}/${BUILD}/${SOURCE}
-    JSON_FILE=`python -c 'import conf; conf.print_json_versions_file();'`
-    local json_file_path=${SCRIPT_PATH}/${BUILD}/${PROJECT_VERSION}/${JSON_FILE}
-    python -c 'import conf; conf.print_json_versions();' > ${json_file_path}
-  else
-    echo "Could not find '${SCRIPT_PATH}/${BUILD}/${SOURCE}'; can not build JSON file"
-  fi
-}
-
-function print_json() {
-  version
-  if [ -d ${SCRIPT_PATH}/${BUILD}/${SOURCE} ]; then
-    cd ${SCRIPT_PATH}/${BUILD}/${SOURCE}
-    python -c 'import conf; conf.pretty_print_json_versions();'
-  else
-    echo "Could not find '${SCRIPT_PATH}/${BUILD}/${SOURCE}'; can not print JSON file"
-  fi
-}
-
 function build_docs() {
   _build_docs "docs" ${GOOGLE_ANALYTICS_WEB} ${WEB} ${TRUE}
   return $?
@@ -326,8 +299,6 @@ function zip_extras() {
   if [ "x${1}" == "x${FALSE}" ]; then
     return
   fi
-  # Add JSON file
-  build_json
   # Add .htaccess file (404 file)
   cd ${SCRIPT_PATH}
   rewrite ${COMMON_SOURCE}/${HTACCESS} ${BUILD}/${PROJECT_VERSION}/.${HTACCESS} "<version>" "${PROJECT_VERSION}"

--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -303,7 +303,7 @@ function zip_extras() {
   cd ${SCRIPT_PATH}
   rewrite ${COMMON_SOURCE}/${HTACCESS} ${BUILD}/${PROJECT_VERSION}/.${HTACCESS} "<version>" "${PROJECT_VERSION}"
   cd ${SCRIPT_PATH}/${BUILD}
-  zip -qr ${ZIP_DIR_NAME}.zip ${PROJECT_VERSION}/${JSON_FILE} ${PROJECT_VERSION}/.${HTACCESS}
+  zip -qr ${ZIP_DIR_NAME}.zip ${PROJECT_VERSION}/.${HTACCESS}
 }
 
 function build_sdk() {

--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -280,7 +280,7 @@ function _build_docs() {
   echo "========================================================"
   echo "Building target \"${1}\"..."
   echo "--------------------------------------------------------"
-  clear_messages
+  clear_messages_set_messages_file
   build_docs_inner_level ${1}
   build_docs_outer_level ${2}
   copy_docs_lower_level

--- a/cdap-docs/developers-manual/build.sh
+++ b/cdap-docs/developers-manual/build.sh
@@ -82,9 +82,9 @@ function download_includes() {
   local ingest_url="${github_url}/cdap-ingest/${ingest_branch}"
 
   download_readme_file_and_test ${includes_dir} ${ingest_url} c9b6db1741afa823c362237488c2d8f0 cdap-flume
-  download_readme_file_and_test ${includes_dir} ${ingest_url} f300df291b910f0bd416a5ea160fdbe1 cdap-stream-clients/java
+  download_readme_file_and_test ${includes_dir} ${ingest_url} 08bb5c37085d354834860cb4ca66c121 cdap-stream-clients/java
 #   download_readme_file_and_test ${includes_dir} ${ingest_url} 277ded1924cb8d9b52a007f262820002 cdap-stream-clients/javascript
-  download_readme_file_and_test ${includes_dir} ${ingest_url} b6dedd629c708dbc68bc918b768edda5 cdap-stream-clients/python
+  download_readme_file_and_test ${includes_dir} ${ingest_url} 3013f72ea3454e43adedda2aed40abc1 cdap-stream-clients/python
   download_readme_file_and_test ${includes_dir} ${ingest_url} 5fc88ec3a658062775403f5be30afbe9 cdap-stream-clients/ruby
 
   echo_red_bold "Check included example files for changes"


### PR DESCRIPTION
This fixes the current build, which is broken as two "guarded" files have triggered warnings and failure.

At the same time, fixes an error in the build script which was causing warning messages not to be repeated correctly.

It removes the JSON generation code (the "json-versions.js", as this has been moved out of the documentation build and over to the doc site building.)

Successful build: http://builds.cask.co/browse/CDAP-DDBD548-3/log