### PR TITLE
(CDAP-20) Remove almost all guava usages from cdap-api

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/common/Bytes.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/common/Bytes.java
@@ -15,8 +15,6 @@
  */
 package co.cask.cdap.api.common;
 
-import com.google.common.collect.ImmutableSortedMap;
-
 import java.io.DataOutput;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -28,6 +26,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.NavigableMap;
+import java.util.TreeMap;
 import java.util.UUID;
 import javax.annotation.Nullable;
 
@@ -1470,7 +1469,11 @@ public class Bytes {
    */
   @Deprecated
   public static <T> NavigableMap<byte[], T> immutableSortedMapOf(byte[] key, T value) {
-    return ImmutableSortedMap.<byte[], T>orderedBy(Bytes.BYTES_COMPARATOR).put(key, value).build();
+    // Not really immutable. However, for the sake of removing
+    // guava usage and given this API is deprecated, it should be fine.
+    TreeMap<byte[], T> result = new TreeMap<byte[], T>(BYTES_COMPARATOR);
+    result.put(key, value);
+    return result;
   }
 
   /**
@@ -1486,8 +1489,11 @@ public class Bytes {
   @Deprecated
   public static <T> NavigableMap<byte[], T> immutableSortedMapOf(byte[] key1, T value1,
                                                                   byte[] key2, T value2) {
-    return ImmutableSortedMap.<byte[], T>orderedBy(Bytes.BYTES_COMPARATOR)
-      .put(key1, value1)
-      .put(key2, value2).build();
+    // Not really immutable. However, for the sake of removing
+    // guava usage and given this API is deprecated, it should be fine.
+    TreeMap<byte[], T> result = new TreeMap<byte[], T>(BYTES_COMPARATOR);
+    result.put(key1, value1);
+    result.put(key2, value2);
+    return result;
   }
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/AbstractCloseableIterator.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/AbstractCloseableIterator.java
@@ -16,14 +16,115 @@
 
 package co.cask.cdap.api.dataset.lib;
 
-import com.google.common.collect.AbstractIterator;
+import java.util.NoSuchElementException;
 
 /**
- * Iterator that extends {@link com.google.common.collect.AbstractIterator} and implements
- * {@link co.cask.cdap.api.dataset.lib.CloseableIterator}.
+ * An abstract that Iterator helps implement an non-removable {@link CloseableIterator}.
+ * This class is copied from guava AbstractIterator.
  * 
  * @param <T> Type of elements returned by this iterator
  */
-public abstract class AbstractCloseableIterator<T> extends AbstractIterator<T> implements CloseableIterator<T> {
+public abstract class AbstractCloseableIterator<T> implements CloseableIterator<T> {
 
+  private State state = State.NOT_READY;
+
+  /** Constructor for use by subclasses. */
+  protected AbstractCloseableIterator() {}
+
+  private enum State {
+    /** We have computed the next element and haven't returned it yet. */
+    READY,
+
+    /** We haven't yet computed or have already returned the element. */
+    NOT_READY,
+
+    /** We have reached the end of the data and are finished. */
+    DONE,
+
+    /** We've suffered an exception and are kaput. */
+    FAILED,
+  }
+
+  private T next;
+
+  /**
+   * Returns the next element. <b>Note:</b> the implementation must call {@link
+   * #endOfData()} when there are no elements left in the iteration. Failure to
+   * do so could result in an infinite loop.
+   *
+   * <p>The initial invocation of {@link #hasNext()} or {@link #next()} calls
+   * this method, as does the first invocation of {@code hasNext} or {@code
+   * next} following each successful call to {@code next}. Once the
+   * implementation either invokes {@code endOfData} or throws an exception,
+   * {@code computeNext} is guaranteed to never be called again.
+   *
+   * <p>If this method throws an exception, it will propagate outward to the
+   * {@code hasNext} or {@code next} invocation that invoked this method. Any
+   * further attempts to use the iterator will result in an {@link
+   * IllegalStateException}.
+   *
+   * <p>The implementation of this method may not invoke the {@code hasNext} or
+   * {@code next} methods on this instance; if it does, an
+   * {@code IllegalStateException} will result.
+   *
+   * @return the next element if there was one. If {@code endOfData} was called
+   *     during execution, the return value will be ignored.
+   * @throws RuntimeException if any unrecoverable error happens. This exception
+   *     will propagate outward to the {@code hasNext()}, {@code next()}, or
+   *     {@code peek()} invocation that invoked this method. Any further
+   *     attempts to use the iterator will result in an
+   *     {@link IllegalStateException}.
+   */
+  protected abstract T computeNext();
+
+  /**
+   * Implementations of {@link #computeNext} <b>must</b> invoke this method when
+   * there are no elements left in the iteration.
+   *
+   * @return {@code null}; a convenience so your {@code computeNext}
+   *     implementation can use the simple statement {@code return endOfData();}
+   */
+  protected final T endOfData() {
+    state = State.DONE;
+    return null;
+  }
+
+  @Override
+  public final boolean hasNext() {
+    if (state == State.FAILED) {
+      throw new IllegalStateException("Unexpected FAILED state");
+    }
+    switch (state) {
+      case DONE:
+        return false;
+      case READY:
+        return true;
+      default:
+    }
+    return tryToComputeNext();
+  }
+
+  private boolean tryToComputeNext() {
+    state = State.FAILED; // temporary pessimism
+    next = computeNext();
+    if (state != State.DONE) {
+      state = State.READY;
+      return true;
+    }
+    return false;
+  }
+
+  @Override
+  public final T next() {
+    if (!hasNext()) {
+      throw new NoSuchElementException();
+    }
+    state = State.NOT_READY;
+    return next;
+  }
+
+  @Override
+  public void remove() {
+    throw new UnsupportedOperationException("Remove not supported");
+  }
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/IndexedObjectStoreDefinition.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/IndexedObjectStoreDefinition.java
@@ -23,7 +23,6 @@ import co.cask.cdap.api.dataset.DatasetDefinition;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.dataset.table.Table;
-import com.google.common.base.Preconditions;
 
 import java.io.IOException;
 import java.util.Map;
@@ -42,8 +41,12 @@ public class IndexedObjectStoreDefinition
                                       DatasetDefinition<? extends Table, ?> tableDef,
                                       DatasetDefinition<? extends ObjectStore, ?> objectStoreDef) {
     super(name);
-    Preconditions.checkArgument(tableDef != null, "Table definition is required");
-    Preconditions.checkArgument(objectStoreDef != null, "ObjectStore definition is required");
+    if (tableDef == null) {
+      throw new IllegalArgumentException("Table definition is required");
+    }
+    if (objectStoreDef == null) {
+      throw new IllegalArgumentException("ObjectStore definition is required");
+    }
     this.tableDef = tableDef;
     this.objectStoreDef = objectStoreDef;
   }

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/IndexedTable.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/IndexedTable.java
@@ -30,13 +30,12 @@ import co.cask.cdap.api.dataset.table.Row;
 import co.cask.cdap.api.dataset.table.Scan;
 import co.cask.cdap.api.dataset.table.Scanner;
 import co.cask.cdap.api.dataset.table.Table;
-import com.google.common.base.Preconditions;
-import com.google.common.primitives.Longs;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Type;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -429,7 +428,9 @@ public class IndexedTable extends AbstractDataset implements Table {
    */
   @Override
   public Row incrementAndGet(byte[] row, byte[][] columns, long[] amounts) {
-    Preconditions.checkArgument(columns.length == amounts.length, "Size of columns and amounts arguments must match");
+    if (columns.length != amounts.length) {
+      throw new IllegalArgumentException("Size of columns and amounts arguments must match");
+    }
 
     Row existingRow = table.get(row, columns);
     byte[][] updatedValues = new byte[columns.length][];
@@ -471,9 +472,15 @@ public class IndexedTable extends AbstractDataset implements Table {
   @Override
   public Row incrementAndGet(Increment increment) {
     Map<byte[], Long> incrementValues = increment.getValues();
+    Collection<Long> values = incrementValues.values();
+    long[] longValues = new long[values.size()];
+    int i = 0;
+    for (long value : values) {
+      longValues[i++] = value;
+    }
     return incrementAndGet(increment.getRow(),
                            incrementValues.keySet().toArray(new byte[incrementValues.size()][]),
-                           Longs.toArray(incrementValues.values()));
+                           longValues);
   }
 
 

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/KeyValueTableDefinition.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/KeyValueTableDefinition.java
@@ -23,7 +23,6 @@ import co.cask.cdap.api.dataset.DatasetDefinition;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.dataset.table.Table;
-import com.google.common.base.Preconditions;
 
 import java.io.IOException;
 import java.util.Map;
@@ -39,7 +38,9 @@ public class KeyValueTableDefinition
 
   public KeyValueTableDefinition(String name, DatasetDefinition<? extends Table, ?> tableDef) {
     super(name);
-    Preconditions.checkArgument(tableDef != null, "Table definition is required");
+    if (tableDef == null) {
+      throw new IllegalArgumentException("Table definition is required");
+    }
     this.tableDef = tableDef;
   }
 

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionConsumerState.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionConsumerState.java
@@ -17,7 +17,6 @@
 package co.cask.cdap.api.dataset.lib;
 
 import co.cask.cdap.api.common.Bytes;
-import com.google.common.base.Preconditions;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -44,7 +43,9 @@ public class PartitionConsumerState {
   private final List<Long> versionsToCheck;
 
   public PartitionConsumerState(long startVersion, List<Long> versionsToCheck) {
-    Preconditions.checkNotNull(versionsToCheck);
+    if (versionsToCheck == null) {
+      throw new IllegalArgumentException("List of versions cannot be null");
+    }
     this.startVersion = startVersion;
     this.versionsToCheck = Collections.unmodifiableList(new ArrayList<>(versionsToCheck));
   }
@@ -58,12 +59,15 @@ public class PartitionConsumerState {
   }
 
   public static PartitionConsumerState fromBytes(byte[] bytes) {
-    Preconditions.checkArgument((bytes.length - 1) % Bytes.SIZEOF_LONG == 0,
-                                "bytes does not have length divisible by %s", Bytes.SIZEOF_LONG);
+    if (((bytes.length - 1) % Bytes.SIZEOF_LONG) != 0) {
+      throw new IllegalArgumentException("bytes does not have length divisible by " + Bytes.SIZEOF_LONG);
+    }
+
     ByteBuffer bb = ByteBuffer.wrap(bytes);
     byte serializationFormatVersion = bb.get();
-    Preconditions.checkArgument(serializationFormatVersion == 0,
-                                "Unsupported serialization format: {}", serializationFormatVersion);
+    if (serializationFormatVersion != 0) {
+      throw new IllegalArgumentException("Unsupported serialization format: " + serializationFormatVersion);
+    }
     long startVersion = bb.getLong();
     List<Long> versionsToCheck = new ArrayList<>();
     while (bb.hasRemaining()) {

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionFilter.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionFilter.java
@@ -16,8 +16,6 @@
 
 package co.cask.cdap.api.dataset.lib;
 
-import com.google.common.base.Preconditions;
-
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -101,7 +99,9 @@ public class PartitionFilter {
     public <T extends Comparable<T>> Builder addRangeCondition(String field,
                                                                @Nullable T lower,
                                                                @Nullable T upper) {
-      Preconditions.checkArgument(field != null && !field.isEmpty(), "field name cannot be null or empty.");
+      if (field == null || field.isEmpty()) {
+        throw new IllegalArgumentException("field name cannot be null or empty.");
+      }
       if (map.containsKey(field)) {
         throw new IllegalArgumentException(String.format("Field '%s' already exists in partition filter.", field));
       }
@@ -123,8 +123,12 @@ public class PartitionFilter {
      *         or if the value is null.
      */
     public <T extends Comparable<T>> Builder addValueCondition(String field, T value) {
-      Preconditions.checkArgument(field != null && !field.isEmpty(), "field name cannot be null or empty.");
-      Preconditions.checkArgument(value != null, "condition value cannot be null.");
+      if (field == null || field.isEmpty()) {
+        throw new IllegalArgumentException("field name cannot be null or empty.");
+      }
+      if (value == null) {
+        throw new IllegalArgumentException("condition value cannot be null.");
+      }
       if (map.containsKey(field)) {
         throw new IllegalArgumentException(String.format("Field '%s' already exists in partition filter.", field));
       }
@@ -138,7 +142,9 @@ public class PartitionFilter {
      * @throws java.lang.IllegalStateException if no fields have been added
      */
     public PartitionFilter build() {
-      Preconditions.checkState(!map.isEmpty(), "Partition filter cannot be empty.");
+      if (map.isEmpty()) {
+        throw new IllegalStateException("Partition filter cannot be empty.");
+      }
       return new PartitionFilter(map);
     }
 
@@ -181,8 +187,10 @@ public class PartitionFilter {
     private final T upper;
     private final boolean isSingleValue;
 
-    private Condition(String fieldName, T lower, T upper) {
-      Preconditions.checkArgument(lower != null || upper != null, "Either lower or upper-bound must be non-null.");
+    private Condition(String fieldName, @Nullable T lower, @Nullable T upper) {
+      if (lower == null && upper == null) {
+        throw new IllegalArgumentException("Either lower or upper-bound must be non-null.");
+      }
       this.fieldName = fieldName;
       this.lower = lower;
       this.upper = upper;
@@ -190,7 +198,9 @@ public class PartitionFilter {
     }
 
     private Condition(String fieldName, T value) {
-      Preconditions.checkArgument(value != null, "Value must not be null.");
+      if (value == null) {
+        throw new IllegalArgumentException("Value must not be null.");
+      }
       this.fieldName = fieldName;
       this.lower = value;
       this.upper = null;

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionKey.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionKey.java
@@ -16,8 +16,6 @@
 
 package co.cask.cdap.api.dataset.lib;
 
-import com.google.common.base.Preconditions;
-
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -94,8 +92,12 @@ public class PartitionKey {
      *         or if the value is null.
      */
     public Builder addField(String name, Comparable value) {
-      Preconditions.checkArgument(name != null && !name.isEmpty(), "field name cannot be null or empty.");
-      Preconditions.checkArgument(value != null, "field name cannot be null.");
+      if (name == null || name.isEmpty()) {
+        throw new IllegalArgumentException("Field name cannot be null or empty.");
+      }
+      if (value == null) {
+        throw new IllegalArgumentException("Field value cannot be null.");
+      }
       if (fields.containsKey(name)) {
         throw new IllegalArgumentException(String.format("Field '%s' already exists in partition key.", name));
       }
@@ -148,7 +150,9 @@ public class PartitionKey {
      * @throws java.lang.IllegalStateException if no fields have been added
      */
     public PartitionKey build() {
-      Preconditions.checkState(!fields.isEmpty(), "Partition key cannot be empty.");
+      if (fields.isEmpty()) {
+        throw new IllegalStateException("Partition key cannot be empty.");
+      }
       return new PartitionKey(fields);
     }
   }

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/Partitioning.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/Partitioning.java
@@ -16,8 +16,6 @@
 
 package co.cask.cdap.api.dataset.lib;
 
-import com.google.common.base.Preconditions;
-
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -116,8 +114,12 @@ public class Partitioning {
      *         or if the type is null.
      */
     public Builder addField(@Nonnull String name, @Nonnull FieldType type) {
-      Preconditions.checkArgument(name != null && !name.isEmpty(), "Field name cannot be null or empty.");
-      Preconditions.checkArgument(type != null, "Field type cannot be null.");
+      if (name == null || name.isEmpty()) {
+        throw new IllegalArgumentException("Field name cannot be null or empty.");
+      }
+      if (type == null) {
+        throw new IllegalArgumentException("Field type cannot be null.");
+      }
       if (fields.containsKey(name)) {
         throw new IllegalArgumentException(String.format("Field '%s' already exists in partitioning.", name));
       }
@@ -164,7 +166,9 @@ public class Partitioning {
      * @throws java.lang.IllegalStateException if no fields have been added
      */
     public Partitioning build() {
-      Preconditions.checkState(!fields.isEmpty(), "Partitioning cannot be empty.");
+      if (fields.isEmpty()) {
+        throw new IllegalStateException("Partitioning cannot be empty.");
+      }
       return new Partitioning(fields);
     }
   }

--- a/cdap-api/src/main/java/co/cask/cdap/api/flow/FlowSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/flow/FlowSpecification.java
@@ -22,10 +22,9 @@ import co.cask.cdap.api.flow.flowlet.Flowlet;
 import co.cask.cdap.internal.UserErrors;
 import co.cask.cdap.internal.UserMessages;
 import co.cask.cdap.internal.flow.DefaultFlowSpecification;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -79,8 +78,8 @@ public interface FlowSpecification extends ProgramSpecification {
   static final class Builder {
     private String name;
     private String description;
-    private final Map<String, FlowletDefinition> flowlets = Maps.newHashMap();
-    private final List<FlowletConnection> connections = Lists.newArrayList();
+    private final Map<String, FlowletDefinition> flowlets = new HashMap<>();
+    private final List<FlowletConnection> connections = new ArrayList<>();
 
     /**
      * Creates a {@link Builder} for building instance of {@link FlowSpecification}.
@@ -102,7 +101,9 @@ public interface FlowSpecification extends ProgramSpecification {
        * @return An instance of {@link DescriptionSetter}
        */
       public DescriptionSetter setName(String name) {
-        Preconditions.checkArgument(name != null, UserMessages.getMessage(UserErrors.FLOW_SPEC_NAME));
+        if (name == null) {
+          throw new IllegalArgumentException(UserMessages.getMessage(UserErrors.FLOW_SPEC_NAME));
+        }
 
         Builder.this.name = name;
         return new DescriptionSetter();
@@ -120,7 +121,9 @@ public interface FlowSpecification extends ProgramSpecification {
        * @return An instance of {@link AfterDescription}
        */
       public AfterDescription setDescription(String description) {
-        Preconditions.checkArgument(description != null, UserMessages.getMessage(UserErrors.FLOW_SPEC_DESC));
+        if (description == null) {
+          throw new IllegalArgumentException(UserMessages.getMessage(UserErrors.FLOW_SPEC_DESC));
+        }
         Builder.this.description = description;
         return new AfterDescription();
       }
@@ -206,17 +209,22 @@ public interface FlowSpecification extends ProgramSpecification {
 
       @Override
       public MoreFlowlet add(String name, Flowlet flowlet, int instances) {
-
-        Preconditions.checkArgument(flowlet != null, UserMessages.getMessage(UserErrors.INVALID_FLOWLET_NULL));
+        if (flowlet == null) {
+          throw new IllegalArgumentException(UserMessages.getMessage(UserErrors.INVALID_FLOWLET_NULL));
+        }
 
         FlowletDefinition flowletDef = new FlowletDefinition(name, flowlet, instances);
         String flowletName = flowletDef.getFlowletSpec().getName();
 
-        Preconditions.checkArgument(instances > 0, String.format(UserMessages.getMessage(UserErrors.INVALID_INSTANCES),
-          flowletName, instances));
+        if (instances <= 0) {
+          throw new IllegalArgumentException(String.format(UserMessages.getMessage(UserErrors.INVALID_INSTANCES),
+                                                           flowletName, instances));
+        }
 
-        Preconditions.checkArgument(!flowlets.containsKey(flowletName),
-                UserMessages.getMessage(UserErrors.INVALID_FLOWLET_EXISTS), flowletName);
+        if (flowlets.containsKey(flowletName)) {
+          throw new IllegalArgumentException(String.format(UserMessages.getMessage(UserErrors.INVALID_FLOWLET_EXISTS),
+                                                           flowletName));
+        }
 
         flowlets.put(flowletName, flowletDef);
 
@@ -307,20 +315,29 @@ public interface FlowSpecification extends ProgramSpecification {
 
       @Override
       public ConnectTo from(Flowlet flowlet) {
-        Preconditions.checkArgument(flowlet != null, UserMessages.getMessage(UserErrors.INVALID_FLOWLET_NULL));
+        if (flowlet == null) {
+          throw new IllegalArgumentException(UserMessages.getMessage(UserErrors.INVALID_FLOWLET_NULL));
+        }
         return from(flowlet.configure().getName());
       }
 
       @Override
       public ConnectTo from(Stream stream) {
-        Preconditions.checkArgument(stream != null, UserMessages.getMessage(UserErrors.INVALID_STREAM_NULL));
+        if (stream == null) {
+          throw new IllegalArgumentException(UserMessages.getMessage(UserErrors.INVALID_STREAM_NULL));
+        }
         return fromStream(stream.configure().getName());
       }
 
       @Override
       public ConnectTo from(String flowlet) {
-        Preconditions.checkArgument(flowlets.containsKey(flowlet),
-                                    UserMessages.getMessage(UserErrors.INVALID_FLOWLET_NAME), flowlet);
+        if (flowlet == null) {
+          throw new IllegalArgumentException(UserMessages.getMessage(UserErrors.INVALID_FLOWLET_NULL));
+        }
+        if (!flowlets.containsKey(flowlet)) {
+          throw new IllegalArgumentException(String.format(UserMessages.getMessage(UserErrors.INVALID_FLOWLET_NAME),
+                                                           flowlet));
+        }
         fromFlowlet = flowlets.get(flowlet);
         fromStream = null;
         return this;
@@ -328,7 +345,9 @@ public interface FlowSpecification extends ProgramSpecification {
 
       @Override
       public ConnectTo fromStream(String stream) {
-        Preconditions.checkArgument(stream != null, UserMessages.getMessage(UserErrors.INVALID_STREAM_NAME), stream);
+        if (stream == null) {
+          throw new IllegalArgumentException(UserMessages.getMessage(UserErrors.INVALID_STREAM_NULL));
+        }
         fromFlowlet = null;
         fromStream = stream;
         return this;
@@ -336,15 +355,21 @@ public interface FlowSpecification extends ProgramSpecification {
 
       @Override
       public MoreConnect to(Flowlet flowlet) {
-        Preconditions.checkArgument(flowlet != null, UserMessages.getMessage(UserErrors.INVALID_FLOWLET_NULL));
+        if (flowlet == null) {
+          throw new IllegalArgumentException(UserMessages.getMessage(UserErrors.INVALID_FLOWLET_NULL));
+        }
         return to(flowlet.configure().getName());
       }
 
       @Override
       public MoreConnect to(String flowlet) {
-        Preconditions.checkArgument(flowlet != null, UserMessages.getMessage(UserErrors.INVALID_FLOWLET_NULL));
-        Preconditions.checkArgument(flowlets.containsKey(flowlet),
-                                    UserMessages.getMessage(UserErrors.INVALID_FLOWLET_NAME), flowlet);
+        if (flowlet == null) {
+          throw new IllegalArgumentException(UserMessages.getMessage(UserErrors.INVALID_FLOWLET_NULL));
+        }
+        if (!flowlets.containsKey(flowlet)) {
+          throw new IllegalArgumentException(String.format(UserMessages.getMessage(UserErrors.INVALID_FLOWLET_NAME),
+                                                           flowlet));
+        }
 
         FlowletConnection.Type sourceType;
         String sourceName;

--- a/cdap-api/src/main/java/co/cask/cdap/api/flow/flowlet/FlowletSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/flow/flowlet/FlowletSpecification.java
@@ -19,10 +19,10 @@ package co.cask.cdap.api.flow.flowlet;
 import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.common.PropertyProvider;
 import co.cask.cdap.internal.flowlet.DefaultFlowletSpecification;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -80,12 +80,12 @@ public interface FlowletSpecification extends PropertyProvider {
    * not reusable, meaning each instance of this class can only be used to create one instance
    * of {@link FlowletSpecification}.
    */
-  static final class Builder {
+  final class Builder {
 
     private String name;
     private String description;
     private FailurePolicy failurePolicy = FailurePolicy.RETRY;
-    private final ImmutableSet.Builder<String> dataSets = ImmutableSet.builder();
+    private final Set<String> dataSets = new HashSet<>();
     private Map<String, String> arguments;
     private Resources resources = new Resources();
 
@@ -105,7 +105,9 @@ public interface FlowletSpecification extends PropertyProvider {
        * @return An instance of {@link DescriptionSetter}
        */
       public DescriptionSetter setName(String name) {
-        Preconditions.checkArgument(name != null, "Name cannot be null.");
+        if (name == null) {
+          throw new IllegalArgumentException("Name cannot be null.");
+        }
         Builder.this.name = name;
         return new DescriptionSetter();
       }
@@ -121,7 +123,9 @@ public interface FlowletSpecification extends PropertyProvider {
        * @return An instance of what needs to be done after description {@link AfterDescription}
        */
       public AfterDescription setDescription(String description) {
-        Preconditions.checkArgument(description != null, "Description cannot be null.");
+        if (description == null) {
+          throw new IllegalArgumentException("Description cannot be null.");
+        }
         Builder.this.description = description;
         return new AfterDescription();
       }
@@ -138,7 +142,9 @@ public interface FlowletSpecification extends PropertyProvider {
        * @return An instance of {@link AfterDescription}
        */
       public AfterDescription setFailurePolicy(FailurePolicy policy) {
-        Preconditions.checkArgument(policy != null, "FailurePolicy cannot be null");
+        if (policy == null) {
+          throw new IllegalArgumentException("FailurePolicy cannot be null");
+        }
         failurePolicy = policy;
         return this;
       }
@@ -151,7 +157,8 @@ public interface FlowletSpecification extends PropertyProvider {
        * @return An instance of {@link AfterDescription}.
        */
       public AfterDescription useDataSet(String dataSet, String...moreDataSets) {
-        dataSets.add(dataSet).add(moreDataSets);
+        dataSets.add(dataSet);
+        dataSets.addAll(Arrays.asList(moreDataSets));
         return this;
       }
 
@@ -162,12 +169,14 @@ public interface FlowletSpecification extends PropertyProvider {
        * @return An instance of {@link AfterDescription}.
        */
       public AfterDescription withArguments(Map<String, String> args) {
-        arguments = ImmutableMap.copyOf(args);
+        arguments = new HashMap<>(args);
         return this;
       }
 
       public AfterDescription withResources(Resources resources) {
-        Preconditions.checkArgument(resources != null, "Resources cannot be null.");
+        if (resources == null) {
+          throw new IllegalArgumentException("Resources cannot be null.");
+        }
         Builder.this.resources = resources;
         return this;
       }
@@ -177,8 +186,7 @@ public interface FlowletSpecification extends PropertyProvider {
        * @return An instance of {@link FlowletSpecification}.
        */
       public FlowletSpecification build() {
-        return new DefaultFlowletSpecification(name, description, failurePolicy,
-                                               dataSets.build(), arguments, resources);
+        return new DefaultFlowletSpecification(name, description, failurePolicy, dataSets, arguments, resources);
       }
     }
 

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowActionSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowActionSpecification.java
@@ -19,10 +19,10 @@ package co.cask.cdap.api.workflow;
 import co.cask.cdap.api.common.PropertyProvider;
 import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.internal.workflow.DefaultWorkflowActionSpecification;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Maps;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -54,11 +54,11 @@ public interface WorkflowActionSpecification extends PropertyProvider {
   /**
    * Builder class for building the {@link WorkflowActionSpecification}.
    */
-  static final class Builder {
+  final class Builder {
     private String name;
     private String description;
-    private Map<String, String> options = Maps.newHashMap();
-    private final ImmutableSet.Builder<String> datasets = ImmutableSet.builder();
+    private Map<String, String> options = new HashMap<>();
+    private final Set<String> datasets = new HashSet<>();
 
     public static NameSetter with() {
       return new Builder().new NameSetter();
@@ -71,7 +71,9 @@ public interface WorkflowActionSpecification extends PropertyProvider {
        * @return An instance of {@link DescriptionSetter}
        */
       public DescriptionSetter setName(String name) {
-        Preconditions.checkArgument(name != null, "Name cannot be null.");
+        if (name == null) {
+          throw new IllegalArgumentException("Name cannot be null.");
+        }
         Builder.this.name = name;
         return new DescriptionSetter();
       }
@@ -87,7 +89,9 @@ public interface WorkflowActionSpecification extends PropertyProvider {
        * @return An instance of what needs to be done after description {@link AfterDescription}
        */
       public AfterDescription setDescription(String description) {
-        Preconditions.checkArgument(description != null, "Description cannot be null.");
+        if (description == null) {
+          throw new IllegalArgumentException("Description cannot be null.");
+        }
         Builder.this.description = description;
         return new AfterDescription();
       }
@@ -104,12 +108,13 @@ public interface WorkflowActionSpecification extends PropertyProvider {
       }
 
       public AfterDescription useDataset(String dataset, String...moreDatasets) {
-        Builder.this.datasets.add(dataset).add(moreDatasets);
+        datasets.add(dataset);
+        datasets.addAll(Arrays.asList(moreDatasets));
         return this;
       }
 
       public WorkflowActionSpecification build() {
-        return new DefaultWorkflowActionSpecification(name, description, options, datasets.build());
+        return new DefaultWorkflowActionSpecification(name, description, options, datasets);
       }
     }
 

--- a/cdap-api/src/main/java/co/cask/cdap/internal/api/DefaultDatasetConfigurer.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/api/DefaultDatasetConfigurer.java
@@ -23,7 +23,6 @@ import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.module.DatasetModule;
 import co.cask.cdap.internal.dataset.DatasetCreationSpec;
-import com.google.common.base.Preconditions;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -64,35 +63,35 @@ public class DefaultDatasetConfigurer implements DatasetConfigurer {
 
   @Override
   public void addStream(Stream stream) {
-    Preconditions.checkArgument(stream != null, "Stream cannot be null.");
+    checkArgument(stream != null, "Stream cannot be null.");
     StreamSpecification spec = stream.configure();
     streams.put(spec.getName(), spec);
   }
 
   @Override
   public void addStream(String streamName) {
-    Preconditions.checkArgument(streamName != null && !streamName.isEmpty(), "Stream Name cannot be null or empty");
+    checkArgument(streamName != null && !streamName.isEmpty(), "Stream Name cannot be null or empty");
     addStream(new Stream(streamName));
   }
 
   @Override
   public void addDatasetModule(String moduleName, Class<? extends DatasetModule> moduleClass) {
-    Preconditions.checkArgument(moduleName != null, "Dataset module name cannot be null.");
-    Preconditions.checkArgument(moduleClass != null, "Dataset module class cannot be null.");
+    checkArgument(moduleName != null, "Dataset module name cannot be null.");
+    checkArgument(moduleClass != null, "Dataset module class cannot be null.");
     datasetModules.put(moduleName, moduleClass.getName());
   }
 
   @Override
   public void addDatasetType(Class<? extends Dataset> datasetClass) {
-    Preconditions.checkArgument(datasetClass != null, "Dataset class cannot be null.");
+    checkArgument(datasetClass != null, "Dataset class cannot be null.");
     datasetModules.put(datasetClass.getName(), datasetClass.getName());
   }
 
   @Override
   public void createDataset(String datasetInstanceName, String typeName, DatasetProperties properties) {
-    Preconditions.checkArgument(datasetInstanceName != null, "Dataset instance name cannot be null.");
-    Preconditions.checkArgument(typeName != null, "Dataset type name cannot be null.");
-    Preconditions.checkArgument(properties != null, "Instance properties name cannot be null.");
+    checkArgument(datasetInstanceName != null, "Dataset instance name cannot be null.");
+    checkArgument(typeName != null, "Dataset type name cannot be null.");
+    checkArgument(properties != null, "Instance properties name cannot be null.");
     datasetSpecs.put(datasetInstanceName,
                          new DatasetCreationSpec(datasetInstanceName, typeName, properties));
   }
@@ -105,9 +104,9 @@ public class DefaultDatasetConfigurer implements DatasetConfigurer {
   @Override
   public void createDataset(String datasetInstanceName, Class<? extends Dataset> datasetClass,
                             DatasetProperties properties) {
-    Preconditions.checkArgument(datasetInstanceName != null, "Dataset instance name cannot be null.");
-    Preconditions.checkArgument(datasetClass != null, "Dataset class name cannot be null.");
-    Preconditions.checkArgument(properties != null, "Instance properties name cannot be null.");
+    checkArgument(datasetInstanceName != null, "Dataset instance name cannot be null.");
+    checkArgument(datasetClass != null, "Dataset class name cannot be null.");
+    checkArgument(properties != null, "Instance properties name cannot be null.");
     datasetSpecs.put(datasetInstanceName,
                          new DatasetCreationSpec(datasetInstanceName, datasetClass.getName(), properties));
     datasetModules.put(datasetClass.getName(), datasetClass.getName());
@@ -116,5 +115,11 @@ public class DefaultDatasetConfigurer implements DatasetConfigurer {
   @Override
   public void createDataset(String datasetName, Class<? extends Dataset> datasetClass) {
     createDataset(datasetName, datasetClass, DatasetProperties.EMPTY);
+  }
+
+  private void checkArgument(boolean condition, String template, Object...args) {
+    if (!condition) {
+      throw new IllegalArgumentException(String.format(template, args));
+    }
   }
 }

--- a/cdap-api/src/main/java/co/cask/cdap/internal/flow/DefaultFlowSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/flow/DefaultFlowSpecification.java
@@ -19,9 +19,10 @@ package co.cask.cdap.internal.flow;
 import co.cask.cdap.api.flow.FlowSpecification;
 import co.cask.cdap.api.flow.FlowletConnection;
 import co.cask.cdap.api.flow.FlowletDefinition;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -50,8 +51,8 @@ public final class DefaultFlowSpecification implements FlowSpecification {
     this.className = className;
     this.name = name;
     this.description = description;
-    this.flowlets = ImmutableMap.copyOf(flowlets);
-    this.connections = ImmutableList.copyOf(connections);
+    this.flowlets = Collections.unmodifiableMap(new HashMap<>(flowlets));
+    this.connections = Collections.unmodifiableList(new ArrayList<>(connections));
   }
 
   @Override

--- a/cdap-api/src/main/java/co/cask/cdap/internal/flow/DefaultFlowletConfigurer.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/flow/DefaultFlowletConfigurer.java
@@ -25,9 +25,6 @@ import co.cask.cdap.internal.api.DefaultDatasetConfigurer;
 import co.cask.cdap.internal.flowlet.DefaultFlowletSpecification;
 import co.cask.cdap.internal.lang.Reflections;
 import co.cask.cdap.internal.specification.PropertyFieldExtractor;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -56,7 +53,7 @@ public class DefaultFlowletConfigurer extends DefaultDatasetConfigurer implement
     this.propertyFields = new HashMap<>();
     this.description = "";
     this.resources = new Resources();
-    this.properties = ImmutableMap.of();
+    this.properties = new HashMap<>();
     this.datasets = new HashSet<>();
 
     // Grab all @Property fields
@@ -75,24 +72,30 @@ public class DefaultFlowletConfigurer extends DefaultDatasetConfigurer implement
 
   @Override
   public void setResources(Resources resources) {
-    Preconditions.checkArgument(resources != null, "Resources cannot be null.");
+    if (resources == null) {
+      throw new IllegalArgumentException("Resources cannot be null.");
+    }
     this.resources = resources;
   }
 
   @Override
   public void setFailurePolicy(FailurePolicy failurePolicy) {
-    Preconditions.checkArgument(failurePolicy != null, "FailurePolicy cannot be null");
+    if (failurePolicy == null) {
+      throw new IllegalArgumentException("FailurePolicy cannot be null");
+    }
     this.failurePolicy = failurePolicy;
   }
 
   @Override
   public void setProperties(Map<String, String> properties) {
-    this.properties = ImmutableMap.copyOf(properties);
+    this.properties = new HashMap<>(properties);
   }
 
   @Override
   public void useDatasets(Iterable<String> datasets) {
-    Iterables.addAll(this.datasets, datasets);
+    for (String dataset : datasets) {
+      this.datasets.add(dataset);
+    }
   }
 
   public FlowletSpecification createSpecification() {

--- a/cdap-api/src/main/java/co/cask/cdap/internal/flowlet/DefaultFlowletSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/flowlet/DefaultFlowletSpecification.java
@@ -19,9 +19,10 @@ package co.cask.cdap.internal.flowlet;
 import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.flow.flowlet.FailurePolicy;
 import co.cask.cdap.api.flow.flowlet.FlowletSpecification;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -52,8 +53,9 @@ public final class DefaultFlowletSpecification implements FlowletSpecification {
     this.name = name;
     this.description = description;
     this.failurePolicy = failurePolicy;
-    this.dataSets = ImmutableSet.copyOf(dataSets);
-    this.properties = properties == null ? ImmutableMap.<String, String>of() : ImmutableMap.copyOf(properties);
+    this.dataSets = Collections.unmodifiableSet(new HashSet<>(dataSets));
+    this.properties = Collections.unmodifiableMap(properties == null ? new HashMap<String, String>()
+                                                                     : new HashMap<>(properties));
     this.resources = resources;
   }
 

--- a/cdap-api/src/main/java/co/cask/cdap/internal/lang/FieldVisitor.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/lang/FieldVisitor.java
@@ -15,9 +15,8 @@
  */
 package co.cask.cdap.internal.lang;
 
-import com.google.common.reflect.TypeToken;
-
 import java.lang.reflect.Method;
+import java.lang.reflect.Type;
 
 /**
  * Visitor for visiting class field.
@@ -25,8 +24,7 @@ import java.lang.reflect.Method;
 public abstract class FieldVisitor implements Visitor {
 
   @Override
-  public final void visit(Object instance, TypeToken<?> inspectType,
-                          TypeToken<?> declareType, Method method) throws Exception {
+  public final void visit(Object instance, Type inspectType, Type declareType, Method method) throws Exception {
     // No-op
   }
 }

--- a/cdap-api/src/main/java/co/cask/cdap/internal/lang/Fields.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/lang/Fields.java
@@ -16,8 +16,6 @@
 
 package co.cask.cdap.internal.lang;
 
-import com.google.common.base.Predicate;
-import com.google.common.base.Predicates;
 import com.google.common.reflect.TypeToken;
 
 import java.lang.reflect.Field;
@@ -36,25 +34,9 @@ public final class Fields {
    * @throws NoSuchFieldException If the field is not found.
    */
   public static Field findField(Type classType, String fieldName) throws NoSuchFieldException {
-    return findField(classType, fieldName, Predicates.<Field>alwaysTrue());
-  }
-
-  /**
-   * Find a {@link Field} in the class hierarchy of the given type that passes the predicate.
-   * @param classType The leaf class to start with.
-   * @param fieldName Name of the field.
-   * @param predicate Predicate for accepting a matched field.
-   * @return A {@link Field} if found.
-   * @throws NoSuchFieldException If the field is not found.
-   */
-  public static Field findField(Type classType, String fieldName,
-                                Predicate<Field> predicate) throws NoSuchFieldException {
     for (Class<?> clz : TypeToken.of(classType).getTypes().classes().rawTypes()) {
       try {
-        Field field = clz.getDeclaredField(fieldName);
-        if (predicate.apply(field)) {
-          return field;
-        }
+        return clz.getDeclaredField(fieldName);
       } catch (NoSuchFieldException e) {
         // OK to ignore, keep finding.
       }

--- a/cdap-api/src/main/java/co/cask/cdap/internal/lang/Fields.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/lang/Fields.java
@@ -21,6 +21,7 @@ import com.google.common.base.Predicates;
 import com.google.common.reflect.TypeToken;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Type;
 
 /**
  *
@@ -34,7 +35,7 @@ public final class Fields {
    * @return A {@link Field} if found.
    * @throws NoSuchFieldException If the field is not found.
    */
-  public static Field findField(TypeToken<?> classType, String fieldName) throws NoSuchFieldException {
+  public static Field findField(Type classType, String fieldName) throws NoSuchFieldException {
     return findField(classType, fieldName, Predicates.<Field>alwaysTrue());
   }
 
@@ -46,9 +47,9 @@ public final class Fields {
    * @return A {@link Field} if found.
    * @throws NoSuchFieldException If the field is not found.
    */
-  public static Field findField(TypeToken<?> classType, String fieldName,
+  public static Field findField(Type classType, String fieldName,
                                 Predicate<Field> predicate) throws NoSuchFieldException {
-    for (Class<?> clz : classType.getTypes().classes().rawTypes()) {
+    for (Class<?> clz : TypeToken.of(classType).getTypes().classes().rawTypes()) {
       try {
         Field field = clz.getDeclaredField(fieldName);
         if (predicate.apply(field)) {

--- a/cdap-api/src/main/java/co/cask/cdap/internal/lang/MethodVisitor.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/lang/MethodVisitor.java
@@ -15,9 +15,8 @@
  */
 package co.cask.cdap.internal.lang;
 
-import com.google.common.reflect.TypeToken;
-
 import java.lang.reflect.Field;
+import java.lang.reflect.Type;
 
 /**
  * Visitor for visiting class method.
@@ -25,8 +24,7 @@ import java.lang.reflect.Field;
 public abstract class MethodVisitor implements Visitor {
 
   @Override
-  public final void visit(Object instance, TypeToken<?> inspectType,
-                          TypeToken<?> declareType, Field field) throws Exception {
+  public final void visit(Object instance, Type inspectType, Type declareType, Field field) throws Exception {
     // no-op
   }
 }

--- a/cdap-api/src/main/java/co/cask/cdap/internal/lang/Reflections.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/lang/Reflections.java
@@ -72,7 +72,7 @@ public final class Reflections {
             field.setAccessible(true);
           }
           for (Visitor visitor : visitors) {
-            visitor.visit(instance, inspectTypeToken, type, field);
+            visitor.visit(instance, inspectTypeToken.getType(), type.getType(), field);
           }
         }
 
@@ -84,7 +84,7 @@ public final class Reflections {
             method.setAccessible(true);
           }
           for (Visitor visitor : visitors) {
-            visitor.visit(instance, inspectTypeToken, type, method);
+            visitor.visit(instance, inspectTypeToken.getType(), type.getType(), method);
           }
         }
       }

--- a/cdap-api/src/main/java/co/cask/cdap/internal/lang/Reflections.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/lang/Reflections.java
@@ -15,8 +15,6 @@
  */
 package co.cask.cdap.internal.lang;
 
-import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableList;
 import com.google.common.reflect.TypeToken;
 
 import java.lang.reflect.Field;
@@ -24,6 +22,8 @@ import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -57,7 +57,9 @@ public final class Reflections {
   public static void visit(Object instance, Type inspectType, Visitor firstVisitor, Visitor... moreVisitors) {
     try {
       TypeToken<?> inspectTypeToken = TypeToken.of(inspectType);
-      List<Visitor> visitors = ImmutableList.<Visitor>builder().add(firstVisitor).add(moreVisitors).build();
+      List<Visitor> visitors = new ArrayList<>(1 + moreVisitors.length);
+      visitors.add(firstVisitor);
+      Collections.addAll(visitors, moreVisitors);
 
       for (TypeToken<?> type : inspectTypeToken.getTypes().classes()) {
         if (Object.class.equals(type.getRawType())) {
@@ -88,8 +90,10 @@ public final class Reflections {
           }
         }
       }
+    } catch (RuntimeException e) {
+      throw e;
     } catch (Exception e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 

--- a/cdap-api/src/main/java/co/cask/cdap/internal/lang/Visitor.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/lang/Visitor.java
@@ -15,10 +15,9 @@
  */
 package co.cask.cdap.internal.lang;
 
-import com.google.common.reflect.TypeToken;
-
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.lang.reflect.Type;
 
 /**
  * Visitor for visiting class members.
@@ -28,10 +27,10 @@ public interface Visitor {
   /**
    * Visits a field in the given type. The field might be declared in one of the parent class of the type.
    */
-  void visit(Object instance, TypeToken<?> inspectType, TypeToken<?> declareType, Field field) throws Exception;
+  void visit(Object instance, Type inspectType, Type declareType, Field field) throws Exception;
 
   /**
    * Visits a method in the given type. The method might be declared in one of the parent class of the type.
    */
-  void visit(Object instance, TypeToken<?> inspectType, TypeToken<?> declareType, Method method) throws Exception;
+  void visit(Object instance, Type inspectType, Type declareType, Method method) throws Exception;
 }

--- a/cdap-api/src/main/java/co/cask/cdap/internal/specification/DataSetFieldExtractor.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/specification/DataSetFieldExtractor.java
@@ -18,9 +18,9 @@ package co.cask.cdap.internal.specification;
 import co.cask.cdap.api.annotation.UseDataSet;
 import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.internal.lang.FieldVisitor;
-import com.google.common.reflect.TypeToken;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Type;
 import java.util.Set;
 
 /**
@@ -39,7 +39,7 @@ public final class DataSetFieldExtractor extends FieldVisitor {
   }
 
   @Override
-  public void visit(Object instance, TypeToken<?> inspectType, TypeToken<?> declareType, Field field) {
+  public void visit(Object instance, Type inspectType, Type declareType, Field field) {
     if (Dataset.class.isAssignableFrom(field.getType())) {
       UseDataSet dataset = field.getAnnotation(UseDataSet.class);
       if (dataset == null || dataset.value().isEmpty()) {

--- a/cdap-api/src/main/java/co/cask/cdap/internal/specification/OutputEmitterFieldExtractor.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/specification/OutputEmitterFieldExtractor.java
@@ -20,13 +20,13 @@ import co.cask.cdap.api.flow.FlowletDefinition;
 import co.cask.cdap.api.flow.flowlet.OutputEmitter;
 import co.cask.cdap.internal.lang.FieldVisitor;
 import co.cask.cdap.internal.lang.Reflections;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.reflect.TypeToken;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -49,9 +49,10 @@ public final class OutputEmitterFieldExtractor extends FieldVisitor {
 
     TypeToken<?> inspectTypeToken = TypeToken.of(inspectType);
     Type emitterType = inspectTypeToken.resolveType(field.getGenericType()).getType();
-    Preconditions.checkArgument(emitterType instanceof ParameterizedType,
-                                "Type info missing for OutputEmitter in %s.%s",
-                                inspectTypeToken.getRawType().getName(), field.getName());
+    if (!(emitterType instanceof ParameterizedType)) {
+      throw new IllegalArgumentException(String.format("Type info missing for OutputEmitter in %s.%s",
+                                                       inspectTypeToken.getRawType().getName(), field.getName()));
+    }
 
     // Extract the Output type from the first type argument of OutputEmitter.
     Type outputType = ((ParameterizedType) emitterType).getActualTypeArguments()[0];
@@ -59,16 +60,20 @@ public final class OutputEmitterFieldExtractor extends FieldVisitor {
     String outputName = field.isAnnotationPresent(Output.class) ?
       field.getAnnotation(Output.class).value() : FlowletDefinition.DEFAULT_OUTPUT;
 
-    Preconditions.checkArgument(Reflections.isResolved(outputType),
-                                "Invalid type in %s.%s. Only Class or ParameterizedType are supported.",
-                                inspectTypeToken.getRawType().getName(), field.getName());
+    if (!Reflections.isResolved(outputType)) {
+      throw new IllegalArgumentException(
+        String.format("Invalid type in %s.%s. Only Class or ParameterizedType are supported.",
+                      inspectTypeToken.getRawType().getName(), field.getName()));
+    }
 
-    Preconditions.checkArgument(
-      !outputTypes.containsKey(outputName),
-      "Output with name '%s' already exists. Use @Output with different name; class: %s, field: %s",
-      outputName, inspectTypeToken.getRawType().toString(), field.getName()
-    );
+    if (outputTypes.containsKey(outputName)) {
+      throw new IllegalArgumentException(
+        String.format("Output with name '%s' already exists. Use @Output with different name; class: %s, field: %s",
+                      outputName, inspectTypeToken.getRawType().toString(), field.getName()));
+    }
 
-    outputTypes.put(outputName, ImmutableSet.of(outputType));
+    Set<Type> types = new HashSet<>();
+    types.add(outputType);
+    outputTypes.put(outputName, Collections.unmodifiableSet(types));
   }
 }

--- a/cdap-api/src/main/java/co/cask/cdap/internal/specification/PropertyFieldExtractor.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/specification/PropertyFieldExtractor.java
@@ -22,6 +22,7 @@ import com.google.common.reflect.TypeToken;
 import com.google.gson.internal.Primitives;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Type;
 import java.util.Map;
 
 /**
@@ -40,11 +41,11 @@ public final class PropertyFieldExtractor extends FieldVisitor {
   }
 
   @Override
-  public void visit(Object instance, TypeToken<?> inspectType, TypeToken<?> declareType, Field field) throws Exception {
+  public void visit(Object instance, Type inspectType, Type declareType, Field field) throws Exception {
     if (field.isAnnotationPresent(Property.class)) {
 
       // Key name is "className.fieldName".
-      String key = declareType.getRawType().getName() + '.' + field.getName();
+      String key = TypeToken.of(declareType).getRawType().getName() + '.' + field.getName();
       if (properties.containsKey(key)) {
         return;
       }

--- a/cdap-api/src/main/java/co/cask/cdap/internal/specification/PropertyFieldExtractor.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/specification/PropertyFieldExtractor.java
@@ -17,7 +17,6 @@ package co.cask.cdap.internal.specification;
 
 import co.cask.cdap.api.annotation.Property;
 import co.cask.cdap.internal.lang.FieldVisitor;
-import com.google.common.base.Preconditions;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.internal.Primitives;
 
@@ -65,11 +64,12 @@ public final class PropertyFieldExtractor extends FieldVisitor {
     Class<?> fieldType = field.getType();
 
     // Only support primitive type, boxed type, String and Enum
-    Preconditions.checkArgument(
-      fieldType.isPrimitive() || Primitives.isWrapperType(fieldType) ||
-        String.class.equals(fieldType) || fieldType.isEnum(),
-      "Unsupported property type %s of field %s in class %s.",
-      fieldType.getName(), field.getName(), field.getDeclaringClass().getName());
+    if (!fieldType.isPrimitive() && !Primitives.isWrapperType(fieldType)
+      && !String.class.equals(fieldType) && !fieldType.isEnum()) {
+      throw new IllegalArgumentException(
+        String.format("Unsupported property type %s of field %s in class %s.",
+                      fieldType.getName(), field.getName(), field.getDeclaringClass().getName()));
+    }
 
     if (!field.isAccessible()) {
       field.setAccessible(true);

--- a/cdap-api/src/main/java/co/cask/cdap/internal/workflow/DefaultWorkflowActionSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/workflow/DefaultWorkflowActionSpecification.java
@@ -20,12 +20,10 @@ import co.cask.cdap.api.workflow.WorkflowActionSpecification;
 import co.cask.cdap.internal.lang.Reflections;
 import co.cask.cdap.internal.specification.DataSetFieldExtractor;
 import co.cask.cdap.internal.specification.PropertyFieldExtractor;
-import com.google.common.base.Objects;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -42,18 +40,14 @@ public class DefaultWorkflowActionSpecification implements WorkflowActionSpecifi
 
   public DefaultWorkflowActionSpecification(String name, String description,
                                             Map<String, String> properties, Set<String> datasets) {
-    this.className = null;
-    this.name = name;
-    this.description = description;
-    this.properties = ImmutableMap.copyOf(properties);
-    this.datasets = ImmutableSet.copyOf(datasets);
+    this(null, name, description, properties, datasets);
   }
 
   public DefaultWorkflowActionSpecification(WorkflowAction action) {
     WorkflowActionSpecification spec = action.configure();
 
-    Map<String, String> properties = Maps.newHashMap(spec.getProperties());
-    Set<String> datasets = Sets.newHashSet();
+    Map<String, String> properties = new HashMap<>(spec.getProperties());
+    Set<String> datasets = new HashSet<>();
     Reflections.visit(action, action.getClass(),
                       new DataSetFieldExtractor(datasets),
                       new PropertyFieldExtractor(properties));
@@ -64,8 +58,8 @@ public class DefaultWorkflowActionSpecification implements WorkflowActionSpecifi
     this.className = action.getClass().getName();
     this.name = spec.getName();
     this.description = spec.getDescription();
-    this.properties = ImmutableMap.copyOf(properties);
-    this.datasets = ImmutableSet.copyOf(datasets);
+    this.properties = Collections.unmodifiableMap(new HashMap<>(properties));
+    this.datasets = Collections.unmodifiableSet(new HashSet<>(datasets));
   }
 
   public DefaultWorkflowActionSpecification(String className, String name, String description,
@@ -73,8 +67,8 @@ public class DefaultWorkflowActionSpecification implements WorkflowActionSpecifi
     this.className = className;
     this.name = name;
     this.description = description;
-    this.properties = ImmutableMap.copyOf(properties);
-    this.datasets = ImmutableSet.copyOf(datasets);
+    this.properties = Collections.unmodifiableMap(new HashMap<>(properties));
+    this.datasets = Collections.unmodifiableSet(new HashSet<>(datasets));
   }
 
   @Override
@@ -104,12 +98,13 @@ public class DefaultWorkflowActionSpecification implements WorkflowActionSpecifi
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(WorkflowActionSpecification.class)
-      .add("name", name)
-      .add("class", className)
-      .add("options", properties)
-      .add("datasets", datasets)
-      .toString();
+    return "DefaultWorkflowActionSpecification{" +
+      "className='" + className + '\'' +
+      ", name='" + name + '\'' +
+      ", description='" + description + '\'' +
+      ", properties=" + properties +
+      ", datasets=" + datasets +
+      '}';
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/DataSetFieldSetter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/DataSetFieldSetter.java
@@ -19,9 +19,9 @@ import co.cask.cdap.api.annotation.UseDataSet;
 import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.internal.lang.FieldVisitor;
-import com.google.common.reflect.TypeToken;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Type;
 
 /**
  * A {@link FieldVisitor} that inject DataSet instance into fields marked with {@link UseDataSet}.
@@ -35,7 +35,7 @@ public final class DataSetFieldSetter extends FieldVisitor {
   }
 
   @Override
-  public void visit(Object instance, TypeToken<?> inspectType, TypeToken<?> declareType, Field field) throws Exception {
+  public void visit(Object instance, Type inspectType, Type declareType, Field field) throws Exception {
     if (Dataset.class.isAssignableFrom(field.getType())) {
       UseDataSet useDataSet = field.getAnnotation(UseDataSet.class);
       if (useDataSet != null && !useDataSet.value().isEmpty()) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/MetricsFieldSetter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/MetricsFieldSetter.java
@@ -17,9 +17,9 @@ package co.cask.cdap.internal.app.runtime;
 
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.internal.lang.FieldVisitor;
-import com.google.common.reflect.TypeToken;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Type;
 
 /**
  * A {@link FieldVisitor} that set Metrics fields.
@@ -33,7 +33,7 @@ public final class MetricsFieldSetter extends FieldVisitor {
   }
 
   @Override
-  public void visit(Object instance, TypeToken<?> inspectType, TypeToken<?> declareType, Field field) throws Exception {
+  public void visit(Object instance, Type inspectType, Type declareType, Field field) throws Exception {
     if (Metrics.class.equals(field.getType())) {
       field.set(instance, metrics);
     }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/PluginInstantiator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/PluginInstantiator.java
@@ -324,9 +324,10 @@ public class PluginInstantiator implements Closeable {
     }
 
     @Override
-    public void visit(Object instance, TypeToken<?> inspectType,
-                      TypeToken<?> declareType, Field field) throws Exception {
-      if (Config.class.equals(declareType.getRawType())) {
+    public void visit(Object instance, Type inspectType, Type declareType, Field field) throws Exception {
+      TypeToken<?> declareTypeToken = TypeToken.of(declareType);
+
+      if (Config.class.equals(declareTypeToken.getRawType())) {
         if (field.getName().equals("properties")) {
           field.set(instance, properties);
         }
@@ -342,7 +343,7 @@ public class PluginInstantiator implements Closeable {
       }
       String value = properties.getProperties().get(name);
       if (pluginPropertyField.isRequired() || value != null) {
-        field.set(instance, convertValue(declareType.resolveType(field.getGenericType()), value));
+        field.set(instance, convertValue(declareTypeToken.resolveType(field.getGenericType()), value));
       }
     }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/PluginInstantiator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/PluginInstantiator.java
@@ -217,7 +217,7 @@ public class PluginInstantiator implements Closeable {
       }
 
       // Create the config instance
-      Field field = Fields.findField(pluginType, configFieldName);
+      Field field = Fields.findField(pluginType.getType(), configFieldName);
       TypeToken<?> configFieldType = pluginType.resolveType(field.getGenericType());
       Object config = instantiatorFactory.get(configFieldType).create();
       Reflections.visit(config, configFieldType.getType(),

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/OutputEmitterFieldSetter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/OutputEmitterFieldSetter.java
@@ -24,6 +24,7 @@ import com.google.common.reflect.TypeToken;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 
 /**
  *
@@ -37,13 +38,15 @@ final class OutputEmitterFieldSetter extends FieldVisitor {
   }
 
   @Override
-  public void visit(Object instance, TypeToken<?> inspectType, TypeToken<?> declareType, Field field) throws Exception {
+  public void visit(Object instance, Type inspectType, Type declareType, Field field) throws Exception {
     if (OutputEmitter.class.equals(field.getType())) {
-      TypeToken<?> emitterType = inspectType.resolveType(field.getGenericType());
+      TypeToken<?> inspectTypeToken = TypeToken.of(inspectType);
+
+      TypeToken<?> emitterType = inspectTypeToken.resolveType(field.getGenericType());
       Preconditions.checkArgument(emitterType.getType() instanceof ParameterizedType,
                                   "Only ParameterizeType is supported for OutputEmitter.");
 
-      TypeToken<?> outputType = inspectType.resolveType(((ParameterizedType) emitterType.getType())
+      TypeToken<?> outputType = inspectTypeToken.resolveType(((ParameterizedType) emitterType.getType())
                                                           .getActualTypeArguments()[0]);
 
       String outputName = field.isAnnotationPresent(Output.class) ?

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ServiceEndpointExtractor.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ServiceEndpointExtractor.java
@@ -26,6 +26,7 @@ import com.google.common.reflect.TypeToken;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Set;
 import javax.ws.rs.DELETE;
@@ -48,14 +49,13 @@ public final class ServiceEndpointExtractor extends MethodVisitor {
   }
 
   @Override
-  public void visit(Object instance, TypeToken<?> inspectType,
-                    TypeToken<?> declareType, Method method) throws Exception {
+  public void visit(Object instance, Type inspectType, Type declareType, Method method) throws Exception {
 
     if (!Modifier.isPublic(method.getModifiers())) {
       return;
     }
 
-    Path classPathAnnotation = inspectType.getRawType().getAnnotation(Path.class);
+    Path classPathAnnotation = TypeToken.of(inspectType).getRawType().getAnnotation(Path.class);
     Path methodPathAnnotation = method.getAnnotation(Path.class);
 
     if (methodPathAnnotation == null && classPathAnnotation == null) {

--- a/cdap-common/src/main/java/co/cask/cdap/common/lang/FieldInitializer.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/lang/FieldInitializer.java
@@ -17,10 +17,10 @@ package co.cask.cdap.common.lang;
 
 import co.cask.cdap.internal.lang.FieldVisitor;
 import com.google.common.base.Defaults;
-import com.google.common.reflect.TypeToken;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.lang.reflect.Type;
 
 /**
  * Package private class for {@link InstantiatorFactory} to initialize fields for instances created using Unsafe.
@@ -28,7 +28,7 @@ import java.lang.reflect.Modifier;
 final class FieldInitializer extends FieldVisitor {
 
   @Override
-  public void visit(Object instance, TypeToken<?> inspectType, TypeToken<?> declareType, Field field) throws Exception {
+  public void visit(Object instance, Type inspectType, Type declareType, Field field) throws Exception {
     if (Modifier.isStatic(field.getModifiers())) {
       return;
     }

--- a/cdap-common/src/main/java/co/cask/cdap/common/lang/PropertyFieldSetter.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/lang/PropertyFieldSetter.java
@@ -22,6 +22,7 @@ import com.google.common.reflect.TypeToken;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Type;
 import java.util.Map;
 
 /**
@@ -36,9 +37,9 @@ public final class PropertyFieldSetter extends FieldVisitor {
   }
 
   @Override
-  public void visit(Object instance, TypeToken<?> inspectType, TypeToken<?> declareType, Field field) throws Exception {
+  public void visit(Object instance, Type inspectType, Type declareType, Field field) throws Exception {
     if (field.isAnnotationPresent(Property.class)) {
-      String key = declareType.getRawType().getName() + '.' + field.getName();
+      String key = TypeToken.of(declareType).getRawType().getName() + '.' + field.getName();
       String value = properties.get(key);
       if (value == null) {
         return;

--- a/cdap-common/src/main/java/co/cask/cdap/internal/io/ASMFieldAccessorFactory.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/io/ASMFieldAccessorFactory.java
@@ -78,8 +78,8 @@ public final class ASMFieldAccessorFactory implements FieldAccessorFactory {
 
       // Generate the FieldAccessor class bytecode.
       ClassDefinition classDef = new FieldAccessorGenerator()
-                                      .generate(key.getType(),
-                                                Fields.findField(key.getType(), key.getFieldName()),
+                                      .generate(key.getType().getRawType(),
+                                                Fields.findField(key.getType().getType(), key.getFieldName()),
                                                 defineClass == null);
       return createAccessor(key.getType(), classDef);
     }

--- a/cdap-common/src/main/java/co/cask/cdap/internal/io/DatumWriterGenerator.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/io/DatumWriterGenerator.java
@@ -776,7 +776,7 @@ final class DatumWriterGenerator {
           fieldType = outputType.resolveType(rawType.getMethod(getter.getName()).getGenericReturnType());
           mg.invokeInterface(Type.getType(rawType), getter);
         } else {
-          fieldType = outputType.resolveType(Fields.findField(outputType, field.getName()).getGenericType());
+          fieldType = outputType.resolveType(Fields.findField(outputType.getType(), field.getName()).getGenericType());
           fieldAccessorRequests.put(outputType, field.getName());
           mg.loadThis();
           mg.dup();

--- a/cdap-common/src/main/java/co/cask/cdap/internal/io/FieldAccessorGenerator.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/io/FieldAccessorGenerator.java
@@ -126,7 +126,7 @@ final class FieldAccessorGenerator {
     mg.visitTryCatchBlock(beginTry, endTry, catchHandle, Type.getInternalName(Exception.class));
     mg.mark(beginTry);
 
-    // Field field = Fields.findField(TypeToken.of(classType), "fieldName")
+    // Field field = Fields.findField(classType, "fieldName")
     mg.loadArg(0);
     mg.invokeStatic(Type.getType(TypeToken.class), getMethod(TypeToken.class, "of", java.lang.reflect.Type.class));
     mg.push(field.getName());

--- a/cdap-common/src/main/java/co/cask/cdap/internal/io/FieldAccessorGenerator.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/io/FieldAccessorGenerator.java
@@ -20,7 +20,6 @@ import co.cask.cdap.internal.asm.ClassDefinition;
 import co.cask.cdap.internal.asm.Methods;
 import co.cask.cdap.internal.lang.Fields;
 import com.google.common.base.Throwables;
-import com.google.common.reflect.TypeToken;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.Opcodes;
@@ -51,10 +50,10 @@ final class FieldAccessorGenerator {
   private String className;
   private boolean isPrivate;
 
-  ClassDefinition generate(TypeToken<?> classType, Field field, boolean publicOnly) {
+  ClassDefinition generate(Class<?> classType, Field field, boolean publicOnly) {
     String name = String.format("%s$GeneratedAccessor%s",
-                                     classType.getRawType().getName(),
-                                     field.getName());
+                                classType.getName(),
+                                field.getName());
     if (name.startsWith("java.") || name.startsWith("javax.")) {
       name = "co.cask.cdap." + name;
       publicOnly = true;
@@ -128,9 +127,9 @@ final class FieldAccessorGenerator {
 
     // Field field = Fields.findField(classType, "fieldName")
     mg.loadArg(0);
-    mg.invokeStatic(Type.getType(TypeToken.class), getMethod(TypeToken.class, "of", java.lang.reflect.Type.class));
     mg.push(field.getName());
-    mg.invokeStatic(Type.getType(Fields.class), getMethod(Field.class, "findField", TypeToken.class, String.class));
+    mg.invokeStatic(Type.getType(Fields.class),
+                    getMethod(Field.class, "findField", java.lang.reflect.Type.class, String.class));
     mg.dup();
 
     // field.setAccessible(true);

--- a/cdap-common/src/test/java/co/cask/cdap/common/lang/InstantiatorTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/lang/InstantiatorTest.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.lang.reflect.Type;
 
 /**
  *
@@ -38,8 +39,7 @@ public class InstantiatorTest {
 
     Reflections.visit(record, Record.class, new FieldVisitor() {
       @Override
-      public void visit(Object instance, TypeToken<?> inspectType,
-                        TypeToken<?> declareType, Field field) throws Exception {
+      public void visit(Object instance, Type inspectType, Type declareType, Field field) throws Exception {
         if (!Modifier.isStatic(field.getModifiers())) {
           Assert.assertEquals(Defaults.defaultValue(field.getType()), field.get(instance));
         }


### PR DESCRIPTION
- Almost all usages are remove except the following:
  - TypeToken
  - BiMap and related implementation
  - Multimap and related implementation

- For TypeToken usages, it's all internal now (meaning not leaking through any interfaces), hence we can just copy the TypeToken (and related classes) into cdap-api
- For BiMap usages, we can replace it with two maps or copy it from guava as well
- For Multimap, it is problematic since it is leaked as part of public API through HttpServiceRequest/Responder. We can do deprecation, however it means we cannot remove guava dependency until two versions later, which we needed for the Cassandra usage case now.