### PR TITLE
CDAP-2780 add a way to scan a directory for system artifacts

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ArtifactHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ArtifactHttpHandler.java
@@ -74,7 +74,7 @@ import javax.ws.rs.QueryParam;
  * {@link co.cask.http.HttpHandler} for managing adapter lifecycle.
  */
 @Singleton
-@Path(Constants.Gateway.API_VERSION_3 + "/namespaces/{namespace-id}")
+@Path(Constants.Gateway.API_VERSION_3)
 public class ArtifactHttpHandler extends AbstractHttpHandler {
   private static final Logger LOG = LoggerFactory.getLogger(ArtifactHttpHandler.class);
   private static final String VERSION_HEADER = "Artifact-Version";
@@ -97,8 +97,25 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
       cConf.get(Constants.AppFabric.TEMP_DIR)).getAbsoluteFile();
   }
 
+  @POST
+  @Path("/namespaces/system/artifacts")
+  public void refreshSystemArtifacts(HttpRequest request, HttpResponder responder,
+                                     @PathParam("namespace-id") String namespaceId) {
+    try {
+      artifactRepository.addSystemArtifacts();
+      responder.sendStatus(HttpResponseStatus.OK);
+    } catch (IOException e) {
+      LOG.error("Error while refreshing system artifacts.", e);
+      responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR,
+        "There was an IO error while refreshing system artifacts, please try again.");
+    } catch (WriteConflictException e) {
+      LOG.error("Error while refreshing system artifacts.", e);
+      responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, e.getMessage());
+    }
+  }
+
   @GET
-  @Path("/artifacts")
+  @Path("/namespaces/{namespace-id}/artifacts")
   public void getArtifacts(HttpRequest request, HttpResponder responder,
                            @PathParam("namespace-id") String namespaceId,
                            @QueryParam("includeSystem") @DefaultValue("true") boolean includeSystem)
@@ -115,7 +132,7 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
   }
 
   @GET
-  @Path("/artifacts/{artifact-name}")
+  @Path("/namespaces/{namespace-id}/artifacts/{artifact-name}")
   public void getArtifactVersions(HttpRequest request, HttpResponder responder,
                                   @PathParam("namespace-id") String namespaceId,
                                   @PathParam("artifact-name") String artifactName,
@@ -135,7 +152,7 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
   }
 
   @GET
-  @Path("/artifacts/{artifact-name}/versions/{artifact-version}")
+  @Path("/namespaces/{namespace-id}/artifacts/{artifact-name}/versions/{artifact-version}")
   public void getArtifactInfo(HttpRequest request, HttpResponder responder,
                               @PathParam("namespace-id") String namespaceId,
                               @PathParam("artifact-name") String artifactName,
@@ -165,7 +182,7 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
   }
 
   @GET
-  @Path("/artifacts/{artifact-name}/versions/{artifact-version}/extensions")
+  @Path("/namespaces/{namespace-id}/artifacts/{artifact-name}/versions/{artifact-version}/extensions")
   public void getArtifactPluginTypes(HttpRequest request, HttpResponder responder,
                                      @PathParam("namespace-id") String namespaceId,
                                      @PathParam("artifact-name") String artifactName,
@@ -193,7 +210,7 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
   }
 
   @GET
-  @Path("/artifacts/{artifact-name}/versions/{artifact-version}/extensions/{plugin-type}")
+  @Path("/namespaces/{namespace-id}/artifacts/{artifact-name}/versions/{artifact-version}/extensions/{plugin-type}")
   public void getArtifactPlugins(HttpRequest request, HttpResponder responder,
                                  @PathParam("namespace-id") String namespaceId,
                                  @PathParam("artifact-name") String artifactName,
@@ -229,7 +246,8 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
   }
 
   @GET
-  @Path("/artifacts/{artifact-name}/versions/{artifact-version}/extensions/{plugin-type}/plugins/{plugin-name}")
+  @Path("/namespaces/{namespace-id}/artifacts/{artifact-name}/" +
+        "versions/{artifact-version}/extensions/{plugin-type}/plugins/{plugin-name}")
   public void getArtifactPlugin(HttpRequest request, HttpResponder responder,
                                 @PathParam("namespace-id") String namespaceId,
                                 @PathParam("artifact-name") String artifactName,
@@ -269,7 +287,7 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
   }
 
   @GET
-  @Path("/classes/apps")
+  @Path("/namespaces/{namespace-id}/classes/apps")
   public void getApplicationClasses(HttpRequest request, HttpResponder responder,
                                     @PathParam("namespace-id") String namespaceId,
                                     @QueryParam("includeSystem") @DefaultValue("true") boolean includeSystem)
@@ -282,7 +300,7 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
   }
 
   @GET
-  @Path("/classes/apps/{classname}")
+  @Path("/namespaces/{namespace-id}/classes/apps/{classname}")
   public void getApplicationClasses(HttpRequest request, HttpResponder responder,
                                     @PathParam("namespace-id") String namespaceId,
                                     @PathParam("classname") String className,
@@ -296,7 +314,7 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
   }
 
   @POST
-  @Path("/artifacts/{artifact-name}")
+  @Path("/namespaces/{namespace-id}/artifacts/{artifact-name}")
   public BodyConsumer addArtifact(HttpRequest request, HttpResponder responder,
                                   @PathParam("namespace-id") String namespaceId,
                                   @PathParam("artifact-name") String artifactName,

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ArtifactHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ArtifactHttpHandler.java
@@ -99,8 +99,7 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
 
   @POST
   @Path("/namespaces/system/artifacts")
-  public void refreshSystemArtifacts(HttpRequest request, HttpResponder responder,
-                                     @PathParam("namespace-id") String namespaceId) {
+  public void refreshSystemArtifacts(HttpRequest request, HttpResponder responder) {
     try {
       artifactRepository.addSystemArtifacts();
       responder.sendStatus(HttpResponseStatus.OK);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/PluginClassDeserializer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/PluginClassDeserializer.java
@@ -50,7 +50,7 @@ public class PluginClassDeserializer implements JsonDeserializer<PluginClass> {
 
     String type = jsonObj.has("type") ? jsonObj.get("type").getAsString() : Plugin.DEFAULT_TYPE;
     String name = getRequired(jsonObj, "name").getAsString();
-    String description = getRequired(jsonObj, "description").getAsString();
+    String description = jsonObj.has("description") ? jsonObj.get("description").getAsString() : "";
     String className = getRequired(jsonObj, "className").getAsString();
 
     Map<String, PluginPropertyField> properties = jsonObj.has("properties")

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/PluginClassDeserializer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/PluginClassDeserializer.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.adapter;
+
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.templates.plugins.PluginClass;
+import co.cask.cdap.api.templates.plugins.PluginPropertyField;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.TypeToken;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+
+/**
+ * A Gson deserializater for creating {@link PluginClass} object from external plugin config file.
+ * Used to verify that required fields are present and property map is never null.
+ */
+public class PluginClassDeserializer implements JsonDeserializer<PluginClass> {
+
+  // Type for the PluginClass.properties map.
+  private static final Type PROPERTIES_TYPE = new TypeToken<Map<String, PluginPropertyField>>() { }.getType();
+
+  @Override
+  public PluginClass deserialize(JsonElement json, Type typeOfT,
+                                 JsonDeserializationContext context) throws JsonParseException {
+    if (!json.isJsonObject()) {
+      throw new JsonParseException("PluginClass should be a JSON Object");
+    }
+
+    JsonObject jsonObj = json.getAsJsonObject();
+
+    String type = jsonObj.has("type") ? jsonObj.get("type").getAsString() : Plugin.DEFAULT_TYPE;
+    String name = getRequired(jsonObj, "name").getAsString();
+    String description = getRequired(jsonObj, "description").getAsString();
+    String className = getRequired(jsonObj, "className").getAsString();
+
+    Map<String, PluginPropertyField> properties = jsonObj.has("properties")
+      ? context.<Map<String, PluginPropertyField>>deserialize(jsonObj.get("properties"), PROPERTIES_TYPE)
+      : ImmutableMap.<String, PluginPropertyField>of();
+
+    return new PluginClass(type, name, description, className, null, properties);
+  }
+
+  private JsonElement getRequired(JsonObject jsonObj, String name) {
+    if (!jsonObj.has(name)) {
+      throw new JsonParseException("Property '" + name + "' is missing from PluginClass.");
+    }
+    return jsonObj.get(name);
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/PluginRepository.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/PluginRepository.java
@@ -16,11 +16,9 @@
 
 package co.cask.cdap.internal.app.runtime.adapter;
 
-import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.artifact.ArtifactClasses;
 import co.cask.cdap.api.templates.plugins.PluginClass;
 import co.cask.cdap.api.templates.plugins.PluginInfo;
-import co.cask.cdap.api.templates.plugins.PluginPropertyField;
 import co.cask.cdap.api.templates.plugins.PluginSelector;
 import co.cask.cdap.api.templates.plugins.PluginVersion;
 import co.cask.cdap.common.InvalidArtifactException;
@@ -35,7 +33,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Charsets;
 import com.google.common.base.Function;
 import com.google.common.base.Predicates;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
@@ -46,11 +43,6 @@ import com.google.common.io.Files;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
 import com.google.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -328,40 +320,4 @@ public class PluginRepository {
     }
   }
 
-  /**
-   * A Gson deserialization for creating {@link PluginClass} object from external plugin config file.
-   */
-  private static final class PluginClassDeserializer implements JsonDeserializer<PluginClass> {
-
-    // Type for the PluginClass.properties map.
-    private static final Type PROPERTIES_TYPE = new TypeToken<Map<String, PluginPropertyField>>() { }.getType();
-
-    @Override
-    public PluginClass deserialize(JsonElement json, Type typeOfT,
-                                   JsonDeserializationContext context) throws JsonParseException {
-      if (!json.isJsonObject()) {
-        throw new JsonParseException("Expects json object");
-      }
-
-      JsonObject jsonObj = json.getAsJsonObject();
-
-      String type = jsonObj.has("type") ? jsonObj.get("type").getAsString() : Plugin.DEFAULT_TYPE;
-      String name = getRequired(jsonObj, "name").getAsString();
-      String description = getRequired(jsonObj, "description").getAsString();
-      String className = getRequired(jsonObj, "className").getAsString();
-
-      Map<String, PluginPropertyField> properties = jsonObj.has("properties")
-        ? context.<Map<String, PluginPropertyField>>deserialize(jsonObj.get("properties"), PROPERTIES_TYPE)
-        : ImmutableMap.<String, PluginPropertyField>of();
-
-      return new PluginClass(type, name, description, className, null, properties);
-    }
-
-    private JsonElement getRequired(JsonObject jsonObj, String name) {
-      if (!jsonObj.has(name)) {
-        throw new JsonParseException("Property '" + name + "' is missing");
-      }
-      return jsonObj.get(name);
-    }
-  }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepository.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepository.java
@@ -18,6 +18,7 @@ package co.cask.cdap.internal.app.runtime.artifact;
 
 import co.cask.cdap.api.artifact.ArtifactClasses;
 import co.cask.cdap.api.artifact.ArtifactDescriptor;
+import co.cask.cdap.api.artifact.ArtifactVersion;
 import co.cask.cdap.api.templates.plugins.PluginClass;
 import co.cask.cdap.common.ArtifactAlreadyExistsException;
 import co.cask.cdap.common.ArtifactNotFoundException;
@@ -26,14 +27,18 @@ import co.cask.cdap.common.InvalidArtifactException;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.io.Locations;
+import co.cask.cdap.common.utils.DirUtils;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.artifact.ArtifactRange;
 import co.cask.cdap.proto.artifact.ArtifactSummary;
+import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.io.Files;
 import com.google.inject.Inject;
 import org.apache.twill.filesystem.Location;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -50,9 +55,11 @@ import javax.annotation.Nullable;
  * metadata for the artifact.
  */
 public class ArtifactRepository {
+  private static final Logger LOG = LoggerFactory.getLogger(ArtifactRepository.class);
   private final ArtifactStore artifactStore;
   private final ArtifactClassLoaderFactory artifactClassLoaderFactory;
   private final ArtifactInspector artifactInspector;
+  private final File systemArtifactDir;
 
   @Inject
   ArtifactRepository(CConfiguration cConf, ArtifactStore artifactStore) {
@@ -61,6 +68,7 @@ public class ArtifactRepository {
       cConf.get(Constants.AppFabric.TEMP_DIR)).getAbsoluteFile();
     this.artifactClassLoaderFactory = new ArtifactClassLoaderFactory(baseUnpackDir);
     this.artifactInspector = new ArtifactInspector(cConf, artifactClassLoaderFactory);
+    this.systemArtifactDir = new File(cConf.get(Constants.AppFabric.SYSTEM_ARTIFACTS_DIR));
   }
 
   /**
@@ -184,6 +192,7 @@ public class ArtifactRepository {
 
   /**
    * Inspects and builds plugin and application information for the given artifact.
+   * TODO (CDAP-3319) check parents don't have parents
    *
    * @param artifactId the id of the artifact to inspect and store
    * @param artifactFile the artifact to inspect and store
@@ -214,10 +223,12 @@ public class ArtifactRepository {
    *                        If null, the given artifact does not extend another artifact
    * @throws IOException if there was an exception reading from the artifact store
    * @throws ArtifactRangeNotFoundException if none of the parent artifacts could be found
-   * @throws WriteConflictException if there was a write conflict writing to the ArtifactStore
-   * @throws ArtifactAlreadyExistsException if the artifact already exists
-   * @throws InvalidArtifactException if the artifact is invalid. For example, if it is not a zip file,
-   *                                  or the application class given is not an Application.
+   * @throws WriteConflictException if there was a write conflict writing to the metatable. Should not happen often,
+   *                                and it should be possible to retry the operation if it occurs.
+   * @throws ArtifactAlreadyExistsException if the artifact already exists and is not a snapshot version
+   * @throws InvalidArtifactException if the artifact is invalid. Can happen if it is not a zip file,
+   *                                  if the application class given is not an Application,
+   *                                  or if it has parents that also have parents.
    */
   public ArtifactDetail addArtifact(Id.Artifact artifactId, File artifactFile,
                                     @Nullable Set<ArtifactRange> parentArtifacts)
@@ -240,6 +251,109 @@ public class ArtifactRepository {
     } finally {
       parentClassLoader.close();
     }
+  }
+
+  /**
+   * Scan all files in the local system artifact directory, looking for jar files and adding them as system artifacts.
+   * If the artifact already exists it will not be added again unless it is a snapshot version.
+   *
+   * @throws IOException if there was some IO error adding the system artifacts
+   * @throws WriteConflictException if there was a write conflicting adding the system artifact. This shouldn't happen,
+   *                                but if it does, it should be ok to retry the operation.
+   */
+  public void addSystemArtifacts() throws IOException, WriteConflictException {
+
+    // scan the directory for artifact .jar files and config files for those artifacts
+    List<SystemArtifactConfig> systemArtifacts = new ArrayList<>();
+    for (File jarFile : DirUtils.listFiles(systemArtifactDir, "jar")) {
+      // parse id from filename
+      Id.Artifact artifactId;
+      try {
+        artifactId = parse(Id.Namespace.SYSTEM, jarFile.getName());
+      } catch (InvalidArtifactException e) {
+        LOG.warn(String.format("Skipping system artifact '%s' because the name is invalid: ", e.getMessage()));
+        continue;
+      }
+
+      // check for a corresponding .json config file
+      String artifactFileName = jarFile.getName();
+      String configFileName = artifactFileName.substring(0, artifactFileName.length() - ".jar".length()) + ".json";
+      File configFile = new File(systemArtifactDir, configFileName);
+      try {
+        if (configFile.isFile()) {
+          // if a config file exists, parse it and add it to the list
+          systemArtifacts.add(SystemArtifactConfig.read(artifactId, configFile, jarFile));
+        } else {
+          // otherwise, don't parse it
+          systemArtifacts.add(SystemArtifactConfig.builder(artifactId, jarFile).build());
+        }
+      } catch (InvalidArtifactException e) {
+        LOG.warn(String.format("Could not add system artifact '%s' because it is invalid.", artifactFileName), e);
+      }
+    }
+
+
+    // Need to be sure to add parent artifacts before artifacts that extend them.
+    Collections.sort(systemArtifacts);
+    for (SystemArtifactConfig systemArtifactConfig : systemArtifacts) {
+      String fileName = systemArtifactConfig.getFile().getName();
+      try {
+        Id.Artifact artifactId = systemArtifactConfig.getArtifactId();
+
+        // if it's not a snapshot and it already exists, don't bother trying to add it since artifacts are immutable
+        if (!artifactId.getVersion().isSnapshot()) {
+          try {
+            artifactStore.getArtifact(artifactId);
+            continue;
+          } catch (ArtifactNotFoundException e) {
+            // this is fine, means it doesn't exist yet and we should add it
+          }
+        }
+
+        // TODO: (CDAP-3272) use plugin classes from config file
+        addArtifact(artifactId,
+                    systemArtifactConfig.getFile(),
+                    systemArtifactConfig.getParents());
+      } catch (ArtifactAlreadyExistsException e) {
+        // shouldn't happen... but if it does for some reason it's fine, it means it was added some other way already.
+      } catch (ArtifactRangeNotFoundException e) {
+        LOG.warn(String.format("Could not add system artifact '%s' because it extends artifacts that do not exist.",
+          fileName), e);
+      } catch (InvalidArtifactException e) {
+        LOG.warn(String.format("Could not add system artifact '%s' because it is invalid.", fileName), e);
+      }
+    }
+  }
+
+  /**
+   * Parses a string expected to be of the form {name}-{version}.jar into an {@link co.cask.cdap.proto.Id.Artifact},
+   * where name is a valid id and version is of the form expected by {@link ArtifactVersion}.
+   *
+   * @param namespace the namespace to use
+   * @param artifactStr the string to parse
+   * @return string parsed into an {@link co.cask.cdap.proto.Id.Artifact}
+   * @throws InvalidArtifactException if the string is not in the expected format
+   */
+  public static Id.Artifact parse(Id.Namespace namespace, String artifactStr) throws InvalidArtifactException {
+    if (!artifactStr.endsWith(".jar")) {
+      throw new InvalidArtifactException(String.format("Artifact name '%s' does not end in .jar", artifactStr));
+    }
+
+    // strip '.jar' from the filename
+    artifactStr = artifactStr.substring(0, artifactStr.length() - ".jar".length());
+
+    // true means try and match version as the end of the string
+    ArtifactVersion artifactVersion = new ArtifactVersion(artifactStr, true);
+    String rawVersion = artifactVersion.getVersion();
+    // this happens if it could not parse the version
+    if (rawVersion == null) {
+      throw new InvalidArtifactException(
+        String.format("Artifact name '%s' is not of the form {name}-{version}.jar", artifactStr));
+    }
+
+    // filename should be {name}-{version}.  Strip -{version} from it to get artifact name
+    String artifactName = artifactStr.substring(0, artifactStr.length() - rawVersion.length() - 1);
+    return Id.Artifact.from(namespace, artifactName, rawVersion);
   }
 
   // convert details to summaries (to hide location and other unnecessary information)
@@ -271,7 +385,8 @@ public class ArtifactRepository {
     }
 
     if (parents.isEmpty()) {
-      throw new ArtifactRangeNotFoundException(parentArtifacts);
+      throw new ArtifactRangeNotFoundException(String.format("Artifact %s extends artifacts '%s' that do not exist",
+        artifactId, Joiner.on('/').join(parentArtifacts)));
     }
 
     // check if any of the parents also have parents, which is not allowed. This is to simplify things

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/SystemArtifactConfig.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/SystemArtifactConfig.java
@@ -1,0 +1,324 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.artifact;
+
+import co.cask.cdap.api.templates.plugins.PluginClass;
+import co.cask.cdap.common.InvalidArtifactException;
+import co.cask.cdap.common.utils.ImmutablePair;
+import co.cask.cdap.internal.app.runtime.adapter.PluginClassDeserializer;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.artifact.ArtifactRange;
+import co.cask.cdap.proto.artifact.InvalidArtifactRangeException;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Charsets;
+import com.google.common.io.Files;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import com.google.gson.JsonSyntaxException;
+import com.google.gson.reflect.TypeToken;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Reader;
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Represents json config file that can be placed in the system artifacts directory. Comparable so that we
+ * can order collections of configs such that artifacts that extends other artifacts are later in the collection.
+ */
+public class SystemArtifactConfig implements Comparable<SystemArtifactConfig> {
+  private static final Gson GSON = new GsonBuilder()
+    .registerTypeAdapter(PluginClass.class, new PluginClassDeserializer())
+    .registerTypeAdapter(ArtifactRange.class, new ArtifactRangeDeserializer())
+    .registerTypeAdapter(SystemArtifactConfig.class, new SystemArtifactConfigDeserializer())
+    .create();
+  private final Set<ArtifactRange> parents;
+  private final Set<PluginClass> plugins;
+  private File artifactFile;
+  private Id.Artifact artifactId;
+
+  private SystemArtifactConfig(Set<ArtifactRange> parents, Set<PluginClass> plugins) {
+    this(null, null, parents, plugins);
+  }
+
+  private SystemArtifactConfig(Id.Artifact artifactId, File artifactFile,
+                               Set<ArtifactRange> parents, Set<PluginClass> plugins) {
+    this.artifactId = artifactId;
+    this.artifactFile = artifactFile;
+    this.parents = parents;
+    this.plugins = plugins;
+  }
+
+  public Id.Artifact getArtifactId() {
+    return artifactId;
+  }
+
+  public File getFile() {
+    return artifactFile;
+  }
+
+  public Set<ArtifactRange> getParents() {
+    return parents;
+  }
+
+  public Set<PluginClass> getPlugins() {
+    return plugins;
+  }
+
+  public boolean hasParent(Id.Artifact artifactId) {
+    for (ArtifactRange range : parents) {
+      if (range.getName().equals(artifactId.getName()) && range.versionIsInRange(artifactId.getVersion())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public String toString() {
+    return GSON.toJson(this);
+  }
+
+  @Override
+  public int compareTo(SystemArtifactConfig that) {
+    // assumes there are no circular dependencies, since extensions should be at most 1 level deep.
+    // that is, an artifact cannot have as a parent another artifact that has parents.
+    boolean thisIsParentOfThat = that.hasParent(artifactId);
+    boolean thatIsParentOfThis = hasParent(that.artifactId);
+    if (thisIsParentOfThat) {
+      return -1;
+    }
+    if (thatIsParentOfThis) {
+      return 1;
+    }
+    return artifactId.compareTo(that.artifactId);
+  }
+
+  /**
+   * Read the contents of the given file and deserialize it into an SystemArtifactConfig.
+   *
+   * @param artifactId the id of the artifact this config file is for
+   * @param configFile the config file to read
+   * @return the contents of the file parsed as an SystemArtifactConfig
+   * @throws IOException if there was a problem reading the file, for example if the file does not exist.
+   * @throws InvalidArtifactException if there was a problem deserializing the file contents due to some invalid
+   *                                  format or unexpected value.
+   */
+  public static SystemArtifactConfig read(Id.Artifact artifactId,
+                                          File configFile,
+                                          File artifactFile) throws IOException, InvalidArtifactException {
+    String fileName = configFile.getName();
+    try (Reader reader = Files.newReader(configFile, Charsets.UTF_8)) {
+      try {
+        SystemArtifactConfig config = GSON.fromJson(reader, SystemArtifactConfig.class);
+        config.artifactId = artifactId;
+        config.artifactFile = artifactFile;
+        return config;
+      } catch (JsonSyntaxException e) {
+        throw new InvalidArtifactException(String.format("%s contains invalid json: %s", fileName, e.getMessage()), e);
+      } catch (JsonParseException e) {
+        throw new InvalidArtifactException(String.format("Unable to parse %s: %s", fileName, e.getMessage()), e);
+      }
+    }
+  }
+
+  /**
+   * Get a builder to create an artifact config for a given artifact id.
+   *
+   * @param artifactId the id of the artifact to create a config for
+   * @return a builder for creating an artifact config
+   */
+  static Builder builder(Id.Artifact artifactId, File artifactFile) {
+    return new Builder(artifactId, artifactFile);
+  }
+
+  /**
+   * Builder for creating a SystemArtifactConfig.
+   */
+  static class Builder {
+    private final Id.Artifact artifactId;
+    private final File artifactFile;
+    private final Set<PluginClass> plugins;
+    private final Set<ArtifactRange> parents;
+
+    private Builder(Id.Artifact artifactId, File artifactFile) {
+      this.artifactId = artifactId;
+      this.artifactFile = artifactFile;
+      this.plugins = new HashSet<>();
+      this.parents = new HashSet<>();
+    }
+
+    @VisibleForTesting
+    Builder addPlugins(PluginClass pluginClass, PluginClass... plugins) {
+      this.plugins.add(pluginClass);
+      for (PluginClass plugin : plugins) {
+        this.plugins.add(plugin);
+      }
+      return this;
+    }
+
+    @VisibleForTesting
+    Builder addParents(ArtifactRange parent, ArtifactRange... parents) {
+      this.parents.add(parent);
+      for (ArtifactRange parentRange : parents) {
+        this.parents.add(parentRange);
+      }
+      return this;
+    }
+
+    SystemArtifactConfig build() throws InvalidArtifactException {
+      validateParentList(parents);
+      validatePluginList(plugins);
+      SystemArtifactConfig config = new SystemArtifactConfig(artifactId, artifactFile,
+        Collections.unmodifiableSet(parents), Collections.unmodifiableSet(plugins));
+      return config;
+    }
+  }
+
+  /**
+   * Deserializer for ArtifactRange in a SystemArtifactConfig. Artifact ranges are expected to be able to be
+   * parsed via {@link ArtifactRange#parse(String)}. Currently, system artifacts can only extend other system artifacts.
+   */
+  private static final class ArtifactRangeDeserializer
+    implements JsonDeserializer<ArtifactRange>, JsonSerializer<ArtifactRange> {
+
+    @Override
+    public ArtifactRange deserialize(JsonElement json, Type typeOfT,
+                                     JsonDeserializationContext context) throws JsonParseException {
+      if (!json.isJsonPrimitive()) {
+        throw new JsonParseException("Parent artifacts should be strings.");
+      }
+
+      try {
+        return ArtifactRange.parse(Id.Namespace.SYSTEM, json.getAsString());
+      } catch (InvalidArtifactRangeException e) {
+        throw new JsonParseException(e.getMessage(), e);
+      }
+    }
+
+    @Override
+    public JsonElement serialize(ArtifactRange src, Type typeOfSrc, JsonSerializationContext context) {
+      return new JsonPrimitive(src.toNonNamespacedString());
+    }
+  }
+
+  /**
+   * Deserializer for SystemArtifactConfig. Used to check validity of an artifact config. For example,
+   * a plugin class should not appear more than once in the list of plugins, and a parent artifact should not
+   * appear more than once in the list of parents.
+   */
+  private static final class SystemArtifactConfigDeserializer
+    implements JsonDeserializer<SystemArtifactConfig>, JsonSerializer<SystemArtifactConfig> {
+    private static final Type PLUGINS_TYPE = new TypeToken<Set<PluginClass>>() { }.getType();
+    private static final Type PARENTS_TYPE = new TypeToken<Set<ArtifactRange>>() { }.getType();
+
+    @Override
+    public SystemArtifactConfig deserialize(JsonElement json, Type typeOfT,
+                                            JsonDeserializationContext context) throws JsonParseException {
+      if (!json.isJsonObject()) {
+        throw new JsonParseException("Config file must be a JSON Object.");
+      }
+      JsonObject obj = json.getAsJsonObject();
+
+      // deserialize fields
+      Set<ArtifactRange> parents = context.deserialize(obj.get("parents"), PARENTS_TYPE);
+      parents = parents == null ? Collections.<ArtifactRange>emptySet() : parents;
+      Set<PluginClass> plugins = context.deserialize(obj.get("plugins"), PLUGINS_TYPE);
+      plugins = plugins == null ? Collections.<PluginClass>emptySet() : plugins;
+
+      try {
+        validateParentList(parents);
+        validatePluginList(plugins);
+      } catch (InvalidArtifactException e) {
+        throw new JsonParseException(e.getMessage());
+      }
+
+      return new SystemArtifactConfig(parents, plugins);
+    }
+
+    @Override
+    public JsonElement serialize(SystemArtifactConfig src, Type typeOfSrc, JsonSerializationContext context) {
+      JsonObject obj = new JsonObject();
+      obj.add("parents", context.serialize(src.getParents()));
+      obj.add("plugins", context.serialize(src.getPlugins()));
+      return obj;
+    }
+  }
+
+  private static void validateParentList(Set<ArtifactRange> parents) throws InvalidArtifactException {
+    boolean isInvalid = false;
+    StringBuilder errMsg = new StringBuilder("Invalid parents field.");
+
+    // check for multiple version ranges for the same artifact.
+    // ex: "parents": [ "etlbatch[1.0.0,2.0.0)", "etlbatch[3.0.0,4.0.0)" ]
+    Set<String> parentNames = new HashSet<>();
+    // keep track of dupes so that we don't have repeat error messages if there are more than 2 ranges for a name
+    Set<String> dupes = new HashSet<>();
+    for (ArtifactRange parent : parents) {
+      String parentName = parent.getName();
+      if (!parentNames.add(parentName) && !dupes.contains(parentName)) {
+        errMsg.append(" Only one version range for parent '");
+        errMsg.append(parentName);
+        errMsg.append("' can be present.");
+        dupes.add(parentName);
+        isInvalid = true;
+      }
+    }
+
+    // final err message should look something like:
+    // "Invalid parents. Only one version range for parent 'etlbatch' can be present."
+    if (isInvalid) {
+      throw new InvalidArtifactException(errMsg.toString());
+    }
+  }
+
+  private static void validatePluginList(Set<PluginClass> plugins) throws InvalidArtifactException {
+    boolean isInvalid = false;
+    StringBuilder errMsg = new StringBuilder("Invalid plugins field.");
+    Set<ImmutablePair<String, String>> existingPlugins = new HashSet<>();
+    Set<ImmutablePair<String, String>> dupes = new HashSet<>();
+    for (PluginClass plugin : plugins) {
+      ImmutablePair<String, String> typeAndName = ImmutablePair.of(plugin.getType(), plugin.getName());
+      if (!existingPlugins.add(typeAndName) && !dupes.contains(typeAndName)) {
+        errMsg.append(" Only one plugin with type '");
+        errMsg.append(typeAndName.getFirst());
+        errMsg.append("' and name '");
+        errMsg.append(typeAndName.getSecond());
+        errMsg.append("' can be present.");
+        dupes.add(typeAndName);
+        isInvalid = true;
+      }
+    }
+
+    // final err message should look something like:
+    // "Invalid plugins. Only one plugin with type 'source' and name 'table' can be present."
+    if (isInvalid) {
+      throw new InvalidArtifactException(errMsg.toString());
+    }
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/SystemArtifactLoader.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/SystemArtifactLoader.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.artifact;
+
+import co.cask.cdap.common.service.RetryOnStartFailureService;
+import co.cask.cdap.common.service.RetryStrategies;
+import com.google.common.base.Supplier;
+import com.google.common.util.concurrent.AbstractService;
+import com.google.common.util.concurrent.Service;
+import com.google.inject.Inject;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Thread that scans the local filesystem for system artifacts and adds them to the artifact repository if they
+ * are not already there.
+ */
+public final class SystemArtifactLoader extends AbstractService {
+  private final Service serviceDelegate;
+
+  @Inject
+  public SystemArtifactLoader(final ArtifactRepository artifactRepository) {
+    this.serviceDelegate = new RetryOnStartFailureService(new Supplier<Service>() {
+      @Override
+      public Service get() {
+        return new AbstractService() {
+          @Override
+          protected void doStart() {
+            try {
+              artifactRepository.addSystemArtifacts();
+              // if there is no exception, all good, continue on
+              notifyStarted();
+            } catch (WriteConflictException e) {
+              // transient error, fail it and retry
+              notifyFailed(e);
+            } catch (IOException e) {
+              // transient error, fail it and retry
+              notifyFailed(e);
+            }
+          }
+
+          @Override
+          protected void doStop() {
+            notifyStopped();
+          }
+        };
+      }
+    }, RetryStrategies.exponentialDelay(200, 5000, TimeUnit.MILLISECONDS));
+  }
+
+  @Override
+  protected void doStart() {
+    serviceDelegate.start();
+    notifyStarted();
+  }
+
+  @Override
+  protected void doStop() {
+    serviceDelegate.stop();
+    notifyStopped();
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AppFabricServer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AppFabricServer.java
@@ -28,6 +28,7 @@ import co.cask.cdap.common.metrics.MetricsReporterHook;
 import co.cask.cdap.data.stream.StreamCoordinatorClient;
 import co.cask.cdap.internal.app.namespace.DefaultNamespaceEnsurer;
 import co.cask.cdap.internal.app.runtime.adapter.AdapterService;
+import co.cask.cdap.internal.app.runtime.artifact.SystemArtifactLoader;
 import co.cask.cdap.internal.app.runtime.schedule.SchedulerService;
 import co.cask.cdap.notifications.service.NotificationService;
 import co.cask.cdap.proto.Id;
@@ -72,6 +73,7 @@ public class AppFabricServer extends AbstractIdleService {
   private final StreamCoordinatorClient streamCoordinatorClient;
   private final ProgramLifecycleService programLifecycleService;
   private final DefaultNamespaceEnsurer defaultNamespaceEnsurer;
+  private final SystemArtifactLoader systemArtifactLoader;
 
   private NettyHttpService httpService;
   private Set<HttpHandler> handlers;
@@ -93,7 +95,8 @@ public class AppFabricServer extends AbstractIdleService {
                          StreamCoordinatorClient streamCoordinatorClient,
                          @Named("appfabric.services.names") Set<String> servicesNames,
                          @Named("appfabric.handler.hooks") Set<String> handlerHookNames,
-                         DefaultNamespaceEnsurer defaultNamespaceEnsurer) {
+                         DefaultNamespaceEnsurer defaultNamespaceEnsurer,
+                         SystemArtifactLoader systemArtifactLoader) {
     this.hostname = hostname;
     this.discoveryService = discoveryService;
     this.schedulerService = schedulerService;
@@ -109,6 +112,7 @@ public class AppFabricServer extends AbstractIdleService {
     this.streamCoordinatorClient = streamCoordinatorClient;
     this.programLifecycleService = programLifecycleService;
     this.defaultNamespaceEnsurer = defaultNamespaceEnsurer;
+    this.systemArtifactLoader = systemArtifactLoader;
   }
 
   /**
@@ -123,6 +127,7 @@ public class AppFabricServer extends AbstractIdleService {
     schedulerService.start();
     applicationLifecycleService.start();
     adapterService.start();
+    systemArtifactLoader.start();
     programRuntimeService.start();
     streamCoordinatorClient.start();
     programLifecycleService.start();
@@ -208,6 +213,7 @@ public class AppFabricServer extends AbstractIdleService {
     programRuntimeService.stopAndWait();
     schedulerService.stopAndWait();
     applicationLifecycleService.stopAndWait();
+    systemArtifactLoader.stopAndWait();
     adapterService.stopAndWait();
     notificationService.stopAndWait();
     programLifecycleService.stopAndWait();

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/StandaloneAppFabricServer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/StandaloneAppFabricServer.java
@@ -24,6 +24,7 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data.stream.StreamCoordinatorClient;
 import co.cask.cdap.internal.app.namespace.DefaultNamespaceEnsurer;
 import co.cask.cdap.internal.app.runtime.adapter.AdapterService;
+import co.cask.cdap.internal.app.runtime.artifact.SystemArtifactLoader;
 import co.cask.cdap.internal.app.runtime.flow.FlowUtils;
 import co.cask.cdap.internal.app.runtime.schedule.SchedulerService;
 import co.cask.cdap.notifications.service.NotificationService;
@@ -62,10 +63,12 @@ public class StandaloneAppFabricServer extends AppFabricServer {
                                    @Named("appfabric.services.names") Set<String> servicesNames,
                                    @Named("appfabric.handler.hooks") Set<String> handlerHookNames,
                                    DefaultNamespaceEnsurer defaultNamespaceEnsurer,
-                                   MetricStore metricStore) {
+                                   MetricStore metricStore,
+                                   SystemArtifactLoader systemArtifactLoader) {
     super(configuration, discoveryService, schedulerService, notificationService, hostname, handlers,
           metricsCollectionService, programRuntimeService, adapterService, applicationLifecycleService,
-          programLifecycleService, streamCoordinatorClient, servicesNames, handlerHookNames, defaultNamespaceEnsurer);
+          programLifecycleService, streamCoordinatorClient, servicesNames, handlerHookNames, defaultNamespaceEnsurer,
+          systemArtifactLoader);
     this.metricStore = metricStore;
   }
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRangeTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRangeTest.java
@@ -21,8 +21,11 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.artifact.ArtifactRange;
 import co.cask.cdap.proto.artifact.InvalidArtifactRangeException;
+import com.google.common.collect.Lists;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.List;
 
 /**
  */
@@ -69,66 +72,53 @@ public class ArtifactRangeTest {
   }
 
   @Test
+  public void testLowerVersionGreaterThanUpper() {
+    List<String> invalidRanges = Lists.newArrayList(
+      "test[1.0.0,0.9.9]",
+      "test[1.0.0,1.0.0-SNAPSHOT]",
+      "test[1.0.0,1.0.0)",
+      "test(1.0.0,0.9.9)",
+      "test(1.0.0,1.0.0-SNAPSHOT)",
+      "test(1.0.2,1.0.0]"
+    );
+
+    for (String invalidRange : invalidRanges) {
+      try {
+        ArtifactRange.parse(invalidRange);
+        Assert.fail();
+      } catch (InvalidArtifactRangeException e) {
+        // expected
+      }
+    }
+  }
+
+  @Test
   public void testParseInvalid() {
-    // test can't find '[' or '('
-    try {
-      ArtifactRange.parse(Id.Namespace.DEFAULT, "test-1.0.0,2.0.0]");
-      Assert.fail();
-    } catch (InvalidArtifactRangeException e) {
-      // expected
-    }
+    List<String> invalidRanges = Lists.newArrayList(
+      // can't find '[' or '('
+      "test-1.0.0,2.0.0]",
+      // can't find ',' between versions
+      "test[1.0.0:2.0.0]",
+      // no ending ']' or ')'
+      "test[1.0.0,2.0.0",
+      // invalid lower version
+      "tes[t1.0.0,2.0.0]",
+      // missing versions
+      "test(,1.0.0)",
+      "test(1.0.0,)",
+      // invalid name
+      "te$t[1.0.0,2.0.0)",
+      // namespace only is InvalidArtifactRangeException and not an out of bounds exception
+      "default:"
+    );
 
-    // test can't find ',' between versions
-    try {
-      ArtifactRange.parse(Id.Namespace.DEFAULT, "test[1.0.0:2.0.0]");
-      Assert.fail();
-    } catch (InvalidArtifactRangeException e) {
-      // expected
-    }
-
-    // test no ending ']' or ')'
-    try {
-      ArtifactRange.parse(Id.Namespace.DEFAULT, "test[1.0.0,2.0.0");
-      Assert.fail();
-    } catch (InvalidArtifactRangeException e) {
-      // expected
-    }
-
-    // test invalid lower version
-    try {
-      ArtifactRange.parse(Id.Namespace.DEFAULT, "tes[t1.0.0,2.0.0]");
-      Assert.fail();
-    } catch (InvalidArtifactRangeException e) {
-      // expected
-    }
-
-    try {
-      ArtifactRange.parse(Id.Namespace.DEFAULT, "test(,1.0.0)");
-      Assert.fail();
-    } catch (InvalidArtifactRangeException e) {
-      // expected
-    }
-    try {
-      ArtifactRange.parse(Id.Namespace.DEFAULT, "test(1.0.0,)");
-      Assert.fail();
-    } catch (InvalidArtifactRangeException e) {
-      // expected
-    }
-
-    // test invalid name
-    try {
-      ArtifactRange.parse(Id.Namespace.DEFAULT, "te$t[1.0.0,2.0.0)");
-      Assert.fail();
-    } catch (InvalidArtifactRangeException e) {
-      // expected
-    }
-
-    // test namespace only in InvalidArtifactRangeException and not an out of bounds exception
-    try {
-      ArtifactRange.parse("default:");
-      Assert.fail();
-    } catch (InvalidArtifactRangeException e) {
-      // expected
+    for (String invalidRange : invalidRanges) {
+      try {
+        ArtifactRange.parse(invalidRange);
+        Assert.fail();
+      } catch (InvalidArtifactRangeException e) {
+        // expected
+      }
     }
   }
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepositoryTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepositoryTest.java
@@ -21,6 +21,7 @@ import co.cask.cdap.api.artifact.ArtifactDescriptor;
 import co.cask.cdap.api.artifact.ArtifactVersion;
 import co.cask.cdap.api.templates.plugins.PluginClass;
 import co.cask.cdap.api.templates.plugins.PluginProperties;
+import co.cask.cdap.api.templates.plugins.PluginPropertyField;
 import co.cask.cdap.app.program.ManifestFields;
 import co.cask.cdap.common.InvalidArtifactException;
 import co.cask.cdap.common.conf.CConfiguration;
@@ -44,6 +45,7 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.artifact.ArtifactRange;
 import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.common.io.Files;
@@ -103,6 +105,20 @@ public class ArtifactRepositoryTest {
       createManifest(ManifestFields.EXPORT_PACKAGE, PluginTestRunnable.class.getPackage().getName()));
     artifactRepository.addArtifact(APP_ARTIFACT_ID, appArtifactFile, null);
     appClassLoader = createAppClassLoader(appArtifactFile);
+  }
+
+  @Test(expected = InvalidArtifactException.class)
+  public void testMultipleParentVersions() throws InvalidArtifactException {
+    ArtifactRepository.validateParentSet(ImmutableSet.of(
+      new ArtifactRange(Id.Namespace.SYSTEM, "r1", new ArtifactVersion("1.0.0"), new ArtifactVersion("2.0.0")),
+      new ArtifactRange(Id.Namespace.SYSTEM, "r1", new ArtifactVersion("3.0.0"), new ArtifactVersion("4.0.0"))));
+  }
+
+  @Test(expected = InvalidArtifactException.class)
+  public void testMultiplePluginClasses() throws InvalidArtifactException {
+    ArtifactRepository.validatePluginSet(ImmutableSet.of(
+      new PluginClass("t1", "n1", "", "co.cask.test1", "cfg", ImmutableMap.<String, PluginPropertyField>of()),
+      new PluginClass("t1", "n1", "", "co.cask.test2", "cfg", ImmutableMap.<String, PluginPropertyField>of())));
   }
 
   @Test

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/SystemArtifactConfigTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/SystemArtifactConfigTest.java
@@ -40,25 +40,6 @@ public class SystemArtifactConfigTest {
   public static TemporaryFolder tmpFolder = new TemporaryFolder();
 
   @Test(expected = InvalidArtifactException.class)
-  public void testMultipleParentVersions() throws InvalidArtifactException {
-    SystemArtifactConfig.builder(null, null)
-      .addParents(
-        new ArtifactRange(Id.Namespace.SYSTEM, "r1", new ArtifactVersion("1.0.0"), new ArtifactVersion("2.0.0")),
-        new ArtifactRange(Id.Namespace.SYSTEM, "r1", new ArtifactVersion("3.0.0"), new ArtifactVersion("4.0.0")))
-      .build();
-  }
-
-  @Test(expected = InvalidArtifactException.class)
-  public void testMultiplePluginClasses() throws InvalidArtifactException {
-    SystemArtifactConfig.builder(null, null)
-      .addPlugins(
-        new PluginClass("t1", "n1", "", "co.cask.test1", "cfg", ImmutableMap.<String, PluginPropertyField>of()),
-        new PluginClass("t1", "n1", "", "co.cask.test2", "cfg", ImmutableMap.<String, PluginPropertyField>of())
-      )
-      .build();
-  }
-
-  @Test(expected = InvalidArtifactException.class)
   public void testBadJsonSyntax() throws IOException, InvalidArtifactException {
     File configFile = new File(tmpFolder.newFolder(), "r1-1.0.0.jar");
     try (BufferedWriter writer = Files.newWriter(configFile, Charsets.UTF_8)) {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/SystemArtifactConfigTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/SystemArtifactConfigTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.artifact;
+
+import co.cask.cdap.api.artifact.ArtifactVersion;
+import co.cask.cdap.api.templates.plugins.PluginClass;
+import co.cask.cdap.api.templates.plugins.PluginPropertyField;
+import co.cask.cdap.common.InvalidArtifactException;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.artifact.ArtifactRange;
+import com.google.common.base.Charsets;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.Files;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.IOException;
+
+/**
+ */
+public class SystemArtifactConfigTest {
+  @ClassRule
+  public static TemporaryFolder tmpFolder = new TemporaryFolder();
+
+  @Test(expected = InvalidArtifactException.class)
+  public void testMultipleParentVersions() throws InvalidArtifactException {
+    SystemArtifactConfig.builder(null, null)
+      .addParents(
+        new ArtifactRange(Id.Namespace.SYSTEM, "r1", new ArtifactVersion("1.0.0"), new ArtifactVersion("2.0.0")),
+        new ArtifactRange(Id.Namespace.SYSTEM, "r1", new ArtifactVersion("3.0.0"), new ArtifactVersion("4.0.0")))
+      .build();
+  }
+
+  @Test(expected = InvalidArtifactException.class)
+  public void testMultiplePluginClasses() throws InvalidArtifactException {
+    SystemArtifactConfig.builder(null, null)
+      .addPlugins(
+        new PluginClass("t1", "n1", "", "co.cask.test1", "cfg", ImmutableMap.<String, PluginPropertyField>of()),
+        new PluginClass("t1", "n1", "", "co.cask.test2", "cfg", ImmutableMap.<String, PluginPropertyField>of())
+      )
+      .build();
+  }
+
+  @Test(expected = InvalidArtifactException.class)
+  public void testBadJsonSyntax() throws IOException, InvalidArtifactException {
+    File configFile = new File(tmpFolder.newFolder(), "r1-1.0.0.jar");
+    try (BufferedWriter writer = Files.newWriter(configFile, Charsets.UTF_8)) {
+      writer.write("I am invalid.");
+    }
+
+    SystemArtifactConfig.read(Id.Artifact.from(Id.Namespace.SYSTEM, "r1", "1.0.0"), configFile, null);
+  }
+
+  @Test(expected = InvalidArtifactException.class)
+  public void testMissingPluginFields() throws IOException, InvalidArtifactException {
+    File configFile = new File(tmpFolder.newFolder(), "r1-1.0.0.jar");
+    try (BufferedWriter writer = Files.newWriter(configFile, Charsets.UTF_8)) {
+      writer.write("{ \"plugins\": [ { \"name\": \"something\" } ] }");
+    }
+
+    SystemArtifactConfig.read(Id.Artifact.from(Id.Namespace.SYSTEM, "r1", "1.0.0"), configFile, null);
+  }
+
+  @Test(expected = InvalidArtifactException.class)
+  public void testMalformedParentArtifact() throws IOException, InvalidArtifactException {
+    File configFile = new File(tmpFolder.newFolder(), "r1-1.0.0.jar");
+    try (BufferedWriter writer = Files.newWriter(configFile, Charsets.UTF_8)) {
+      writer.write("{ \"parents\": [ \"r2:[1.0.0,2.0.0) \" ] }");
+    }
+
+    SystemArtifactConfig.read(Id.Artifact.from(Id.Namespace.SYSTEM, "r1", "1.0.0"), configFile, null);
+  }
+
+  @Test(expected = InvalidArtifactException.class)
+  public void testBadParentArtifactName() throws IOException, InvalidArtifactException {
+    File configFile = new File(tmpFolder.newFolder(), "r1-1.0.0.jar");
+    try (BufferedWriter writer = Files.newWriter(configFile, Charsets.UTF_8)) {
+      writer.write("{ \"parents\": [ \"r!2[1.0.0,2.0.0) \" ] }");
+    }
+
+    SystemArtifactConfig.read(Id.Artifact.from(Id.Namespace.SYSTEM, "r1", "1.0.0"), configFile, null);
+  }
+
+  @Test(expected = InvalidArtifactException.class)
+  public void testBadParentArtifactRange() throws IOException, InvalidArtifactException {
+    File configFile = new File(tmpFolder.newFolder(), "r1-1.0.0.jar");
+    try (BufferedWriter writer = Files.newWriter(configFile, Charsets.UTF_8)) {
+      writer.write("{ \"parents\": [ \"r2(2.0.0,1.0.0) \" ] }");
+    }
+
+    SystemArtifactConfig.read(Id.Artifact.from(Id.Namespace.SYSTEM, "r1", "1.0.0"), configFile, null);
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/ArtifactRangeNotFoundException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/ArtifactRangeNotFoundException.java
@@ -26,6 +26,10 @@ import java.util.Collection;
  */
 public class ArtifactRangeNotFoundException extends NotFoundException {
 
+  public ArtifactRangeNotFoundException(String message) {
+    super(message);
+  }
+
   public ArtifactRangeNotFoundException(Collection<ArtifactRange> artifactRanges) {
     super("artifacts", Joiner.on(',').join(artifactRanges).toString());
   }

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -98,6 +98,7 @@ public final class Constants {
     public static final String MAPREDUCE_JOB_CLIENT_CONNECT_MAX_RETRIES = "mapreduce.jobclient.connect.max.retries";
     public static final String MAPREDUCE_INCLUDE_CUSTOM_CLASSES = "mapreduce.include.custom.format.classes";
     public static final String PROGRAM_RUNID_CORRECTOR_INTERVAL_SECONDS = "app.program.runid.corrector.interval";
+    public static final String SYSTEM_ARTIFACTS_DIR = "app.artifact.dir";
 
     /**
      * Guice named bindings.

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -579,6 +579,14 @@
         <final>true</final>
     </property>
 
+    <!-- Artifact configuration -->
+
+    <property>
+        <name>app.artifact.dir</name>
+        <value>/opt/cdap/master/artifacts</value>
+        <description>Directory where all archives for app templates are stored</description>
+    </property>
+
     <!-- App Fabric related changes -->
 
     <property>

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/Id.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/Id.java
@@ -1274,7 +1274,7 @@ public abstract class Id {
   /**
    * Artifact Id identifies an artifact by its namespace, name, and version.
    */
-  public static class Artifact extends NamespacedId {
+  public static class Artifact extends NamespacedId implements Comparable<Artifact> {
     private final Namespace namespace;
     private final String name;
     private final ArtifactVersion version;
@@ -1329,9 +1329,7 @@ public abstract class Id {
 
       Artifact that = (Artifact) o;
 
-      return Objects.equal(namespace, that.namespace) &&
-        Objects.equal(name, that.name)
-        && Objects.equal(version, that.version);
+      return this.compareTo(that) == 0;
     }
 
     @Override
@@ -1345,6 +1343,20 @@ public abstract class Id {
 
     public static boolean isValidName(String name) {
       return isValidId(name);
+    }
+
+    @Override
+    public int compareTo(Artifact o) {
+      int code = namespace.getId().compareTo(o.namespace.getId());
+      if (code != 0) {
+        return code;
+      }
+      code = name.compareTo(o.name);
+      if (code != 0) {
+        return code;
+      }
+      code = version.compareTo(o.version);
+      return code;
     }
   }
 

--- a/cdap-standalone/src/main/resources/cdap-site.xml
+++ b/cdap-standalone/src/main/resources/cdap-site.xml
@@ -119,4 +119,13 @@
       <description>Directory where all archives for app templates are stored</description>
     </property>
 
+    <!--
+        Artifact configuration
+    -->
+    <property>
+        <name>app.artifact.dir</name>
+        <value>artifacts</value>
+        <description>Directory where system artifacts are stored</description>
+    </property>
+
 </configuration>


### PR DESCRIPTION
Adding a method to ArtifactRepository to scan a directory for
system artifacts to add. This will be done when AppFabricServer
starts up, and can also be called on command through a RESTful
call in case system artifacts need to be added without restarting
AppFabric.