### PR TITLE
Correct the spelling of "ZooKeeper".

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/realtime/kafka/KafkaSimpleApiConsumer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/realtime/kafka/KafkaSimpleApiConsumer.java
@@ -110,7 +110,7 @@ public abstract class KafkaSimpleApiConsumer<KEY, PAYLOAD, OFFSET> {
     configureKafka(kafkaConfigurer);
 
     if (kafkaConfigurer.getZookeeper() == null && kafkaConfigurer.getBrokers() == null) {
-      throw new IllegalStateException("Kafka not configured. Must provide either zookeeper or broker list.");
+      throw new IllegalStateException("Kafka not configured. Must provide either ZooKeeper or broker list.");
     }
 
     kafkaConfig = new KafkaConfig(kafkaConfigurer.getZookeeper(), kafkaConfigurer.getBrokers());

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/realtime/source/KafkaSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/realtime/source/KafkaSource.java
@@ -178,12 +178,12 @@ public class KafkaSource extends RealtimeSource<StructuredRecord> {
     private final String topic;
 
     @Name(KAFKA_ZOOKEEPER)
-    @Description("The connect string location of Zookeeper. Either this or the list of brokers is required.")
+    @Description("The connect string location of ZooKeeper. Either this or the list of brokers is required.")
     @Nullable
     private final String zkConnect;
 
     @Name(KAFKA_BROKERS)
-    @Description("Comma-separated list of Kafka brokers. Either this or the Zookeeper connect info is required.")
+    @Description("Comma-separated list of Kafka brokers. Either this or the ZooKeeper connect info is required.")
     @Nullable
     private final String kafkaBrokers;
 

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -52,7 +52,7 @@ public final class Constants {
   }
 
   /**
-   * Zookeeper Configuration.
+   * ZooKeeper Configuration.
    */
   public static final class Zookeeper {
     public static final String QUORUM = "zookeeper.quorum";
@@ -319,7 +319,7 @@ public final class Constants {
     // Period in seconds between two heartbeats in a stream service
     public static final int HEARTBEAT_INTERVAL = 2;
 
-    // Zookeeper namespace in which to keep the coordination metadata
+    // ZooKeeper namespace in which to keep the coordination metadata
     public static final String STREAM_ZK_COORDINATION_NAMESPACE = String.format("/%s/coordination", Service.STREAMS);
   }
 
@@ -834,7 +834,7 @@ public final class Constants {
     }
 
     /**
-     * Constants used by Zookeeper.
+     * Constants used by ZooKeeper.
      */
     public static final class Zookeeper {
       public static final String ENV_AUTH_PROVIDER_1 = "zookeeper.authProvider.1";

--- a/cdap-common/src/main/java/co/cask/cdap/common/guice/ZKClientModule.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/guice/ZKClientModule.java
@@ -48,7 +48,7 @@ public class ZKClientModule extends AbstractModule {
   @Singleton
   private ZKClientService provideZKClientService(CConfiguration cConf) {
     String zookeeper = cConf.get(Constants.Zookeeper.QUORUM);
-    Preconditions.checkNotNull(zookeeper, "Missing Zookeeper configuration '%s'", Constants.Zookeeper.QUORUM);
+    Preconditions.checkNotNull(zookeeper, "Missing ZooKeeper configuration '%s'", Constants.Zookeeper.QUORUM);
 
     return ZKClientServices.delegate(
       ZKClients.reWatchOnExpire(

--- a/cdap-common/src/main/java/co/cask/cdap/common/resource/ResourceBalancerService.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/resource/ResourceBalancerService.java
@@ -69,7 +69,7 @@ public abstract class ResourceBalancerService extends AbstractIdleService {
    * Creates instance of {@link ResourceBalancerService}.
    * @param serviceName name of the service
    * @param partitionCount number of partitions of the resource to balance
-   * @param zkClient Zookeeper place to keep metadata for sync; will be further namespaced with service name
+   * @param zkClient ZooKeeper place to keep metadata for sync; will be further namespaced with service name
    * @param discoveryService discovery service to register this service
    * @param discoveryServiceClient discovery service client to discover other instances of this service
    */

--- a/cdap-docs/admin-manual/source/installation/installation.rst
+++ b/cdap-docs/admin-manual/source/installation/installation.rst
@@ -33,7 +33,7 @@ These are the CDAP components:
 - **CDAP Authentication Server:** Performs client authentication for CDAP when security is enabled.
 
 Before installing the CDAP components, you must first install a Hadoop cluster
-with *HDFS*, *YARN*, *HBase*, and *Zookeeper*. In order to use the ad-hoc querying capabilities
+with *HDFS*, *YARN*, *HBase*, and *ZooKeeper*. In order to use the ad-hoc querying capabilities
 of CDAP, you will also need *Hive*. All CDAP components can be installed on the
 same boxes as your Hadoop cluster, or on separate boxes that can connect to the Hadoop services.
 
@@ -167,7 +167,7 @@ For a distributed enterprise, you must install these Hadoop components:
 +               +-------------------+-----------------------------------------------------+
 |               | MapR              | 4.1 (with Apache HBase)                             |
 +---------------+-------------------+-----------------------------------------------------+
-| **Zookeeper** | Apache            | Version 3.4.3 through 3.4.5                         |
+| **ZooKeeper** | Apache            | Version 3.4.3 through 3.4.5                         |
 +               +-------------------+-----------------------------------------------------+
 |               | CDH or HDP        | (CDH) 5.0.0 through 5.4.4 or (HDP) 2.0, 2.1, or 2.2 |
 +               +-------------------+-----------------------------------------------------+
@@ -187,8 +187,8 @@ but have not necessarily have been either tested or confirmed compatible.
 **Note:** Certain CDAP components need to reference your *Hadoop*, *HBase*, *YARN* (and
 possibly *Hive*) cluster configurations by adding your configuration to their class paths.
 
-**Note:** Zookeeper's ``maxClientCnxns`` must be raised from its default.  We suggest setting it to zero
-(unlimited connections). As each YARN container launched by CDAP makes a connection to Zookeeper, 
+**Note:** ZooKeeper's ``maxClientCnxns`` must be raised from its default.  We suggest setting it to zero
+(unlimited connections). As each YARN container launched by CDAP makes a connection to ZooKeeper, 
 the number of connections required is a function of usage.
 
 .. _deployment-architectures:

--- a/cdap-docs/admin-manual/source/installation/quick-start.rst
+++ b/cdap-docs/admin-manual/source/installation/quick-start.rst
@@ -54,8 +54,8 @@ the packages, and prior to starting services.
 - The CDAP user should be able to write temp files; if not, see the instructions in 
   :ref:`the installation guide <install-tmp-files>`.
 
-- **Note:** Zookeeper's ``maxClientCnxns`` must be raised from its default.  We suggest setting it to zero
-  (unlimited connections). As each YARN container launched by CDAP makes a connection to Zookeeper, 
+- **Note:** ZooKeeper's ``maxClientCnxns`` must be raised from its default.  We suggest setting it to zero
+  (unlimited connections). As each YARN container launched by CDAP makes a connection to ZooKeeper, 
   the number of connections required is a function of usage.
 
 

--- a/cdap-docs/admin-manual/source/installation/security.rst
+++ b/cdap-docs/admin-manual/source/installation/security.rst
@@ -81,19 +81,19 @@ Property                                          Default Value        Descripti
 ``cdap.master.kerberos.principal``                *None*               Kerberos principal associated with the keytab
 ================================================= ==================== ======================================================
 
-Configuring Zookeeper (required)
+Configuring ZooKeeper (required)
 ................................
-To configure Zookeeper to enable SASL authentication, add the following to your ``zoo.cfg``::
+To configure ZooKeeper to enable SASL authentication, add the following to your ``zoo.cfg``::
 
   authProvider.1=org.apache.zookeeper.server.auth.SASLAuthenticationProvider
   jaasLoginRenew=3600000
   kerberos.removeHostFromPrincipal=true
   kerberos.removeRealmFromPrincipal=true
 
-This will let Zookeeper use the ``SASLAuthenticationProvider`` as an auth provider, and the ``jaasLoginRenew`` line
-will cause the Zookeeper server to renew its Kerberos ticket once an hour.
+This will let ZooKeeper use the ``SASLAuthenticationProvider`` as an auth provider, and the ``jaasLoginRenew`` line
+will cause the ZooKeeper server to renew its Kerberos ticket once an hour.
 
-Then, create a ``jaas.conf`` file for your Zookeeper server::
+Then, create a ``jaas.conf`` file for your ZooKeeper server::
 
   Server {
        com.sun.security.auth.module.Krb5LoginModule required
@@ -104,10 +104,10 @@ Then, create a ``jaas.conf`` file for your Zookeeper server::
        principal="<your-zookeeper-principal>";
   };
 
-The keytab file must be readable by the Zookeeper server, and ``<your-zookeeper-principal>`` must correspond
+The keytab file must be readable by the ZooKeeper server, and ``<your-zookeeper-principal>`` must correspond
 to the keytab file.
 
-Finally, start Zookeeper server with the following JVM option::
+Finally, start ZooKeeper server with the following JVM option::
 
   -Djava.security.auth.login.config=/path/to/jaas.conf
 

--- a/cdap-docs/application-templates/source/etl/templates/sources/real-time/kafka.rst
+++ b/cdap-docs/application-templates/source/etl/templates/sources/real-time/kafka.rst
@@ -63,7 +63,7 @@ If no format is given, Kafka message payloads will be treated as bytes, resultin
   }
 
 This example reads from ten partitions of the 'purchases' topic of a Kafka instance.
-It connects to Kafka via a Zookeeper instance running on 'localhost'. It then 
+It connects to Kafka via a ZooKeeper instance running on 'localhost'. It then 
 parses Kafka messages using the 'csv' format into records with the specified schema.
 For each Kafka message read, it will output a record with the schema::
 

--- a/cdap-docs/application-templates/source/etl/templates/sources/real-time/kafka.rst
+++ b/cdap-docs/application-templates/source/etl/templates/sources/real-time/kafka.rst
@@ -21,10 +21,10 @@ from Kafka and write them to a stream.
 
 **kafka.topic:** Topic of the messages.
 
-**kafka.zookeeper:** The connect string location of Zookeeper.
+**kafka.zookeeper:** The connect string location of ZooKeeper.
 Either this or the list of brokers is required.
 
-**kafka.brokers:** Comma-separated list of Kafka brokers. Either this or the Zookeeper connect info is required.
+**kafka.brokers:** Comma-separated list of Kafka brokers. Either this or the ZooKeeper connect info is required.
 
 **kafka.default.offset:** The default offset for the partition. Default value is kafka.api.OffsetRequest.EarliestTime.
 

--- a/cdap-docs/integrations/source/partners/cloudera/configuring.rst
+++ b/cdap-docs/integrations/source/partners/cloudera/configuring.rst
@@ -36,7 +36,7 @@ The CDAP CSD consists of four mandatory roles:
 
 and an optional role |---| Security Auth Service |---| plus a Gateway client configuration. 
 
-CDAP depends on HBase, YARN, HDFS, Zookeeper, and |---| optionally |---| Hive. It must also be placed on a cluster host with full
+CDAP depends on HBase, YARN, HDFS, ZooKeeper, and |---| optionally |---| Hive. It must also be placed on a cluster host with full
 client configurations for these dependent services. Therefore, CDAP roles must be colocated on a cluster host with at least
 an HDFS Gateway, Yarn Gateway, HBase Gateway, and |---| optionally |---| a Hive Gateway. Note that Gateways are redundant if colocating
 CDAP on cluster hosts with actual services, such as the HBase Master, Yarn Resourcemanager, or HDFS Namenode.
@@ -51,8 +51,8 @@ Prerequisites
    role instance will run. You can download the appropriate version of Node.js from `nodejs.org
    <http://nodejs.org/dist/>`__.
 
-#. Zookeeper's ``maxClientCnxns`` must be raised from its default.  We suggest setting it to zero
-   (unlimited connections). As each YARN container launched by CDAP makes a connection to Zookeeper, 
+#. ZooKeeper's ``maxClientCnxns`` must be raised from its default.  We suggest setting it to zero
+   (unlimited connections). As each YARN container launched by CDAP makes a connection to ZooKeeper, 
    the number of connections required is a function of usage.
 
 #. For Kerberos-enabled Hadoop clusters:

--- a/cdap-docs/introduction/source/index.rst
+++ b/cdap-docs/introduction/source/index.rst
@@ -1501,7 +1501,7 @@ Building Real World Applications
 
      * - Without CDAP
        - - Discover the host and port where the service is running on by looking at the host 
-           and port in the YARN logs or by writing a discovery client that is co-ordinated using **Zookeeper**
+           and port in the YARN logs or by writing a discovery client that is co-ordinated using **ZooKeeper**
          - Run ``curl http://hostname:port/ip/69.181.160.120/count``
          
      * - Using CDAP

--- a/cdap-docs/reference-manual/source/faq.rst
+++ b/cdap-docs/reference-manual/source/faq.rst
@@ -22,7 +22,7 @@ Cask Data Application Platform
 
 Cask Data Application Platform (CDAP) is the industry’s first Big Data Application Server for Hadoop. It
 abstracts all the complexities and integrates the components of the Hadoop ecosystem (YARN, MapReduce, 
-Zookeeper, HBase, etc.) enabling developers to build, test, deploy, and manage Big Data applications
+ZooKeeper, HBase, etc.) enabling developers to build, test, deploy, and manage Big Data applications
 without having to worry about infrastructure, interoperability, or the complexities of distributed
 systems.
 

--- a/cdap-docs/reference-manual/source/licenses/index.rst
+++ b/cdap-docs/reference-manual/source/licenses/index.rst
@@ -50,9 +50,10 @@ Other product and company names mentioned herein, within our documentation or we
 be the trademarks of their respective owners. Where the ownership or registration is known,
 the addition of appropriate symbols has been made.
 
-Apache®, `Apache Hadoop <http://hadoop.apache.org>`__, and `Hadoop®
-<http://hadoop.apache.org>`__ are either registered trademarks or trademarks of the
-`Apache Software Foundation <http://www.apache.org>`__ in the United States and/or other
+Apache®, `Apache Hadoop <https://hadoop.apache.org>`__, `Hadoop®
+<https://hadoop.apache.org>`__, and `Apache ZooKeeper <https://zookeeper.apache.org/>`__, 
+are either registered trademarks or trademarks of the
+`Apache Software Foundation <https://www.apache.org>`__ in the United States and/or other
 countries.
 
 Cloudera, Cloudera Impala, and Impala are trademarks of `Cloudera, Inc. <http://www.cloudera.com>`__ 

--- a/cdap-docs/reference-manual/source/release-notes.rst
+++ b/cdap-docs/reference-manual/source/release-notes.rst
@@ -1144,7 +1144,7 @@ Bug Fixes
   `CDAP-2946 <https://issues.cask.co/browse/CDAP-2946>`__,
   `TEPHRA-101 <https://issues.cask.co/browse/TEPHRA-101>`__).
   
-- Fixed a problem with CDAP Master not being resilient in the handling of Zookeeper 
+- Fixed a problem with CDAP Master not being resilient in the handling of ZooKeeper 
   exceptions
   (`CDAP-2569 <https://issues.cask.co/browse/CDAP-2569>`__).
   
@@ -1879,7 +1879,7 @@ Known Issues
 - Writing to datasets through Hive is not supported in CDH4.x
   (`CDAP-988 <https://issues.cask.co/browse/CDAP-988>`__).
 - A race condition resulting in a deadlock can occur when a TwillRunnable container
-  shutdowns while it still has Zookeeper events to process. This occasionally surfaces when
+  shutdowns while it still has ZooKeeper events to process. This occasionally surfaces when
   running with OpenJDK or JDK7, though not with Oracle JDK6. It is caused by a change in the
   ``ThreadPoolExecutor`` implementation between Oracle JDK6 and OpenJDK/JDK7. Until Twill is
   updated in a future version of CDAP, a work-around is to kill the errant process. The Yarn
@@ -2009,7 +2009,7 @@ Services
 Security
 .................
 - Added authorization logging
-- Added Kerberos authentication to Zookeeper secret keys
+- Added Kerberos authentication to ZooKeeper secret keys
 - Added support for SSL
 
 Spark Integration

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterMain.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterMain.java
@@ -67,7 +67,7 @@ public class RouterMain extends DaemonMain {
       // Initialize ZK client
       String zookeeper = cConf.get(Constants.Zookeeper.QUORUM);
       if (zookeeper == null) {
-        LOG.error("No zookeeper quorum provided.");
+        LOG.error("No ZooKeeper quorum provided.");
         System.exit(1);
       }
 

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/TransactionServiceTwillRunnable.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/TransactionServiceTwillRunnable.java
@@ -88,7 +88,7 @@ public class TransactionServiceTwillRunnable extends AbstractMasterTwillRunnable
       LOG.info("{} Setting host name to {}", name, context.getHost().getCanonicalHostName());
 
 
-      //Get Zookeeper and Kafka Client Instances
+      //Get ZooKeeper and Kafka Client Instances
       zkClient = injector.getInstance(ZKClientService.class);
       kafkaClient = injector.getInstance(KafkaClientService.class);
 

--- a/cdap-security/src/main/java/co/cask/cdap/security/auth/DistributedKeyManager.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/auth/DistributedKeyManager.java
@@ -80,10 +80,10 @@ public class DistributedKeyManager extends AbstractKeyManager implements Resourc
     this.zookeeper = ZKClients.namespace(zookeeper, parentZNode);
 
     if (acls.isEmpty()) {
-      LOG.warn("Zookeeper ACL list is empty for keys!");
+      LOG.warn("ZooKeeper ACL list is empty for keys!");
       acls = ZooDefs.Ids.OPEN_ACL_UNSAFE;
     }
-    LOG.info("Zookeeper ACLs {} for keys", acls);
+    LOG.info("ZooKeeper ACLs {} for keys", acls);
     this.keyCache = new SharedResourceCache<>(zookeeper, codec, "/keys", acls);
   }
 
@@ -209,7 +209,7 @@ public class DistributedKeyManager extends AbstractKeyManager implements Resourc
       return ZooDefs.Ids.CREATOR_ALL_ACL;
     }
 
-    LOG.warn("Not adding ACLs on keys in Zookeeper as Kerberos is not enabled");
+    LOG.warn("Not adding ACLs on keys in ZooKeeper as Kerberos is not enabled");
     return ZooDefs.Ids.OPEN_ACL_UNSAFE;
   }
 }

--- a/cdap-ui/templates/ETLRealtime/Kafka.json
+++ b/cdap-ui/templates/ETLRealtime/Kafka.json
@@ -8,8 +8,8 @@
        "fields" : {
           "kafka.zookeeper" : {
              "widget": "textbox",
-             "label": "Zookeeper Quorum",
-             "description" : "Specify the zookeeper connection string. E.g. host:2181,host2:2181,host3:2181. Either we can specify zookeeper quorum or broker list.",
+             "label": "ZooKeeper Quorum",
+             "description" : "Specify the ZooKeeper connection string. Example: host:2181,host2:2181,host3:2181. Either specify ZooKeeper quorum or broker list.",
              "properties": {
                "width": "large"
              }
@@ -18,7 +18,7 @@
           "kafka.brokers" : {
              "widget": "csv",
              "label": "Kafka Brokers",
-             "description" : "Server names on which kafka server is running. Kafka is run as a cluster comprised of one or more servers each of which is called broker. Either we can specify zookeeper connection string or this configuration.",
+             "description" : "Server names on which kafka server is running. Kafka is run as a cluster comprised of one or more servers each of which is called broker. Either specify ZooKeeper connection string or this configuration.",
              "properties": {
                "width": "medium",
                "delimiter" : ","

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/run/LogSaverTwillRunnable.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/run/LogSaverTwillRunnable.java
@@ -115,8 +115,8 @@ public final class LogSaverTwillRunnable extends AbstractTwillRunnable {
       // Initialize ZK client
       String zookeeper = cConf.get(Constants.Zookeeper.QUORUM);
       if (zookeeper == null) {
-        LOG.error("No zookeeper quorum provided.");
-        throw new IllegalStateException("No zookeeper quorum provided.");
+        LOG.error("No ZooKeeper quorum provided.");
+        throw new IllegalStateException("No ZooKeeper quorum provided.");
       }
 
       Injector injector = createGuiceInjector(cConf, hConf);


### PR DESCRIPTION
In most cases, it should be spelt "ZooKeeper". This corrects it in both the documentation and the application template. It adds Apache ZooKeeper as trademark of the Apache Foundation.

Fixes https://issues.cask.co/browse/CDAP-3375