### PR TITLE
[CDAP-3073] Fixed an OOM while running with Oracle by unregistering a…

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/common/DBUtils.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/common/DBUtils.java
@@ -21,11 +21,20 @@ import co.cask.cdap.template.etl.batch.source.DBSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.management.ManagementFactory;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.sql.Driver;
 import java.sql.DriverManager;
+import java.util.Hashtable;
 import java.util.List;
+import javax.management.InstanceNotFoundException;
+import javax.management.IntrospectionException;
+import javax.management.MBeanRegistrationException;
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import javax.management.ReflectionException;
 
 /**
  * Utility methods for Database plugins shared by {@link DBSource} and {@link DBSink}
@@ -39,7 +48,15 @@ public final class DBUtils {
    * @param driverClass the JDBC driver class
    */
   public static void cleanup(Class<? extends Driver> driverClass) {
-    shutDownMySQLAbandonedConnectionCleanupThread(driverClass.getClassLoader());
+    ClassLoader pluginClassLoader = driverClass.getClassLoader();
+    if (pluginClassLoader == null) {
+      // This could only be null if the classLoader is the Bootstrap/Primordial classloader. This should never be the
+      // case since the driver class is always loaded from the plugin classloader.
+      LOG.warn("PluginClassLoader is null. This should never happen. Aborting cleanup.");
+      return;
+    }
+    shutDownMySQLAbandonedConnectionCleanupThread(pluginClassLoader);
+    unregisterOracleMBean(pluginClassLoader);
   }
 
   /**
@@ -81,9 +98,6 @@ public final class DBUtils {
    * @param classLoader the unfiltered classloader of the jdbc driver class
    */
   private static void shutDownMySQLAbandonedConnectionCleanupThread(ClassLoader classLoader) {
-    if (classLoader == null) {
-      return;
-    }
     try {
       Class<?> mysqlCleanupThreadClass;
       try {
@@ -100,6 +114,45 @@ public final class DBUtils {
     } catch (Throwable e) {
       // cleanup failed, ignoring silently with a log, since not much can be done.
       LOG.warn("Failed to shutdown MySQL connection cleanup thread. Ignoring.", e);
+    }
+  }
+
+  private static void unregisterOracleMBean(ClassLoader classLoader) {
+    try {
+      classLoader.loadClass("oracle.jdbc.driver.OracleDriver");
+    } catch (ClassNotFoundException e) {
+      LOG.debug("Oracle JDBC Driver not found. Presuming that the DB Adapter is not being run with an Oracle DB. " +
+                  "Not attempting to cleanup.");
+      return;
+    }
+    MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+    Hashtable<String, String> keys = new Hashtable<>();
+    keys.put("type", "diagnosability");
+    keys.put("name",
+             classLoader.getClass().getName() + "@" + Integer.toHexString(classLoader.hashCode()).toLowerCase());
+    ObjectName oracleJdbcMBeanName;
+    try {
+      oracleJdbcMBeanName = new ObjectName("com.oracle.jdbc", keys);
+    } catch (MalformedObjectNameException e) {
+      // This should never happen, since we're constructing the ObjectName correctly
+      LOG.debug("Exception while constructing Oracle JDBC MBean Name - {}. Aborting cleanup.", e.getMessage());
+      return;
+    }
+    try {
+      mbs.getMBeanInfo(oracleJdbcMBeanName);
+    } catch (InstanceNotFoundException e) {
+      LOG.debug("Oracle JDBC MBean not found. No cleanup necessary.");
+      return;
+    } catch (IntrospectionException | ReflectionException e) {
+      LOG.debug("Exception while attempting to retrieve Oracle JDBC MBean - {}. Aborting cleanup.", e.getMessage());
+      return;
+    }
+
+    try {
+      mbs.unregisterMBean(oracleJdbcMBeanName);
+      LOG.debug("Oracle MBean unregistered successfully.");
+    } catch (InstanceNotFoundException | MBeanRegistrationException e) {
+      LOG.debug("Exception while attempting to cleanup Oracle JDBCMBean - {}. Aborting cleanup.", e.getMessage());
     }
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/common/DBUtils.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/common/DBUtils.java
@@ -52,7 +52,7 @@ public final class DBUtils {
     if (pluginClassLoader == null) {
       // This could only be null if the classLoader is the Bootstrap/Primordial classloader. This should never be the
       // case since the driver class is always loaded from the plugin classloader.
-      LOG.warn("PluginClassLoader is null. This should never happen. Aborting cleanup.");
+      LOG.warn("PluginClassLoader is null. Cleanup not necessary.");
       return;
     }
     shutDownMySQLAbandonedConnectionCleanupThread(pluginClassLoader);
@@ -122,7 +122,7 @@ public final class DBUtils {
       classLoader.loadClass("oracle.jdbc.driver.OracleDriver");
     } catch (ClassNotFoundException e) {
       LOG.debug("Oracle JDBC Driver not found. Presuming that the DB Adapter is not being run with an Oracle DB. " +
-                  "Not attempting to cleanup.");
+                  "Not attempting to cleanup Oracle MBean.");
       return;
     }
     MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
@@ -135,7 +135,7 @@ public final class DBUtils {
       oracleJdbcMBeanName = new ObjectName("com.oracle.jdbc", keys);
     } catch (MalformedObjectNameException e) {
       // This should never happen, since we're constructing the ObjectName correctly
-      LOG.debug("Exception while constructing Oracle JDBC MBean Name - {}. Aborting cleanup.", e.getMessage());
+      LOG.debug("Exception while constructing Oracle JDBC MBean Name. Aborting cleanup.", e);
       return;
     }
     try {
@@ -144,7 +144,7 @@ public final class DBUtils {
       LOG.debug("Oracle JDBC MBean not found. No cleanup necessary.");
       return;
     } catch (IntrospectionException | ReflectionException e) {
-      LOG.debug("Exception while attempting to retrieve Oracle JDBC MBean - {}. Aborting cleanup.", e.getMessage());
+      LOG.debug("Exception while attempting to retrieve Oracle JDBC MBean. Aborting cleanup.", e);
       return;
     }
 
@@ -152,7 +152,7 @@ public final class DBUtils {
       mbs.unregisterMBean(oracleJdbcMBeanName);
       LOG.debug("Oracle MBean unregistered successfully.");
     } catch (InstanceNotFoundException | MBeanRegistrationException e) {
-      LOG.debug("Exception while attempting to cleanup Oracle JDBCMBean - {}. Aborting cleanup.", e.getMessage());
+      LOG.debug("Exception while attempting to cleanup Oracle JDBCMBean. Aborting cleanup.", e);
     }
   }
 


### PR DESCRIPTION
…n MBean that holds a reference to the plugin classloader in the destroy() method.

Reference: https://blogs.reucon.com/srt/classloader-leaks-by-oracle-9056/

Jira: [CDAP-3073](https://issues.cask.co/browse/CDAP-3073)
Build: http://builds.cask.co/browse/CDAP-DUT2504