### PR TITLE
CDAP-3272 add ability to explicitly specify artifact classes

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ArtifactHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ArtifactHttpHandler.java
@@ -29,6 +29,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.http.AbstractBodyConsumer;
 import co.cask.cdap.internal.app.namespace.NamespaceAdmin;
+import co.cask.cdap.internal.app.runtime.adapter.PluginClassDeserializer;
 import co.cask.cdap.internal.app.runtime.artifact.ArtifactDetail;
 import co.cask.cdap.internal.app.runtime.artifact.ArtifactRepository;
 import co.cask.cdap.internal.app.runtime.artifact.PluginNotExistsException;
@@ -45,10 +46,13 @@ import co.cask.http.AbstractHttpHandler;
 import co.cask.http.BodyConsumer;
 import co.cask.http.HttpResponder;
 import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonParseException;
+import com.google.gson.reflect.TypeToken;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import org.jboss.netty.handler.codec.http.HttpRequest;
@@ -58,6 +62,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -83,9 +88,12 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
   private static final Logger LOG = LoggerFactory.getLogger(ArtifactHttpHandler.class);
   private static final String VERSION_HEADER = "Artifact-Version";
   private static final String EXTENDS_HEADER = "Artifact-Extends";
+  private static final String PLUGINS_HEADER = "Artifact-Plugins";
   private static final Gson GSON = new GsonBuilder()
     .registerTypeAdapter(Schema.class, new SchemaTypeAdapter())
+    .registerTypeAdapter(PluginClass.class, new PluginClassDeserializer())
     .create();
+  private static final Type PLUGINS_TYPE = new TypeToken<Set<PluginClass>>() { }.getType();
 
   private final ArtifactRepository artifactRepository;
   private final NamespaceAdmin namespaceAdmin;
@@ -322,7 +330,8 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
                                   @PathParam("namespace-id") String namespaceId,
                                   @PathParam("artifact-name") final String artifactName,
                                   @HeaderParam(VERSION_HEADER) final String artifactVersion,
-                                  @HeaderParam(EXTENDS_HEADER) final String parentArtifactsStr)
+                                  @HeaderParam(EXTENDS_HEADER) final String parentArtifactsStr,
+                                  @HeaderParam(PLUGINS_HEADER) String pluginClasses)
     throws NamespaceNotFoundException, BadRequestException {
 
     final Id.Namespace namespace = validateAndGetNamespace(namespaceId);
@@ -334,6 +343,19 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
     }
 
     final Set<ArtifactRange> parentArtifacts = parseExtendsHeader(namespace, parentArtifactsStr);
+
+    final Set<PluginClass> additionalPluginClasses;
+    if (pluginClasses == null) {
+      additionalPluginClasses = ImmutableSet.of();
+    } else {
+      try {
+        additionalPluginClasses = GSON.fromJson(pluginClasses, PLUGINS_TYPE);
+      } catch (JsonParseException e) {
+        responder.sendString(HttpResponseStatus.BAD_REQUEST, String.format(
+          "%s header '%s' is invalid: %s", PLUGINS_HEADER, pluginClasses, e.getMessage()));
+        return null;
+      }
+    }
 
     try {
       // copy the artifact contents to local tmp directory
@@ -349,7 +371,7 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
             Id.Artifact artifactId = validateAndGetArtifactId(namespace, artifactName, version);
 
             // add the artifact to the repo
-            artifactRepository.addArtifact(artifactId, uploadedFile, parentArtifacts);
+            artifactRepository.addArtifact(artifactId, uploadedFile, parentArtifacts, additionalPluginClasses);
             responder.sendString(HttpResponseStatus.OK, "Artifact added successfully");
           } catch (ArtifactRangeNotFoundException e) {
             responder.sendString(HttpResponseStatus.NOT_FOUND, e.getMessage());

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/PluginRepository.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/PluginRepository.java
@@ -319,5 +319,4 @@ public class PluginRepository {
       return first.getName().compareTo(second.getName());
     }
   }
-
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepository.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepository.java
@@ -210,7 +210,7 @@ public class ArtifactRepository {
 
     Location artifactLocation = Locations.toLocation(artifactFile);
     try (CloseableClassLoader parentClassLoader = artifactClassLoaderFactory.createClassLoader(artifactLocation)) {
-      ArtifactClasses artifactClasses = artifactInspector.inspectArtifact(artifactId, artifactFile, parentClassLoader);
+      ArtifactClasses artifactClasses = inspectArtifact(artifactId, artifactFile, null, parentClassLoader);
       validatePluginSet(artifactClasses.getPlugins());
       ArtifactMeta meta = new ArtifactMeta(artifactClasses, ImmutableSet.<ArtifactRange>of());
       return artifactStore.write(artifactId, meta, Files.newInputStreamSupplier(artifactFile));
@@ -238,16 +238,62 @@ public class ArtifactRepository {
     throws IOException, ArtifactRangeNotFoundException, WriteConflictException,
     ArtifactAlreadyExistsException, InvalidArtifactException {
 
-    if (parentArtifacts == null || parentArtifacts.isEmpty()) {
-      return addArtifact(artifactId, artifactFile);
-    }
-    validateParentSet(parentArtifacts);
+    return addArtifact(artifactId, artifactFile, parentArtifacts, null);
+  }
 
-    try (CloseableClassLoader parentClassLoader = createParentClassLoader(artifactId, parentArtifacts)) {
-      ArtifactClasses artifactClasses = artifactInspector.inspectArtifact(artifactId, artifactFile, parentClassLoader);
-      validatePluginSet(artifactClasses.getPlugins());
+  /**
+   * Inspects and builds plugin and application information for the given artifact, adding an additional set of
+   * plugin classes to the plugins found through inspection. This method is used when all plugin classes
+   * cannot be derived by inspecting the artifact but need to be explicitly set. This is true for 3rd party plugins
+   * like jdbc drivers.
+   *
+   * @param artifactId the id of the artifact to inspect and store
+   * @param artifactFile the artifact to inspect and store
+   * @param parentArtifacts artifacts the given artifact extends.
+   *                        If null, the given artifact does not extend another artifact
+   * @param additionalPlugins the set of additional plugin classes to add to the plugins found through inspection.
+   *                          If null, no additional plugin classes will be added
+   * @throws IOException if there was an exception reading from the artifact store
+   * @throws ArtifactRangeNotFoundException if none of the parent artifacts could be found
+   */
+  public ArtifactDetail addArtifact(Id.Artifact artifactId, File artifactFile,
+                                    @Nullable Set<ArtifactRange> parentArtifacts,
+                                    @Nullable Set<PluginClass> additionalPlugins)
+    throws IOException, ArtifactAlreadyExistsException, WriteConflictException,
+    InvalidArtifactException, ArtifactRangeNotFoundException {
+
+    parentArtifacts = parentArtifacts == null ? Collections.<ArtifactRange>emptySet() : parentArtifacts;
+    CloseableClassLoader parentClassLoader;
+    if (parentArtifacts.isEmpty()) {
+      parentClassLoader =
+        artifactClassLoaderFactory.createClassLoader(Locations.toLocation(artifactFile));
+    } else {
+      parentClassLoader = createParentClassLoader(artifactId, parentArtifacts);
+      validateParentSet(parentArtifacts);
+    }
+
+    try {
+      ArtifactClasses artifactClasses = inspectArtifact(artifactId, artifactFile, additionalPlugins, parentClassLoader);
       ArtifactMeta meta = new ArtifactMeta(artifactClasses, parentArtifacts);
       return artifactStore.write(artifactId, meta, Files.newInputStreamSupplier(artifactFile));
+    } finally {
+      parentClassLoader.close();
+    }
+  }
+
+  private ArtifactClasses inspectArtifact(Id.Artifact artifactId, File artifactFile,
+                                          @Nullable Set<PluginClass> additionalPlugins,
+                                          ClassLoader parentClassLoader) throws IOException, InvalidArtifactException {
+    ArtifactClasses artifactClasses = artifactInspector.inspectArtifact(artifactId, artifactFile, parentClassLoader);
+    validatePluginSet(artifactClasses.getPlugins());
+    if (additionalPlugins == null || additionalPlugins.isEmpty()) {
+      return artifactClasses;
+    } else {
+      return ArtifactClasses.builder()
+        .addApps(artifactClasses.getApps())
+        .addPlugins(artifactClasses.getPlugins())
+        .addPlugins(additionalPlugins)
+        .build();
     }
   }
 
@@ -311,10 +357,10 @@ public class ArtifactRepository {
           }
         }
 
-        // TODO: (CDAP-3272) use plugin classes from config file
         addArtifact(artifactId,
                     systemArtifactConfig.getFile(),
-                    systemArtifactConfig.getParents());
+                    systemArtifactConfig.getParents(),
+                    systemArtifactConfig.getPlugins());
       } catch (ArtifactAlreadyExistsException e) {
         // shouldn't happen... but if it does for some reason it's fine, it means it was added some other way already.
       } catch (ArtifactRangeNotFoundException e) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepository.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepository.java
@@ -262,6 +262,10 @@ public class ArtifactRepository {
     throws IOException, ArtifactAlreadyExistsException, WriteConflictException,
     InvalidArtifactException, ArtifactRangeNotFoundException {
 
+    if (additionalPlugins != null) {
+      validatePluginSet(additionalPlugins);
+    }
+
     parentArtifacts = parentArtifacts == null ? Collections.<ArtifactRange>emptySet() : parentArtifacts;
     CloseableClassLoader parentClassLoader;
     if (parentArtifacts.isEmpty()) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/SystemArtifactConfig.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/SystemArtifactConfig.java
@@ -42,6 +42,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.Reader;
 import java.lang.reflect.Type;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -178,6 +179,12 @@ public class SystemArtifactConfig implements Comparable<SystemArtifactConfig> {
     Builder addPlugins(PluginClass pluginClass, PluginClass... plugins) {
       this.plugins.add(pluginClass);
       Collections.addAll(this.plugins, plugins);
+      return this;
+    }
+
+    @VisibleForTesting
+    Builder addPlugins(Collection<PluginClass> plugins) {
+      this.plugins.addAll(plugins);
       return this;
     }
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepositoryTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepositoryTest.java
@@ -61,6 +61,7 @@ import org.junit.rules.TemporaryFolder;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -134,10 +135,17 @@ public class ArtifactRepositoryTest {
     createPluginJar(TestPlugin.class, new File(systemArtifactsDir, "myPlugin-1.0.0.jar"), manifest);
 
     // write plugins config file
+    Map<String, PluginPropertyField> emptyMap = Collections.emptyMap();
+    Set<PluginClass> manuallyAddedPlugins = ImmutableSet.of(
+      new PluginClass("typeA", "manual1", "desc", "co.cask.classname", null, emptyMap),
+      new PluginClass("typeB", "manual2", "desc", "co.cask.otherclassname", null, emptyMap)
+    );
     File pluginConfigFile = new File(systemArtifactsDir, "myPlugin-1.0.0.json");
     SystemArtifactConfig pluginConfig = SystemArtifactConfig.builder(pluginArtifactId, pluginConfigFile)
       .addParents(new ArtifactRange(
         Id.Namespace.SYSTEM, "PluginTest", new ArtifactVersion("0.9.0"), new ArtifactVersion("2.0.0")))
+      // add a dummy plugin to test explicit addition of plugins through the config file
+      .addPlugins(manuallyAddedPlugins)
       .build();
     try (BufferedWriter writer = Files.newWriter(pluginConfigFile, Charsets.UTF_8)) {
       writer.write(pluginConfig.toString());
@@ -155,7 +163,7 @@ public class ArtifactRepositoryTest {
     for (PluginClass pluginClass : pluginClasses) {
       pluginNames.add(pluginClass.getName());
     }
-    Assert.assertEquals(Sets.newHashSet("TestPlugin", "TestPlugin2"), pluginNames);
+    Assert.assertEquals(Sets.newHashSet("manual1", "manual2", "TestPlugin", "TestPlugin2"), pluginNames);
     Assert.assertEquals(systemAppArtifactId.getName(), appArtifactDetail.getDescriptor().getName());
     Assert.assertEquals(systemAppArtifactId.getVersion(), appArtifactDetail.getDescriptor().getVersion());
 
@@ -163,6 +171,8 @@ public class ArtifactRepositoryTest {
     ArtifactDetail pluginArtifactDetail = artifactRepository.getArtifact(pluginArtifactId);
     Assert.assertEquals(pluginArtifactId.getName(), pluginArtifactDetail.getDescriptor().getName());
     Assert.assertEquals(pluginArtifactId.getVersion(), pluginArtifactDetail.getDescriptor().getVersion());
+    // check manually added plugins are there
+    Assert.assertTrue(pluginArtifactDetail.getMeta().getClasses().getPlugins().containsAll(manuallyAddedPlugins));
   }
 
   @Test

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/ArtifactClientTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/ArtifactClientTestRun.java
@@ -57,6 +57,7 @@ import org.junit.rules.TemporaryFolder;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.jar.Manifest;
@@ -111,7 +112,7 @@ public class ArtifactClientTestRun extends ClientTestBase {
     Set<ArtifactRange> parents = Sets.newHashSet(
       new ArtifactRange(Id.Namespace.DEFAULT, "ghost", new ArtifactVersion("1"), new ArtifactVersion("2")));
     try {
-      artifactClient.add(Id.Namespace.DEFAULT, "abc", "1.0.0", parents, DUMMY_SUPPLIER);
+      artifactClient.add(Id.Namespace.DEFAULT, "abc", DUMMY_SUPPLIER, "1.0.0", parents);
       Assert.fail();
     } catch (NotFoundException e) {
       // expected
@@ -122,7 +123,7 @@ public class ArtifactClientTestRun extends ClientTestBase {
   public void testAddArtifactBadIds() throws Exception {
     // test bad version
     try {
-      artifactClient.add(Id.Namespace.DEFAULT, "abc", "1/0.0", null, DUMMY_SUPPLIER);
+      artifactClient.add(Id.Namespace.DEFAULT, "abc", DUMMY_SUPPLIER, "1/0.0");
       Assert.fail();
     } catch (BadRequestException e) {
       // expected
@@ -130,7 +131,7 @@ public class ArtifactClientTestRun extends ClientTestBase {
 
     // test bad name
     try {
-      artifactClient.add(Id.Namespace.DEFAULT, "ab:c", "1.0.0", null, DUMMY_SUPPLIER);
+      artifactClient.add(Id.Namespace.DEFAULT, "ab:c", DUMMY_SUPPLIER, "1.0.0");
       Assert.fail();
     } catch (BadRequestException e) {
       // expected
@@ -154,9 +155,9 @@ public class ArtifactClientTestRun extends ClientTestBase {
       }
     };
     artifactClient.add(myapp1Id.getNamespace(), myapp1Id.getName(),
-                       myapp1Id.getVersion().getVersion(), null, inputSupplier);
+                       inputSupplier, myapp1Id.getVersion().getVersion());
     // let it derive version from jar manifest, which has bundle-version at 2.0.0
-    artifactClient.add(myapp2Id.getNamespace(), myapp2Id.getName(), null, null, inputSupplier);
+    artifactClient.add(myapp2Id.getNamespace(), myapp2Id.getName(), inputSupplier, null, null);
 
     // add an artifact that contains a plugin, but only extends myapp-2.0.0
     Id.Artifact pluginId = Id.Artifact.from(Id.Namespace.DEFAULT, "myapp-plugins", "2.0.0");
@@ -171,8 +172,10 @@ public class ArtifactClientTestRun extends ClientTestBase {
     };
     Set<ArtifactRange> parents = Sets.newHashSet(new ArtifactRange(
       myapp2Id.getNamespace(), myapp2Id.getName(), myapp2Id.getVersion(), new ArtifactVersion("3.0.0")));
-    artifactClient.add(pluginId.getNamespace(), pluginId.getName(),
-                       pluginId.getVersion().getVersion(), parents, inputSupplier);
+    Set<PluginClass> additionalPlugins = Sets.newHashSet(new PluginClass(
+      "jdbc", "mysql", "", "com.mysql.jdbc.Driver", null, Collections.<String, PluginPropertyField>emptyMap()));
+    artifactClient.add(pluginId.getNamespace(), pluginId.getName(), inputSupplier,
+                       pluginId.getVersion().getVersion(), parents, additionalPlugins);
 
     ArtifactSummary myapp1Summary = new ArtifactSummary(myapp1Id.getName(), myapp1Id.getVersion().getVersion(), false);
     ArtifactSummary myapp2Summary = new ArtifactSummary(myapp2Id.getName(), myapp2Id.getVersion().getVersion(), false);
@@ -213,6 +216,7 @@ public class ArtifactClientTestRun extends ClientTestBase {
       "x", new PluginPropertyField("x", "", "int", true));
     ArtifactClasses pluginClasses = ArtifactClasses.builder()
       .addPlugin(new PluginClass("callable", "plugin1", "p1 description", Plugin1.class.getName(), "conf", props))
+      .addPlugins(additionalPlugins)
       .build();
     ArtifactInfo pluginArtifactInfo =
       new ArtifactInfo(pluginId.getName(), pluginId.getVersion().getVersion(), false, pluginClasses);
@@ -222,7 +226,7 @@ public class ArtifactClientTestRun extends ClientTestBase {
     Assert.assertTrue(artifactClient.getPluginTypes(myapp1Id).isEmpty());
 
     // test get plugin types for myapp-2.0.0
-    Assert.assertEquals(Lists.newArrayList("callable"), artifactClient.getPluginTypes(myapp2Id));
+    Assert.assertEquals(Lists.newArrayList("callable", "jdbc"), artifactClient.getPluginTypes(myapp2Id));
 
     // test get plugins of type callable for myapp-2.0.0
     PluginSummary pluginSummary =

--- a/cdap-client/src/main/java/co/cask/cdap/client/ArtifactClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ArtifactClient.java
@@ -18,6 +18,7 @@ package co.cask.cdap.client;
 
 import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.templates.plugins.PluginClass;
 import co.cask.cdap.client.config.ClientConfig;
 import co.cask.cdap.client.util.RESTClient;
 import co.cask.cdap.common.ArtifactAlreadyExistsException;
@@ -302,18 +303,71 @@ public class ArtifactClient {
    *
    * @param namespace the namespace to add the artifact to
    * @param artifactName the name of the artifact to add
+   * @param artifactContents an input supplier for the contents of the artifact
    * @param artifactVersion the version of the artifact to add. If null, the version will be derived from the
    *                        manifest of the artifact.
-   * @param parentArtifacts the set of artifacts this artifact extends.
-   * @param artifactContents an input supplier for the contents of the artifact
    * @throws ArtifactAlreadyExistsException if the artifact already exists
    * @throws BadRequestException if the request is invalid. For example, if the artifact name or version is invalid
    * @throws ArtifactRangeNotFoundException if the parent artifacts do not exist
    * @throws IOException if a network error occurred
    * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
    */
-  public void add(Id.Namespace namespace, String artifactName, @Nullable String artifactVersion,
-                  @Nullable Set<ArtifactRange> parentArtifacts, InputSupplier<? extends InputStream> artifactContents)
+  public void add(Id.Namespace namespace, String artifactName,
+                  InputSupplier<? extends InputStream> artifactContents,
+                  @Nullable String artifactVersion)
+    throws ArtifactAlreadyExistsException, BadRequestException, IOException,
+    UnauthorizedException, ArtifactRangeNotFoundException {
+
+    add(namespace, artifactName, artifactContents, artifactVersion, null, null);
+  }
+
+  /**
+   * Add an artifact.
+   *
+   * @param namespace the namespace to add the artifact to
+   * @param artifactName the name of the artifact to add
+   * @param artifactContents an input supplier for the contents of the artifact
+   * @param artifactVersion the version of the artifact to add. If null, the version will be derived from the
+   *                        manifest of the artifact
+   * @param parentArtifacts the set of artifacts this artifact extends
+   * @throws ArtifactAlreadyExistsException if the artifact already exists
+   * @throws BadRequestException if the request is invalid. For example, if the artifact name or version is invalid
+   * @throws ArtifactRangeNotFoundException if the parent artifacts do not exist
+   * @throws IOException if a network error occurred
+   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   */
+  public void add(Id.Namespace namespace, String artifactName, InputSupplier<? extends InputStream> artifactContents,
+                  @Nullable String artifactVersion, @Nullable Set<ArtifactRange> parentArtifacts)
+    throws ArtifactAlreadyExistsException, BadRequestException, IOException,
+    UnauthorizedException, ArtifactRangeNotFoundException {
+
+    add(namespace, artifactName, artifactContents, artifactVersion, parentArtifacts, null);
+  }
+
+  /**
+   * Add an artifact.
+   *
+   * @param namespace the namespace to add the artifact to
+   * @param artifactName the name of the artifact to add
+   * @param artifactContents an input supplier for the contents of the artifact
+   * @param artifactVersion the version of the artifact to add. If null, the version will be derived from the
+   *                        manifest of the artifact
+   * @param parentArtifacts the set of artifacts this artifact extends
+   * @param additionalPlugins the set of plugins contained in the artifact that cannot be determined
+   *                          through jar inspection. This set should include any classes that are plugins but could
+   *                          not be annotated as such. For example, 3rd party classes like jdbc drivers fall into
+   *                          this category.
+   * @throws ArtifactAlreadyExistsException if the artifact already exists
+   * @throws BadRequestException if the request is invalid. For example, if the artifact name or version is invalid
+   * @throws ArtifactRangeNotFoundException if the parent artifacts do not exist
+   * @throws IOException if a network error occurred
+   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   */
+  public void add(Id.Namespace namespace, String artifactName,
+                  InputSupplier<? extends InputStream> artifactContents,
+                  @Nullable String artifactVersion,
+                  @Nullable Set<ArtifactRange> parentArtifacts,
+                  @Nullable Set<PluginClass> additionalPlugins)
     throws ArtifactAlreadyExistsException, BadRequestException, IOException,
     UnauthorizedException, ArtifactRangeNotFoundException {
 
@@ -324,6 +378,9 @@ public class ArtifactClient {
     }
     if (parentArtifacts != null) {
       requestBuilder.addHeader("Artifact-Extends", Joiner.on('/').join(parentArtifacts));
+    }
+    if (additionalPlugins != null) {
+      requestBuilder.addHeader("Artifact-Plugins", GSON.toJson(additionalPlugins));
     }
     HttpRequest request = requestBuilder.withBody(artifactContents).build();
 


### PR DESCRIPTION
Through the RESTful API, explicit plugins are given through a
header. For system artifacts, the list of plugins can be placed
in a json config file similar to how it is done for
ApplicationTemplate now.