### PR TITLE
CDAP-3224 add api for creating an app from an artifact

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppLifecycleHttpHandler.java
@@ -265,6 +265,10 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
     responder.sendString(status.getCode(), status.getMessage());
   }
 
+  // normally we wouldn't want to use a body consumer but would just want to read the request body directly
+  // since it wont be big. But the deploy app API has one path with different behavior based on content type
+  // the other behavior requires a BodyConsumer and only have one method per path is allowed,
+  // so we have to use a BodyConsumer
   private BodyConsumer deployAppFromArtifact(final Id.Namespace namespace, final String appId) throws IOException {
 
     return new AbstractBodyConsumer(File.createTempFile(appId, ".json", tmpDir)) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppLifecycleHttpHandler.java
@@ -28,6 +28,7 @@ import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.app.runtime.ProgramRuntimeService;
 import co.cask.cdap.app.store.Store;
 import co.cask.cdap.common.ArtifactAlreadyExistsException;
+import co.cask.cdap.common.ArtifactNotFoundException;
 import co.cask.cdap.common.CannotBeDeletedException;
 import co.cask.cdap.common.InvalidArtifactException;
 import co.cask.cdap.common.NotFoundException;
@@ -57,12 +58,15 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramRecord;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.StreamDetail;
+import co.cask.cdap.proto.artifact.ArtifactSummary;
+import co.cask.cdap.proto.artifact.CreateAppRequest;
 import co.cask.http.BodyConsumer;
 import co.cask.http.HttpResponder;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Lists;
+import com.google.gson.Gson;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import org.apache.twill.filesystem.Location;
@@ -73,6 +77,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.FileReader;
 import java.io.IOException;
 import java.util.List;
 import java.util.Set;
@@ -84,6 +89,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.core.MediaType;
 
 /**
  * {@link co.cask.http.HttpHandler} for managing application lifecycle.
@@ -91,6 +97,7 @@ import javax.ws.rs.PathParam;
 @Singleton
 @Path(Constants.Gateway.API_VERSION_3 + "/namespaces/{namespace-id}")
 public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
+  private static final Gson GSON = new Gson();
   private static final Logger LOG = LoggerFactory.getLogger(AppLifecycleHttpHandler.class);
 
   /**
@@ -111,6 +118,7 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   private final ApplicationLifecycleService applicationLifecycleService;
   private final AdapterService adapterService;
   private final ArtifactRepository artifactRepository;
+  private final File tmpDir;
 
   @Inject
   public AppLifecycleHttpHandler(CConfiguration configuration,
@@ -130,6 +138,8 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
     this.applicationLifecycleService = applicationLifecycleService;
     this.adapterService = adapterService;
     this.artifactRepository = artifactRepository;
+    this.tmpDir = new File(new File(configuration.get(Constants.CFG_LOCAL_DATA_DIR)),
+                           configuration.get(Constants.AppFabric.TEMP_DIR)).getAbsoluteFile();
   }
 
   /**
@@ -141,14 +151,25 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
                              @PathParam("namespace-id") final String namespaceId,
                              @PathParam("app-id") final String appId,
                              @HeaderParam(ARCHIVE_NAME_HEADER) final String archiveName,
-                             @HeaderParam(APP_CONFIG_HEADER) String configString) {
+                             @HeaderParam(APP_CONFIG_HEADER) String configString,
+                             @HeaderParam(HttpHeaders.Names.CONTENT_TYPE) String contentType) {
+
+    Id.Namespace namespace = Id.Namespace.from(namespaceId);
+
+    // yes this is weird... here for backwards compatibility. If content type is json, use the preferred method
+    // of creating an app from an artifact. Otherwise use the old method where the body is the jar contents.
+    boolean createFromArtifact = MediaType.APPLICATION_JSON.equals(contentType);
+
     try {
-      return deployApplication(responder, namespaceId, appId, archiveName, configString);
+      if (createFromArtifact) {
+        return deployAppFromArtifact(namespace, appId);
+      } else {
+        return deployApplication(responder, namespaceId, appId, archiveName, configString);
+      }
     } catch (Exception ex) {
       responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, "Deploy failed: {}" + ex.getMessage());
       return null;
     }
-
   }
 
   /**
@@ -244,6 +265,54 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
     responder.sendString(status.getCode(), status.getMessage());
   }
 
+  private BodyConsumer deployAppFromArtifact(final Id.Namespace namespace, final String appId) throws IOException {
+
+    return new AbstractBodyConsumer(File.createTempFile(appId, ".json", tmpDir)) {
+
+      @Override
+      protected void onFinish(HttpResponder responder, File uploadedFile) {
+        try (FileReader fileReader = new FileReader(uploadedFile)) {
+
+          CreateAppRequest<?> createAppRequest = GSON.fromJson(fileReader, CreateAppRequest.class);
+          ArtifactSummary artifactSummary = createAppRequest.getArtifact();
+          Id.Namespace artifactNamespace = artifactSummary.isSystem() ? Id.Namespace.SYSTEM : namespace;
+          Id.Artifact artifactId =
+            Id.Artifact.from(artifactNamespace, artifactSummary.getName(), artifactSummary.getVersion());
+
+          ArtifactDetail artifactDetail;
+          try {
+            artifactDetail = artifactRepository.getArtifact(artifactId);
+          } catch (ArtifactNotFoundException e) {
+            responder.sendString(HttpResponseStatus.NOT_FOUND, e.getMessage());
+            return;
+          }
+
+          Set<ApplicationClass> appClasses = artifactDetail.getMeta().getClasses().getApps();
+          if (appClasses.isEmpty()) {
+            responder.sendString(HttpResponseStatus.BAD_REQUEST, String.format(
+              "No application classes found in artifact %s.", artifactId));
+            return;
+          }
+          String className = appClasses.iterator().next().getClassName();
+          Location location = artifactDetail.getDescriptor().getLocation();
+
+          // if we don't null check, it get serialized to "null"
+          String configString = createAppRequest.getConfig() == null ? null : GSON.toJson(createAppRequest.getConfig());
+          AppDeploymentInfo deploymentInfo = new AppDeploymentInfo(artifactId, className, location, configString);
+          deploy(namespace.getId(), appId, deploymentInfo);
+          responder.sendString(HttpResponseStatus.OK, "Deploy Complete");
+        } catch (IOException e) {
+          LOG.error("Error reading request body for creating app {}.", appId);
+          responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, String.format(
+            "Error while reading json request body for app %s.", appId));
+        } catch (Exception e) {
+          LOG.error("Deploy failure", e);
+          responder.sendString(HttpResponseStatus.BAD_REQUEST, e.getMessage());
+        }
+      }
+    };
+  }
+
   private BodyConsumer deployApplication(final HttpResponder responder,
                                          final String namespaceId,
                                          final String appId,
@@ -271,7 +340,6 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
                            ImmutableMultimap.of(HttpHeaders.Names.CONNECTION, HttpHeaders.Values.CLOSE));
       return null;
     }
-
 
     // TODO: (CDAP-3258) error handling needs to be refactored here, should be able just to throw the exception,
     // but the caller catches all exceptions and responds with a 500

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AppFabricTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AppFabricTestBase.java
@@ -37,13 +37,17 @@ import co.cask.cdap.gateway.handlers.UsageHandler;
 import co.cask.cdap.internal.app.services.AppFabricServer;
 import co.cask.cdap.internal.guice.AppFabricTestModule;
 import co.cask.cdap.internal.test.AppJarHelper;
+import co.cask.cdap.internal.test.PluginJarHelper;
 import co.cask.cdap.metrics.query.MetricsQueryService;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.RunRecord;
+import co.cask.cdap.proto.artifact.ArtifactRange;
+import co.cask.cdap.proto.artifact.CreateAppRequest;
 import co.cask.tephra.TransactionManager;
 import co.cask.tephra.TransactionSystemClient;
 import com.google.common.base.Charsets;
+import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
@@ -93,6 +97,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.jar.JarEntry;
@@ -100,6 +105,7 @@ import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
 import java.util.zip.ZipEntry;
 import javax.annotation.Nullable;
+import javax.ws.rs.core.MediaType;
 
 /**
  * AppFabric HttpHandler Test classes can extend this class, this will allow the HttpService be setup before
@@ -320,6 +326,48 @@ public abstract class AppFabricTestBase {
     return gson.fromJson(readResponse(response), type);
   }
 
+  protected HttpResponse addAppArtifact(Id.Artifact artifactId, Class<?> cls) throws Exception {
+
+    Location appJar = AppJarHelper.createDeploymentJar(locationFactory, cls, new Manifest());
+
+    try (InputStream artifactInputStream = appJar.getInputStream()) {
+      return addArtifact(artifactId, artifactInputStream, null);
+    } finally {
+      appJar.delete();
+    }
+  }
+
+  protected HttpResponse addPluginArtifact(Id.Artifact artifactId, Class<?> cls,
+                                           Manifest manifest,
+                                           Set<ArtifactRange> parents) throws Exception {
+
+    Location appJar = PluginJarHelper.createPluginJar(locationFactory, manifest, cls);
+
+    try (InputStream artifactInputStream = appJar.getInputStream()) {
+      return addArtifact(artifactId, artifactInputStream, parents);
+    } finally {
+      appJar.delete();
+    }
+  }
+
+  // add an artifact and return the response code
+  protected HttpResponse addArtifact(Id.Artifact artifactId, InputStream artifactContents,
+                                     Set<ArtifactRange> parents) throws Exception {
+    String path = getVersionedAPIPath("artifacts/" + artifactId.getName(), artifactId.getNamespace().getId());
+    HttpEntityEnclosingRequestBase request = getPost(path);
+    request.setHeader(Constants.Gateway.API_KEY, "api-key-example");
+    request.setHeader("Artifact-Version", artifactId.getVersion().getVersion());
+    if (parents != null && !parents.isEmpty()) {
+      request.setHeader("Artifact-Extends", Joiner.on('/').join(parents));
+    }
+
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    ByteStreams.copy(artifactContents, bos);
+    bos.close();
+    request.setEntity(new ByteArrayEntity(bos.toByteArray()));
+    return execute(request);
+  }
+
   /**
    * Deploys an application.
    */
@@ -349,6 +397,17 @@ public abstract class AppFabricTestBase {
   protected HttpResponse deploy(Class<?> application, @Nullable String apiVersion, @Nullable String namespace,
                                 @Nullable String appName, @Nullable String appVersion) throws Exception {
     return deploy(application, apiVersion, namespace, appName, appVersion, null);
+  }
+
+  protected HttpResponse deploy(Id.Application appId,
+                                CreateAppRequest<? extends Config> createAppRequest) throws Exception {
+    HttpEntityEnclosingRequestBase request;
+    String deployPath = getVersionedAPIPath("apps/" + appId.getId(), appId.getNamespaceId());
+    request = getPut(deployPath);
+    request.setHeader(Constants.Gateway.API_KEY, "api-key-example");
+    request.setHeader(HttpHeaders.Names.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+    request.setEntity(new StringEntity(GSON.toJson(createAppRequest)));
+    return execute(request);
   }
 
   /**

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/AppLifecycleHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/AppLifecycleHttpHandlerTest.java
@@ -21,11 +21,14 @@ import co.cask.cdap.AppWithDatasetDuplicate;
 import co.cask.cdap.BloatedWordCountApp;
 import co.cask.cdap.ConfigTestApp;
 import co.cask.cdap.WordCountApp;
+import co.cask.cdap.api.Config;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.gateway.handlers.AppLifecycleHttpHandler;
 import co.cask.cdap.internal.app.services.http.AppFabricTestBase;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.artifact.ArtifactSummary;
+import co.cask.cdap.proto.artifact.CreateAppRequest;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import org.apache.http.HttpResponse;
@@ -69,6 +72,33 @@ public class AppLifecycleHttpHandlerTest extends AppFabricTestBase {
     Assert.assertEquals(200, response.getStatusLine().getStatusCode());
     JsonObject appDetails = getAppDetails(Id.Namespace.DEFAULT.getId(), "ConfigApp");
     Assert.assertEquals(GSON.toJson(config), appDetails.get("configuration").getAsString());
+  }
+
+  @Test
+  public void testDeployUsingNonexistantArtifact404() throws Exception {
+    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "badapp");
+    CreateAppRequest<Config> createAppRequest =
+      new CreateAppRequest<>(new ArtifactSummary("something", "1.0.0", false), null);
+    HttpResponse response = deploy(appId, createAppRequest);
+    Assert.assertEquals(404, response.getStatusLine().getStatusCode());
+  }
+
+  @Test
+  public void testDeployUsingArtifact() throws Exception {
+    Id.Artifact artifactId = Id.Artifact.from(Id.Namespace.DEFAULT, "configapp", "1.0.0");
+    addAppArtifact(artifactId, ConfigTestApp.class);
+
+    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "cfgApp");
+    ConfigTestApp.ConfigClass config = new ConfigTestApp.ConfigClass("abc", "def");
+    CreateAppRequest<ConfigTestApp.ConfigClass> request = new CreateAppRequest<>(
+      new ArtifactSummary(artifactId.getName(), artifactId.getVersion().getVersion(), false), config);
+    Assert.assertEquals(200, deploy(appId, request).getStatusLine().getStatusCode());
+
+    JsonObject appDetails = getAppDetails(Id.Namespace.DEFAULT.getId(), appId.getId());
+    Assert.assertEquals(GSON.toJson(config), appDetails.get("configuration").getAsString());
+
+    Assert.assertEquals(200,
+      doDelete(getVersionedAPIPath("apps/" + appId.getId(), appId.getNamespaceId())).getStatusLine().getStatusCode());
   }
 
   @Test

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/artifact/CreateAppRequest.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/artifact/CreateAppRequest.java
@@ -16,6 +16,8 @@
 
 package co.cask.cdap.proto.artifact;
 
+import javax.annotation.Nullable;
+
 /**
  * Request body when creating an app
  *
@@ -25,7 +27,11 @@ public class CreateAppRequest<T> {
   private final ArtifactSummary artifact;
   private final T config;
 
-  public CreateAppRequest(ArtifactSummary artifact, T config) {
+  public CreateAppRequest(ArtifactSummary artifact) {
+    this(artifact, null);
+  }
+
+  public CreateAppRequest(ArtifactSummary artifact, @Nullable T config) {
     this.artifact = artifact;
     this.config = config;
   }
@@ -34,6 +40,7 @@ public class CreateAppRequest<T> {
     return artifact;
   }
 
+  @Nullable
   public T getConfig() {
     return config;
   }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/artifact/CreateAppRequest.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/artifact/CreateAppRequest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.proto.artifact;
+
+/**
+ * Request body when creating an app
+ *
+ * @param <T> the type of application config
+ */
+public class CreateAppRequest<T> {
+  private final ArtifactSummary artifact;
+  private final T config;
+
+  public CreateAppRequest(ArtifactSummary artifact, T config) {
+    this.artifact = artifact;
+    this.config = config;
+  }
+
+  public ArtifactSummary getArtifact() {
+    return artifact;
+  }
+
+  public T getConfig() {
+    return config;
+  }
+}


### PR DESCRIPTION
Modifies the current PUT /apps/<appid> api so that requests with
a json content type are interpreted as a request to create an app
based on an artifact that already exists.