### PR TITLE
Feature/r3.0.4 tx manager

### DIFF
--- a/cdap-docs/admin-manual/source/index.rst
+++ b/cdap-docs/admin-manual/source/index.rst
@@ -87,7 +87,7 @@ transaction service maintenance, troubleshooting, and introduces the CDAP UI.**
 .. |tx-maintenance| replace:: **Transaction Service Maintenance:**
 .. _tx-maintenance: operations/tx-maintenance.html
 
-- |tx-maintenance|_ Periodic maintenance of **Transaction Service.**
+- |tx-maintenance|_ Periodic maintenance of the **Transaction Service.**
 
 .. |troubleshooting| replace:: **Troubleshooting:**
 .. _troubleshooting: operations/troubleshooting.html

--- a/cdap-docs/admin-manual/source/operations/index.rst
+++ b/cdap-docs/admin-manual/source/operations/index.rst
@@ -69,7 +69,7 @@ Operations
 .. |tx-maintenance| replace:: **Transaction Service Maintenance:**
 .. _tx-maintenance: tx-maintenance.html
 
-- |tx-maintenance|_ Periodic maintenance of **Transaction Service.**
+- |tx-maintenance|_ Periodic maintenance of the **Transaction Service.**
 
 
 .. |troubleshooting| replace:: **Troubleshooting:**

--- a/cdap-docs/admin-manual/source/operations/tx-maintenance.rst
+++ b/cdap-docs/admin-manual/source/operations/tx-maintenance.rst
@@ -10,18 +10,19 @@ Transaction Service Maintenance
 
 .. highlight:: console
 
-The Transaction Service keeps track of all invalid transactions to exclude their writes from all future reads. 
+The Transaction Service keeps track of all invalid transactions so as to exclude their writes from all future reads. 
 Over time, this *invalid* list can grow and lead to performance degradation. To avoid that, you can prune the *invalid*
-list after the data of invalid transactions has been removed |---| which happens during major HBase compactions of the
-transactional tables.
+list after the data of invalid transactions has been removed |---| the removal of which happens during major HBase 
+compactions of the transactional tables.
 
-To prune the invalid list manually, follow the below steps:
+To prune the invalid list manually, follow these steps:
 
 - Run a major compaction on all CDAP transactional tables.
 
 - Find the minimum transaction state cache reload time across all region servers before the major compaction started.
-  This can be done by grepping for ``Transaction state reloaded with snapshot`` in HBase region server logs.
-  This should give lines like::
+  This can be done by grepping for ``Transaction state reloaded with snapshot`` in the HBase region server logs.
+  
+  This should give lines such as::
 
     15/08/22 00:22:34 INFO coprocessor.TransactionStateCache: Transaction state reloaded with snapshot from 1440202895873
     15/08/22 00:22:42 INFO coprocessor.TransactionStateCache: Transaction state reloaded with snapshot from 1440202956306
@@ -29,9 +30,9 @@ To prune the invalid list manually, follow the below steps:
     15/08/22 00:22:47 INFO coprocessor.TransactionStateCache: Transaction state reloaded with snapshot from 1440202956306
     15/08/22 00:23:34 INFO coprocessor.TransactionStateCache: Transaction state reloaded with snapshot from 1440202956306
 
-  Pick the minimum time across all region servers.
+  Pick the minimum time across all region servers. In this case, ``1440202895873``.
 
-- Find the minimum prune time across all queues by running tool ``SimpleHBaseQueueDebugger``. This should print lines like::
+- Find the minimum prune time across all queues by running the tool ``SimpleHBaseQueueDebugger``. This should print lines such as::
 
     $ /opt/cdap/master/bin/svc-master run co.cask.cdap.data.tools.SimpleHBaseQueueDebugger
     Results for queue queue:///ns1/WordCount/WordCounter/counter/queue: min tx timestamp: 1440198510309
@@ -43,13 +44,14 @@ To prune the invalid list manually, follow the below steps:
     Results for queue queue:///default/WordCount/WordCounter/splitter/wordOut: min tx timestamp: 1440194184476
     Total results for all queues: min tx timestamp: 1440194184476
 
-  Pick the timestamp from line ``Total results for all queues``.
+  Pick the timestamp from the line ``Total results for all queues``. In this case, ``1440194184476``.
 
-- Get the minimum time from the above two steps, let this be time ``t``.
+- Get the minimum time from the above two steps, let this be time ``t``. In this case, ``1440194184476``.
+
 Now, the invalid transaction list can be safely pruned
-until ``t - 1 day`` using :ref:`a call <http-restful-api-transactions-truncate>`
-from the :ref:`Transaction Service HTTP RESTful API <http-restful-api-transactions-truncate>`.
+until ``(t - 1 day)`` using :ref:`a call <http-restful-api-transactions-truncate>`
+with the :ref:`Transaction Service HTTP RESTful API <http-restful-api-transactions-truncate>`.
 
 The current length of the invalid transaction list can be obtained using 
 :ref:`a call <http-restful-api-transactions-number>` 
-from the :ref:`Transaction Service HTTP RESTful API <http-restful-api-transactions-number>`.
+with the :ref:`Transaction Service HTTP RESTful API <http-restful-api-transactions-number>`.

--- a/cdap-docs/developers-manual/build.sh
+++ b/cdap-docs/developers-manual/build.sh
@@ -82,9 +82,9 @@ function download_includes() {
   local ingest_url="${github_url}/cdap-ingest/${ingest_branch}"
 
   download_readme_file_and_test ${includes_dir} ${ingest_url} c9b6db1741afa823c362237488c2d8f0 cdap-flume
-  download_readme_file_and_test ${includes_dir} ${ingest_url} f300df291b910f0bd416a5ea160fdbe1 cdap-stream-clients/java
+  download_readme_file_and_test ${includes_dir} ${ingest_url} 08bb5c37085d354834860cb4ca66c121 cdap-stream-clients/java
 #   download_readme_file_and_test ${includes_dir} ${ingest_url} 277ded1924cb8d9b52a007f262820002 cdap-stream-clients/javascript
-  download_readme_file_and_test ${includes_dir} ${ingest_url} b6dedd629c708dbc68bc918b768edda5 cdap-stream-clients/python
+  download_readme_file_and_test ${includes_dir} ${ingest_url} 3013f72ea3454e43adedda2aed40abc1 cdap-stream-clients/python
   download_readme_file_and_test ${includes_dir} ${ingest_url} 5fc88ec3a658062775403f5be30afbe9 cdap-stream-clients/ruby
 }
 

--- a/cdap-docs/examples-manual/build.sh
+++ b/cdap-docs/examples-manual/build.sh
@@ -145,7 +145,7 @@ function download_includes() {
   test_an_include d9c7f594204f42adaac7ad866c11ed7a ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseStore.java
   
   test_an_include f8e8f0fba3d26cc26f06325b7c55d715 ../../cdap-examples/SparkKMeans/src/main/java/co/cask/cdap/examples/sparkkmeans/SparkKMeansApp.java
-  test_an_include 8632b56f39c02e695f11c74729fbc456 ../../cdap-examples/SparkPageRank/src/main/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankApp.java
+  test_an_include 97e355542831d767a297b52ff09f5674 ../../cdap-examples/SparkPageRank/src/main/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankApp.java
 
   test_an_include afe12d26b79607a846d3eaa58958ea5f ../../cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/SportResults.java
   test_an_include f58086a5f0c86aa4e8d47ea09fa3f0f1 ../../cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/UploadService.java


### PR DESCRIPTION
Fixes broken build (MD5 checksums).
Corrects minor editing and formatting issues with the Tx Manager Maintenance instructions.

Build:
- [Run results](http://builds.cask.co/browse/CDAP-DDBD560-2)
- [Transaction Service Maintenance page](http://docs-staging.cask.co/staging/cdap/3.0.4-feature-r3.0.4_tx_manager/en/admin-manual/operations/tx-maintenance.html)