### PR TITLE
(Cdap-20) Incremental effort to remove guava from api

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/common/RuntimeArguments.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/common/RuntimeArguments.java
@@ -16,8 +16,6 @@
 
 package co.cask.cdap.api.common;
 
-import com.google.common.base.Splitter;
-
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -42,7 +40,11 @@ public final class RuntimeArguments {
   public static Map<String, String> fromPosixArray(String[] args) {
     Map<String, String> kvMap = new HashMap<>();
     for (String arg : args) {
-      kvMap.putAll(Splitter.on("--").omitEmptyStrings().trimResults().withKeyValueSeparator("=").split(arg));
+      int idx = arg.indexOf('=');
+      int keyOff = arg.startsWith("--") ? "--".length() : 0;
+      String key = idx < 0 ? arg.substring(keyOff) : arg.substring(keyOff, idx);
+      String value = idx < 0 ? "" : arg.substring(idx + 1);
+      kvMap.put(key, value);
     }
     return kvMap;
   }

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/FileSetArguments.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/FileSetArguments.java
@@ -16,11 +16,10 @@
 
 package co.cask.cdap.api.dataset.lib;
 
-import com.google.common.base.Splitter;
-import com.google.common.collect.Lists;
-
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -100,8 +99,13 @@ public class FileSetArguments {
     if (pathsArg == null) {
       return Collections.emptyList();
     }
-    Iterable<String> paths = Splitter.on(',').omitEmptyStrings().trimResults().split(pathsArg);
-    return Lists.newArrayList(paths);
+    List<String> paths = new ArrayList<>();
+    for (String path : pathsArg.split("\\s*,\\s*")) {
+      if (!path.isEmpty()) {
+        paths.add(path);
+      }
+    }
+    return paths;
   }
 
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionedFileSetProperties.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionedFileSetProperties.java
@@ -17,7 +17,6 @@
 package co.cask.cdap.api.dataset.lib;
 
 import co.cask.cdap.api.annotation.Beta;
-import com.google.common.base.Joiner;
 
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -92,7 +91,13 @@ public class PartitionedFileSetProperties extends FileSetProperties {
      * Sets the base path for the file dataset.
      */
     public Builder setPartitioning(Partitioning partitioning) {
-      add(PARTITIONING_FIELDS, Joiner.on(",").join(partitioning.getFields().keySet()));
+      StringBuilder builder = new StringBuilder();
+      String sep = "";
+      for (String key : partitioning.getFields().keySet()) {
+        builder.append(sep).append(key);
+        sep = ",";
+      }
+      add(PARTITIONING_FIELDS, builder.toString());
       for (Map.Entry<String, Partitioning.FieldType> entry : partitioning.getFields().entrySet()) {
         add(PARTITIONING_FIELD_PREFIX + entry.getKey(), entry.getValue().name());
       }

--- a/cdap-api/src/main/java/co/cask/cdap/api/flow/FlowletDefinition.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/flow/FlowletDefinition.java
@@ -36,7 +36,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import com.google.common.reflect.TypeToken;
 
 import java.lang.reflect.Type;
 import java.util.Collections;
@@ -81,7 +80,7 @@ public final class FlowletDefinition {
     Map<String, Set<Type>> inputTypes = Maps.newHashMap();
     Map<String, Set<Type>> outputTypes = Maps.newHashMap();
     Map<String, String> properties = Maps.newHashMap(flowletSpec.getProperties());
-    Reflections.visit(flowlet, TypeToken.of(flowlet.getClass()),
+    Reflections.visit(flowlet, flowlet.getClass(),
                       new DataSetFieldExtractor(datasets),
                       new PropertyFieldExtractor(properties),
                       new OutputEmitterFieldExtractor(outputTypes),

--- a/cdap-api/src/main/java/co/cask/cdap/internal/flow/DefaultFlowletConfigurer.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/flow/DefaultFlowletConfigurer.java
@@ -28,7 +28,6 @@ import co.cask.cdap.internal.specification.PropertyFieldExtractor;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
-import com.google.common.reflect.TypeToken;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -61,7 +60,7 @@ public class DefaultFlowletConfigurer extends DefaultDatasetConfigurer implement
     this.datasets = new HashSet<>();
 
     // Grab all @Property fields
-    Reflections.visit(flowlet, TypeToken.of(flowlet.getClass()), new PropertyFieldExtractor(propertyFields));
+    Reflections.visit(flowlet, flowlet.getClass(), new PropertyFieldExtractor(propertyFields));
   }
 
   @Override

--- a/cdap-api/src/main/java/co/cask/cdap/internal/io/AbstractFieldAccessor.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/io/AbstractFieldAccessor.java
@@ -16,7 +16,7 @@
 
 package co.cask.cdap.internal.io;
 
-import com.google.common.reflect.TypeToken;
+import java.lang.reflect.Type;
 
 /**
  * A base implementation of {@link FieldAccessor} that throws {@link UnsupportedOperationException}
@@ -24,9 +24,9 @@ import com.google.common.reflect.TypeToken;
  */
 public abstract class AbstractFieldAccessor implements FieldAccessor {
 
-  private final TypeToken<?> type;
+  private final Type type;
 
-  protected AbstractFieldAccessor(TypeToken<?> type) {
+  protected AbstractFieldAccessor(Type type) {
     this.type = type;
   }
 
@@ -121,7 +121,7 @@ public abstract class AbstractFieldAccessor implements FieldAccessor {
   }
 
   @Override
-  public final TypeToken<?> getType() {
+  public final Type getType() {
     return type;
   }
 }

--- a/cdap-api/src/main/java/co/cask/cdap/internal/io/FieldAccessor.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/io/FieldAccessor.java
@@ -16,7 +16,7 @@
 
 package co.cask.cdap.internal.io;
 
-import com.google.common.reflect.TypeToken;
+import java.lang.reflect.Type;
 
 /**
  *
@@ -59,5 +59,5 @@ public interface FieldAccessor {
 
   void setDouble(Object object, double value);
 
-  TypeToken<?> getType();
+  Type getType();
 }

--- a/cdap-api/src/main/java/co/cask/cdap/internal/lang/Reflections.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/lang/Reflections.java
@@ -54,12 +54,12 @@ public final class Reflections {
    * Inspect all members in the given type. Fields and Methods that are given to Visitor are
    * always having accessible flag being set.
    */
-  public static void visit(Object instance, TypeToken<?> inspectType, Visitor firstVisitor, Visitor... moreVisitors) {
-
+  public static void visit(Object instance, Type inspectType, Visitor firstVisitor, Visitor... moreVisitors) {
     try {
+      TypeToken<?> inspectTypeToken = TypeToken.of(inspectType);
       List<Visitor> visitors = ImmutableList.<Visitor>builder().add(firstVisitor).add(moreVisitors).build();
 
-      for (TypeToken<?> type : inspectType.getTypes().classes()) {
+      for (TypeToken<?> type : inspectTypeToken.getTypes().classes()) {
         if (Object.class.equals(type.getRawType())) {
           break;
         }
@@ -72,7 +72,7 @@ public final class Reflections {
             field.setAccessible(true);
           }
           for (Visitor visitor : visitors) {
-            visitor.visit(instance, inspectType, type, field);
+            visitor.visit(instance, inspectTypeToken, type, field);
           }
         }
 
@@ -84,7 +84,7 @@ public final class Reflections {
             method.setAccessible(true);
           }
           for (Visitor visitor : visitors) {
-            visitor.visit(instance, inspectType, type, method);
+            visitor.visit(instance, inspectTypeToken, type, method);
           }
         }
       }

--- a/cdap-api/src/main/java/co/cask/cdap/internal/workflow/DefaultWorkflowActionSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/workflow/DefaultWorkflowActionSpecification.java
@@ -25,7 +25,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import com.google.common.reflect.TypeToken;
 
 import java.util.Map;
 import java.util.Set;
@@ -55,7 +54,7 @@ public class DefaultWorkflowActionSpecification implements WorkflowActionSpecifi
 
     Map<String, String> properties = Maps.newHashMap(spec.getProperties());
     Set<String> datasets = Sets.newHashSet();
-    Reflections.visit(action, TypeToken.of(action.getClass()),
+    Reflections.visit(action, action.getClass(),
                       new DataSetFieldExtractor(datasets),
                       new PropertyFieldExtractor(properties));
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/PluginInstantiator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/PluginInstantiator.java
@@ -220,7 +220,8 @@ public class PluginInstantiator implements Closeable {
       Field field = Fields.findField(pluginType, configFieldName);
       TypeToken<?> configFieldType = pluginType.resolveType(field.getGenericType());
       Object config = instantiatorFactory.get(configFieldType).create();
-      Reflections.visit(config, configFieldType, new ConfigFieldSetter(pluginClass, artifactDescriptor, properties));
+      Reflections.visit(config, configFieldType.getType(),
+                        new ConfigFieldSetter(pluginClass, artifactDescriptor, properties));
 
       // Create the plugin instance
       return newInstance(pluginType, field, configFieldType, config);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
@@ -165,7 +165,7 @@ public class MapReduceProgramRunner implements ProgramRunner {
                                     pluginInstantiator);
 
 
-      Reflections.visit(mapReduce, TypeToken.of(mapReduce.getClass()),
+      Reflections.visit(mapReduce, mapReduce.getClass(),
                         new PropertyFieldSetter(context.getSpecification().getProperties()),
                         new MetricsFieldSetter(context.getMetrics()),
                         new DataSetFieldSetter(context));

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapperWrapper.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapperWrapper.java
@@ -26,7 +26,6 @@ import co.cask.cdap.internal.app.runtime.DataSetFieldSetter;
 import co.cask.cdap.internal.app.runtime.MetricsFieldSetter;
 import co.cask.cdap.internal.lang.Reflections;
 import com.google.common.base.Throwables;
-import com.google.common.reflect.TypeToken;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.MRJobConfig;
@@ -77,7 +76,7 @@ public class MapperWrapper extends Mapper {
 
       // injecting runtime components, like datasets, etc.
       try {
-        Reflections.visit(delegate, TypeToken.of(delegate.getClass()),
+        Reflections.visit(delegate, delegate.getClass(),
                           new PropertyFieldSetter(basicMapReduceContext.getSpecification().getProperties()),
                           new MetricsFieldSetter(basicMapReduceContext.getMetrics()),
                           new DataSetFieldSetter(basicMapReduceContext));

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/ReducerWrapper.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/ReducerWrapper.java
@@ -26,7 +26,6 @@ import co.cask.cdap.internal.app.runtime.DataSetFieldSetter;
 import co.cask.cdap.internal.app.runtime.MetricsFieldSetter;
 import co.cask.cdap.internal.lang.Reflections;
 import com.google.common.base.Throwables;
-import com.google.common.reflect.TypeToken;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.MRJobConfig;
@@ -75,7 +74,7 @@ public class ReducerWrapper extends Reducer {
 
       // injecting runtime components, like datasets, etc.
       try {
-        Reflections.visit(delegate, TypeToken.of(delegate.getClass()),
+        Reflections.visit(delegate, delegate.getClass(),
                           new PropertyFieldSetter(basicMapReduceContext.getSpecification().getProperties()),
                           new MetricsFieldSetter(basicMapReduceContext.getMetrics()),
                           new DataSetFieldSetter(basicMapReduceContext));

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowUtils.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowUtils.java
@@ -68,6 +68,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
@@ -266,7 +267,7 @@ public final class FlowUtils {
           Class<?> flowletClass = program.getClassLoader().loadClass(flowletDefinition.getFlowletSpec().getClassName());
           long groupId = generateConsumerGroupId(program, flowletId);
 
-          addConsumerGroup(queueSpec, TypeToken.of(flowletClass), groupId,
+          addConsumerGroup(queueSpec, flowletClass, groupId,
                            flowletDefinition.getInstances(), schemaGenerator, groupConfigs);
         } catch (ClassNotFoundException e) {
           // There is no way for not able to load a Flowlet class as it should be verified during deployment.
@@ -282,7 +283,7 @@ public final class FlowUtils {
    * Finds all consumer group for the given queue from the given flowlet.
    */
   private static void addConsumerGroup(final QueueSpecification queueSpec,
-                                       final TypeToken<?> flowletType,
+                                       final Type flowletType,
                                        final long groupId, final int groupSize,
                                        final SchemaGenerator schemaGenerator,
                                        final Collection<ConsumerGroupConfig> groupConfigs) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowletProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowletProgramRunner.java
@@ -223,7 +223,7 @@ public final class FlowletProgramRunner implements ProgramRunner {
 
       // Inject DataSet, OutputEmitter, Metric fields
       ImmutableList.Builder<ProducerSupplier> queueProducerSupplierBuilder = ImmutableList.builder();
-      Reflections.visit(flowlet, TypeToken.of(flowlet.getClass()),
+      Reflections.visit(flowlet, flowlet.getClass(),
                         new PropertyFieldSetter(flowletDef.getFlowletSpec().getProperties()),
                         new DataSetFieldSetter(flowletContext),
                         new MetricsFieldSetter(flowletContext.getMetrics()),

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkProgramRunner.java
@@ -126,7 +126,7 @@ public class SparkProgramRunner implements ProgramRunner {
       spark = new InstantiatorFactory(false).get(TypeToken.of(program.<Spark>getMainClass())).create();
 
       // Fields injection
-      Reflections.visit(spark, TypeToken.of(spark.getClass()),
+      Reflections.visit(spark, spark.getClass(),
                         new PropertyFieldSetter(spec.getProperties()),
                         new DataSetFieldSetter(context),
                         new MetricsFieldSetter(context.getMetrics()));

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/WorkerDriver.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/WorkerDriver.java
@@ -62,7 +62,7 @@ public class WorkerDriver extends AbstractExecutionThreadService {
     worker = new InstantiatorFactory(false).get(workerType).create();
 
     // Fields injection
-    Reflections.visit(worker, workerType,
+    Reflections.visit(worker, workerType.getType(),
                       new MetricsFieldSetter(context.getMetrics()),
                       new PropertyFieldSetter(spec.getProperties()));
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowDriver.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowDriver.java
@@ -515,7 +515,7 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
 
     ClassLoader oldClassLoader = setContextCombinedClassLoader(action);
     try {
-      Reflections.visit(action, TypeToken.of(action.getClass()),
+      Reflections.visit(action, action.getClass(),
                         new PropertyFieldSetter(actionSpec.getProperties()),
                         new DataSetFieldSetter(workflowContext),
                         new MetricsFieldSetter(workflowContext.getMetrics()));

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/DefaultHttpServiceHandlerConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/DefaultHttpServiceHandlerConfigurer.java
@@ -29,7 +29,6 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import com.google.common.reflect.TypeToken;
 
 import java.util.List;
 import java.util.Map;
@@ -62,7 +61,7 @@ public class DefaultHttpServiceHandlerConfigurer extends DefaultDatasetConfigure
     this.endpoints = Lists.newArrayList();
 
     // Inspect the handler to grab all @UseDataset, @Property and endpoints.
-    Reflections.visit(handler, TypeToken.of(handler.getClass()),
+    Reflections.visit(handler, handler.getClass(),
                       new DataSetFieldExtractor(datasets),
                       new PropertyFieldExtractor(propertyFields),
                       new ServiceEndpointExtractor(endpoints));

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ServiceHttpServer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ServiceHttpServer.java
@@ -399,7 +399,7 @@ public class ServiceHttpServer extends AbstractIdleService {
       // Instantiate the user handler and injects Metrics and Dataset fields.
       HttpServiceHandler handler = instantiatorFactory.get(handlerType).create();
       BasicHttpServiceContext context = contextFactory.create(spec);
-      Reflections.visit(handler, handlerType,
+      Reflections.visit(handler, handlerType.getType(),
                         new MetricsFieldSetter(context.getMetrics()),
                         new DataSetFieldSetter(context),
                         new PropertyFieldSetter(spec.getProperties()));

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/spark/DefaultSparkConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/spark/DefaultSparkConfigurer.java
@@ -25,7 +25,6 @@ import co.cask.cdap.internal.lang.Reflections;
 import co.cask.cdap.internal.specification.PropertyFieldExtractor;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.reflect.TypeToken;
 
 import java.util.Collections;
 import java.util.Map;
@@ -83,7 +82,7 @@ public final class DefaultSparkConfigurer extends DefaultDatasetConfigurer imple
 
   public SparkSpecification createSpecification() {
     // Grab all @Property fields
-    Reflections.visit(spark, TypeToken.of(spark.getClass()), new PropertyFieldExtractor(properties));
+    Reflections.visit(spark, spark.getClass(), new PropertyFieldExtractor(properties));
     return new SparkSpecification(spark.getClass().getName(), name, description,
                                   mainClassName, properties, driverResources, executorResources);
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/worker/DefaultWorkerConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/worker/DefaultWorkerConfigurer.java
@@ -28,7 +28,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import com.google.common.reflect.TypeToken;
 
 import java.util.Map;
 import java.util.Set;
@@ -59,7 +58,7 @@ public class DefaultWorkerConfigurer extends DefaultDatasetConfigurer implements
     this.datasets = Sets.newHashSet();
 
     // Grab all @Property fields
-    Reflections.visit(worker, TypeToken.of(worker.getClass()), new PropertyFieldExtractor(propertyFields));
+    Reflections.visit(worker, worker.getClass(), new PropertyFieldExtractor(propertyFields));
   }
 
   @Override

--- a/cdap-common/src/main/java/co/cask/cdap/common/lang/InstantiatorFactory.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/lang/InstantiatorFactory.java
@@ -180,7 +180,7 @@ public final class InstantiatorFactory {
       public T create() {
         try {
           Object instance = UNSAFE.allocateInstance(type.getRawType());
-          Reflections.visit(instance, type, new FieldInitializer());
+          Reflections.visit(instance, type.getType(), new FieldInitializer());
           return (T) instance;
         } catch (InstantiationException e) {
           throw Throwables.propagate(e);

--- a/cdap-common/src/main/java/co/cask/cdap/internal/io/ASMFieldAccessorFactory.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/io/ASMFieldAccessorFactory.java
@@ -24,6 +24,7 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.reflect.TypeToken;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.Type;
 
 /**
  * A {@link FieldAccessorFactory} that uses ASM to generate a specific {@link FieldAccessor} class
@@ -96,7 +97,7 @@ public final class ASMFieldAccessorFactory implements FieldAccessorFactory {
         byte[] bytecode = classDef.getBytecode();
         result = (Class<?>) defineClass.invoke(classLoader, className, bytecode, 0, bytecode.length);
       }
-      return (FieldAccessor) result.getConstructor(TypeToken.class).newInstance(type);
+      return (FieldAccessor) result.getConstructor(Type.class).newInstance(type.getType());
     }
   }
 }

--- a/cdap-common/src/main/java/co/cask/cdap/internal/io/FieldAccessorGenerator.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/io/FieldAccessorGenerator.java
@@ -94,12 +94,12 @@ final class FieldAccessorGenerator {
                  .visitEnd();
     }
 
-    // Constructor(TypeToken<?> classType)
-    GeneratorAdapter mg = new GeneratorAdapter(Opcodes.ACC_PUBLIC, getMethod(void.class, "<init>", TypeToken.class),
-                                               null, new Type[0], classWriter);
+    // Constructor(Type classType)
+    Method constructor = getMethod(void.class, "<init>", java.lang.reflect.Type.class);
+    GeneratorAdapter mg = new GeneratorAdapter(Opcodes.ACC_PUBLIC, constructor, null, new Type[0], classWriter);
     mg.loadThis();
     mg.loadArg(0);
-    mg.invokeConstructor(Type.getType(AbstractFieldAccessor.class), getMethod(void.class, "<init>", TypeToken.class));
+    mg.invokeConstructor(Type.getType(AbstractFieldAccessor.class), constructor);
     if (isPrivate) {
       initializeReflectionField(mg, field);
     }
@@ -126,8 +126,9 @@ final class FieldAccessorGenerator {
     mg.visitTryCatchBlock(beginTry, endTry, catchHandle, Type.getInternalName(Exception.class));
     mg.mark(beginTry);
 
-    // Field field = findField(classType, "fieldName")
+    // Field field = Fields.findField(TypeToken.of(classType), "fieldName")
     mg.loadArg(0);
+    mg.invokeStatic(Type.getType(TypeToken.class), getMethod(TypeToken.class, "of", java.lang.reflect.Type.class));
     mg.push(field.getName());
     mg.invokeStatic(Type.getType(Fields.class), getMethod(Field.class, "findField", TypeToken.class, String.class));
     mg.dup();

--- a/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionDatumReader.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionDatumReader.java
@@ -199,7 +199,8 @@ public final class ReflectionDatumReader<T> extends ReflectionReader<Decoder, T>
         }
         FieldAccessor fieldAccessor = getFieldAccessor(targetTypeToken, sourceField.getName());
         fieldAccessor.set(record,
-                          read(decoder, sourceField.getSchema(), targetField.getSchema(), fieldAccessor.getType()));
+                          read(decoder, sourceField.getSchema(), targetField.getSchema(),
+                               TypeToken.of(fieldAccessor.getType())));
       }
       return record;
     } catch (Exception e) {

--- a/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionFieldAccessorFactory.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionFieldAccessorFactory.java
@@ -24,6 +24,7 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.reflect.TypeToken;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Type;
 
 /**
  *
@@ -155,8 +156,8 @@ public final class ReflectionFieldAccessorFactory implements FieldAccessorFactor
           }
 
           @Override
-          public TypeToken<?> getType() {
-            return fieldType;
+          public Type getType() {
+            return fieldType.getType();
           }
         };
       }

--- a/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionRowReader.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionRowReader.java
@@ -66,7 +66,7 @@ public class ReflectionRowReader<T> extends ReflectionReader<Row, T> {
         }
         FieldAccessor fieldAccessor = getFieldAccessor(type, sourceFieldName);
         fieldAccessor.set(record, read(row, sourceField.getSchema(),
-                                       targetField.getSchema(), fieldAccessor.getType()));
+                                       targetField.getSchema(), TypeToken.of(fieldAccessor.getType())));
       }
       return (T) record;
     } catch (Exception e) {

--- a/cdap-common/src/test/java/co/cask/cdap/common/lang/InstantiatorTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/lang/InstantiatorTest.java
@@ -36,7 +36,7 @@ public class InstantiatorTest {
   public void testUnsafe() {
     Record record = new InstantiatorFactory(false).get(TypeToken.of(Record.class)).create();
 
-    Reflections.visit(record, TypeToken.of(Record.class), new FieldVisitor() {
+    Reflections.visit(record, Record.class, new FieldVisitor() {
       @Override
       public void visit(Object instance, TypeToken<?> inspectType,
                         TypeToken<?> declareType, Field field) throws Exception {

--- a/cdap-unit-test/src/test/java/co/cask/cdap/RuntimeArgumentsTest.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/RuntimeArgumentsTest.java
@@ -22,8 +22,6 @@ import co.cask.cdap.internal.app.runtime.BasicArguments;
 import com.google.common.collect.Maps;
 import org.junit.Assert;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -32,7 +30,6 @@ import java.util.Map;
  * Test RuntimeArguments class.
  */
 public class RuntimeArgumentsTest {
-  private static final Logger LOG = LoggerFactory.getLogger(RuntimeArgumentsTest.class);
 
   @Test
   public void testMaptoString() {


### PR DESCRIPTION
There are three changes:

1. Replace usage of TypeToken to Type in FieldAccessor.
2. Change Reflections.visit to take Type instead of TypeToken
3. Remove usage of Guava Joiner and Splitter in cdap-api