### PR TITLE
CDAP-3419: Record min write pointer in HBaseQueueDebugger

### DIFF
--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/HBaseQueueDebugger.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/HBaseQueueDebugger.java
@@ -17,14 +17,32 @@
 package co.cask.cdap.data.tools;
 
 import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.flow.FlowSpecification;
+import co.cask.cdap.api.flow.FlowletConnection;
+import co.cask.cdap.app.ApplicationSpecification;
+import co.cask.cdap.app.guice.AppFabricServiceRuntimeModule;
+import co.cask.cdap.app.guice.ProgramRunnerRuntimeModule;
+import co.cask.cdap.app.guice.ServiceStoreModules;
+import co.cask.cdap.app.queue.QueueSpecification;
+import co.cask.cdap.app.queue.QueueSpecificationGenerator;
+import co.cask.cdap.app.store.Store;
+import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.exception.NotFoundException;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
+import co.cask.cdap.common.guice.IOModule;
+import co.cask.cdap.common.guice.KafkaClientModule;
 import co.cask.cdap.common.guice.LocationRuntimeModule;
+import co.cask.cdap.common.guice.TwillModule;
 import co.cask.cdap.common.guice.ZKClientModule;
+import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.common.queue.QueueName;
 import co.cask.cdap.common.utils.ImmutablePair;
+import co.cask.cdap.data.runtime.DataFabricDistributedModule;
 import co.cask.cdap.data.runtime.DataSetsModules;
+import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;
+import co.cask.cdap.data.stream.StreamAdminModules;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.queue.ConsumerConfig;
 import co.cask.cdap.data2.queue.ConsumerGroupConfig;
 import co.cask.cdap.data2.queue.DequeueStrategy;
@@ -43,16 +61,25 @@ import co.cask.cdap.data2.transaction.queue.hbase.ShardedHBaseQueueStrategy;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
+import co.cask.cdap.explore.guice.ExploreClientModule;
+import co.cask.cdap.gateway.auth.AuthModule;
+import co.cask.cdap.internal.app.namespace.NamespaceAdmin;
+import co.cask.cdap.internal.app.queue.SimpleQueueSpecificationGenerator;
 import co.cask.cdap.internal.app.runtime.flow.FlowUtils;
+import co.cask.cdap.internal.app.store.DefaultStore;
+import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
+import co.cask.cdap.notifications.feeds.client.NotificationFeedClientModule;
+import co.cask.cdap.notifications.guice.NotificationServiceRuntimeModule;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.tephra.Transaction;
 import co.cask.tephra.TransactionExecutor;
 import co.cask.tephra.TransactionExecutorFactory;
 import co.cask.tephra.TransactionFailureException;
 import co.cask.tephra.TransactionNotInProgressException;
-import co.cask.tephra.runtime.TransactionClientModule;
-import co.cask.tephra.runtime.TransactionModules;
+import co.cask.tephra.TxConstants;
+import com.google.common.base.Optional;
 import com.google.common.base.Predicates;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Iterators;
@@ -60,20 +87,26 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import com.google.common.collect.PeekingIterator;
+import com.google.common.collect.Table;
 import com.google.common.util.concurrent.AbstractIdleService;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
+import com.google.inject.Provides;
 import com.google.inject.Singleton;
+import com.google.inject.name.Named;
+import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.client.HTable;
 import org.apache.hadoop.hbase.client.Scan;
+import org.apache.twill.filesystem.LocationFactory;
 import org.apache.twill.zookeeper.ZKClientService;
 
 import java.net.URI;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
@@ -81,20 +114,30 @@ import javax.annotation.Nullable;
  */
 public class HBaseQueueDebugger extends AbstractIdleService {
 
+  public static final String PROP_SHOW_TX_TIMESTAMP_ONLY = "show.tx.timestamp.only";
+  public static final String PROP_SHOW_PROGRESS = "show.progress";
+  public static final String PROP_ROWS_CACHE = "rows.cache";
+
   private final HBaseQueueAdmin queueAdmin;
   private final ZKClientService zkClientService;
   private final HBaseQueueClientFactory queueClientFactory;
   private final TransactionExecutorFactory txExecutorFactory;
+  private final NamespaceAdmin namespaceAdmin;
+  private final Store store;
 
   @Inject
   public HBaseQueueDebugger(HBaseQueueAdmin queueAdmin,
                             HBaseQueueClientFactory queueClientFactory,
                             ZKClientService zkClientService,
-                            TransactionExecutorFactory txExecutorFactory) {
+                            TransactionExecutorFactory txExecutorFactory,
+                            NamespaceAdmin namespaceAdmin,
+                            Store store) {
     this.queueAdmin = queueAdmin;
     this.queueClientFactory = queueClientFactory;
     this.zkClientService = zkClientService;
     this.txExecutorFactory = txExecutorFactory;
+    this.namespaceAdmin = namespaceAdmin;
+    this.store = store;
   }
 
   @Override
@@ -105,6 +148,40 @@ public class HBaseQueueDebugger extends AbstractIdleService {
   @Override
   protected void shutDown() throws Exception {
     zkClientService.stopAndWait();
+  }
+
+  public void scanAllQueues() throws Exception {
+    QueueStatistics totalStats = new QueueStatistics();
+
+    List<NamespaceMeta> namespaceMetas = namespaceAdmin.listNamespaces();
+    for (NamespaceMeta namespaceMeta : namespaceMetas) {
+      Id.Namespace namespaceId = Id.Namespace.from(namespaceMeta.getName());
+
+      Collection<ApplicationSpecification> apps = store.getAllApplications(namespaceId);
+      for (ApplicationSpecification app : apps) {
+        Id.Application appId = Id.Application.from(namespaceId, app.getName());
+
+        for (FlowSpecification flow : app.getFlows().values()) {
+          Id.Flow flowId = Id.Flow.from(appId, flow.getName());
+
+          SimpleQueueSpecificationGenerator queueSpecGenerator =
+            new SimpleQueueSpecificationGenerator(flowId.getApplication());
+
+          Table<QueueSpecificationGenerator.Node, String, Set<QueueSpecification>> table =
+            queueSpecGenerator.create(flow);
+          for (Table.Cell<QueueSpecificationGenerator.Node, String, Set<QueueSpecification>> cell : table.cellSet()) {
+            if (cell.getRowKey().getType() == FlowletConnection.Type.FLOWLET) {
+              for (QueueSpecification queue : cell.getValue()) {
+                QueueStatistics queueStats = scanQueue(queue.getQueueName(), null);
+                totalStats.add(queueStats);
+              }
+            }
+          }
+        }
+      }
+    }
+
+    System.out.printf("Total results for all queues: %s\n", totalStats.getReport(showTxTimestampOnly()));
   }
 
   /**
@@ -126,7 +203,7 @@ public class HBaseQueueDebugger extends AbstractIdleService {
           return input.getAllBarriers();
         }
       }, stateStore);
-    System.out.printf("Got %d barriers\n", barriers.size());
+    printProgress("Got %d barriers\n", barriers.size());
 
     QueueStatistics stats = new QueueStatistics();
 
@@ -138,7 +215,7 @@ public class HBaseQueueDebugger extends AbstractIdleService {
       long groupId = entry.getKey();
       Collection<QueueBarrier> groupBarriers = entry.getValue();
 
-      System.out.printf("Scanning barriers for group %d\n", groupId);
+      printProgress("Scanning barriers for group %d\n", groupId);
 
       int currentSection = 1;
       PeekingIterator<QueueBarrier> barrierIterator = Iterators.peekingIterator(groupBarriers.iterator());
@@ -146,16 +223,31 @@ public class HBaseQueueDebugger extends AbstractIdleService {
         QueueBarrier start = barrierIterator.next();
         QueueBarrier end = barrierIterator.hasNext() ? barrierIterator.peek() : null;
 
-        System.out.printf("Scanning section %d/%d...\n", currentSection, groupBarriers.size());
+        printProgress("Scanning section %d/%d...\n", currentSection, groupBarriers.size());
         scanQueue(txExecutor, stateStore, queueName, start, end, stats);
-        System.out.printf("Current results: %s\n", stats.getReport());
+        printProgress("Current results: %s\n", stats.getReport(showTxTimestampOnly()));
         currentSection++;
       }
-      System.out.println("Scanning complete");
+      printProgress("Scanning complete");
     }
 
-    System.out.printf("Total results: %s\n", stats.getReport());
+    System.out.printf("Results for queue %s: %s\n",
+                      queueName.toString(), stats.getReport(showTxTimestampOnly()));
     return stats;
+  }
+
+  private void printProgress(String format, Object... args) {
+    if (showProgress()) {
+      System.out.printf(format, args);
+    }
+  }
+
+  private boolean showTxTimestampOnly() {
+    return Boolean.parseBoolean(System.getProperty(PROP_SHOW_TX_TIMESTAMP_ONLY));
+  }
+
+  private boolean showProgress() {
+    return Boolean.parseBoolean(System.getProperty(PROP_SHOW_PROGRESS));
   }
 
   private void scanQueue(TransactionExecutor txExecutor, HBaseConsumerStateStore stateStore,
@@ -165,13 +257,13 @@ public class HBaseQueueDebugger extends AbstractIdleService {
     final byte[] queueRowPrefix = QueueEntryRow.getQueueRowPrefix(queueName);
 
     ConsumerGroupConfig groupConfig = start.getGroupConfig();
-    System.out.printf("Got consumer group config: %s\n", groupConfig);
+    printProgress("Got consumer group config: %s\n", groupConfig);
 
     HBaseQueueAdmin admin = queueClientFactory.getQueueAdmin();
     TableId tableId = admin.getDataTableId(queueName, QueueConstants.QueueType.SHARDED_QUEUE);
     HTable hTable = queueClientFactory.createHTable(tableId);
 
-    System.out.printf("Looking at HBase table: %s\n", Bytes.toString(hTable.getTableName()));
+    printProgress("Looking at HBase table: %s\n", Bytes.toString(hTable.getTableName()));
 
     final byte[] stateColumnName = Bytes.add(QueueEntryRow.STATE_COLUMN_PREFIX,
                                              Bytes.toBytes(groupConfig.getGroupId()));
@@ -194,7 +286,7 @@ public class HBaseQueueDebugger extends AbstractIdleService {
     scan.setCacheBlocks(false);
     scan.setMaxVersions(1);
 
-    System.out.printf("Scanning section with scan: %s\n", scan.toString());
+    printProgress("Scanning section with scan: %s\n", scan.toString());
 
     List<Integer> instanceIds = Lists.newArrayList();
     if (groupConfig.getDequeueStrategy() == DequeueStrategy.FIFO) {
@@ -205,9 +297,9 @@ public class HBaseQueueDebugger extends AbstractIdleService {
       }
     }
 
-    final int rowsCache = Integer.parseInt(System.getProperty("rows.cache", "100000"));
+    final int rowsCache = Integer.parseInt(System.getProperty(PROP_ROWS_CACHE, "100000"));
     for (final int instanceId : instanceIds) {
-      System.out.printf("Processing instance %d", instanceId);
+      printProgress("Processing instance %d", instanceId);
       ConsumerConfig consConfig = new ConsumerConfig(groupConfig, instanceId);
       final QueueScanner scanner = queueStrategy.createScanner(consConfig, hTable, scan, rowsCache);
 
@@ -221,8 +313,9 @@ public class HBaseQueueDebugger extends AbstractIdleService {
               Map<byte[], byte[]> columns = result.getSecond();
               visitRow(outStats, input.getTransaction(), rowKey, columns.get(stateColumnName), queueRowPrefix.length);
 
-              if (Boolean.parseBoolean(System.getProperty("show.progress")) && outStats.getTotal() % rowsCache == 0) {
-                System.out.printf("\rProcessing instance %d: %s", instanceId, outStats.getReport());
+              if (showProgress() && outStats.getTotal() % rowsCache == 0) {
+                System.out.printf("\rProcessing instance %d: %s",
+                                  instanceId, outStats.getReport(showTxTimestampOnly()));
               }
             }
           }
@@ -233,7 +326,7 @@ public class HBaseQueueDebugger extends AbstractIdleService {
           throw Throwables.propagate(e);
         }
       }
-      System.out.printf("\rProcessing instance %d: %s\n", instanceId, outStats.getReport());
+      printProgress("\rProcessing instance %d: %s\n", instanceId, outStats.getReport(showTxTimestampOnly()));
     }
   }
 
@@ -253,6 +346,7 @@ public class HBaseQueueDebugger extends AbstractIdleService {
     ConsumerEntryState state = QueueEntryRow.getState(stateValue);
     if (state == ConsumerEntryState.PROCESSED) {
       long writePointer = QueueEntryRow.getWritePointer(rowKey, queueRowPrefixLength);
+      stats.recordMinWritePointer(writePointer);
       if (tx.isVisible(writePointer)) {
         stats.countProcessedAndVisible(1);
       } else {
@@ -266,11 +360,20 @@ public class HBaseQueueDebugger extends AbstractIdleService {
    */
   public static final class QueueStatistics {
 
+    private Optional<Long> minWritePointer = Optional.absent();
     private long unprocessed;
     private long processedAndVisible;
     private long processedAndNotVisible;
 
     private QueueStatistics() {
+    }
+
+    public void recordMinWritePointer(long writePointer) {
+      if (minWritePointer.isPresent()) {
+        this.minWritePointer = Optional.of(Math.min(minWritePointer.get(), writePointer));
+      } else {
+        this.minWritePointer = Optional.of(writePointer);
+      }
     }
 
     public void countUnprocessed(long count) {
@@ -301,28 +404,124 @@ public class HBaseQueueDebugger extends AbstractIdleService {
       return unprocessed + processedAndVisible + processedAndNotVisible;
     }
 
-    public String getReport() {
-      return String.format("unprocessed: %d; processed and visible: %d; processed and not visible: %d; total: %d",
-                           getUnprocessed(), getProcessedAndVisible(), getProcessedAndNotVisible(), getTotal());
+    public Optional<Long> getMinWritePointer() {
+      return minWritePointer;
+    }
+
+    public String getMinWritePointerString() {
+      if (minWritePointer.isPresent()) {
+        return Long.toString(minWritePointer.get());
+      } else {
+        return "n/a";
+      }
+    }
+
+    public String getMinWritePointerTimestampString() {
+      if (minWritePointer.isPresent()) {
+        return Long.toString(minWritePointer.get() / TxConstants.MAX_TX_PER_MS);
+      } else {
+        return "n/a";
+      }
+    }
+
+    private String getTxTimestampReport() {
+      return String.format("min tx timestamp: %s", getMinWritePointerTimestampString());
+    }
+
+    private String getDetailedReport() {
+      return String.format("min write pointer: %s; unprocessed: %d; processed and visible: %d; " +
+                             "processed and not visible: %d; total: %d",
+                           getMinWritePointerString(), getUnprocessed(), getProcessedAndVisible(),
+                           getProcessedAndNotVisible(), getTotal());
+    }
+
+    public String getReport(boolean showTxTimestampOnly) {
+      if (showTxTimestampOnly) {
+        return getTxTimestampReport();
+      } else {
+        return getDetailedReport();
+      }
+    }
+
+    public void add(QueueStatistics stats) {
+      if (stats.getMinWritePointer().isPresent()) {
+        recordMinWritePointer(stats.getMinWritePointer().get());
+      }
+      countUnprocessed(stats.getUnprocessed());
+      countProcessedAndNotVisible(stats.getProcessedAndNotVisible());
+      countProcessedAndVisible(stats.getProcessedAndVisible());
     }
   }
 
+  public static HBaseQueueDebugger createDebugger() {
+    Injector injector = Guice.createInjector(
+      new ConfigModule(CConfiguration.create(), HBaseConfiguration.create()),
+      new IOModule(),
+      new ZKClientModule(),
+      new LocationRuntimeModule().getDistributedModules(),
+      new DiscoveryRuntimeModule().getDistributedModules(),
+      new StreamAdminModules().getDistributedModules(),
+      new NotificationFeedClientModule(),
+      new TwillModule(),
+      new AuthModule(),
+      new ExploreClientModule(),
+      new DataFabricDistributedModule(),
+      new ServiceStoreModules().getDistributedModules(),
+      new DataSetsModules().getDistributedModules(),
+      new AppFabricServiceRuntimeModule().getDistributedModules(),
+      new ProgramRunnerRuntimeModule().getDistributedModules(),
+      new SystemDatasetRuntimeModule().getDistributedModules(),
+      new NotificationServiceRuntimeModule().getDistributedModules(),
+      new MetricsClientRuntimeModule().getDistributedModules(),
+      new KafkaClientModule(),
+      new AbstractModule() {
+        @Override
+        protected void configure() {
+          bind(QueueClientFactory.class).to(HBaseQueueClientFactory.class).in(Singleton.class);
+          bind(QueueAdmin.class).to(HBaseQueueAdmin.class).in(Singleton.class);
+          bind(HBaseTableUtil.class).toProvider(HBaseTableUtilFactory.class);
+        }
+
+        @Provides
+        @Singleton
+        @Named("defaultStore")
+        public Store getStore(DatasetFramework dsFramework,
+                              CConfiguration cConf, LocationFactory locationFactory,
+                              NamespacedLocationFactory namespacedLocationFactory,
+                              TransactionExecutorFactory txExecutorFactory) {
+          return new DefaultStore(cConf, locationFactory, namespacedLocationFactory, txExecutorFactory, dsFramework);
+        }
+
+        // This is needed because the LocalAdapterManager, LocalApplicationManager, LocalApplicationTemplateManager
+        // expects a dsframework injection named datasetMDS
+        @Provides
+        @Singleton
+        @Named("datasetMDS")
+        public DatasetFramework getInDsFramework(DatasetFramework dsFramework) {
+          return dsFramework;
+        }
+      });
+
+    return injector.getInstance(HBaseQueueDebugger.class);
+  }
+
   public static void main(String[] args) throws Exception {
-    // TODO: Use commons-cli for parsing command-line args
-    if (args.length == 0) {
-      System.out.println("Expected arguments: <queue-uri> [consumer-flowlet]");
+    if (args.length >= 1 && args[0].equals("help")) {
+      System.out.println("Arguments: [<queue-uri> [consumer-flowlet]]");
       System.out.println("queue-uri: queue:///<namespace>/<app>/<flow>/<flowlet>/<queue>");
       System.out.println("consumer-flowlet: <flowlet>");
+      System.out.println("If queue-uri is not provided, scan all queues");
       System.out.println("Example: queue:///default/PurchaseHistory/PurchaseFlow/reader/queue collector");
       System.out.println();
       System.out.println("System properties:");
-      System.out.println("-Dshow.progress=true         Show progress while scanning the queue table");
-      System.out.println("-Drows.cache=[num_of_rows]   Number of rows to pass to HBase Scan.setCaching() method");
+      System.out.println("-D" + PROP_SHOW_PROGRESS + "=true         Show progress while scanning the queue table");
+      System.out.println("-D" + PROP_ROWS_CACHE + "=[num_of_rows]   " +
+                         "Number of rows to pass to HBase Scan.setCaching() method");
       System.exit(1);
     }
 
     // e.g. "queue:///default/PurchaseHistory/PurchaseFlow/reader/queue"
-    final QueueName queueName = QueueName.from(URI.create(args[0]));
+    final QueueName queueName = args.length >= 1 ? QueueName.from(URI.create(args[0])) : null;
     Long consumerGroupId = null;
     if (args.length >= 2) {
       String consumerFlowlet = args[1];
@@ -331,27 +530,13 @@ public class HBaseQueueDebugger extends AbstractIdleService {
       consumerGroupId = FlowUtils.generateConsumerGroupId(flowId, consumerFlowlet);
     }
 
-    Injector injector = Guice.createInjector(
-      new ConfigModule(),
-      new ZKClientModule(),
-      new TransactionClientModule(),
-      new AbstractModule() {
-        @Override
-        protected void configure() {
-          bind(QueueClientFactory.class).to(HBaseQueueClientFactory.class).in(Singleton.class);
-          bind(QueueAdmin.class).to(HBaseQueueAdmin.class).in(Singleton.class);
-          bind(HBaseTableUtil.class).toProvider(HBaseTableUtilFactory.class);
-        }
-      },
-      new DiscoveryRuntimeModule().getDistributedModules(),
-      new LocationRuntimeModule().getDistributedModules(),
-      new DataSetsModules().getDistributedModules(),
-      new TransactionModules().getDistributedModules()
-    );
-
-    HBaseQueueDebugger debugger = injector.getInstance(HBaseQueueDebugger.class);
+    HBaseQueueDebugger debugger = createDebugger();
     debugger.startAndWait();
-    debugger.scanQueue(queueName, consumerGroupId);
+    if (queueName != null) {
+      debugger.scanQueue(queueName, consumerGroupId);
+    } else {
+      debugger.scanAllQueues();
+    }
     debugger.stopAndWait();
   }
 }

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/SimpleHBaseQueueDebugger.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/SimpleHBaseQueueDebugger.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data.tools;
+
+/**
+ * {@link HBaseQueueDebugger} with simple defaults.
+ */
+public class SimpleHBaseQueueDebugger {
+  public static void main(String[] args) throws Exception {
+    if (args.length >= 1 && args[0].equals("help")) {
+      System.out.printf("Displays the minimum transaction time for all events in all queues.\n\n");
+      System.out.printf("Uses HBaseQueueDebugger with the following options:\n");
+      System.out.printf("-D" + HBaseQueueDebugger.PROP_SHOW_PROGRESS + "=false\n");
+      System.out.printf("-D" + HBaseQueueDebugger.PROP_SHOW_TX_TIMESTAMP_ONLY + "=true\n");
+      return;
+    }
+
+    System.setProperty(HBaseQueueDebugger.PROP_SHOW_PROGRESS, "false");
+    System.setProperty(HBaseQueueDebugger.PROP_SHOW_TX_TIMESTAMP_ONLY, "true");
+    HBaseQueueDebugger.main(args);
+  }
+}

--- a/cdap-master/src/test/java/co/cask/cdap/data/tools/flow/HBaseQueueDebuggerTest.java
+++ b/cdap-master/src/test/java/co/cask/cdap/data/tools/flow/HBaseQueueDebuggerTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data.tools.flow;
+
+import co.cask.cdap.data.tools.HBaseQueueDebugger;
+import org.junit.Test;
+
+/**
+ *
+ */
+public class HBaseQueueDebuggerTest {
+  @Test
+  public void testInjector() throws Exception {
+    HBaseQueueDebugger.createDebugger();
+    // should not throw exception
+  }
+}


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-3419

Output looks like this:

```
Running class co.cask.cdap.data.tools.SimpleHBaseQueueDebugger
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/opt/cdap/master/lib/ch.qos.logback.logback-classic-1.0.9.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/usr/lib/hadoop/lib/slf4j-log4j12-1.7.5.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/usr/lib/zookeeper/lib/slf4j-log4j12-1.6.1.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [ch.qos.logback.classic.util.ContextSelectorStaticBinder]
2015-08-19 20:34:04,485 - WARN  [main:c.c.c.c.c.Configuration@570] - security.auth.server.address is deprecated. Instead, use security.auth.server.bind.address
2015-08-19 20:34:04,496 - WARN  [main:c.c.c.c.c.Configuration@570] - security.auth.server.address is deprecated. Instead, use security.auth.server.bind.address
2015-08-19 20:34:05,522 - INFO  [main:c.c.c.c.g.LocationRuntimeModule$HDFSLocationModule@88] - HDFS namespace is /cdap
2015-08-19 20:34:05,742 - WARN  [main:o.a.h.u.NativeCodeLoader@62] - Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
Results for queue queue:///default/WordCount/WordCounter/counter/queue: min tx timestamp: n/a
Results for queue queue:///default/WordCount/WordCounter/splitter/wordArrayOut: min tx timestamp: n/a
Results for queue queue:///default/WordCount/WordCounter/splitter/wordOut: min tx timestamp: n/a
Results for queue queue:///default/PurchaseHistory/PurchaseFlow/reader/queue: min tx timestamp: 1440016236129
Total results for all queues: min tx timestamp: 1440016236129
```