### PR TITLE
Updated code to return the root cause of the exception through the service handler.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/DelayedHttpServiceResponder.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/DelayedHttpServiceResponder.java
@@ -21,6 +21,7 @@ import co.cask.cdap.api.service.http.HttpServiceResponder;
 import co.cask.http.HttpResponder;
 import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import com.google.gson.Gson;
@@ -176,11 +177,15 @@ public final class DelayedHttpServiceResponder implements HttpServiceResponder {
    * Since calling one of the send methods multiple times logs a warning, upon transaction failures this
    * method is called to allow setting the failure response without an additional warning.
    */
-  public void setTransactionFailureResponse() {
-    ByteBuffer buffer = Charsets.UTF_8.encode("Transaction failure when committing changes. Aborted transaction.");
+  public void setTransactionFailureResponse(Throwable t) {
+    Throwable rootCause = Throwables.getRootCause(t);
+    ByteBuffer buffer = Charsets.UTF_8.encode("Exception occurred while handling request: "
+                                                + Throwables.getStackTraceAsString(rootCause));
+
     bufferedResponse = new BufferedResponse(HttpResponseStatus.INTERNAL_SERVER_ERROR.getCode(),
                                             ChannelBuffers.wrappedBuffer(buffer),
                                             "text/plain; charset=" + Charsets.UTF_8.name(), null);
+
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/DelayedHttpServiceResponder.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/DelayedHttpServiceResponder.java
@@ -185,7 +185,6 @@ public final class DelayedHttpServiceResponder implements HttpServiceResponder {
     bufferedResponse = new BufferedResponse(HttpResponseStatus.INTERNAL_SERVER_ERROR.getCode(),
                                             ChannelBuffers.wrappedBuffer(buffer),
                                             "text/plain; charset=" + Charsets.UTF_8.name(), null);
-
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/HttpHandlerGenerator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/HttpHandlerGenerator.java
@@ -499,7 +499,7 @@ final class HttpHandlerGenerator {
      *       txContext.finish();
      *     } catch (TransactionFailureException e) {
      *        LOG.error("Transaction failure: ", e);
-     *        wrappedResponder.setTransactionFailureResponse();
+     *        wrappedResponder.setTransactionFailureResponse(e);
      *     }
      *     wrappedResponder.execute();
      *   }
@@ -611,7 +611,7 @@ final class HttpHandlerGenerator {
       mg.invokeInterface(loggerType, Methods.getMethod(void.class, "error", String.class,
                                                        Throwable.class));
 
-      // wrappedResponder.setTransactionFailureResponse();
+      // wrappedResponder.setTransactionFailureResponse(e);
       mg.loadLocal(wrappedResponder);
       mg.loadLocal(txFailureException);
       mg.invokeVirtual(delayedHttpServiceResponderType, Methods.getMethod(void.class, "setTransactionFailureResponse",

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/HttpHandlerGenerator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/HttpHandlerGenerator.java
@@ -613,7 +613,9 @@ final class HttpHandlerGenerator {
 
       // wrappedResponder.setTransactionFailureResponse();
       mg.loadLocal(wrappedResponder);
-      mg.invokeVirtual(delayedHttpServiceResponderType, Methods.getMethod(void.class, "setTransactionFailureResponse"));
+      mg.loadLocal(txFailureException);
+      mg.invokeVirtual(delayedHttpServiceResponderType, Methods.getMethod(void.class, "setTransactionFailureResponse",
+                                                                          Throwable.class));
 
       mg.mark(txFinish);
 

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
@@ -665,7 +665,7 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     request = HttpRequest.get(url).build();
     response = HttpRequests.execute(request);
     Assert.assertEquals(500, response.getResponseCode());
-    Assert.assertTrue(response.getResponseBodyAsString().contains("Transaction failure"));
+    Assert.assertTrue(response.getResponseBodyAsString().contains("IllegalStateException"));
 
     // Call the verify ClassLoader endpoint
     url = new URL(serviceURL, "verifyClassLoader");


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-1892

Before the fix service always returned the same message `Error: 500: Transaction failure when committing changes. Aborted transaction.` irrespective of the root cause.

After the fix, we return the stack trace of the root cause, so that it is easier for the user to pin point the reason for the exception through UI as well as through CLI without checking the master log files.

