### PR TITLE
Fix/ui adapter modal+gridsterupdate

### DIFF
--- a/cdap-ui/app/features/adapters/etlapps.less
+++ b/cdap-ui/app/features/adapters/etlapps.less
@@ -202,7 +202,7 @@ body.theme-cdap.state-adapters-create {
             }
 
             .transition(all 0.2s ease);
-            @media (max-width: @screen-sm-max) {
+            @media (max-width: @screen-xs-min) {
               width: 20%;
             }
             &:last-child {
@@ -216,6 +216,9 @@ body.theme-cdap.state-adapters-create {
             }
             &:only-child {
               margin-right: -1px;
+              @media (max-width: @screen-xs-max) {
+                width: 100%;
+              }
             }
             &:hover, &:focus {
               background-color: @cdap-header;
@@ -227,6 +230,11 @@ body.theme-cdap.state-adapters-create {
           &.btn-group {
             display: block;
             > div {
+
+              @media (max-width: @screen-xs-max) {
+                width: 20%;
+              }
+
               display: inline-block;
               margin-right: -4px;
               &:last-child {

--- a/cdap-ui/app/features/adapters/templates/create/metadata.html
+++ b/cdap-ui/app/features/adapters/templates/create/metadata.html
@@ -1,8 +1,8 @@
 <div class="modal-header">
-  <div class="col-xs-6 col-md-9">
+  <div class="col-xs-6 col-md-7">
     <h3 class="modal-title"> Edit Metadata</p>
   </div>
-  <div class="col-xs-6 col-md-3">
+  <div class="col-xs-6 col-md-5">
     <div class="btn-group modal-btns">
       <div>
         <a class="btn" ng-click="reset()">

--- a/cdap-ui/app/features/adapters/templates/create/settings.html
+++ b/cdap-ui/app/features/adapters/templates/create/settings.html
@@ -1,8 +1,8 @@
 <div class="modal-header">
-  <div class="col-xs-6 col-md-9">
+  <div class="col-xs-6 col-md-7">
     <h3 class="modal-title"> Edit Settings</p>
   </div>
-  <div class="col-xs-6 col-md-3">
+  <div class="col-xs-6 col-md-5">
     <div class="btn-group modal-btns">
       <div>
         <a class="btn" ng-click="reset()">

--- a/cdap-ui/bower.json
+++ b/cdap-ui/bower.json
@@ -35,7 +35,7 @@
     "c3": "0.4.10",
     "angular-ui-ace": "bower",
     "jsPlumb": "1.7.5",
-    "angular-gridster": "0.13.2"
+    "angular-gridster": "0.13.5"
   },
   "resolutions": {
     "angular": "1.4.3",

--- a/cdap-ui/pom.xml
+++ b/cdap-ui/pom.xml
@@ -145,6 +145,15 @@
                 </configuration>
               </execution>
               <execution>
+                <id>bower-cache-clean</id>
+                <goals>
+                  <goal>bower</goal>
+                </goals>
+                <configuration>
+                  <arguments>cache clean</arguments>
+                </configuration>
+              </execution>
+              <execution>
                 <id>bower-install</id>
                 <goals>
                   <goal>bower</goal>


### PR DESCRIPTION
- Updates angular gridster 
   Right now we have jserror when we switch tabs. angular-gridster internally nullifies grid data when we switch tab which causes issue (https://github.com/ManifestWebDesign/angular-gridster/issues/262). Hence the upgrade.
- Fixes adapter modal right buttons when browser size is reduced.