### PR TITLE
CDAP-3138: CLI shouldn't stack trace on unable to connect at startup

### DIFF
--- a/cdap-cli/src/main/java/co/cask/cdap/cli/CLIConfig.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/CLIConfig.java
@@ -129,7 +129,7 @@ public class CLIConfig implements TableRendererConfig {
 
   public Id.Namespace getCurrentNamespace() {
     if (connectionConfig == null || connectionConfig.getNamespace() == null) {
-      throw new DisconnectedException();
+      throw new DisconnectedException(connectionConfig);
     }
     return connectionConfig.getNamespace();
   }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/CLIMain.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/CLIMain.java
@@ -108,7 +108,8 @@ public class CLIMain {
   private final LaunchOptions options;
   private final FilePathResolver filePathResolver;
 
-  public CLIMain(final LaunchOptions options, final CLIConfig cliConfig) throws URISyntaxException, IOException {
+  public CLIMain(final LaunchOptions options,
+                 final CLIConfig cliConfig) throws URISyntaxException, IOException {
     this.options = options;
     this.cliConfig = cliConfig;
 
@@ -171,19 +172,26 @@ public class CLIMain {
   /**
    * Tries to autoconnect to the provided URI in options.
    */
-  public void tryAutoconnect() {
+  public boolean tryAutoconnect(CommandLine command) {
+    if (!options.isAutoconnect()) {
+      return true;
+    }
+
     InstanceURIParser instanceURIParser = injector.getInstance(InstanceURIParser.class);
-    if (options.isAutoconnect()) {
-      try {
-        CLIConnectionConfig connection = instanceURIParser.parse(options.getUri());
-        cliConfig.tryConnect(connection, cliConfig.getOutput(), options.isDebug());
-      } catch (Exception e) {
-        if (options.isDebug()) {
-          e.printStackTrace(cliConfig.getOutput());
-        } else {
-          cliConfig.getOutput().println(e.getMessage());
-        }
+    try {
+      CLIConnectionConfig connection = instanceURIParser.parse(options.getUri());
+      cliConfig.tryConnect(connection, cliConfig.getOutput(), options.isDebug());
+      return true;
+    } catch (Exception e) {
+      if (options.isDebug()) {
+        e.printStackTrace(cliConfig.getOutput());
+      } else {
+        cliConfig.getOutput().println(e.getMessage());
       }
+      if (!command.hasOption(URI_OPTION.getOpt())) {
+        cliConfig.getOutput().printf("Specify the CDAP instance URI with the -u command line argument.\n");
+      }
+      return false;
     }
   }
 
@@ -268,7 +276,9 @@ public class CLIMain {
         CLIMain cliMain = new CLIMain(launchOptions, cliConfig);
         CLI cli = cliMain.getCLI();
 
-        cliMain.tryAutoconnect();
+        if (!cliMain.tryAutoconnect(command)) {
+          System.exit(0);
+        }
 
         CLIConnectionConfig connectionConfig = new CLIConnectionConfig(
           cliConfig.getClientConfig().getConnectionConfig(), Id.Namespace.DEFAULT, null);
@@ -292,6 +302,8 @@ public class CLIMain {
         } else {
           cli.execute(Joiner.on(" ").join(commandArgs), output);
         }
+      } catch (DisconnectedException e) {
+        output.printf("Couldn't reach the CDAP instance at '%s'.", e.getConnectionConfig().getURI().toString());
       } catch (Exception e) {
         e.printStackTrace(output);
       }

--- a/cdap-client/src/main/java/co/cask/cdap/client/exception/DisconnectedException.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/exception/DisconnectedException.java
@@ -15,8 +15,28 @@
  */
 package co.cask.cdap.client.exception;
 
+import co.cask.cdap.client.config.ConnectionConfig;
+
+import javax.annotation.Nullable;
+
 /**
  * Thrown when the client is not connected, but a request was attempted.
  */
 public class DisconnectedException extends RuntimeException {
+
+  @Nullable
+  private final ConnectionConfig connectionConfig;
+
+  public DisconnectedException(@Nullable ConnectionConfig connectionConfig) {
+    this.connectionConfig = connectionConfig;
+  }
+
+  public DisconnectedException() {
+    this(null);
+  }
+
+  @Nullable
+  public ConnectionConfig getConnectionConfig() {
+    return connectionConfig;
+  }
 }


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-3138
http://builds.cask.co/browse/CDAP-DUT2496

With this change, connection refused messages are nicer.

Without specifying -u:

```
CDAP instance at 'http://myhost:10000/default' could not be reached: Connection refused
Specify the CDAP instance URI with the -u command line argument.
```

With specifying -u:

```
CDAP instance at 'http://myhost:10000/default' could not be reached: Connection refused
```