### PR TITLE
Feature/r3.1 fix spark docs

### DIFF
--- a/cdap-docs/developers-manual/source/building-blocks/spark-programs.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/spark-programs.rst
@@ -8,6 +8,8 @@
 Spark Programs
 ==============
 
+.. rubric:: Beta, on Standalone and insecure Clusters only
+
 *Apache Spark* is used for in-memory cluster computing. It lets you load large sets of
 data into memory and query them repeatedly. This makes it suitable for both iterative and
 interactive programs. Similar to MapReduce, Spark can access **datasets** as both input

--- a/cdap-docs/developers-manual/source/building-blocks/spark-programs.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/spark-programs.rst
@@ -4,16 +4,14 @@
 
 .. _spark:
 
-=============================================
-Spark Programs *(Beta, Standalone CDAP only)*
-=============================================
+==============
+Spark Programs
+==============
 
 *Apache Spark* is used for in-memory cluster computing. It lets you load large sets of
 data into memory and query them repeatedly. This makes it suitable for both iterative and
 interactive programs. Similar to MapReduce, Spark can access **datasets** as both input
 and output. *Spark programs* in CDAP can be written in either Java or Scala.
-
-In the current release, Spark (version 1.0 or higher) is supported only in the Standalone CDAP. 
 
 To process data using Spark, specify ``addSpark()`` in your application specification::
 
@@ -223,8 +221,10 @@ Spark programs in CDAP can also be added to a :ref:`workflow <workflows>`, simil
 Examples of Using Spark Programs
 --------------------------------
 
-- For an example of **a Spark program,** see the :ref:`Spark K-Means <examples-spark-k-means>`
-  and :ref:`Spark Page Rank <examples-spark-page-rank>` examples.
+- Examples of **Spark programs** include the :ref:`Spark K-Means <examples-spark-k-means>`,
+  :ref:`Spark Page Rank <examples-spark-page-rank>`, 
+  :ref:`Log Analysis <examples-log-analysis>`, and
+  :ref:`Wikipedia Pipeline <examples-wikipedia-data-pipeline>` examples.
 
 - For a longer example, the how-to guide :ref:`cdap-spark-guide` gives another demonstration.
 

--- a/cdap-docs/developers-manual/source/building-blocks/spark-programs.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/spark-programs.rst
@@ -8,12 +8,16 @@
 Spark Programs
 ==============
 
-.. rubric:: Beta, on Standalone and insecure Clusters only
+.. rubric:: Beta
 
 *Apache Spark* is used for in-memory cluster computing. It lets you load large sets of
 data into memory and query them repeatedly. This makes it suitable for both iterative and
 interactive programs. Similar to MapReduce, Spark can access **datasets** as both input
 and output. *Spark programs* in CDAP can be written in either Java or Scala.
+
+A *beta* feature of CDAP, Spark is currently supported on standalone mode and non-secure
+clusters only. We are using Spark 1.3 in standalone mode, and support Spark 1.2, 1.3, or
+1.4 on clusters.
 
 To process data using Spark, specify ``addSpark()`` in your application specification::
 


### PR DESCRIPTION
Alter to include insecure Clusters and link to additional examples added in 3.1

Staged at: [CDAP Developers’ Manual » Building Blocks » Spark Programs](http://docs-staging.cask.co/staging/cdap/3.1.0-feature-r3.1_fix_Spark_docs/en/developers-manual/building-blocks/spark-programs.html)