### PR TITLE
turn off host key check on initial ssh

### DIFF
--- a/cdap-distributions/bin/build_artifact_upload.sh
+++ b/cdap-distributions/bin/build_artifact_upload.sh
@@ -129,7 +129,7 @@ function sync_build_artifacts_to_server () {
       OUTGOING_DIR=snapshot/cask/${BUILD_PACKAGE}/${_version}  ## send snapshots to a different directory
     fi
     echo "Create remote directory ${REMOTE_INCOMING_DIR}/${OUTGOING_DIR} if necessary"
-    ssh -l ${REMOTE_USER} ${REMOTE_HOST} "mkdir -p ${REMOTE_INCOMING_DIR}/${OUTGOING_DIR}" || die "could not create remote directory"
+    ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -l ${REMOTE_USER} ${REMOTE_HOST} "mkdir -p ${REMOTE_INCOMING_DIR}/${OUTGOING_DIR}" || die "could not create remote directory"
 
     # sync package(s) to remote server
     decho "rsyncing with rsync -av -e \"ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null\" ${RSYNC_QUIET} ${i} ${REMOTE_BASE_DIR}/${OUTGOING_DIR}/ ${DRY_RUN} 2>&1"


### PR DESCRIPTION
turns off hostkey checking on the initial ssh attempt.  This needs to be ported to release branches as well.