### PR TITLE
Use MockAppConfigurer instead of DefaultAppConfigurer to get the name of the App

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/MockAppConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/MockAppConfigurer.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app;
+
+import co.cask.cdap.api.app.Application;
+import co.cask.cdap.api.app.ApplicationConfigurer;
+import co.cask.cdap.api.artifact.PluginSelector;
+import co.cask.cdap.api.data.stream.Stream;
+import co.cask.cdap.api.dataset.Dataset;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.module.DatasetModule;
+import co.cask.cdap.api.flow.Flow;
+import co.cask.cdap.api.mapreduce.MapReduce;
+import co.cask.cdap.api.schedule.SchedulableProgramType;
+import co.cask.cdap.api.schedule.Schedule;
+import co.cask.cdap.api.service.Service;
+import co.cask.cdap.api.spark.Spark;
+import co.cask.cdap.api.templates.plugins.PluginProperties;
+import co.cask.cdap.api.worker.Worker;
+import co.cask.cdap.api.workflow.Workflow;
+
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Used in unit-test and integration-test simply to get the name of the Application.
+ */
+public final class MockAppConfigurer implements ApplicationConfigurer {
+
+  private static final String ERROR_MSG = "Applications that use plugins cannot be deployed/created using " +
+    "deployApplication(Id.Namespace namespace, Class<? extends Application> applicationClz) method." +
+    "Instead use addAppArtifact, addPluginArtifact and " +
+    "deployApplication(Id.Artifact artifactId, AppRequest appRequest) method.";
+
+  private String name;
+
+  public MockAppConfigurer(Application app) {
+    this.name = app.getClass().getSimpleName();
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  @Override
+  public void setDescription(String description) {
+
+  }
+
+  @Override
+  public void addFlow(Flow flow) {
+
+  }
+
+  @Override
+  public void addMapReduce(MapReduce mapReduce) {
+
+  }
+
+  @Override
+  public void addSpark(Spark spark) {
+
+  }
+
+  @Override
+  public void addWorkflow(Workflow workflow) {
+
+  }
+
+  @Override
+  public void addService(Service service) {
+
+  }
+
+  @Override
+  public void addWorker(Worker worker) {
+
+  }
+
+  @Override
+  public void addSchedule(Schedule schedule, SchedulableProgramType programType, String programName,
+                          Map<String, String> properties) {
+
+  }
+
+  @Nullable
+  @Override
+  public <T> T usePlugin(String pluginType, String pluginName, String pluginId, PluginProperties properties) {
+    throw new UnsupportedOperationException(ERROR_MSG);
+  }
+
+  @Nullable
+  @Override
+  public <T> T usePlugin(String pluginType, String pluginName, String pluginId, PluginProperties properties,
+                         PluginSelector selector) {
+    throw new UnsupportedOperationException(ERROR_MSG);
+  }
+
+  @Nullable
+  @Override
+  public <T> Class<T> usePluginClass(String pluginType, String pluginName, String pluginId,
+                                     PluginProperties properties) {
+    throw new UnsupportedOperationException(ERROR_MSG);
+  }
+
+  @Nullable
+  @Override
+  public <T> Class<T> usePluginClass(String pluginType, String pluginName, String pluginId, PluginProperties properties,
+                                     PluginSelector selector) {
+    throw new UnsupportedOperationException(ERROR_MSG);
+  }
+
+  @Override
+  public void addStream(Stream stream) {
+
+  }
+
+  @Override
+  public void addStream(String streamName) {
+
+  }
+
+  @Override
+  public void addDatasetModule(String moduleName, Class<? extends DatasetModule> moduleClass) {
+
+  }
+
+  @Override
+  public void addDatasetType(Class<? extends Dataset> datasetClass) {
+
+  }
+
+  @Override
+  public void createDataset(String datasetName, String typeName, DatasetProperties properties) {
+
+  }
+
+  @Override
+  public void createDataset(String datasetName, String typeName) {
+
+  }
+
+  @Override
+  public void createDataset(String datasetName, Class<? extends Dataset> datasetClass, DatasetProperties props) {
+
+  }
+
+  @Override
+  public void createDataset(String datasetName, Class<? extends Dataset> datasetClass) {
+
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/BasicHttpServiceContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/BasicHttpServiceContext.java
@@ -31,6 +31,7 @@ import co.cask.cdap.internal.app.runtime.adapter.PluginInstantiator;
 import co.cask.tephra.TransactionContext;
 import co.cask.tephra.TransactionSystemClient;
 import com.google.common.collect.Maps;
+import com.google.common.io.Closeables;
 import org.apache.twill.api.RunId;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.apache.twill.filesystem.LocationFactory;
@@ -104,6 +105,12 @@ public class BasicHttpServiceContext extends AbstractContext implements Transact
   @Override
   public Metrics getMetrics() {
     return userMetrics;
+  }
+
+  @Override
+  public void close() {
+    super.close();
+    Closeables.closeQuietly(getArtifactPluginInstantiator());
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/BasicWorkerContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/BasicWorkerContext.java
@@ -54,6 +54,7 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.cache.RemovalListener;
 import com.google.common.cache.RemovalNotification;
 import com.google.common.collect.Maps;
+import com.google.common.io.Closeables;
 import org.apache.twill.api.RunId;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.apache.twill.filesystem.LocationFactory;
@@ -231,6 +232,7 @@ public class BasicWorkerContext extends AbstractContext implements WorkerContext
     // Close all existing datasets that haven't been invalidated by the cache already.
     datasetsCache.invalidateAll();
     datasetsCache.cleanUp();
+    Closeables.closeQuietly(getArtifactPluginInstantiator());
   }
 
   @Override

--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestManager.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestManager.java
@@ -24,8 +24,8 @@ import co.cask.cdap.api.dataset.module.DatasetModule;
 import co.cask.cdap.api.templates.ApplicationTemplate;
 import co.cask.cdap.api.templates.plugins.PluginClass;
 import co.cask.cdap.api.templates.plugins.PluginPropertyField;
-import co.cask.cdap.app.DefaultAppConfigurer;
 import co.cask.cdap.app.DefaultApplicationContext;
+import co.cask.cdap.app.MockAppConfigurer;
 import co.cask.cdap.app.program.ManifestFields;
 import co.cask.cdap.client.AdapterClient;
 import co.cask.cdap.client.ApplicationClient;
@@ -146,9 +146,9 @@ public class IntegrationTestManager implements TestManager {
 
       // Extracts application id from the application class
       Application application = applicationClz.newInstance();
-      DefaultAppConfigurer configurer = new DefaultAppConfigurer(application);
+      MockAppConfigurer configurer = new MockAppConfigurer(application);
       application.configure(configurer, new DefaultApplicationContext(configObject));
-      String applicationId = configurer.createSpecification().getName();
+      String applicationId = configurer.getName();
       return new RemoteApplicationManager(Id.Application.from(namespace, applicationId), clientConfig, restClient);
     } catch (Exception e) {
       throw Throwables.propagate(e);

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/UnitTestManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/UnitTestManager.java
@@ -25,9 +25,8 @@ import co.cask.cdap.api.dataset.module.DatasetModule;
 import co.cask.cdap.api.templates.ApplicationTemplate;
 import co.cask.cdap.api.templates.plugins.PluginClass;
 import co.cask.cdap.api.templates.plugins.PluginPropertyField;
-import co.cask.cdap.app.ApplicationSpecification;
-import co.cask.cdap.app.DefaultAppConfigurer;
 import co.cask.cdap.app.DefaultApplicationContext;
+import co.cask.cdap.app.MockAppConfigurer;
 import co.cask.cdap.app.program.ManifestFields;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
@@ -166,12 +165,11 @@ public class UnitTestManager implements TestManager {
       }
 
       Application app = applicationClz.newInstance();
-      DefaultAppConfigurer configurer = new DefaultAppConfigurer(app);
+      MockAppConfigurer configurer = new MockAppConfigurer(app);
       app.configure(configurer, new DefaultApplicationContext(configObject));
-      ApplicationSpecification appSpec = configurer.createSpecification();
-      Location deployedJar = appFabricClient.deployApplication(namespace, appSpec.getName(),
+      Location deployedJar = appFabricClient.deployApplication(namespace, configurer.getName(),
                                                                applicationClz, appConfig, bundleEmbeddedJars);
-      return appManagerFactory.create(Id.Application.from(namespace, appSpec.getName()), deployedJar);
+      return appManagerFactory.create(Id.Application.from(namespace, configurer.getName()), deployedJar);
     } catch (Exception e) {
       throw Throwables.propagate(e);
     }

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
@@ -18,7 +18,6 @@ package co.cask.cdap.test.app;
 
 import co.cask.cdap.ConfigTestApp;
 import co.cask.cdap.api.app.Application;
-import co.cask.cdap.api.artifact.ArtifactVersion;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.lib.CloseableIterator;
@@ -43,7 +42,6 @@ import co.cask.cdap.proto.RunRecord;
 import co.cask.cdap.proto.WorkflowTokenDetail;
 import co.cask.cdap.proto.WorkflowTokenNodeDetail;
 import co.cask.cdap.proto.artifact.AppRequest;
-import co.cask.cdap.proto.artifact.ArtifactRange;
 import co.cask.cdap.proto.artifact.ArtifactSummary;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.DataSetManager;
@@ -69,7 +67,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import org.junit.Assert;
@@ -203,11 +200,8 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     Id.Artifact artifactId = Id.Artifact.from(Id.Namespace.DEFAULT, "app-with-plugin", "1.0.0-SNAPSHOT");
     addAppArtifact(artifactId, AppWithPlugin.class);
 
-    ArtifactRange artifactRange = new ArtifactRange(artifactId.getNamespace(), artifactId.getName(),
-                                                    artifactId.getVersion(), true, new ArtifactVersion("2.0.0"), true);
     Id.Artifact pluginArtifactId = Id.Artifact.from(Id.Namespace.DEFAULT, "test-plugin", "1.0.0-SNAPSHOT");
-    // TODO: Using ArtifactRange should not be required. Comparison of versions in ArtifactStore needs to be fixed.
-    addPluginArtifact(pluginArtifactId, Sets.<ArtifactRange>newHashSet(artifactRange), ToStringPlugin.class);
+    addPluginArtifact(pluginArtifactId, artifactId, ToStringPlugin.class);
 
     Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "AppWithPlugin");
     AppRequest createRequest = new AppRequest(
@@ -632,8 +626,9 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     }
   }
 
+  // AppFabricClient returns IllegalStateException if the app fails to deploy
   @Category(SlowTests.class)
-  @Test(expected = IllegalArgumentException.class)
+  @Test(expected = IllegalStateException.class)
   public void testServiceWithInvalidHandler() throws Exception {
     deployApplication(AppWithInvalidHandler.class);
   }


### PR DESCRIPTION
MockConfigurer is required so that we don't have to pass in ArtifactRepository/PluginInstantiator. Moreover it is logically not possible since the artifact itself is not available and thus instantiating plugins before that won't be possible. Hence deployApplication method itself won't work for applications using plugins. Users will have to resort to using addArtifact, addPluginArtifact, addApplication route

Also, Close the ArtifactPluginInstantiator in Worker, ServiceHandler

Build : http://builds.cask.co/browse/CDAP-DUT2634