### PR TITLE
Upgrade tool output example and --force option.

### DIFF
--- a/cdap-docs/admin-manual/source/installation/installation.rst
+++ b/cdap-docs/admin-manual/source/installation/installation.rst
@@ -803,10 +803,10 @@ please follow the upgrade instructions for the earlier versions and upgrade firs
         y
         Starting upgrade ...
 
-   You can run the tool in a non-interactive fashion by using the ``--force`` flag, in which case
+   You can run the tool in a non-interactive fashion by using the ``force`` flag, in which case
    it will run unattended and not prompt for continuing::
    
-     $ /opt/cdap/master/bin/svc-master run co.cask.cdap.data.tools.UpgradeTool upgrade --force
+     $ /opt/cdap/master/bin/svc-master run co.cask.cdap.data.tools.UpgradeTool upgrade force
 
 #. Restart the CDAP processes::
 

--- a/cdap-docs/admin-manual/source/installation/installation.rst
+++ b/cdap-docs/admin-manual/source/installation/installation.rst
@@ -779,6 +779,34 @@ please follow the upgrade instructions for the earlier versions and upgrade firs
 #. Run the upgrade tool, as the user that runs CDAP Master (the CDAP user)::
 
      $ /opt/cdap/master/bin/svc-master run co.cask.cdap.data.tools.UpgradeTool upgrade
+     
+   Note that once you have upgraded an instance of CDAP, you cannot reverse the process; down-grades
+   to a previous version are not possible.
+   
+   The Upgrade Tool will produce output similar to the following, prompting you to continue with the upgrade:
+   
+    .. container:: highlight
+
+      .. parsed-literal::    
+    
+        UpgradeTool - version |short-version|-xxxxx.
+
+        upgrade - Upgrades CDAP to |short-version|
+          The upgrade tool upgrades the following:
+          1. User Datasets
+              - Upgrades the coprocessor jars for tables
+              - Migrates the metadata for PartitionedFileSets
+          2. System Datasets
+          3. UsageRegistry Dataset Type
+          Note: Once you run the upgrade tool you cannot rollback to the previous version.
+        Do you want to continue (y/n)
+        y
+        Starting upgrade ...
+
+   You can run the tool in a non-interactive fashion by using the ``--force`` flag, in which case
+   it will run unattended and not prompt for continuing::
+   
+     $ /opt/cdap/master/bin/svc-master run co.cask.cdap.data.tools.UpgradeTool upgrade --force
 
 #. Restart the CDAP processes::
 


### PR DESCRIPTION
Fix for https://issues.cask.co/browse/CDAP-3403

Adds to the description of the upgrade tool an example output (created with a parsed literal block so that it will use the current CDAP version string) and explains use of the ``--force`` option.

Building at : [Installation#upgrading-an-existing-version](http://docs-staging.cask.co/staging/cdap/3.2.0-SNAPSHOT-feature-3.2_3403_Installation/en/admin-manual/installation/installation.html#upgrading-an-existing-version)