### PR TITLE
Correct the name of the property used to enable CDAP Explore service.

### DIFF
--- a/cdap-docs/admin-manual/source/installation/installation.rst
+++ b/cdap-docs/admin-manual/source/installation/installation.rst
@@ -427,7 +427,7 @@ Depending on your installation, you may want to set these properties:
   ``conf/cdap-site.xml`` (by default, it is disabled)::
 
     <property>
-      <name>cdap.explore.enabled</name>
+      <name>explore.enabled</name>
       <value>true</value>
       <description>Enable Explore functionality</description>
     </property>


### PR DESCRIPTION
A check was made in the documentation for other cases of this error, and this was the only instance found.

Fixes https://issues.cask.co/browse/CDAP-3404.