### PR TITLE
Update the copyright header for CDAP from 2014 to 2014-2015

### DIFF
--- a/cdap-api-common/pom.xml
+++ b/cdap-api-common/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api-common/src/main/java/co/cask/cdap/api/annotation/Beta.java
+++ b/cdap-api-common/src/main/java/co/cask/cdap/api/annotation/Beta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api-common/src/main/java/co/cask/cdap/api/common/Bytes.java
+++ b/cdap-api-common/src/main/java/co/cask/cdap/api/common/Bytes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api-common/src/main/java/co/cask/cdap/api/data/format/FormatSpecification.java
+++ b/cdap-api-common/src/main/java/co/cask/cdap/api/data/format/FormatSpecification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api-common/src/main/java/co/cask/cdap/api/data/format/RecordFormat.java
+++ b/cdap-api-common/src/main/java/co/cask/cdap/api/data/format/RecordFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api-common/src/main/java/co/cask/cdap/api/data/format/StructuredRecord.java
+++ b/cdap-api-common/src/main/java/co/cask/cdap/api/data/format/StructuredRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api-common/src/main/java/co/cask/cdap/api/data/format/UnexpectedFormatException.java
+++ b/cdap-api-common/src/main/java/co/cask/cdap/api/data/format/UnexpectedFormatException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api-common/src/main/java/co/cask/cdap/api/data/schema/Schema.java
+++ b/cdap-api-common/src/main/java/co/cask/cdap/api/data/schema/Schema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api-common/src/main/java/co/cask/cdap/api/data/schema/SchemaHash.java
+++ b/cdap-api-common/src/main/java/co/cask/cdap/api/data/schema/SchemaHash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api-common/src/main/java/co/cask/cdap/api/data/schema/UnsupportedTypeException.java
+++ b/cdap-api-common/src/main/java/co/cask/cdap/api/data/schema/UnsupportedTypeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api-common/src/main/java/co/cask/cdap/api/flow/flowlet/StreamEvent.java
+++ b/cdap-api-common/src/main/java/co/cask/cdap/api/flow/flowlet/StreamEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api-common/src/main/java/co/cask/cdap/api/stream/StreamEventData.java
+++ b/cdap-api-common/src/main/java/co/cask/cdap/api/stream/StreamEventData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api-common/src/main/java/co/cask/cdap/api/stream/StreamEventDecoder.java
+++ b/cdap-api-common/src/main/java/co/cask/cdap/api/stream/StreamEventDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api-common/src/main/java/co/cask/cdap/api/stream/package-info.java
+++ b/cdap-api-common/src/main/java/co/cask/cdap/api/stream/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api-common/src/main/java/co/cask/cdap/internal/io/SchemaTypeAdapter.java
+++ b/cdap-api-common/src/main/java/co/cask/cdap/internal/io/SchemaTypeAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/pom.xml
+++ b/cdap-api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/Processor.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/Processor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/ProgramLifecycle.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/ProgramLifecycle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/ProgramSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/ProgramSpecification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/Resources.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/Resources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/RuntimeContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/RuntimeContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/ServiceDiscoverer.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/ServiceDiscoverer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/SingleRunnableApplication.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/SingleRunnableApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/TxRunnable.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/TxRunnable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/annotation/Batch.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/annotation/Batch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/annotation/HashPartition.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/annotation/HashPartition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/annotation/Output.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/annotation/Output.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/annotation/ProcessInput.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/annotation/ProcessInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/annotation/Property.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/annotation/Property.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/annotation/RoundRobin.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/annotation/RoundRobin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/annotation/Tick.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/annotation/Tick.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/annotation/package-info.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/annotation/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/app/Application.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/app/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/app/ApplicationContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/app/ApplicationContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/builder/Creator.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/builder/Creator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/builder/DescriptionSetter.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/builder/DescriptionSetter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/builder/NameSetter.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/builder/NameSetter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/builder/OptionsSetter.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/builder/OptionsSetter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/builder/package-info.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/builder/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/common/PropertyProvider.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/common/PropertyProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/common/RuntimeArguments.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/common/RuntimeArguments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/common/Scope.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/common/Scope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/common/package-info.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/common/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/data/DatasetContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/data/DatasetContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/data/DatasetInstantiationException.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/data/DatasetInstantiationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/data/batch/BatchReadable.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/data/batch/BatchReadable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/data/batch/BatchWritable.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/data/batch/BatchWritable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/data/batch/InputFormatProvider.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/data/batch/InputFormatProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/data/batch/IteratorBasedSplitReader.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/data/batch/IteratorBasedSplitReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/data/batch/OutputFormatProvider.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/data/batch/OutputFormatProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/data/batch/RecordScannable.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/data/batch/RecordScannable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/data/batch/RecordScanner.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/data/batch/RecordScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/data/batch/RecordWritable.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/data/batch/RecordWritable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/data/batch/Scannables.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/data/batch/Scannables.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/data/batch/SimpleSplit.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/data/batch/SimpleSplit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/data/batch/Split.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/data/batch/Split.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/data/batch/SplitReader.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/data/batch/SplitReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/data/batch/SplitReaderAdapter.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/data/batch/SplitReaderAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/data/batch/SplitReaderBase.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/data/batch/SplitReaderBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/data/batch/package-info.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/data/batch/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/data/package-info.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/data/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/data/stream/Stream.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/data/stream/Stream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/data/stream/StreamSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/data/stream/StreamSpecification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/data/stream/package-info.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/data/stream/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/DataSetException.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/DataSetException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/Dataset.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/Dataset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/DatasetAdmin.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/DatasetAdmin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/DatasetDefinition.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/DatasetDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/DatasetProperties.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/DatasetProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/DatasetSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/DatasetSpecification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/AbstractCloseableIterator.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/AbstractCloseableIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/AbstractDataset.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/AbstractDataset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/AbstractDatasetDefinition.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/AbstractDatasetDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/CloseableIterator.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/CloseableIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/CompositeDatasetAdmin.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/CompositeDatasetAdmin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/CompositeDatasetDefinition.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/CompositeDatasetDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/CounterTimeseriesTable.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/CounterTimeseriesTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/CounterTimeseriesTableDefinition.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/CounterTimeseriesTableDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/IndexedObjectStore.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/IndexedObjectStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/IndexedObjectStoreDefinition.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/IndexedObjectStoreDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/IndexedTable.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/IndexedTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/IndexedTableDefinition.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/IndexedTableDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/KeyValue.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/KeyValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/KeyValueTable.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/KeyValueTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/KeyValueTableDefinition.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/KeyValueTableDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/ObjectStore.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/ObjectStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/ObjectStores.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/ObjectStores.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/TimeseriesDataset.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/TimeseriesDataset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/TimeseriesTable.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/TimeseriesTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/TimeseriesTableDefinition.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/TimeseriesTableDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/TimeseriesTables.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/TimeseriesTables.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/cube/Interpolator.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/cube/Interpolator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/cube/Interpolators.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/cube/Interpolators.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/cube/MeasureType.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/cube/MeasureType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/package-info.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/metrics/MeteredDataset.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/metrics/MeteredDataset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/metrics/package-info.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/metrics/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/module/DatasetDefinitionRegistry.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/module/DatasetDefinitionRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/module/DatasetModule.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/module/DatasetModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/module/DatasetType.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/module/DatasetType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/module/EmbeddedDataset.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/module/EmbeddedDataset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/module/package-info.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/module/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/package-info.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/ConflictDetection.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/ConflictDetection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/Delete.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/Delete.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/EmptyRow.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/EmptyRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/Get.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/Get.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/Increment.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/Increment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/MemoryTable.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/MemoryTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/OrderedTable.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/OrderedTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/Put.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/Put.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/Result.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/Result.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/Row.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/Row.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/RowColumns.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/RowColumns.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/Scanner.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/Scanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/TableSplit.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/TableSplit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/Tables.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/Tables.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/package-info.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/flow/Flow.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/flow/Flow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/flow/FlowSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/flow/FlowSpecification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/flow/FlowletConnection.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/flow/FlowletConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/flow/FlowletDefinition.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/flow/FlowletDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/flow/flowlet/AbstractFlowlet.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/flow/flowlet/AbstractFlowlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/flow/flowlet/Callback.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/flow/flowlet/Callback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/flow/flowlet/FailurePolicy.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/flow/flowlet/FailurePolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/flow/flowlet/FailureReason.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/flow/flowlet/FailureReason.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/flow/flowlet/Flowlet.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/flow/flowlet/Flowlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/flow/flowlet/FlowletContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/flow/flowlet/FlowletContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/flow/flowlet/FlowletException.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/flow/flowlet/FlowletException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/flow/flowlet/FlowletSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/flow/flowlet/FlowletSpecification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/flow/flowlet/InputContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/flow/flowlet/InputContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/flow/flowlet/OutputEmitter.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/flow/flowlet/OutputEmitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/flow/flowlet/package-info.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/flow/flowlet/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/flow/package-info.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/flow/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/AbstractMapReduce.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/AbstractMapReduce.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduce.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduce.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceConfigurer.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceSpecification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/package-info.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/metrics/Metrics.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/metrics/Metrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/metrics/package-info.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/metrics/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/package-info.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/schedule/SchedulableProgramSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/schedule/SchedulableProgramSpecification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/schedule/package-info.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/schedule/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/service/AbstractService.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/service/AbstractService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/service/BasicService.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/service/BasicService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/service/Service.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/service/Service.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/service/ServiceConfigurer.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/service/ServiceConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/service/ServiceSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/service/ServiceSpecification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/service/http/AbstractHttpServiceHandler.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/service/http/AbstractHttpServiceHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/service/http/HttpServiceConfigurer.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/service/http/HttpServiceConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/service/http/HttpServiceHandler.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/service/http/HttpServiceHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/service/http/HttpServiceHandlerSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/service/http/HttpServiceHandlerSpecification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/service/http/HttpServiceRequest.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/service/http/HttpServiceRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/service/http/HttpServiceResponder.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/service/http/HttpServiceResponder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/service/http/ServiceHttpEndpoint.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/service/http/ServiceHttpEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/service/http/package-info.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/service/http/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/service/package-info.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/service/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/spark/AbstractSpark.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/spark/AbstractSpark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/spark/JavaSparkProgram.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/spark/JavaSparkProgram.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/spark/ScalaSparkProgram.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/spark/ScalaSparkProgram.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/spark/Spark.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/spark/Spark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/spark/SparkConfigurer.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/spark/SparkConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/spark/SparkContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/spark/SparkContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/spark/SparkProgram.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/spark/SparkProgram.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/spark/SparkSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/spark/SparkSpecification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/spark/package-info.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/spark/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/webapp/WebappSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/webapp/WebappSpecification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/webapp/package-info.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/webapp/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/AbstractWorkflowAction.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/AbstractWorkflowAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowAction.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowActionSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowActionSpecification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowCompletion.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowCompletion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/package-info.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/internal/UserErrors.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/UserErrors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/internal/UserMessages.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/UserMessages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/internal/flow/DefaultFlowSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/flow/DefaultFlowSpecification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/internal/flow/package-info.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/flow/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/internal/flowlet/DefaultFlowletSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/flowlet/DefaultFlowletSpecification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/internal/flowlet/package-info.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/flowlet/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/internal/io/AbstractFieldAccessor.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/io/AbstractFieldAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/internal/io/AbstractSchemaGenerator.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/io/AbstractSchemaGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/internal/io/FieldAccessor.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/io/FieldAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/internal/io/ReflectionSchemaGenerator.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/io/ReflectionSchemaGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/internal/io/SchemaGenerator.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/io/SchemaGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/internal/io/TypeRepresentation.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/io/TypeRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/internal/io/package-info.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/io/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/internal/lang/FieldVisitor.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/lang/FieldVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/internal/lang/Fields.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/lang/Fields.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/internal/lang/MethodVisitor.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/lang/MethodVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/internal/lang/Reflections.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/lang/Reflections.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/internal/lang/Visitor.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/lang/Visitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/internal/lang/package-info.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/lang/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/internal/package-info.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/internal/schedule/package-info.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/schedule/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/internal/specification/DataSetFieldExtractor.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/specification/DataSetFieldExtractor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/internal/specification/FlowletMethod.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/specification/FlowletMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/internal/specification/OutputEmitterFieldExtractor.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/specification/OutputEmitterFieldExtractor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/internal/specification/ProcessMethodExtractor.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/specification/ProcessMethodExtractor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/internal/specification/PropertyFieldExtractor.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/specification/PropertyFieldExtractor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/internal/specification/package-info.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/specification/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/internal/workflow/DefaultWorkflowActionSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/workflow/DefaultWorkflowActionSpecification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/internal/workflow/package-info.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/workflow/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/pom.xml
+++ b/cdap-app-fabric/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/authorization/AuthorizationFactory.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/authorization/AuthorizationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/deploy/ConfigResponse.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/deploy/ConfigResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/deploy/ConfigResult.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/deploy/ConfigResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/deploy/Configurator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/deploy/Configurator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/deploy/ManagerFactory.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/deploy/ManagerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/DataFabricFacadeModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/DataFabricFacadeModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/ProgramRunnerRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/ProgramRunnerRuntimeModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/ServiceStoreModules.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/ServiceStoreModules.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/metrics/MapReduceMetrics.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/metrics/MapReduceMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/metrics/ProgramUserMetrics.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/metrics/ProgramUserMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/program/Archive.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/program/Archive.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/program/ManifestFields.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/program/ManifestFields.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/program/Version.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/program/Version.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/queue/InputDatum.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/queue/InputDatum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/queue/QueueReader.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/queue/QueueReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/queue/QueueSpecification.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/queue/QueueSpecification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/queue/QueueSpecificationGenerator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/queue/QueueSpecificationGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/queue/package-info.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/queue/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/Arguments.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/Arguments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/ProgramController.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/ProgramController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/ProgramOptions.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/ProgramOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/ProgramResourceReporter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/ProgramResourceReporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/ProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/ProgramRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/services/Data.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/services/Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/ServiceStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/ServiceStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/verification/AbstractVerifier.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/verification/AbstractVerifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/verification/Verifier.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/verification/Verifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/verification/VerifyResult.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/verification/VerifyResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/archive/ArchiveBundler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/archive/ArchiveBundler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/error/Errors.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/error/Errors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/DatasetServiceStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/DatasetServiceStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/WorkflowClient.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/WorkflowClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/dataset/package-info.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/dataset/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/package-info.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/util/ThriftHelper.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/util/ThriftHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/BufferFileInputStream.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/BufferFileInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/ForwardingFlowSpecification.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/ForwardingFlowSpecification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/ForwardingResourceSpecification.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/ForwardingResourceSpecification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/ForwardingRuntimeSpecification.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/ForwardingRuntimeSpecification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/ForwardingTwillSpecification.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/ForwardingTwillSpecification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/SchemaFinder.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/SchemaFinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/ServiceSpecificationCodec.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/ServiceSpecificationCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/Specifications.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/Specifications.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/DefaultConfigResponse.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/DefaultConfigResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/SandboxConfigurator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/SandboxConfigurator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/ApplicationDeployable.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/ApplicationDeployable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/ApplicationRegistrationStage.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/ApplicationRegistrationStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/ApplicationWithPrograms.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/ApplicationWithPrograms.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/CreateDatasetInstancesStage.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/CreateDatasetInstancesStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/CreateStreamsStage.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/CreateStreamsStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/DeployDatasetModulesStage.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/DeployDatasetModulesStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/mapreduce/DefaultMapReduceConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/mapreduce/DefaultMapReduceConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/queue/BasicInputDatum.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/queue/BasicInputDatum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/queue/NullInputDatum.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/queue/NullInputDatum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/queue/QueueReaderFactory.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/queue/QueueReaderFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/queue/RoundRobinQueueReader.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/queue/RoundRobinQueueReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/queue/SimpleQueueSpecificationGenerator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/queue/SimpleQueueSpecificationGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/queue/SingleItemQueueReader.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/queue/SingleItemQueueReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/queue/SingleQueue2Reader.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/queue/SingleQueue2Reader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/queue/StreamQueueReader.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/queue/StreamQueueReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/queue/TimeTrackingQueueReader.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/queue/TimeTrackingQueueReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/queue/package-info.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/queue/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractDataFabricFacade.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractDataFabricFacade.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractListener.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractProgramController.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractProgramController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractResourceReporter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractResourceReporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/BasicArguments.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/BasicArguments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/CloseableQueueConsumer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/CloseableQueueConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/DataFabricFacade.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/DataFabricFacade.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/DataFabricFacadeFactory.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/DataFabricFacadeFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/DataSetFieldSetter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/DataSetFieldSetter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/Datasets.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/Datasets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/MetricsFieldSetter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/MetricsFieldSetter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/ProgramControllerServiceAdapter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/ProgramControllerServiceAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/SimpleProgramOptions.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/SimpleProgramOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/AbstractMapReduceContextBuilder.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/AbstractMapReduceContextBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/InMemoryTransactionServiceManager.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/InMemoryTransactionServiceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceMetricsWriter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceMetricsWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramController.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/DataSetInputSplit.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/DataSetInputSplit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/DataSetOutputCommitter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/DataSetOutputCommitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/DataSetOutputFormat.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/DataSetOutputFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/DataSetRecordReader.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/DataSetRecordReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/DataSetRecordWriter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/DataSetRecordWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/distributed/DistributedMapReduceContextBuilder.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/distributed/DistributedMapReduceContextBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/inmemory/InMemoryMapReduceContextBuilder.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/inmemory/InMemoryMapReduceContextBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/inmemory/LocalClientProtocolProvider.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/inmemory/LocalClientProtocolProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractTwillProgramController.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractTwillProgramController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedServiceRunnableInstanceUpdater.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedServiceRunnableInstanceUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/FlowTwillProgramController.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/FlowTwillProgramController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/FlowletTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/FlowletTwillRunnable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/MapReduceTwillProgramController.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/MapReduceTwillProgramController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/MapReduceTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/MapReduceTwillRunnable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/ProgramCommands.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/ProgramCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/RunnableOptions.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/RunnableOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/ServiceTwillProgramController.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/ServiceTwillProgramController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/ServiceTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/ServiceTwillRunnable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/TransactionServiceManager.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/TransactionServiceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/WebappTwillApplication.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/WebappTwillApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/WebappTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/WebappTwillRunnable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/WorkflowTwillProgramController.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/WorkflowTwillProgramController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/WorkflowTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/WorkflowTwillRunnable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/ConsumerSupplier.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/ConsumerSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/DataObject.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/DataObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/DatumOutputEmitter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/DatumOutputEmitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowletProcessDriver.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowletProcessDriver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowletProcessEntry.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowletProcessEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowletProgramController.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowletProgramController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowletRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowletRuntimeService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/InputAcknowledger.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/InputAcknowledger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/OutputEmitterFactory.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/OutputEmitterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/OutputEmitterFieldSetter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/OutputEmitterFieldSetter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/ProcessMethod.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/ProcessMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/ProcessMethodCallback.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/ProcessMethodCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/ProcessSpecification.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/ProcessSpecification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/ReflectionProcessMethod.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/ReflectionProcessMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/SchemaCache.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/SchemaCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/package-info.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/DistributedSchedulerService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/DistributedSchedulerService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/ExecutorThreadPool.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/ExecutorThreadPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/LocalSchedulerService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/LocalSchedulerService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/SchedulerService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/SchedulerService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/package-info.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/store/DatasetBasedTimeScheduleStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/store/DatasetBasedTimeScheduleStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/store/ScheduleStoreTableUtil.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/store/ScheduleStoreTableUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/InMemoryProgramRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/InMemoryProgramRuntimeService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/AbstractHttpHandlerDelegator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/AbstractHttpHandlerDelegator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/DefaultHttpServiceRequest.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/DefaultHttpServiceRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/DelayedHttpServiceResponder.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/DelayedHttpServiceResponder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/DelegatorContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/DelegatorContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/HttpHandlerFactory.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/HttpHandlerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/HttpHandlerGenerator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/HttpHandlerGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/TransactionalHttpServiceContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/TransactionalHttpServiceContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkContextConfig.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkContextConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkProgramController.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkProgramController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/dataset/DatasetRecordReader.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/dataset/DatasetRecordReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/dataset/DatasetRecordWriter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/dataset/DatasetRecordWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/dataset/SparkDatasetInputFormat.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/dataset/SparkDatasetInputFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/dataset/SparkDatasetOutputFormat.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/dataset/SparkDatasetOutputFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/metrics/SparkMetricsReporter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/metrics/SparkMetricsReporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/metrics/SparkMetricsSink.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/metrics/SparkMetricsSink.java
@@ -1,6 +1,6 @@
 /*
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/webapp/ExplodeJarHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/webapp/ExplodeJarHttpHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/webapp/IntactJarHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/webapp/IntactJarHttpHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/webapp/JarExploder.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/webapp/JarExploder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/webapp/JarHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/webapp/JarHttpHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/webapp/ServePathGenerator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/webapp/ServePathGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/webapp/WebappHttpHandlerFactory.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/webapp/WebappHttpHandlerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/webapp/WebappProgramController.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/webapp/WebappProgramController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/webapp/WebappURLRewriter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/webapp/WebappURLRewriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/webapp/package-info.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/webapp/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/AbstractProgramWorkflowRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/AbstractProgramWorkflowRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowServiceHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowServiceHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AppFabricServer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AppFabricServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/BasicHttpServiceContextFactory.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/BasicHttpServiceContextFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/DefaultHttpServiceHandlerConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/DefaultHttpServiceHandlerConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/DefaultServiceConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/DefaultServiceConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ServiceEndpointExtractor.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ServiceEndpointExtractor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/spark/DefaultSparkConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/spark/DefaultSparkConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/ApplicationMeta.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/ApplicationMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/ProgramArgs.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/ProgramArgs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/verification/DatasetCreationSpecVerifier.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/verification/DatasetCreationSpecVerifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/verification/FlowVerification.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/verification/FlowVerification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/verification/ProgramVerification.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/verification/ProgramVerification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/verification/StreamVerification.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/verification/StreamVerification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/pipeline/AbstractPipeline.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/pipeline/AbstractPipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/pipeline/StageContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/pipeline/StageContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/pipeline/SynchronousPipeline.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/pipeline/SynchronousPipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/pipeline/SynchronousPipelineFactory.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/pipeline/SynchronousPipelineFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/pipeline/AbstractStage.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/pipeline/AbstractStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/pipeline/Context.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/pipeline/Context.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/pipeline/Pipeline.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/pipeline/Pipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/pipeline/PipelineFactory.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/pipeline/PipelineFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/pipeline/Stage.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/pipeline/Stage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/security/ApplicationPermissionCollection.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/security/ApplicationPermissionCollection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/security/ApplicationSecurity.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/security/ApplicationSecurity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/resources/META-INF/mime.types
+++ b/cdap-app-fabric/src/main/resources/META-INF/mime.types
@@ -1,5 +1,5 @@
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/resources/META-INF/services/org.apache.hadoop.mapreduce.protocol.ClientProtocolProvider
+++ b/cdap-app-fabric/src/main/resources/META-INF/services/org.apache.hadoop.mapreduce.protocol.ClientProtocolProvider
@@ -1,5 +1,5 @@
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/resources/UserMessages.properties
+++ b/cdap-app-fabric/src/main/resources/UserMessages.properties
@@ -1,5 +1,5 @@
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/main/resources/mapred-site-local.xml
+++ b/cdap-app-fabric/src/main/resources/mapred-site-local.xml
@@ -2,7 +2,7 @@
 <?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
 
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/AppWithDataset.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/AppWithDataset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/FlowMapReduceApp.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/FlowMapReduceApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/InvalidFlowOutputApp.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/InvalidFlowOutputApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/NoProgramsApp.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/NoProgramsApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/TestCountRandomApp.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/TestCountRandomApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/ToyApp.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/ToyApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/WebCrawlApp.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/WebCrawlApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/app/runtime/ProgramControllerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/app/runtime/ProgramControllerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/app/verification/AbstractVerifierTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/app/verification/AbstractVerifierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/MockResponder.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/MockResponder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/TempFolder.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/TempFolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AggregateMetricsByTag.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AggregateMetricsByTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithMapReduce.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithMapReduce.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithMapReduceUsingFileSet.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithMapReduceUsingFileSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithMapReduceUsingObjectStore.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithMapReduceUsingObjectStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/spark/ScalaSparkAppUsingObjectStore.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/spark/ScalaSparkAppUsingObjectStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/spark/SparkAppUsingObjectStore.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/spark/SparkAppUsingObjectStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/webapp/ExplodeJarHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/webapp/ExplodeJarHttpHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/webapp/IntactJarHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/webapp/IntactJarHttpHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/webapp/JarExploderTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/webapp/JarExploderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/webapp/JarHttpHandlerTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/webapp/JarHttpHandlerTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/webapp/ServePathGeneratorTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/webapp/ServePathGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/webapp/WebappProgramRunnerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/webapp/WebappProgramRunnerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/scheduler/LogPrintingJob.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/scheduler/LogPrintingJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/scheduler/SchedulerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/scheduler/SchedulerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/AppFabricServerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/AppFabricServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/NotificationFeedHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/NotificationFeedHttpHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/PingHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/PingHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/verification/ApplicationVerificationTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/verification/ApplicationVerificationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/verification/FlowVerificationTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/verification/FlowVerificationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/pipeline/PipelineTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/pipeline/PipelineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/runtime/app/MultiApp.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/runtime/app/MultiApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/security/ApplicationSecurityTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/security/ApplicationSecurityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/stream/app/StreamApp.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/stream/app/StreamApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/test/resources/logback-test.xml
+++ b/cdap-app-fabric/src/test/resources/logback-test.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-fabric/src/test/scala/co/cask/cdap/internal/app/runtime/spark/ScalaCharCountProgram.scala
+++ b/cdap-app-fabric/src/test/scala/co/cask/cdap/internal/app/runtime/spark/ScalaCharCountProgram.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-batch-sink-archetype/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-batch-sink-archetype/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-batch-source-archetype/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-batch-source-archetype/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-realtime-sink-archetype/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-realtime-sink-archetype/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-realtime-source-archetype/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-realtime-source-archetype/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-transform-archetype/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-transform-archetype/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/resources/logback-test.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/resources/logback-test.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/common/SchemaConverter.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/common/SchemaConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-templates/cdap-etl/pom.xml
+++ b/cdap-app-templates/cdap-etl/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-app-templates/pom.xml
+++ b/cdap-app-templates/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-archetypes/cdap-app-archetype/README.rst
+++ b/cdap-archetypes/cdap-app-archetype/README.rst
@@ -33,7 +33,7 @@ To confirm project creation, type Y and press ENTER.
 License and Trademarks
 ======================
 
-Copyright © 2014 Cask Data, Inc.
+Copyright © 2014-2015 Cask Data, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 in compliance with the License. You may obtain a copy of the License at

--- a/cdap-archetypes/cdap-app-archetype/pom.xml
+++ b/cdap-archetypes/cdap-app-archetype/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-archetypes/cdap-app-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/cdap-archetypes/cdap-app-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-archetypes/cdap-app-archetype/src/main/resources/archetype-resources/bin/app-manager.bat
+++ b/cdap-archetypes/cdap-app-archetype/src/main/resources/archetype-resources/bin/app-manager.bat
@@ -2,7 +2,7 @@
 
 REM #################################################################################
 REM ##
-REM ## Copyright © 2014 Cask Data, Inc.
+REM ## Copyright © 2014-2015 Cask Data, Inc.
 REM ##
 REM ## Licensed under the Apache License, Version 2.0 (the "License"); you may not
 REM ## use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-archetypes/cdap-app-archetype/src/main/resources/archetype-resources/bin/app-manager.sh
+++ b/cdap-archetypes/cdap-app-archetype/src/main/resources/archetype-resources/bin/app-manager.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-archetypes/cdap-app-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/cdap-archetypes/cdap-app-archetype/src/main/resources/archetype-resources/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-archetypes/cdap-app-archetype/src/main/resources/archetype-resources/src/main/java/HelloWorld.java
+++ b/cdap-archetypes/cdap-app-archetype/src/main/resources/archetype-resources/src/main/java/HelloWorld.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-archetypes/cdap-app-archetype/src/main/resources/archetype-resources/src/main/java/package-info.java
+++ b/cdap-archetypes/cdap-app-archetype/src/main/resources/archetype-resources/src/main/java/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-archetypes/cdap-app-archetype/src/main/resources/archetype-resources/src/test/java/HelloWorldTest.java
+++ b/cdap-archetypes/cdap-app-archetype/src/main/resources/archetype-resources/src/test/java/HelloWorldTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-archetypes/cdap-spark-java-archetype/README.rst
+++ b/cdap-archetypes/cdap-spark-java-archetype/README.rst
@@ -33,7 +33,7 @@ To confirm project creation, type Y and press ENTER.
 License and Trademarks
 ======================
 
-Copyright © 2014 Cask Data, Inc.
+Copyright © 2014-2015 Cask Data, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 in compliance with the License. You may obtain a copy of the License at

--- a/cdap-archetypes/cdap-spark-java-archetype/pom.xml
+++ b/cdap-archetypes/cdap-spark-java-archetype/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-archetypes/cdap-spark-java-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/cdap-archetypes/cdap-spark-java-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-archetypes/cdap-spark-java-archetype/src/main/resources/archetype-resources/bin/app-manager.bat
+++ b/cdap-archetypes/cdap-spark-java-archetype/src/main/resources/archetype-resources/bin/app-manager.bat
@@ -2,7 +2,7 @@
 
 REM #################################################################################
 REM ##
-REM ## Copyright © 2014 Cask Data, Inc.
+REM ## Copyright © 2014-2015 Cask Data, Inc.
 REM ##
 REM ## Licensed under the Apache License, Version 2.0 (the "License"); you may not
 REM ## use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-archetypes/cdap-spark-java-archetype/src/main/resources/archetype-resources/bin/app-manager.sh
+++ b/cdap-archetypes/cdap-spark-java-archetype/src/main/resources/archetype-resources/bin/app-manager.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-archetypes/cdap-spark-java-archetype/src/main/resources/archetype-resources/bin/inject-data.bat
+++ b/cdap-archetypes/cdap-spark-java-archetype/src/main/resources/archetype-resources/bin/inject-data.bat
@@ -2,7 +2,7 @@
 
 REM #################################################################################
 REM ##
-REM ## Copyright © 2014 Cask Data, Inc.
+REM ## Copyright © 2014-2015 Cask Data, Inc.
 REM ##
 REM ## Licensed under the Apache License, Version 2.0 (the "License"); you may not
 REM ## use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-archetypes/cdap-spark-java-archetype/src/main/resources/archetype-resources/bin/inject-data.sh
+++ b/cdap-archetypes/cdap-spark-java-archetype/src/main/resources/archetype-resources/bin/inject-data.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-archetypes/cdap-spark-java-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/cdap-archetypes/cdap-spark-java-archetype/src/main/resources/archetype-resources/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-archetypes/cdap-spark-java-archetype/src/main/resources/archetype-resources/src/main/java/package-info.java
+++ b/cdap-archetypes/cdap-spark-java-archetype/src/main/resources/archetype-resources/src/main/java/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-archetypes/cdap-spark-java-archetype/src/main/resources/archetype-resources/src/test/java/SparkPageRankAppTest.java
+++ b/cdap-archetypes/cdap-spark-java-archetype/src/main/resources/archetype-resources/src/test/java/SparkPageRankAppTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-archetypes/cdap-spark-scala-archetype/README.rst
+++ b/cdap-archetypes/cdap-spark-scala-archetype/README.rst
@@ -33,7 +33,7 @@ To confirm project creation, type Y and press ENTER.
 License and Trademarks
 ======================
 
-Copyright © 2014 Cask Data, Inc.
+Copyright © 2014-2015 Cask Data, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 in compliance with the License. You may obtain a copy of the License at

--- a/cdap-archetypes/cdap-spark-scala-archetype/pom.xml
+++ b/cdap-archetypes/cdap-spark-scala-archetype/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-archetypes/cdap-spark-scala-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/cdap-archetypes/cdap-spark-scala-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-archetypes/cdap-spark-scala-archetype/src/main/resources/archetype-resources/bin/app-manager.bat
+++ b/cdap-archetypes/cdap-spark-scala-archetype/src/main/resources/archetype-resources/bin/app-manager.bat
@@ -2,7 +2,7 @@
 
 REM #################################################################################
 REM ##
-REM ## Copyright © 2014 Cask Data, Inc.
+REM ## Copyright © 2014-2015 Cask Data, Inc.
 REM ##
 REM ## Licensed under the Apache License, Version 2.0 (the "License"); you may not
 REM ## use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-archetypes/cdap-spark-scala-archetype/src/main/resources/archetype-resources/bin/app-manager.sh
+++ b/cdap-archetypes/cdap-spark-scala-archetype/src/main/resources/archetype-resources/bin/app-manager.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-archetypes/cdap-spark-scala-archetype/src/main/resources/archetype-resources/bin/inject-data.bat
+++ b/cdap-archetypes/cdap-spark-scala-archetype/src/main/resources/archetype-resources/bin/inject-data.bat
@@ -2,7 +2,7 @@
 
 REM #################################################################################
 REM ##
-REM ## Copyright © 2014 Cask Data, Inc.
+REM ## Copyright © 2014-2015 Cask Data, Inc.
 REM ##
 REM ## Licensed under the Apache License, Version 2.0 (the "License"); you may not
 REM ## use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-archetypes/cdap-spark-scala-archetype/src/main/resources/archetype-resources/bin/inject-data.sh
+++ b/cdap-archetypes/cdap-spark-scala-archetype/src/main/resources/archetype-resources/bin/inject-data.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-archetypes/cdap-spark-scala-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/cdap-archetypes/cdap-spark-scala-archetype/src/main/resources/archetype-resources/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-archetypes/cdap-spark-scala-archetype/src/main/resources/archetype-resources/src/main/scala/SparkKMeansProgram.scala
+++ b/cdap-archetypes/cdap-spark-scala-archetype/src/main/resources/archetype-resources/src/main/scala/SparkKMeansProgram.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-archetypes/cdap-spark-scala-archetype/src/main/resources/archetype-resources/src/test/java/SparkKMeansAppTest.java
+++ b/cdap-archetypes/cdap-spark-scala-archetype/src/main/resources/archetype-resources/src/test/java/SparkKMeansAppTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-archetypes/pom.xml
+++ b/cdap-archetypes/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/bin/cdap-cli.bat
+++ b/cdap-cli/bin/cdap-cli.bat
@@ -2,7 +2,7 @@
 
 REM #################################################################################
 REM ##
-REM ## Copyright © 2014 Cask Data, Inc.
+REM ## Copyright © 2014-2015 Cask Data, Inc.
 REM ##
 REM ## Licensed under the Apache License, Version 2.0 (the "License"); you may not
 REM ## use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/bin/cdap-cli.sh
+++ b/cdap-cli/bin/cdap-cli.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/ProgramIdArgument.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/ProgramIdArgument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/CallServiceCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/CallServiceCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/CreateDatasetInstanceCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/CreateDatasetInstanceCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/CreateStreamCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/CreateStreamCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeleteAppCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeleteAppCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeleteDatasetInstanceCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeleteDatasetInstanceCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeleteDatasetModuleCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeleteDatasetModuleCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramInstancesCommandSet.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramInstancesCommandSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramLiveInfoCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramLiveInfoCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramLiveInfoCommandSet.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramLiveInfoCommandSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramLogsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramLogsCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramLogsCommandSet.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramLogsCommandSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramRunsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramRunsCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramRuntimeArgsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramRuntimeArgsCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramStatusCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramStatusCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramStatusCommandSet.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramStatusCommandSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetServiceEndpointsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetServiceEndpointsCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetStreamEventsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetStreamEventsCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListAllProgramsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListAllProgramsCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListAppsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListAppsCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListDatasetInstancesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListDatasetInstancesCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListDatasetModulesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListDatasetModulesCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListDatasetTypesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListDatasetTypesCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListProgramsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListProgramsCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListStreamsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListStreamsCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/SendStreamEventCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/SendStreamEventCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetProgramRuntimeArgsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetProgramRuntimeArgsCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetStreamTTLCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetStreamTTLCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/StartProgramCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/StartProgramCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/StartProgramCommandSet.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/StartProgramCommandSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/StopProgramCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/StopProgramCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/StopProgramCommandSet.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/StopProgramCommandSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/TruncateDatasetInstanceCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/TruncateDatasetInstanceCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/TruncateStreamCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/TruncateStreamCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/package-info.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/completer/element/EndpointCompleter.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/completer/element/EndpointCompleter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/completer/element/HttpEndpointPrefixCompleter.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/completer/element/HttpEndpointPrefixCompleter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/completer/element/HttpMethodPrefixCompleter.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/completer/element/HttpMethodPrefixCompleter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/completer/element/package-info.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/completer/element/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/completer/package-info.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/completer/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/completer/supplier/EndpointSupplier.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/completer/supplier/EndpointSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/exception/package-info.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/exception/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/package-info.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/util/AbstractCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/util/AbstractCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/util/ArgumentParser.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/util/ArgumentParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/util/package-info.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/util/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/test/java/co/cask/cdap/cli/util/ArgumentParserTest.java
+++ b/cdap-cli/src/test/java/co/cask/cdap/cli/util/ArgumentParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/test/java/co/cask/cdap/cli/util/FilePathResolverTest.java
+++ b/cdap-cli/src/test/java/co/cask/cdap/cli/util/FilePathResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-client-tests/src/main/java/co/cask/cdap/client/app/FakeDataset.java
+++ b/cdap-client-tests/src/main/java/co/cask/cdap/client/app/FakeDataset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-client-tests/src/main/java/co/cask/cdap/client/app/FakeDatasetDefinition.java
+++ b/cdap-client-tests/src/main/java/co/cask/cdap/client/app/FakeDatasetDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-client-tests/src/main/java/co/cask/cdap/client/app/FakeDatasetModule.java
+++ b/cdap-client-tests/src/main/java/co/cask/cdap/client/app/FakeDatasetModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-client-tests/src/main/java/co/cask/cdap/client/app/FakeFlow.java
+++ b/cdap-client-tests/src/main/java/co/cask/cdap/client/app/FakeFlow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-client-tests/src/main/java/co/cask/cdap/client/app/FakeSpark.java
+++ b/cdap-client-tests/src/main/java/co/cask/cdap/client/app/FakeSpark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-client-tests/src/main/java/co/cask/cdap/client/app/FakeWorkflow.java
+++ b/cdap-client-tests/src/main/java/co/cask/cdap/client/app/FakeWorkflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-client-tests/src/main/java/co/cask/cdap/client/app/PingService.java
+++ b/cdap-client-tests/src/main/java/co/cask/cdap/client/app/PingService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-client-tests/src/main/java/co/cask/cdap/client/app/PrefixedEchoHandler.java
+++ b/cdap-client-tests/src/main/java/co/cask/cdap/client/app/PrefixedEchoHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-client-tests/src/main/java/co/cask/cdap/client/app/StandaloneDataset.java
+++ b/cdap-client-tests/src/main/java/co/cask/cdap/client/app/StandaloneDataset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-client-tests/src/main/java/co/cask/cdap/client/app/StandaloneDatasetDefinition.java
+++ b/cdap-client-tests/src/main/java/co/cask/cdap/client/app/StandaloneDatasetDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-client-tests/src/main/java/co/cask/cdap/client/app/StandaloneDatasetModule.java
+++ b/cdap-client-tests/src/main/java/co/cask/cdap/client/app/StandaloneDatasetModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/DatasetClientTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/DatasetClientTestRun.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/MetaClientTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/MetaClientTestRun.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/MetricsClientTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/MetricsClientTestRun.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/MonitorClientTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/MonitorClientTestRun.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/ServiceClientTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/ServiceClientTestRun.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/util/RESTClientTest.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/util/RESTClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-client/pom.xml
+++ b/cdap-client/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-client/src/main/java/co/cask/cdap/client/DatasetClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/DatasetClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-client/src/main/java/co/cask/cdap/client/DatasetModuleClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/DatasetModuleClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-client/src/main/java/co/cask/cdap/client/DatasetTypeClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/DatasetTypeClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-client/src/main/java/co/cask/cdap/client/MetaClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/MetaClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-client/src/main/java/co/cask/cdap/client/MonitorClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/MonitorClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-client/src/main/java/co/cask/cdap/client/QueryClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/QueryClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-client/src/main/java/co/cask/cdap/client/ServiceClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ServiceClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-client/src/main/java/co/cask/cdap/client/util/RESTClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/util/RESTClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common-unit-test/pom.xml
+++ b/cdap-common-unit-test/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common-unit-test/src/main/java/co/cask/cdap/test/SlowTests.java
+++ b/cdap-common-unit-test/src/main/java/co/cask/cdap/test/SlowTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common-unit-test/src/main/java/co/cask/cdap/test/XSlowTests.java
+++ b/cdap-common-unit-test/src/main/java/co/cask/cdap/test/XSlowTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/bin/common-env.sh
+++ b/cdap-common/bin/common-env.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/bin/common.sh
+++ b/cdap-common/bin/common.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/bin/service
+++ b/cdap-common/bin/service
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/pom.xml
+++ b/cdap-common/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/AlreadyExistsException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/AlreadyExistsException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/ApplicationNotFoundException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/ApplicationNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/BadRequestException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/BadRequestException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/CannotBeCreatedException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/CannotBeCreatedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/CannotBeDeletedException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/CannotBeDeletedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/DatasetAlreadyExistsException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/DatasetAlreadyExistsException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/DatasetModuleAlreadyExistsException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/DatasetModuleAlreadyExistsException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/DatasetModuleCannotBeDeletedException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/DatasetModuleCannotBeDeletedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/DatasetModuleNotFoundException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/DatasetModuleNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/DatasetNotFoundException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/DatasetNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/DatasetTypeNotFoundException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/DatasetTypeNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/HandlerException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/HandlerException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/NotFoundException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/NotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/NotImplementedException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/NotImplementedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/ProgramNotFoundException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/ProgramNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/QueryNotFoundException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/QueryNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/ScheduleAlreadyExistsException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/ScheduleAlreadyExistsException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/ServiceNotEnabledException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/ServiceNotEnabledException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/ServiceNotFoundException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/ServiceNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/StreamNotFoundException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/StreamNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/async/AsyncFunctions.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/async/AsyncFunctions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/async/ExecutorUtils.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/async/ExecutorUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/async/package-info.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/async/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/builder/BuilderException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/builder/BuilderException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/builder/package-info.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/builder/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/collect/AllCollector.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/collect/AllCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/collect/Collector.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/collect/Collector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/collect/FirstNCollector.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/collect/FirstNCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/collect/LastNCollector.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/collect/LastNCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/collect/package-info.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/collect/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/AbstractPropertyChangeListener.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/AbstractPropertyChangeListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/AbstractPropertyStore.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/AbstractPropertyStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/CConfiguration.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/CConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/CConfigurationUtil.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/CConfigurationUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Configurable.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Configurable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Configuration.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Configuration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/InMemoryPropertyStore.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/InMemoryPropertyStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/KafkaConstants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/KafkaConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/PropertyChangeListener.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/PropertyChangeListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/PropertyStore.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/PropertyStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/PropertyUpdater.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/PropertyUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/ReflectionUtils.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/ReflectionUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/SConfiguration.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/SConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/StringUtils.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/StringUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/SyncPropertyUpdater.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/SyncPropertyUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/package-info.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/db/DBConnectionPoolManager.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/db/DBConnectionPoolManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/db/package-info.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/db/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/discovery/EndpointStrategy.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/discovery/EndpointStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/discovery/RandomEndpointStrategy.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/discovery/RandomEndpointStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/discovery/ServicePayload.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/discovery/ServicePayload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/discovery/StickyEndpointStrategy.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/discovery/StickyEndpointStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/discovery/package-info.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/discovery/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/election/InMemoryElectionRegistry.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/election/InMemoryElectionRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/AlreadyExistsException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/AlreadyExistsException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/ApplicationNotFoundException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/ApplicationNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/BadRequestException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/BadRequestException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/CannotBeCreatedException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/CannotBeCreatedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/CannotBeDeletedException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/CannotBeDeletedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/DatasetAlreadyExistsException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/DatasetAlreadyExistsException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/DatasetModuleAlreadyExistsException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/DatasetModuleAlreadyExistsException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/DatasetModuleCannotBeDeletedException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/DatasetModuleCannotBeDeletedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/DatasetModuleNotFoundException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/DatasetModuleNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/DatasetNotFoundException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/DatasetNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/DatasetTypeNotFoundException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/DatasetTypeNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/HandlerException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/HandlerException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/NotFoundException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/NotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/NotImplementedException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/NotImplementedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/ProgramNotFoundException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/ProgramNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/QueryNotFoundException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/QueryNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/ScheduleAlreadyExistsException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/ScheduleAlreadyExistsException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/ServiceNotEnabledException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/ServiceNotEnabledException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/ServiceNotFoundException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/ServiceNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/exception/StreamNotFoundException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/exception/StreamNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/guice/ConfigModule.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/guice/ConfigModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/guice/DiscoveryRuntimeModule.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/guice/DiscoveryRuntimeModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/guice/IOModule.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/guice/IOModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/guice/KafkaClientModule.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/guice/KafkaClientModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/guice/LocationRuntimeModule.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/guice/LocationRuntimeModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/guice/TwillModule.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/guice/TwillModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/guice/ZKClientModule.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/guice/ZKClientModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/guice/package-info.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/guice/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/http/AbstractBodyConsumer.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/http/AbstractBodyConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/http/AuthenticationChannelHandler.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/http/AuthenticationChannelHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/http/CommonNettyHttpServiceBuilder.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/http/CommonNettyHttpServiceBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/http/SecurityRequestContext.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/http/SecurityRequestContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/internal/guava/ClassPath.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/internal/guava/ClassPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/io/BinaryDecoder.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/io/BinaryDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/io/BinaryEncoder.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/io/BinaryEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/io/BufferedEncoder.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/io/BufferedEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/io/Codec.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/io/Codec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/io/Decoder.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/io/Decoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/io/Encoder.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/io/Encoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/io/package-info.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/io/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/kerberos/SecurityUtil.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/kerberos/SecurityUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/lang/ClassLoaders.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/lang/ClassLoaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/lang/DirectoryClassLoader.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/lang/DirectoryClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/lang/FieldInitializer.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/lang/FieldInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/lang/Instantiator.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/lang/Instantiator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/lang/InstantiatorFactory.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/lang/InstantiatorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/lang/ProgramClassLoader.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/lang/ProgramClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/lang/ProgramResources.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/lang/ProgramResources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/lang/PropertyFieldSetter.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/lang/PropertyFieldSetter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/lang/jar/BundleJarUtil.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/lang/jar/BundleJarUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/lang/jar/JarResources.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/lang/jar/JarResources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/lang/jar/UnpackedJarDirEntry.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/lang/jar/UnpackedJarDirEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/lang/jar/UnpackedJarDirIterator.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/lang/jar/UnpackedJarDirIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/lang/jar/package-info.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/lang/jar/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/lang/package-info.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/lang/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/logging/AuditLogEntry.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/logging/AuditLogEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/logging/ComponentLoggingContext.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/logging/ComponentLoggingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/logging/LogCollector.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/logging/LogCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/logging/LogConfiguration.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/logging/LogConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/logging/LogEvent.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/logging/LogEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/logging/LogFileReader.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/logging/LogFileReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/logging/LogFileWriter.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/logging/LogFileWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/logging/LogReader.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/logging/LogReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/logging/LogWriter.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/logging/LogWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/logging/LoggingConstants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/logging/LoggingConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/logging/LoggingContext.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/logging/LoggingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/logging/LoggingContextAccessor.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/logging/LoggingContextAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/logging/ServiceLoggingContext.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/logging/ServiceLoggingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/logging/common/HumanReadableLogMessageFormat.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/logging/common/HumanReadableLogMessageFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/logging/common/LocalLogWriter.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/logging/common/LocalLogWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/logging/common/LogMessageFormat.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/logging/common/LogMessageFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/logging/common/LogWriter.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/logging/common/LogWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/logging/common/package-info.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/logging/common/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/logging/logback/CAppender.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/logging/logback/CAppender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/logging/logback/package-info.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/logging/logback/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/logging/package-info.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/logging/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/logging/perf/Timing.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/logging/perf/Timing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/logging/perf/package-info.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/logging/perf/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/metrics/MetricsReporterHook.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/metrics/MetricsReporterHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/metrics/NoOpMetricsCollectionService.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/metrics/NoOpMetricsCollectionService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/options/DuplicateOptionException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/options/DuplicateOptionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/options/IllegalOptionValueException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/options/IllegalOptionValueException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/options/Option.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/options/Option.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/options/OptionSpec.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/options/OptionSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/options/OptionsParser.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/options/OptionsParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/options/UnrecognizedOptionException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/options/UnrecognizedOptionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/options/UnsupportedOptionTypeException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/options/UnsupportedOptionTypeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/options/package-info.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/options/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/queue/package-info.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/queue/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/resource/ResourceBalancerService.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/resource/ResourceBalancerService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/runtime/DaemonMain.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/runtime/DaemonMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/runtime/RuntimeModule.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/runtime/RuntimeModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/runtime/package-info.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/runtime/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/service/CommandPortService.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/service/CommandPortService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/service/RUOKHandler.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/service/RUOKHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/service/RegisteredServerInfo.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/service/RegisteredServerInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/service/Server.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/service/Server.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/service/ServerException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/service/ServerException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/service/package-info.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/service/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/stream/StreamEventCodec.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/stream/StreamEventCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/stream/StreamEventComparator.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/stream/StreamEventComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/stream/StreamEventTypeAdapter.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/stream/StreamEventTypeAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/stream/package-info.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/stream/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/twill/AbortOnTimeoutEventHandler.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/twill/AbortOnTimeoutEventHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/twill/AbstractDistributedMasterServiceManager.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/twill/AbstractDistributedMasterServiceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/twill/AbstractInMemoryMasterServiceManager.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/twill/AbstractInMemoryMasterServiceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/twill/AbstractMasterTwillRunnable.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/twill/AbstractMasterTwillRunnable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/twill/MasterServiceManager.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/twill/MasterServiceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/twill/package-info.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/twill/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/utils/DirUtils.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/utils/DirUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/utils/ImmutablePair.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/utils/ImmutablePair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/utils/Networks.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/utils/Networks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/utils/OSDetector.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/utils/OSDetector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/utils/PortDetector.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/utils/PortDetector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/utils/ProjectInfo.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/utils/ProjectInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/utils/StringUtils.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/utils/StringUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/utils/Tasks.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/utils/Tasks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/utils/TimeMathParser.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/utils/TimeMathParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/utils/UsageException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/utils/UsageException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/utils/package-info.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/utils/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/ZKExtOperations.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/ZKExtOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/coordination/AssignmentChangeListener.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/coordination/AssignmentChangeListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/coordination/AssignmentStrategy.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/coordination/AssignmentStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/coordination/BalancedAssignmentStrategy.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/coordination/BalancedAssignmentStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/coordination/CoordinationConstants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/coordination/CoordinationConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/coordination/DefaultResourceAssigner.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/coordination/DefaultResourceAssigner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/coordination/DiscoverableCodec.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/coordination/DiscoverableCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/coordination/DiscoverableComparator.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/coordination/DiscoverableComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/coordination/PartitionReplica.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/coordination/PartitionReplica.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/coordination/ResourceAssigner.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/coordination/ResourceAssigner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/coordination/ResourceAssignment.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/coordination/ResourceAssignment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/coordination/ResourceAssignmentTypeAdapter.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/coordination/ResourceAssignmentTypeAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/coordination/ResourceCoordinator.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/coordination/ResourceCoordinator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/coordination/ResourceCoordinatorClient.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/coordination/ResourceCoordinatorClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/coordination/ResourceHandler.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/coordination/ResourceHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/coordination/ResourceModifier.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/coordination/ResourceModifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/coordination/ResourceRequirement.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/coordination/ResourceRequirement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/coordination/ServiceDiscoveredCodec.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/coordination/ServiceDiscoveredCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/coordination/package-info.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/coordination/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/election/package-info.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/election/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/package-info.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/store/ZKPropertyStore.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/store/ZKPropertyStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/gateway/handlers/PingHandler.java
+++ b/cdap-common/src/main/java/co/cask/cdap/gateway/handlers/PingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/gateway/handlers/VersionHandler.java
+++ b/cdap-common/src/main/java/co/cask/cdap/gateway/handlers/VersionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/gateway/handlers/package-info.java
+++ b/cdap-common/src/main/java/co/cask/cdap/gateway/handlers/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/gateway/util/package-info.java
+++ b/cdap-common/src/main/java/co/cask/cdap/gateway/util/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/internal/asm/ByteCodeClassLoader.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/asm/ByteCodeClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/internal/asm/ClassDefinition.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/asm/ClassDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/internal/asm/Debugs.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/asm/Debugs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/internal/asm/Methods.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/asm/Methods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/internal/asm/Signatures.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/asm/Signatures.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/internal/asm/package-info.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/asm/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/internal/io/ASMDatumWriterFactory.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/io/ASMDatumWriterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/internal/io/ASMFieldAccessorFactory.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/io/ASMFieldAccessorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/internal/io/DatumReader.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/io/DatumReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/internal/io/DatumReaderFactory.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/io/DatumReaderFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/internal/io/DatumWriter.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/io/DatumWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/internal/io/DatumWriterFactory.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/io/DatumWriterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/internal/io/DatumWriterGenerator.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/io/DatumWriterGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/internal/io/FieldAccessorFactory.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/io/FieldAccessorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/internal/io/FieldAccessorGenerator.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/io/FieldAccessorGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/internal/io/FieldEntry.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/io/FieldEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionDatumReader.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionDatumReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionDatumReaderFactory.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionDatumReaderFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionDatumWriter.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionDatumWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionFieldAccessorFactory.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionFieldAccessorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/co/cask/cdap/internal/io/package-info.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/io/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/resources/build.properties
+++ b/cdap-common/src/main/resources/build.properties
@@ -1,5 +1,5 @@
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/test/java/co/cask/cdap/common/collect/CollectorTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/collect/CollectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/test/java/co/cask/cdap/common/conf/CConfigurationTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/conf/CConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/test/java/co/cask/cdap/common/conf/InMemoryPropertyStoreTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/conf/InMemoryPropertyStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/test/java/co/cask/cdap/common/conf/PropertyStoreTestBase.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/conf/PropertyStoreTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/test/java/co/cask/cdap/common/conf/ZKPropertyStoreTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/conf/ZKPropertyStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/test/java/co/cask/cdap/common/election/InMemoryElectionTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/election/InMemoryElectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/test/java/co/cask/cdap/common/kerberos/SecurityUtilTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/kerberos/SecurityUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/test/java/co/cask/cdap/common/lang/InstantiatorTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/lang/InstantiatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/test/java/co/cask/cdap/common/lang/ReflectionsTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/lang/ReflectionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/test/java/co/cask/cdap/common/lang/jar/JarResourcesTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/lang/jar/JarResourcesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/test/java/co/cask/cdap/common/logging/LogCollectorTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/logging/LogCollectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/test/java/co/cask/cdap/common/logging/SyncTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/logging/SyncTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/test/java/co/cask/cdap/common/options/OptionsParserTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/options/OptionsParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/test/java/co/cask/cdap/common/service/CommandPortServiceTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/service/CommandPortServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/test/java/co/cask/cdap/common/service/CommandPortTestUtil.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/service/CommandPortTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/test/java/co/cask/cdap/common/utils/ImmutablePairTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/utils/ImmutablePairTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/test/java/co/cask/cdap/common/utils/NetworksTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/utils/NetworksTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/test/java/co/cask/cdap/common/utils/ProjectInfoTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/utils/ProjectInfoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/test/java/co/cask/cdap/common/utils/TimeMathParserTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/utils/TimeMathParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/test/java/co/cask/cdap/common/zookeeper/ZKExtOperationsTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/zookeeper/ZKExtOperationsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/test/java/co/cask/cdap/common/zookeeper/coordination/AssignmentStrategyTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/zookeeper/coordination/AssignmentStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/test/java/co/cask/cdap/common/zookeeper/coordination/ResourceCoordinatorTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/zookeeper/coordination/ResourceCoordinatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/test/java/co/cask/cdap/io/ASMDatumCodecTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/io/ASMDatumCodecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/test/java/co/cask/cdap/io/CodecTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/io/CodecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/test/java/co/cask/cdap/io/DatumCodecTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/io/DatumCodecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/test/java/co/cask/cdap/io/FieldAccessorTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/io/FieldAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/test/java/co/cask/cdap/io/SchemaTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/io/SchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/test/java/co/cask/cdap/streamevent/StreamEventCodecTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/streamevent/StreamEventCodecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/test/java/co/cask/cdap/streamevent/StreamEventTypeAdapterTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/streamevent/StreamEventTypeAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/test/resources/logback-test.xml
+++ b/cdap-common/src/test/resources/logback-test.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/test/resources/test-default.xml
+++ b/cdap-common/src/test/resources/test-default.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/test/resources/test-override.xml
+++ b/cdap-common/src/test/resources/test-override.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric-tests/pom.xml
+++ b/cdap-data-fabric-tests/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/DFSMultiLiveStreamFileReaderTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/DFSMultiLiveStreamFileReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/DFSStreamDataFileTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/DFSStreamDataFileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/DFSStreamFileJanitorTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/DFSStreamFileJanitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/DFSTimePartitionedStreamTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/DFSTimePartitionedStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/DistributedStreamCoordinatorClientTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/DistributedStreamCoordinatorClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/InMemoryStreamCoordinatorClientTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/InMemoryStreamCoordinatorClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/LocalMultiLiveStreamFileReaderTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/LocalMultiLiveStreamFileReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/LocalStreamDataFileTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/LocalStreamDataFileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/LocalStreamFileJanitorTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/LocalStreamFileJanitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/LocalTimePartitionedStreamTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/LocalTimePartitionedStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/MultiLiveStreamFileReaderTestBase.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/MultiLiveStreamFileReaderTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/StreamCoordinatorTestBase.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/StreamCoordinatorTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/StreamFileTestUtils.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/StreamFileTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/distributed/TransactionServiceClientTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/distributed/TransactionServiceClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/distributed/TransactionServiceTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/distributed/TransactionServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/StreamConsumerStateTestBase.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/StreamConsumerStateTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/leveldb/LevelDBStreamConsumerStateTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/leveldb/LevelDBStreamConsumerStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/leveldb/LevelDBStreamConsumerTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/leveldb/LevelDBStreamConsumerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/bin/dfbench
+++ b/cdap-data-fabric/bin/dfbench
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/bin/tx-debugger
+++ b/cdap-data-fabric/bin/tx-debugger
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/bin/tx-debugger.bat
+++ b/cdap-data-fabric/bin/tx-debugger.bat
@@ -1,7 +1,7 @@
 @echo OFF
 
 REM #################################################################################
-REM ## Copyright © 2014 Cask Data, Inc.
+REM ## Copyright © 2014-2015 Cask Data, Inc.
 REM ##
 REM ## Licensed under the Apache License, Version 2.0 (the "License"); you may not
 REM ## use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/bin/tx-test-main.sh
+++ b/cdap-data-fabric/bin/tx-test-main.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/pom.xml
+++ b/cdap-data-fabric/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/dataset/package-info.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/dataset/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/file/FileReader.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/file/FileReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/file/LiveFileReader.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/file/LiveFileReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/file/PositionReporter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/file/PositionReporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/file/ReadFilter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/file/ReadFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/file/ReadFilters.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/file/ReadFilters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/file/filter/AndReadFilter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/file/filter/AndReadFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/file/filter/TTLReadFilter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/file/filter/TTLReadFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/file/package-info.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/file/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/package-info.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataFabricDistributedModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataFabricDistributedModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataFabricInMemoryModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataFabricInMemoryModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataFabricLevelDBModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataFabricLevelDBModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataFabricLocalModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataFabricLocalModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataFabricModules.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataFabricModules.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataSetsModules.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataSetsModules.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/HDFSTransactionStateStorageProvider.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/HDFSTransactionStateStorageProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/TransactionManagerProvider.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/TransactionManagerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/package-info.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/security/HBaseTokenUtils.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/security/HBaseTokenUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/AbstractStreamCoordinatorClient.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/AbstractStreamCoordinatorClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/DistributedStreamCoordinatorClient.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/DistributedStreamCoordinatorClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/LiveStreamFileReader.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/LiveStreamFileReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/PositionStreamEvent.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/PositionStreamEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamCoordinatorClient.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamCoordinatorClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamDataFileIndex.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamDataFileIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamDataFileIndexIterator.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamDataFileIndexIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamDataFileSplitter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamDataFileSplitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamEventOffset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamEventOffset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamFileOffset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamFileOffset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamFileType.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamFileType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamInputFormat.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamInputFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamInputSplit.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamInputSplit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamInputSplitFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamInputSplitFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamPropertyListener.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamPropertyListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamRecordReader.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamRecordReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamServiceManager.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamServiceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamTailer.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamTailer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/decoder/BytesStreamEventDecoder.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/decoder/BytesStreamEventDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/decoder/FormatStreamEventDecoder.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/decoder/FormatStreamEventDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/decoder/IdentityStreamEventDecoder.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/decoder/IdentityStreamEventDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/decoder/StringStreamEventDecoder.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/decoder/StringStreamEventDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/decoder/TextStreamEventDecoder.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/decoder/TextStreamEventDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/package-info.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/DistributedStreamFileJanitorService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/DistributedStreamFileJanitorService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/LocalStreamFileJanitorService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/LocalStreamFileJanitorService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamFileJanitorService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamFileJanitorService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamMetaStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamMetaStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamServiceModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamServiceModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamServiceRuntimeModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamServiceRuntimeModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/package-info.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetExecutorServiceManager.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetExecutorServiceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetMetaTableUtil.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetMetaTableUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetType.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetsUtil.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetsUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFramework.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/instance/DatasetInstanceManager.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/instance/DatasetInstanceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceMeta.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/DatasetAdminOpResponse.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/DatasetAdminOpResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/DatasetOpExecutor.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/DatasetOpExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/InMemoryDatasetOpExecutor.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/InMemoryDatasetOpExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/InternalDatasetCreationParams.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/InternalDatasetCreationParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/InternalDatasetDropParams.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/InternalDatasetDropParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/LocalDatasetOpExecutor.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/LocalDatasetOpExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/RemoteDatasetOpExecutor.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/RemoteDatasetOpExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/YarnDatasetOpExecutor.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/YarnDatasetOpExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/mds/AbstractObjectsStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/mds/AbstractObjectsStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/mds/MDSDatasets.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/mds/MDSDatasets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/type/ConstantClassLoaderProvider.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/type/ConstantClassLoaderProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/type/DatasetClassLoaderProvider.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/type/DatasetClassLoaderProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/type/DatasetDefinitionLoader.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/type/DatasetDefinitionLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/type/DatasetModuleConflictException.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/type/DatasetModuleConflictException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/type/DirectoryClassLoaderProvider.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/type/DirectoryClassLoaderProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DatasetDefinitionRegistryFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DatasetDefinitionRegistryFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DatasetManagementException.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DatasetManagementException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DefaultDatasetDefinitionRegistry.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DefaultDatasetDefinitionRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/InMemoryDatasetDefinitionRegistry.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/InMemoryDatasetDefinitionRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/InstanceConflictException.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/InstanceConflictException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/ModuleConflictException.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/ModuleConflictException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/SingleTypeModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/SingleTypeModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/TypeConflictException.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/TypeConflictException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/file/FileSetModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/file/FileSetModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/hbase/package-info.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/hbase/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/kv/HBaseKVTableDefinition.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/kv/HBaseKVTableDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/kv/InMemoryKVTableDefinition.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/kv/InMemoryKVTableDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/kv/NoTxKeyValueTable.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/kv/NoTxKeyValueTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetDefinition.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/CoreDatasetsModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/CoreDatasetsModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/FuzzyRowFilter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/FuzzyRowFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/MetadataStoreDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/MetadataStoreDataset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/MetricsTable.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/MetricsTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/ObjectStoreDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/ObjectStoreDataset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/ObjectStoreDefinition.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/ObjectStoreDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/package-info.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/inmemory/InMemoryScanner.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/inmemory/InMemoryScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/inmemory/InMemoryTableDefinition.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/inmemory/InMemoryTableDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/inmemory/InMemoryTableService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/inmemory/InMemoryTableService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/inmemory/package-info.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/inmemory/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/KeyValue.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/KeyValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableAdmin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableCore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableCore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableDefinition.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/package-info.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/timeseries/EntityTable.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/timeseries/EntityTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/timeseries/FactScanResult.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/timeseries/FactScanResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/timeseries/FactScanner.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/timeseries/FactScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/timeseries/FactTable.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/timeseries/FactTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/module/lib/DatasetModules.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/module/lib/DatasetModules.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/module/lib/hbase/HBaseMetricsTableModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/module/lib/hbase/HBaseMetricsTableModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/module/lib/hbase/HBaseTableModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/module/lib/hbase/HBaseTableModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/module/lib/inmemory/InMemoryMetricsTableModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/module/lib/inmemory/InMemoryMetricsTableModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/module/lib/inmemory/InMemoryTableModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/module/lib/inmemory/InMemoryTableModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/module/lib/leveldb/LevelDBMetricsTableModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/module/lib/leveldb/LevelDBMetricsTableModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/module/lib/leveldb/LevelDBTableModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/module/lib/leveldb/LevelDBTableModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/package-info.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/tx/DatasetContext.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/tx/DatasetContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/tx/Transactional.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/tx/Transactional.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/tx/TransactionalDatasetRegistry.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/tx/TransactionalDatasetRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/tx/TxCallable.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/tx/TxCallable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/tx/TxContext.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/tx/TxContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metrics/DatasetMetricsReporter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metrics/DatasetMetricsReporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/package-info.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/queue/DequeueResult.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/queue/DequeueResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/queue/DequeueStrategy.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/queue/DequeueStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/queue/ForwardingQueueConsumer.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/queue/ForwardingQueueConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/queue/QueueClientFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/queue/QueueClientFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/queue/QueueConsumer.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/queue/QueueConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/queue/QueueEntry.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/queue/QueueEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/queue/QueueProducer.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/queue/QueueProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/queue/package-info.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/queue/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/TransactionManagerDebuggerMain.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/TransactionManagerDebuggerMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/coprocessor/DefaultTransactionStateCache.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/coprocessor/DefaultTransactionStateCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/coprocessor/DefaultTransactionStateCacheSupplier.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/coprocessor/DefaultTransactionStateCacheSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/metrics/TransactionManagerMetricsCollector.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/metrics/TransactionManagerMetricsCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/AbstractQueueProducer.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/AbstractQueueProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/ConsumerEntryState.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/ConsumerEntryState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/QueueEvictor.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/QueueEvictor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/QueueMetrics.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/QueueMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/QueueScanner.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/QueueScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/SimpleQueueEntry.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/SimpleQueueEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/DequeueScanAttributes.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/DequeueScanAttributes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueUtilFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueUtilFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/coprocessor/ConsumerConfigCache.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/coprocessor/ConsumerConfigCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/coprocessor/ConsumerInstance.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/coprocessor/ConsumerInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/coprocessor/QueueConsumerConfig.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/coprocessor/QueueConsumerConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/package-info.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/inmemory/InMemoryQueue.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/inmemory/InMemoryQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/inmemory/InMemoryQueueClientFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/inmemory/InMemoryQueueClientFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/inmemory/InMemoryQueueConsumer.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/inmemory/InMemoryQueueConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/inmemory/InMemoryQueueProducer.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/inmemory/InMemoryQueueProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/inmemory/InMemoryQueueService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/inmemory/InMemoryQueueService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/inmemory/InMemoryStreamAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/inmemory/InMemoryStreamAdmin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/inmemory/package-info.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/inmemory/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/leveldb/LevelDBAndInMemoryQueueClientFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/leveldb/LevelDBAndInMemoryQueueClientFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/leveldb/LevelDBQueueEvictor.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/leveldb/LevelDBQueueEvictor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/leveldb/LevelDBQueueProducer.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/leveldb/LevelDBQueueProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/leveldb/package-info.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/leveldb/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/package-info.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/snapshot/AbstractSnapshotCodec.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/snapshot/AbstractSnapshotCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/snapshot/SnapshotCodecV1.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/snapshot/SnapshotCodecV1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/snapshot/SnapshotCodecV2.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/snapshot/SnapshotCodecV2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/AbstractStreamFileConsumer.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/AbstractStreamFileConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/ConsumerState.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/ConsumerState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/ConsumerStateStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/ConsumerStateStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/FileStreamAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/FileStreamAdmin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/ForwardingStreamConsumer.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/ForwardingStreamConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/QueueToStreamConsumer.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/QueueToStreamConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/StreamAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/StreamAdmin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/StreamConfig.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/StreamConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/StreamConsumer.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/StreamConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/StreamConsumerFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/StreamConsumerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/StreamConsumerState.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/StreamConsumerState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/StreamConsumerStateStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/StreamConsumerStateStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/StreamConsumerStateStoreFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/StreamConsumerStateStoreFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseStreamConsumerStateStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseStreamConsumerStateStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseStreamFileConsumer.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseStreamFileConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseStreamFileConsumerFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseStreamFileConsumerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/hbase/package-info.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/hbase/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/inmemory/InMemoryStreamConsumerStateStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/inmemory/InMemoryStreamConsumerStateStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/inmemory/InMemoryStreamConsumerStateStoreFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/inmemory/InMemoryStreamConsumerStateStoreFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/leveldb/LevelDBStreamConsumerStateStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/leveldb/LevelDBStreamConsumerStateStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/leveldb/LevelDBStreamConsumerStateStoreFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/leveldb/LevelDBStreamConsumerStateStoreFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/leveldb/LevelDBStreamFileConsumer.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/leveldb/LevelDBStreamFileConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/leveldb/LevelDBStreamFileConsumerFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/leveldb/LevelDBStreamFileConsumerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/leveldb/package-info.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/leveldb/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/package-info.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseTableUtilFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseTableUtilFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseVersionSpecificFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseVersionSpecificFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/hbase/wd/AbstractRowKeyDistributor.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/hbase/wd/AbstractRowKeyDistributor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/hbase/wd/DistributedScanner.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/hbase/wd/DistributedScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/hbase/wd/Parametrizable.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/hbase/wd/Parametrizable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/hbase/wd/RowKeyDistributorByHashPrefix.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/hbase/wd/RowKeyDistributorByHashPrefix.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/hbase/wd/RowKeyDistributorByOneBytePrefix.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/hbase/wd/RowKeyDistributorByOneBytePrefix.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/hbase/wd/WdTableInputFormat.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/hbase/wd/WdTableInputFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/hbase/wd/package-info.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/hbase/wd/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/DatasetSpecificationTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/DatasetSpecificationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/CounterTimeseriesTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/CounterTimeseriesTableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/DatasetWithArgumentsTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/DatasetWithArgumentsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/Feed.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/Feed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/IndexedObjectStoreTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/IndexedObjectStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/IndexedTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/IndexedTableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/IntegerStore.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/IntegerStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/IntegerStoreDefinition.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/IntegerStoreDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/IntegerStoreModule.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/IntegerStoreModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/KeyValueTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/KeyValueTableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/PrefixedTableModule.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/PrefixedTableModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/TimeseriesTableScannerTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/TimeseriesTableScannerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/TimeseriesTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/TimeseriesTableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/cube/InterpolatorTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/cube/InterpolatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data/dataset/package-info.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data/dataset/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data/hbase/HBaseTestFactory.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data/hbase/HBaseTestFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data/hbase/package-info.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data/hbase/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data/operation/executor/remote/ElasticPoolTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data/operation/executor/remote/ElasticPoolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data/operation/executor/remote/package-info.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data/operation/executor/remote/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data/runtime/TransactionMetricsModule.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data/runtime/TransactionMetricsModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/InMemoryDefinitionRegistryFactory.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/InMemoryDefinitionRegistryFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/TestModule1.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/TestModule1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/TestModule2.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/TestModule2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/executor/DatasetOpExecutorServiceTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/executor/DatasetOpExecutorServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/mds/AbstractObjectsStoreTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/mds/AbstractObjectsStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/DoubleWrappedKVTable.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/DoubleWrappedKVTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/KeyValueTable.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/KeyValueTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/SimpleKVTable.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/SimpleKVTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/SingleTypeModuleTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/SingleTypeModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/TableAssert.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/TableAssert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/TestObject.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/TestObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/kv/InMemoryKVTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/kv/InMemoryKVTableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/kv/LevelDBKVTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/kv/LevelDBKVTableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/Custom.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/Custom.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/CustomWithInner.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/CustomWithInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/ObjectStoreDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/ObjectStoreDatasetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/inmemory/InMemoryMetricsTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/inmemory/InMemoryMetricsTableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBMetricsTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBMetricsTableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableServiceTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/timeseries/EntityTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/timeseries/EntityTableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/timeseries/FactTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/timeseries/FactTableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/queue/inmemory/InMemoryQueueTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/queue/inmemory/InMemoryQueueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/snapshot/SnapshotCodecCompatibilityTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/snapshot/SnapshotCodecCompatibilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/hbase/wd/DistributorTestsSuite.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/hbase/wd/DistributorTestsSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/hbase/wd/IdentityHashDistributorTestRun.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/hbase/wd/IdentityHashDistributorTestRun.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/hbase/wd/MultiBytesPrefixHashDistributorTestRun.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/hbase/wd/MultiBytesPrefixHashDistributorTestRun.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/hbase/wd/OneByteSimpleHashDistributorTestRun.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/hbase/wd/OneByteSimpleHashDistributorTestRun.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/hbase/wd/OneByteSimpleHashTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/hbase/wd/OneByteSimpleHashTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/hbase/wd/RowKeyDistributorByOneBytePrefixTestRun.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/hbase/wd/RowKeyDistributorByOneBytePrefixTestRun.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/hbase/wd/RowKeyDistributorTestBase.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/hbase/wd/RowKeyDistributorTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/resources/hbase-site.xml
+++ b/cdap-data-fabric/src/test/resources/hbase-site.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-data-fabric/src/test/resources/logback-test.xml
+++ b/cdap-data-fabric/src/test/resources/logback-test.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-distributions/pom.xml
+++ b/cdap-distributions/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-distributions/src/debian/scripts/common-postinst
+++ b/cdap-distributions/src/debian/scripts/common-postinst
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-distributions/src/debian/scripts/common-preinst
+++ b/cdap-distributions/src/debian/scripts/common-preinst
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-distributions/src/debian/scripts/common-prerm
+++ b/cdap-distributions/src/debian/scripts/common-prerm
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-distributions/src/debian/scripts/postinst
+++ b/cdap-distributions/src/debian/scripts/postinst
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-distributions/src/debian/scripts/postrm
+++ b/cdap-distributions/src/debian/scripts/postrm
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-distributions/src/debian/scripts/prerm
+++ b/cdap-distributions/src/debian/scripts/prerm
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-distributions/src/etc/cdap/conf.dist/cdap-site.xml
+++ b/cdap-distributions/src/etc/cdap/conf.dist/cdap-site.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-distributions/src/etc/cdap/conf.dist/cdap-site.xml.example
+++ b/cdap-distributions/src/etc/cdap/conf.dist/cdap-site.xml.example
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-distributions/src/etc/cdap/conf.dist/logback.xml
+++ b/cdap-distributions/src/etc/cdap/conf.dist/logback.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-distributions/src/main/assembly/tgz.xml
+++ b/cdap-distributions/src/main/assembly/tgz.xml
@@ -1,5 +1,5 @@
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-distributions/src/rpm/scripts/common-postinst
+++ b/cdap-distributions/src/rpm/scripts/common-postinst
@@ -1,5 +1,5 @@
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-distributions/src/rpm/scripts/common-preinst
+++ b/cdap-distributions/src/rpm/scripts/common-preinst
@@ -1,5 +1,5 @@
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-distributions/src/rpm/scripts/common-prerm
+++ b/cdap-distributions/src/rpm/scripts/common-prerm
@@ -1,5 +1,5 @@
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-distributions/src/rpm/scripts/postinst
+++ b/cdap-distributions/src/rpm/scripts/postinst
@@ -1,5 +1,5 @@
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-distributions/src/rpm/scripts/postrm
+++ b/cdap-distributions/src/rpm/scripts/postrm
@@ -1,5 +1,5 @@
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-distributions/src/rpm/scripts/prerm
+++ b/cdap-distributions/src/rpm/scripts/prerm
@@ -1,5 +1,5 @@
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-docs/_common/_locale/en_CDAP/LC_MESSAGES/sphinx.po
+++ b/cdap-docs/_common/_locale/en_CDAP/LC_MESSAGES/sphinx.po
@@ -1,5 +1,5 @@
 # Translations template for Sphinx.
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2015 Cask Data, Inc.
 # This file is distributed under the same license as the Sphinx project.
 # 
 # Translators:

--- a/cdap-docs/admin-manual/source/installation/cdap-security.rst
+++ b/cdap-docs/admin-manual/source/installation/cdap-security.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 .. _appendix-cdap-security.xml:
 

--- a/cdap-docs/admin-manual/source/installation/cdap-site.rst
+++ b/cdap-docs/admin-manual/source/installation/cdap-site.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 .. _appendix-cdap-site.xml:
 

--- a/cdap-docs/admin-manual/source/installation/index.rst
+++ b/cdap-docs/admin-manual/source/installation/index.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 :hide-toc: true
 

--- a/cdap-docs/admin-manual/source/installation/monitoring.rst
+++ b/cdap-docs/admin-manual/source/installation/monitoring.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 ===============
 Monitoring CDAP

--- a/cdap-docs/admin-manual/source/installation/quick-start.rst
+++ b/cdap-docs/admin-manual/source/installation/quick-start.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 .. _installation-quick-start:
 

--- a/cdap-docs/admin-manual/source/installation/security.rst
+++ b/cdap-docs/admin-manual/source/installation/security.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 .. _configuration-security:
 

--- a/cdap-docs/admin-manual/source/operations/cdap-ui.rst
+++ b/cdap-docs/admin-manual/source/operations/cdap-ui.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 .. _cdap-console:
 .. _cdap-ui:

--- a/cdap-docs/admin-manual/source/operations/metrics.rst
+++ b/cdap-docs/admin-manual/source/operations/metrics.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 .. _operations-metrics:
 

--- a/cdap-docs/admin-manual/source/operations/scaling-instances.rst
+++ b/cdap-docs/admin-manual/source/operations/scaling-instances.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 ============================================
 Scaling Instances

--- a/cdap-docs/admin-manual/source/operations/troubleshooting.rst
+++ b/cdap-docs/admin-manual/source/operations/troubleshooting.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 ============================================
 Troubleshooting CDAP

--- a/cdap-docs/admin-manual/source/table-of-contents.rst
+++ b/cdap-docs/admin-manual/source/table-of-contents.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 ============================================
 CDAP Administration Manual Table of Contents

--- a/cdap-docs/developers-manual/source/advanced/best-practices.rst
+++ b/cdap-docs/developers-manual/source/advanced/best-practices.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 ==========================================
 Best Practices for Developing Applications

--- a/cdap-docs/developers-manual/source/building-blocks/datasets/index.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/datasets/index.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 .. _datasets-index:
 

--- a/cdap-docs/developers-manual/source/building-blocks/datasets/system-custom.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/datasets/system-custom.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 ==========================
 System and Custom Datasets

--- a/cdap-docs/developers-manual/source/building-blocks/datasets/table.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/datasets/table.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 ============================================
 Table API

--- a/cdap-docs/developers-manual/source/building-blocks/flows-flowlets/batch-execution.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/flows-flowlets/batch-execution.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 ===============
 Batch Execution

--- a/cdap-docs/developers-manual/source/building-blocks/flows-flowlets/connecting-flowlets.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/flows-flowlets/connecting-flowlets.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 ===================
 Connecting Flowlets

--- a/cdap-docs/developers-manual/source/building-blocks/flows-flowlets/flowlets-instances.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/flows-flowlets/flowlets-instances.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 ======================
 Flowlets and Instances

--- a/cdap-docs/developers-manual/source/building-blocks/flows-flowlets/flowlets.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/flows-flowlets/flowlets.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 .. _flowlets:
 

--- a/cdap-docs/developers-manual/source/building-blocks/flows-flowlets/index.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/flows-flowlets/index.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 .. _flows-flowlets-index:
 .. _flows:

--- a/cdap-docs/developers-manual/source/building-blocks/flows-flowlets/input-context.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/flows-flowlets/input-context.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 =============
 Input Context

--- a/cdap-docs/developers-manual/source/building-blocks/flows-flowlets/partitioning-strategies.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/flows-flowlets/partitioning-strategies.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 =======================
 Partitioning Strategies

--- a/cdap-docs/developers-manual/source/building-blocks/flows-flowlets/stream-event.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/flows-flowlets/stream-event.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 ============
 Stream Event

--- a/cdap-docs/developers-manual/source/building-blocks/flows-flowlets/tick-methods.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/flows-flowlets/tick-methods.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 ============
 Tick Methods

--- a/cdap-docs/developers-manual/source/building-blocks/flows-flowlets/type-projection.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/flows-flowlets/type-projection.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 ===============
 Type Projection

--- a/cdap-docs/developers-manual/source/getting-started/standalone/index.rst
+++ b/cdap-docs/developers-manual/source/getting-started/standalone/index.rst
@@ -1,7 +1,7 @@
 .. meta::
     :author: Cask Data, Inc.
     :description: Index document
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 :hide-toc: true
 

--- a/cdap-docs/developers-manual/source/getting-started/standalone/virtual-machine.rst
+++ b/cdap-docs/developers-manual/source/getting-started/standalone/virtual-machine.rst
@@ -1,7 +1,7 @@
 .. meta::
     :author: Cask Data, Inc.
     :description: CDAP Virtual Machine
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 ============================================
 Virtual Machine Image

--- a/cdap-docs/developers-manual/source/getting-started/standalone/zip.rst
+++ b/cdap-docs/developers-manual/source/getting-started/standalone/zip.rst
@@ -1,7 +1,7 @@
 .. meta::
     :author: Cask Data, Inc.
     :description: CDAP SDK Zip
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 .. highlight:: console
   

--- a/cdap-docs/developers-manual/source/overview/abstractions.rst
+++ b/cdap-docs/developers-manual/source/overview/abstractions.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 =================
 CDAP Abstractions

--- a/cdap-docs/developers-manual/source/overview/anatomy.rst
+++ b/cdap-docs/developers-manual/source/overview/anatomy.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 =================================
 Anatomy of a Big Data Application

--- a/cdap-docs/developers-manual/source/overview/concepts.rst
+++ b/cdap-docs/developers-manual/source/overview/concepts.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 ============================================
 Concepts and Components of CDAP

--- a/cdap-docs/developers-manual/source/overview/index.rst
+++ b/cdap-docs/developers-manual/source/overview/index.rst
@@ -1,7 +1,7 @@
 .. meta::
     :author: Cask Data, Inc.
     :description: Architecture of the Cask Data Application Platform
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 :hide-toc: true
 

--- a/cdap-docs/developers-manual/source/overview/interfaces.rst
+++ b/cdap-docs/developers-manual/source/overview/interfaces.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 ===========================
 CDAP Programming Interfaces

--- a/cdap-docs/developers-manual/source/security/client-authentication.rst
+++ b/cdap-docs/developers-manual/source/security/client-authentication.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 .. _client-authentication:
 

--- a/cdap-docs/developers-manual/source/security/custom-authentication.rst
+++ b/cdap-docs/developers-manual/source/security/custom-authentication.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 .. _developers-custom-authentication:
 

--- a/cdap-docs/developers-manual/source/security/index.rst
+++ b/cdap-docs/developers-manual/source/security/index.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 :hide-toc: true
 

--- a/cdap-docs/developers-manual/source/testing/index.rst
+++ b/cdap-docs/developers-manual/source/testing/index.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 :hide-toc: true
 

--- a/cdap-docs/developers-manual/source/testing/packaging.rst
+++ b/cdap-docs/developers-manual/source/testing/packaging.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 :orphan:
 

--- a/cdap-docs/examples-manual/source/apps-packs.rst
+++ b/cdap-docs/examples-manual/source/apps-packs.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 .. _apps-and-packs:
 

--- a/cdap-docs/examples-manual/source/examples/count-random.rst
+++ b/cdap-docs/examples-manual/source/examples/count-random.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 .. _examples-count-random:
 

--- a/cdap-docs/examples-manual/source/examples/hello-world.rst
+++ b/cdap-docs/examples-manual/source/examples/hello-world.rst
@@ -1,7 +1,7 @@
 .. meta::
     :author: Cask Data, Inc.
     :description: Cask Data Application Platform Hello World Example
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 .. _examples-hello-world:
 

--- a/cdap-docs/examples-manual/source/examples/spark-k-means.rst
+++ b/cdap-docs/examples-manual/source/examples/spark-k-means.rst
@@ -1,7 +1,7 @@
 .. meta::
     :author: Cask Data, Inc.
     :description: Cask Data Application Platform SparkKMeans Application
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 .. _examples-spark-k-means:
 

--- a/cdap-docs/examples-manual/source/examples/web-analytics.rst
+++ b/cdap-docs/examples-manual/source/examples/web-analytics.rst
@@ -1,7 +1,7 @@
 .. meta::
     :author: Cask Data, Inc.
     :description: An example Cask Data Application Platform application
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 .. _examples-web-analytics:
 

--- a/cdap-docs/examples-manual/source/examples/word-count.rst
+++ b/cdap-docs/examples-manual/source/examples/word-count.rst
@@ -1,7 +1,7 @@
 .. meta::
     :author: Cask Data, Inc.
     :description: Cask Data Application Platform WordCount Application
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 .. _examples-word-count:
 

--- a/cdap-docs/examples-manual/source/how-to-guides/cdap-flume-guide.rst
+++ b/cdap-docs/examples-manual/source/how-to-guides/cdap-flume-guide.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 .. highlight:: console
 

--- a/cdap-docs/examples-manual/source/how-to-guides/cdap-mapreduce-guide.rst
+++ b/cdap-docs/examples-manual/source/how-to-guides/cdap-mapreduce-guide.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 .. highlight:: console
 

--- a/cdap-docs/examples-manual/source/how-to-guides/cdap-spark-guide.rst
+++ b/cdap-docs/examples-manual/source/how-to-guides/cdap-spark-guide.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 .. highlight:: console
 

--- a/cdap-docs/examples-manual/source/how-to-guides/cdap-timeseries-guide.rst
+++ b/cdap-docs/examples-manual/source/how-to-guides/cdap-timeseries-guide.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 .. highlight:: console
 

--- a/cdap-docs/examples-manual/source/how-to-guides/cdap-twitter-ingest-guide.rst
+++ b/cdap-docs/examples-manual/source/how-to-guides/cdap-twitter-ingest-guide.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 .. highlight:: console
 

--- a/cdap-docs/examples-manual/source/index.rst
+++ b/cdap-docs/examples-manual/source/index.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 .. _examples-introduction-index:
 

--- a/cdap-docs/examples-manual/source/table-of-contents.rst
+++ b/cdap-docs/examples-manual/source/table-of-contents.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 ======================================================
 CDAP Examples, Guides, and Tutorials Table of Contents

--- a/cdap-docs/examples-manual/source/tutorials/index.rst
+++ b/cdap-docs/examples-manual/source/tutorials/index.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 :hide-toc: true
 

--- a/cdap-docs/reference-manual/build.sh
+++ b/cdap-docs/reference-manual/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2015 Cask Data, Inc.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-docs/reference-manual/source/faq.rst
+++ b/cdap-docs/reference-manual/source/faq.rst
@@ -1,7 +1,7 @@
 .. meta::
     :author: Cask Data, Inc.
     :description: Frequently Asked Questions about the Cask Data Application Platform
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 :hide-nav: true
 :orphan:

--- a/cdap-docs/reference-manual/source/http-restful-api/introduction.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/introduction.rst
@@ -1,7 +1,7 @@
 .. meta::
     :author: Cask Data, Inc.
     :description: HTTP RESTful Interface to the Cask Data Application Platform
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 .. _http-restful-api-introduction:
 

--- a/cdap-docs/reference-manual/source/http-restful-api/monitor.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/monitor.rst
@@ -1,7 +1,7 @@
 .. meta::
     :author: Cask Data, Inc.
     :description: HTTP RESTful Interface to the Cask Data Application Platform
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 .. _http-restful-api-monitor:
 

--- a/cdap-docs/reference-manual/source/http-restful-api/query.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/query.rst
@@ -1,7 +1,7 @@
 .. meta::
     :author: Cask Data, Inc.
     :description: HTTP RESTful Interface to the Cask Data Application Platform
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 .. _http-restful-api-query:
 

--- a/cdap-docs/reference-manual/source/http-restful-api/service.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/service.rst
@@ -1,7 +1,7 @@
 .. meta::
     :author: Cask Data, Inc.
     :description: HTTP RESTful Interface to the Cask Data Application Platform
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 .. _http-restful-api-service:
 

--- a/cdap-docs/reference-manual/source/table-of-contents.rst
+++ b/cdap-docs/reference-manual/source/table-of-contents.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
 
 =================================================
 CDAP Reference Manual Table of Contents

--- a/cdap-docs/tools/doc-gen.py
+++ b/cdap-docs/tools/doc-gen.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2015 Cask Data, Inc.
 #
 # Used to generate documentation media files from .rst sources.
 #

--- a/cdap-examples/CountRandom/pom.xml
+++ b/cdap-examples/CountRandom/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/CountRandom/src/main/java/co/cask/cdap/examples/countrandom/CountRandom.java
+++ b/cdap-examples/CountRandom/src/main/java/co/cask/cdap/examples/countrandom/CountRandom.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/CountRandom/src/main/java/co/cask/cdap/examples/countrandom/CountRandomFlow.java
+++ b/cdap-examples/CountRandom/src/main/java/co/cask/cdap/examples/countrandom/CountRandomFlow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/CountRandom/src/main/java/co/cask/cdap/examples/countrandom/NumberCounter.java
+++ b/cdap-examples/CountRandom/src/main/java/co/cask/cdap/examples/countrandom/NumberCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/CountRandom/src/main/java/co/cask/cdap/examples/countrandom/NumberSplitter.java
+++ b/cdap-examples/CountRandom/src/main/java/co/cask/cdap/examples/countrandom/NumberSplitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/CountRandom/src/main/java/co/cask/cdap/examples/countrandom/RandomSource.java
+++ b/cdap-examples/CountRandom/src/main/java/co/cask/cdap/examples/countrandom/RandomSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/CountRandom/src/main/java/co/cask/cdap/examples/countrandom/package-info.java
+++ b/cdap-examples/CountRandom/src/main/java/co/cask/cdap/examples/countrandom/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/FileSetExample/pom.xml
+++ b/cdap-examples/FileSetExample/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetExample.java
+++ b/cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetService.java
+++ b/cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/WordCount.java
+++ b/cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/WordCount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/HelloWorld/README.md
+++ b/cdap-examples/HelloWorld/README.md
@@ -9,7 +9,7 @@
 
 Cask is a trademark of Cask Data, Inc. All rights reserved.
 
-Copyright © 2014 Cask Data, Inc.
+Copyright © 2014-2015 Cask Data, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
 except in compliance with the License. You may obtain a copy of the License at

--- a/cdap-examples/HelloWorld/pom.xml
+++ b/cdap-examples/HelloWorld/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/HelloWorld/src/main/java/co/cask/cdap/examples/helloworld/HelloWorld.java
+++ b/cdap-examples/HelloWorld/src/main/java/co/cask/cdap/examples/helloworld/HelloWorld.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/HelloWorld/src/main/java/co/cask/cdap/examples/helloworld/package-info.java
+++ b/cdap-examples/HelloWorld/src/main/java/co/cask/cdap/examples/helloworld/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/HelloWorld/src/test/java/co/cask/cdap/examples/helloworld/HelloWorldTest.java
+++ b/cdap-examples/HelloWorld/src/test/java/co/cask/cdap/examples/helloworld/HelloWorldTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/Purchase/README.md
+++ b/cdap-examples/Purchase/README.md
@@ -31,7 +31,7 @@ http://docs.cask.co/cdap/current/en/examples-manual/examples/index.html.
 
 Cask is a trademark of Cask Data, Inc. All rights reserved.
 
-Copyright © 2014 Cask Data, Inc.
+Copyright © 2014-2015 Cask Data, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
 except in compliance with the License. You may obtain a copy of the License at

--- a/cdap-examples/Purchase/bin/inject-data.bat
+++ b/cdap-examples/Purchase/bin/inject-data.bat
@@ -2,7 +2,7 @@
 
 REM #################################################################################
 REM ##
-REM ## Copyright © 2014 Cask Data, Inc.
+REM ## Copyright © 2014-2015 Cask Data, Inc.
 REM ##
 REM ## Licensed under the Apache License, Version 2.0 (the "License"); you may not
 REM ## use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/Purchase/bin/inject-data.sh
+++ b/cdap-examples/Purchase/bin/inject-data.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/Purchase/pom.xml
+++ b/cdap-examples/Purchase/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/CatalogLookupService.java
+++ b/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/CatalogLookupService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/Purchase.java
+++ b/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/Purchase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseFlow.java
+++ b/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseFlow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistory.java
+++ b/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryService.java
+++ b/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryStore.java
+++ b/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseStore.java
+++ b/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseStreamReader.java
+++ b/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseStreamReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/UserProfile.java
+++ b/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/UserProfile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/UserProfileServiceHandler.java
+++ b/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/UserProfileServiceHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/SparkKMeans/bin/inject-data.bat
+++ b/cdap-examples/SparkKMeans/bin/inject-data.bat
@@ -2,7 +2,7 @@
 
 REM #################################################################################
 REM ##
-REM ## Copyright © 2014 Cask Data, Inc.
+REM ## Copyright © 2014-2015 Cask Data, Inc.
 REM ##
 REM ## Licensed under the Apache License, Version 2.0 (the "License"); you may not
 REM ## use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/SparkKMeans/bin/inject-data.sh
+++ b/cdap-examples/SparkKMeans/bin/inject-data.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/SparkKMeans/pom.xml
+++ b/cdap-examples/SparkKMeans/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/SparkKMeans/src/main/java/co/cask/cdap/examples/sparkkmeans/Point.java
+++ b/cdap-examples/SparkKMeans/src/main/java/co/cask/cdap/examples/sparkkmeans/Point.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/SparkKMeans/src/main/java/co/cask/cdap/examples/sparkkmeans/SparkKMeansApp.java
+++ b/cdap-examples/SparkKMeans/src/main/java/co/cask/cdap/examples/sparkkmeans/SparkKMeansApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/SparkKMeans/src/main/scala/co/cask/cdap/examples/sparkkmeans/SparkKMeansProgram.scala
+++ b/cdap-examples/SparkKMeans/src/main/scala/co/cask/cdap/examples/sparkkmeans/SparkKMeansProgram.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/SparkKMeans/src/test/java/co/cask/cdap/examples/sparkkmeans/SparkKMeansAppTest.java
+++ b/cdap-examples/SparkKMeans/src/test/java/co/cask/cdap/examples/sparkkmeans/SparkKMeansAppTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/SparkPageRank/bin/inject-data.bat
+++ b/cdap-examples/SparkPageRank/bin/inject-data.bat
@@ -2,7 +2,7 @@
 
 REM #################################################################################
 REM ##
-REM ## Copyright © 2014 Cask Data, Inc.
+REM ## Copyright © 2014-2015 Cask Data, Inc.
 REM ##
 REM ## Licensed under the Apache License, Version 2.0 (the "License"); you may not
 REM ## use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/SparkPageRank/bin/inject-data.sh
+++ b/cdap-examples/SparkPageRank/bin/inject-data.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/SparkPageRank/pom.xml
+++ b/cdap-examples/SparkPageRank/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/SparkPageRank/src/main/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankApp.java
+++ b/cdap-examples/SparkPageRank/src/main/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/SparkPageRank/src/main/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankProgram.java
+++ b/cdap-examples/SparkPageRank/src/main/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankProgram.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/SparkPageRank/src/main/java/co/cask/cdap/examples/sparkpagerank/package-info.java
+++ b/cdap-examples/SparkPageRank/src/main/java/co/cask/cdap/examples/sparkpagerank/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/SparkPageRank/src/test/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankAppTest.java
+++ b/cdap-examples/SparkPageRank/src/test/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankAppTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/WebAnalytics/bin/inject-data.bat
+++ b/cdap-examples/WebAnalytics/bin/inject-data.bat
@@ -2,7 +2,7 @@
 
 REM #################################################################################
 REM ##
-REM ## Copyright © 2014 Cask Data, Inc.
+REM ## Copyright © 2014-2015 Cask Data, Inc.
 REM ##
 REM ## Licensed under the Apache License, Version 2.0 (the "License"); you may not
 REM ## use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/WebAnalytics/bin/inject-data.sh
+++ b/cdap-examples/WebAnalytics/bin/inject-data.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/WebAnalytics/pom.xml
+++ b/cdap-examples/WebAnalytics/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/WebAnalytics/src/main/java/co/cask/cdap/examples/webanalytics/UniqueVisitCount.java
+++ b/cdap-examples/WebAnalytics/src/main/java/co/cask/cdap/examples/webanalytics/UniqueVisitCount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/WebAnalytics/src/main/java/co/cask/cdap/examples/webanalytics/UniqueVisitor.java
+++ b/cdap-examples/WebAnalytics/src/main/java/co/cask/cdap/examples/webanalytics/UniqueVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/WebAnalytics/src/main/java/co/cask/cdap/examples/webanalytics/WebAnalytics.java
+++ b/cdap-examples/WebAnalytics/src/main/java/co/cask/cdap/examples/webanalytics/WebAnalytics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/WebAnalytics/src/main/java/co/cask/cdap/examples/webanalytics/WebAnalyticsFlow.java
+++ b/cdap-examples/WebAnalytics/src/main/java/co/cask/cdap/examples/webanalytics/WebAnalyticsFlow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/WebAnalytics/src/test/java/co/cask/cdap/examples/webanalytics/WebAnalyticsTest.java
+++ b/cdap-examples/WebAnalytics/src/test/java/co/cask/cdap/examples/webanalytics/WebAnalyticsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/WordCount/pom.xml
+++ b/cdap-examples/WordCount/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/WordCount/src/main/java/co/cask/cdap/examples/wordcount/AssociationTable.java
+++ b/cdap-examples/WordCount/src/main/java/co/cask/cdap/examples/wordcount/AssociationTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/WordCount/src/main/java/co/cask/cdap/examples/wordcount/Counter.java
+++ b/cdap-examples/WordCount/src/main/java/co/cask/cdap/examples/wordcount/Counter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/WordCount/src/main/java/co/cask/cdap/examples/wordcount/RetrieveCounts.java
+++ b/cdap-examples/WordCount/src/main/java/co/cask/cdap/examples/wordcount/RetrieveCounts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/WordCount/src/main/java/co/cask/cdap/examples/wordcount/RetrieveCountsHandler.java
+++ b/cdap-examples/WordCount/src/main/java/co/cask/cdap/examples/wordcount/RetrieveCountsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/WordCount/src/main/java/co/cask/cdap/examples/wordcount/UniqueCountTable.java
+++ b/cdap-examples/WordCount/src/main/java/co/cask/cdap/examples/wordcount/UniqueCountTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/WordCount/src/main/java/co/cask/cdap/examples/wordcount/UniqueCounter.java
+++ b/cdap-examples/WordCount/src/main/java/co/cask/cdap/examples/wordcount/UniqueCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/WordCount/src/main/java/co/cask/cdap/examples/wordcount/WordAssociator.java
+++ b/cdap-examples/WordCount/src/main/java/co/cask/cdap/examples/wordcount/WordAssociator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/WordCount/src/main/java/co/cask/cdap/examples/wordcount/WordCount.java
+++ b/cdap-examples/WordCount/src/main/java/co/cask/cdap/examples/wordcount/WordCount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/WordCount/src/main/java/co/cask/cdap/examples/wordcount/WordCounter.java
+++ b/cdap-examples/WordCount/src/main/java/co/cask/cdap/examples/wordcount/WordCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/WordCount/src/main/java/co/cask/cdap/examples/wordcount/WordSplitter.java
+++ b/cdap-examples/WordCount/src/main/java/co/cask/cdap/examples/wordcount/WordSplitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/WordCount/src/main/java/co/cask/cdap/examples/wordcount/package-info.java
+++ b/cdap-examples/WordCount/src/main/java/co/cask/cdap/examples/wordcount/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/WordCount/src/test/java/co/cask/cdap/examples/wordcount/WordCountTest.java
+++ b/cdap-examples/WordCount/src/test/java/co/cask/cdap/examples/wordcount/WordCountTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-examples/deploy_pom.xml
+++ b/cdap-examples/deploy_pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore-client/pom.xml
+++ b/cdap-explore-client/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/AbstractExploreClient.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/AbstractExploreClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/DiscoveryExploreClient.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/DiscoveryExploreClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/ExploreClient.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/ExploreClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/ExploreExecutionResult.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/ExploreExecutionResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/ExploreFacade.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/ExploreFacade.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/ExploreHttpClient.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/ExploreHttpClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/FixedAddressExploreClient.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/FixedAddressExploreClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/SuppliedAddressExploreClient.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/SuppliedAddressExploreClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/guice/ExploreClientModule.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/guice/ExploreClientModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/service/Explore.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/service/Explore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/service/ExploreException.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/service/ExploreException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/service/ExploreServiceManager.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/service/ExploreServiceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/service/HandleNotFoundException.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/service/HandleNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/service/MetaDataInfo.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/service/MetaDataInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/service/TableNotFoundException.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/service/TableNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/service/UnexpectedQueryStatusException.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/service/UnexpectedQueryStatusException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/utils/ColumnsArgs.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/utils/ColumnsArgs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/utils/FunctionsArgs.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/utils/FunctionsArgs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/utils/SchemasArgs.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/utils/SchemasArgs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/utils/TablesArgs.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/utils/TablesArgs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore-jdbc/pom.xml
+++ b/cdap-explore-jdbc/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore-jdbc/src/main/java/co/cask/cdap/explore/jdbc/BaseExploreResultSet.java
+++ b/cdap-explore-jdbc/src/main/java/co/cask/cdap/explore/jdbc/BaseExploreResultSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore-jdbc/src/main/java/co/cask/cdap/explore/jdbc/ExploreConnection.java
+++ b/cdap-explore-jdbc/src/main/java/co/cask/cdap/explore/jdbc/ExploreConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore-jdbc/src/main/java/co/cask/cdap/explore/jdbc/ExploreDatabaseMetaData.java
+++ b/cdap-explore-jdbc/src/main/java/co/cask/cdap/explore/jdbc/ExploreDatabaseMetaData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore-jdbc/src/main/java/co/cask/cdap/explore/jdbc/ExploreDriver.java
+++ b/cdap-explore-jdbc/src/main/java/co/cask/cdap/explore/jdbc/ExploreDriver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore-jdbc/src/main/java/co/cask/cdap/explore/jdbc/ExploreJDBCUtils.java
+++ b/cdap-explore-jdbc/src/main/java/co/cask/cdap/explore/jdbc/ExploreJDBCUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore-jdbc/src/main/java/co/cask/cdap/explore/jdbc/ExplorePreparedStatement.java
+++ b/cdap-explore-jdbc/src/main/java/co/cask/cdap/explore/jdbc/ExplorePreparedStatement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore-jdbc/src/main/java/co/cask/cdap/explore/jdbc/ExploreResultSet.java
+++ b/cdap-explore-jdbc/src/main/java/co/cask/cdap/explore/jdbc/ExploreResultSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore-jdbc/src/main/java/co/cask/cdap/explore/jdbc/ExploreResultSetMetaData.java
+++ b/cdap-explore-jdbc/src/main/java/co/cask/cdap/explore/jdbc/ExploreResultSetMetaData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore-jdbc/src/main/java/co/cask/cdap/explore/jdbc/ExploreStatement.java
+++ b/cdap-explore-jdbc/src/main/java/co/cask/cdap/explore/jdbc/ExploreStatement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore-jdbc/src/main/java/co/cask/cdap/explore/jdbc/JdbcColumn.java
+++ b/cdap-explore-jdbc/src/main/java/co/cask/cdap/explore/jdbc/JdbcColumn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore-jdbc/src/main/java/co/cask/cdap/explore/jdbc/StaticEmptyExploreResultSet.java
+++ b/cdap-explore-jdbc/src/main/java/co/cask/cdap/explore/jdbc/StaticEmptyExploreResultSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore-jdbc/src/test/java/co/cask/cdap/explore/jdbc/ExploreDatabaseMetaDataTest.java
+++ b/cdap-explore-jdbc/src/test/java/co/cask/cdap/explore/jdbc/ExploreDatabaseMetaDataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore-jdbc/src/test/java/co/cask/cdap/explore/jdbc/ExploreDriverTest.java
+++ b/cdap-explore-jdbc/src/test/java/co/cask/cdap/explore/jdbc/ExploreDriverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore-jdbc/src/test/java/co/cask/cdap/explore/jdbc/ExplorePreparedStatementTest.java
+++ b/cdap-explore-jdbc/src/test/java/co/cask/cdap/explore/jdbc/ExplorePreparedStatementTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore-jdbc/src/test/java/co/cask/cdap/explore/jdbc/ExploreResultSetMetaDataTest.java
+++ b/cdap-explore-jdbc/src/test/java/co/cask/cdap/explore/jdbc/ExploreResultSetMetaDataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore-jdbc/src/test/java/co/cask/cdap/explore/jdbc/ExploreResultSetTest.java
+++ b/cdap-explore-jdbc/src/test/java/co/cask/cdap/explore/jdbc/ExploreResultSetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore-jdbc/src/test/java/co/cask/cdap/explore/jdbc/ExploreStatementTest.java
+++ b/cdap-explore-jdbc/src/test/java/co/cask/cdap/explore/jdbc/ExploreStatementTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore-jdbc/src/test/java/co/cask/cdap/explore/jdbc/MockExploreClient.java
+++ b/cdap-explore-jdbc/src/test/java/co/cask/cdap/explore/jdbc/MockExploreClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore-jdbc/src/test/java/co/cask/cdap/explore/jdbc/MockHttpService.java
+++ b/cdap-explore-jdbc/src/test/java/co/cask/cdap/explore/jdbc/MockHttpService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/guice/LocalMapreduceClasspathSetter.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/guice/LocalMapreduceClasspathSetter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/ExploreService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/ExploreService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/ActiveOperationRemovalHandler.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/ActiveOperationRemovalHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/table/SchemaConverter.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/table/SchemaConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/context/CConfCodec.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/context/CConfCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/context/ConfigurationUtil.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/context/ConfigurationUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/context/ContextManager.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/context/ContextManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/context/HConfCodec.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/context/HConfCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/context/NullJobConfException.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/context/NullJobConfException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/context/TxnCodec.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/context/TxnCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/datasets/DatasetAccessor.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/datasets/DatasetAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/datasets/DatasetInputFormat.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/datasets/DatasetInputFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/datasets/DatasetOutputFormat.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/datasets/DatasetOutputFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/datasets/DatasetSerDe.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/datasets/DatasetSerDe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/datasets/DatasetStorageHandler.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/datasets/DatasetStorageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/objectinspector/ObjectInspectorFactory.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/objectinspector/ObjectInspectorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/objectinspector/ReflectionStructObjectInspector.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/objectinspector/ReflectionStructObjectInspector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/objectinspector/StandardListObjectInspector.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/objectinspector/StandardListObjectInspector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/objectinspector/StandardMapObjectInspector.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/objectinspector/StandardMapObjectInspector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/objectinspector/StandardStructObjectInspector.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/objectinspector/StandardStructObjectInspector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/objectinspector/StandardUnionObjectInspector.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/objectinspector/StandardUnionObjectInspector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/serde/ObjectDeserializer.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/serde/ObjectDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/stream/HiveStreamInputFormat.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/stream/HiveStreamInputFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/stream/StreamInputSplit.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/stream/StreamInputSplit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/stream/StreamRecordReader.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/stream/StreamRecordReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/stream/StreamSerDe.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/stream/StreamSerDe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/stream/StreamStorageHandler.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/stream/StreamStorageHandler.java
@@ -1,5 +1,5 @@
 /*
-  * Copyright © 2014 Cask Data, Inc.
+  * Copyright © 2014-2015 Cask Data, Inc.
   *
   * Licensed under the Apache License, Version 2.0 (the "License"); you may not
   * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/stream/UnsupportedOutputFormat.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/stream/UnsupportedOutputFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/guice/LocalMapreduceClasspathSetterTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/guice/LocalMapreduceClasspathSetterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/BaseHiveExploreServiceTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/BaseHiveExploreServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreDisabledTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreDisabledTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreExtensiveSchemaTableTestRun.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreExtensiveSchemaTableTestRun.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreMetadataTestRun.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreMetadataTestRun.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreServiceTestsSuite.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreServiceTestsSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceStopTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceStopTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceStreamTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceStreamTest.java
@@ -1,5 +1,5 @@
 /*
-  * Copyright © 2014 Cask Data, Inc.
+  * Copyright © 2014-2015 Cask Data, Inc.
   *
   * Licensed under the Apache License, Version 2.0 (the "License"); you may not
   * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceTestRun.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceTestRun.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceTimeoutTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceTimeoutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/InMemoryExploreServiceTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/InMemoryExploreServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/WritableDatasetTestRun.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/WritableDatasetTestRun.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/datasets/ExtensiveSchemaTableDefinition.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/datasets/ExtensiveSchemaTableDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/datasets/KeyExtendedStructValueTableDefinition.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/datasets/KeyExtendedStructValueTableDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/datasets/KeyStructValueTableDefinition.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/datasets/KeyStructValueTableDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/datasets/KeyValueTableDefinition.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/datasets/KeyValueTableDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/datasets/NotRecordScannableTableDefinition.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/datasets/NotRecordScannableTableDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/datasets/WritableKeyStructValueTableDefinition.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/datasets/WritableKeyStructValueTableDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/table/SchemaConverterTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/table/SchemaConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/test/java/co/cask/cdap/hive/ConfCodecTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/hive/ConfCodecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/test/java/co/cask/cdap/hive/HiveConfTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/hive/HiveConfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/test/java/co/cask/cdap/hive/objectinspector/ObjectInspectorFactoryTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/hive/objectinspector/ObjectInspectorFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/test/java/co/cask/cdap/hive/serde/ObjectDeserializerTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/hive/serde/ObjectDeserializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/test/resources/hive-site.xml
+++ b/cdap-explore/src/test/resources/hive-site.xml
@@ -1,5 +1,5 @@
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-explore/src/test/resources/logback-test.xml
+++ b/cdap-explore/src/test/resources/logback-test.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-gateway/conf/router-env.sh
+++ b/cdap-gateway/conf/router-env.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-gateway/pom.xml
+++ b/cdap-gateway/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/package-info.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/NettyRouter.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/NettyRouter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/ProxyRule.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/ProxyRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterModules.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterModules.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterServiceLookup.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterServiceLookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/handlers/HttpRequestHandler.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/handlers/HttpRequestHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/handlers/HttpStatusRequestHandler.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/handlers/HttpStatusRequestHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/handlers/OutboundHandler.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/handlers/OutboundHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/handlers/SecurityAuthenticationHttpHandler.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/handlers/SecurityAuthenticationHttpHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/handlers/WrappedDiscoverable.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/handlers/WrappedDiscoverable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/handlers/package-info.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/handlers/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/package-info.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/GatewayTestBase.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/GatewayTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/MetricsServiceTestsSuite.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/MetricsServiceTestsSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/PingHandlerTestRun.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/PingHandlerTestRun.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/StreamHandlerTest.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/StreamHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/hooks/MetricsReporterHookTestRun.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/hooks/MetricsReporterHookTestRun.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/log/LogLine.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/log/LogLine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/package-info.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/MockHttpService.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/MockHttpService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/NettyRouterHttpTest.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/NettyRouterHttpTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/NettyRouterHttpsTest.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/NettyRouterHttpsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/NettyRouterTestBase.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/NettyRouterTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/RouterMainTest.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/RouterMainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/SuccessTokenValidator.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/SuccessTokenValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/run/MetricsTwillRunnableTest.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/run/MetricsTwillRunnableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-gateway/src/test/resources/cdap-security.xml
+++ b/cdap-gateway/src/test/resources/cdap-security.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-gateway/src/test/resources/logback-test.xml
+++ b/cdap-gateway/src/test/resources/logback-test.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-hbase-compat-0.96/pom.xml
+++ b/cdap-hbase-compat-0.96/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/increment/hbase96/IncrementFilter.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/increment/hbase96/IncrementFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/increment/hbase96/IncrementSummingScanner.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/increment/hbase96/IncrementSummingScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/transaction/coprocessor/hbase96/DefaultTransactionProcessor.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/transaction/coprocessor/hbase96/DefaultTransactionProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/util/hbase/MockRegionServerServices.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/util/hbase/MockRegionServerServices.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data/hbase/HBase96Test.java
+++ b/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data/hbase/HBase96Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data2/increment/hbase96/IncrementHandlerTest.java
+++ b/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data2/increment/hbase96/IncrementHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data2/increment/hbase96/IncrementSummingScannerTest.java
+++ b/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data2/increment/hbase96/IncrementSummingScannerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data2/transaction/queue/hbase/HBase96QueueTest.java
+++ b/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data2/transaction/queue/hbase/HBase96QueueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-hbase-compat-0.98/pom.xml
+++ b/cdap-hbase-compat-0.98/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/increment/hbase98/IncrementFilter.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/increment/hbase98/IncrementFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/increment/hbase98/IncrementSummingScanner.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/increment/hbase98/IncrementSummingScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/transaction/coprocessor/hbase98/DefaultTransactionProcessor.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/transaction/coprocessor/hbase98/DefaultTransactionProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/util/hbase/MockRegionServerServices.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/util/hbase/MockRegionServerServices.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data/hbase/HBase98Test.java
+++ b/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data/hbase/HBase98Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data2/increment/hbase98/IncrementHandlerTest.java
+++ b/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data2/increment/hbase98/IncrementHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data2/increment/hbase98/IncrementSummingScannerTest.java
+++ b/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data2/increment/hbase98/IncrementSummingScannerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data2/transaction/queue/hbase/HBase98QueueTest.java
+++ b/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data2/transaction/queue/hbase/HBase98QueueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-hbase-compat-1.0-cdh/pom.xml
+++ b/cdap-hbase-compat-1.0-cdh/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/increment/hbase10cdh/IncrementFilter.java
+++ b/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/increment/hbase10cdh/IncrementFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/increment/hbase10cdh/IncrementSummingScanner.java
+++ b/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/increment/hbase10cdh/IncrementSummingScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/transaction/coprocessor/hbase10cdh/DefaultTransactionProcessor.java
+++ b/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/transaction/coprocessor/hbase10cdh/DefaultTransactionProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-hbase-compat-1.0-cdh/src/test/java/co/cask/cdap/data/hbase/HBase10CDHTest.java
+++ b/cdap-hbase-compat-1.0-cdh/src/test/java/co/cask/cdap/data/hbase/HBase10CDHTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-hbase-compat-1.0-cdh/src/test/java/co/cask/cdap/data2/increment/hbase10cdh/IncrementHandlerTest.java
+++ b/cdap-hbase-compat-1.0-cdh/src/test/java/co/cask/cdap/data2/increment/hbase10cdh/IncrementHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-hbase-compat-1.0-cdh/src/test/java/co/cask/cdap/data2/increment/hbase10cdh/IncrementSummingScannerTest.java
+++ b/cdap-hbase-compat-1.0-cdh/src/test/java/co/cask/cdap/data2/increment/hbase10cdh/IncrementSummingScannerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-hbase-compat-1.0-cdh/src/test/java/co/cask/cdap/data2/transaction/queue/hbase/HBase10CDHQueueTest.java
+++ b/cdap-hbase-compat-1.0-cdh/src/test/java/co/cask/cdap/data2/transaction/queue/hbase/HBase10CDHQueueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-hbase-compat-1.0/pom.xml
+++ b/cdap-hbase-compat-1.0/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/increment/hbase10/IncrementFilter.java
+++ b/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/increment/hbase10/IncrementFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/increment/hbase10/IncrementSummingScanner.java
+++ b/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/increment/hbase10/IncrementSummingScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/transaction/coprocessor/hbase10/DefaultTransactionProcessor.java
+++ b/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/transaction/coprocessor/hbase10/DefaultTransactionProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-hbase-compat-1.0/src/test/java/co/cask/cdap/data/hbase/HBase10Test.java
+++ b/cdap-hbase-compat-1.0/src/test/java/co/cask/cdap/data/hbase/HBase10Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-hbase-compat-1.0/src/test/java/co/cask/cdap/data2/increment/hbase10/IncrementHandlerTest.java
+++ b/cdap-hbase-compat-1.0/src/test/java/co/cask/cdap/data2/increment/hbase10/IncrementHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-hbase-compat-1.0/src/test/java/co/cask/cdap/data2/increment/hbase10/IncrementSummingScannerTest.java
+++ b/cdap-hbase-compat-1.0/src/test/java/co/cask/cdap/data2/increment/hbase10/IncrementSummingScannerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-hbase-compat-1.0/src/test/java/co/cask/cdap/data2/transaction/queue/hbase/HBase10QueueTest.java
+++ b/cdap-hbase-compat-1.0/src/test/java/co/cask/cdap/data2/transaction/queue/hbase/HBase10QueueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-kafka/conf/kafka-server-env.sh
+++ b/cdap-kafka/conf/kafka-server-env.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-kafka/conf/log4j.properties
+++ b/cdap-kafka/conf/log4j.properties
@@ -1,5 +1,5 @@
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-kafka/pom.xml
+++ b/cdap-kafka/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-kafka/src/main/java/co/cask/cdap/kafka/run/KafkaServerMain.java
+++ b/cdap-kafka/src/main/java/co/cask/cdap/kafka/run/KafkaServerMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-kafka/src/main/java/co/cask/cdap/kafka/run/package-info.java
+++ b/cdap-kafka/src/main/java/co/cask/cdap/kafka/run/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-master/conf/master-env.sh
+++ b/cdap-master/conf/master-env.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-master/pom.xml
+++ b/cdap-master/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterTwillApplication.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterTwillApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/package-info.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-master/src/test/java/co/cask/cdap/data/runtime/main/TransactionServiceGuiceTest.java
+++ b/cdap-master/src/test/java/co/cask/cdap/data/runtime/main/TransactionServiceGuiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-master/src/test/java/co/cask/cdap/data/tools/UpgradeToolTest.java
+++ b/cdap-master/src/test/java/co/cask/cdap/data/tools/UpgradeToolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-master/src/test/java/co/cask/cdap/data/tools/flow/FlowQueuePendingCorrectorTest.java
+++ b/cdap-master/src/test/java/co/cask/cdap/data/tools/flow/FlowQueuePendingCorrectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-notifications/pom.xml
+++ b/cdap-notifications/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-notifications/src/test/resources/logback-test.xml
+++ b/cdap-notifications/src/test/resources/logback-test.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright © 2014 Cask Data, Inc.
+  ~ Copyright © 2014-2015 Cask Data, Inc.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
   ~ use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-proto/pom.xml
+++ b/cdap-proto/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/ApplicationRecord.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/ApplicationRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/ColumnDesc.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/ColumnDesc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/DatasetInstanceConfiguration.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/DatasetInstanceConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/DatasetMeta.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/DatasetMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/DatasetModuleMeta.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/DatasetModuleMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/DatasetRecord.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/DatasetRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/DatasetTypeMeta.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/DatasetTypeMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/DistributedProgramLiveInfo.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/DistributedProgramLiveInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/InMemoryProgramLiveInfo.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/InMemoryProgramLiveInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/Instances.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/Instances.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/NamespaceMeta.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/NamespaceMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/NotRunningProgramLiveInfo.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/NotRunningProgramLiveInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/ProgramLiveInfo.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/ProgramLiveInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/ProgramRecord.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/ProgramRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/ProgramRunStatus.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/ProgramRunStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/ProgramStatus.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/ProgramStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/QueryHandle.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/QueryHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/QueryInfo.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/QueryInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/QueryResult.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/QueryResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/QueryStatus.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/QueryStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/RunRecord.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/RunRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/ScheduledRuntime.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/ScheduledRuntime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/ServiceInstances.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/ServiceInstances.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/StreamProperties.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/StreamProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/StreamRecord.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/StreamRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/SystemServiceMeta.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/SystemServiceMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/TableInfo.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/TableInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/TableNameInfo.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/TableNameInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/Version.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/Version.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/codec/AbstractSpecificationCodec.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/codec/AbstractSpecificationCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/codec/FlowSpecificationCodec.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/codec/FlowSpecificationCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/codec/FlowletSpecificationCodec.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/codec/FlowletSpecificationCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/codec/MapReduceSpecificationCodec.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/codec/MapReduceSpecificationCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/codec/SparkSpecificationCodec.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/codec/SparkSpecificationCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/codec/WorkflowActionSpecificationCodec.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/codec/WorkflowActionSpecificationCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/codec/WorkflowTokenNodeDetailCodec.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/codec/WorkflowTokenNodeDetailCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/conf/auth-server-env.sh
+++ b/cdap-security/conf/auth-server-env.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/pom.xml
+++ b/cdap-security/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/main/java/co/cask/cdap/security/auth/AbstractKeyManager.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/auth/AbstractKeyManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/main/java/co/cask/cdap/security/auth/AccessToken.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/auth/AccessToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/main/java/co/cask/cdap/security/auth/AccessTokenCodec.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/auth/AccessTokenCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/main/java/co/cask/cdap/security/auth/AccessTokenIdentifier.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/auth/AccessTokenIdentifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/main/java/co/cask/cdap/security/auth/AccessTokenIdentifierCodec.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/auth/AccessTokenIdentifierCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/main/java/co/cask/cdap/security/auth/AccessTokenTransformer.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/auth/AccessTokenTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/main/java/co/cask/cdap/security/auth/AccessTokenValidator.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/auth/AccessTokenValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/main/java/co/cask/cdap/security/auth/DistributedKeyManager.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/auth/DistributedKeyManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/main/java/co/cask/cdap/security/auth/FileBasedKeyManager.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/auth/FileBasedKeyManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/main/java/co/cask/cdap/security/auth/InMemoryKeyManager.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/auth/InMemoryKeyManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/main/java/co/cask/cdap/security/auth/InvalidDigestException.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/auth/InvalidDigestException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/main/java/co/cask/cdap/security/auth/InvalidTokenException.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/auth/InvalidTokenException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/main/java/co/cask/cdap/security/auth/KeyIdentifier.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/auth/KeyIdentifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/main/java/co/cask/cdap/security/auth/KeyIdentifierCodec.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/auth/KeyIdentifierCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/main/java/co/cask/cdap/security/auth/KeyManager.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/auth/KeyManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/main/java/co/cask/cdap/security/auth/MapBackedKeyManager.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/auth/MapBackedKeyManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/main/java/co/cask/cdap/security/auth/Signed.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/auth/Signed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/main/java/co/cask/cdap/security/auth/TokenManager.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/auth/TokenManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/main/java/co/cask/cdap/security/auth/TokenState.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/auth/TokenState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/main/java/co/cask/cdap/security/auth/TokenValidator.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/auth/TokenValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/main/java/co/cask/cdap/security/auth/package-info.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/auth/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/main/java/co/cask/cdap/security/guice/DistributedSecurityModule.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/guice/DistributedSecurityModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/main/java/co/cask/cdap/security/guice/FileBasedSecurityModule.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/guice/FileBasedSecurityModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/main/java/co/cask/cdap/security/guice/InMemorySecurityModule.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/guice/InMemorySecurityModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/main/java/co/cask/cdap/security/guice/SecurityModule.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/guice/SecurityModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/main/java/co/cask/cdap/security/guice/SecurityModules.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/guice/SecurityModules.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/main/java/co/cask/cdap/security/guice/package-info.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/guice/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/main/java/co/cask/cdap/security/package-info.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/main/java/co/cask/cdap/security/runtime/AuthenticationServerMain.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/runtime/AuthenticationServerMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/main/java/co/cask/cdap/security/server/AbstractAuthenticationHandler.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/server/AbstractAuthenticationHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/main/java/co/cask/cdap/security/server/AuditLogHandler.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/server/AuditLogHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/main/java/co/cask/cdap/security/server/AuthenticationGuiceServletContextListener.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/server/AuthenticationGuiceServletContextListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/main/java/co/cask/cdap/security/server/BasicAuthenticationHandler.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/server/BasicAuthenticationHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/main/java/co/cask/cdap/security/server/ExternalAuthenticationServer.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/server/ExternalAuthenticationServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/main/java/co/cask/cdap/security/server/GrantAccessToken.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/server/GrantAccessToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/main/java/co/cask/cdap/security/server/JAASAuthenticationHandler.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/server/JAASAuthenticationHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/main/java/co/cask/cdap/security/server/JAASLoginService.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/server/JAASLoginService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/main/java/co/cask/cdap/security/server/JAASUserPrincipal.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/server/JAASUserPrincipal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/main/java/co/cask/cdap/security/server/JASPIAuthenticationHandler.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/server/JASPIAuthenticationHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/main/java/co/cask/cdap/security/server/LDAPAuthenticationHandler.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/server/LDAPAuthenticationHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/main/java/co/cask/cdap/security/server/LDAPLoginModule.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/server/LDAPLoginModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/main/java/co/cask/cdap/security/server/StatusRequestHandler.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/server/StatusRequestHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/main/java/co/cask/cdap/security/server/package-info.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/server/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/main/java/co/cask/cdap/security/zookeeper/BaseResourceListener.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/zookeeper/BaseResourceListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/main/java/co/cask/cdap/security/zookeeper/ResourceListener.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/zookeeper/ResourceListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/main/java/co/cask/cdap/security/zookeeper/SharedResourceCache.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/zookeeper/SharedResourceCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/main/resources/realm.properties
+++ b/cdap-security/src/main/resources/realm.properties
@@ -1,5 +1,5 @@
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/test/java/co/cask/cdap/security/auth/DistributedKeyManagerTest.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/auth/DistributedKeyManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/test/java/co/cask/cdap/security/auth/TestFileBasedTokenManager.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/auth/TestFileBasedTokenManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/test/java/co/cask/cdap/security/auth/TestInMemoryTokenManager.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/auth/TestInMemoryTokenManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/test/java/co/cask/cdap/security/auth/TestKeyIdentifierCodec.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/auth/TestKeyIdentifierCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/test/java/co/cask/cdap/security/auth/TestTokenManager.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/auth/TestTokenManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/test/java/co/cask/cdap/security/auth/package-info.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/auth/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/test/java/co/cask/cdap/security/guice/FileBasedSecurityTestModule.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/guice/FileBasedSecurityTestModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/test/java/co/cask/cdap/security/guice/package-info.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/guice/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/test/java/co/cask/cdap/security/server/ExternalAuthenticationServerSSLTest.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/server/ExternalAuthenticationServerSSLTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/test/java/co/cask/cdap/security/server/ExternalAuthenticationServerTest.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/server/ExternalAuthenticationServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/test/java/co/cask/cdap/security/server/ExternalAuthenticationServerTestBase.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/server/ExternalAuthenticationServerTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/test/java/co/cask/cdap/security/server/package-info.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/server/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/test/java/co/cask/cdap/security/zookeeper/SharedResourceCacheTest.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/zookeeper/SharedResourceCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-security/src/test/resources/cdap-security.xml
+++ b/cdap-security/src/test/resources/cdap-security.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-standalone/src/main/assembly/sandbox.xml
+++ b/cdap-standalone/src/main/assembly/sandbox.xml
@@ -1,5 +1,5 @@
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-standalone/src/main/assembly/sdk.xml
+++ b/cdap-standalone/src/main/assembly/sdk.xml
@@ -1,5 +1,5 @@
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-standalone/src/main/java/co/cask/cdap/StartStandaloneAndDeployApplicationHelper.java
+++ b/cdap-standalone/src/main/java/co/cask/cdap/StartStandaloneAndDeployApplicationHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-standalone/src/main/java/co/cask/cdap/UserInterfaceService.java
+++ b/cdap-standalone/src/main/java/co/cask/cdap/UserInterfaceService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-standalone/src/main/java/co/cask/cdap/package-info.java
+++ b/cdap-standalone/src/main/java/co/cask/cdap/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-standalone/src/main/resources/cdap-site.xml
+++ b/cdap-standalone/src/main/resources/cdap-site.xml
@@ -1,5 +1,5 @@
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-standalone/src/main/resources/hive-site.xml
+++ b/cdap-standalone/src/main/resources/hive-site.xml
@@ -1,5 +1,5 @@
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-standalone/src/main/resources/logback.xml
+++ b/cdap-standalone/src/main/resources/logback.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-standalone/src/test/resources/logback-test.xml
+++ b/cdap-standalone/src/test/resources/logback-test.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-test/src/main/java/co/cask/cdap/test/DataSetManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/DataSetManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-test/src/main/java/co/cask/cdap/test/FlowManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/FlowManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-test/src/main/java/co/cask/cdap/test/MapReduceManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/MapReduceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-test/src/main/java/co/cask/cdap/test/ScheduleManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/ScheduleManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-test/src/main/java/co/cask/cdap/test/SparkManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/SparkManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-test/src/main/java/co/cask/cdap/test/StreamWriter.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/StreamWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-test/src/main/java/co/cask/cdap/test/package-info.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-ui/pom.xml
+++ b/cdap-ui/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-ui/src/test/resources/cdap-security.xml
+++ b/cdap-ui/src/test/resources/cdap-security.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
 <!--
-  ~ Copyright © 2014 Cask Data, Inc.
+  ~ Copyright © 2014-2015 Cask Data, Inc.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
   ~ use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-unit-test/pom.xml
+++ b/cdap-unit-test/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/ApplicationManagerFactory.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/ApplicationManagerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultFlowManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultFlowManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultStreamWriter.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultStreamWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/StreamWriterFactory.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/StreamWriterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/package-info.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-unit-test/src/test/java/co/cask/cdap/batch/stream/BatchStreamIntegrationTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/batch/stream/BatchStreamIntegrationTestRun.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-unit-test/src/test/java/co/cask/cdap/batch/stream/NoMapperApp.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/batch/stream/NoMapperApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-unit-test/src/test/java/co/cask/cdap/batch/stream/TestBatchStreamIntegrationApp.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/batch/stream/TestBatchStreamIntegrationApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-unit-test/src/test/java/co/cask/cdap/batch/stream/package-info.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/batch/stream/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-unit-test/src/test/java/co/cask/cdap/flow/stream/FlowStreamIntegrationTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/flow/stream/FlowStreamIntegrationTestRun.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-unit-test/src/test/java/co/cask/cdap/flow/stream/TestFlowStreamIntegrationApp.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/flow/stream/TestFlowStreamIntegrationApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-unit-test/src/test/java/co/cask/cdap/flow/stream/package-info.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/flow/stream/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-unit-test/src/test/java/co/cask/cdap/mapreduce/AppWithMapReduceUsingStream.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/mapreduce/AppWithMapReduceUsingStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-unit-test/src/test/java/co/cask/cdap/mapreduce/service/MapReduceServiceIntegrationTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/mapreduce/service/MapReduceServiceIntegrationTestRun.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-unit-test/src/test/java/co/cask/cdap/mapreduce/service/TestMapReduceServiceIntegrationApp.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/mapreduce/service/TestMapReduceServiceIntegrationApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-unit-test/src/test/java/co/cask/cdap/spark/metrics/SparkMetricsIntegrationTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/spark/metrics/SparkMetricsIntegrationTestRun.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-unit-test/src/test/java/co/cask/cdap/spark/metrics/TestSparkMetricsIntegrationApp.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/spark/metrics/TestSparkMetricsIntegrationApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-unit-test/src/test/java/co/cask/cdap/spark/service/TestSparkServiceIntegrationApp.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/spark/service/TestSparkServiceIntegrationApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-unit-test/src/test/java/co/cask/cdap/spark/stream/SparkStreamIntegrationTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/spark/stream/SparkStreamIntegrationTestRun.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-unit-test/src/test/java/co/cask/cdap/spark/stream/TestSparkStreamIntegrationApp.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/spark/stream/TestSparkStreamIntegrationApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/AppWithInvalidHandler.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/AppWithInvalidHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/AppWithServices.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/AppWithServices.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/ClassLoaderTestApp.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/ClassLoaderTestApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/DataSetInitApp.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/DataSetInitApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/DummyApp.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/DummyApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/DummyAppClone.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/DummyAppClone.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/GenSinkApp2.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/GenSinkApp2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/MyKeyValueTableDefinition.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/MyKeyValueTableDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/UniqueCountTableDefinition.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/UniqueCountTableDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/package-info.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-unit-test/src/test/java/net/fake/test/app/package-info.java
+++ b/cdap-unit-test/src/test/java/net/fake/test/app/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-unit-test/src/test/resources/logback-test.xml
+++ b/cdap-unit-test/src/test/resources/logback-test.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog-api/pom.xml
+++ b/cdap-watchdog-api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog-api/src/main/java/co/cask/cdap/api/log/ContainsMarkerFilter.java
+++ b/cdap-watchdog-api/src/main/java/co/cask/cdap/api/log/ContainsMarkerFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog-api/src/main/java/co/cask/cdap/api/log/LogMarkerFilter.java
+++ b/cdap-watchdog-api/src/main/java/co/cask/cdap/api/log/LogMarkerFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog-api/src/main/java/co/cask/cdap/api/log/LogMarkerFilterList.java
+++ b/cdap-watchdog-api/src/main/java/co/cask/cdap/api/log/LogMarkerFilterList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog-api/src/main/java/co/cask/cdap/api/log/LogMessage.java
+++ b/cdap-watchdog-api/src/main/java/co/cask/cdap/api/log/LogMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog-api/src/main/java/co/cask/cdap/api/log/LogQuery.java
+++ b/cdap-watchdog-api/src/main/java/co/cask/cdap/api/log/LogQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog-api/src/main/java/co/cask/cdap/api/log/LogQueryBuilder.java
+++ b/cdap-watchdog-api/src/main/java/co/cask/cdap/api/log/LogQueryBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog-api/src/main/java/co/cask/cdap/api/log/LogService.java
+++ b/cdap-watchdog-api/src/main/java/co/cask/cdap/api/log/LogService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog-api/src/main/java/co/cask/cdap/api/log/LogServiceClientExample.java
+++ b/cdap-watchdog-api/src/main/java/co/cask/cdap/api/log/LogServiceClientExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog-api/src/main/java/co/cask/cdap/api/log/LogServiceException.java
+++ b/cdap-watchdog-api/src/main/java/co/cask/cdap/api/log/LogServiceException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog-api/src/main/java/co/cask/cdap/api/log/SystemLoggerConstants.java
+++ b/cdap-watchdog-api/src/main/java/co/cask/cdap/api/log/SystemLoggerConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog-api/src/main/java/co/cask/cdap/api/log/UnsupportedLogQueryException.java
+++ b/cdap-watchdog-api/src/main/java/co/cask/cdap/api/log/UnsupportedLogQueryException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog-api/src/main/java/co/cask/cdap/api/log/package-info.java
+++ b/cdap-watchdog-api/src/main/java/co/cask/cdap/api/log/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog-api/src/main/java/co/cask/cdap/api/metrics/MetricType.java
+++ b/cdap-watchdog-api/src/main/java/co/cask/cdap/api/metrics/MetricType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog-api/src/main/java/co/cask/cdap/api/metrics/MetricsCollectionService.java
+++ b/cdap-watchdog-api/src/main/java/co/cask/cdap/api/metrics/MetricsCollectionService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog-api/src/main/java/co/cask/cdap/api/metrics/MetricsContext.java
+++ b/cdap-watchdog-api/src/main/java/co/cask/cdap/api/metrics/MetricsContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/pom.xml
+++ b/cdap-watchdog/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/LoggingConfiguration.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/LoggingConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/appender/AsyncLogAppender.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/appender/AsyncLogAppender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/appender/LogAppender.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/appender/LogAppender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/appender/LogAppenderInitializer.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/appender/LogAppenderInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/appender/LogMessage.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/appender/LogMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/appender/file/package-info.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/appender/file/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/appender/kafka/KafkaLogAppender.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/appender/kafka/KafkaLogAppender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/appender/kafka/KafkaTopic.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/appender/kafka/KafkaTopic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/appender/kafka/LoggingEventSerializer.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/appender/kafka/LoggingEventSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/appender/kafka/SimpleKafkaProducer.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/appender/kafka/SimpleKafkaProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/appender/kafka/StringPartitioner.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/appender/kafka/StringPartitioner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/appender/kafka/package-info.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/appender/kafka/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/appender/package-info.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/appender/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/filter/AndFilter.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/filter/AndFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/filter/Filter.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/filter/Filter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/filter/FilterParser.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/filter/FilterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/filter/LogLevelExpression.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/filter/LogLevelExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/filter/MdcExpression.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/filter/MdcExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/filter/OrFilter.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/filter/OrFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/filter/package-info.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/filter/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/ChunkedLogReaderCallback.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/ChunkedLogReaderCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/LogReaderCallback.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/LogReaderCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/package-info.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/guice/LogSaverServiceModule.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/guice/LogSaverServiceModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/guice/LoggingModules.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/guice/LoggingModules.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/guice/package-info.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/guice/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/kafka/Callback.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/kafka/Callback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/kafka/KafkaConsumer.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/kafka/KafkaConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/kafka/KafkaLogEvent.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/kafka/KafkaLogEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/kafka/KafkaMessage.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/kafka/KafkaMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/kafka/package-info.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/kafka/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/package-info.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/read/Callback.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/read/Callback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/read/DistributedLogReader.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/read/DistributedLogReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/read/FileLogReader.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/read/FileLogReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/read/LogEvent.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/read/LogEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/read/package-info.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/read/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/run/AppFabricServiceManager.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/run/AppFabricServiceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/run/InMemoryDatasetExecutorServiceManager.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/run/InMemoryDatasetExecutorServiceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/run/InMemoryExploreServiceManager.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/run/InMemoryExploreServiceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/run/InMemoryLogSaverServiceManager.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/run/InMemoryLogSaverServiceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/run/InMemoryMetricsProcessorServiceManager.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/run/InMemoryMetricsProcessorServiceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/run/InMemoryMetricsServiceManager.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/run/InMemoryMetricsServiceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/run/InMemoryStreamServiceManager.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/run/InMemoryStreamServiceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/run/LogSaverStatusServiceManager.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/run/LogSaverStatusServiceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/run/LogSaverTwillRunnable.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/run/LogSaverTwillRunnable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/run/package-info.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/run/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/CheckpointManager.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/CheckpointManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/CheckpointingLogFileWriter.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/CheckpointingLogFileWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/KafkaLogSaverService.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/KafkaLogSaverService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/LogWriter.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/LogWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/package-info.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/serialize/CallerDataSerializer.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/serialize/CallerDataSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/serialize/ClassPackagingDataSerializer.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/serialize/ClassPackagingDataSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/serialize/LogSchema.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/serialize/LogSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/serialize/LoggerContextSerializer.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/serialize/LoggerContextSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/serialize/LoggingEvent.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/serialize/LoggingEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/serialize/StackTraceElementProxyArraySerializer.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/serialize/StackTraceElementProxyArraySerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/serialize/StackTraceElementProxySerializer.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/serialize/StackTraceElementProxySerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/serialize/StackTraceElementSerializer.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/serialize/StackTraceElementSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/serialize/ThrowableProxyArraySerializer.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/serialize/ThrowableProxyArraySerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/serialize/ThrowableProxyImpl.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/serialize/ThrowableProxyImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/serialize/ThrowableProxySerializer.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/serialize/ThrowableProxySerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/serialize/Util.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/serialize/Util.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/serialize/package-info.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/serialize/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/write/LogFileWriter.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/write/LogFileWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/write/LogWriteEvent.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/write/LogWriteEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/write/SimpleLogFileWriter.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/write/SimpleLogFileWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/write/package-info.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/write/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/collect/AggregatedMetricsCollectionService.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/collect/AggregatedMetricsCollectionService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/collect/AggregatedMetricsEmitter.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/collect/AggregatedMetricsEmitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/collect/KafkaMetricsCollectionService.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/collect/KafkaMetricsCollectionService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/collect/LocalMetricsCollectionService.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/collect/LocalMetricsCollectionService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/collect/MetricsEmitter.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/collect/MetricsEmitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/collect/package-info.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/collect/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/guice/DistributedMetricsClientModule.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/guice/DistributedMetricsClientModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/guice/MetricsClientRuntimeModule.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/guice/MetricsClientRuntimeModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/guice/MetricsHandlerModule.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/guice/MetricsHandlerModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/guice/MetricsProcessorStatusServiceModule.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/guice/MetricsProcessorStatusServiceModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/guice/package-info.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/guice/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/package-info.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/process/KafkaConsumerMetaTable.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/process/KafkaConsumerMetaTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/process/KafkaMetricsProcessorService.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/process/KafkaMetricsProcessorService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/process/KafkaMetricsProcessorServiceFactory.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/process/KafkaMetricsProcessorServiceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/process/MessageCallbackFactory.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/process/MessageCallbackFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/process/MetricsMessageCallback.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/process/MetricsMessageCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/process/MetricsMessageCallbackFactory.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/process/MetricsMessageCallbackFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/process/PersistedMessageCallback.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/process/PersistedMessageCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/process/package-info.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/process/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/AggregateResponse.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/AggregateResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/MetricsPathException.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/MetricsPathException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/TimeSeriesResponse.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/TimeSeriesResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/TimeseriesId.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/TimeseriesId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/package-info.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/runtime/MetricsProcessorService.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/runtime/MetricsProcessorService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/runtime/MetricsProcessorStatusServiceManager.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/runtime/MetricsProcessorStatusServiceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/runtime/MetricsServiceManager.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/runtime/MetricsServiceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/runtime/package-info.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/runtime/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/store/upgrade/MetricsEntityCodec.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/store/upgrade/MetricsEntityCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/store/upgrade/MetricsEntityType.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/store/upgrade/MetricsEntityType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/KafkaTestBase.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/KafkaTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/LoggingTester.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/LoggingTester.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/TestResilientLogging.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/TestResilientLogging.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/serialize/LoggingEventTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/serialize/LoggingEventTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/test/java/co/cask/cdap/metrics/collect/KafkaMetricsCollectionServiceTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/metrics/collect/KafkaMetricsCollectionServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/test/java/co/cask/cdap/metrics/query/TimeseriesIdTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/metrics/query/TimeseriesIdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-watchdog/src/test/resources/logback-test.xml
+++ b/cdap-watchdog/src/test/resources/logback-test.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2015 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of


### PR DESCRIPTION
This PR Contains large number of files but the goal is to change copyright header year.

The copyright information in the header need to be updated to reflect 2015.

From: Copyright © 2014 Cask Data, Inc.
To: Copyright © 2014-2015 Cask Data, Inc.