### PR TITLE
Wait till the workflow stop before calling the current endpoint.

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowHttpHandlerTest.java
@@ -522,6 +522,9 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
     // Stop the program while in fork
     stopProgram(programId, 200);
 
+    // Wait till the program stop
+    waitState(programId, "STOPPED");
+
     // Current endpoint would return 404
     response = getWorkflowCurrentStatus(programId, runId);
     Assert.assertEquals(404, response.getStatusLine().getStatusCode());


### PR DESCRIPTION
Backporting #3532, to avoid unit test failures during release