### PR TITLE
adds white border to popover arrow

### DIFF
--- a/cdap-ui/app/styles/themes/cdap/theme.less
+++ b/cdap-ui/app/styles/themes/cdap/theme.less
@@ -453,4 +453,22 @@ body.theme-cdap {
     text-align: left;
     .border-radius(3px);
   }
+
+  //
+  // Popovers
+  // --------------------------------------------------
+  .popover {
+    &.top > .arrow {
+      border-top-color: white;
+    }
+    &.right > .arrow {
+      border-right-color: white;
+    }
+    &.bottom > .arrow {
+      border-bottom-color: white;
+    }
+    &.left > .arrow {
+      border-left-color: white;
+    }
+  }
 }

--- a/cdap-ui/app/styles/themes/cdap/theme.less
+++ b/cdap-ui/app/styles/themes/cdap/theme.less
@@ -454,21 +454,4 @@ body.theme-cdap {
     .border-radius(3px);
   }
 
-  //
-  // Popovers
-  // --------------------------------------------------
-  .popover {
-    &.top > .arrow {
-      border-top-color: white;
-    }
-    &.right > .arrow {
-      border-right-color: white;
-    }
-    &.bottom > .arrow {
-      border-bottom-color: white;
-    }
-    &.left > .arrow {
-      border-left-color: white;
-    }
-  }
 }

--- a/cdap-ui/app/styles/variables.less
+++ b/cdap-ui/app/styles/variables.less
@@ -51,6 +51,9 @@
 @tooltip-color:         #333;
 @tooltip-arrow-color:   rgb(255,255,255);
 
+// Popovers
+@popover-arrow-outer-color: white;
+
 @font-size-base:            13px;
 @headings-font-weight:      300; // thin headers
 @btn-default-color:         rgb(106, 115, 135);


### PR DESCRIPTION
*  Changes popover arrow border color to white to fix Firefox styling inconsistency

![ff](https://cloud.githubusercontent.com/assets/5335210/9397391/e4f77606-4750-11e5-96c1-835c0c79d200.gif)
