### PR TITLE
CDAP-3542 Wait till the executor shutdown is completed

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowDriver.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowDriver.java
@@ -276,6 +276,7 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
       throw Throwables.propagate(t);
     } finally {
       executor.shutdownNow();
+      executor.awaitTermination(Integer.MAX_VALUE, TimeUnit.NANOSECONDS);
       status.remove(node.getNodeId());
     }
     store.updateWorkflowToken(workflowId, runId.getId(), token);


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-3542

When program on one of the fork branches fails, after shutting down the executor service for the nodes executing on the other branches, wait till the shutdown complete, so that the RunRecord of the underlying program gets updated correctly.