### PR TITLE
Feature/ui styling dashboard pixel pushing

### DIFF
--- a/cdap-ui/app/features/dashboard/style.less
+++ b/cdap-ui/app/features/dashboard/style.less
@@ -45,8 +45,16 @@ body.state-dashboard {
         .btn.dropdown-toggle { margin: 0 10px; }
         .dropdown-menu { left: 10px; }
         .input-group {
-          .form-control { max-width: 100px; }
           &:first-child { margin-right: 10px; }
+          .form-control {
+            border: 1px solid #ccc;
+            border-right: 0;
+            max-width: 100px;
+          }
+          .input-group-addon {
+            border: 1px solid #ccc;
+            border-left: 0;
+          }
         }
       }
     }

--- a/cdap-ui/app/styles/themes/cdap/tabs.less
+++ b/cdap-ui/app/styles/themes/cdap/tabs.less
@@ -6,6 +6,7 @@ body.theme-cdap {
     .slanted-tabs.nav-tabs, my-tabs .nav-tabs {
       > li {
         min-width: 80px;
+        margin-bottom: 0;
         > a {
           color: @cdap-gray;
           font-weight: 500;


### PR DESCRIPTION
Pixel pushing documented in JIRA 3341:
*  Removes 1px extra margin-bottom on slanted tabs
*  Fixes inconsistent border issue affecting input-groups in the dashboard inline form
(Note: Caret positioning within dropdowns was already resolved in a previous PR)

![inline](https://cloud.githubusercontent.com/assets/5335210/9322078/672d76be-4523-11e5-9190-9b48fd460118.gif)
