### PR TITLE
make IntegrationTestBase#checkSystemServices private --> protected

### DIFF
--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestBase.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestBase.java
@@ -93,8 +93,7 @@ public class IntegrationTestBase {
     assertIsClear();
   }
 
-  private void checkSystemServices() throws ServiceUnavailableException {
-
+  protected void checkSystemServices() throws ServiceUnavailableException {
     Callable<Boolean> monitorCallable = new Callable<Boolean>() {
       @Override
       public Boolean call() throws Exception {


### PR DESCRIPTION
Use case is that the system services need to be checked for `OK` status from subclass (cdap-integration-test repo, for instance), and this functionality is already implemented in here.