### PR TITLE
Feature/ui styling ns dropdown scroll

### DIFF
--- a/cdap-ui/app/directives/breadcrumbs/breadcrumbs-ctrl.js
+++ b/cdap-ui/app/directives/breadcrumbs/breadcrumbs-ctrl.js
@@ -19,7 +19,7 @@ angular.module(PKG.name + '.commons')
         // namespace dropdown
         $dropdown(element, {
           template: 'breadcrumbs/namespace.html',
-          animation: 'am-flip-x',
+          animation: 'none',
           scope: $scope
         });
       }

--- a/cdap-ui/app/directives/breadcrumbs/breadcrumbs.less
+++ b/cdap-ui/app/directives/breadcrumbs/breadcrumbs.less
@@ -84,11 +84,6 @@ my-breadcrumbs, my-breadcrumb {
       .box-shadow(0 6px 12px rgba(0, 0, 0, 0.175));
       overflow-x: hidden;
       overflow-y: scroll;
-      &.am-flip-x {
-        .transition(none);
-        -webkit-animation-duration: 0s;
-        animation-duration: 0s;
-      }
       @media (max-width: @screen-md-max) {
         position: absolute;
       }

--- a/cdap-ui/app/directives/breadcrumbs/breadcrumbs.less
+++ b/cdap-ui/app/directives/breadcrumbs/breadcrumbs.less
@@ -15,6 +15,7 @@ my-breadcrumbs, my-breadcrumb {
     left: 0;
     height: 40px;
     line-height: 40px;
+
     .crumbs {
       .flexbox();
       flex-direction: row;
@@ -23,50 +24,6 @@ my-breadcrumbs, my-breadcrumb {
       height: 40px;
 
       li.dropdown {
-        ul.dropdown-menu {
-          width: 120px;
-          max-height: 290px;
-          min-width: 0;
-          background-color: white;
-          border-color: white;
-          padding: 10px 0;
-          margin-top: 1px;
-          .border-radius(4px);
-          .box-shadow(0 6px 12px rgba(0, 0, 0, 0.175));
-          overflow-x: hidden;
-          overflow-y: scroll;
-          @media (max-width: @screen-md-max) {
-            position: absolute;
-          }
-          > li {
-            background-color: white;
-            padding: 0;
-            &:focus {
-              outline: 0;
-            }
-            > a {
-              color: @cdap-header;
-              font-weight: 500;
-              background-color: white;
-              padding-right: 10px;
-              padding-left: 10px;
-              &:hover, &:focus {
-                color: @cdap-orange;
-              }
-              &:focus {
-                outline: 0;
-              }
-            }
-            i {
-              display: inline-block;
-              width: 13px;
-            }
-            .active {
-              color: #c4c4c4;
-              pointer-events: none;
-            }
-          }
-        }
         &.open {
           a.ns-dropdown-toggle:focus {
             border-color: transparent;
@@ -110,6 +67,57 @@ my-breadcrumbs, my-breadcrumb {
         }
         &:last-child {
           margin-right: 7px;
+        }
+      }
+    }
+
+    ul.dropdown-menu {
+      width: 120px;
+      height: auto;
+      max-height: 290px;
+      min-width: 0;
+      background-color: white;
+      border-color: white;
+      padding: 10px 0;
+      margin-top: 1px;
+      .border-radius(4px);
+      .box-shadow(0 6px 12px rgba(0, 0, 0, 0.175));
+      overflow-x: hidden;
+      overflow-y: scroll;
+      &.am-flip-x {
+        .transition(none);
+        -webkit-animation-duration: 0s;
+        animation-duration: 0s;
+      }
+      @media (max-width: @screen-md-max) {
+        position: absolute;
+      }
+      > li {
+        background-color: white;
+        padding: 0;
+        &:focus {
+          outline: 0;
+        }
+        > a {
+          color: @cdap-header;
+          font-weight: 500;
+          background-color: white;
+          padding-right: 10px;
+          padding-left: 10px;
+          &:hover, &:focus {
+            color: @cdap-orange;
+          }
+          &:focus {
+            outline: 0;
+          }
+        }
+        i {
+          display: inline-block;
+          width: 13px;
+        }
+        .active {
+          color: #c4c4c4;
+          pointer-events: none;
         }
       }
     }

--- a/cdap-ui/app/styles/themes/cdap/header.less
+++ b/cdap-ui/app/styles/themes/cdap/header.less
@@ -2,8 +2,8 @@
 @import "../../../../bower_components/bootstrap/less/mixins.less";
 
 body {
-  header {
-
+  header.navbar {
+    margin-bottom: 0;
     [my-navbar] {
       padding-top: 10px;
       padding-bottom: 15px;


### PR DESCRIPTION
*  Removes 18px bottom margin from global header (unnecessary since the header is fixed and main.container is positioned around it)
*  Disables namespace dropdown animation, which was causing the dropdown scroll to stop working intermittently

cluster name: ns-dd-scroll