### PR TITLE
CDAP-3282 api to update an existing application

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/DeletedProgramHandlerStage.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/DeletedProgramHandlerStage.java
@@ -40,6 +40,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -120,7 +121,7 @@ public class DeletedProgramHandlerStage extends AbstractStage<ApplicationDeploya
       tags.put(Constants.Metrics.Tag.NAMESPACE, namespace);
       tags.put(Constants.Metrics.Tag.APP, application);
       tags.put(Constants.Metrics.Tag.FLOW, flow);
-      MetricDeleteQuery deleteQuery = new MetricDeleteQuery(0, endTs, null, tags);
+      MetricDeleteQuery deleteQuery = new MetricDeleteQuery(0, endTs, Collections.<String>emptyList(), tags);
       metricStore.delete(deleteQuery);
     }
   }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AppFabricTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AppFabricTestBase.java
@@ -42,8 +42,8 @@ import co.cask.cdap.metrics.query.MetricsQueryService;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.RunRecord;
+import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.artifact.ArtifactRange;
-import co.cask.cdap.proto.artifact.CreateAppRequest;
 import co.cask.tephra.TransactionManager;
 import co.cask.tephra.TransactionSystemClient;
 import com.google.common.base.Charsets;
@@ -402,13 +402,13 @@ public abstract class AppFabricTestBase {
   }
 
   protected HttpResponse deploy(Id.Application appId,
-                                CreateAppRequest<? extends Config> createAppRequest) throws Exception {
+                                AppRequest<? extends Config> appRequest) throws Exception {
     HttpEntityEnclosingRequestBase request;
     String deployPath = getVersionedAPIPath("apps/" + appId.getId(), appId.getNamespaceId());
     request = getPut(deployPath);
     request.setHeader(Constants.Gateway.API_KEY, "api-key-example");
     request.setHeader(HttpHeaders.Names.CONTENT_TYPE, MediaType.APPLICATION_JSON);
-    request.setEntity(new StringEntity(GSON.toJson(createAppRequest)));
+    request.setEntity(new StringEntity(GSON.toJson(appRequest)));
     return execute(request);
   }
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/AppLifecycleHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/AppLifecycleHttpHandlerTest.java
@@ -27,8 +27,8 @@ import co.cask.cdap.gateway.handlers.AppLifecycleHttpHandler;
 import co.cask.cdap.internal.app.services.http.AppFabricTestBase;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.artifact.ArtifactSummary;
-import co.cask.cdap.proto.artifact.CreateAppRequest;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import org.apache.http.HttpResponse;
@@ -77,9 +77,9 @@ public class AppLifecycleHttpHandlerTest extends AppFabricTestBase {
   @Test
   public void testDeployUsingNonexistantArtifact404() throws Exception {
     Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "badapp");
-    CreateAppRequest<Config> createAppRequest =
-      new CreateAppRequest<>(new ArtifactSummary("something", "1.0.0", false), null);
-    HttpResponse response = deploy(appId, createAppRequest);
+    AppRequest<Config> appRequest =
+      new AppRequest<>(new ArtifactSummary("something", "1.0.0", false), null);
+    HttpResponse response = deploy(appId, appRequest);
     Assert.assertEquals(404, response.getStatusLine().getStatusCode());
   }
 
@@ -90,7 +90,7 @@ public class AppLifecycleHttpHandlerTest extends AppFabricTestBase {
 
     Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "cfgApp");
     ConfigTestApp.ConfigClass config = new ConfigTestApp.ConfigClass("abc", "def");
-    CreateAppRequest<ConfigTestApp.ConfigClass> request = new CreateAppRequest<>(
+    AppRequest<ConfigTestApp.ConfigClass> request = new AppRequest<>(
       new ArtifactSummary(artifactId.getName(), artifactId.getVersion().getVersion(), false), config);
     Assert.assertEquals(200, deploy(appId, request).getStatusLine().getStatusCode());
 

--- a/cdap-client-tests/src/main/java/co/cask/cdap/client/app/ConfigurableProgramsApp.java
+++ b/cdap-client-tests/src/main/java/co/cask/cdap/client/app/ConfigurableProgramsApp.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.client.app;
+
+import co.cask.cdap.api.Config;
+import co.cask.cdap.api.annotation.ProcessInput;
+import co.cask.cdap.api.annotation.Property;
+import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.dataset.lib.KeyValueTable;
+import co.cask.cdap.api.flow.AbstractFlow;
+import co.cask.cdap.api.flow.flowlet.AbstractFlowlet;
+import co.cask.cdap.api.flow.flowlet.FlowletConfigurer;
+import co.cask.cdap.api.flow.flowlet.FlowletContext;
+import co.cask.cdap.api.flow.flowlet.StreamEvent;
+import co.cask.cdap.api.worker.AbstractWorker;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+
+/**
+ * Test Application that will register different programs based on the config.
+ */
+public class ConfigurableProgramsApp extends AbstractApplication<ConfigurableProgramsApp.Programs> {
+
+  /**
+   * Application Config Class.
+   */
+  public static class Programs extends Config {
+    @Nullable
+    private String flow;
+    @Nullable
+    private String worker;
+    @Nullable
+    private String stream;
+    @Nullable
+    private String dataset;
+
+    public Programs() {
+      this.stream = "streem";
+      this.dataset = "dutaset";
+    }
+
+    public Programs(String flow, String worker, String stream, String dataset) {
+      this.flow = flow;
+      this.worker = worker;
+      this.stream = stream;
+      this.dataset = dataset;
+    }
+  }
+
+  @Override
+  public void configure() {
+    Programs config = getConfig();
+    if (config.flow != null) {
+      addFlow(new Floh(config.flow, config.stream, config.dataset));
+    }
+    if (config.worker != null) {
+      addWorker(new Wurker(config.stream));
+    }
+  }
+
+  private static class Floh extends AbstractFlow {
+    private final String name;
+    private final String stream;
+    private final String dataset;
+
+    public Floh(String name, String stream, String dataset) {
+      this.name = name;
+      this.stream = stream;
+      this.dataset = dataset;
+    }
+
+    @Override
+    protected void configureFlow() {
+      setName(name);
+      addFlowlet("flohlet", new Flohlet(dataset));
+      connectStream(stream, "flohlet");
+    }
+  }
+
+  private static class Flohlet extends AbstractFlowlet {
+
+    @Property
+    private final String datasetName;
+
+    private KeyValueTable keyValueTable;
+
+    public Flohlet(String datasetName) {
+      this.datasetName = datasetName;
+    }
+
+    @ProcessInput
+    public void process(StreamEvent event) {
+      String data = Bytes.toString(event.getBody());
+      String[] fields = data.split(",");
+      keyValueTable.write(fields[0], fields[1]);
+    }
+
+    @Override
+    public void configure(FlowletConfigurer configurer) {
+      super.configure(configurer);
+      useDatasets(datasetName);
+    }
+
+    @Override
+    public void initialize(FlowletContext context) throws Exception {
+      super.initialize(context);
+      keyValueTable = context.getDataset(datasetName);
+    }
+  }
+
+  private static class Wurker extends AbstractWorker {
+    private final String streamName;
+    private volatile boolean running;
+
+    public Wurker(String streamName) {
+      this.streamName = streamName;
+    }
+
+    @Override
+    public void run() {
+      running = true;
+      while (running) {
+        try {
+          TimeUnit.SECONDS.sleep(1);
+        } catch (InterruptedException e) {
+          // shouldn't happen in test
+        }
+
+        try {
+          getContext().write(streamName, "Samuel,L. Jackson");
+          getContext().write(streamName, "Dwayne,Johnson");
+        } catch (IOException e) {
+          // shouldn't happen in test
+        }
+      }
+    }
+
+    @Override
+    public void stop() {
+      running = false;
+    }
+  }
+}

--- a/cdap-client-tests/src/main/java/co/cask/cdap/client/app/ConfigurableProgramsApp2.java
+++ b/cdap-client-tests/src/main/java/co/cask/cdap/client/app/ConfigurableProgramsApp2.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.client.app;
+
+import co.cask.cdap.api.Config;
+import co.cask.cdap.api.annotation.ProcessInput;
+import co.cask.cdap.api.annotation.Property;
+import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.dataset.lib.KeyValueTable;
+import co.cask.cdap.api.flow.AbstractFlow;
+import co.cask.cdap.api.flow.flowlet.AbstractFlowlet;
+import co.cask.cdap.api.flow.flowlet.FlowletConfigurer;
+import co.cask.cdap.api.flow.flowlet.FlowletContext;
+import co.cask.cdap.api.flow.flowlet.StreamEvent;
+import co.cask.cdap.api.worker.AbstractWorker;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+
+
+/**
+ * Test Application that will register different programs based on the config.
+ */
+public class ConfigurableProgramsApp2 extends AbstractApplication<ConfigurableProgramsApp2.Programs> {
+
+  /**
+   * Application Config Class.
+   */
+  public static class Programs extends Config {
+    @Nullable
+    private String flow;
+    @Nullable
+    private String worker;
+    @Nullable
+    private String stream;
+    @Nullable
+    private String dataset;
+    @Nullable
+    private String service;
+
+    public Programs() {
+      this.stream = "streem";
+      this.dataset = "dutaset";
+    }
+
+    public Programs(String flow, String worker, String stream, String dataset, String service) {
+      this.flow = flow;
+      this.worker = worker;
+      this.stream = stream;
+      this.dataset = dataset;
+      this.service = service;
+    }
+  }
+
+  @Override
+  public void configure() {
+    Programs config = getConfig();
+    if (config.flow != null) {
+      addFlow(new Floh(config.flow, config.stream, config.dataset));
+    }
+    if (config.worker != null) {
+      addWorker(new Wurker(config.stream));
+    }
+    if (config.service != null) {
+      addService(config.service, new PingService());
+    }
+  }
+
+  private static class Floh extends AbstractFlow {
+    private final String name;
+    private final String stream;
+    private final String dataset;
+
+    public Floh(String name, String stream, String dataset) {
+      this.name = name;
+      this.stream = stream;
+      this.dataset = dataset;
+    }
+
+    @Override
+    protected void configureFlow() {
+      setName(name);
+      addFlowlet("flohlet", new Flohlet(dataset));
+      connectStream(stream, "flohlet");
+    }
+  }
+
+  private static class Flohlet extends AbstractFlowlet {
+
+    @Property
+    private final String datasetName;
+
+    private KeyValueTable keyValueTable;
+
+    public Flohlet(String datasetName) {
+      this.datasetName = datasetName;
+    }
+
+    @ProcessInput
+    public void process(StreamEvent event) {
+      String data = Bytes.toString(event.getBody());
+      String[] fields = data.split(",");
+      keyValueTable.write(fields[0], fields[1]);
+    }
+
+    @Override
+    public void configure(FlowletConfigurer configurer) {
+      super.configure(configurer);
+      useDatasets(datasetName);
+    }
+
+    @Override
+    public void initialize(FlowletContext context) throws Exception {
+      super.initialize(context);
+      keyValueTable = context.getDataset(datasetName);
+    }
+  }
+
+  private static class Wurker extends AbstractWorker {
+    private final String streamName;
+    private volatile boolean running;
+
+    public Wurker(String streamName) {
+      this.streamName = streamName;
+    }
+
+    @Override
+    public void run() {
+      running = true;
+      while (running) {
+        try {
+          TimeUnit.SECONDS.sleep(1);
+        } catch (InterruptedException e) {
+          // shouldn't happen in test
+        }
+
+        try {
+          getContext().write(streamName, "Samuel,L. Jackson");
+          getContext().write(streamName, "Dwayne,Johnson");
+        } catch (IOException e) {
+          // shouldn't happen in test
+        }
+      }
+    }
+
+    @Override
+    public void stop() {
+      running = false;
+    }
+  }
+}

--- a/cdap-client/src/main/java/co/cask/cdap/client/ApplicationClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ApplicationClient.java
@@ -21,6 +21,8 @@ import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.client.config.ClientConfig;
 import co.cask.cdap.client.util.RESTClient;
 import co.cask.cdap.common.ApplicationNotFoundException;
+import co.cask.cdap.common.BadRequestException;
+import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.UnauthorizedException;
 import co.cask.cdap.common.utils.Tasks;
 import co.cask.cdap.proto.ApplicationDetail;
@@ -28,7 +30,7 @@ import co.cask.cdap.proto.ApplicationRecord;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramRecord;
 import co.cask.cdap.proto.ProgramType;
-import co.cask.cdap.proto.artifact.CreateAppRequest;
+import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.common.http.HttpMethod;
 import co.cask.common.http.HttpRequest;
 import co.cask.common.http.HttpResponse;
@@ -44,7 +46,6 @@ import com.google.gson.Gson;
 import java.io.File;
 import java.io.IOException;
 import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
 import java.util.Map;
@@ -234,13 +235,41 @@ public class ApplicationClient {
    * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
    */
   public void deploy(Id.Application appId,
-                     CreateAppRequest<? extends Config> createRequest) throws IOException, UnauthorizedException {
+                     AppRequest<? extends Config> createRequest) throws IOException, UnauthorizedException {
     URL url = config.resolveNamespacedURLV3(appId.getNamespace(), "apps/" + appId.getId());
     HttpRequest request = HttpRequest.put(url)
       .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
       .withBody(GSON.toJson(createRequest))
       .build();
     restClient.upload(request, config.getAccessToken());
+  }
+
+  /**
+   * Update an existing app to use a different artifact version or config.
+   *
+   * @param appId the id of the application to update
+   * @param updateRequest the request to update the application with
+   * @throws IOException if a network error occurred
+   * @throws UnauthorizedException if the request is not authorized successfully in the gateway server
+   * @throws NotFoundException if the app or requested artifact could not be found
+   * @throws BadRequestException if the request is invalid
+   */
+  public void update(Id.Application appId, AppRequest<? extends Config> updateRequest)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+
+    URL url = config.resolveNamespacedURLV3(appId.getNamespace(), String.format("apps/%s/update", appId.getId()));
+    HttpRequest request = HttpRequest.post(url)
+      .withBody(GSON.toJson(updateRequest))
+      .build();
+    HttpResponse response = restClient.execute(request, config.getAccessToken(),
+      HttpURLConnection.HTTP_NOT_FOUND, HttpURLConnection.HTTP_BAD_REQUEST);
+
+    int responseCode = response.getResponseCode();
+    if (responseCode == HttpURLConnection.HTTP_NOT_FOUND) {
+      throw new NotFoundException(response.getResponseBodyAsString());
+    } else if (responseCode == HttpURLConnection.HTTP_BAD_REQUEST) {
+      throw new BadRequestException(response.getResponseBodyAsString());
+    }
   }
 
   private void deployApp(Id.Namespace namespace, File jarFile, Map<String, String> headers)

--- a/cdap-client/src/main/java/co/cask/cdap/client/ArtifactClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ArtifactClient.java
@@ -77,6 +77,10 @@ public class ArtifactClient {
     this.restClient = restClient;
   }
 
+  public ArtifactClient(ClientConfig config) {
+    this(config, new RESTClient(config));
+  }
+
   /**
    * Lists all artifacts in the given namespace, including all system artifacts.
    *

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/Id.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/Id.java
@@ -1341,6 +1341,10 @@ public abstract class Id {
       return new Artifact(namespace, name, new ArtifactVersion(version));
     }
 
+    public static Artifact from(Namespace namespace, String name, ArtifactVersion version) {
+      return new Artifact(namespace, name, version);
+    }
+
     public static boolean isValidName(String name) {
       return isValidId(name);
     }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/artifact/AppRequest.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/artifact/AppRequest.java
@@ -19,19 +19,19 @@ package co.cask.cdap.proto.artifact;
 import javax.annotation.Nullable;
 
 /**
- * Request body when creating an app
+ * Request body when creating or updating an app.
  *
  * @param <T> the type of application config
  */
-public class CreateAppRequest<T> {
+public class AppRequest<T> {
   private final ArtifactSummary artifact;
   private final T config;
 
-  public CreateAppRequest(ArtifactSummary artifact) {
+  public AppRequest(ArtifactSummary artifact) {
     this(artifact, null);
   }
 
-  public CreateAppRequest(ArtifactSummary artifact, @Nullable T config) {
+  public AppRequest(ArtifactSummary artifact, @Nullable T config) {
     this.artifact = artifact;
     this.config = config;
   }


### PR DESCRIPTION
An application's config can be updated, as well as the artifact
version it uses. Changing artifact name is invalid. If no config
is given, the existing config will be used. Otherwise, the
existing config is completely overwritten by the requested config.