### PR TITLE
CDAP-3450 move app deploy logic from http handler into service

### DIFF
--- a/cdap-proto/src/main/java/co/cask/cdap/proto/Id.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/Id.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.proto;
 
+import co.cask.cdap.api.artifact.ArtifactDescriptor;
 import co.cask.cdap.api.artifact.ArtifactVersion;
 import com.google.common.base.CharMatcher;
 import com.google.common.base.Charsets;
@@ -1343,6 +1344,11 @@ public abstract class Id {
 
     public static Artifact from(Namespace namespace, String name, ArtifactVersion version) {
       return new Artifact(namespace, name, version);
+    }
+
+    public static Artifact from(Id.Namespace namespace, ArtifactDescriptor descriptor) {
+      return new Artifact(descriptor.isSystem() ? Namespace.SYSTEM : namespace,
+                          descriptor.getName(), descriptor.getVersion());
     }
 
     public static boolean isValidName(String name) {


### PR DESCRIPTION
Some refactoring to move logic out of the AppLifecycleHttpHandler
into AppLifecycleService. Http handlers should contain as little
logic as possible, with most logic residing in the services since
they can be re-used in different places. For example, CDAP upgrade
may need to make use of this logic when upgrading existing apps to
the new artifact framework.