### PR TITLE
modifies breadcrumb text for ops and mgmt

### DIFF
--- a/cdap-ui/app/features/admin/routes.js
+++ b/cdap-ui/app/features/admin/routes.js
@@ -18,8 +18,7 @@ angular.module(PKG.name + '.feature.admin')
           templateUrl: '/assets/features/admin/templates/overview.html',
           controller: 'OverviewController',
           ncyBreadcrumb: {
-            label: 'Management',
-            parent: 'overview'
+            label: 'Management'
           }
         })
 

--- a/cdap-ui/app/features/dashboard/controllers/dashboard-ctrl.js
+++ b/cdap-ui/app/features/dashboard/controllers/dashboard-ctrl.js
@@ -29,8 +29,7 @@ function ($scope, $state, rDashboardsModel, MY_CONFIG, $alert, $timeout) {
     if (index !== $scope.dashboards.activeIndex || !$state.includes('dashboard.user')) {
       $scope.unknownBoard = true;
       $state.go('dashboard.user', {
-        tab: index,
-        activeDashboard: $scope.dashboards[index].title
+        tab: index
       });
       $scope.dashboards.activeIndex = index;
       return;
@@ -80,7 +79,6 @@ function ($scope, $state, rDashboardsModel, MY_CONFIG, $alert, $timeout) {
         $scope.dashboards.activeIndex = 'system';
       } else {
         $scope.dashboards.activeIndex = parseInt(toParams.tab, 10);
-        $state.params.activeDashboard = $scope.dashboards[toParams.tab].title;
       }
     }
   });
@@ -93,9 +91,6 @@ function ($scope, $state, rDashboardsModel, MY_CONFIG, $alert, $timeout) {
       });
     }
   };
-  if ($state.params.tab) {
-    $state.params.activeDashboard = $scope.dashboards[$state.params.tab].title;
-  }
 })
 .directive('tabDdMenu', function() {
     return {

--- a/cdap-ui/app/features/dashboard/controllers/dashboard-ctrl.js
+++ b/cdap-ui/app/features/dashboard/controllers/dashboard-ctrl.js
@@ -66,6 +66,25 @@ function ($scope, $state, rDashboardsModel, MY_CONFIG, $alert, $timeout) {
       });
   };
 
+  $scope.$on('$stateChangeSuccess', function(event, toState, toParams, fromState) {
+    // This might be redundant if the user navigates by clicking on the tabs,
+    // but its just re-assignment. This is really useful when the user navigates through
+    // the browser's back button or (or BACKSPACE). re-assignment is ok, not assigning proper
+    // values is a problem.
+    if (
+      fromState.name.indexOf('dashboard') !== -1 &&
+      toState.name.indexOf('dashboard') !== -1
+    ) {
+      if ($state.includes('dashboard.standard.*')) {
+        $scope.unknownBoard = true;
+        $scope.dashboards.activeIndex = 'system';
+      } else {
+        $scope.dashboards.activeIndex = parseInt(toParams.tab, 10);
+        $state.params.activeDashboard = $scope.dashboards[toParams.tab].title;
+      }
+    }
+  });
+
   $scope.reorderDashboard = function (reverse) {
     var newIndex = rDashboardsModel.reorder(reverse);
     if (newIndex > 0) {

--- a/cdap-ui/app/features/dashboard/routes.js
+++ b/cdap-ui/app/features/dashboard/routes.js
@@ -36,8 +36,7 @@ angular.module(PKG.name+'.feature.dashboard')
         templateUrl: '/assets/features/dashboard/templates/staticdashboard.html',
         controller: 'OpsCdapCtrl',
         ncyBreadcrumb: {
-          label: 'System',
-          parent: 'overview'
+          label: 'Operations'
         }
       })
 
@@ -54,8 +53,7 @@ angular.module(PKG.name+'.feature.dashboard')
           }
         },
         ncyBreadcrumb: {
-          label: '{{$state.params.activeDashboard}}',
-          parent: 'overview'
+          label: 'Operations'
         }
       })
 

--- a/cdap-ui/app/features/dashboard/routes.js
+++ b/cdap-ui/app/features/dashboard/routes.js
@@ -42,9 +42,6 @@ angular.module(PKG.name+'.feature.dashboard')
 
       .state('dashboard.user', {
         url: '/user/:tab',
-        params: {
-          activeDashboard: null
-        },
         templateUrl: '/assets/features/dashboard/templates/userdashboard.html',
         controller: 'UserDashboardCtrl',
         resolve: {


### PR DESCRIPTION
*  Removes "Home" and dashboard names from Operations. Breadcrumb now always shows namespace dropdown + "Operations," regardless of the active tab showing system or user dashboard
*  Removes "Home" from Management breadcrumbs - base parent is now always "Management"

![bcrumbs](https://cloud.githubusercontent.com/assets/5335210/9453846/32e78dbe-4a72-11e5-8c07-ca81f59d600e.gif)

