### PR TITLE
CDAP-3283 index application class information and expose it

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/Store.java
@@ -200,8 +200,8 @@ public interface Store {
    * @param specification        Application specification
    * @return                     List of ProgramSpecifications that are deleted
    */
-  List<ProgramSpecification> getDeletedProgramSpecifications (Id.Application id,
-                                                              ApplicationSpecification specification);
+  List<ProgramSpecification> getDeletedProgramSpecifications(Id.Application id,
+                                                             ApplicationSpecification specification);
 
   /**
    * Returns application specification by id.
@@ -213,9 +213,27 @@ public interface Store {
   ApplicationSpecification getApplication(Id.Application id);
 
   /**
-   * Returns a collection of all application specs.
+   * Returns a collection of all application specs in the specified namespace
+   *
+   * @param id the namespace to get application specs from
+   * @return collection of all application specs in the namespace
    */
   Collection<ApplicationSpecification> getAllApplications(Id.Namespace id);
+
+  /**
+   * Returns a collection of all application specs in the specified namespace, optionally filtered to contain
+   * only applications that use the specified artifact name and version.
+   *
+   * @param namespace the namespace to get application specs from
+   * @param artifactName the name of the artifact to filter on.
+   *                     If null, app specs will not be filtered by artifact name.
+   * @param artifactVersion the version of the artifact to filter on.
+   *                        If null, app specs will not be filtered by artifact version.
+   * @return collection of all application specs in the namespace
+   */
+  Collection<ApplicationSpecification> getApplications(Id.Namespace namespace,
+                                                       @Nullable String artifactName,
+                                                       @Nullable String artifactVersion);
 
   /**
    * Returns location of the application archive.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppLifecycleHttpHandler.java
@@ -85,6 +85,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
 /**
@@ -186,8 +187,10 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   @GET
   @Path("/apps")
   public void getAllApps(HttpRequest request, HttpResponder responder,
-                         @PathParam("namespace-id") String namespaceId) throws NamespaceNotFoundException {
-    getAppRecords(responder, store, namespaceId);
+                         @PathParam("namespace-id") String namespaceId,
+                         @QueryParam("artifactName") String artifactName,
+                         @QueryParam("artifactVersion") String artifactVersion) throws NamespaceNotFoundException {
+    getAppRecords(responder, store, namespaceId, artifactName, artifactVersion);
   }
 
   /**
@@ -514,7 +517,7 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
       datasets.add(new DatasetDetail(datasetSpec.getInstanceName(), datasetSpec.getTypeName()));
     }
 
-    return new ApplicationDetail(spec.getName(), spec.getVersion(), spec.getDescription(), spec.getConfiguration(),
-                                 streams, datasets, programs);
+    return new ApplicationDetail(spec.getName(), spec.getDescription(), spec.getConfiguration(),
+                                 streams, datasets, programs, ArtifactSummary.from(spec.getArtifactId()));
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ArtifactHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ArtifactHttpHandler.java
@@ -311,7 +311,7 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
 
     try {
       responder.sendJson(HttpResponseStatus.OK, artifactRepository.getApplicationClasses(namespace, includeSystem),
-        APPCLASS_SUMMARIES_TYPE, GSON);
+                         APPCLASS_SUMMARIES_TYPE, GSON);
     } catch (IOException e) {
       LOG.error("Error getting app classes for namespace {}.", namespaceId, e);
       responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR,

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStore.java
@@ -358,7 +358,6 @@ public class ArtifactStore {
       });
   }
 
-
   /**
    * Get all plugin classes that extend the given parent artifact.
    * Results are returned as a sorted map from plugin artifact to plugins in that artifact.
@@ -607,6 +606,12 @@ public class ArtifactStore {
           Bytes.toBytes(String.format("%s:%s;", PLUGIN_PREFIX, namespace.getId()))
         );
         scanner = table.scan(pluginsScan);
+        while ((row = scanner.next()) != null) {
+          table.delete(row.getRow());
+        }
+
+        // delete app classes in this namespace
+        scanner = table.scan(scanAppClasses(namespace));
         while ((row = scanner.next()) != null) {
           table.delete(row.getRow());
         }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStore.java
@@ -16,6 +16,8 @@
 
 package co.cask.cdap.internal.app.runtime.artifact;
 
+import co.cask.cdap.api.artifact.ApplicationClass;
+import co.cask.cdap.api.artifact.ArtifactClasses;
 import co.cask.cdap.api.artifact.ArtifactDescriptor;
 import co.cask.cdap.api.artifact.ArtifactVersion;
 import co.cask.cdap.api.common.Bytes;
@@ -71,6 +73,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.reflect.Type;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -90,7 +93,6 @@ import java.util.SortedMap;
  * The first adds metadata about the artifact, with
  * rowkey r:{namespace}:{artifact-name}, column {artifact-version}, and ArtifactData as the value
  *
- * TODO: (CDAP-2764) add this part when we have a better idea of what needs to be in AppClass.
  * The second adds metadata about any Application Class contained in the artifact, with
  * rowkey a:{namespace}:{classname}, column {artifact-name}:{artifact-version}, and AppClass as the value
  *
@@ -135,6 +137,7 @@ public class ArtifactStore {
   private static final String ARTIFACTS_PATH = "artifacts";
   private static final String ARTIFACT_PREFIX = "r";
   private static final String PLUGIN_PREFIX = "p";
+  private static final String APPCLASS_PREFIX = "a";
   private static final Id.DatasetInstance META_ID = Id.DatasetInstance.from(Id.Namespace.SYSTEM, "artifact.meta");
 
   private final LocationFactory locationFactory;
@@ -278,6 +281,83 @@ public class ArtifactStore {
     }
     return new ArtifactDetail(getDescriptor(artifactId, locationFactory.create(data.locationURI)), data.meta);
   }
+
+  /**
+   * Get all application classes that belong to the specified namespace.
+   * Results are returned as a sorted map from artifact to application classes in that artifact.
+   * Map entries are sorted by the artifact.
+   *
+   * @param namespace the namespace from which to get application classes
+   * @return an unmodifiable map of artifact to a list of all application classes in that artifact.
+   *         The map will never be null. If there are no application classes, an empty map will be returned.
+   */
+  public SortedMap<ArtifactDescriptor, List<ApplicationClass>> getApplicationClasses(final Id.Namespace namespace) {
+
+    return metaTable.executeUnchecked(
+      new TransactionExecutor.Function<DatasetContext<Table>, SortedMap<ArtifactDescriptor, List<ApplicationClass>>>() {
+        @Override
+        public SortedMap<ArtifactDescriptor, List<ApplicationClass>> apply(DatasetContext<Table> context) {
+          SortedMap<ArtifactDescriptor, List<ApplicationClass>> result = Maps.newTreeMap();
+
+          Scanner scanner = context.get().scan(scanAppClasses(namespace));
+          Row row;
+          while ((row = scanner.next()) != null) {
+            // columns are {artifact-name}:{artifact-version}. vals are serialized AppData
+            for (Map.Entry<byte[], byte[]> column : row.getColumns().entrySet()) {
+              ArtifactColumn artifactColumn = ArtifactColumn.parse(column.getKey());
+              AppData appData = gson.fromJson(Bytes.toString(column.getValue()), AppData.class);
+
+              ArtifactDescriptor artifactDescriptor =
+                getDescriptor(artifactColumn.artifactId, locationFactory.create(appData.artifactLocationURI));
+              List<ApplicationClass> existingAppClasses = result.get(artifactDescriptor);
+              if (existingAppClasses == null) {
+                existingAppClasses = new ArrayList<>();
+                result.put(artifactDescriptor, existingAppClasses);
+              }
+              existingAppClasses.add(appData.appClass);
+            }
+          }
+          return Collections.unmodifiableSortedMap(result);
+        }
+      });
+  }
+
+  /**
+   * Get all application classes that belong to the specified namespace of the specified classname.
+   * Results are returned as a sorted map from artifact to application classes in that artifact.
+   * Map entries are sorted by the artifact.
+   *
+   * @param namespace the namespace from which to get application classes
+   * @param className the classname of application classes to get
+   * @return an unmodifiable map of artifact the application classes in that artifact.
+   *         The map will never be null. If there are no application classes, an empty map will be returned.
+   */
+  public SortedMap<ArtifactDescriptor, ApplicationClass> getApplicationClasses(final Id.Namespace namespace,
+                                                                               final String className) {
+
+    return metaTable.executeUnchecked(
+      new TransactionExecutor.Function<DatasetContext<Table>, SortedMap<ArtifactDescriptor, ApplicationClass>>() {
+        @Override
+        public SortedMap<ArtifactDescriptor, ApplicationClass> apply(DatasetContext<Table> context) {
+          SortedMap<ArtifactDescriptor, ApplicationClass> result = Maps.newTreeMap();
+
+          Row row = context.get().get(new AppClassKey(namespace, className).getRowKey());
+          if (!row.isEmpty()) {
+            // columns are {artifact-name}:{artifact-version}. vals are serialized AppData
+            for (Map.Entry<byte[], byte[]> column : row.getColumns().entrySet()) {
+              ArtifactColumn artifactColumn = ArtifactColumn.parse(column.getKey());
+              AppData appData = gson.fromJson(Bytes.toString(column.getValue()), AppData.class);
+
+              ArtifactDescriptor artifactDescriptor =
+                getDescriptor(artifactColumn.artifactId, locationFactory.create(appData.artifactLocationURI));
+              result.put(artifactDescriptor, appData.appClass);
+            }
+          }
+          return Collections.unmodifiableSortedMap(result);
+        }
+      });
+  }
+
 
   /**
    * Get all plugin classes that extend the given parent artifact.
@@ -561,10 +641,12 @@ public class ArtifactStore {
 
     // column for plugin meta and app meta. {artifact-name}:{artifact-version}
     // does not need to contain namespace because namespace is in the rowkey
-    ArtifactColumn artifactColumn = new ArtifactColumn(artifactId);
+    byte[] artifactColumn = new ArtifactColumn(artifactId).getColumn();
 
+    ArtifactClasses classes = data.meta.getClasses();
+    Location artifactLocation = locationFactory.create(data.locationURI);
     // write pluginClass metadata
-    for (PluginClass pluginClass : data.meta.getClasses().getPlugins()) {
+    for (PluginClass pluginClass : classes.getPlugins()) {
       // write metadata for each artifact this plugin extends
       for (ArtifactRange artifactRange : data.meta.getUsableBy()) {
         // p:{namespace}:{type}:{name}
@@ -572,12 +654,18 @@ public class ArtifactStore {
           artifactRange.getNamespace(), artifactRange.getName(), pluginClass.getType(), pluginClass.getName());
 
         byte[] pluginDataBytes = Bytes.toBytes(
-          gson.toJson(new PluginData(pluginClass, artifactRange, locationFactory.create(data.locationURI))));
-        table.put(pluginKey.getRowKey(), artifactColumn.getColumn(), pluginDataBytes);
+          gson.toJson(new PluginData(pluginClass, artifactRange, artifactLocation)));
+        table.put(pluginKey.getRowKey(), artifactColumn, pluginDataBytes);
       }
     }
 
-    // TODO: write appClass metadata
+    // write appClass metadata
+    for (ApplicationClass appClass : classes.getApps()) {
+      // a:{namespace}:{classname}
+      AppClassKey appClassKey = new AppClassKey(artifactId.getNamespace(), appClass.getClassName());
+      byte[] appDataBytes = Bytes.toBytes(gson.toJson(new AppData(appClass, artifactLocation)));
+      table.put(appClassKey.getRowKey(), artifactColumn, appDataBytes);
+    }
   }
 
   private void deleteMeta(Table table, Id.Artifact artifactId, byte[] oldData) throws IOException {
@@ -587,7 +675,7 @@ public class ArtifactStore {
 
     // delete old plugins
     ArtifactData oldMeta = gson.fromJson(Bytes.toString(oldData), ArtifactData.class);
-    ArtifactColumn artifactColumn = new ArtifactColumn(artifactId);
+    byte[] artifactColumn = new ArtifactColumn(artifactId).getColumn();
 
     for (PluginClass pluginClass : oldMeta.meta.getClasses().getPlugins()) {
       // delete metadata for each artifact this plugin extends
@@ -595,11 +683,15 @@ public class ArtifactStore {
         // p:{namespace}:{type}:{name}
         PluginKey pluginKey = new PluginKey(
           artifactRange.getNamespace(), artifactRange.getName(), pluginClass.getType(), pluginClass.getName());
-        table.delete(pluginKey.getRowKey(), artifactColumn.getColumn());
+        table.delete(pluginKey.getRowKey(), artifactColumn);
       }
     }
 
-    // TODO: delete appClass metadata
+    // delete old appclass metadata
+    for (ApplicationClass appClass : oldMeta.meta.getClasses().getApps()) {
+      AppClassKey appClassKey = new AppClassKey(artifactId.getNamespace(), appClass.getClassName());
+      table.delete(appClassKey.getRowKey(), artifactColumn);
+    }
 
     // delete the old jar file
     locationFactory.create(oldMeta.locationURI).delete();
@@ -664,6 +756,26 @@ public class ArtifactStore {
         PLUGIN_PREFIX, parentArtifactId.getNamespace().getId(), parentArtifactId.getName(), type)),
       Bytes.toBytes(String.format("%s:%s:%s:%s;",
         PLUGIN_PREFIX, parentArtifactId.getNamespace().getId(), parentArtifactId.getName(), type)));
+  }
+
+  private Scan scanAppClasses(Id.Namespace namespace) {
+    return new Scan(
+      Bytes.toBytes(String.format("%s:%s:", APPCLASS_PREFIX, namespace.getId())),
+      Bytes.toBytes(String.format("%s:%s;", APPCLASS_PREFIX, namespace.getId())));
+  }
+
+  private static class AppClassKey {
+    private final Id.Namespace namespace;
+    private final String className;
+
+    public AppClassKey(Id.Namespace namespace, String className) {
+      this.namespace = namespace;
+      this.className = className;
+    }
+
+    private byte[] getRowKey() {
+      return Bytes.toBytes(Joiner.on(':').join(APPCLASS_PREFIX, namespace.getId(), className));
+    }
   }
 
   private static class PluginKey {
@@ -760,6 +872,17 @@ public class ArtifactStore {
     public PluginData(PluginClass pluginClass, ArtifactRange usableBy, Location artifactLocation) {
       this.pluginClass = pluginClass;
       this.usableBy = usableBy;
+      this.artifactLocationURI = artifactLocation.toURI();
+    }
+  }
+  
+  // Data that will be stored for an application class.
+  private static class AppData {
+    private final ApplicationClass appClass;
+    private final URI artifactLocationURI;
+
+    public AppData(ApplicationClass appClass, Location artifactLocation) {
+      this.appClass = appClass;
       this.artifactLocationURI = artifactLocation.toURI();
     }
   }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStoreTest.java
@@ -52,7 +52,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.SortedMap;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
@@ -190,6 +189,8 @@ public class ArtifactStoreTest {
     artifactStore.delete(parentId);
     // nothing should be in the list
     Assert.assertTrue(artifactStore.getArtifacts(parentId.getNamespace()).isEmpty());
+    // shouldn't be able to see app class either
+    Assert.assertTrue(artifactStore.getApplicationClasses(Id.Namespace.DEFAULT, appClass.getClassName()).isEmpty());
   }
 
   @Test(expected = ArtifactAlreadyExistsException.class)

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStoreTest.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.internal.app.runtime.artifact;
 
+import co.cask.cdap.WordCountApp;
 import co.cask.cdap.api.artifact.ApplicationClass;
 import co.cask.cdap.api.artifact.ArtifactClasses;
 import co.cask.cdap.api.artifact.ArtifactDescriptor;
@@ -51,6 +52,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedMap;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
@@ -341,6 +343,70 @@ public class ArtifactStoreTest {
     artifactVersions = artifactStore.getArtifacts(range);
     Assert.assertEquals(1, artifactVersions.size());
     assertEqual(artifact2V1, meta2V1, contents2V1, artifactVersions.get(0));
+  }
+
+  @Test
+  public void testGetAppClasses() throws Exception {
+    // create 2 versions of the same artifact with the same app class
+    Id.Artifact app1v1Id = Id.Artifact.from(Id.Namespace.DEFAULT, "appA", "1.0.0");
+    ApplicationClass inspectionClass1 = new ApplicationClass(
+      InspectionApp.class.getName(), "v1",
+      new ReflectionSchemaGenerator().generate(InspectionApp.AConfig.class));
+    ArtifactMeta artifactMeta =
+      new ArtifactMeta(ArtifactClasses.builder().addApp(inspectionClass1).build());
+    writeArtifact(app1v1Id, artifactMeta, "my artifact contents");
+    ArtifactDetail app1v1Detail = artifactStore.getArtifact(app1v1Id);
+
+    Id.Artifact app1v2Id = Id.Artifact.from(Id.Namespace.DEFAULT, "appA", "2.0.0");
+    ApplicationClass inspectionClass2 = new ApplicationClass(
+      InspectionApp.class.getName(), "v2",
+      new ReflectionSchemaGenerator().generate(InspectionApp.AConfig.class));
+    artifactMeta = new ArtifactMeta(ArtifactClasses.builder().addApp(inspectionClass2).build());
+    writeArtifact(app1v2Id, artifactMeta, "my artifact contents");
+    ArtifactDetail app1v2Detail = artifactStore.getArtifact(app1v2Id);
+
+    // create a different artifact with the same app class
+    Id.Artifact app2v1Id = Id.Artifact.from(Id.Namespace.DEFAULT, "appB", "1.0.0");
+    artifactMeta = new ArtifactMeta(ArtifactClasses.builder().addApp(inspectionClass1).build());
+    writeArtifact(app2v1Id, artifactMeta, "other contents");
+    ArtifactDetail app2v1Detail = artifactStore.getArtifact(app2v1Id);
+
+    // create another artifact with a different app class
+    Id.Artifact app3v1Id = Id.Artifact.from(Id.Namespace.DEFAULT, "appC", "1.0.0");
+    ApplicationClass wordCountClass1 = new ApplicationClass(
+      WordCountApp.class.getName(), "v1",
+      new ReflectionSchemaGenerator().generate(InspectionApp.AConfig.class));
+    artifactMeta = new ArtifactMeta(ArtifactClasses.builder().addApp(wordCountClass1).build());
+    writeArtifact(app3v1Id, artifactMeta, "wc contents");
+    ArtifactDetail app3v1Detail = artifactStore.getArtifact(app3v1Id);
+
+    // test getting all app classes in the namespace
+    Map<ArtifactDescriptor, List<ApplicationClass>> appClasses =
+      artifactStore.getApplicationClasses(Id.Namespace.DEFAULT);
+    Map<ArtifactDescriptor, List<ApplicationClass>> expected =
+      ImmutableMap.<ArtifactDescriptor, List<ApplicationClass>>of(
+        app1v1Detail.getDescriptor(), ImmutableList.of(inspectionClass1),
+        app1v2Detail.getDescriptor(), ImmutableList.of(inspectionClass2),
+        app2v1Detail.getDescriptor(), ImmutableList.of(inspectionClass1),
+        app3v1Detail.getDescriptor(), ImmutableList.of(wordCountClass1)
+      );
+    Assert.assertEquals(expected, appClasses);
+
+    // test getting all app classes by class name
+    Map<ArtifactDescriptor, ApplicationClass> appArtifacts =
+      artifactStore.getApplicationClasses(Id.Namespace.DEFAULT, InspectionApp.class.getName());
+    Map<ArtifactDescriptor, ApplicationClass> expectedAppArtifacts = ImmutableMap.of(
+      app1v1Detail.getDescriptor(), inspectionClass1,
+      app1v2Detail.getDescriptor(), inspectionClass2,
+      app2v1Detail.getDescriptor(), inspectionClass1
+    );
+    Assert.assertEquals(expectedAppArtifacts, appArtifacts);
+
+    appArtifacts = artifactStore.getApplicationClasses(Id.Namespace.DEFAULT, WordCountApp.class.getName());
+    expectedAppArtifacts = ImmutableMap.of(app3v1Detail.getDescriptor(), wordCountClass1);
+    Assert.assertEquals(expectedAppArtifacts, appArtifacts);
+
+    Assert.assertTrue(artifactStore.getApplicationClasses(Id.Namespace.from("ghost")).isEmpty());
   }
 
   @Test

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/ApplicationClientTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/ApplicationClientTestRun.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.client;
 
+import co.cask.cdap.api.Config;
 import co.cask.cdap.client.app.AppReturnsArgs;
 import co.cask.cdap.client.app.ConfigTestApp;
 import co.cask.cdap.client.app.ConfigurableProgramsApp;
@@ -27,14 +28,17 @@ import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.common.DatasetModuleNotFoundException;
 import co.cask.cdap.common.DatasetNotFoundException;
 import co.cask.cdap.common.NotFoundException;
+import co.cask.cdap.proto.ApplicationDetail;
+import co.cask.cdap.proto.ApplicationRecord;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramRecord;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.artifact.ArtifactSummary;
 import co.cask.cdap.test.XSlowTests;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 import com.google.common.io.Files;
-import com.google.gson.Gson;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -45,6 +49,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -54,7 +59,6 @@ import java.util.concurrent.TimeUnit;
 public class ApplicationClientTestRun extends ClientTestBase {
 
   private static final Logger LOG = LoggerFactory.getLogger(ApplicationClientTestRun.class);
-  private static final Gson GSON = new Gson();
 
   private ApplicationClient appClient;
   private DatasetClient datasetClient;
@@ -98,7 +102,7 @@ public class ApplicationClientTestRun extends ClientTestBase {
 
     // deploy app
     LOG.info("Deploying app");
-    appClient.deploy(Id.Namespace.DEFAULT, createAppJarFile(FakeApp.class));
+    appClient.deploy(Id.Namespace.DEFAULT, createAppJarFile(FakeApp.class, FakeApp.NAME, "1.0.0-SNAPSHOT"));
     appClient.waitForDeployed(app, 30, TimeUnit.SECONDS);
     Assert.assertEquals(1, appClient.list(Id.Namespace.DEFAULT).size());
 
@@ -122,6 +126,10 @@ public class ApplicationClientTestRun extends ClientTestBase {
       verifyProgramNames(FakeApp.SERVICES, appClient.listAllPrograms(Id.Namespace.DEFAULT, ProgramType.SERVICE));
 
       verifyProgramRecords(FakeApp.ALL_PROGRAMS, appClient.listAllPrograms(Id.Namespace.DEFAULT));
+
+      ApplicationDetail appDetail = appClient.get(app);
+      ArtifactSummary expected = new ArtifactSummary(FakeApp.NAME, "1.0.0-SNAPSHOT", false);
+      Assert.assertEquals(expected, appDetail.getArtifact());
     } finally {
       // delete app
       LOG.info("Deleting app");
@@ -155,11 +163,11 @@ public class ApplicationClientTestRun extends ClientTestBase {
     Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "ProgramsApp");
     try {
       artifactClient.add(Id.Namespace.DEFAULT, artifactName,
-                         Files.newInputStreamSupplier(createAppJarFile(ConfigurableProgramsApp.class)),
-                         "1.0.0");
+        Files.newInputStreamSupplier(createAppJarFile(ConfigurableProgramsApp.class)),
+        "1.0.0");
       artifactClient.add(Id.Namespace.DEFAULT, artifactName,
-                         Files.newInputStreamSupplier(createAppJarFile(ConfigurableProgramsApp2.class)),
-                         "2.0.0");
+        Files.newInputStreamSupplier(createAppJarFile(ConfigurableProgramsApp2.class)),
+        "2.0.0");
 
       // deploy the app with just the worker
       ConfigurableProgramsApp.Programs conf =
@@ -226,6 +234,77 @@ public class ApplicationClientTestRun extends ClientTestBase {
       appClient.waitForDeleted(appId, 30, TimeUnit.SECONDS);
       artifactClient.delete(artifactIdV1);
       artifactClient.delete(artifactIdV2);
+    }
+  }
+
+  @Test
+  public void testArtifactFilter() throws Exception {
+    Id.Application appId1 = Id.Application.from(Id.Namespace.DEFAULT, FakeApp.NAME);
+    Id.Application appId2 = Id.Application.from(Id.Namespace.DEFAULT, "fake2");
+    Id.Application appId3 = Id.Application.from(Id.Namespace.DEFAULT, "fake3");
+    try {
+      // app1 should use fake-1.0.0-SNAPSHOT
+      appClient.deploy(Id.Namespace.DEFAULT, createAppJarFile(FakeApp.class, "otherfake", "1.0.0-SNAPSHOT"));
+      appClient.deploy(Id.Namespace.DEFAULT, createAppJarFile(FakeApp.class, "fake", "0.1.0-SNAPSHOT"));
+      // app1 should end up with fake-1.0.0-SNAPSHOT
+      appClient.deploy(Id.Namespace.DEFAULT, createAppJarFile(FakeApp.class, "fake", "1.0.0-SNAPSHOT"));
+      // app2 should use fake-0.1.0-SNAPSHOT
+      appClient.deploy(appId2, new AppRequest<Config>(new ArtifactSummary("fake", "0.1.0-SNAPSHOT", false)));
+      // app3 should use otherfake-1.0.0-SNAPSHOT
+      appClient.deploy(appId3, new AppRequest<Config>(new ArtifactSummary("otherfake", "1.0.0-SNAPSHOT", false)));
+      appClient.waitForDeployed(appId1, 30, TimeUnit.SECONDS);
+      appClient.waitForDeployed(appId2, 30, TimeUnit.SECONDS);
+      appClient.waitForDeployed(appId3, 30, TimeUnit.SECONDS);
+
+
+      // check calls that should return nothing
+      // these don't match anything
+      Assert.assertTrue(appClient.list(Id.Namespace.DEFAULT, "ghost", null).isEmpty());
+      Assert.assertTrue(appClient.list(Id.Namespace.DEFAULT, null, "1.0.0").isEmpty());
+      Assert.assertTrue(appClient.list(Id.Namespace.DEFAULT, "ghost", "1.0.0").isEmpty());
+      // these match one but not the other
+      Assert.assertTrue(appClient.list(Id.Namespace.DEFAULT, "otherfake", "0.1.0-SNAPSHOT").isEmpty());
+      Assert.assertTrue(appClient.list(Id.Namespace.DEFAULT, "fake", "1.0.0").isEmpty());
+
+      // check filter by name only
+      Set<ApplicationRecord> apps = Sets.newHashSet(appClient.list(Id.Namespace.DEFAULT, "fake", null));
+      Set<ApplicationRecord> expected = ImmutableSet.of(
+        new ApplicationRecord(new ArtifactSummary("fake", "1.0.0-SNAPSHOT", false), appId1.getId(), ""),
+        new ApplicationRecord(new ArtifactSummary("fake", "0.1.0-SNAPSHOT", false), appId2.getId(), "")
+      );
+      Assert.assertEquals(expected, apps);
+
+      apps = Sets.newHashSet(appClient.list(Id.Namespace.DEFAULT, "otherfake", null));
+      expected = ImmutableSet.of(
+        new ApplicationRecord(new ArtifactSummary("otherfake", "1.0.0-SNAPSHOT", false), appId3.getId(), ""));
+      Assert.assertEquals(expected, apps);
+
+      // check filter by version only
+      apps = Sets.newHashSet(appClient.list(Id.Namespace.DEFAULT, null, "0.1.0-SNAPSHOT"));
+      expected = ImmutableSet.of(
+        new ApplicationRecord(new ArtifactSummary("fake", "0.1.0-SNAPSHOT", false), appId2.getId(), "")
+      );
+      Assert.assertEquals(expected, apps);
+
+      apps = Sets.newHashSet(appClient.list(Id.Namespace.DEFAULT, null, "1.0.0-SNAPSHOT"));
+      expected = ImmutableSet.of(
+        new ApplicationRecord(new ArtifactSummary("fake", "1.0.0-SNAPSHOT", false), appId1.getId(), ""),
+        new ApplicationRecord(new ArtifactSummary("otherfake", "1.0.0-SNAPSHOT", false), appId3.getId(), "")
+      );
+      Assert.assertEquals(expected, apps);
+
+      // check filter by both
+      apps = Sets.newHashSet(appClient.list(Id.Namespace.DEFAULT, "fake", "0.1.0-SNAPSHOT"));
+      expected = ImmutableSet.of(
+        new ApplicationRecord(new ArtifactSummary("fake", "0.1.0-SNAPSHOT", false), appId2.getId(), "")
+      );
+      Assert.assertEquals(expected, apps);
+    } finally {
+      appClient.deleteAll(Id.Namespace.DEFAULT);
+      appClient.waitForDeleted(appId1, 30, TimeUnit.SECONDS);
+      appClient.waitForDeleted(appId2, 30, TimeUnit.SECONDS);
+      appClient.waitForDeleted(appId3, 30, TimeUnit.SECONDS);
+      Assert.assertEquals(0, appClient.list(Id.Namespace.DEFAULT).size());
     }
   }
 

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/ArtifactClientTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/ArtifactClientTestRun.java
@@ -228,20 +228,18 @@ public class ArtifactClientTestRun extends ClientTestBase {
     Assert.assertEquals(pluginArtifactInfo, artifactClient.getArtifactInfo(pluginId));
 
     // test get all app classes in namespace
-    // no way to delete artifacts yet... when run in a suite will see other app classes from app deployments,
-    // so just check the expected ones are in the list returned.
     Set<ApplicationClassSummary> expectedSummaries = ImmutableSet.of(
       new ApplicationClassSummary(myapp1Summary, MyApp.class.getName()),
       new ApplicationClassSummary(myapp2Summary, MyApp.class.getName())
     );
     Set<ApplicationClassSummary> appClassSummaries = Sets.newHashSet(
       artifactClient.getApplicationClasses(Id.Namespace.DEFAULT));
-    Assert.assertTrue(appClassSummaries.containsAll(expectedSummaries));
+    Assert.assertEquals(expectedSummaries, appClassSummaries);
 
     // test get all app classes in namespace with name MyApp.class.getName()
-    List<ApplicationClassInfo> appClassInfos =
-      artifactClient.getApplicationClasses(Id.Namespace.DEFAULT, MyApp.class.getName());
-    List<ApplicationClassInfo> expectedInfos = ImmutableList.of(
+    Set<ApplicationClassInfo> appClassInfos = Sets.newHashSet(
+      artifactClient.getApplicationClasses(Id.Namespace.DEFAULT, MyApp.class.getName()));
+    Set<ApplicationClassInfo> expectedInfos = ImmutableSet.of(
       new ApplicationClassInfo(myapp1Summary, MyApp.class.getName(), myAppConfigSchema),
       new ApplicationClassInfo(myapp2Summary, MyApp.class.getName(), myAppConfigSchema)
     );

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/ArtifactClientTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/ArtifactClientTestRun.java
@@ -34,13 +34,17 @@ import co.cask.cdap.internal.io.ReflectionSchemaGenerator;
 import co.cask.cdap.internal.test.AppJarHelper;
 import co.cask.cdap.internal.test.PluginJarHelper;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.artifact.ApplicationClassInfo;
+import co.cask.cdap.proto.artifact.ApplicationClassSummary;
 import co.cask.cdap.proto.artifact.ArtifactInfo;
 import co.cask.cdap.proto.artifact.ArtifactRange;
 import co.cask.cdap.proto.artifact.ArtifactSummary;
 import co.cask.cdap.proto.artifact.PluginInfo;
 import co.cask.cdap.proto.artifact.PluginSummary;
 import co.cask.cdap.test.XSlowTests;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.io.InputSupplier;
@@ -57,6 +61,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.jar.Manifest;
@@ -221,6 +226,26 @@ public class ArtifactClientTestRun extends ClientTestBase {
     ArtifactInfo pluginArtifactInfo =
       new ArtifactInfo(pluginId.getName(), pluginId.getVersion().getVersion(), false, pluginClasses);
     Assert.assertEquals(pluginArtifactInfo, artifactClient.getArtifactInfo(pluginId));
+
+    // test get all app classes in namespace
+    // no way to delete artifacts yet... when run in a suite will see other app classes from app deployments,
+    // so just check the expected ones are in the list returned.
+    Set<ApplicationClassSummary> expectedSummaries = ImmutableSet.of(
+      new ApplicationClassSummary(myapp1Summary, MyApp.class.getName()),
+      new ApplicationClassSummary(myapp2Summary, MyApp.class.getName())
+    );
+    Set<ApplicationClassSummary> appClassSummaries = Sets.newHashSet(
+      artifactClient.getApplicationClasses(Id.Namespace.DEFAULT));
+    Assert.assertTrue(appClassSummaries.containsAll(expectedSummaries));
+
+    // test get all app classes in namespace with name MyApp.class.getName()
+    List<ApplicationClassInfo> appClassInfos =
+      artifactClient.getApplicationClasses(Id.Namespace.DEFAULT, MyApp.class.getName());
+    List<ApplicationClassInfo> expectedInfos = ImmutableList.of(
+      new ApplicationClassInfo(myapp1Summary, MyApp.class.getName(), myAppConfigSchema),
+      new ApplicationClassInfo(myapp2Summary, MyApp.class.getName(), myAppConfigSchema)
+    );
+    Assert.assertEquals(expectedInfos, appClassInfos);
 
     // test get plugin types for myapp-1.0.0. should be empty, since plugins only extends versions [2.0.0 - 3.0.0)
     Assert.assertTrue(artifactClient.getPluginTypes(myapp1Id).isEmpty());

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/common/ClientTestBase.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/common/ClientTestBase.java
@@ -123,11 +123,14 @@ public abstract class ClientTestBase {
   }
 
   protected File createAppJarFile(Class<?> cls) throws IOException {
+    return createAppJarFile(cls, cls.getSimpleName(), String.format("1.0.%d-SNAPSHOT", System.currentTimeMillis()));
+  }
+
+  protected File createAppJarFile(Class<?> cls, String name, String version) throws IOException {
     File tmpJarFolder = TMP_FOLDER.newFolder();
     LocationFactory locationFactory = new LocalLocationFactory(tmpJarFolder);
     Location deploymentJar = AppJarHelper.createDeploymentJar(locationFactory, cls);
-    File appJarFile =
-      new File(tmpJarFolder, String.format("%s-1.0.%d-SNAPSHOT.jar", cls.getSimpleName(), System.currentTimeMillis()));
+    File appJarFile = new File(tmpJarFolder, String.format("%s-%s.jar", name, version));
     Files.copy(Locations.newInputSupplier(deploymentJar), appJarFile);
     return appJarFile;
   }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/ApplicationDetail.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/ApplicationDetail.java
@@ -16,6 +16,8 @@
 
 package co.cask.cdap.proto;
 
+import co.cask.cdap.proto.artifact.ArtifactSummary;
+
 import java.util.List;
 
 /**
@@ -29,27 +31,35 @@ public class ApplicationDetail {
   private final List<StreamDetail> streams;
   private final List<DatasetDetail> datasets;
   private final List<ProgramRecord> programs;
+  private final ArtifactSummary artifact;
 
   public ApplicationDetail(String name,
-                           String version,
                            String description,
                            String configuration,
                            List<StreamDetail> streams,
                            List<DatasetDetail> datasets,
-                           List<ProgramRecord> programs) {
+                           List<ProgramRecord> programs,
+                           ArtifactSummary artifact) {
     this.name = name;
-    this.version = version;
+    this.version = artifact.getVersion();
     this.description = description;
     this.configuration = configuration;
     this.streams = streams;
     this.datasets = datasets;
     this.programs = programs;
+    this.artifact = artifact;
   }
 
   public String getName() {
     return name;
   }
 
+  /**
+   * @deprecated use {@link #getArtifact()} instead
+   *
+   * @return the version of the artifact used to create the application
+   */
+  @Deprecated
   public String getVersion() {
     return version;
   }
@@ -72,5 +82,9 @@ public class ApplicationDetail {
 
   public List<ProgramRecord> getPrograms() {
     return programs;
+  }
+
+  public ArtifactSummary getArtifact() {
+    return artifact;
   }
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/ApplicationRecord.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/ApplicationRecord.java
@@ -16,6 +16,10 @@
 
 package co.cask.cdap.proto;
 
+import co.cask.cdap.proto.artifact.ArtifactSummary;
+
+import java.util.Objects;
+
 /**
  * Represents item in the list from /apps
  */
@@ -25,7 +29,18 @@ public class ApplicationRecord {
   private final String name;
   private final String version;
   private final String description;
+  private final ArtifactSummary artifact;
 
+  public ApplicationRecord(ArtifactSummary artifact, String name, String description) {
+    this.type = "App";
+    this.artifact = artifact;
+    this.name = name;
+    this.description = description;
+    this.version = artifact.getVersion();
+    this.id = name;
+  }
+
+  @Deprecated
   public ApplicationRecord(String name, String version, String description) {
     this("App", name, name, version, description);
   }
@@ -37,8 +52,18 @@ public class ApplicationRecord {
     this.name = name;
     this.version = version;
     this.description = description;
+    this.artifact = null;
   }
 
+  public ArtifactSummary getArtifact() {
+    return artifact;
+  }
+
+  /**
+   * @deprecated use {@link #getArtifact()} instead
+   * @return the version of the artifact used to create the application
+   */
+  @Deprecated
   public String getVersion() {
     return version;
   }
@@ -58,5 +83,39 @@ public class ApplicationRecord {
 
   public String getDescription() {
     return description;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    ApplicationRecord that = (ApplicationRecord) o;
+
+    return Objects.equals(type, that.type) &&
+      Objects.equals(name, that.name) &&
+      Objects.equals(version, that.version) &&
+      Objects.equals(description, that.description) &&
+      Objects.equals(artifact, that.artifact);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(type, name, version, description, artifact);
+  }
+
+  @Override
+  public String toString() {
+    return "ApplicationRecord{" +
+      "type='" + type + '\'' +
+      ", name='" + name + '\'' +
+      ", version='" + version + '\'' +
+      ", description='" + description + '\'' +
+      ", artifact=" + artifact +
+      '}';
   }
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/artifact/ApplicationClassInfo.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/artifact/ApplicationClassInfo.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.proto.artifact;
+
+import co.cask.cdap.api.data.schema.Schema;
+
+import java.util.Objects;
+
+/**
+ * Represents the objects returned by /classes/app/{classname}
+ */
+public class ApplicationClassInfo extends ApplicationClassSummary {
+  private Schema configSchema;
+
+  public ApplicationClassInfo(ArtifactSummary artifact, String className, Schema configSchema) {
+    super(artifact, className);
+    this.configSchema = configSchema;
+  }
+
+  public Schema getConfigSchema() {
+    return configSchema;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    ApplicationClassInfo that = (ApplicationClassInfo) o;
+    return super.equals(o) && Objects.equals(configSchema, that.configSchema);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), configSchema);
+  }
+}

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/artifact/ApplicationClassSummary.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/artifact/ApplicationClassSummary.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.proto.artifact;
+
+import java.util.Objects;
+
+/**
+ * Represents the objects returned by /classes/app
+ */
+public class ApplicationClassSummary {
+  private final ArtifactSummary artifact;
+  private final String className;
+
+  public ApplicationClassSummary(ArtifactSummary artifact, String className) {
+    this.artifact = artifact;
+    this.className = className;
+  }
+
+  public ArtifactSummary getArtifact() {
+    return artifact;
+  }
+
+  public String getClassName() {
+    return className;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    ApplicationClassSummary that = (ApplicationClassSummary) o;
+
+    return Objects.equals(artifact, that.artifact) && Objects.equals(className, that.className);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(artifact, className);
+  }
+
+  @Override
+  public String toString() {
+    return "ApplicationClassSummary{" +
+      "artifact=" + artifact +
+      ", className='" + className + '\'' +
+      '}';
+  }
+}

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/artifact/ArtifactSummary.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/artifact/ArtifactSummary.java
@@ -17,6 +17,8 @@
 package co.cask.cdap.proto.artifact;
 
 import co.cask.cdap.api.annotation.Beta;
+import co.cask.cdap.api.artifact.ArtifactDescriptor;
+import co.cask.cdap.proto.Id;
 
 import java.util.Objects;
 
@@ -28,6 +30,15 @@ public class ArtifactSummary {
   protected final String name;
   protected final String version;
   protected final boolean isSystem;
+
+  public static ArtifactSummary from(Id.Artifact artifactId) {
+    return new ArtifactSummary(artifactId.getName(), artifactId.getVersion().getVersion(),
+                               Id.Namespace.SYSTEM.equals(artifactId.getNamespace()));
+  }
+
+  public static ArtifactSummary from(ArtifactDescriptor descriptor) {
+    return new ArtifactSummary(descriptor.getName(), descriptor.getVersion().getVersion(), descriptor.isSystem());
+  }
 
   public ArtifactSummary(String name, String version, boolean isSystem) {
     this.name = name;

--- a/cdap-ui/app/features/apps/templates/list.html
+++ b/cdap-ui/app/features/apps/templates/list.html
@@ -74,9 +74,9 @@
     <tbody>
       <tr ng-repeat="app in ListController.filtered = (ListController.apps | filter: ListController.searchText ) | myPaginate:ListController.currentPage | orderBy:sortable.predicate:sortable.reverse">
         <td >
-          <a ui-sref="apps.detail.overview.status({ appId: app.id })"
+          <a ui-sref="apps.detail.overview.status({ appId: app.name })"
               ng-if="app.type !== 'adapter'"
-              ng-click="MyOrderings.appClicked(app.id)">
+              ng-click="MyOrderings.appClicked(app.name)">
             <strong tooltip="{{app.name}}"
                     tooltip-enable="app.name.length > 35"
                     tooltip-append-to-body="true">


### PR DESCRIPTION
adding rows to the ArtifactStore metatable for application classes
found in artifacts to allow efficient lookup of app classes in
a namespace and for a given class name. This functionality is
exposed through the ArtifactRepository and through the http
handler.

Filling in the REST endpoint for getting application classes in
a namespace and by classname. Also adding artifact name and version
filters to the get apps REST endpoint.

Finally, also added methods to ArtifactClient corresponding to the
new REST APIs, and a new method to ApplicationClient for filtering
applications by artifact.