### PR TITLE
Improved flowlet error messages.

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/flow/FlowSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/flow/FlowSpecification.java
@@ -320,7 +320,7 @@ public interface FlowSpecification extends ProgramSpecification {
       @Override
       public ConnectTo from(String flowlet) {
         Preconditions.checkArgument(flowlets.containsKey(flowlet),
-                UserMessages.getMessage(UserErrors.INVALID_FLOWLET_NAME), flowlet);
+                                    UserMessages.getMessage(UserErrors.INVALID_FLOWLET_NAME), flowlet);
         fromFlowlet = flowlets.get(flowlet);
         fromStream = null;
         return this;
@@ -344,7 +344,7 @@ public interface FlowSpecification extends ProgramSpecification {
       public MoreConnect to(String flowlet) {
         Preconditions.checkArgument(flowlet != null, UserMessages.getMessage(UserErrors.INVALID_FLOWLET_NULL));
         Preconditions.checkArgument(flowlets.containsKey(flowlet),
-                UserMessages.getMessage(UserErrors.INVALID_FLOWLET_NAME), flowlet);
+                                    UserMessages.getMessage(UserErrors.INVALID_FLOWLET_NAME), flowlet);
 
         FlowletConnection.Type sourceType;
         String sourceName;

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowSpecification.java
@@ -36,7 +36,7 @@ public final class WorkflowSpecification implements ProgramSpecification, Proper
   private final List<WorkflowNode> nodes;
 
   public WorkflowSpecification(String className, String name, String description,
-                                      Map<String, String> properties, List<WorkflowNode> nodes) {
+                               Map<String, String> properties, List<WorkflowNode> nodes) {
     this.className = className;
     this.name = name;
     this.description = description;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/DefaultFlowConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/DefaultFlowConfigurer.java
@@ -102,8 +102,10 @@ public class DefaultFlowConfigurer implements FlowConfigurer {
   @Override
   public void connect(String from, String to) {
     Preconditions.checkArgument(from != null && to != null, UserMessages.getMessage(UserErrors.INVALID_FLOWLET_NULL));
-    Preconditions.checkArgument(flowlets.containsKey(from) && flowlets.containsKey(to),
-                                UserMessages.getMessage(UserErrors.INVALID_FLOWLET_NAME));
+    Preconditions.checkArgument(flowlets.containsKey(from),
+                                UserMessages.getMessage(UserErrors.INVALID_FLOWLET_NAME), from);
+    Preconditions.checkArgument(flowlets.containsKey(to),
+                                UserMessages.getMessage(UserErrors.INVALID_FLOWLET_NAME), to);
     connections.add(new FlowletConnection(FlowletConnection.Type.FLOWLET, from, to));
   }
 
@@ -127,10 +129,10 @@ public class DefaultFlowConfigurer implements FlowConfigurer {
 
   @Override
   public void connectStream(String stream, String flowlet) {
-    Preconditions.checkArgument(stream != null, UserMessages.getMessage(UserErrors.INVALID_STREAM_NAME));
+    Preconditions.checkArgument(stream != null, UserMessages.getMessage(UserErrors.INVALID_STREAM_NULL));
     Preconditions.checkArgument(flowlet != null, UserMessages.getMessage(UserErrors.INVALID_FLOWLET_NULL));
     Preconditions.checkArgument(flowlets.containsKey(flowlet),
-                                UserMessages.getMessage(UserErrors.INVALID_FLOWLET_NAME));
+                                UserMessages.getMessage(UserErrors.INVALID_FLOWLET_NAME), flowlet);
     connections.add(new FlowletConnection(FlowletConnection.Type.STREAM, stream, flowlet));
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/AppMetadataStore.java
@@ -243,8 +243,8 @@ public class AppMetadataStore extends MetadataStoreDataset {
   }
 
   public List<RunRecordMeta> getRuns(@Nullable Id.Program program, ProgramRunStatus status,
-                                 long startTime, long endTime, int limit, String adapter,
-                                 @Nullable Predicate<RunRecordMeta> filter) {
+                                     long startTime, long endTime, int limit, String adapter,
+                                     @Nullable Predicate<RunRecordMeta> filter) {
     if (status.equals(ProgramRunStatus.ALL)) {
       List<RunRecordMeta> resultRecords = Lists.newArrayList();
       resultRecords.addAll(getSuspendedRuns(program, startTime, endTime, limit, adapter, filter));
@@ -261,7 +261,7 @@ public class AppMetadataStore extends MetadataStoreDataset {
   }
 
   public List<RunRecordMeta> getRuns(@Nullable Id.Program program, ProgramRunStatus status,
-                                 long startTime, long endTime, int limit, String adapter) {
+                                     long startTime, long endTime, int limit, String adapter) {
     return getRuns(program, status, startTime, endTime, limit, adapter, null);
   }
 
@@ -338,18 +338,18 @@ public class AppMetadataStore extends MetadataStoreDataset {
   }
 
   private List<RunRecordMeta> getSuspendedRuns(Id.Program program, long startTime, long endTime, int limit,
-                                           final String adapter, @Nullable Predicate<RunRecordMeta> filter) {
+                                               final String adapter, @Nullable Predicate<RunRecordMeta> filter) {
     return getNonCompleteRuns(program, TYPE_RUN_RECORD_SUSPENDED, startTime, endTime, limit, adapter, filter);
   }
 
   private List<RunRecordMeta> getActiveRuns(Id.Program program, final long startTime, final long endTime, int limit,
-                                        final String adapter, @Nullable Predicate<RunRecordMeta> filter) {
+                                            final String adapter, @Nullable Predicate<RunRecordMeta> filter) {
     return getNonCompleteRuns(program, TYPE_RUN_RECORD_STARTED, startTime, endTime, limit, adapter, filter);
     }
 
   private List<RunRecordMeta> getNonCompleteRuns(Id.Program program, String recordType,
-                                             final long startTime, final long endTime, int limit,
-                                             final String adapter, Predicate<RunRecordMeta> filter) {
+                                                 final long startTime, final long endTime, int limit,
+                                                 final String adapter, Predicate<RunRecordMeta> filter) {
     MDSKey activeKey = getProgramKeyBuilder(recordType, program).build();
 
     return list(activeKey, null, RunRecordMeta.class, limit, andPredicate(new Predicate<RunRecordMeta>() {
@@ -366,8 +366,8 @@ public class AppMetadataStore extends MetadataStoreDataset {
   }
 
   private List<RunRecordMeta> getHistoricalRuns(Id.Program program, ProgramRunStatus status,
-                                            final long startTime, final long endTime, int limit, final String adapter,
-                                            @Nullable Predicate<RunRecordMeta> filter) {
+                                                final long startTime, final long endTime, int limit,
+                                                final String adapter, @Nullable Predicate<RunRecordMeta> filter) {
     MDSKey historyKey = getProgramKeyBuilder(TYPE_RUN_RECORD_COMPLETED, program).build();
 
     MDSKey start = new MDSKey.Builder(historyKey).add(getInvertedTsScanKeyPart(endTime)).build();

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
@@ -253,7 +253,7 @@ public class DefaultStore implements Store {
 
   @Override
   public List<RunRecordMeta> getRuns(final Id.Program id, final ProgramRunStatus status,
-                                 final long startTime, final long endTime, final int limit, final String adapter) {
+                                     final long startTime, final long endTime, final int limit, final String adapter) {
     return txnl.executeUnchecked(new TransactionExecutor.Function<AppMds, List<RunRecordMeta>>() {
       @Override
       public List<RunRecordMeta> apply(AppMds mds) throws Exception {


### PR DESCRIPTION
The code was using `UserErrors.INVALID_STREAM_NAME`, where it should've been using
`UserErrors.INVALID_STREAM_NULL`.
Also, some places, it was using `UserErrors.INVALID_FLOWLET_NAME`, but didn't specify the string of the requested flowlet name, so the error message was getting logged/outputted with a `%s` in it:
`java.lang.IllegalArgumentException: Your FlowSpecification attempts to connect from an invalid Flowlet; "%s" does not exist`

http://builds.cask.co/browse/CDAP-DUT2478-1