### PR TITLE
Use 3.1.1-2 release artifacts

### DIFF
--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu12.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu12.json
@@ -1,6 +1,6 @@
 {
   "variables": {
-    "sdk_version": "3.1.0"
+    "sdk_version": "3.1.1"
   },
   "builders": [
     {
@@ -106,7 +106,12 @@
       "remote_cookbook_paths": "/var/chef/cookbooks",
       "run_list": "recipe[cdap::sdk]",
       "prevent_sudo": true,
-      "skip_install": true
+      "skip_install": true,
+      "json": {
+        "cdap": {
+          "version": "{{user `sdk_version`}}-2"
+        }
+      }
     },
     {
       "type": "shell",


### PR DESCRIPTION
Otherwise, it'll use whatever is CDAP cookbook default. Same as #3668 for 3.1