### PR TITLE
(CDAP-3008) Refactor the way of how to submit Spark program

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedSparkProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedSparkProgramRunner.java
@@ -87,7 +87,7 @@ public class DistributedSparkProgramRunner extends AbstractDistributedProgramRun
 
   private static Configuration createConfiguration(Configuration hConf) {
     Configuration configuration = new Configuration(hConf);
-    configuration.set(SparkContextConfig.HCONF_ATTR_EXECUTION_MODE, SparkContextConfig.YARN_EXECUTION_MODE);
+    configuration.setBoolean(SparkContextConfig.HCONF_ATTR_CLUSTER_MODE, true);
     return configuration;
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWorkflowProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWorkflowProgramRunner.java
@@ -147,7 +147,7 @@ public final class DistributedWorkflowProgramRunner extends AbstractDistributedP
 
   private static Configuration createConfiguration(Configuration hConf) {
     Configuration configuration = new Configuration(hConf);
-    configuration.set(SparkContextConfig.HCONF_ATTR_EXECUTION_MODE, SparkContextConfig.YARN_EXECUTION_MODE);
+    configuration.setBoolean(SparkContextConfig.HCONF_ATTR_CLUSTER_MODE, true);
     return configuration;
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/LocalizeResource.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/LocalizeResource.java
@@ -30,7 +30,11 @@ public final class LocalizeResource {
   private final boolean archive;
 
   public LocalizeResource(File file) {
-    this(file.toURI(), false);
+    this(file, false);
+  }
+
+  public LocalizeResource(File file, boolean archive) {
+    this(file.toURI(), archive);
   }
 
   public LocalizeResource(URI uri, boolean archive) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/AbstractSparkSubmitter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/AbstractSparkSubmitter.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.spark;
+
+import co.cask.cdap.api.spark.SparkSpecification;
+import co.cask.cdap.common.lang.ClassLoaders;
+import co.cask.cdap.common.lang.WeakReferenceDelegatorClassLoader;
+import co.cask.cdap.internal.app.runtime.distributed.LocalizeResource;
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.util.concurrent.Uninterruptibles;
+import org.apache.spark.deploy.SparkSubmit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+
+/**
+ * Provides common implementation for different {@link SparkSubmitter}.
+ */
+public abstract class AbstractSparkSubmitter implements SparkSubmitter {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractSparkSubmitter.class);
+
+  // Filter for getting archive resources only
+  private static final Predicate<LocalizeResource> ARCHIVE_FILTER = new Predicate<LocalizeResource>() {
+    @Override
+    public boolean apply(LocalizeResource input) {
+      return input.isArchive();
+    }
+  };
+
+  // Transforms LocalizeResource to URI string
+  private static final Function<LocalizeResource, String> RESOURCE_TO_PATH = new Function<LocalizeResource, String>() {
+    @Override
+    public String apply(LocalizeResource input) {
+      return input.getURI().toString();
+    }
+  };
+
+  @Override
+  public final <V> ExecutionFuture<V> submit(final ExecutionSparkContext sparkContext, Map<String, String> configs,
+                                             List<LocalizeResource> resources, File jobJar, final V result) {
+
+    final SparkSpecification spec = sparkContext.getSpecification();
+    final List<String> args = createSubmitArguments(spec.getMainClassName(), configs, resources, jobJar);
+
+    // Spark submit is called from this executor
+    // Use an executor to simplify logic that is needed to interrupt the running thread on stopping
+    final ExecutorService executor = Executors.newSingleThreadExecutor(new ThreadFactory() {
+      @Override
+      public Thread newThread(Runnable r) {
+        return new Thread(r, "spark-submitter-" + spec.getName() + "-" + sparkContext.getRunId());
+      }
+    });
+
+    // Latch for the Spark job completion
+    final CountDownLatch completion = new CountDownLatch(1);
+    final SettableExecutionFuture<V> resultFuture = new SettableExecutionFuture<V>(sparkContext) {
+      @Override
+      protected void cancelTask() {
+        triggerShutdown(sparkContext);
+        // Calling shutdownNow will interrupt the executing thread
+        executor.shutdownNow();
+        Uninterruptibles.awaitUninterruptibly(completion);
+      }
+    };
+
+    // Submit the Spark job
+    executor.submit(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          submit(sparkContext, args.toArray(new String[args.size()]));
+          resultFuture.set(result);
+        } catch (Throwable t) {
+          resultFuture.setException(t);
+        } finally {
+          completion.countDown();
+        }
+      }
+    });
+    // Shutdown the executor right after submit since the thread is only used for one submission.
+    executor.shutdown();
+    return resultFuture;
+  }
+
+  /**
+   * Returns the value for the {@code --master} argument for the Spark submission.
+   */
+  protected abstract String getMaster();
+
+  /**
+   * Invoked for stopping the Spark job explicitly.
+   */
+  protected abstract void triggerShutdown(ExecutionSparkContext sparkContext);
+
+  /**
+   * Submits the Spark job using {@link SparkSubmit}.
+   *
+   * @param sparkContext context representing the Spark program
+   * @param args arguments for the {@link SparkSubmit#main(String[])} method.
+   */
+  protected void submit(ExecutionSparkContext sparkContext, String[] args) {
+    SparkClassLoader sparkClassLoader = new SparkClassLoader(sparkContext);
+    ClassLoader oldClassLoader = ClassLoaders.setContextClassLoader(
+      new WeakReferenceDelegatorClassLoader(sparkClassLoader));
+
+    try {
+      LOG.debug("Calling SparkSubmit for {}: {}", sparkContext, Arrays.toString(args));
+      SparkSubmit.main(args);
+      LOG.debug("SparkSubmit returned for {}", sparkContext);
+    } finally {
+      ClassLoaders.setContextClassLoader(oldClassLoader);
+    }
+  }
+
+  /**
+   * Creates the list of arguments that will be used for calling {@link SparkSubmit#main(String[])}.
+   *
+   * @param className name of the main class
+   * @param configs set of Spark configurations
+   * @param resources list of resources that needs to be localized to Spark containers
+   * @param jobJar the job jar file for Spark
+   * @return a list of arguments
+   */
+  private List<String> createSubmitArguments(String className, Map<String, String> configs,
+                                             List<LocalizeResource> resources, File jobJar) {
+    ImmutableList.Builder<String> builder = ImmutableList.builder();
+
+    builder.add("--master").add(getMaster());
+    builder.add("--class").add(SparkProgramWrapper.class.getName());
+
+    for (Map.Entry<String, String> entry : configs.entrySet()) {
+      builder.add("--conf").add(entry.getKey() + "=" + entry.getValue());
+    }
+
+    String archives = Joiner.on(',')
+      .join(Iterables.transform(Iterables.filter(resources, ARCHIVE_FILTER), RESOURCE_TO_PATH));
+    String files = Joiner.on(',')
+      .join(Iterables.transform(Iterables.filter(resources, Predicates.not(ARCHIVE_FILTER)), RESOURCE_TO_PATH));
+
+    if (!archives.isEmpty()) {
+      builder.add("--archives").add(archives);
+    }
+    if (!files.isEmpty()) {
+      builder.add("--files").add(files);
+    }
+
+    return builder
+      .add(jobJar.getAbsolutePath())
+      .add(className)
+      .build();
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/DistributedSparkSubmitter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/DistributedSparkSubmitter.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.spark;
+
+/**
+ * A {@link SparkSubmitter} to submit Spark job that runs on cluster.
+ */
+public class DistributedSparkSubmitter extends AbstractSparkSubmitter {
+
+  @Override
+  protected String getMaster() {
+    return "yarn-client";
+  }
+
+  @Override
+  protected void triggerShutdown(ExecutionSparkContext sparkContext) {
+    sparkContext.close();
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/ExecutionFuture.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/ExecutionFuture.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.spark;
+
+import com.google.common.util.concurrent.ListenableFuture;
+
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A {@link ListenableFuture} that represents execution of a job in the Spark framework.
+ *
+ * @param <V> Type of the future result
+ * @see SparkSubmitter#submit(ExecutionSparkContext, Map, List, File, Object)
+ */
+public interface ExecutionFuture<V> extends ListenableFuture<V> {
+
+  /**
+   * Returns the {@link ExecutionSparkContext} representing the Spark program being executed.
+   */
+  ExecutionSparkContext getSparkContext();
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/LocalSparkSubmitter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/LocalSparkSubmitter.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.spark;
+
+/**
+ * A {@link SparkSubmitter} to submit Spark job that runs in the same local process.
+ */
+public class LocalSparkSubmitter extends AbstractSparkSubmitter {
+
+  @Override
+  protected String getMaster() {
+    return "local";
+  }
+
+  @Override
+  protected void triggerShutdown(ExecutionSparkContext context) {
+    context.close();
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SettableExecutionFuture.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SettableExecutionFuture.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.spark;
+
+import com.google.common.util.concurrent.AbstractFuture;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Implementation of {@link ExecutionFuture} with result can be set explicitly.
+ */
+class SettableExecutionFuture<V> extends AbstractFuture<V> implements ExecutionFuture<V> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SettableExecutionFuture.class);
+  private final AtomicBoolean done;
+  private final ExecutionSparkContext context;
+
+  SettableExecutionFuture(ExecutionSparkContext context) {
+    this.done = new AtomicBoolean();
+    this.context = context;
+  }
+
+  @Override
+  protected boolean set(V value) {
+    if (done.compareAndSet(false, true)) {
+      return super.set(value);
+    }
+    return false;
+  }
+
+  @Override
+  protected boolean setException(Throwable throwable) {
+    if (done.compareAndSet(false, true)) {
+      return super.setException(throwable);
+    }
+    return false;
+  }
+
+  @Override
+  public boolean cancel(boolean mayInterruptIfRunning) {
+    if (!done.compareAndSet(false, true)) {
+      return false;
+    }
+
+    try {
+      cancelTask();
+      return super.cancel(mayInterruptIfRunning);
+    } catch (Throwable t) {
+      // Only log and reset state, but not propagate since Future.cancel() doesn't expect exception to be thrown.
+      LOG.warn("Failed to cancel Spark execution for {}.", context, t);
+      done.set(false);
+      return false;
+    }
+  }
+
+  @Override
+  public ExecutionSparkContext getSparkContext() {
+    return context;
+  }
+
+  /**
+   * Will be called to cancel an executing task. Sub-class can override this method to provide
+   * custom cancellation logic. This method will be called before the future changed to cancelled state.
+   */
+  protected void cancelTask() {
+    // no-op
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkContextConfig.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkContextConfig.java
@@ -41,9 +41,10 @@ public class SparkContextConfig {
   private static final Gson GSON = ApplicationSpecificationAdapter.addTypeAdapters(new GsonBuilder()).create();
   private static final Type ARGS_TYPE = new TypeToken<Map<String, String>>() { }.getType();
 
-  public static final String HCONF_ATTR_EXECUTION_MODE = "cdap.spark.execution.mode";
-  public static final String LOCAL_EXECUTION_MODE = "local";
-  public static final String YARN_EXECUTION_MODE = "yarn-client";
+  /**
+   * Configuration key for boolean value to tell whether Spark program is executed on a cluster or not.
+   */
+  public static final String HCONF_ATTR_CLUSTER_MODE = "cdap.spark.cluster.mode";
 
   private static final String HCONF_ATTR_PROGRAM_SPEC = "cdap.spark.program.spec";
   private static final String HCONF_ATTR_PROGRAM_ID = "cdap.spark.program.id";
@@ -73,7 +74,7 @@ public class SparkContextConfig {
    * Returns true if in local mode.
    */
   public boolean isLocal() {
-    return LOCAL_EXECUTION_MODE.equals(getExecutionMode());
+    return !hConf.getBoolean(HCONF_ATTR_CLUSTER_MODE, false);
   }
 
   /**
@@ -89,10 +90,6 @@ public class SparkContextConfig {
     setWorkflowToken(context.getWorkflowToken());
 
     return this;
-  }
-
-  public String getExecutionMode() {
-    return hConf.get(HCONF_ATTR_EXECUTION_MODE, LOCAL_EXECUTION_MODE);
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkProgramRunner.java
@@ -135,9 +135,11 @@ public class SparkProgramRunner implements ProgramRunner {
       throw Throwables.propagate(e);
     }
 
+    SparkSubmitter submitter = new SparkContextConfig(hConf).isLocal() ? new LocalSparkSubmitter()
+                                                                       : new DistributedSparkSubmitter();
     Service sparkRuntimeService = new SparkRuntimeService(
       cConf, hConf, spark, new SparkContextFactory(hConf, context, datasetFramework, streamAdmin),
-      program.getJarLocation(), txSystemClient
+      submitter, program.getJarLocation(), txSystemClient
     );
 
     sparkRuntimeService.addListener(createRuntimeServiceListener(program.getId(), runId, arguments),

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkSubmitter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkSubmitter.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.spark;
+
+import co.cask.cdap.api.spark.SparkProgram;
+import co.cask.cdap.internal.app.runtime.distributed.LocalizeResource;
+
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Interface to provide abstraction for submitting a {@link SparkProgram} to
+ * the Spark framework for execution.
+ */
+public interface SparkSubmitter {
+
+  /**
+   * Submits a Spark job to the Spark framework.
+   *
+   * @param sparkContext the {@link ExecutionSparkContext} representing the Spark program
+   * @param configs configurations for the Spark framework
+   * @param resources list of resources to be localized to Spark containers
+   * @param jobJar location of the job JAR file required by the framework
+   * @param result object instance to be available through the returned {@link ExecutionFuture} when it completes
+   * @param <V> Type of the result object
+   * @return An {@link ExecutionFuture} that will be completed when the job finished. If the job execution failed,
+   *         the future will also be failed with the cause wrapped inside an {@link ExecutionException}
+   *         when {@link ExecutionFuture#get} is called. If {@link ExecutionFuture#cancel(boolean)} is called,
+   *         the running job will be terminated immediately.
+   */
+  <V> ExecutionFuture<V> submit(ExecutionSparkContext sparkContext, Map<String, String> configs,
+                                List<LocalizeResource> resources, File jobJar, V result);
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/metrics/SparkMetricsSink.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/metrics/SparkMetricsSink.java
@@ -68,12 +68,12 @@ public class SparkMetricsSink implements Sink {
   }
 
   /**
-   * Generate a properties file which is used to config Spark Metrics in {@link SparkConf}
+   * Writes a properties file which is used to config Spark Metrics in {@link SparkConf}.
    *
    * @param file the {@link File} where this file should be generated
    * @return the same File argument provided.
    */
-  public static File generateSparkMetricsConfig(File file) throws IOException {
+  public static File writeConfig(File file) throws IOException {
     Properties properties = new Properties();
     properties.setProperty("*.sink.cdap.class", SparkMetricsSink.class.getName());
 


### PR DESCRIPTION
- A new interface, SparkSubmitter, is created for abstracting out submission
- Provide two implementations, Local and Distributed SparkSubmitter
  - Currently they are implemented the same way
  - Will diverge when using yarn-cluster mode