### PR TITLE
Show 0 instead of a dash, when there are 0 stream events

### DIFF
--- a/cdap-ui/app/features/streams/templates/tabs/status.html
+++ b/cdap-ui/app/features/streams/templates/tabs/status.html
@@ -11,9 +11,9 @@
           </thead>
           <tbody>
             <td ng-if="StatusController.storage"> {{StatusController.storage | bytes}} </td>
-            <td ng-if="StatusController.storage == null"> &mdash; </td>
+            <td ng-if="StatusController.storage == null"> 0b </td>
             <td ng-if="StatusController.events"> {{StatusController.events | number}} </td>
-            <td ng-if="StatusController.events == null"> &mdash; </td>
+            <td ng-if="StatusController.events == null"> 0 </td>
           </tbody>
         </table>
     </div>


### PR DESCRIPTION
This is now consistent with the datasets page, which shows 0b (as opposed to a dash), when there isn't a non-zero metric value for that metric:
https://github.com/caskdata/cdap/blob/feature-ui/stream-page-show-0/cdap-ui/app/features/datasets/templates/tabs/status.html#L17

Before:
![image](https://s3.amazonaws.com/uploads.hipchat.com/26476/1011205/n7ydHFnqbFeLtQN/upload.png)

Now:
![image](https://cloud.githubusercontent.com/assets/2440977/9148165/653ca896-3d28-11e5-89c8-05b29e4d5f2d.png)
