### PR TITLE
CDAP-3319 make sure artifacts cant have grandparents

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepository.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepository.java
@@ -37,6 +37,7 @@ import org.apache.twill.filesystem.Location;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -229,7 +230,7 @@ public class ArtifactRepository {
       // if this artifact doesn't extend another, use itself to create the parent classloader
       parentClassLoader = artifactClassLoaderFactory.createClassLoader(Locations.toLocation(artifactFile));
     } else {
-      parentClassLoader = createClassLoader(parentArtifacts);
+      parentClassLoader = createParentClassLoader(artifactId, parentArtifacts);
     }
 
     try {
@@ -251,20 +252,54 @@ public class ArtifactRepository {
     return summaries;
   }
 
-  // create a classloader using an artifact from one of the artifacts in the specified parents.
-  private CloseableClassLoader createClassLoader(Set<ArtifactRange> parentArtifacts)
-    throws ArtifactRangeNotFoundException, IOException {
+  /**
+   * Create a parent classloader using an artifact from one of the artifacts in the specified parents.
+   *
+   * @param artifactId the id of the artifact to create the parent classloader for
+   * @param parentArtifacts the ranges of parents to create the classloader from
+   * @return a classloader based off a parent artifact
+   * @throws ArtifactRangeNotFoundException if none of the parents could be found
+   * @throws InvalidArtifactException if one of the parents also has parents
+   * @throws IOException if there was some error reading from the store
+   */
+  private CloseableClassLoader createParentClassLoader(Id.Artifact artifactId, Set<ArtifactRange> parentArtifacts)
+    throws ArtifactRangeNotFoundException, IOException, InvalidArtifactException {
 
-    Location parentLocation = null;
+    List<ArtifactDetail> parents = new ArrayList<>();
     for (ArtifactRange parentRange : parentArtifacts) {
-      List<ArtifactDetail> parents = artifactStore.getArtifacts(parentRange);
-      if (!parents.isEmpty()) {
-        parentLocation = parents.get(0).getDescriptor().getLocation();
-      }
+      parents.addAll(artifactStore.getArtifacts(parentRange));
     }
-    if (parentLocation == null) {
+
+    if (parents.isEmpty()) {
       throw new ArtifactRangeNotFoundException(parentArtifacts);
     }
+
+    // check if any of the parents also have parents, which is not allowed. This is to simplify things
+    // so that we don't have to chain a bunch of classloaders, and also to keep it simple for users to avoid
+    // complicated dependency trees that are hard to manage.
+    boolean isInvalid = false;
+    StringBuilder errMsg = new StringBuilder("Invalid artifact '")
+      .append(artifactId)
+      .append("'.")
+      .append(" Artifact parents cannot have parents.");
+    for (ArtifactDetail parent : parents) {
+      Set<ArtifactRange> grandparents = parent.getMeta().getUsableBy();
+      if (!grandparents.isEmpty()) {
+        isInvalid = true;
+        errMsg
+          .append(" Parent '")
+          .append(parent.getDescriptor().getName())
+          .append("-")
+          .append(parent.getDescriptor().getVersion().getVersion())
+          .append("' has parents.");
+      }
+    }
+    if (isInvalid) {
+      throw new InvalidArtifactException(errMsg.toString());
+    }
+
+    // assumes any of the parents will do
+    Location parentLocation = parents.get(0).getDescriptor().getLocation();
     return artifactClassLoaderFactory.createClassLoader(parentLocation);
   }
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/Id.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/Id.java
@@ -1315,11 +1315,7 @@ public abstract class Id {
 
     @Override
     public String toString() {
-      return Objects.toStringHelper(this)
-        .add("namespace", namespace)
-        .add("name", name)
-        .add("version", version)
-        .toString();
+      return String.format("%s:%s-%s", namespace.getId(), name, version.getVersion());
     }
 
     @Override


### PR DESCRIPTION
This is already a limitation of the plugin system, but it was not
being enforced by the artifact framework. We want to keep things
simple so that an artifact can extend another artifact, but only
to one level. This makes it simpler for our framework, but also
prevents users from creating complicated dependency trees that
are hard for them to manage as well.