### PR TITLE
Fixes all race condition in Worker.stop() usage. Generally, stop() me…

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/AppWithWorker.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/AppWithWorker.java
@@ -47,7 +47,7 @@ public class AppWithWorker extends AbstractApplication {
 
   public class TableWriter extends AbstractWorker {
 
-    private volatile boolean running;
+    private volatile boolean stopped;
 
     @Override
     public void configure() {
@@ -64,9 +64,8 @@ public class AppWithWorker extends AbstractApplication {
 
     @Override
     public void run() {
-      running = true;
       writeToTable(RUN, RUN);
-      while (running) {
+      while (!stopped) {
         try {
           TimeUnit.MILLISECONDS.sleep(100);
         } catch (InterruptedException e) {
@@ -76,9 +75,13 @@ public class AppWithWorker extends AbstractApplication {
     }
 
     @Override
-    public void stop() {
-      running = false;
+    public void destroy() {
       writeToTable(STOP, STOP);
+    }
+
+    @Override
+    public void stop() {
+      stopped = true;
     }
 
     private void writeToTable(final String key, final String value) {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/ConfigTestApp.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/ConfigTestApp.java
@@ -123,7 +123,7 @@ public class ConfigTestApp extends AbstractApplication<ConfigTestApp.ConfigClass
 
   private static class DefaultWorker extends AbstractWorker {
     private final String streamName;
-    private volatile boolean running;
+    private volatile boolean stopped;
 
     public DefaultWorker(String streamName) {
       this.streamName = streamName;
@@ -131,8 +131,7 @@ public class ConfigTestApp extends AbstractApplication<ConfigTestApp.ConfigClass
 
     @Override
     public void run() {
-      running = true;
-      while (running) {
+      while (!stopped) {
         try {
           TimeUnit.SECONDS.sleep(1);
         } catch (InterruptedException e) {
@@ -155,7 +154,7 @@ public class ConfigTestApp extends AbstractApplication<ConfigTestApp.ConfigClass
 
     @Override
     public void stop() {
-      running = false;
+      stopped = true;
     }
   }
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/DummyWorkerTemplate.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/DummyWorkerTemplate.java
@@ -57,7 +57,7 @@ public class DummyWorkerTemplate extends ApplicationTemplate<DummyWorkerTemplate
   public static class TWorker extends AbstractWorker {
     private static final Logger LOG = LoggerFactory.getLogger(TWorker.class);
     public static final String NAME = TWorker.class.getSimpleName();
-    private volatile boolean running;
+    private volatile boolean stopped;
 
     @Override
     public void configure() {
@@ -66,12 +66,11 @@ public class DummyWorkerTemplate extends ApplicationTemplate<DummyWorkerTemplate
 
     @Override
     public void run() {
-      running = true;
       String adapterName = getContext().getRuntimeArguments().get(ADAPTER_NAME);
       int instanceCount = getContext().getInstanceCount();
       int instanceId = getContext().getInstanceId();
       Preconditions.checkNotNull(adapterName);
-      while (running) {
+      while (!stopped) {
         try {
           LOG.info("Adapter {}; Instance: Count {} Id {}", adapterName, instanceCount, instanceId);
           TimeUnit.MILLISECONDS.sleep(250);
@@ -83,7 +82,7 @@ public class DummyWorkerTemplate extends ApplicationTemplate<DummyWorkerTemplate
 
     @Override
     public void stop() {
-      running = false;
+      stopped = true;
     }
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/main/java/co/cask/cdap/template/etl/realtime/ETLWorker.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/main/java/co/cask/cdap/template/etl/realtime/ETLWorker.java
@@ -70,7 +70,7 @@ public class ETLWorker extends AbstractWorker {
   private byte[] stateStoreKeyBytes;
   private Metrics metrics;
 
-  private volatile boolean running;
+  private volatile boolean stopped;
 
   @Override
   public void configure() {
@@ -178,7 +178,6 @@ public class ETLWorker extends AbstractWorker {
     final SourceState currentState = new SourceState();
     final SourceState nextState = new SourceState();
     final List<Object> dataToSink = Lists.newArrayList();
-    running = true;
 
     // Fetch SourceState from State Table.
     // Only required at the beginning since we persist the state if there is a change.
@@ -194,7 +193,7 @@ public class ETLWorker extends AbstractWorker {
       }
     });
 
-    while (running) {
+    while (!stopped) {
       // Invoke poll method of the source to fetch data
       try {
         SourceState newState = source.poll(sourceEmitter, new SourceState(currentState));
@@ -256,7 +255,7 @@ public class ETLWorker extends AbstractWorker {
 
   @Override
   public void stop() {
-    running = false;
+    stopped = true;
   }
 
   @Override

--- a/cdap-client-tests/src/main/java/co/cask/cdap/client/app/ConfigTestApp.java
+++ b/cdap-client-tests/src/main/java/co/cask/cdap/client/app/ConfigTestApp.java
@@ -129,7 +129,7 @@ public class ConfigTestApp extends AbstractApplication<ConfigTestApp.ConfigClass
 
   private static class DefaultWorker extends AbstractWorker {
     private final String streamName;
-    private volatile boolean running;
+    private volatile boolean stopped;
 
     public DefaultWorker(String streamName) {
       this.streamName = streamName;
@@ -137,8 +137,7 @@ public class ConfigTestApp extends AbstractApplication<ConfigTestApp.ConfigClass
 
     @Override
     public void run() {
-      running = true;
-      while (running) {
+      while (!stopped) {
         try {
           TimeUnit.SECONDS.sleep(1);
         } catch (InterruptedException e) {
@@ -155,7 +154,7 @@ public class ConfigTestApp extends AbstractApplication<ConfigTestApp.ConfigClass
 
     @Override
     public void stop() {
-      running = false;
+      stopped = true;
     }
   }
 }

--- a/cdap-client-tests/src/main/java/co/cask/cdap/client/app/DummyWorkerTemplate.java
+++ b/cdap-client-tests/src/main/java/co/cask/cdap/client/app/DummyWorkerTemplate.java
@@ -63,7 +63,7 @@ public class DummyWorkerTemplate extends ApplicationTemplate<DummyWorkerTemplate
   public static class TWorker extends AbstractWorker {
     private static final Logger LOG = LoggerFactory.getLogger(TWorker.class);
     public static final String NAME = TWorker.class.getSimpleName();
-    private volatile boolean running;
+    private volatile boolean stopped;
 
     @Override
     public void configure() {
@@ -72,12 +72,11 @@ public class DummyWorkerTemplate extends ApplicationTemplate<DummyWorkerTemplate
 
     @Override
     public void run() {
-      running = true;
       String adapterName = getContext().getRuntimeArguments().get(ADAPTER_NAME);
       int instanceCount = getContext().getInstanceCount();
       int instanceId = getContext().getInstanceId();
       Preconditions.checkNotNull(adapterName);
-      while (running) {
+      while (!stopped) {
         try {
           LOG.info("Adapter {}; Instance: Count {} Id {}", adapterName, instanceCount, instanceId);
           TimeUnit.MILLISECONDS.sleep(250);
@@ -89,7 +88,7 @@ public class DummyWorkerTemplate extends ApplicationTemplate<DummyWorkerTemplate
 
     @Override
     public void stop() {
-      running = false;
+      stopped = true;
     }
   }
 }

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/AppUsingGetServiceURL.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/AppUsingGetServiceURL.java
@@ -130,7 +130,7 @@ public class AppUsingGetServiceURL extends AbstractApplication {
    */
   public static final class LifecycleWorker extends AbstractWorker {
     private static final Logger LOG = LoggerFactory.getLogger(LifecycleWorker.class);
-    private volatile boolean isRunning;
+    private volatile boolean stopped;
 
     @Override
     protected void configure() {
@@ -150,8 +150,7 @@ public class AppUsingGetServiceURL extends AbstractApplication {
 
     @Override
     public void run() {
-      isRunning = true;
-      while (isRunning) {
+      while (!stopped) {
         try {
           TimeUnit.MILLISECONDS.sleep(50);
         } catch (InterruptedException e) {
@@ -161,12 +160,15 @@ public class AppUsingGetServiceURL extends AbstractApplication {
     }
 
     @Override
-    public void stop() {
-      isRunning = false;
-
+    public void destroy() {
       String key = String.format("stop.%d", getContext().getInstanceId());
       byte[] value = Bytes.toBytes(getContext().getInstanceCount());
       writeToDataSet(getContext(), WORKER_INSTANCES_DATASET, key, value);
+    }
+
+    @Override
+    public void stop() {
+      stopped = true;
     }
   }
 

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/AppWithWorker.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/AppWithWorker.java
@@ -46,7 +46,7 @@ public class AppWithWorker extends AbstractApplication {
 
   private static class TableWriter extends AbstractWorker {
 
-    private volatile boolean running;
+    private volatile boolean stopped;
 
     @Override
     protected void configure() {
@@ -61,9 +61,8 @@ public class AppWithWorker extends AbstractApplication {
 
     @Override
     public void run() {
-      running = true;
       writeToTable(RUN, RUN);
-      while (running) {
+      while (!stopped) {
         try {
           TimeUnit.MILLISECONDS.sleep(100);
         } catch (InterruptedException e) {
@@ -73,9 +72,13 @@ public class AppWithWorker extends AbstractApplication {
     }
 
     @Override
-    public void stop() {
-      running = false;
+    public void destroy() {
       writeToTable(STOP, STOP);
+    }
+
+    @Override
+    public void stop() {
+      stopped = true;
     }
 
     private void writeToTable(final String key, final String value) {

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/template/WorkerTemplate.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/template/WorkerTemplate.java
@@ -74,7 +74,7 @@ public class WorkerTemplate extends ApplicationTemplate<WorkerTemplate.Config> {
   public static class Worker extends AbstractWorker {
     public static final String NAME = "worker";
     private Config config;
-    private volatile boolean running;
+    private volatile boolean stopped;
     private Callable<Long> plugin;
 
     @Override
@@ -83,7 +83,6 @@ public class WorkerTemplate extends ApplicationTemplate<WorkerTemplate.Config> {
       config = GSON.fromJson(context.getRuntimeArguments().get("config"), Config.class);
       String pluginId = context.getRuntimeArguments().get("pluginId");
       plugin = context.newPluginInstance(pluginId);
-      running = true;
     }
 
     @Override
@@ -101,7 +100,7 @@ public class WorkerTemplate extends ApplicationTemplate<WorkerTemplate.Config> {
           table.write(Bytes.toBytes(config.x), Bytes.toBytes(y));
         }
       });
-      while (running) {
+      while (!stopped) {
         try {
           TimeUnit.MILLISECONDS.sleep(100);
         } catch (InterruptedException e) {
@@ -112,7 +111,7 @@ public class WorkerTemplate extends ApplicationTemplate<WorkerTemplate.Config> {
 
     @Override
     public void stop() {
-      running = false;
+      stopped = true;
     }
   }
 


### PR DESCRIPTION
…thod happens in different thread than the init(), run() and destroy() methods. In specifics:

- Shouldn’t set running = true in the run() method and setting it to false in stop(). It is because it is possible that stop() get called from another thread which set the “running” to false, before run() is able to set it to true. If that happen, the Worker thread will be keep running forever.
- Shouldn’t use getContext() from stop() because the context field is not volatile, and also it’s possible stop() is called from another thread which even before the initialize() is being invoked.