### PR TITLE
[CDAP-3374] Warning messages indicating that the Runrecords with status running

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramLifecycleService.java
@@ -254,7 +254,7 @@ public class ProgramLifecycleService extends AbstractIdleService {
    * @param programType The type of program the run records need to validate and update.
    * @param processedInvalidRunRecordIds the {@link Set} of processed invalid run record ids.
    */
-  void validateAndCorrectRunningRunRecords(ProgramType programType, Set<String> processedInvalidRunRecordIds) {
+  void validateAndCorrectRunningRunRecords(final ProgramType programType, Set<String> processedInvalidRunRecordIds) {
     final Map<RunId, RuntimeInfo> runIdToRuntimeInfo = runtimeService.list(programType);
 
     List<RunRecordMeta> invalidRunRecords = store.getRuns(ProgramRunStatus.RUNNING, new Predicate<RunRecordMeta>() {
@@ -265,7 +265,11 @@ public class ProgramLifecycleService extends AbstractIdleService {
         }
         // Check if it is actually running
         String runId = input.getPid();
-        return !runIdToRuntimeInfo.containsKey(RunIds.fromString(runId));
+        // check for program Id for the run record, if null then it is invalid program type.
+        Id.Program targetProgramId = retrieveProgramIdForRunRecord(programType, runId);
+
+        // Check if run id is for the right program type and it is not actually running.
+        return (targetProgramId != null) && !runIdToRuntimeInfo.containsKey(RunIds.fromString(runId));
       }
     });
 
@@ -278,11 +282,6 @@ public class ProgramLifecycleService extends AbstractIdleService {
     for (RunRecordMeta invalidRunRecordMeta : invalidRunRecords) {
       String runId = invalidRunRecordMeta.getPid();
       Id.Program targetProgramId = retrieveProgramIdForRunRecord(programType, runId);
-      if (targetProgramId == null) {
-        // wrong program type
-        continue;
-      }
-
       boolean shouldCorrect = shouldCorrectForWorkflowChildren(invalidRunRecordMeta, processedInvalidRunRecordIds);
       if (!shouldCorrect) {
         continue;


### PR DESCRIPTION
Move the check for Program ID for program type and run id early to avoid excessive logging for invalid run records with wrong program type for the run records.

Previously for each program type we have 2 checks, one at the beginning to filter run records with RUNNING status and actually does not have container running for that program type, and then later check if the run record id is actually belong to that program type.