### PR TITLE
Add link to SQS logging to documentation template

### DIFF
--- a/cdap-docs/_common/_themes/cdap/layout.html
+++ b/cdap-docs/_common/_themes/cdap/layout.html
@@ -104,6 +104,12 @@
     {%- for scriptfile in script_files %}
     <script type="text/javascript" src="{{ pathto(scriptfile, 1) }}"></script>
     {%- endfor %}
+    
+    <!-- Amazon SQS Page Usage Logging start-->
+    <script type="text/javascript" src="https://sdk.amazonaws.com/js/aws-sdk-2.1.35.min.js"></script>
+    <script type="text/javascript" src="http://docs.cask.co/resources/scripts/aws-sqs-1.0.0.js"></script>
+    <!-- Amazon SQS Page Usage Logging end-->
+    
 {%- endmacro %}
 
 {%- macro css() %}


### PR DESCRIPTION
Staged at: [CDAP docs](http://docs-staging.cask.co/staging/cdap/3.2.0-SNAPSHOT-feature-3.2_amazon_sqs_logging/en/index.html)
