### PR TITLE
CDAP-3427: Fix cdap-master packaging

### DIFF
--- a/cdap-master/pom.xml
+++ b/cdap-master/pom.xml
@@ -29,7 +29,7 @@
 
   <artifactId>cdap-master</artifactId>
   <name>CDAP Master</name>
-  <packaging>pom</packaging>
+  <packaging>jar</packaging>
 
   <dependencies>
     <dependency>


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-3427

Built cdap-master and verified that the expected classes are in the jar.