### PR TITLE
CDAP-3343 make sure plugin inspector has spark access

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactClassLoaderFactory.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactClassLoaderFactory.java
@@ -16,9 +16,11 @@
 
 package co.cask.cdap.internal.app.runtime.artifact;
 
+import co.cask.cdap.common.lang.FilterClassLoader;
 import co.cask.cdap.common.lang.ProgramClassLoader;
 import co.cask.cdap.common.lang.jar.BundleJarUtil;
 import co.cask.cdap.common.utils.DirUtils;
+import co.cask.cdap.proto.ProgramType;
 import com.google.common.io.Closeables;
 import org.apache.twill.filesystem.Location;
 import org.slf4j.Logger;
@@ -27,6 +29,7 @@ import org.slf4j.LoggerFactory;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
+import javax.annotation.Nullable;
 
 /**
  * Given an artifact, creates a {@link CloseableClassLoader} from it. Takes care of unpacking the artifact and
@@ -40,10 +43,33 @@ public class ArtifactClassLoaderFactory {
     this.baseUnpackDir = baseUnpackDir;
   }
 
+  /**
+   * Create a classloader that uses the artifact at the specified location to load classes.
+   *
+   * @param artifactLocation the location of the artifact to create the classloader from
+   * @return a closeable classloader based off the specified artifact
+   * @throws IOException if there was an error copying or unpacking the artifact
+   */
   public CloseableClassLoader createClassLoader(Location artifactLocation) throws IOException {
+    return createClassLoader(artifactLocation, null);
+  }
+
+  /**
+   * Create a classloader that uses the artifact at the specified location to load classes, with access to
+   * packages that the given program type has access to. See {@link FilterClassLoader} for more detail on
+   * what program types have access to what packages.
+   *
+   * @param artifactLocation the location of the artifact to create the classloader from
+   * @param programType the type of program the classloader is for.
+   * @return a closeable classloader based off the specified artifact
+   * @throws IOException if there was an error copying or unpacking the artifact
+   */
+  public CloseableClassLoader createClassLoader(Location artifactLocation,
+                                                @Nullable ProgramType programType) throws IOException {
     final File unpackDir = DirUtils.createTempDir(baseUnpackDir);
     BundleJarUtil.unpackProgramJar(artifactLocation, unpackDir);
-    final ProgramClassLoader programClassLoader = ProgramClassLoader.create(unpackDir, getClass().getClassLoader());
+    final ProgramClassLoader programClassLoader =
+      ProgramClassLoader.create(unpackDir, getClass().getClassLoader(), programType);
     return new CloseableClassLoader(programClassLoader, new Closeable() {
       @Override
       public void close() {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactInspector.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactInspector.java
@@ -227,9 +227,10 @@ public class ArtifactInspector {
         }
       }
     } catch (Throwable t) {
-      throw new InvalidArtifactException(
-        "Class could not be found while inspecting artifact for plugins. Please check dependencies are available, " +
-          "and that the correct parent artifact was specified.", t);
+      throw new InvalidArtifactException(String.format(
+        "Class could not be found while inspecting artifact for plugins. " +
+        "Please check dependencies are available, and that the correct parent artifact was specified. " +
+        "Error class: %s, message: %s.", t.getClass(), t.getMessage()), t);
     }
 
     return builder;


### PR DESCRIPTION
Make changes so that when the framework is inspecting an artifact
for plugins it has access to spark packages in case the artifact
contains spark programs. The classloader is only used when
inspecting artifacts and is closed right after inspection finishes.