### PR TITLE
need the quotes to force string comparison

### DIFF
--- a/cdap-distributions/bin/build_artifact_upload.sh
+++ b/cdap-distributions/bin/build_artifact_upload.sh
@@ -117,7 +117,7 @@ function sync_build_artifacts_to_server () {
     _version=`echo ${_version_stub} | awk -F - '{ print $1 }' | awk -F . '{ print $1"."$2"."$3 }'`
     decho "version = ${_version}"
     _snapshot_time=`echo ${_version_stub} | awk -F - '{ print $1 }' | sed 's/[0-9]\.[0-9]\.[0-9][\.]*\([0-9]*\)/\1/'`
-    if [ "${_version}" == ${_snapshot_time} ]; then
+    if [ "${_version}" == "${_snapshot_time}" ]; then
       _snapshot_time=''
     fi
     decho "snapshot time = ${_snapshot_time}"


### PR DESCRIPTION
Porting (merged) CDAP-3437 to 3.1, 3.0, 2.8.
This only affects build artifacts upload.
