### PR TITLE
CDAP-3488 create etl batch application

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractContext.java
@@ -236,10 +236,6 @@ public abstract class AbstractContext extends AbstractServiceDiscoverer
     for (Closeable ds : datasets.values()) {
       closeDataSet(ds);
     }
-
-    if (artifactPluginInstantiator != null) {
-      Closeables.closeQuietly(artifactPluginInstantiator);
-    }
   }
 
   /**

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/template/etl/api/batch/BatchContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/template/etl/api/batch/BatchContext.java
@@ -21,6 +21,8 @@ import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.templates.AdapterContext;
 import co.cask.cdap.template.etl.api.TransformContext;
 
+import java.util.Map;
+
 /**
  * Context passed to Batch Source and Sink.
  */
@@ -35,6 +37,13 @@ public interface BatchContext extends DatasetContext, TransformContext, AdapterC
    * @return Time in milliseconds since epoch time (00:00:00 January 1, 1970 UTC).
    */
   long getLogicalStartTime();
+
+  /**
+   * Returns runtime arguments of the Batch Job.
+   *
+   * @return runtime arguments of the Batch Job.
+   */
+  Map<String, String> getRuntimeArguments();
 
   /**
    */

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch-app/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch-app/pom.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright © 2015 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>co.cask.cdap</groupId>
+    <artifactId>cdap-etl</artifactId>
+    <version>3.2.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>cdap-etl-batch-app</artifactId>
+  <name>CDAP ETL Batch Application</name>
+  <packaging>jar</packaging>
+
+  <properties>
+    <app.main.class>co.cask.cdap.app.etl.batch.ETLBatch</app.main.class>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-etl-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-etl-lib</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-etl-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-mapreduce-client-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-common</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <!-- change to hadoop-aws when hadoop dependency is updated to 2.6 -->
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-common</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hsqldb</groupId>
+      <artifactId>hsqldb</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.felix</groupId>
+          <artifactId>maven-bundle-plugin</artifactId>
+          <version>2.3.7</version>
+          <extensions>true</extensions>
+          <configuration>
+            <archive>
+              <manifest>
+                <mainClass>${app.main.class}</mainClass>
+              </manifest>
+            </archive>
+            <instructions>
+              <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
+              <Embed-Transitive>true</Embed-Transitive>
+              <Embed-Directory>lib</Embed-Directory>
+              <Export-Package>co.cask.cdap.template.etl.api.*</Export-Package>
+            </instructions>
+          </configuration>
+          <executions>
+            <execution>
+              <phase>package</phase>
+              <goals>
+                <goal>bundle</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.14.1</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>2.3.7</version>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch-app/src/main/java/co/cask/cdap/app/etl/batch/ETLBatchApplication.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch-app/src/main/java/co/cask/cdap/app/etl/batch/ETLBatchApplication.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.etl.batch;
+
+import co.cask.cdap.api.schedule.Schedules;
+import co.cask.cdap.template.etl.batch.config.ETLBatchConfig;
+import co.cask.cdap.template.etl.common.ETLApplication;
+import com.google.gson.Gson;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * ETL Batch Template.
+ */
+public class ETLBatchApplication extends ETLApplication<ETLBatchConfig> {
+  public static final String SCHEDULE_NAME = "etlWorkflow";
+
+  @Override
+  public void configure() {
+    super.configure();
+    ETLBatchConfig config = getConfig();
+    setDescription("Batch Extract-Transform-Load (ETL) Template");
+    addMapReduce(new ETLMapReduce(config));
+    addWorkflow(new ETLWorkflow());
+    scheduleWorkflow(Schedules.createTimeSchedule(SCHEDULE_NAME, "batch etl schedule", config.getSchedule()),
+                     ETLWorkflow.NAME);
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch-app/src/main/java/co/cask/cdap/app/etl/batch/ETLMapReduce.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch-app/src/main/java/co/cask/cdap/app/etl/batch/ETLMapReduce.java
@@ -1,0 +1,299 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.etl.batch;
+
+import co.cask.cdap.api.ProgramLifecycle;
+import co.cask.cdap.api.Resources;
+import co.cask.cdap.api.dataset.lib.KeyValue;
+import co.cask.cdap.api.mapreduce.AbstractMapReduce;
+import co.cask.cdap.api.mapreduce.MapReduceConfigurer;
+import co.cask.cdap.api.mapreduce.MapReduceContext;
+import co.cask.cdap.api.metrics.Metrics;
+import co.cask.cdap.api.templates.plugins.PluginProperties;
+import co.cask.cdap.template.etl.api.PipelineConfigurable;
+import co.cask.cdap.template.etl.api.PipelineConfigurer;
+import co.cask.cdap.template.etl.api.Transform;
+import co.cask.cdap.template.etl.api.Transformation;
+import co.cask.cdap.template.etl.api.batch.BatchSink;
+import co.cask.cdap.template.etl.api.batch.BatchSinkContext;
+import co.cask.cdap.template.etl.api.batch.BatchSource;
+import co.cask.cdap.template.etl.api.batch.BatchSourceContext;
+import co.cask.cdap.template.etl.batch.BatchTransformContext;
+import co.cask.cdap.template.etl.batch.MapReduceSinkContext;
+import co.cask.cdap.template.etl.batch.MapReduceSourceContext;
+import co.cask.cdap.template.etl.batch.config.ETLBatchConfig;
+import co.cask.cdap.template.etl.common.Constants;
+import co.cask.cdap.template.etl.common.DefaultPipelineConfigurer;
+import co.cask.cdap.template.etl.common.Destroyables;
+import co.cask.cdap.template.etl.common.ETLStage;
+import co.cask.cdap.template.etl.common.PipelineValidator;
+import co.cask.cdap.template.etl.common.PluginID;
+import co.cask.cdap.template.etl.common.StageMetrics;
+import co.cask.cdap.template.etl.common.TransformExecutor;
+import com.google.common.base.Throwables;
+import com.google.common.collect.Lists;
+import com.google.common.reflect.TypeToken;
+import com.google.gson.Gson;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.Mapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * MapReduce driver for Batch ETL Adapters.
+ */
+public class ETLMapReduce extends AbstractMapReduce {
+  public static final String NAME = ETLMapReduce.class.getSimpleName();
+  private static final Logger LOG = LoggerFactory.getLogger(ETLMapReduce.class);
+  private static final Gson GSON = new Gson();
+  private static final String SOURCE_ID_KEY = "sourceId";
+  private static final String SINK_ID_KEY = "sinkId";
+  private static final String TRANSFORM_IDS_KEY = "transformIds";
+  private static final String RESOURCES_KEY = "resources";
+
+  private BatchSource batchSource;
+  private BatchSink batchSink;
+  private Metrics mrMetrics;
+
+  // this is only visible at configure time, not at runtime
+  private final ETLBatchConfig config;
+
+  public ETLMapReduce(ETLBatchConfig config) {
+    this.config = config;
+  }
+
+  @Override
+  public void configure() {
+    setName(NAME);
+    setDescription("MapReduce driver for Batch ETL Adapters");
+
+    ETLStage sourceConfig = config.getSource();
+    ETLStage sinkConfig = config.getSink();
+    List<ETLStage> transformConfigs = config.getTransforms();
+    String sourcePluginId = PluginID.from(Constants.Source.PLUGINTYPE, sourceConfig.getName(), 1).getID();
+    // 2 + since we start at 1, and there is always a source.  For example, if there are 0 transforms, sink is stage 2.
+    String sinkPluginId =
+      PluginID.from(Constants.Sink.PLUGINTYPE, sinkConfig.getName(), 2 + transformConfigs.size()).getID();
+
+    // Instantiate Source, Transforms, Sink stages.
+    // Use the plugin name as the plugin id for source and sink stages since there can be only one source and one sink.
+    PipelineConfigurable source = usePlugin(Constants.Source.PLUGINTYPE, sourceConfig.getName(),
+                                            sourcePluginId, getPluginProperties(sourceConfig));
+    if (source == null) {
+      throw new IllegalArgumentException(String.format("No Plugin of type '%s' named '%s' was found.",
+                                                       Constants.Source.PLUGINTYPE, sourceConfig.getName()));
+    }
+
+    PipelineConfigurable sink = usePlugin(Constants.Sink.PLUGINTYPE, sinkConfig.getName(),
+                                          sinkPluginId, getPluginProperties(sinkConfig));
+    if (sink == null) {
+      throw new IllegalArgumentException(String.format("No Plugin of type '%s' named '%s' was found.",
+                                                       Constants.Sink.PLUGINTYPE, sinkConfig.getName()));
+    }
+
+    // Store transform id list to be serialized and passed to the driver program
+    List<String> transformIds = Lists.newArrayListWithCapacity(transformConfigs.size());
+    List<Transformation> transforms = Lists.newArrayListWithCapacity(transformConfigs.size());
+    for (int i = 0; i < transformConfigs.size(); i++) {
+      ETLStage transformConfig = transformConfigs.get(i);
+
+      // Generate a transformId based on transform name and the array index (since there could
+      // multiple transforms - ex, N filter transforms in the same pipeline)
+      // stage number starts from 1, plus source is always #1, so add 2 for stage number.
+      String transformId = PluginID.from(Constants.Transform.PLUGINTYPE, transformConfig.getName(), 2 + i).getID();
+      PluginProperties transformProperties = getPluginProperties(transformConfig);
+      Transform transformObj = usePlugin(Constants.Transform.PLUGINTYPE, transformConfig.getName(),
+                                         transformId, transformProperties);
+      if (transformObj == null) {
+        throw new IllegalArgumentException(String.format("No Plugin of type '%s' named '%s' was found",
+                                                         Constants.Transform.PLUGINTYPE, transformConfig.getName()));
+      }
+
+      transformIds.add(transformId);
+      transforms.add(transformObj);
+    }
+
+    // add source, sink, transform ids to the properties. These are needed at runtime to instantiate the plugins
+    Map<String, String> properties = new HashMap<>();
+    properties.put(SOURCE_ID_KEY, sourcePluginId);
+    properties.put(SINK_ID_KEY, sinkPluginId);
+    properties.put(TRANSFORM_IDS_KEY, GSON.toJson(transformIds));
+    if (config.getResources() != null) {
+      properties.put(RESOURCES_KEY, GSON.toJson(config.getResources()));
+    }
+    setProperties(properties);
+
+    // Validate Source -> Transform -> Sink hookup
+    try {
+      MapReduceConfigurer mrConfigurer = getConfigurer();
+      PipelineValidator.validateStages(source, sink, transforms);
+      PipelineConfigurer sourceConfigurer = new DefaultPipelineConfigurer(mrConfigurer, sourcePluginId);
+      PipelineConfigurer sinkConfigurer = new DefaultPipelineConfigurer(mrConfigurer, sinkPluginId);
+      source.configurePipeline(sourceConfigurer);
+      sink.configurePipeline(sinkConfigurer);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public void beforeSubmit(MapReduceContext context) throws Exception {
+    Job job = context.getHadoopJob();
+
+    Map<String, String> properties = context.getSpecification().getProperties();
+    String sourcePluginId = properties.get(SOURCE_ID_KEY);
+    String sinkPluginId = properties.get(SINK_ID_KEY);
+
+    batchSource = context.newInstance(sourcePluginId);
+    BatchSourceContext sourceContext = new MapReduceSourceContext(context, mrMetrics, sourcePluginId);
+    batchSource.prepareRun(sourceContext);
+
+    batchSink = context.newInstance(sinkPluginId);
+    BatchSinkContext sinkContext = new MapReduceSinkContext(context, mrMetrics, sinkPluginId);
+    batchSink.prepareRun(sinkContext);
+
+    if (properties.containsKey(RESOURCES_KEY)) {
+      Resources resources = GSON.fromJson(properties.get(RESOURCES_KEY), Resources.class);
+      context.setMapperResources(resources);
+    }
+    job.setMapperClass(ETLMapper.class);
+    job.setNumReduceTasks(0);
+  }
+
+  @Override
+  public void onFinish(boolean succeeded, MapReduceContext context) throws Exception {
+    onRunFinishSource(context, succeeded);
+    onRunFinishSink(context, succeeded);
+    LOG.info("Batch Run finished : succeeded = {}", succeeded);
+  }
+
+  private void onRunFinishSource(MapReduceContext context, boolean succeeded) {
+    String sourcePluginId = context.getSpecification().getProperty(SOURCE_ID_KEY);
+    BatchSourceContext sourceContext = new MapReduceSourceContext(context, mrMetrics, sourcePluginId);
+    LOG.info("On RunFinish Source : {}", batchSource.getClass().getName());
+    try {
+      batchSource.onRunFinish(succeeded, sourceContext);
+    } catch (Throwable t) {
+      LOG.warn("Exception when calling onRunFinish on {}", batchSource, t);
+    }
+  }
+
+  private void onRunFinishSink(MapReduceContext context, boolean succeeded) {
+    String sinkPluginId = context.getSpecification().getProperty(SINK_ID_KEY);
+    BatchSinkContext sinkContext = new MapReduceSinkContext(context, mrMetrics, sinkPluginId);
+    LOG.info("On RunFinish Sink : {}", batchSink.getClass().getName());
+    try {
+      batchSink.onRunFinish(succeeded, sinkContext);
+    } catch (Throwable t) {
+      LOG.warn("Exception when calling onRunFinish on {}", batchSink, t);
+    }
+  }
+
+  private PluginProperties getPluginProperties(ETLStage config) {
+    PluginProperties.Builder builder = PluginProperties.builder();
+    if (config.getProperties() != null) {
+      builder.addAll(config.getProperties());
+    }
+    return builder.build();
+  }
+
+  /**
+   * Mapper Driver for ETL Transforms.
+   */
+  public static class ETLMapper extends Mapper implements ProgramLifecycle<MapReduceContext> {
+    private static final Logger LOG = LoggerFactory.getLogger(ETLMapper.class);
+    private static final Gson GSON = new Gson();
+    private static final Type STRING_LIST_TYPE = new TypeToken<List<String>>() { }.getType();
+
+    private List<Transform> transforms;
+
+    private TransformExecutor<KeyValue, KeyValue> transformExecutor;
+    private Metrics mapperMetrics;
+
+    @Override
+    public void initialize(MapReduceContext context) throws Exception {
+      context.getSpecification().getProperties();
+      Map<String, String> properties = context.getSpecification().getProperties();
+
+      String sourcePluginId = properties.get(SOURCE_ID_KEY);
+      String sinkPluginId = properties.get(SINK_ID_KEY);
+      List<String> transformIds = GSON.fromJson(properties.get(TRANSFORM_IDS_KEY), STRING_LIST_TYPE);
+      transforms = Lists.newArrayListWithCapacity(transformIds.size());
+
+      List<Transformation> pipeline = Lists.newArrayListWithCapacity(transformIds.size() + 2);
+      List<StageMetrics> stageMetrics = Lists.newArrayListWithCapacity(pipeline.size());
+
+      BatchSource source = context.newInstance(sourcePluginId);
+      BatchSourceContext batchSourceContext = new MapReduceSourceContext(context, mapperMetrics, sourcePluginId);
+      source.initialize(batchSourceContext);
+      pipeline.add(source);
+      stageMetrics.add(new StageMetrics(mapperMetrics, PluginID.from(sourcePluginId)));
+
+      addTransforms(pipeline, stageMetrics, transformIds, context);
+
+      BatchSink sink = context.newInstance(sinkPluginId);
+      BatchSinkContext batchSinkContext = new MapReduceSinkContext(context, mapperMetrics, sinkPluginId);
+      sink.initialize(batchSinkContext);
+      pipeline.add(sink);
+      stageMetrics.add(new StageMetrics(mapperMetrics, PluginID.from(sinkPluginId)));
+
+      transformExecutor = new TransformExecutor<>(pipeline, stageMetrics);
+    }
+
+    private void addTransforms(List<Transformation> pipeline,
+                               List<StageMetrics> stageMetrics,
+                               List<String> transformIds,
+                               MapReduceContext context) throws Exception {
+
+      for (int i = 0; i < transformIds.size(); i++) {
+        String transformId = transformIds.get(i);
+        Transform transform = context.newInstance(transformId);
+        BatchTransformContext transformContext = new BatchTransformContext(context, mapperMetrics, transformId);
+        LOG.debug("Transform Class : {}", transform.getClass().getName());
+        transform.initialize(transformContext);
+        pipeline.add(transform);
+        transforms.add(transform);
+        stageMetrics.add(new StageMetrics(mapperMetrics, PluginID.from(transformId)));
+      }
+    }
+
+    @Override
+    public void map(Object key, Object value, Context context) throws IOException, InterruptedException {
+      try {
+        KeyValue input = new KeyValue(key, value);
+        for (KeyValue output : transformExecutor.runOneIteration(input)) {
+          context.write(output.getKey(), output.getValue());
+        }
+      } catch (Exception e) {
+        LOG.error("Exception thrown in BatchDriver Mapper : {}", e);
+        Throwables.propagate(e);
+      }
+    }
+
+    @Override
+    public void destroy() {
+      // Both BatchSource and BatchSink implements Transform, hence are inside the transformExecutor as well
+      Destroyables.destroyQuietly(transformExecutor);
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch-app/src/main/java/co/cask/cdap/app/etl/batch/ETLWorkflow.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch-app/src/main/java/co/cask/cdap/app/etl/batch/ETLWorkflow.java
@@ -14,16 +14,20 @@
  * the License.
  */
 
-package co.cask.cdap.template.etl.api;
+package co.cask.cdap.app.etl.batch;
 
-import co.cask.cdap.api.annotation.Beta;
-import co.cask.cdap.api.artifact.PluginConfigurer;
+import co.cask.cdap.api.workflow.AbstractWorkflow;
 
 /**
- * Configures an ETL Pipeline. Allows adding datasets and streams, which will be created when a pipeline is created.
- * Using this as a layer between plugins and CDAP's PluginConfigurer in case pipelines need etl specific methods.
+ * Workflow for scheduling Batch ETL MapReduce Driver.
  */
-@Beta
-public interface PipelineConfigurer extends PluginConfigurer {
+public class ETLWorkflow extends AbstractWorkflow {
+  public static final String NAME = "ETLWorkflow";
 
+  @Override
+  protected void configure() {
+    setName(NAME);
+    setDescription("Workflow for Batch ETL MapReduce Driver");
+    addMapReduce(ETLMapReduce.NAME);
+  }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch-app/src/main/java/co/cask/cdap/app/etl/batch/config/ETLBatchConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch-app/src/main/java/co/cask/cdap/app/etl/batch/config/ETLBatchConfig.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.template.etl.batch.config;
+
+import co.cask.cdap.api.Resources;
+import co.cask.cdap.template.etl.common.ETLConfig;
+import co.cask.cdap.template.etl.common.ETLStage;
+import com.google.common.annotations.VisibleForTesting;
+
+import java.util.List;
+
+/**
+ * ETL Batch Adapter Configuration.
+ */
+public final class ETLBatchConfig extends ETLConfig {
+  private final String schedule;
+
+  public ETLBatchConfig(String schedule, ETLStage source, ETLStage sink, List<ETLStage> transforms,
+                        Resources resources) {
+    super(source, sink, transforms, resources);
+    this.schedule = schedule;
+  }
+
+  @VisibleForTesting
+  public ETLBatchConfig(String schedule, ETLStage source, ETLStage sink, List<ETLStage> transforms) {
+    this(schedule, source, sink, transforms, null);
+  }
+
+  @VisibleForTesting
+  public ETLBatchConfig(String schedule, ETLStage source, ETLStage sink) {
+    this(schedule, source, sink, null);
+  }
+
+  public String getSchedule() {
+    return schedule;
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch-app/src/test/java/co/cask/cdap/app/etl/batch/BaseETLBatchTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch-app/src/test/java/co/cask/cdap/app/etl/batch/BaseETLBatchTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.etl.batch;
+
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.dataset.lib.TimePartitionedFileSet;
+import co.cask.cdap.api.templates.plugins.PluginClass;
+import co.cask.cdap.api.templates.plugins.PluginPropertyField;
+import co.cask.cdap.app.test.sink.MetaKVTableSink;
+import co.cask.cdap.app.test.source.MetaKVTableSource;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.artifact.ArtifactSummary;
+import co.cask.cdap.template.etl.api.PipelineConfigurable;
+import co.cask.cdap.template.etl.api.batch.BatchSource;
+import co.cask.cdap.template.etl.batch.sink.BatchCubeSink;
+import co.cask.cdap.template.etl.batch.sink.BatchElasticsearchSink;
+import co.cask.cdap.template.etl.batch.sink.DBSink;
+import co.cask.cdap.template.etl.batch.sink.KVTableSink;
+import co.cask.cdap.template.etl.batch.sink.TableSink;
+import co.cask.cdap.template.etl.batch.sink.TimePartitionedFileSetDatasetAvroSink;
+import co.cask.cdap.template.etl.batch.sink.TimePartitionedFileSetDatasetParquetSink;
+import co.cask.cdap.template.etl.batch.source.DBSource;
+import co.cask.cdap.template.etl.batch.source.KVTableSource;
+import co.cask.cdap.template.etl.batch.source.StreamBatchSource;
+import co.cask.cdap.template.etl.batch.source.TableSource;
+import co.cask.cdap.template.etl.batch.source.TimePartitionedFileSetDatasetAvroSource;
+import co.cask.cdap.template.etl.common.DBRecord;
+import co.cask.cdap.template.etl.transform.ProjectionTransform;
+import co.cask.cdap.template.etl.transform.ScriptFilterTransform;
+import co.cask.cdap.template.etl.transform.StructuredRecordToGenericRecordTransform;
+import co.cask.cdap.test.TestBase;
+import co.cask.cdap.test.TestConfiguration;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.google.gson.Gson;
+import org.apache.avro.file.DataFileStream;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.mapred.AvroKey;
+import org.apache.avro.mapreduce.AvroKeyOutputFormat;
+import org.apache.hadoop.fs.Path;
+import org.apache.twill.filesystem.Location;
+import org.hsqldb.jdbc.JDBCDriver;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import parquet.avro.AvroParquetOutputFormat;
+import parquet.avro.AvroParquetReader;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Base test class that sets up plugins and the batch template.
+ */
+public class BaseETLBatchTest extends TestBase {
+
+  @ClassRule
+  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
+
+  protected static final Id.Artifact APP_ARTIFACT_ID = Id.Artifact.from(Id.Namespace.DEFAULT, "etlbatch", "3.2.0");
+  protected static final ArtifactSummary ETLBATCH_ARTIFACT = new ArtifactSummary("etlbatch", "3.2.0", false);
+  protected static final Id.Namespace NAMESPACE = Id.Namespace.DEFAULT;
+  protected static final Id.ApplicationTemplate TEMPLATE_ID = Id.ApplicationTemplate.from("ETLBatch");
+  protected static final Gson GSON = new Gson();
+
+  @BeforeClass
+  public static void setupTest() throws Exception {
+    // add the artifact for etl batch app
+    addAppArtifact(APP_ARTIFACT_ID, ETLBatchApplication.class,
+      BatchSource.class.getPackage().getName(),
+      PipelineConfigurable.class.getPackage().getName());
+
+    // add artifact for batch sources and sinks
+    addPluginArtifact(Id.Artifact.from(Id.Namespace.DEFAULT, "batch-plugins", "1.0.0"), APP_ARTIFACT_ID,
+      DBSource.class, KVTableSource.class, StreamBatchSource.class, TableSource.class, DBRecord.class,
+      TimePartitionedFileSetDatasetAvroSource.class,
+      BatchCubeSink.class, DBSink.class, KVTableSink.class, TableSink.class,
+      TimePartitionedFileSetDatasetAvroSink.class, AvroKeyOutputFormat.class, AvroKey.class,
+      TimePartitionedFileSetDatasetParquetSink.class, AvroParquetOutputFormat.class, BatchElasticsearchSink.class);
+    // add artifact for transforms
+    addPluginArtifact(Id.Artifact.from(Id.Namespace.DEFAULT, "transforms", "1.0.0"), APP_ARTIFACT_ID,
+      ProjectionTransform.class, ScriptFilterTransform.class, StructuredRecordToGenericRecordTransform.class);
+
+    // add some test plugins
+    addPluginArtifact(Id.Artifact.from(Id.Namespace.DEFAULT, "test-sources", "1.0.0"), APP_ARTIFACT_ID,
+      MetaKVTableSource.class);
+    addPluginArtifact(Id.Artifact.from(Id.Namespace.DEFAULT, "test-sinks", "1.0.0"), APP_ARTIFACT_ID,
+      MetaKVTableSink.class);
+
+    // add hypersql 3rd party plugin
+    PluginClass hypersql = new PluginClass("jdbc", "hypersql", "hypersql jdbc driver", JDBCDriver.class.getName(),
+      null, Collections.<String, PluginPropertyField>emptyMap());
+    addPluginArtifact(Id.Artifact.from(Id.Namespace.DEFAULT, "hsql-jdbc", "1.0.0"), APP_ARTIFACT_ID,
+      Sets.newHashSet(hypersql), JDBCDriver.class);
+  }
+
+  protected List<GenericRecord> readOutput(TimePartitionedFileSet fileSet, Schema schema) throws IOException {
+    org.apache.avro.Schema avroSchema = new org.apache.avro.Schema.Parser().parse(schema.toString());
+    DatumReader<GenericRecord> datumReader = new GenericDatumReader<>(avroSchema);
+    List<GenericRecord> records = Lists.newArrayList();
+    for (Location dayLoc : fileSet.getEmbeddedFileSet().getBaseLocation().list()) {
+      // this level should be the day (ex: 2015-01-19)
+      for (Location timeLoc : dayLoc.list()) {
+        // this level should be the time (ex: 21-23.1234567890000)
+        for (Location file : timeLoc.list()) {
+          // this level should be the actual mapred output
+          String locName = file.getName();
+
+          if (locName.endsWith(".avro")) {
+            DataFileStream<GenericRecord> fileStream =
+              new DataFileStream<>(file.getInputStream(), datumReader);
+            Iterables.addAll(records, fileStream);
+            fileStream.close();
+          }
+          if (locName.endsWith(".parquet")) {
+            Path parquetFile = new Path(file.toString());
+            AvroParquetReader<GenericRecord> reader = new AvroParquetReader<GenericRecord>(parquetFile);
+            GenericRecord result = reader.read();
+            while (result != null) {
+              records.add(result);
+              result = reader.read();
+            }
+          }
+        }
+      }
+    }
+    return records;
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch-app/src/test/java/co/cask/cdap/app/etl/batch/BatchCubeSinkTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch-app/src/test/java/co/cask/cdap/app/etl/batch/BatchCubeSinkTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.etl.batch;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.dataset.lib.cube.AggregationFunction;
+import co.cask.cdap.api.dataset.lib.cube.Cube;
+import co.cask.cdap.api.dataset.lib.cube.CubeQuery;
+import co.cask.cdap.api.dataset.lib.cube.TimeSeries;
+import co.cask.cdap.api.dataset.table.Put;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.data2.dataset2.lib.cube.CubeDatasetDefinition;
+import co.cask.cdap.proto.AdapterConfig;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.artifact.AppRequest;
+import co.cask.cdap.template.etl.batch.config.ETLBatchConfig;
+import co.cask.cdap.template.etl.common.ETLStage;
+import co.cask.cdap.template.etl.common.Properties;
+import co.cask.cdap.test.AdapterManager;
+import co.cask.cdap.test.ApplicationManager;
+import co.cask.cdap.test.DataSetManager;
+import co.cask.cdap.test.MapReduceManager;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.gson.Gson;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ *
+ */
+public class BatchCubeSinkTest extends BaseETLBatchTest {
+  @Test
+  public void test() throws Exception {
+
+    Schema schema = Schema.recordOf(
+      "action",
+      Schema.Field.of("rowkey", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("user", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("count", Schema.of(Schema.Type.INT))
+    );
+
+    ETLStage source = new ETLStage("Table",
+      ImmutableMap.of(
+        Properties.BatchReadableWritable.NAME, "inputTable",
+        Properties.Table.PROPERTY_SCHEMA_ROW_FIELD, "rowkey",
+        Properties.Table.PROPERTY_SCHEMA, schema.toString()));
+
+    // single aggregation
+    Map<String, String> datasetProps = ImmutableMap.of(
+      CubeDatasetDefinition.PROPERTY_AGGREGATION_PREFIX + "byUser.dimensions", "user"
+    );
+    Map<String, String> measurementsProps = ImmutableMap.of(
+      Properties.Cube.MEASUREMENT_PREFIX + "count", "COUNTER"
+    );
+    ETLStage sink = new ETLStage("Cube",
+                                 ImmutableMap.of(Properties.Cube.DATASET_NAME, "batch_cube",
+                                                 Properties.Cube.DATASET_OTHER, new Gson().toJson(datasetProps),
+                                                 Properties.Cube.MEASUREMENTS, new Gson().toJson(measurementsProps)));
+
+    ETLBatchConfig etlConfig = new ETLBatchConfig("* * * * *", source, sink, Lists.<ETLStage>newArrayList());
+
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
+    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "testCubeAdapter");
+    ApplicationManager appManager = deployApplication(appId, appRequest);
+
+    // add some data to the input table
+    DataSetManager<Table> inputManager = getDataset("inputTable");
+    Table inputTable = inputManager.get();
+    Put put = new Put(Bytes.toBytes("row1"));
+    put.add("user", "samuel");
+    put.add("count", 5);
+    put.add("price", 123.45);
+    put.add("item", "scotch");
+    inputTable.put(put);
+    inputManager.flush();
+
+    long startTs = System.currentTimeMillis() / 1000;
+
+    MapReduceManager mrManager = appManager.getMapReduceManager(ETLMapReduce.NAME);
+    mrManager.start();
+    mrManager.waitForFinish(5, TimeUnit.MINUTES);
+
+    long endTs = System.currentTimeMillis() / 1000;
+
+    // verify
+    DataSetManager<Cube> tableManager = getDataset("batch_cube");
+    Cube cube = tableManager.get();
+    Collection<TimeSeries> result = cube.query(CubeQuery.builder()
+                                                 .select().measurement("count", AggregationFunction.LATEST)
+                                                 .from("byUser").resolution(1, TimeUnit.SECONDS)
+                                                 .where().timeRange(startTs, endTs).limit(100).build());
+    Assert.assertFalse(result.isEmpty());
+    Iterator<TimeSeries> iterator = result.iterator();
+    Assert.assertTrue(iterator.hasNext());
+    TimeSeries timeSeries = iterator.next();
+    Assert.assertEquals("count", timeSeries.getMeasureName());
+    Assert.assertFalse(timeSeries.getTimeValues().isEmpty());
+    Assert.assertEquals(5, timeSeries.getTimeValues().get(0).getValue());
+    Assert.assertFalse(iterator.hasNext());
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch-app/src/test/java/co/cask/cdap/app/etl/batch/BatchETLDBAdapterTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch-app/src/test/java/co/cask/cdap/app/etl/batch/BatchETLDBAdapterTest.java
@@ -1,0 +1,428 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.etl.batch;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.dataset.table.Put;
+import co.cask.cdap.api.dataset.table.Row;
+import co.cask.cdap.api.dataset.table.Scanner;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.artifact.AppRequest;
+import co.cask.cdap.template.etl.batch.config.ETLBatchConfig;
+import co.cask.cdap.template.etl.common.ETLStage;
+import co.cask.cdap.template.etl.common.Properties;
+import co.cask.cdap.test.ApplicationManager;
+import co.cask.cdap.test.DataSetManager;
+import co.cask.cdap.test.MapReduceManager;
+import co.cask.cdap.test.SlowTests;
+import com.google.common.base.Charsets;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import org.hsqldb.Server;
+import org.hsqldb.server.ServerAcl;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.sql.Connection;
+import java.sql.Date;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.text.SimpleDateFormat;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import javax.sql.rowset.serial.SerialBlob;
+
+/**
+ * Test for ETL using databases
+ */
+public class BatchETLDBAdapterTest extends BaseETLBatchTest {
+  private static final long currentTs = System.currentTimeMillis();
+  private static final String clobData = "this is a long string with line separators \n that can be used as \n a clob";
+  private static HSQLDBServer hsqlDBServer;
+  private static Schema schema;
+
+  @ClassRule
+  public static TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    String hsqlDBDir = temporaryFolder.newFolder("hsqldb").getAbsolutePath();
+    hsqlDBServer = new HSQLDBServer(hsqlDBDir, "testdb");
+    hsqlDBServer.start();
+    try (Connection conn = hsqlDBServer.getConnection()) {
+      createTestTables(conn);
+      prepareTestData(conn);
+    }
+
+    Schema nullableString = Schema.nullableOf(Schema.of(Schema.Type.STRING));
+    Schema nullableBoolean = Schema.nullableOf(Schema.of(Schema.Type.BOOLEAN));
+    Schema nullableInt = Schema.nullableOf(Schema.of(Schema.Type.INT));
+    Schema nullableLong = Schema.nullableOf(Schema.of(Schema.Type.LONG));
+    Schema nullableFloat = Schema.nullableOf(Schema.of(Schema.Type.FLOAT));
+    Schema nullableDouble = Schema.nullableOf(Schema.of(Schema.Type.DOUBLE));
+    Schema nullableBytes = Schema.nullableOf(Schema.of(Schema.Type.BYTES));
+    schema = Schema.recordOf("student",
+                             Schema.Field.of("ID", Schema.of(Schema.Type.INT)),
+                             Schema.Field.of("NAME", Schema.of(Schema.Type.STRING)),
+                             Schema.Field.of("SCORE", nullableDouble),
+                             Schema.Field.of("GRADUATED", nullableBoolean),
+                             Schema.Field.of("TINY", nullableInt),
+                             Schema.Field.of("SMALL", nullableInt),
+                             Schema.Field.of("BIG", nullableLong),
+                             Schema.Field.of("FLOAT_COL", nullableFloat),
+                             Schema.Field.of("REAL_COL", nullableFloat),
+                             Schema.Field.of("NUMERIC_COL", nullableDouble),
+                             Schema.Field.of("DECIMAL_COL", nullableDouble),
+                             Schema.Field.of("BIT_COL", nullableBoolean),
+                             Schema.Field.of("DATE_COL", nullableLong),
+                             Schema.Field.of("TIME_COL", nullableLong),
+                             Schema.Field.of("TIMESTAMP_COL", nullableLong),
+                             Schema.Field.of("BINARY_COL", nullableBytes),
+                             Schema.Field.of("BLOB_COL", nullableBytes),
+                             Schema.Field.of("CLOB_COL", nullableString));
+  }
+
+  private static void createTestTables(Connection conn) throws SQLException {
+    try (Statement stmt = conn.createStatement()) {
+      stmt.execute("CREATE TABLE my_table" +
+                     "(" +
+                     "ID INT NOT NULL, " +
+                     "NAME VARCHAR(40) NOT NULL, " +
+                     "SCORE DOUBLE, " +
+                     "GRADUATED BOOLEAN, " +
+                     "NOT_IMPORTED VARCHAR(30), " +
+                     "TINY TINYINT, " +
+                     "SMALL SMALLINT, " +
+                     "BIG BIGINT, " +
+                     "FLOAT_COL FLOAT, " +
+                     "REAL_COL REAL, " +
+                     "NUMERIC_COL NUMERIC(10, 2), " +
+                     "DECIMAL_COL DECIMAL(10, 2), " +
+                     "BIT_COL BIT, " +
+                     "DATE_COL DATE, " +
+                     "TIME_COL TIME, " +
+                     "TIMESTAMP_COL TIMESTAMP, " +
+                     "BINARY_COL BINARY(100)," +
+                     "BLOB_COL BLOB(100), " +
+                     "CLOB_COL CLOB(100)" +
+                     ")");
+      stmt.execute("CREATE TABLE my_dest_table AS (" +
+                     "SELECT * FROM my_table) WITH DATA");
+    }
+  }
+
+  private static void prepareTestData(Connection conn) throws SQLException {
+    try (
+      PreparedStatement pStmt =
+        conn.prepareStatement("INSERT INTO my_table VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
+    ) {
+      for (int i = 1; i <= 5; i++) {
+        String name = "user" + i;
+        pStmt.setInt(1, i);
+        pStmt.setString(2, name);
+        pStmt.setDouble(3, 123.45 + i);
+        pStmt.setBoolean(4, (i % 2 == 0));
+        pStmt.setString(5, "random" + i);
+        pStmt.setShort(6, (short) i);
+        pStmt.setShort(7, (short) i);
+        pStmt.setLong(8, (long) i);
+        pStmt.setFloat(9, (float) 123.45 + i);
+        pStmt.setFloat(10, (float) 123.45 + i);
+        pStmt.setDouble(11, 123.45 + i);
+        if ((i % 2 == 0)) {
+          pStmt.setNull(12, Types.DOUBLE);
+        } else {
+          pStmt.setDouble(12, 123.45 + i);
+        }
+        pStmt.setBoolean(13, (i % 2 == 1));
+        pStmt.setDate(14, new Date(currentTs));
+        pStmt.setTime(15, new Time(currentTs));
+        pStmt.setTimestamp(16, new Timestamp(currentTs));
+        pStmt.setBytes(17, name.getBytes(Charsets.UTF_8));
+        pStmt.setBlob(18, new SerialBlob(name.getBytes(Charsets.UTF_8)));
+        pStmt.setClob(19, new InputStreamReader(new ByteArrayInputStream(clobData.getBytes(Charsets.UTF_8))));
+        pStmt.executeUpdate();
+      }
+    }
+  }
+
+  @Test
+  @Category(SlowTests.class)
+  @SuppressWarnings("ConstantConditions")
+  public void testDBSourceWithCaseInsensitiveRowKey() throws Exception {
+    String importQuery = "SELECT ID, NAME, SCORE, GRADUATED, TINY, SMALL, BIG, FLOAT_COL, REAL_COL, NUMERIC_COL, " +
+      "DECIMAL_COL, BIT_COL, DATE_COL, TIME_COL, TIMESTAMP_COL, BINARY_COL, BLOB_COL, CLOB_COL FROM my_table " +
+      "WHERE ID < 3";
+    String countQuery = "SELECT COUNT(ID) from my_table WHERE id < 3";
+    ETLStage source = new ETLStage("Database", ImmutableMap.<String, String>builder()
+                                     .put(Properties.DB.CONNECTION_STRING, hsqlDBServer.getConnectionUrl())
+                                     .put(Properties.DB.IMPORT_QUERY, importQuery)
+                                     .put(Properties.DB.COUNT_QUERY, countQuery)
+                                     .put(Properties.DB.JDBC_PLUGIN_NAME, "hypersql")
+                                     .build()
+                                   );
+
+    ETLStage sink = new ETLStage("Table", ImmutableMap.of(
+      "name", "outputTable",
+      Properties.Table.PROPERTY_SCHEMA, schema.toString(),
+      Properties.Table.PROPERTY_SCHEMA_ROW_FIELD, "id",
+      // Test case-insensitive row key matching
+      Properties.Table.CASE_SENSITIVE_ROW_FIELD, "false"));
+
+    ETLBatchConfig etlConfig = new ETLBatchConfig("* * * * *", source, sink, Lists.<ETLStage>newArrayList());
+
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
+    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "dbSourceTest");
+    ApplicationManager appManager = deployApplication(appId, appRequest);
+
+    MapReduceManager mrManager = appManager.getMapReduceManager(ETLMapReduce.NAME);
+    mrManager.start();
+    mrManager.waitForFinish(5, TimeUnit.MINUTES);
+
+    DataSetManager<Table> outputManager = getDataset("outputTable");
+    Table outputTable = outputManager.get();
+
+    // Using get to verify the rowkey
+    Assert.assertEquals(17, outputTable.get(Bytes.toBytes(1)).getColumns().size());
+    // In the second record, the 'decimal' column is null
+    Assert.assertEquals(16, outputTable.get(Bytes.toBytes(2)).getColumns().size());
+    // Scanner to verify number of rows
+    Scanner scanner = outputTable.scan(null, null);
+    Row row1 = scanner.next();
+    Row row2 = scanner.next();
+    Assert.assertNotNull(row1);
+    Assert.assertNotNull(row2);
+    Assert.assertNull(scanner.next());
+    scanner.close();
+    // Verify data
+    Assert.assertEquals("user1", row1.getString("NAME"));
+    Assert.assertEquals("user2", row2.getString("NAME"));
+    Assert.assertEquals(124.45, row1.getDouble("SCORE"), 0.000001);
+    Assert.assertEquals(125.45, row2.getDouble("SCORE"), 0.000001);
+    Assert.assertEquals(false, row1.getBoolean("GRADUATED"));
+    Assert.assertEquals(true, row2.getBoolean("GRADUATED"));
+    Assert.assertNull(row1.get("NOT_IMPORTED"));
+    Assert.assertNull(row2.get("NOT_IMPORTED"));
+    // TODO: Reading from table as SHORT seems to be giving the wrong value.
+    Assert.assertEquals(1, (int) row1.getInt("TINY"));
+    Assert.assertEquals(2, (int) row2.getInt("TINY"));
+    Assert.assertEquals(1, (int) row1.getInt("SMALL"));
+    Assert.assertEquals(2, (int) row2.getInt("SMALL"));
+    Assert.assertEquals(1, (long) row1.getLong("BIG"));
+    Assert.assertEquals(2, (long) row2.getLong("BIG"));
+    // TODO: Reading from table as FLOAT seems to be giving back the wrong value.
+    Assert.assertEquals(124.45, row1.getDouble("FLOAT_COL"), 0.00001);
+    Assert.assertEquals(125.45, row2.getDouble("FLOAT_COL"), 0.00001);
+    Assert.assertEquals(124.45, row1.getDouble("REAL_COL"), 0.00001);
+    Assert.assertEquals(125.45, row2.getDouble("REAL_COL"), 0.00001);
+    Assert.assertEquals(124.45, row1.getDouble("NUMERIC_COL"), 0.000001);
+    Assert.assertEquals(125.45, row2.getDouble("NUMERIC_COL"), 0.000001);
+    Assert.assertEquals(124.45, row1.getDouble("DECIMAL_COL"), 0.000001);
+    Assert.assertEquals(null, row2.get("DECIMAL_COL"));
+    Assert.assertEquals(true, row1.getBoolean("BIT_COL"));
+    Assert.assertEquals(false, row2.getBoolean("BIT_COL"));
+    // Verify time columns
+    java.util.Date date = new java.util.Date(currentTs);
+    SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+    long expectedDateTimestamp = Date.valueOf(sdf.format(date)).getTime();
+    sdf = new SimpleDateFormat("H:mm:ss");
+    long expectedTimeTimestamp = Time.valueOf(sdf.format(date)).getTime();
+    Assert.assertEquals(expectedDateTimestamp, (long) row1.getLong("DATE_COL"));
+    Assert.assertEquals(expectedDateTimestamp, (long) row2.getLong("DATE_COL"));
+    Assert.assertEquals(expectedTimeTimestamp, (long) row1.getLong("TIME_COL"));
+    Assert.assertEquals(expectedTimeTimestamp, (long) row2.getLong("TIME_COL"));
+    Assert.assertEquals(currentTs, (long) row1.getLong("TIMESTAMP_COL"));
+    Assert.assertEquals(currentTs, (long) row2.getLong("TIMESTAMP_COL"));
+    // verify binary columns
+    Assert.assertEquals("user1", Bytes.toString(row1.get("BINARY_COL"), 0, 5));
+    Assert.assertEquals("user2", Bytes.toString(row2.get("BINARY_COL"), 0, 5));
+    Assert.assertEquals("user1", Bytes.toString(row1.get("BLOB_COL"), 0, 5));
+    Assert.assertEquals("user2", Bytes.toString(row2.get("BLOB_COL"), 0, 5));
+    Assert.assertEquals(clobData, Bytes.toString(row1.get("CLOB_COL"), 0, clobData.length()));
+    Assert.assertEquals(clobData, Bytes.toString(row2.get("CLOB_COL"), 0, clobData.length()));
+  }
+
+  @Test
+  @Category(SlowTests.class)
+  public void testDBSourceWithCaseSensitiveRowKey() throws Exception {
+    String importQuery = "SELECT ID, NAME FROM my_table WHERE ID < 3";
+    String countQuery = "SELECT COUNT(ID) from my_table WHERE id < 3";
+    ETLStage source = new ETLStage("Database", ImmutableMap.<String, String>builder()
+      .put(Properties.DB.CONNECTION_STRING, hsqlDBServer.getConnectionUrl())
+      .put(Properties.DB.IMPORT_QUERY, importQuery)
+      .put(Properties.DB.COUNT_QUERY, countQuery)
+      .put(Properties.DB.JDBC_PLUGIN_NAME, "hypersql")
+      .build()
+    );
+
+    ETLStage sink = new ETLStage("Table", ImmutableMap.of(
+      "name", "outputTable1",
+      Properties.Table.PROPERTY_SCHEMA, schema.toString(),
+      Properties.Table.PROPERTY_SCHEMA_ROW_FIELD, "id"));
+
+    ETLBatchConfig etlConfig = new ETLBatchConfig("* * * * *", source, sink, Lists.<ETLStage>newArrayList());
+
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
+    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "dbSourceTest");
+    ApplicationManager appManager = deployApplication(appId, appRequest);
+
+    MapReduceManager mrManager = appManager.getMapReduceManager(ETLMapReduce.NAME);
+    mrManager.start();
+    mrManager.waitForFinish(5, TimeUnit.MINUTES);
+
+    // No records should be written
+    DataSetManager<Table> outputManager = getDataset("outputTable1");
+    Table outputTable = outputManager.get();
+    Scanner scan = outputTable.scan(null, null);
+    Assert.assertNull(scan.next());
+  }
+
+  // Test is ignored - Currently DBOutputFormat does a statement.executeBatch which seems to fail in HSQLDB.
+  // Need to investigate alternatives to HSQLDB.
+  @Ignore
+  @Test
+  @Category(SlowTests.class)
+  public void testDBSink() throws Exception {
+    String cols = "ID, NAME, SCORE, GRADUATED, TINY, SMALL, BIG, FLOAT_COL, REAL_COL, NUMERIC_COL, DECIMAL_COL, " +
+      "BIT_COL, DATE_COL, TIME_COL, TIMESTAMP_COL, BINARY_COL, BLOB_COL, CLOB_COL";
+    ETLStage source = new ETLStage("Table",
+                                   ImmutableMap.of(
+                                     Properties.BatchReadableWritable.NAME, "inputTable",
+                                     Properties.Table.PROPERTY_SCHEMA_ROW_FIELD, "ID",
+                                     Properties.Table.PROPERTY_SCHEMA, schema.toString()));
+    ETLStage sink = new ETLStage("Database",
+                                 ImmutableMap.of(Properties.DB.CONNECTION_STRING, hsqlDBServer.getConnectionUrl(),
+                                                 Properties.DB.TABLE_NAME, "my_dest_table",
+                                                 Properties.DB.COLUMNS, cols,
+                                                 Properties.DB.JDBC_PLUGIN_NAME, "hypersql"
+                                 ));
+    List<ETLStage> transforms = Lists.newArrayList();
+    ETLBatchConfig etlConfig = new ETLBatchConfig("* * * * *", source, sink, transforms);
+
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
+    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "dbSinkTest");
+    ApplicationManager appManager = deployApplication(appId, appRequest);
+
+    createInputData();
+
+    MapReduceManager mrManager = appManager.getMapReduceManager(ETLMapReduce.NAME);
+    mrManager.start();
+    mrManager.waitForFinish(5, TimeUnit.MINUTES);
+  }
+
+  private void createInputData() throws Exception {
+    // add some data to the input table
+    DataSetManager<Table> inputManager = getDataset("inputTable");
+    Table inputTable = inputManager.get();
+    for (int i = 1; i <= 2; i++) {
+      Put put = new Put(Bytes.toBytes("row" + i));
+      String name = "user" + i;
+      put.add("ID", i);
+      put.add("NAME", name);
+      put.add("SCORE", 3.451);
+      put.add("GRADUATED", (i % 2 == 0));
+      put.add("TINY", i + 1);
+      put.add("SMALL", i + 2);
+      put.add("BIG", 3456987L);
+      put.add("FLOAT", 3.456f);
+      put.add("REAL", 3.457f);
+      put.add("NUMERIC", 3.458);
+      put.add("DECIMAL", 3.459);
+      put.add("BIT", (i % 2 == 1));
+      put.add("DATE", currentTs);
+      put.add("TIME", currentTs);
+      put.add("TIMESTAMP", currentTs);
+      put.add("BINARY", name.getBytes(Charsets.UTF_8));
+      put.add("BLOB", name.getBytes(Charsets.UTF_8));
+      put.add("CLOB", clobData);
+      inputTable.put(put);
+      inputManager.flush();
+    }
+  }
+
+  @AfterClass
+  public static void tearDown() throws SQLException {
+    try (
+      Connection conn = hsqlDBServer.getConnection();
+      Statement stmt = conn.createStatement()
+    ) {
+      stmt.execute("DROP TABLE my_table");
+    }
+
+    hsqlDBServer.stop();
+  }
+
+  private static class HSQLDBServer {
+
+    private final String locationUrl;
+    private final String database;
+    private final String connectionUrl;
+    private final Server server;
+    private final String hsqlDBDriver = "org.hsqldb.jdbcDriver";
+
+    HSQLDBServer(String location, String database) {
+      this.locationUrl = String.format("%s/%s", location, database);
+      this.database = database;
+      this.connectionUrl = String.format("jdbc:hsqldb:hsql://localhost/%s", database);
+      this.server = new Server();
+    }
+
+    public int start() throws IOException, ServerAcl.AclFormatException {
+      server.setDatabasePath(0, locationUrl);
+      server.setDatabaseName(0, database);
+      return server.start();
+    }
+
+    public int stop() {
+      return server.stop();
+    }
+
+    public Connection getConnection() {
+      try {
+        Class.forName(hsqlDBDriver);
+        return DriverManager.getConnection(connectionUrl);
+      } catch (Exception e) {
+        throw Throwables.propagate(e);
+      }
+    }
+
+    public String getConnectionUrl() {
+      return this.connectionUrl;
+    }
+
+    public String getHsqlDBDriver() {
+      return this.hsqlDBDriver;
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch-app/src/test/java/co/cask/cdap/app/etl/batch/ETLESTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch-app/src/test/java/co/cask/cdap/app/etl/batch/ETLESTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.etl.batch;
+
+import co.cask.cdap.api.data.format.Formats;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.dataset.table.Row;
+import co.cask.cdap.api.dataset.table.Scanner;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.common.utils.Networks;
+import co.cask.cdap.proto.AdapterConfig;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.artifact.AppRequest;
+import co.cask.cdap.template.etl.batch.config.ETLBatchConfig;
+import co.cask.cdap.template.etl.batch.sink.BatchElasticsearchSink;
+import co.cask.cdap.template.etl.batch.source.ElasticsearchSource;
+import co.cask.cdap.template.etl.common.ETLStage;
+import co.cask.cdap.template.etl.common.Properties;
+import co.cask.cdap.test.AdapterManager;
+import co.cask.cdap.test.ApplicationManager;
+import co.cask.cdap.test.DataSetManager;
+import co.cask.cdap.test.MapReduceManager;
+import co.cask.cdap.test.SlowTests;
+import co.cask.cdap.test.StreamManager;
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.elasticsearch.action.admin.indices.delete.DeleteIndexResponse;
+import org.elasticsearch.action.delete.DeleteResponse;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.node.Node;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TemporaryFolder;
+
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
+import static org.elasticsearch.node.NodeBuilder.nodeBuilder;
+
+/**
+ *  Unit test for batch {@link BatchElasticsearchSink} and {@link ElasticsearchSource} classes.
+ */
+public class ETLESTest extends BaseETLBatchTest {
+  private static final Gson GSON = new Gson();
+  private static final String STREAM_NAME = "myStream";
+  private static final String TABLE_NAME = "outputTable";
+
+  private static final Schema BODY_SCHEMA = Schema.recordOf(
+    "event",
+    Schema.Field.of("ticker", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("num", Schema.of(Schema.Type.INT)),
+    Schema.Field.of("price", Schema.of(Schema.Type.DOUBLE)));
+
+  @ClassRule
+  public static TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  private Client client;
+  private Node node;
+  private int port;
+
+
+  @Before
+  public void beforeTest() throws Exception {
+    port = Networks.getRandomPort();
+    ImmutableSettings.Builder elasticsearchSettings = ImmutableSettings.settingsBuilder()
+      .put("path.data", tmpFolder.newFolder("data"))
+      .put("http.port", port);
+    node = nodeBuilder().settings(elasticsearchSettings.build()).client(false).node();
+    client = node.client();
+  }
+
+  @After
+  public void afterTest() {
+    try {
+      DeleteIndexResponse delete = client.admin().indices().delete(new DeleteIndexRequest("test")).actionGet();
+      Assert.assertTrue(delete.isAcknowledged());
+    } finally {
+      node.close();
+    }
+  }
+
+  @Test
+  @Category(SlowTests.class)
+  public void testES() throws Exception {
+    testESSink();
+    testESSource();
+  }
+
+  private void testESSink() throws Exception {
+    StreamManager streamManager = getStreamManager(STREAM_NAME);
+    streamManager.createStream();
+    streamManager.send(ImmutableMap.of("header1", "bar"), "AAPL|10|500.32");
+    streamManager.send(ImmutableMap.of("header1", "bar"), "CDAP|13|212.36");
+
+    ETLStage source = new ETLStage("Stream", ImmutableMap.<String, String>builder()
+      .put(Properties.Stream.NAME, STREAM_NAME)
+      .put(Properties.Stream.DURATION, "10m")
+      .put(Properties.Stream.DELAY, "0d")
+      .put(Properties.Stream.FORMAT, Formats.CSV)
+      .put(Properties.Stream.SCHEMA, BODY_SCHEMA.toString())
+      .put("format.setting.delimiter", "|")
+      .build());
+
+    ETLStage sink = new ETLStage("Elasticsearch",
+                                 ImmutableMap.of(Properties.Elasticsearch.HOST,
+                                   InetAddress.getLocalHost().getHostName() + ":" + port,
+                                   Properties.Elasticsearch.INDEX_NAME, "test",
+                                   Properties.Elasticsearch.TYPE_NAME, "testing",
+                                   Properties.Elasticsearch.ID_FIELD, "ticker"
+                                 ));
+    List<ETLStage> transforms = new ArrayList<>();
+    ETLBatchConfig etlConfig = new ETLBatchConfig("* * * * *", source, sink, transforms);
+
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
+    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "esSinkTest");
+    ApplicationManager appManager = deployApplication(appId, appRequest);
+
+    MapReduceManager mrManager = appManager.getMapReduceManager(ETLMapReduce.NAME);
+    mrManager.start();
+    mrManager.waitForFinish(5, TimeUnit.MINUTES);
+
+    SearchResponse searchResponse = client.prepareSearch("test").execute().actionGet();
+    Assert.assertEquals(2, searchResponse.getHits().getTotalHits());
+    searchResponse = client.prepareSearch().setQuery(matchQuery("ticker", "AAPL")).execute().actionGet();
+    Assert.assertEquals(1, searchResponse.getHits().getTotalHits());
+    Assert.assertEquals("test", searchResponse.getHits().getAt(0).getIndex());
+    Assert.assertEquals("testing", searchResponse.getHits().getAt(0).getType());
+    Assert.assertEquals("AAPL", searchResponse.getHits().getAt(0).getId());
+    searchResponse = client.prepareSearch().setQuery(matchQuery("ticker", "ABCD")).execute().actionGet();
+    Assert.assertEquals(0, searchResponse.getHits().getTotalHits());
+
+    DeleteResponse response = client.prepareDelete("test", "testing", "CDAP").execute().actionGet();
+    Assert.assertTrue(response.isFound());
+  }
+
+  @SuppressWarnings("ConstantConditions")
+  private void testESSource() throws Exception {
+    ETLStage source = new ETLStage("Elasticsearch",
+                                   ImmutableMap.of(Properties.Elasticsearch.HOST,
+                                                   InetAddress.getLocalHost().getHostName() + ":" + port,
+                                                   Properties.Elasticsearch.INDEX_NAME, "test",
+                                                   Properties.Elasticsearch.TYPE_NAME, "testing",
+                                                   Properties.Elasticsearch.QUERY, "?q=*",
+                                                   Properties.Elasticsearch.SCHEMA, BODY_SCHEMA.toString()));
+    ETLStage sink = new ETLStage("Table",
+                                 ImmutableMap.of("name", TABLE_NAME,
+                                                 Properties.Table.PROPERTY_SCHEMA, BODY_SCHEMA.toString(),
+                                                 Properties.Table.PROPERTY_SCHEMA_ROW_FIELD, "ticker"));
+
+    List<ETLStage> transforms = new ArrayList<>();
+    ETLBatchConfig etlConfig = new ETLBatchConfig("* * * * *", source, sink, transforms);
+
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
+    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "esSourceTest");
+    ApplicationManager appManager = deployApplication(appId, appRequest);
+
+    MapReduceManager mrManager = appManager.getMapReduceManager(ETLMapReduce.NAME);
+    mrManager.start();
+    mrManager.waitForFinish(5, TimeUnit.MINUTES);
+
+    DataSetManager<Table> outputManager = getDataset(TABLE_NAME);
+    Table outputTable = outputManager.get();
+
+    // Scanner to verify number of rows
+    Scanner scanner = outputTable.scan(null, null);
+    Row row1 = scanner.next();
+    Assert.assertNotNull(row1);
+    Assert.assertNull(scanner.next());
+    scanner.close();
+    // Verify data
+    Assert.assertEquals(10, (int) row1.getInt("num"));
+    Assert.assertEquals(500.32, row1.getDouble("price"), 0.000001);
+    Assert.assertNull(row1.get("NOT_IMPORTED"));
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch-app/src/test/java/co/cask/cdap/app/etl/batch/ETLMapReduceTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch-app/src/test/java/co/cask/cdap/app/etl/batch/ETLMapReduceTest.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.etl.batch;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.dataset.lib.KeyValueTable;
+import co.cask.cdap.api.dataset.lib.TimePartitionedFileSet;
+import co.cask.cdap.api.dataset.table.Put;
+import co.cask.cdap.api.dataset.table.Row;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.app.test.sink.MetaKVTableSink;
+import co.cask.cdap.app.test.source.MetaKVTableSource;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.artifact.AppRequest;
+import co.cask.cdap.template.etl.batch.config.ETLBatchConfig;
+import co.cask.cdap.template.etl.batch.source.FileBatchSource;
+import co.cask.cdap.template.etl.common.ETLStage;
+import co.cask.cdap.template.etl.common.Properties;
+import co.cask.cdap.test.ApplicationManager;
+import co.cask.cdap.test.DataSetManager;
+import co.cask.cdap.test.MapReduceManager;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.s3native.S3NInMemoryFileSystem;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tests for ETLBatch.
+ */
+public class ETLMapReduceTest extends BaseETLBatchTest {
+
+  @Test
+  public void testKVToKV() throws Exception {
+    // kv table to kv table pipeline
+    ETLStage source = new ETLStage("KVTable", ImmutableMap.of(Properties.BatchReadableWritable.NAME, "table1"));
+    ETLStage sink = new ETLStage("KVTable", ImmutableMap.of(Properties.BatchReadableWritable.NAME, "table2"));
+    ETLStage transform = new ETLStage("Projection", ImmutableMap.<String, String>of());
+    List<ETLStage> transformList = Lists.newArrayList(transform);
+    ETLBatchConfig etlConfig = new ETLBatchConfig("* * * * *", source, sink, transformList);
+
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
+    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "KVToKV");
+    ApplicationManager appManager = deployApplication(appId, appRequest);
+
+    // add some data to the input table
+    DataSetManager<KeyValueTable> table1 = getDataset("table1");
+    KeyValueTable inputTable = table1.get();
+    for (int i = 0; i < 10000; i++) {
+      inputTable.write("hello" + i, "world" + i);
+    }
+    table1.flush();
+
+    MapReduceManager mrManager = appManager.getMapReduceManager(ETLMapReduce.NAME);
+    mrManager.start();
+    mrManager.waitForFinish(5, TimeUnit.MINUTES);
+
+    DataSetManager<KeyValueTable> table2 = getDataset("table2");
+    KeyValueTable outputTable = table2.get();
+    for (int i = 0; i < 10000; i++) {
+      Assert.assertEquals("world" + i, Bytes.toString(outputTable.read("hello" + i)));
+    }
+  }
+
+  @Test
+  public void testKVToKVMeta() throws Exception {
+    ETLStage source = new ETLStage("MetaKVTable", ImmutableMap.of(Properties.BatchReadableWritable.NAME, "mtable1"));
+    ETLStage sink = new ETLStage("MetaKVTable", ImmutableMap.of(Properties.BatchReadableWritable.NAME, "mtable2"));
+    ETLBatchConfig etlConfig = new ETLBatchConfig("* * * * *", source, sink);
+
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
+    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "KVToKVMeta");
+    ApplicationManager appManager = deployApplication(appId, appRequest);
+
+    MapReduceManager mrManager = appManager.getMapReduceManager(ETLMapReduce.NAME);
+    mrManager.start();
+    mrManager.waitForFinish(5, TimeUnit.MINUTES);
+
+    DataSetManager<KeyValueTable> sourceMetaTable = getDataset(MetaKVTableSource.META_TABLE);
+    KeyValueTable sourceTable = sourceMetaTable.get();
+    Assert.assertEquals(MetaKVTableSource.PREPARE_RUN_KEY,
+                        Bytes.toString(sourceTable.read(MetaKVTableSource.PREPARE_RUN_KEY)));
+    Assert.assertEquals(MetaKVTableSource.FINISH_RUN_KEY,
+                        Bytes.toString(sourceTable.read(MetaKVTableSource.FINISH_RUN_KEY)));
+
+    DataSetManager<KeyValueTable> sinkMetaTable = getDataset(MetaKVTableSink.META_TABLE);
+    KeyValueTable sinkTable = sinkMetaTable.get();
+    Assert.assertEquals(MetaKVTableSink.PREPARE_RUN_KEY,
+                        Bytes.toString(sinkTable.read(MetaKVTableSink.PREPARE_RUN_KEY)));
+    Assert.assertEquals(MetaKVTableSink.FINISH_RUN_KEY,
+                        Bytes.toString(sinkTable.read(MetaKVTableSink.FINISH_RUN_KEY)));
+  }
+
+  @SuppressWarnings("ConstantConditions")
+  @Test
+  public void testTableToTable() throws Exception {
+
+    Schema schema = Schema.recordOf(
+      "purchase",
+      Schema.Field.of("rowkey", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("user", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("count", Schema.of(Schema.Type.INT)),
+      Schema.Field.of("price", Schema.of(Schema.Type.DOUBLE)),
+      Schema.Field.of("item", Schema.of(Schema.Type.STRING))
+    );
+
+    ETLStage source = new ETLStage("Table",
+      ImmutableMap.of(
+        Properties.BatchReadableWritable.NAME, "inputTable",
+        Properties.Table.PROPERTY_SCHEMA_ROW_FIELD, "rowkey",
+        Properties.Table.PROPERTY_SCHEMA, schema.toString()));
+    ETLStage sink = new ETLStage("Table",
+      ImmutableMap.of(
+        Properties.BatchReadableWritable.NAME, "outputTable",
+        Properties.Table.PROPERTY_SCHEMA_ROW_FIELD, "rowkey"));
+    ETLBatchConfig etlConfig = new ETLBatchConfig("* * * * *", source, sink, Lists.<ETLStage>newArrayList());
+
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
+    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "TableToTable");
+    ApplicationManager appManager = deployApplication(appId, appRequest);
+
+    // add some data to the input table
+    DataSetManager<Table> inputManager = getDataset("inputTable");
+    Table inputTable = inputManager.get();
+    Put put = new Put(Bytes.toBytes("row1"));
+    put.add("user", "samuel");
+    put.add("count", 5);
+    put.add("price", 123.45);
+    put.add("item", "scotch");
+    inputTable.put(put);
+    inputManager.flush();
+    put = new Put(Bytes.toBytes("row2"));
+    put.add("user", "jackson");
+    put.add("count", 10);
+    put.add("price", 123456789d);
+    put.add("item", "island");
+    inputTable.put(put);
+    inputManager.flush();
+
+    MapReduceManager mrManager = appManager.getMapReduceManager(ETLMapReduce.NAME);
+    mrManager.start();
+    mrManager.waitForFinish(5, TimeUnit.MINUTES);
+
+    DataSetManager<Table> outputManager = getDataset("outputTable");
+    Table outputTable = outputManager.get();
+
+    Row row = outputTable.get(Bytes.toBytes("row1"));
+    Assert.assertEquals("samuel", row.getString("user"));
+    Assert.assertEquals(5, (int) row.getInt("count"));
+    Assert.assertTrue(Math.abs(123.45 - row.getDouble("price")) < 0.000001);
+    Assert.assertEquals("scotch", row.getString("item"));
+
+    row = outputTable.get(Bytes.toBytes("row2"));
+    Assert.assertEquals("jackson", row.getString("user"));
+    Assert.assertEquals(10, (int) row.getInt("count"));
+    Assert.assertTrue(Math.abs(123456789 - row.getDouble("price")) < 0.000001);
+    Assert.assertEquals("island", row.getString("item"));
+  }
+
+  @Test
+  public void testS3toTPFS() throws Exception {
+    String testPath = "s3n://test/2015-06-17-00-00-00.txt";
+    String testData = "Sample data for testing.";
+
+    S3NInMemoryFileSystem fs = new S3NInMemoryFileSystem();
+    Configuration conf = new Configuration();
+    conf.set("fs.s3n.impl", S3NInMemoryFileSystem.class.getName());
+    fs.initialize(URI.create("s3n://test/"), conf);
+    fs.createNewFile(new Path(testPath));
+
+    FSDataOutputStream writeData = fs.create(new Path(testPath));
+    writeData.write(testData.getBytes());
+    writeData.flush();
+    writeData.close();
+
+    Method method = FileSystem.class.getDeclaredMethod("addFileSystemForTesting",
+                                                       new Class[]{URI.class, Configuration.class, FileSystem.class});
+    method.setAccessible(true);
+    method.invoke(FileSystem.class, URI.create("s3n://test/"), conf, fs);
+    ETLStage source = new ETLStage("S3", ImmutableMap.<String, String>builder()
+      .put(Properties.S3.ACCESS_KEY, "key")
+      .put(Properties.S3.ACCESS_ID, "ID")
+      .put(Properties.S3.PATH, testPath)
+      .build());
+
+    ETLStage sink = new ETLStage("TPFSAvro",
+                                 ImmutableMap.of(Properties.TimePartitionedFileSetDataset.SCHEMA,
+                                   FileBatchSource.DEFAULT_SCHEMA.toString(),
+                                   Properties.TimePartitionedFileSetDataset.TPFS_NAME, "TPFSsink"));
+    ETLBatchConfig etlConfig = new ETLBatchConfig("* * * * *", source, sink, Lists.<ETLStage>newArrayList());
+
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
+    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "S3ToTPFS");
+    ApplicationManager appManager = deployApplication(appId, appRequest);
+
+    MapReduceManager mrManager = appManager.getMapReduceManager(ETLMapReduce.NAME);
+    mrManager.start();
+    mrManager.waitForFinish(2, TimeUnit.MINUTES);
+
+    DataSetManager<TimePartitionedFileSet> fileSetManager = getDataset("TPFSsink");
+    TimePartitionedFileSet fileSet = fileSetManager.get();
+    List<GenericRecord> records = readOutput(fileSet, FileBatchSource.DEFAULT_SCHEMA);
+    Assert.assertEquals(1, records.size());
+    Assert.assertEquals(testData, records.get(0).get("body").toString());
+    fileSet.close();
+  }
+
+  @Test
+  public void testFiletoTPFS() throws Exception {
+    String filePath = "file:///tmp/test/text.txt";
+    String testData = "String for testing purposes.";
+
+    Path textFile = new Path(filePath);
+    Configuration conf = new Configuration();
+    FileSystem fs = FileSystem.get(conf);
+    FSDataOutputStream writeData = fs.create(textFile);
+    writeData.write(testData.getBytes());
+    writeData.flush();
+    writeData.close();
+
+    ETLStage source = new ETLStage("File", ImmutableMap.<String, String>builder()
+      .put(Properties.File.FILESYSTEM, "Text")
+      .put(Properties.File.PATH, filePath)
+      .build());
+
+    ETLStage sink = new ETLStage("TPFSAvro",
+                                 ImmutableMap.of(Properties.TimePartitionedFileSetDataset.SCHEMA,
+                                                 FileBatchSource.DEFAULT_SCHEMA.toString(),
+                                                 Properties.TimePartitionedFileSetDataset.TPFS_NAME, "fileSink"));
+    ETLBatchConfig etlConfig = new ETLBatchConfig("* * * * *", source, sink, Lists.<ETLStage>newArrayList());
+
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
+    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "FileToTPFS");
+    ApplicationManager appManager = deployApplication(appId, appRequest);
+
+    MapReduceManager mrManager = appManager.getMapReduceManager(ETLMapReduce.NAME);
+    mrManager.start();
+    mrManager.waitForFinish(2, TimeUnit.MINUTES);
+
+    DataSetManager<TimePartitionedFileSet> fileSetManager = getDataset("fileSink");
+    TimePartitionedFileSet fileSet = fileSetManager.get();
+    List<GenericRecord> records = readOutput(fileSet, FileBatchSource.DEFAULT_SCHEMA);
+    Assert.assertEquals(1, records.size());
+    Assert.assertEquals(testData, records.get(0).get("body").toString());
+    fileSet.close();
+  }
+
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch-app/src/test/java/co/cask/cdap/app/etl/batch/ETLStreamConversionTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch-app/src/test/java/co/cask/cdap/app/etl/batch/ETLStreamConversionTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.etl.batch;
+
+import co.cask.cdap.api.data.format.Formats;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.dataset.lib.TimePartitionedFileSet;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.artifact.AppRequest;
+import co.cask.cdap.template.etl.batch.config.ETLBatchConfig;
+import co.cask.cdap.template.etl.common.ETLStage;
+import co.cask.cdap.template.etl.common.Properties;
+import co.cask.cdap.test.ApplicationManager;
+import co.cask.cdap.test.DataSetManager;
+import co.cask.cdap.test.MapReduceManager;
+import co.cask.cdap.test.StreamManager;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import org.apache.avro.generic.GenericRecord;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tests for {@link ETLBatchApplication} for Stream conversion from stream to avro format for writing to
+ * {@link TimePartitionedFileSet}
+ */
+public class ETLStreamConversionTest extends BaseETLBatchTest {
+
+  private static final Schema BODY_SCHEMA = Schema.recordOf(
+    "event",
+    Schema.Field.of("ticker", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("num", Schema.of(Schema.Type.INT)),
+    Schema.Field.of("price", Schema.of(Schema.Type.DOUBLE)));
+
+  private static final Schema EVENT_SCHEMA = Schema.recordOf(
+    "streamEvent",
+    Schema.Field.of("ts", Schema.of(Schema.Type.LONG)),
+    Schema.Field.of("headers", Schema.mapOf(Schema.of(Schema.Type.STRING), Schema.of(Schema.Type.STRING))),
+    Schema.Field.of("ticker", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("num", Schema.of(Schema.Type.INT)),
+    Schema.Field.of("price", Schema.of(Schema.Type.DOUBLE)));
+
+  @Test
+  public void testStreamConversionTPFSParquetSink() throws Exception {
+    String sinkType = "TPFSParquet";
+    testSink(sinkType);
+  }
+
+  @Test
+  public void testStreamConversionTPFSAvroSink() throws Exception {
+    String sinkType = "TPFSAvro";
+    testSink(sinkType);
+  }
+
+  private void testSink(String sinkType) throws Exception {
+    String filesetName = "converted_stream";
+    StreamManager streamManager = getStreamManager("myStream");
+    streamManager.createStream();
+    streamManager.send(ImmutableMap.of("header1", "bar"), "AAPL|10|500.32");
+
+    ETLBatchConfig etlConfig = constructETLBatchConfig(filesetName, sinkType);
+
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
+    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "sconversion");
+    ApplicationManager appManager = deployApplication(appId, appRequest);
+
+    MapReduceManager mrManager = appManager.getMapReduceManager(ETLMapReduce.NAME);
+    mrManager.start();
+    mrManager.waitForFinish(4, TimeUnit.MINUTES);
+
+    // get the output fileset, and read the parquet/avro files it output.
+    DataSetManager<TimePartitionedFileSet> fileSetManager = getDataset(filesetName);
+    TimePartitionedFileSet fileSet = fileSetManager.get();
+
+    List<GenericRecord> records = readOutput(fileSet, EVENT_SCHEMA);
+    Assert.assertEquals(1, records.size());
+
+  }
+
+  private ETLBatchConfig constructETLBatchConfig(String fileSetName, String sinkType) {
+    ETLStage source = new ETLStage("Stream", ImmutableMap.<String, String>builder()
+      .put(Properties.Stream.NAME, "myStream")
+      .put(Properties.Stream.DURATION, "10m")
+      .put(Properties.Stream.DELAY, "0d")
+      .put(Properties.Stream.FORMAT, Formats.CSV)
+      .put(Properties.Stream.SCHEMA, BODY_SCHEMA.toString())
+      .put("format.setting.delimiter", "|")
+      .build());
+    ETLStage sink = new ETLStage(sinkType,
+                                 ImmutableMap.of(Properties.TimePartitionedFileSetDataset.SCHEMA,
+                                                 EVENT_SCHEMA.toString(),
+                                                 Properties.TimePartitionedFileSetDataset.TPFS_NAME, fileSetName));
+    ETLStage transform = new ETLStage("Projection", ImmutableMap.<String, String>of());
+    return new ETLBatchConfig("* * * * *", source, sink, Lists.newArrayList(transform));
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch-app/src/test/java/co/cask/cdap/app/etl/batch/ETLTPFSTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch-app/src/test/java/co/cask/cdap/app/etl/batch/ETLTPFSTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.etl.batch;
+
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.dataset.lib.FileSetProperties;
+import co.cask.cdap.api.dataset.lib.TimePartitionedFileSet;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.artifact.AppRequest;
+import co.cask.cdap.template.etl.batch.config.ETLBatchConfig;
+import co.cask.cdap.template.etl.common.ETLStage;
+import co.cask.cdap.template.etl.common.Properties;
+import co.cask.cdap.test.ApplicationManager;
+import co.cask.cdap.test.DataSetManager;
+import co.cask.cdap.test.MapReduceManager;
+import co.cask.cdap.test.WorkflowManager;
+import co.cask.tephra.Transaction;
+import co.cask.tephra.TransactionAware;
+import co.cask.tephra.TransactionManager;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.GenericRecordBuilder;
+import org.apache.avro.mapreduce.AvroKeyInputFormat;
+import org.apache.avro.mapreduce.AvroKeyOutputFormat;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.twill.filesystem.Location;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+public class ETLTPFSTest extends BaseETLBatchTest {
+
+  @Test
+  public void testAvroSourceConversionToAvroSink() throws Exception {
+
+    Schema eventSchema = Schema.recordOf(
+      "record",
+      Schema.Field.of("int", Schema.of(Schema.Type.INT)));
+
+    org.apache.avro.Schema avroSchema = new org.apache.avro.Schema.Parser().parse(eventSchema.toString());
+
+    GenericRecord record = new GenericRecordBuilder(avroSchema)
+      .set("int", Integer.MAX_VALUE)
+      .build();
+
+    String filesetName = "tpfs";
+    addDatasetInstance(TimePartitionedFileSet.class.getName(), filesetName, FileSetProperties.builder()
+      .setInputFormat(AvroKeyInputFormat.class)
+      .setOutputFormat(AvroKeyOutputFormat.class)
+      .setInputProperty("schema", avroSchema.toString())
+      .setOutputProperty("schema", avroSchema.toString())
+      .setEnableExploreOnCreate(true)
+      .setSerDe("org.apache.hadoop.hive.serde2.avro.AvroSerDe")
+      .setExploreInputFormat("org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat")
+      .setExploreOutputFormat("org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat")
+      .setTableProperty("avro.schema.literal", (avroSchema.toString()))
+      .build());
+    DataSetManager<TimePartitionedFileSet> fileSetManager = getDataset(filesetName);
+    TimePartitionedFileSet tpfs = fileSetManager.get();
+
+    TransactionManager txService = getTxService();
+    Transaction tx1 = txService.startShort(100);
+    TransactionAware txTpfs = (TransactionAware) tpfs;
+    txTpfs.startTx(tx1);
+
+    long timeInMillis = System.currentTimeMillis();
+    fileSetManager.get().addPartition(timeInMillis, "directory", ImmutableMap.of("key1", "value1"));
+    Location location = fileSetManager.get().getPartitionByTime(timeInMillis).getLocation();
+    location = location.append("file.avro");
+    FSDataOutputStream outputStream = new FSDataOutputStream(location.getOutputStream(), null);
+    DataFileWriter dataFileWriter = new DataFileWriter<>(new GenericDatumWriter<GenericRecord>(avroSchema));
+    dataFileWriter.create(avroSchema, outputStream);
+    dataFileWriter.append(record);
+    dataFileWriter.flush();
+
+    txTpfs.commitTx();
+    txService.canCommit(tx1, txTpfs.getTxChanges());
+    txService.commit(tx1);
+    txTpfs.postTxCommit();
+
+    String newFilesetName = filesetName + "_op";
+    ETLBatchConfig etlBatchConfig = constructTPFSETLConfig(filesetName, newFilesetName, eventSchema);
+
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlBatchConfig);
+    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "sconversion1");
+    ApplicationManager appManager = deployApplication(appId, appRequest);
+
+    WorkflowManager workflowManager = appManager.getWorkflowManager(ETLWorkflow.NAME);
+    // add a minute to the end time to make sure the newly added partition is included in the run.
+    workflowManager.start(ImmutableMap.of("runtime", String.valueOf(timeInMillis + 60 * 1000)));
+    workflowManager.waitForFinish(4, TimeUnit.MINUTES);
+
+    DataSetManager<TimePartitionedFileSet> newFileSetManager = getDataset(newFilesetName);
+    TimePartitionedFileSet newFileSet = newFileSetManager.get();
+
+    List<GenericRecord> newRecords = readOutput(newFileSet, eventSchema);
+    Assert.assertEquals(1, newRecords.size());
+    Assert.assertEquals(Integer.MAX_VALUE, newRecords.get(0).get("int"));
+  }
+
+  private ETLBatchConfig constructTPFSETLConfig(String filesetName, String newFilesetName, Schema eventSchema) {
+    ETLStage source = new ETLStage("TPFSAvro",
+                                   ImmutableMap.of(Properties.TimePartitionedFileSetDataset.SCHEMA,
+                                                   eventSchema.toString(),
+                                                   Properties.TimePartitionedFileSetDataset.TPFS_NAME, filesetName,
+                                                   Properties.TimePartitionedFileSetDataset.DELAY, "0d",
+                                                   Properties.TimePartitionedFileSetDataset.DURATION, "2m"));
+    ETLStage sink = new ETLStage("TPFSAvro",
+                                 ImmutableMap.of(Properties.TimePartitionedFileSetDataset.SCHEMA,
+                                                 eventSchema.toString(),
+                                                 Properties.TimePartitionedFileSetDataset.TPFS_NAME,
+                                                 newFilesetName));
+
+    ETLStage transform = new ETLStage("Projection", ImmutableMap.<String, String>of());
+    return new ETLBatchConfig("* * * * *", source, sink, Lists.newArrayList(transform));
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch-app/src/test/java/co/cask/cdap/app/test/sink/MetaKVTableSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch-app/src/test/java/co/cask/cdap/app/test/sink/MetaKVTableSink.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.test.sink;
+
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.lib.KeyValueTable;
+import co.cask.cdap.template.etl.api.PipelineConfigurer;
+import co.cask.cdap.template.etl.api.batch.BatchSink;
+import co.cask.cdap.template.etl.api.batch.BatchSinkContext;
+import co.cask.cdap.template.etl.batch.sink.KVTableSink;
+
+/**
+ * Test Batch Sink that writes to a table in {@link BatchSink#prepareRun} and {@link BatchSink#onRunFinish}.
+ */
+@Plugin(type = "sink")
+@Name("MetaKVTable")
+public class MetaKVTableSink extends KVTableSink {
+  public static final String META_TABLE = "sinkMetaTable";
+  public static final String PREPARE_RUN_KEY = "sink.prepare.run";
+  public static final String FINISH_RUN_KEY = "sink.finish.run";
+
+  public MetaKVTableSink(KVTableConfig kvTableConfig) {
+    super(kvTableConfig);
+  }
+
+  @Override
+  public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
+    super.configurePipeline(pipelineConfigurer);
+    pipelineConfigurer.createDataset(META_TABLE, KeyValueTable.class, DatasetProperties.EMPTY);
+  }
+
+  @Override
+  public void prepareRun(BatchSinkContext context) {
+    super.prepareRun(context);
+    KeyValueTable table = context.getDataset(META_TABLE);
+    table.write(PREPARE_RUN_KEY, PREPARE_RUN_KEY);
+  }
+
+  @Override
+  public void onRunFinish(boolean succeeded, BatchSinkContext context) {
+    super.onRunFinish(succeeded, context);
+    KeyValueTable table = context.getDataset(META_TABLE);
+    table.write(FINISH_RUN_KEY, FINISH_RUN_KEY);
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch-app/src/test/java/co/cask/cdap/app/test/source/MetaKVTableSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch-app/src/test/java/co/cask/cdap/app/test/source/MetaKVTableSource.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.test.source;
+
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.lib.KeyValueTable;
+import co.cask.cdap.template.etl.api.PipelineConfigurer;
+import co.cask.cdap.template.etl.api.batch.BatchSource;
+import co.cask.cdap.template.etl.api.batch.BatchSourceContext;
+import co.cask.cdap.template.etl.batch.source.KVTableSource;
+
+/**
+ * Test Batch Source that writes to a table in {@link BatchSource#prepareRun} and {@link BatchSource#onRunFinish}.
+ */
+@Plugin(type = "source")
+@Name("MetaKVTable")
+public class MetaKVTableSource extends KVTableSource {
+  public static final String META_TABLE = "sourceMetaTable";
+  public static final String PREPARE_RUN_KEY = "source.prepare.run";
+  public static final String FINISH_RUN_KEY = "source.finish.run";
+
+  public MetaKVTableSource(KVTableConfig kvTableConfig) {
+    super(kvTableConfig);
+  }
+
+  @Override
+  public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
+    super.configurePipeline(pipelineConfigurer);
+    pipelineConfigurer.createDataset(META_TABLE, KeyValueTable.class, DatasetProperties.EMPTY);
+  }
+
+  @Override
+  public void prepareRun(BatchSourceContext context) {
+    super.prepareRun(context);
+    KeyValueTable table = context.getDataset(META_TABLE);
+    table.write(PREPARE_RUN_KEY, PREPARE_RUN_KEY);
+  }
+
+  @Override
+  public void onRunFinish(boolean succeeded, BatchSourceContext context) {
+    super.onRunFinish(succeeded, context);
+    KeyValueTable table = context.getDataset(META_TABLE);
+    table.write(FINISH_RUN_KEY, FINISH_RUN_KEY);
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch-app/src/test/java/org/apache/hadoop/fs/s3native/S3NInMemoryFileSystem.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch-app/src/test/java/org/apache/hadoop/fs/s3native/S3NInMemoryFileSystem.java
@@ -14,16 +14,14 @@
  * the License.
  */
 
-package co.cask.cdap.template.etl.api;
-
-import co.cask.cdap.api.annotation.Beta;
-import co.cask.cdap.api.artifact.PluginConfigurer;
+package org.apache.hadoop.fs.s3native;
 
 /**
- * Configures an ETL Pipeline. Allows adding datasets and streams, which will be created when a pipeline is created.
- * Using this as a layer between plugins and CDAP's PluginConfigurer in case pipelines need etl specific methods.
+ * TODO: [CDAP-2824] - Delete this class when Hadoop dependency is updated to 2.6.0
+ * Used for testing File without actually connecting to an File instance.
  */
-@Beta
-public interface PipelineConfigurer extends PluginConfigurer {
-
+public class S3NInMemoryFileSystem extends NativeS3FileSystem {
+  public S3NInMemoryFileSystem() {
+    super(new InMemoryNativeFileSystemStore());
+  }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch-app/src/test/resources/logback-test.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch-app/src/test/resources/logback-test.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Copyright © 2014 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+  -->
+
+<!--                                                                         -->
+<!-- AppFabric Logging Configuration                                         -->
+<!--                                                                         -->
+<!-- We use the LogBack project for logging in AppFabric. The manual for     -->
+<!-- Logback can be found here: http://logback.qos.ch/manual                 -->
+<!--                                                                         -->
+
+<configuration>
+    <!--Supressing some chatty loggers -->
+    <logger name="org.apache.hadoop" level="INFO"/>
+    <logger name="org.mortbay.log" level="INFO"/>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{ISO8601} - %-5p [%t:%C{1}@%L] - %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="CLOG" class="co.cask.cdap.common.logging.logback.CAppender">              
+        <layout>                      
+            <!-- Note: we don't insert new line in the pattern as this is done on higher level (in old back-end) -->
+            <pattern>%d{ISO8601} - %-5p [%t:%C{1}@%L] - %m</pattern>       
+        </layout>
+    </appender>
+
+    <logger name="co.cask.cdap" level="INFO" />
+
+    <root level="WARN">
+        <appender-ref ref="CLOG"/>
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+</configuration>

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/batch/BatchTransformContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/batch/BatchTransformContext.java
@@ -28,12 +28,12 @@ public class BatchTransformContext implements TransformContext {
   private final MapReduceContext context;
   private final Metrics metrics;
 
-  protected final String pluginPrefix;
+  protected final String pluginId;
 
-  public BatchTransformContext(MapReduceContext context, Metrics metrics, String pluginPrefix) {
+  public BatchTransformContext(MapReduceContext context, Metrics metrics, String pluginId) {
     this.context = context;
     this.metrics = metrics;
-    this.pluginPrefix = pluginPrefix;
+    this.pluginId = pluginId;
   }
 
   @Override
@@ -43,6 +43,11 @@ public class BatchTransformContext implements TransformContext {
 
   @Override
   public PluginProperties getPluginProperties() {
-    return context.getPluginProperties(pluginPrefix);
+    // temporary hack to let it support both templates and applications. Will be removed when templates are removed.
+    try {
+      return context.getPluginProperties(pluginId);
+    } catch (UnsupportedOperationException e) {
+      return context.getPluginProps(pluginId);
+    }
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/batch/MapReduceBatchContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/batch/MapReduceBatchContext.java
@@ -69,20 +69,40 @@ public abstract class MapReduceBatchContext extends BatchTransformContext implem
 
   @Override
   public PluginProperties getPluginProperties(String pluginId) {
-    return mrContext.getPluginProperties(getPluginId(pluginId));
+    // temporary hack until templates are removed, and to let this work for both apps and templates
+    try {
+      return mrContext.getPluginProperties(getPluginId(pluginId));
+    } catch (UnsupportedOperationException e) {
+      return mrContext.getPluginProps(getPluginId(pluginId));
+    }
   }
 
   @Override
   public <T> Class<T> loadPluginClass(String pluginId) {
-    return mrContext.loadPluginClass(getPluginId(pluginId));
+    // temporary hack until templates are removed, and to let this work for both apps and templates
+    try {
+      return mrContext.loadPluginClass(getPluginId(pluginId));
+    } catch (UnsupportedOperationException e) {
+      return mrContext.loadClass(getPluginId(pluginId));
+    }
   }
 
   @Override
   public <T> T newPluginInstance(String pluginId) throws InstantiationException {
-    return mrContext.newPluginInstance(getPluginId(pluginId));
+    // temporary hack until templates are removed, and to let this work for both apps and templates
+    try {
+      return mrContext.newPluginInstance(getPluginId(pluginId));
+    } catch (UnsupportedOperationException e) {
+      return mrContext.newInstance(getPluginId(pluginId));
+    }
+  }
+
+  @Override
+  public Map<String, String> getRuntimeArguments() {
+    return mrContext.getRuntimeArguments();
   }
 
   private String getPluginId(String childPluginId) {
-    return String.format("%s%s%s", pluginPrefix, Constants.ID_SEPARATOR, childPluginId);
+    return String.format("%s%s%s", pluginId, Constants.ID_SEPARATOR, childPluginId);
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/common/AdapterPipelineConfigurer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/common/AdapterPipelineConfigurer.java
@@ -16,96 +16,98 @@
 
 package co.cask.cdap.template.etl.common;
 
-import co.cask.cdap.api.artifact.PluginConfigurer;
 import co.cask.cdap.api.artifact.PluginSelector;
 import co.cask.cdap.api.data.stream.Stream;
 import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.module.DatasetModule;
+import co.cask.cdap.api.templates.AdapterConfigurer;
 import co.cask.cdap.api.templates.plugins.PluginProperties;
 import co.cask.cdap.template.etl.api.PipelineConfigurer;
 
 import javax.annotation.Nullable;
 
 /**
- * Configurer for a pipeline, that delegates all operations to a PluginConfigurer, except it prefixes plugin ids
- * to provide isolation for each etl stage. For example, a source can use a plugin with id 'jdbcdriver' and
- * a sink can also use a plugin with id 'jdbcdriver' without clobbering each other.
+ * Configurer for a pipeline, that delegates all operations to an AdapterConfigurer.
  */
-public class DefaultPipelineConfigurer implements PipelineConfigurer {
-  private final PluginConfigurer configurer;
+public class AdapterPipelineConfigurer implements PipelineConfigurer {
+  private final AdapterConfigurer adapterConfigurer;
   private final String pluginPrefix;
 
-  public DefaultPipelineConfigurer(PluginConfigurer configurer, String pluginPrefix) {
-    this.configurer = configurer;
+  public AdapterPipelineConfigurer(AdapterConfigurer adapterConfigurer, String pluginPrefix) {
+    this.adapterConfigurer = adapterConfigurer;
     this.pluginPrefix = pluginPrefix;
   }
 
   @Override
   public void addStream(Stream stream) {
-    configurer.addStream(stream);
+    adapterConfigurer.addStream(stream);
   }
 
   @Override
   public void addStream(String streamName) {
-    configurer.addStream(streamName);
+    adapterConfigurer.addStream(new Stream(streamName));
   }
 
   @Override
   public void addDatasetModule(String moduleName, Class<? extends DatasetModule> moduleClass) {
-    configurer.addDatasetModule(moduleName, moduleClass);
+    adapterConfigurer.addDatasetModule(moduleName, moduleClass);
   }
 
   @Override
   public void addDatasetType(Class<? extends Dataset> datasetClass) {
-    configurer.addDatasetType(datasetClass);
+    adapterConfigurer.addDatasetType(datasetClass);
   }
 
   @Override
   public void createDataset(String datasetName, String typeName, DatasetProperties properties) {
-    configurer.createDataset(datasetName, typeName, properties);
+    adapterConfigurer.createDataset(datasetName, typeName, properties);
   }
 
   @Override
   public void createDataset(String datasetName, String typeName) {
-    configurer.createDataset(datasetName, typeName);
+    adapterConfigurer.createDataset(datasetName, typeName, DatasetProperties.EMPTY);
   }
 
   @Override
   public void createDataset(String datasetName, Class<? extends Dataset> datasetClass, DatasetProperties props) {
-    configurer.createDataset(datasetName, datasetClass, props);
+    adapterConfigurer.createDataset(datasetName, datasetClass, props);
   }
 
   @Override
   public void createDataset(String datasetName, Class<? extends Dataset> datasetClass) {
-    configurer.createDataset(datasetName, datasetClass);
+    adapterConfigurer.createDataset(datasetName, datasetClass, DatasetProperties.EMPTY);
   }
 
   @Nullable
   @Override
   public <T> T usePlugin(String pluginType, String pluginName, String pluginId, PluginProperties properties) {
-    return configurer.usePlugin(pluginType, pluginName, getPluginId(pluginId), properties);
+    return adapterConfigurer.usePlugin(pluginType, pluginName, getPluginId(pluginId), properties);
   }
 
   @Nullable
   @Override
   public <T> T usePlugin(String pluginType, String pluginName, String pluginId, PluginProperties properties,
                          PluginSelector selector) {
-    return configurer.usePlugin(pluginType, pluginName, pluginId, properties, selector);
+    // Adapter's PluginSelector is incompatible with artifact's PluginSelector.
+    // currently not used today anyway, plus this class is going to be removed when templates are removed.
+    throw new UnsupportedOperationException();
   }
 
   @Nullable
   @Override
   public <T> Class<T> usePluginClass(String pluginType, String pluginName, String pluginId,
                                      PluginProperties properties) {
-    return configurer.usePluginClass(pluginType, pluginName, getPluginId(pluginId), properties);
+    return adapterConfigurer.usePluginClass(pluginType, pluginName, getPluginId(pluginId), properties);
   }
 
   @Nullable
   @Override
   public <T> Class<T> usePluginClass(String pluginType, String pluginName, String pluginId, PluginProperties properties,
                                      PluginSelector selector) {
-    return configurer.usePluginClass(pluginType, pluginName, pluginId, properties, selector);
+    // Adapter's PluginSelector is incompatible with artifact's PluginSelector.
+    // currently not used today anyway, plus this class is going to be removed when templates are removed.
+    throw new UnsupportedOperationException();
   }
   
   private String getPluginId(String childPluginId) {

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/common/ETLConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/common/ETLConfig.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.template.etl.common;
 
+import co.cask.cdap.api.Config;
 import co.cask.cdap.api.Resources;
 import com.google.common.collect.Lists;
 
@@ -24,7 +25,7 @@ import java.util.List;
 /**
  * Common ETL Config.
  */
-public class ETLConfig {
+public class ETLConfig extends Config {
   private final ETLStage source;
   private final ETLStage sink;
   private final List<ETLStage> transforms;

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/common/PipelineValidator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/common/PipelineValidator.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.template.etl.common;
+
+import co.cask.cdap.template.etl.api.PipelineConfigurable;
+import co.cask.cdap.template.etl.api.Transformation;
+import co.cask.cdap.template.etl.api.realtime.RealtimeSink;
+import co.cask.cdap.template.etl.api.realtime.RealtimeSource;
+import co.cask.cdap.template.etl.common.guice.TypeResolver;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.common.reflect.TypeToken;
+
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Validates an ETL Pipeline by checking that the output of one stage matches the input of the next.
+ */
+public class PipelineValidator {
+
+  public static void validateStages(PipelineConfigurable source, PipelineConfigurable sink,
+                                    List<Transformation> transforms) throws Exception {
+    ArrayList<Type> unresTypeList = Lists.newArrayListWithCapacity(transforms.size() + 2);
+    Type inType = Transformation.class.getTypeParameters()[0];
+    Type outType = Transformation.class.getTypeParameters()[1];
+
+    // Load the classes using the class names provided
+    Class<?> sourceClass = source.getClass();
+    Class<?> sinkClass = sink.getClass();
+    TypeToken sourceToken = TypeToken.of(sourceClass);
+    TypeToken sinkToken = TypeToken.of(sinkClass);
+
+    // Extract the source's output type
+    if (RealtimeSource.class.isAssignableFrom(sourceClass)) {
+      Type type = RealtimeSource.class.getTypeParameters()[0];
+      unresTypeList.add(sourceToken.resolveType(type).getType());
+    } else {
+      unresTypeList.add(sourceToken.resolveType(outType).getType());
+    }
+
+    // Extract the transforms' input and output type
+    for (Transformation transform : transforms) {
+      Class<?> klass = transform.getClass();
+      TypeToken transformToken = TypeToken.of(klass);
+      unresTypeList.add(transformToken.resolveType(inType).getType());
+      unresTypeList.add(transformToken.resolveType(outType).getType());
+    }
+
+    // Extract the sink's input type
+    if (RealtimeSink.class.isAssignableFrom(sinkClass)) {
+      Type type = RealtimeSink.class.getTypeParameters()[0];
+      unresTypeList.add(sinkToken.resolveType(type).getType());
+    } else {
+      unresTypeList.add(sinkToken.resolveType(inType).getType());
+    }
+
+    // Invoke validation method with list of unresolved types
+    validateTypes(unresTypeList);
+  }
+
+  /**
+   * Takes in an unresolved type list and resolves the types and verifies if the types are assignable.
+   * Ex: An unresolved type could be : String, T, List<T>, List<String>
+   *     The above will resolve to   : String, String, List<String>, List<String>
+   *     And the assignability will be checked : String --> String && List<String> --> List<String>
+   *     which is true in the case above.
+   */
+  @VisibleForTesting
+  static void validateTypes(ArrayList<Type> unresTypeList) {
+    Preconditions.checkArgument(unresTypeList.size() % 2 == 0, "ETL Stages validation expects even number of types");
+    List<Type> resTypeList = Lists.newArrayListWithCapacity(unresTypeList.size());
+
+    // Add the source output to resolved type list as the first resolved type.
+    resTypeList.add(unresTypeList.get(0));
+    try {
+      // Resolve the second type using just the first resolved type.
+      Type nType = (new TypeResolver()).where(unresTypeList.get(1), resTypeList.get(0)).resolveType(
+        unresTypeList.get(1));
+      resTypeList.add(nType);
+    } catch (IllegalArgumentException e) {
+      // If unable to resolve type, add the second type as is, to the resolved list.
+      resTypeList.add(unresTypeList.get(1));
+    }
+
+    for (int i = 2; i < unresTypeList.size(); i++) {
+      // ActualType is previous resolved type; FormalType is previous unresolved type;
+      // ToResolveType is current unresolved type;
+      // Ex: Actual = String; Formal = T; ToResolve = List<T>;  ==> newType = List<String>
+      Type actualType = resTypeList.get(i - 1);
+      Type formalType = unresTypeList.get(i - 1);
+      Type toResolveType = unresTypeList.get(i);
+      try {
+        Type newType;
+        // If the toResolveType is a TypeVariable or a Generic Array, then try to resolve
+        // using just the previous resolved type.
+        // Ex: Actual = List<String> ; Formal = List<T> ; ToResolve = T ==> newType = String which is not correct;
+        // newType should be List<String>. Hence resolve only from the previous resolved type (Actual)
+        if ((toResolveType instanceof TypeVariable) || (toResolveType instanceof GenericArrayType)) {
+          newType = (new TypeResolver()).where(toResolveType, actualType).resolveType(toResolveType);
+        } else {
+          newType = (new TypeResolver()).where(formalType, actualType).resolveType(toResolveType);
+        }
+        resTypeList.add(newType);
+      } catch (IllegalArgumentException e) {
+        // If resolution failed, add the type as is to the resolved list.
+        resTypeList.add(toResolveType);
+      }
+    }
+
+    // Check isAssignable on the resolved list for every paired elements. 0 --> 1 | 2 --> 3 | 4 --> 5 where | is a
+    // transform (which takes in type on its left and emits the type on its right).
+    for (int i = 0; i < resTypeList.size(); i += 2) {
+      Type firstType = resTypeList.get(i);
+      Type secondType = resTypeList.get(i + 1);
+      // Check if secondType can accept firstType
+      Preconditions.checkArgument(TypeToken.of(secondType).isAssignableFrom(firstType),
+        "Types between stages didn't match. Mismatch between {} -> {}",
+        firstType, secondType);
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/template/etl/common/PipelineValidatorTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/template/etl/common/PipelineValidatorTest.java
@@ -30,9 +30,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Testing the Validation of Adapter stage hookups.
+ * Testing the Validation of etl stage hookups.
  */
-public class ValidationTest {
+public class PipelineValidatorTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void testSimpleInvalidMatch() throws Exception {
@@ -40,7 +40,7 @@ public class ValidationTest {
     ArrayList<Type> typeList = Lists.newArrayList();
     typeList.add(String.class);
     typeList.add(Integer.class);
-    ETLTemplate.validateTypes(typeList);
+    PipelineValidator.validateTypes(typeList);
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -53,7 +53,7 @@ public class ValidationTest {
     typeList.add(Object.class);
     typeList.addAll(getBothParameters(ParamToListParam.class));
     typeList.add(getFirstTypeParameter(StringListSink.class));
-    ETLTemplate.validateTypes(typeList);
+    PipelineValidator.validateTypes(typeList);
   }
 
   @Test
@@ -64,7 +64,7 @@ public class ValidationTest {
     typeList.add(GenericRecord.class);
     typeList.add(Integer.class);
     typeList.add(Object.class);
-    ETLTemplate.validateTypes(typeList);
+    PipelineValidator.validateTypes(typeList);
   }
 
   @Test
@@ -74,7 +74,7 @@ public class ValidationTest {
     typeList.add(String.class);
     typeList.addAll(getBothParameters(ParamToListParam.class));
     typeList.add(getFirstTypeParameter(StringListSink.class));
-    ETLTemplate.validateTypes(typeList);
+    PipelineValidator.validateTypes(typeList);
   }
 
   @Test
@@ -86,7 +86,7 @@ public class ValidationTest {
     typeList.addAll(getBothParameters(ParamToListParam.class));
     typeList.addAll(getBothParameters(ParamToListParam.class));
     typeList.add(getFirstTypeParameter(NoOpSink.class));
-    ETLTemplate.validateTypes(typeList);
+    PipelineValidator.validateTypes(typeList);
   }
 
   @Test
@@ -96,7 +96,7 @@ public class ValidationTest {
     typeList.add(String[].class);
     typeList.addAll(getBothParameters(ArrayToListArray.class));
     typeList.add(getFirstTypeParameter(NoOpSink.class));
-    ETLTemplate.validateTypes(typeList);
+    PipelineValidator.validateTypes(typeList);
   }
 
   @Test
@@ -107,7 +107,7 @@ public class ValidationTest {
     typeList.addAll(getBothParameters(ArrayToListArray.class));
     typeList.addAll(getBothParameters(ParamToListParam.class));
     typeList.add(getFirstTypeParameter(NoOpSink.class));
-    ETLTemplate.validateTypes(typeList);
+    PipelineValidator.validateTypes(typeList);
   }
 
   @Test
@@ -117,7 +117,7 @@ public class ValidationTest {
     typeList.add(getFirstTypeParameter(ParamToListParam.class));
     typeList.addAll(getBothParameters(ParamToListParam.class));
     typeList.add(getFirstTypeParameter(ParamToListParam.class));
-    ETLTemplate.validateTypes(typeList);
+    PipelineValidator.validateTypes(typeList);
   }
 
   private static List<Type> getBothParameters(Class klass) {

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/source/TimePartitionedFileSetDatasetAvroSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/source/TimePartitionedFileSetDatasetAvroSource.java
@@ -126,10 +126,16 @@ public class TimePartitionedFileSetDatasetAvroSource extends
 
   @Override
   public void prepareRun(BatchSourceContext context) {
+    Map<String, String> runtimeArgs = context.getRuntimeArguments();
+    long runtime = context.getLogicalStartTime();
+    if (runtimeArgs.containsKey("runtime")) {
+      runtime = Long.parseLong(runtimeArgs.get("runtime"));
+    }
+
     long duration = ETLUtils.parseDuration(tpfsAvroSourceConfig.duration);
     long delay = Strings.isNullOrEmpty(tpfsAvroSourceConfig.delay) ? 0 :
       ETLUtils.parseDuration(tpfsAvroSourceConfig.delay);
-    long endTime = context.getLogicalStartTime() - delay;
+    long endTime = runtime - delay;
     long startTime = endTime - duration;
     Map<String, String> sourceArgs = Maps.newHashMap();
     TimePartitionedFileSetArguments.setInputStartTime(sourceArgs, startTime);

--- a/cdap-app-templates/cdap-etl/pom.xml
+++ b/cdap-app-templates/cdap-etl/pom.xml
@@ -32,6 +32,7 @@
   <modules>
     <module>cdap-etl-api</module>
     <module>cdap-etl-batch</module>
+    <module>cdap-etl-batch-app</module>
     <module>cdap-etl-core</module>
     <module>cdap-etl-lib</module>
     <module>cdap-etl-realtime</module>


### PR DESCRIPTION
Creating the application version of ETLBatch. This will replace
the ETLBatch ApplicationTemplate, but we can't remove the template
until the UI is moved off templates and adapters.