### PR TITLE
[CDAP-3374] Warning messages indicating that the Runrecords with status running

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/ProgramLifecycleServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/ProgramLifecycleServiceTest.java
@@ -107,7 +107,10 @@ public class ProgramLifecycleServiceTest extends AppFabricTestBase {
 
     // Lets fix it
     Set<String> processedInvalidRunRecordIds = Sets.newHashSet();
-    programLifecycleService.validateAndCorrectRunningRunRecords(ProgramType.FLOW, processedInvalidRunRecordIds);
+
+    final List<RunRecordMeta> invalidRunRecords = store.getRuns(ProgramRunStatus.RUNNING, null);
+    programLifecycleService.validateAndCorrectRunningRunRecords(ProgramType.FLOW, processedInvalidRunRecordIds,
+                                                                invalidRunRecords);
 
     // Verify there is one FAILED run record for the application
     runRecords = getProgramRuns(wordcountFlow1, ProgramRunStatus.FAILED.toString());


### PR DESCRIPTION
This fix move getting the invalid run records early to avoid excessive warning logs when processing per program type.