### PR TITLE
CDAP-3501 store artifact range inclusive information

### DIFF
--- a/cdap-proto/src/main/java/co/cask/cdap/proto/artifact/ArtifactRange.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/artifact/ArtifactRange.java
@@ -37,13 +37,13 @@ public class ArtifactRange {
   }
 
   public ArtifactRange(Id.Namespace namespace, String name, ArtifactVersion lower, boolean isLowerInclusive,
-                       ArtifactVersion upper, boolean isUpperInclusives) {
+                       ArtifactVersion upper, boolean isUpperInclusive) {
     this.namespace = namespace;
     this.name = name;
     this.lower = lower;
     this.upper = upper;
     this.isLowerInclusive = isLowerInclusive;
-    this.isUpperInclusive = isUpperInclusives;
+    this.isUpperInclusive = isUpperInclusive;
   }
 
   public Id.Namespace getNamespace() {


### PR DESCRIPTION
Fixes a bug where information about version inclusivity is dropped
in the artifact store which can cause bugs if the version range
originally used non-default inclusive flags.