### PR TITLE
Fix/ui nodeproxy ssl enabled

### DIFF
--- a/cdap-ui/app/services/data/cdap-url.js
+++ b/cdap-ui/app/services/data/cdap-url.js
@@ -24,10 +24,10 @@ angular.module(PKG.name + '.services')
       // further sugar for building absolute url
       if(resource._cdapPath || resource._cdapPathV2) {
         url = [
-          'http://',
+          MY_CONFIG.sslEnabled? 'https://': 'http://',
           MY_CONFIG.cdap.routerServerUrl,
           ':',
-          MY_CONFIG.cdap.routerServerPort,
+          MY_CONFIG.sslEnabled? MY_CONFIG.cdap.routerSSLServerPort: MY_CONFIG.cdap.routerServerPort,
           resource._cdapPathV2 ? '/v2' : '/v3',
           resource._cdapPath || resource._cdapPathV2
         ].join('');

--- a/cdap-ui/app/services/status-factory.js
+++ b/cdap-ui/app/services/status-factory.js
@@ -7,7 +7,12 @@ angular.module(PKG.name + '.services')
     function beginPolling() {
 
       _.debounce(function() {
-        $http.get('http://' + window.location.host + '/backendstatus', {ignoreLoadingBar: true})
+        $http.get(
+          (MY_CONFIG.sslEnabled? 'https://': 'http://')
+          + window.location.host
+          + '/backendstatus',
+          {ignoreLoadingBar: true}
+        )
              .success(success.bind(this))
              .error(error.bind(this));
       }.bind(this), 2000)();

--- a/cdap-ui/server.js
+++ b/cdap-ui/server.js
@@ -6,18 +6,19 @@ var express = require('./server/express.js'),
     parser = require('./server/config/parser.js'),
     sockjs = require('sockjs'),
     http = require('http'),
+    fs = require('fs'),
     log4js = require('log4js'),
     https = require('https');
-  
+
 var cdapConfig, securityConfig;
 
 /**
- * Configuring the logger. In order to use the logger anywhere 
+ * Configuring the logger. In order to use the logger anywhere
  * in the BE, include the following:
  *    var log4js = require('log4js');
  *    var logger = log4js.getLogger();
- * 
- * We configure using LOG4JS_CONFIG specified file or we use 
+ *
+ * We configure using LOG4JS_CONFIG specified file or we use
  * the default provided in the conf/log4js.json file.
  */
 if(process.env.LOG4JS_CONFIG) {
@@ -55,10 +56,14 @@ parser.extractConfig('cdap')
         process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
       }
 
-      server = https.createServer({
-        key: fs.readFileSync(securityConfig['dashboard.ssl.cert']),
-        cert: fs.readFileSync(securityConfig['dashboard.ssl.key'])
-      }, app);
+      try {
+        server = https.createServer({
+          key: fs.readFileSync(securityConfig['dashboard.ssl.key']),
+          cert: fs.readFileSync(securityConfig['dashboard.ssl.cert'])
+        }, app);
+      } catch(e) {
+        log.debug('SSL key/cert files read failed. Pleas fix the key/ssl certificate files and restart node server -  ', e);
+      }
       port = cdapConfig['dashboard.ssl.bind.port'];
     }
     else {

--- a/cdap-ui/server.js
+++ b/cdap-ui/server.js
@@ -62,7 +62,7 @@ parser.extractConfig('cdap')
           cert: fs.readFileSync(securityConfig['dashboard.ssl.cert'])
         }, app);
       } catch(e) {
-        log.debug('SSL key/cert files read failed. Pleas fix the key/ssl certificate files and restart node server -  ', e);
+        log.debug('SSL key/cert files read failed. Please fix the key/ssl certificate files and restart node server -  ', e);
       }
       port = cdapConfig['dashboard.ssl.bind.port'];
     }

--- a/cdap-ui/server/config/auth-address.js
+++ b/cdap-ui/server/config/auth-address.js
@@ -20,7 +20,7 @@ var log = log4js.getLogger('default');
 
 var PING_INTERVAL = 1000,
     PING_MAX_RETRIES = 1000,
-    PING_PATH = '/v3/ping';
+    PING_PATH = '/ping';
 
 
 function AuthAddress () {
@@ -98,4 +98,3 @@ AuthAddress.prototype.get = function () {
   }
   return this.addresses[Math.floor(Math.random() * this.addresses.length)];
 };
-

--- a/cdap-ui/server/express.js
+++ b/cdap-ui/server/express.js
@@ -47,8 +47,10 @@ function makeApp (authAddress, cdapConfig) {
       authorization: req.headers.authorization,
       cdap: {
         routerServerUrl: cdapConfig['router.server.address'],
-        routerServerPort: cdapConfig['router.server.port']
+        routerServerPort: cdapConfig['router.server.port'],
+        routerSSLServerPort: cdapConfig['router.ssl.bind.port']
       },
+      sslEnabled: cdapConfig['ssl.enabled'] === 'true',
       securityEnabled: authAddress.enabled,
       isEnterprise: process.env.NODE_ENV === 'production'
     });
@@ -114,12 +116,15 @@ function makeApp (authAddress, cdapConfig) {
     For now it handles file upload POST /namespaces/:namespace/apps API
   */
   app.post('/namespaces/:namespace/:path(*)', function (req, res) {
-    var url = 'http://' + cdapConfig['router.server.address'] +
-              ':' +
-              cdapConfig['router.server.port'] +
-              '/v3/namespaces/' +
-              req.param('namespace') +
-              '/' + req.param('path');
+    var url = (cdapConfig['ssl.enabled'] === 'true'? 'https://': 'http://')
+              + cdapConfig['router.server.address']
+              + ':'
+              + (cdapConfig['ssl.enabled'] === 'true'?
+                  cdapConfig['router.ssl.bind.port'] :  cdapConfig['router.server.port'])
+              + '/v3/namespaces/'
+              + req.param('namespace')
+              + '/'
+              + req.param('path');
 
     var opts = {
       method: 'POST',
@@ -176,10 +181,12 @@ function makeApp (authAddress, cdapConfig) {
   app.get('/backendstatus', [
     function (req, res) {
 
-      var link = 'http://' + cdapConfig['router.server.address'] +
-              ':' +
-              cdapConfig['router.server.port'] +
-              '/v3/namespaces';
+      var link = (cdapConfig['ssl.enabled'] === 'true'? 'https://': 'http://')
+                + cdapConfig['router.server.address']
+                + ':'
+                + (cdapConfig['ssl.enabled'] === 'true'?
+                    cdapConfig['router.ssl.bind.port']: cdapConfig['router.server.port'])
+                + '/v3/namespaces';
 
       request({
         method: 'GET',


### PR DESCRIPTION
- Fixes node proxy to read correct key/certificate files when ssl is enabled.
- Fixes node proxy to send it as config so that UI will change its behavior while making queries through websockets and directly to backend.