### PR TITLE
CDAP-3065 add artifact methods to TestBase for unit tests

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppLifecycleHttpHandler.java
@@ -350,7 +350,7 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
     // but the caller catches all exceptions and responds with a 500
     final Id.Artifact artifactId;
     try {
-      artifactId = parseArchiveName(namespace, archiveName);
+      artifactId = ArtifactRepository.parse(namespace, archiveName);
     } catch (InvalidArtifactException e) {
       responder.sendString(HttpResponseStatus.BAD_REQUEST, e.getMessage());
       return null;
@@ -484,30 +484,6 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
       LOG.error("Got exception : ", e);
       responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
     }
-  }
-
-  // parse a filename into an Id.Artifact, assuming the filename is of format {name}-{version}.jar
-  @VisibleForTesting
-  static Id.Artifact parseArchiveName(Id.Namespace namespace, String archiveName) throws InvalidArtifactException {
-    if (!archiveName.endsWith(".jar")) {
-      throw new InvalidArtifactException(String.format("Archive name '%s' does not end in .jar", archiveName));
-    }
-
-    // strip '.jar' from the filename
-    archiveName = archiveName.substring(0, archiveName.length() - ".jar".length());
-
-    // true means try and match version as the end of the string
-    ArtifactVersion artifactVersion = new ArtifactVersion(archiveName, true);
-    String rawVersion = artifactVersion.getVersion();
-    // this happens if it could not parse the version
-    if (rawVersion == null) {
-      throw new InvalidArtifactException(
-        String.format("Archive name '%s' is not of the form {name}-{version}.jar", archiveName));
-    }
-
-    // filename should be {name}-{version}.  Strip -{version} from it to get artifact name
-    String artifactName = archiveName.substring(0, archiveName.length() - rawVersion.length() - 1);
-    return Id.Artifact.from(namespace, artifactName, rawVersion);
   }
 
   private static ApplicationDetail makeAppDetail(ApplicationSpecification spec) {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricClient.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricClient.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.internal;
 
+import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.schedule.ScheduleSpecification;
 import co.cask.cdap.api.workflow.WorkflowToken;
 import co.cask.cdap.common.NotFoundException;
@@ -38,6 +39,7 @@ import co.cask.cdap.proto.RunRecord;
 import co.cask.cdap.proto.ServiceInstances;
 import co.cask.cdap.proto.WorkflowTokenDetail;
 import co.cask.cdap.proto.WorkflowTokenNodeDetail;
+import co.cask.cdap.proto.artifact.CreateAppRequest;
 import co.cask.cdap.proto.codec.ScheduleSpecificationCodec;
 import co.cask.cdap.proto.codec.WorkflowTokenDetailCodec;
 import co.cask.cdap.proto.codec.WorkflowTokenNodeDetailCodec;
@@ -54,6 +56,7 @@ import org.apache.twill.filesystem.Location;
 import org.apache.twill.filesystem.LocationFactory;
 import org.jboss.netty.buffer.ChannelBuffers;
 import org.jboss.netty.handler.codec.http.DefaultHttpRequest;
+import org.jboss.netty.handler.codec.http.HttpHeaders;
 import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.jboss.netty.handler.codec.http.HttpRequest;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
@@ -66,6 +69,9 @@ import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.MediaType;
 
 /**
  * Client tool for AppFabricHttpHandler.
@@ -380,6 +386,25 @@ public class AppFabricClient {
       verifyResponse(HttpResponseStatus.OK, mockResponder.getStatus(), "Failed to deploy app");
     }
     return deployedJar;
+  }
+
+  public void deployApplication(Id.Application appId, CreateAppRequest createAppRequest) throws Exception {
+
+    DefaultHttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.PUT,
+      String.format("/v3/namespaces/%s/apps/%s", appId.getNamespaceId(), appId.getId()));
+    request.setHeader(Constants.Gateway.API_KEY, "api-key-example");
+
+    MockResponder mockResponder = new MockResponder();
+
+    BodyConsumer bodyConsumer = appLifecycleHttpHandler.deploy(request, mockResponder,
+      appId.getNamespaceId(), appId.getId(),
+      createAppRequest.getArtifact().getName(),
+      GSON.toJson(createAppRequest.getConfig()),
+      MediaType.APPLICATION_JSON);
+    Preconditions.checkNotNull(bodyConsumer, "BodyConsumer from deploy call should not be null");
+
+    bodyConsumer.chunk(ChannelBuffers.wrappedBuffer(Bytes.toBytes(GSON.toJson(createAppRequest))), mockResponder);
+    bodyConsumer.finished(mockResponder);
   }
 
   public void deployTemplate(Id.Namespace namespace, Id.ApplicationTemplate templateId) {

--- a/cdap-client/src/main/java/co/cask/cdap/client/ArtifactClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ArtifactClient.java
@@ -300,6 +300,27 @@ public class ArtifactClient {
   /**
    * Add an artifact.
    *
+   * @param artifactId the id of the artifact to add
+   * @param parentArtifacts the set of artifacts this artifact extends
+   * @param artifactContents an input supplier for the contents of the artifact
+   * @throws ArtifactAlreadyExistsException if the artifact already exists
+   * @throws BadRequestException if the request is invalid. For example, if the artifact name or version is invalid
+   * @throws ArtifactRangeNotFoundException if the parent artifacts do not exist
+   * @throws IOException if a network error occurred
+   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   */
+  public void add(Id.Artifact artifactId, @Nullable Set<ArtifactRange> parentArtifacts,
+                  InputSupplier<? extends InputStream> artifactContents)
+    throws UnauthorizedException, BadRequestException, ArtifactRangeNotFoundException,
+    ArtifactAlreadyExistsException, IOException {
+
+    add(artifactId.getNamespace(), artifactId.getName(), artifactContents,
+        artifactId.getVersion().getVersion(), parentArtifacts);
+  }
+
+  /**
+   * Add an artifact.
+   *
    * @param namespace the namespace to add the artifact to
    * @param artifactName the name of the artifact to add
    * @param artifactContents an input supplier for the contents of the artifact

--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestManager.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestManager.java
@@ -22,23 +22,30 @@ import co.cask.cdap.api.dataset.DatasetAdmin;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.module.DatasetModule;
 import co.cask.cdap.api.templates.ApplicationTemplate;
+import co.cask.cdap.api.templates.plugins.PluginClass;
 import co.cask.cdap.api.templates.plugins.PluginPropertyField;
 import co.cask.cdap.app.DefaultAppConfigurer;
 import co.cask.cdap.app.DefaultApplicationContext;
+import co.cask.cdap.app.program.ManifestFields;
 import co.cask.cdap.client.AdapterClient;
 import co.cask.cdap.client.ApplicationClient;
+import co.cask.cdap.client.ArtifactClient;
 import co.cask.cdap.client.NamespaceClient;
 import co.cask.cdap.client.ProgramClient;
 import co.cask.cdap.client.config.ClientConfig;
 import co.cask.cdap.client.util.RESTClient;
 import co.cask.cdap.common.io.Locations;
 import co.cask.cdap.internal.test.AppJarHelper;
+import co.cask.cdap.internal.test.PluginJarHelper;
 import co.cask.cdap.proto.AdapterConfig;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.proto.artifact.ArtifactRange;
+import co.cask.cdap.proto.artifact.CreateAppRequest;
 import co.cask.cdap.test.remote.RemoteAdapterManager;
 import co.cask.cdap.test.remote.RemoteApplicationManager;
 import co.cask.cdap.test.remote.RemoteStreamManager;
+import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.io.Files;
@@ -56,6 +63,9 @@ import java.io.IOException;
 import java.net.JarURLConnection;
 import java.net.URL;
 import java.sql.Connection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.jar.Manifest;
 import javax.annotation.Nullable;
 
 /**
@@ -66,6 +76,7 @@ public class IntegrationTestManager implements TestManager {
   private static final Logger LOG = LoggerFactory.getLogger(IntegrationTestManager.class);
   private static final Gson GSON = new Gson();
 
+  private final ArtifactClient artifactClient;
   private final ApplicationClient applicationClient;
   private final ClientConfig clientConfig;
   private final RESTClient restClient;
@@ -84,6 +95,7 @@ public class IntegrationTestManager implements TestManager {
     this.programClient = new ProgramClient(clientConfig, restClient);
     this.namespaceClient = new NamespaceClient(clientConfig, restClient);
     this.adapterClient = new AdapterClient(clientConfig, restClient);
+    this.artifactClient = new ArtifactClient(clientConfig, restClient);
   }
 
   @Override
@@ -142,6 +154,13 @@ public class IntegrationTestManager implements TestManager {
   }
 
   @Override
+  public ApplicationManager deployApplication(Id.Application appId,
+                                              CreateAppRequest createAppRequest) throws Exception {
+    applicationClient.deploy(appId, createAppRequest);
+    return new RemoteApplicationManager(appId, clientConfig, restClient);
+  }
+
+  @Override
   public void deployTemplate(Id.Namespace namespace, Id.ApplicationTemplate templateId,
                              Class<? extends ApplicationTemplate> templateClz,
                              String... exportPackages) throws IOException {
@@ -159,6 +178,68 @@ public class IntegrationTestManager implements TestManager {
                                     String description, String className,
                                     PluginPropertyField... fields) throws IOException {
     throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void addArtifact(Id.Artifact artifactId, File artifactFile) throws Exception {
+    artifactClient.add(artifactId, null, Files.newInputStreamSupplier(artifactFile));
+  }
+
+  @Override
+  public void addAppArtifact(Id.Artifact artifactId, Class<?> appClass) throws Exception {
+    Location appJar = AppJarHelper.createDeploymentJar(locationFactory, appClass, new Manifest());
+    File destination =
+      new File(tmpFolder, String.format("%s-%s.jar", artifactId.getName(), artifactId.getVersion().getVersion()));
+    Files.copy(Locations.newInputSupplier(appJar), destination);
+    appJar.delete();
+
+    artifactClient.add(artifactId, null, Files.newInputStreamSupplier(destination));
+  }
+
+  @Override
+  public void addPluginArtifact(Id.Artifact artifactId, Id.Artifact parent,
+                                Class<?> pluginClass, Class<?>... pluginClasses) throws Exception {
+    Set<ArtifactRange> parents = new HashSet<>();
+    parents.add(new ArtifactRange(
+      parent.getNamespace(), parent.getName(), parent.getVersion(), true, parent.getVersion(), true));
+    addPluginArtifact(artifactId, parents, pluginClass, pluginClasses);
+  }
+
+  @Override
+  public void addPluginArtifact(Id.Artifact artifactId, Set<ArtifactRange> parents,
+                                Class<?> pluginClass,
+                                Class<?>... pluginClasses) throws Exception {
+    Manifest manifest = createManifest(pluginClass, pluginClasses);
+    Location appJar = PluginJarHelper.createPluginJar(locationFactory, manifest, pluginClass, pluginClasses);
+    File destination =
+      new File(tmpFolder, String.format("%s-%s.jar", artifactId.getName(), artifactId.getVersion().getVersion()));
+    Files.copy(Locations.newInputSupplier(appJar), destination);
+    appJar.delete();
+
+    artifactClient.add(artifactId, parents, Files.newInputStreamSupplier(destination));
+  }
+
+  @Override
+  public void addPluginArtifact(Id.Artifact artifactId, Id.Artifact parent,
+                                Set<PluginClass> additionalPlugins,
+                                Class<?> pluginClass,
+                                Class<?>... pluginClasses) throws Exception {
+    Set<ArtifactRange> parents = new HashSet<>();
+    parents.add(new ArtifactRange(
+      parent.getNamespace(), parent.getName(), parent.getVersion(), true, parent.getVersion(), true));
+    addPluginArtifact(artifactId, parents, additionalPlugins, pluginClass, pluginClasses);
+  }
+
+  @Override
+  public void addPluginArtifact(Id.Artifact artifactId, Set<ArtifactRange> parents,
+                                @Nullable Set<PluginClass> additionalPlugins,
+                                Class<?> pluginClass, Class<?>... pluginClasses) throws Exception {
+    // TODO: implement once supported
+  }
+
+  @Override
+  public void deleteArtifact(Id.Artifact artifactId) throws Exception {
+    artifactClient.delete(artifactId);
   }
 
   @Override
@@ -238,5 +319,17 @@ public class IntegrationTestManager implements TestManager {
     } catch (IOException e) {
       throw Throwables.propagate(e);
     }
+  }
+
+  private Manifest createManifest(Class<?> cls, Class<?>... classes) {
+    Manifest manifest = new Manifest();
+    Set<String> exportPackages = new HashSet<>();
+    exportPackages.add(cls.getPackage().getName());
+    for (Class<?> clz : classes) {
+      exportPackages.add(clz.getPackage().getName());
+    }
+
+    manifest.getMainAttributes().put(ManifestFields.EXPORT_PACKAGE, Joiner.on(',').join(exportPackages));
+    return manifest;
   }
 }

--- a/cdap-test/src/main/java/co/cask/cdap/test/TestManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/TestManager.java
@@ -26,14 +26,18 @@ import co.cask.cdap.api.dataset.DatasetAdmin;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.module.DatasetModule;
 import co.cask.cdap.api.templates.ApplicationTemplate;
+import co.cask.cdap.api.templates.plugins.PluginClass;
 import co.cask.cdap.api.templates.plugins.PluginPropertyField;
 import co.cask.cdap.proto.AdapterConfig;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.proto.artifact.ArtifactRange;
+import co.cask.cdap.proto.artifact.CreateAppRequest;
 
 import java.io.File;
 import java.io.IOException;
 import java.sql.Connection;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
@@ -64,6 +68,16 @@ public interface TestManager {
    */
   ApplicationManager deployApplication(Id.Namespace namespace, Class<? extends Application> applicationClz,
                                        @Nullable Config configObject, File... bundleEmbeddedJars);
+
+  /**
+   * Deploys an {@link Application}.
+   *
+   * @param appId the id of the application to create
+   * @param createAppRequest the app creation request that includes the artifact to create the app from and any config
+   *                         to pass to the application.
+   * @return An {@link ApplicationManager} to manage the deployed application.
+   */
+  ApplicationManager deployApplication(Id.Application appId, CreateAppRequest createAppRequest) throws Exception;
 
   /**
    * Deploys an {@link ApplicationTemplate}. Only supported in unit tests.
@@ -117,6 +131,118 @@ public interface TestManager {
   void addTemplatePluginJson(Id.ApplicationTemplate templateId, String fileName, String type, String name,
                              String description, String className,
                              PluginPropertyField... fields) throws IOException;
+
+  /**
+   * Add the specified artifact.
+   *
+   * @param artifactId the id of the artifact to add
+   * @param artifactFile the contents of the artifact. Must be a valid jar file containing apps or plugins
+   * @throws Exception
+   */
+  void addArtifact(Id.Artifact artifactId, File artifactFile) throws Exception;
+
+  /**
+   * Build an application artifact from the specified class and then add it.
+   *
+   * @param artifactId the id of the artifact to add
+   * @param appClass the application class to build the artifact from
+   * @throws Exception
+   */
+  void addAppArtifact(Id.Artifact artifactId, Class<?> appClass) throws Exception;
+
+  /**
+   * Build an artifact from the specified plugin classes and then add it. The
+   * jar created will include all classes in the same package as the give classes, plus any dependencies of the
+   * given classes. If another plugin in the same package as the given plugin requires a different set of dependent
+   * classes, you must include both plugins. For example, suppose you have two plugins,
+   * com.company.myapp.functions.functionX and com.company.myapp.function.functionY, with functionX having
+   * one set of dependencies and functionY having another set of dependencies. If you only add functionX, functionY
+   * will also be included in the created jar since it is in the same package. However, only functionX's dependencies
+   * will be traced and added to the jar, so you will run into issues when the platform tries to register functionY.
+   * In this scenario, you must be certain to include specify both functionX and functionY when calling this method.
+   *
+   * @param artifactId the id of the artifact to add
+   * @param parent the parent artifact it extends
+   * @param pluginClass the plugin class to build the jar from
+   * @param pluginClasses any additional plugin classes that should be included in the jar
+   * @throws Exception
+   */
+  void addPluginArtifact(Id.Artifact artifactId, Id.Artifact parent,
+                         Class<?> pluginClass, Class<?>... pluginClasses) throws Exception;
+
+  /**
+   * Build an artifact from the specified plugin classes and then add it. The
+   * jar created will include all classes in the same package as the give classes, plus any dependencies of the
+   * given classes. If another plugin in the same package as the given plugin requires a different set of dependent
+   * classes, you must include both plugins. For example, suppose you have two plugins,
+   * com.company.myapp.functions.functionX and com.company.myapp.function.functionY, with functionX having
+   * one set of dependencies and functionY having another set of dependencies. If you only add functionX, functionY
+   * will also be included in the created jar since it is in the same package. However, only functionX's dependencies
+   * will be traced and added to the jar, so you will run into issues when the platform tries to register functionY.
+   * In this scenario, you must be certain to include specify both functionX and functionY when calling this method.
+   *
+   * @param artifactId the id of the artifact to add
+   * @param parents the parent artifacts it extends
+   * @param pluginClass the plugin class to build the jar from
+   * @param pluginClasses any additional plugin classes that should be included in the jar
+   * @throws Exception
+   */
+  void addPluginArtifact(Id.Artifact artifactId, Set<ArtifactRange> parents,
+                         Class<?> pluginClass, Class<?>... pluginClasses) throws Exception;
+
+
+  /**
+   * Build an artifact from the specified plugin classes and then add it. The
+   * jar created will include all classes in the same package as the give classes, plus any dependencies of the
+   * given classes. If another plugin in the same package as the given plugin requires a different set of dependent
+   * classes, you must include both plugins. For example, suppose you have two plugins,
+   * com.company.myapp.functions.functionX and com.company.myapp.function.functionY, with functionX having
+   * one set of dependencies and functionY having another set of dependencies. If you only add functionX, functionY
+   * will also be included in the created jar since it is in the same package. However, only functionX's dependencies
+   * will be traced and added to the jar, so you will run into issues when the platform tries to register functionY.
+   * In this scenario, you must be certain to include specify both functionX and functionY when calling this method.
+   *
+   * @param artifactId the id of the artifact to add
+   * @param parent the parent artifact it extends
+   * @param additionalPlugins any plugin classes that need to be explicitly declared because they cannot be found
+   *                          by inspecting the jar. This is true for 3rd party plugins, such as jdbc drivers
+   * @param pluginClass the plugin class to build the jar from
+   * @param pluginClasses any additional plugin classes that should be included in the jar
+   * @throws Exception
+   */
+  void addPluginArtifact(Id.Artifact artifactId, Id.Artifact parent,
+                         @Nullable Set<PluginClass> additionalPlugins,
+                         Class<?> pluginClass, Class<?>... pluginClasses) throws Exception;
+
+  /**
+   * Build an artifact from the specified plugin classes and then add it. The
+   * jar created will include all classes in the same package as the give classes, plus any dependencies of the
+   * given classes. If another plugin in the same package as the given plugin requires a different set of dependent
+   * classes, you must include both plugins. For example, suppose you have two plugins,
+   * com.company.myapp.functions.functionX and com.company.myapp.function.functionY, with functionX having
+   * one set of dependencies and functionY having another set of dependencies. If you only add functionX, functionY
+   * will also be included in the created jar since it is in the same package. However, only functionX's dependencies
+   * will be traced and added to the jar, so you will run into issues when the platform tries to register functionY.
+   * In this scenario, you must be certain to include specify both functionX and functionY when calling this method.
+   *
+   * @param artifactId the id of the artifact to add
+   * @param parents the parent artifacts it extends
+   * @param additionalPlugins any plugin classes that need to be explicitly declared because they cannot be found
+   *                          by inspecting the jar. This is true for 3rd party plugins, such as jdbc drivers
+   * @param pluginClass the plugin class to build the jar from
+   * @param pluginClasses any additional plugin classes that should be included in the jar
+   * @throws Exception
+   */
+  void addPluginArtifact(Id.Artifact artifactId, Set<ArtifactRange> parents,
+                         @Nullable Set<PluginClass> additionalPlugins,
+                         Class<?> pluginClass, Class<?>... pluginClasses) throws Exception;
+
+  /**
+   * Delete the specified artifact.
+   *
+   * @param artifactId the id of the artifact to delete
+   */
+  void deleteArtifact(Id.Artifact artifactId) throws Exception;
 
   /**
    * Creates an adapter.

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/ConfigurableTestBase.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/ConfigurableTestBase.java
@@ -26,6 +26,7 @@ import co.cask.cdap.api.dataset.module.DatasetModule;
 import co.cask.cdap.api.metrics.MetricStore;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.api.templates.ApplicationTemplate;
+import co.cask.cdap.api.templates.plugins.PluginClass;
 import co.cask.cdap.api.templates.plugins.PluginPropertyField;
 import co.cask.cdap.app.guice.AppFabricServiceRuntimeModule;
 import co.cask.cdap.app.guice.InMemoryProgramRunnerModule;
@@ -79,6 +80,7 @@ import co.cask.cdap.notifications.guice.NotificationServiceRuntimeModule;
 import co.cask.cdap.proto.AdapterConfig;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.proto.artifact.CreateAppRequest;
 import co.cask.cdap.test.internal.ApplicationManagerFactory;
 import co.cask.cdap.test.internal.DefaultApplicationManager;
 import co.cask.cdap.test.internal.DefaultStreamManager;
@@ -119,6 +121,7 @@ import java.net.URL;
 import java.sql.Connection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
@@ -416,7 +419,7 @@ public class ConfigurableTestBase {
    * other programs defined in the application must be in the same or children package as the application.
    *
    * @param applicationClz The application class
-   * @return An {@link co.cask.cdap.test.ApplicationManager} to manage the deployed application.
+   * @return An {@link ApplicationManager} to manage the deployed application.
    */
   protected static ApplicationManager deployApplication(Id.Namespace namespace,
                                                         Class<? extends Application> applicationClz,
@@ -438,7 +441,7 @@ public class ConfigurableTestBase {
    * other programs defined in the application must be in the same or children package as the application.
    *
    * @param applicationClz The application class
-   * @return An {@link co.cask.cdap.test.ApplicationManager} to manage the deployed application.
+   * @return An {@link ApplicationManager} to manage the deployed application.
    */
   protected static ApplicationManager deployApplication(Class<? extends Application> applicationClz,
                                                         File... bundleEmbeddedJars) {
@@ -448,6 +451,18 @@ public class ConfigurableTestBase {
   protected static ApplicationManager deployApplication(Class<? extends Application> applicationClz, Config appConfig,
                                                         File... bundleEmbeddedJars) {
     return deployApplication(Id.Namespace.DEFAULT, applicationClz, appConfig, bundleEmbeddedJars);
+  }
+
+  /**
+   * Deploys an {@link Application}. The application artifact must already exist.
+   *
+   * @param appId the id of the application to create
+   * @param createAppRequest the application create request
+   * @return An {@link ApplicationManager} to manage the deployed application
+   */
+  protected static ApplicationManager deployApplication(Id.Application appId,
+                                                        CreateAppRequest createAppRequest) throws Exception {
+    return getTestManager().deployApplication(appId, createAppRequest);
   }
 
   /**
@@ -523,6 +538,25 @@ public class ConfigurableTestBase {
                                               String description, String className,
                                               PluginPropertyField... fields) throws IOException {
     getTestManager().addTemplatePluginJson(templateId, fileName, type, name, description, className, fields);
+  }
+
+  protected static void addArtifact(Id.Artifact artifactId, File artifactFile) throws Exception {
+    getTestManager().addArtifact(artifactId, artifactFile);
+  }
+
+  protected static void addAppArtifact(Id.Artifact artifactId, Class<?> appClass) throws Exception {
+    getTestManager().addAppArtifact(artifactId, appClass);
+  }
+
+  protected static void addPluginArtifact(Id.Artifact artifactId, Id.Artifact parent,
+                                          Class<?> pluginClass, Class<?>... pluginClasses) throws Exception {
+    getTestManager().addPluginArtifact(artifactId, parent, pluginClass, pluginClasses);
+  }
+
+  protected static void addPluginArtifact(Id.Artifact artifactId, Id.Artifact parent,
+                                          Set<PluginClass> additionalPlugins,
+                                          Class<?> pluginClass, Class<?>... pluginClasses) throws Exception {
+    getTestManager().addPluginArtifact(artifactId, parent, additionalPlugins, pluginClass, pluginClasses);
   }
 
   /**

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/ApplicationManagerFactory.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/ApplicationManagerFactory.java
@@ -16,7 +16,6 @@
 
 package co.cask.cdap.test.internal;
 
-import co.cask.cdap.app.ApplicationSpecification;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.test.ApplicationManager;
 import com.google.inject.assistedinject.Assisted;
@@ -27,6 +26,5 @@ import org.apache.twill.filesystem.Location;
  */
 public interface ApplicationManagerFactory {
 
-  ApplicationManager create(@Assisted("applicationId") Id.Application applicationId,
-                            Location deployedJar, ApplicationSpecification appSpec);
+  ApplicationManager create(@Assisted("applicationId") Id.Application applicationId, Location deployedJar);
 }


### PR DESCRIPTION
Adding methods to add an application artifact or a plugin artifact
to TestManager and its implementations. Also adding a method to
deploy an application from an artifact.