### PR TITLE
CDAP-3482 Sort CLASSPATH in Standalone

### DIFF
--- a/cdap-standalone/bin/cdap.sh
+++ b/cdap-standalone/bin/cdap.sh
@@ -72,7 +72,16 @@ SAVED="`pwd`"
 cd "`dirname \"$PRG\"`/.." >&-
 APP_HOME="`pwd -P`"
 
-CLASSPATH="$APP_HOME/lib/*":"$APP_HOME/conf/"
+i=0
+for jar in `ls -1 $APP_HOME/lib/* | sort` ; do
+    ((i++))
+    if [ $i -eq 1 ] ; then
+        CLASSPATH=${jar}
+    else
+        CLASSPATH=${CLASSPATH}:${jar}
+    fi
+done
+CLASSPATH="${CLASSPATH}:$APP_HOME/conf/"
 
 # Determine the Java command to use to start the JVM.
 if [ -n "$JAVA_HOME" ] ; then


### PR DESCRIPTION
Standalone loads all JARs from CDAP_HOME/lib/* which relies on the
underlying file-system's ordering, which is not guaranteed. This
was causing instability due to the differences between Mac OS X
file-system (HFS+) and Linux (Ext3/4).

(cherry picked from commit 3da35a5e24ad1a913aa18afe95651f070017ea40)