### PR TITLE
[CDAP-3014] Propagate the actual cause instead of wrapping a RuntimeE…

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowDriver.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowDriver.java
@@ -268,7 +268,7 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
       });
       future.get();
     } catch (Throwable t) {
-      LOG.error("Exception on WorkflowAction.run(), aborting Workflow. {}", actionSpec);
+      LOG.error("Exception on WorkflowAction.run(), aborting Workflow. {}", actionSpec, t);
       Throwables.propagateIfPossible(t, Exception.class);
       throw Throwables.propagate(t);
     } finally {
@@ -376,8 +376,8 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
 
       for (int i = 0; i < fork.getBranches().size(); i++) {
         try {
-          Future<Map.Entry<String, WorkflowToken>> f = completionService.take();
-          Map.Entry<String, WorkflowToken> retValue = f.get();
+          Future<Map.Entry<String, WorkflowToken>> forkBranchResult = completionService.take();
+          Map.Entry<String, WorkflowToken> retValue = forkBranchResult.get();
           String branchInfo = retValue.getKey();
           WorkflowToken branchToken = retValue.getValue();
           ((BasicWorkflowToken) token).mergeToken((BasicWorkflowToken) branchToken);
@@ -385,15 +385,15 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
         } catch (Throwable t) {
           Throwable rootCause = Throwables.getRootCause(t);
           if (rootCause instanceof ExecutionException) {
-            LOG.error("Exception occurred in the execution of the fork node {}", fork);
-            throw (ExecutionException) t;
+            LOG.error("Exception occurred in the execution of the fork node {}.", fork, rootCause);
+            throw (ExecutionException) rootCause;
           }
           if (rootCause instanceof InterruptedException) {
-            LOG.error("Workflow execution aborted.");
+            LOG.error("Workflow execution aborted.", rootCause);
             break;
           }
-          Throwables.propagateIfPossible(t, Exception.class);
-          throw Throwables.propagate(t);
+          Throwables.propagateIfPossible(rootCause, Exception.class);
+          throw Throwables.propagate(rootCause);
         }
       }
     } finally {
@@ -469,10 +469,10 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
       } catch (Throwable t) {
         Throwable rootCause = Throwables.getRootCause(t);
         if (rootCause instanceof InterruptedException) {
-          LOG.error("Workflow execution aborted.");
+          LOG.error("Workflow execution aborted.", rootCause);
           break;
         }
-        Throwables.propagate(t);
+        throw Throwables.propagate(rootCause);
       }
     }
   }


### PR DESCRIPTION
…xception inside another RuntimeException in WorkflowDriver.

Also log the exception when exceptions occur.

Jira: [CDAP-3014](https://issues.cask.co/browse/CDAP-3014)
Build: http://builds.cask.co/browse/CDAP-DUT2576