### PR TITLE
(CDAP-3458) Don’t reset the position to 0 on IOException

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamDataFileReader.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamDataFileReader.java
@@ -262,7 +262,6 @@ public final class StreamDataFileReader implements FileReader<PositionStreamEven
         }
       }
     } catch (IOException e) {
-      position = 0;
       if (eventInput != null) {
         eventInput.close();
         eventInput = null;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/AbstractStreamFileConsumer.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/AbstractStreamFileConsumer.java
@@ -551,8 +551,7 @@ public abstract class AbstractStreamFileConsumer implements StreamConsumer {
     byte[] stopRow = Arrays.copyOf(row, row.length);
     Bytes.putLong(stopRow, stopRow.length - Longs.BYTES, Long.MAX_VALUE);
 
-    StateScanner scanner = scanStates(row, stopRow);
-    try {
+    try (StateScanner scanner = scanStates(row, stopRow)) {
       // Scan until MAX_SCAN_ROWS or exhausted the scanner
       int rowCached = 0;
       while (scanner.nextStateRow() && rowCached < MAX_SCAN_ROWS) {
@@ -565,8 +564,6 @@ public abstract class AbstractStreamFileConsumer implements StreamConsumer {
       if (rowCached == 0) {
         entryStatesScanCompleted.add(row);
       }
-    } finally {
-      scanner.close();
     }
     return rowStates;
   }


### PR DESCRIPTION
- If the exception is EOFException, the StreamDataFileReader won’t get closed, hence the reopening of the underlying input stream should just resume from where it left off
- If the exception is other type of IOException, it will get propagated outside, which the expected behavior is to close and create a new StreamDataFileReader, which the initial position will be passed from the caller, hence resetting of position to 0 is not need.
(cherry picked from commit 0d02d34d7d0222914d90abefa08aea242ae5947b)