### PR TITLE
ability to add multiple events when sending events to streams

### DIFF
--- a/cdap-ui/app/features/flows/templates/tabs/runs/streams/detail.html
+++ b/cdap-ui/app/features/flows/templates/tabs/runs/streams/detail.html
@@ -12,7 +12,7 @@
 
   <div class="modal-body">
 
-    <textarea class="flow-injector-input form-control" placeholder="Events injected here will be consumed by all attached programs." ng-model="userInput" ng-keyup="$event.keyCode == 13 ? doInject($event) : null"></textarea>
+    <textarea class="flow-injector-input form-control" placeholder="Events injected here will be consumed by all attached programs." ng-model="userInput" ng-keyup="$event.keyCode == 13  && !$event.shiftKey? doInject($event) : null"></textarea>
 
   </div>
 

--- a/cdap-ui/app/features/streams/templates/tabs/explore.html
+++ b/cdap-ui/app/features/streams/templates/tabs/explore.html
@@ -61,7 +61,7 @@
                 {{event.timestamp | amDateFormat: 'MM/DD/YY h:mm:ss a'}}
               </td>
               <td>{{event.timestamp | amTimeAgo}}</td>
-              <td>{{event.body | json | myEllipsis: 80 }}</td>
+              <td>{{event.body | myEllipsis: 80 }}</td>
             </tr>
           </tbody>
         </table>

--- a/cdap-ui/app/services/streams/my-streams-service.js
+++ b/cdap-ui/app/services/streams/my-streams-service.js
@@ -35,7 +35,12 @@ angular.module(PKG.name + '.services')
         streamId: $scope.streamId,
         scope: $scope
       };
-      myStreamApi.sendEvent(params, $scope.userInput);
+
+      var lines = $scope.userInput.replace(/\r\n/g, '\n').split('\n');
+
+      angular.forEach(lines, function (line) {
+        myStreamApi.sendEvent(params, line);
+      });
 
       $scope.userInput = null;
     };


### PR DESCRIPTION
- Ability to copy paste multiple lines (events) when sending events to a stream
- User can press shift + enter to go to a newline

![multipleevents](https://cloud.githubusercontent.com/assets/4398643/9101060/e2c21492-3b96-11e5-830f-8e3137b8813f.gif)
