### PR TITLE
Unify namespace interfaces. Make NamespaceAdmin is the common interfa…

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -23,6 +23,7 @@ import co.cask.cdap.app.mapreduce.MRJobInfoFetcher;
 import co.cask.cdap.app.store.Store;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.common.runtime.RuntimeModule;
 import co.cask.cdap.common.twill.MasterServiceManager;
 import co.cask.cdap.common.utils.Networks;
@@ -59,7 +60,6 @@ import co.cask.cdap.internal.app.deploy.pipeline.ApplicationWithPrograms;
 import co.cask.cdap.internal.app.deploy.pipeline.DeploymentInfo;
 import co.cask.cdap.internal.app.deploy.pipeline.adapter.AdapterDeploymentInfo;
 import co.cask.cdap.internal.app.namespace.DefaultNamespaceAdmin;
-import co.cask.cdap.internal.app.namespace.NamespaceAdmin;
 import co.cask.cdap.internal.app.runtime.adapter.AdapterService;
 import co.cask.cdap.internal.app.runtime.adapter.PluginRepository;
 import co.cask.cdap.internal.app.runtime.artifact.ArtifactStore;
@@ -334,6 +334,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
 
     @Provides
     @Named(Constants.AppFabric.SERVER_ADDRESS)
+    @SuppressWarnings("unused")
     public InetAddress providesHostname(CConfiguration cConf) {
       return Networks.resolve(cConf.get(Constants.AppFabric.SERVER_ADDRESS),
                               new InetSocketAddress("localhost", 0).getAddress());
@@ -344,6 +345,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
      * injection. It returns a singleton of Scheduler.
      */
     @Provides
+    @SuppressWarnings("unused")
     public Supplier<org.quartz.Scheduler> providesSchedulerSupplier(final DatasetBasedTimeScheduleStore scheduleStore,
                                                                     final CConfiguration cConf) {
       return new Supplier<org.quartz.Scheduler>() {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AdapterHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AdapterHttpHandler.java
@@ -17,11 +17,10 @@
 package co.cask.cdap.gateway.handlers;
 
 import co.cask.cdap.common.AdapterNotFoundException;
-import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.gateway.handlers.util.AbstractAppFabricHttpHandler;
-import co.cask.cdap.internal.app.namespace.NamespaceAdmin;
 import co.cask.cdap.internal.app.runtime.adapter.AdapterAlreadyExistsException;
 import co.cask.cdap.internal.app.runtime.adapter.AdapterService;
 import co.cask.cdap.internal.app.runtime.adapter.ApplicationTemplateInfo;
@@ -83,7 +82,7 @@ public class AdapterHttpHandler extends AbstractAppFabricHttpHandler {
   public void deployTemplate(HttpRequest request, HttpResponder responder,
                              @PathParam("namespace-id") String namespaceId,
                              @PathParam("template-id") String templateId) throws Exception {
-    if (!namespaceAdmin.hasNamespace(Id.Namespace.from(namespaceId))) {
+    if (!namespaceAdmin.exists(Id.Namespace.from(namespaceId))) {
       responder.sendString(HttpResponseStatus.NOT_FOUND,
                            String.format("Namespace '%s' does not exist.", namespaceId));
       return;
@@ -105,8 +104,8 @@ public class AdapterHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/adapters")
   public void listAdapters(HttpRequest request, HttpResponder responder,
                            @PathParam("namespace-id") String namespaceId,
-                           @QueryParam("template") String template) {
-    if (!namespaceAdmin.hasNamespace(Id.Namespace.from(namespaceId))) {
+                           @QueryParam("template") String template) throws Exception {
+    if (!namespaceAdmin.exists(Id.Namespace.from(namespaceId))) {
       responder.sendString(HttpResponseStatus.NOT_FOUND,
                            String.format("Namespace '%s' does not exist.", namespaceId));
       return;
@@ -247,8 +246,7 @@ public class AdapterHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/adapters/{adapter-id}")
   public void createAdapter(HttpRequest request, HttpResponder responder,
                             @PathParam("namespace-id") String namespaceId,
-                            @PathParam("adapter-id") String adapterName)
-    throws AdapterAlreadyExistsException, BadRequestException {
+                            @PathParam("adapter-id") String adapterName) throws Exception {
 
     AdapterConfig config;
     try {
@@ -267,7 +265,7 @@ public class AdapterHttpHandler extends AbstractAppFabricHttpHandler {
     }
 
     Id.Namespace namespace = Id.Namespace.from(namespaceId);
-    if (!namespaceAdmin.hasNamespace(namespace)) {
+    if (!namespaceAdmin.exists(namespace)) {
       responder.sendString(HttpResponseStatus.NOT_FOUND,
                            String.format("Create adapter failed - namespace '%s' does not exist.", namespaceId));
       return;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/NamespaceHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/NamespaceHttpHandler.java
@@ -21,8 +21,8 @@ import co.cask.cdap.common.NamespaceCannotBeDeletedException;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.gateway.handlers.util.AbstractAppFabricHttpHandler;
-import co.cask.cdap.internal.app.namespace.NamespaceAdmin;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceConfig;
 import co.cask.cdap.proto.NamespaceMeta;
@@ -62,7 +62,7 @@ public class NamespaceHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/namespaces")
   public void getAllNamespaces(HttpRequest request, HttpResponder responder) {
     try {
-      responder.sendJson(HttpResponseStatus.OK, namespaceAdmin.listNamespaces());
+      responder.sendJson(HttpResponseStatus.OK, namespaceAdmin.list());
     } catch (Exception e) {
       LOG.error("Internal error while listing all namespaces", e);
       responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, e.getMessage());
@@ -74,7 +74,7 @@ public class NamespaceHttpHandler extends AbstractAppFabricHttpHandler {
   public void getNamespace(HttpRequest request, HttpResponder responder,
                            @PathParam("namespace-id") String namespaceId) {
     try {
-      NamespaceMeta ns = namespaceAdmin.getNamespace(Id.Namespace.from(namespaceId));
+      NamespaceMeta ns = namespaceAdmin.get(Id.Namespace.from(namespaceId));
       responder.sendJson(HttpResponseStatus.OK, ns);
     } catch (NotFoundException e) {
       responder.sendString(HttpResponseStatus.NOT_FOUND, String.format("Namespace %s not found", namespaceId));
@@ -147,7 +147,7 @@ public class NamespaceHttpHandler extends AbstractAppFabricHttpHandler {
     }
 
     try {
-      namespaceAdmin.createNamespace(builder.build());
+      namespaceAdmin.create(builder.build());
       responder.sendString(HttpResponseStatus.OK,
                            String.format("Namespace '%s' created successfully.", namespaceId));
     } catch (AlreadyExistsException e) {
@@ -170,7 +170,7 @@ public class NamespaceHttpHandler extends AbstractAppFabricHttpHandler {
     }
     Id.Namespace namespaceId = Id.Namespace.from(namespace);
     try {
-      namespaceAdmin.deleteNamespace(namespaceId);
+      namespaceAdmin.delete(namespaceId);
       responder.sendStatus(HttpResponseStatus.OK);
     } catch (NotFoundException e) {
       responder.sendString(HttpResponseStatus.NOT_FOUND, String.format("Namespace %s not found.", namespace));

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdmin.java
@@ -27,6 +27,7 @@ import co.cask.cdap.common.NamespaceCannotBeDeletedException;
 import co.cask.cdap.common.NamespaceNotFoundException;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.config.DashboardStore;
 import co.cask.cdap.config.PreferencesStore;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
@@ -101,7 +102,7 @@ public final class DefaultNamespaceAdmin implements NamespaceAdmin {
    *
    * @return a list of {@link NamespaceMeta} for all namespaces
    */
-  public List<NamespaceMeta> listNamespaces() {
+  public List<NamespaceMeta> list() {
     return store.listNamespaces();
   }
 
@@ -112,7 +113,7 @@ public final class DefaultNamespaceAdmin implements NamespaceAdmin {
    * @return the {@link NamespaceMeta} of the requested namespace
    * @throws NamespaceNotFoundException if the requested namespace is not found
    */
-  public NamespaceMeta getNamespace(Id.Namespace namespaceId) throws NamespaceNotFoundException {
+  public NamespaceMeta get(Id.Namespace namespaceId) throws NamespaceNotFoundException {
     NamespaceMeta ns = store.getNamespace(namespaceId);
     if (ns == null) {
       throw new NamespaceNotFoundException(namespaceId);
@@ -126,9 +127,9 @@ public final class DefaultNamespaceAdmin implements NamespaceAdmin {
    * @param namespaceId the {@link Id.Namespace} to check for existence
    * @return true, if the specifed namespace exists, false otherwise
    */
-  public boolean hasNamespace(Id.Namespace namespaceId) {
+  public boolean exists(Id.Namespace namespaceId) {
     try {
-      getNamespace(namespaceId);
+      get(namespaceId);
     } catch (NotFoundException e) {
       return false;
     }
@@ -141,12 +142,12 @@ public final class DefaultNamespaceAdmin implements NamespaceAdmin {
    * @param metadata the {@link NamespaceMeta} for the new namespace to be created
    * @throws NamespaceAlreadyExistsException if the specified namespace already exists
    */
-  public synchronized void createNamespace(NamespaceMeta metadata)
+  public synchronized void create(NamespaceMeta metadata)
     throws NamespaceCannotBeCreatedException, NamespaceAlreadyExistsException {
     // TODO: CDAP-1427 - This should be transactional, but we don't support transactions on files yet
     Preconditions.checkArgument(metadata != null, "Namespace metadata should not be null.");
     Id.Namespace namespace = Id.Namespace.from(metadata.getName());
-    if (hasNamespace(Id.Namespace.from(metadata.getName()))) {
+    if (exists(Id.Namespace.from(metadata.getName()))) {
       throw new NamespaceAlreadyExistsException(namespace);
     }
 
@@ -166,10 +167,10 @@ public final class DefaultNamespaceAdmin implements NamespaceAdmin {
    * @throws NamespaceCannotBeDeletedException if the specified namespace cannot be deleted
    * @throws NamespaceNotFoundException if the specified namespace does not exist
    */
-  public synchronized void deleteNamespace(final Id.Namespace namespaceId)
+  public synchronized void delete(final Id.Namespace namespaceId)
     throws NamespaceCannotBeDeletedException, NamespaceNotFoundException {
     // TODO: CDAP-870, CDAP-1427: Delete should be in a single transaction.
-    if (!hasNamespace(namespaceId)) {
+    if (!exists(namespaceId)) {
       throw new NamespaceNotFoundException(namespaceId);
     }
 
@@ -258,7 +259,7 @@ public final class DefaultNamespaceAdmin implements NamespaceAdmin {
   public synchronized void deleteDatasets(Id.Namespace namespaceId)
     throws NamespaceNotFoundException, NamespaceCannotBeDeletedException {
     // TODO: CDAP-870, CDAP-1427: Delete should be in a single transaction.
-    if (!hasNamespace(namespaceId)) {
+    if (!exists(namespaceId)) {
       throw new NamespaceNotFoundException(namespaceId);
     }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceEnsurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceEnsurer.java
@@ -17,8 +17,7 @@
 package co.cask.cdap.internal.app.namespace;
 
 import co.cask.cdap.common.AlreadyExistsException;
-import co.cask.cdap.common.NamespaceCannotBeCreatedException;
-import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.common.service.RetryOnStartFailureService;
 import co.cask.cdap.common.service.RetryStrategies;
 import co.cask.cdap.proto.NamespaceMeta;
@@ -49,7 +48,7 @@ public final class DefaultNamespaceEnsurer extends AbstractService {
           @Override
           protected void doStart() {
             try {
-              namespaceAdmin.createNamespace(NamespaceMeta.DEFAULT);
+              namespaceAdmin.create(NamespaceMeta.DEFAULT);
               // if there is no exception, assume successfully created and break
               LOG.info("Created default namespace successfully.");
               notifyStarted();
@@ -57,7 +56,7 @@ public final class DefaultNamespaceEnsurer extends AbstractService {
               // default namespace already exists
               LOG.info("Default namespace already exists.");
               notifyStarted();
-            } catch (NamespaceCannotBeCreatedException e) {
+            } catch (Exception e) {
               notifyFailed(e);
             }
           }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricClient.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricClient.java
@@ -21,13 +21,13 @@ import co.cask.cdap.api.schedule.ScheduleSpecification;
 import co.cask.cdap.api.workflow.WorkflowToken;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.gateway.handlers.AdapterHttpHandler;
 import co.cask.cdap.gateway.handlers.AppLifecycleHttpHandler;
 import co.cask.cdap.gateway.handlers.NamespaceHttpHandler;
 import co.cask.cdap.gateway.handlers.ProgramLifecycleHttpHandler;
 import co.cask.cdap.gateway.handlers.WorkflowHttpHandler;
 import co.cask.cdap.internal.app.BufferFileInputStream;
-import co.cask.cdap.internal.app.namespace.NamespaceAdmin;
 import co.cask.cdap.internal.test.AppJarHelper;
 import co.cask.cdap.proto.AdapterConfig;
 import co.cask.cdap.proto.Id;
@@ -118,7 +118,7 @@ public class AppFabricClient {
     HttpRequest request;
 
     // delete all namespaces
-    for (NamespaceMeta namespaceMeta : namespaceAdmin.listNamespaces()) {
+    for (NamespaceMeta namespaceMeta : namespaceAdmin.list()) {
       Id.Namespace namespace = Id.Namespace.from(namespaceMeta.getName());
 
       responder = new MockResponder();

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricTestHelper.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricTestHelper.java
@@ -23,6 +23,7 @@ import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.program.Programs;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.common.utils.DirUtils;
 import co.cask.cdap.common.utils.Networks;
 import co.cask.cdap.data.stream.StreamCoordinatorClient;
@@ -32,7 +33,6 @@ import co.cask.cdap.internal.app.deploy.LocalApplicationManager;
 import co.cask.cdap.internal.app.deploy.ProgramTerminator;
 import co.cask.cdap.internal.app.deploy.pipeline.AppDeploymentInfo;
 import co.cask.cdap.internal.app.deploy.pipeline.ApplicationWithPrograms;
-import co.cask.cdap.internal.app.namespace.NamespaceAdmin;
 import co.cask.cdap.internal.app.runtime.schedule.SchedulerService;
 import co.cask.cdap.internal.guice.AppFabricTestModule;
 import co.cask.cdap.internal.test.AppJarHelper;
@@ -128,8 +128,8 @@ public class AppFabricTestHelper {
 
   private static void ensureNamespaceExists(Id.Namespace namespace) throws Exception {
     NamespaceAdmin namespaceAdmin = getInjector().getInstance(NamespaceAdmin.class);
-    if (!namespaceAdmin.hasNamespace(namespace)) {
-      namespaceAdmin.createNamespace(new NamespaceMeta.Builder().setName(namespace).build());
+    if (!namespaceAdmin.exists(namespace)) {
+      namespaceAdmin.create(new NamespaceMeta.Builder().setName(namespace).build());
     }
   }
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/LocalNamespaceClient.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/LocalNamespaceClient.java
@@ -16,13 +16,9 @@
 
 package co.cask.cdap.internal;
 
-import co.cask.cdap.common.NamespaceAlreadyExistsException;
-import co.cask.cdap.common.NamespaceCannotBeCreatedException;
-import co.cask.cdap.common.NamespaceCannotBeDeletedException;
-import co.cask.cdap.common.NamespaceNotFoundException;
 import co.cask.cdap.common.UnauthorizedException;
 import co.cask.cdap.common.namespace.AbstractNamespaceClient;
-import co.cask.cdap.internal.app.namespace.NamespaceAdmin;
+import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.common.http.HttpRequest;
@@ -34,7 +30,7 @@ import java.net.URL;
 import java.util.List;
 
 /**
- * NamespaceClient which directly interacts with a {@link NamespaceAdmin}
+ * Local implementation of {@link AbstractNamespaceClient}
  */
 public class LocalNamespaceClient extends AbstractNamespaceClient {
   private final NamespaceAdmin namespaceAdmin;
@@ -45,25 +41,23 @@ public class LocalNamespaceClient extends AbstractNamespaceClient {
   }
 
   @Override
-  public List<NamespaceMeta> list() throws IOException, UnauthorizedException {
-    return namespaceAdmin.listNamespaces();
+  public List<NamespaceMeta> list() throws Exception {
+    return namespaceAdmin.list();
   }
 
   @Override
-  public NamespaceMeta get(String namespaceId) throws NamespaceNotFoundException, IOException, UnauthorizedException {
-    return namespaceAdmin.getNamespace(Id.Namespace.from(namespaceId));
+  public NamespaceMeta get(Id.Namespace namespaceId) throws Exception {
+    return namespaceAdmin.get(namespaceId);
   }
 
   @Override
-  public void delete(String namespaceId)
-    throws NamespaceNotFoundException, NamespaceCannotBeDeletedException, IOException, UnauthorizedException {
-    namespaceAdmin.deleteNamespace(Id.Namespace.from(namespaceId));
+  public void delete(Id.Namespace namespaceId) throws Exception {
+    namespaceAdmin.delete(namespaceId);
   }
 
   @Override
-  public void create(NamespaceMeta namespaceMeta)
-    throws NamespaceAlreadyExistsException, NamespaceCannotBeCreatedException {
-    namespaceAdmin.createNamespace(namespaceMeta);
+  public void create(NamespaceMeta namespaceMeta) throws Exception {
+    namespaceAdmin.create(namespaceMeta);
   }
 
   // This class overrides all public API methods to use in-memory namespaceAdmin, and so the following two are not used.

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/deploy/LocalApplicationManagerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/deploy/LocalApplicationManagerTest.java
@@ -19,11 +19,11 @@ package co.cask.cdap.internal.app.deploy;
 import co.cask.cdap.ConfigTestApp;
 import co.cask.cdap.ToyApp;
 import co.cask.cdap.common.io.Locations;
+import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.internal.AppFabricTestHelper;
 import co.cask.cdap.internal.DefaultId;
 import co.cask.cdap.internal.app.deploy.pipeline.AppDeploymentInfo;
 import co.cask.cdap.internal.app.deploy.pipeline.ApplicationWithPrograms;
-import co.cask.cdap.internal.app.namespace.NamespaceAdmin;
 import co.cask.cdap.internal.test.AppJarHelper;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
@@ -60,7 +60,7 @@ public class LocalApplicationManagerTest {
     lf = new LocalLocationFactory(TMP_FOLDER.newFolder());
 
     NamespaceAdmin namespaceAdmin = AppFabricTestHelper.getInjector().getInstance(NamespaceAdmin.class);
-    namespaceAdmin.createNamespace(NamespaceMeta.DEFAULT);
+    namespaceAdmin.create(NamespaceMeta.DEFAULT);
   }
 
   /**

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdminTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdminTest.java
@@ -16,19 +16,15 @@
 
 package co.cask.cdap.internal.app.namespace;
 
-import co.cask.cdap.common.AlreadyExistsException;
 import co.cask.cdap.common.NamespaceAlreadyExistsException;
-import co.cask.cdap.common.NamespaceCannotBeCreatedException;
-import co.cask.cdap.common.NamespaceCannotBeDeletedException;
 import co.cask.cdap.common.NamespaceNotFoundException;
 import co.cask.cdap.common.NotFoundException;
+import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.internal.app.services.http.AppFabricTestBase;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import org.junit.Assert;
 import org.junit.Test;
-
-import java.io.IOException;
 
 /**
  * Tests for {@link DefaultNamespaceAdmin}
@@ -37,18 +33,17 @@ public class DefaultNamespaceAdminTest extends AppFabricTestBase {
   private static final NamespaceAdmin namespaceAdmin = getInjector().getInstance(NamespaceAdmin.class);
 
   @Test
-  public void testNamespaces() throws AlreadyExistsException, IOException, NamespaceCannotBeCreatedException,
-    NamespaceCannotBeDeletedException {
+  public void testNamespaces() throws Exception {
     String namespace = "namespace";
     Id.Namespace namespaceId = Id.Namespace.from(namespace);
     NamespaceMeta.Builder builder = new NamespaceMeta.Builder();
 
-    int initialCount = namespaceAdmin.listNamespaces().size();
+    int initialCount = namespaceAdmin.list().size();
 
     // TEST_NAMESPACE_META1 is already created in AppFabricTestBase#beforeClass
-    Assert.assertTrue(namespaceAdmin.hasNamespace(Id.Namespace.from(TEST_NAMESPACE1)));
+    Assert.assertTrue(namespaceAdmin.exists(Id.Namespace.from(TEST_NAMESPACE1)));
     try {
-      namespaceAdmin.createNamespace(TEST_NAMESPACE_META1);
+      namespaceAdmin.create(TEST_NAMESPACE_META1);
       Assert.fail("Should not create duplicate namespace.");
     } catch (NamespaceAlreadyExistsException e) {
       Assert.assertEquals(Id.Namespace.from(TEST_NAMESPACE_META1.getName()), e.getId());
@@ -56,67 +51,67 @@ public class DefaultNamespaceAdminTest extends AppFabricTestBase {
 
     // "random" namespace should not exist
     try {
-      namespaceAdmin.getNamespace(Id.Namespace.from("random"));
+      namespaceAdmin.get(Id.Namespace.from("random"));
       Assert.fail("Namespace 'random' should not exist.");
     } catch (NamespaceNotFoundException e) {
       Assert.assertEquals(Id.Namespace.from("random"), e.getObject());
     }
 
     try {
-      namespaceAdmin.createNamespace(null);
+      namespaceAdmin.create(null);
       Assert.fail("Namespace with null metadata should fail.");
     } catch (IllegalArgumentException e) {
       Assert.assertEquals("Namespace metadata should not be null.", e.getMessage());
     }
 
-    Assert.assertEquals(initialCount, namespaceAdmin.listNamespaces().size());
-    Assert.assertFalse(namespaceAdmin.hasNamespace(Id.Namespace.from(namespace)));
+    Assert.assertEquals(initialCount, namespaceAdmin.list().size());
+    Assert.assertFalse(namespaceAdmin.exists(Id.Namespace.from(namespace)));
 
     try {
-      namespaceAdmin.createNamespace(builder.build());
+      namespaceAdmin.create(builder.build());
       Assert.fail("Namespace with no name should fail");
     } catch (IllegalArgumentException e) {
       Assert.assertEquals("Namespace id cannot be null.", e.getMessage());
     }
 
-    Assert.assertEquals(initialCount, namespaceAdmin.listNamespaces().size());
-    Assert.assertFalse(namespaceAdmin.hasNamespace(namespaceId));
+    Assert.assertEquals(initialCount, namespaceAdmin.list().size());
+    Assert.assertFalse(namespaceAdmin.exists(namespaceId));
 
     // namespace with default fields
-    namespaceAdmin.createNamespace(builder.setName(namespace).build());
-    Assert.assertEquals(initialCount + 1, namespaceAdmin.listNamespaces().size());
-    Assert.assertTrue(namespaceAdmin.hasNamespace(namespaceId));
+    namespaceAdmin.create(builder.setName(namespace).build());
+    Assert.assertEquals(initialCount + 1, namespaceAdmin.list().size());
+    Assert.assertTrue(namespaceAdmin.exists(namespaceId));
     try {
-      NamespaceMeta namespaceMeta = namespaceAdmin.getNamespace(namespaceId);
+      NamespaceMeta namespaceMeta = namespaceAdmin.get(namespaceId);
       Assert.assertEquals(namespaceId.getId(), namespaceMeta.getName());
       Assert.assertEquals("", namespaceMeta.getDescription());
 
-      namespaceAdmin.deleteNamespace(namespaceId);
+      namespaceAdmin.delete(namespaceId);
     } catch (NotFoundException e) {
       Assert.fail(String.format("Namespace '%s' should be found since it was just created.", namespaceId.getId()));
     }
 
-    namespaceAdmin.createNamespace(builder.setDescription("describes " + namespace).build());
-    Assert.assertEquals(initialCount + 1, namespaceAdmin.listNamespaces().size());
-    Assert.assertTrue(namespaceAdmin.hasNamespace(namespaceId));
+    namespaceAdmin.create(builder.setDescription("describes " + namespace).build());
+    Assert.assertEquals(initialCount + 1, namespaceAdmin.list().size());
+    Assert.assertTrue(namespaceAdmin.exists(namespaceId));
 
     try {
-      NamespaceMeta namespaceMeta = namespaceAdmin.getNamespace(namespaceId);
+      NamespaceMeta namespaceMeta = namespaceAdmin.get(namespaceId);
       Assert.assertEquals(namespaceId.getId(), namespaceMeta.getName());
       Assert.assertEquals("describes " + namespaceId.getId(), namespaceMeta.getDescription());
 
-      namespaceAdmin.deleteNamespace(namespaceId);
+      namespaceAdmin.delete(namespaceId);
     } catch (NotFoundException e) {
       Assert.fail(String.format("Namespace '%s' should be found since it was just created.", namespaceId.getId()));
     }
 
-    // Verify NotFoundException's contents as well, instead of just checking namespaceService.hasNamespace = false
+    // Verify NotFoundException's contents as well, instead of just checking namespaceService.exists = false
     verifyNotFound(namespaceId);
   }
 
-  private static void verifyNotFound(Id.Namespace namespaceId) {
+  private static void verifyNotFound(Id.Namespace namespaceId) throws Exception {
     try {
-      namespaceAdmin.getNamespace(namespaceId);
+      namespaceAdmin.get(namespaceId);
       Assert.fail(String.format("Namespace '%s' should not be found since it was just deleted", namespaceId.getId()));
     } catch (NamespaceNotFoundException e) {
       Assert.assertEquals(Id.Namespace.from(namespaceId.getId()), e.getId());

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/SchedulerServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/SchedulerServiceTest.java
@@ -24,11 +24,9 @@ import co.cask.cdap.api.schedule.Schedules;
 import co.cask.cdap.api.workflow.ScheduleProgramInfo;
 import co.cask.cdap.app.ApplicationSpecification;
 import co.cask.cdap.app.store.Store;
-import co.cask.cdap.common.NamespaceCannotBeDeletedException;
-import co.cask.cdap.common.NotFoundException;
+import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.internal.AppFabricTestHelper;
 import co.cask.cdap.internal.app.DefaultApplicationSpecification;
-import co.cask.cdap.internal.app.namespace.NamespaceAdmin;
 import co.cask.cdap.internal.schedule.TimeSchedule;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
@@ -77,13 +75,13 @@ public class SchedulerServiceTest {
     store = AppFabricTestHelper.getInjector().getInstance(Store.class);
     locationFactory = AppFabricTestHelper.getInjector().getInstance(LocationFactory.class);
     namespaceAdmin = AppFabricTestHelper.getInjector().getInstance(NamespaceAdmin.class);
-    namespaceAdmin.createNamespace(new NamespaceMeta.Builder().setName(namespace).build());
-    namespaceAdmin.createNamespace(NamespaceMeta.DEFAULT);
+    namespaceAdmin.create(new NamespaceMeta.Builder().setName(namespace).build());
+    namespaceAdmin.create(NamespaceMeta.DEFAULT);
   }
 
   @AfterClass
-  public static void finish() throws NotFoundException, NamespaceCannotBeDeletedException {
-    namespaceAdmin.deleteNamespace(namespace);
+  public static void finish() throws Exception {
+    namespaceAdmin.delete(namespace);
     namespaceAdmin.deleteDatasets(Id.Namespace.DEFAULT);
     schedulerService.stopAndWait();
   }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/SchedulerTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/SchedulerTestBase.java
@@ -23,12 +23,10 @@ import co.cask.cdap.api.schedule.Schedule;
 import co.cask.cdap.api.schedule.Schedules;
 import co.cask.cdap.app.runtime.ProgramRuntimeService;
 import co.cask.cdap.app.store.Store;
-import co.cask.cdap.common.NamespaceCannotBeDeletedException;
-import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.common.utils.Tasks;
 import co.cask.cdap.internal.AppFabricTestHelper;
-import co.cask.cdap.internal.app.namespace.NamespaceAdmin;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.ProgramRunStatus;
@@ -80,7 +78,7 @@ public abstract class SchedulerTestBase {
     store = injector.getInstance(Store.class);
     metricStore = injector.getInstance(MetricStore.class);
     namespaceAdmin = injector.getInstance(NamespaceAdmin.class);
-    namespaceAdmin.createNamespace(NamespaceMeta.DEFAULT);
+    namespaceAdmin.create(NamespaceMeta.DEFAULT);
     runtimeService = injector.getInstance(ProgramRuntimeService.class);
   }
 
@@ -146,8 +144,8 @@ public abstract class SchedulerTestBase {
   }
 
   @AfterClass
-  public static void tearDown() throws NotFoundException, NamespaceCannotBeDeletedException {
-    namespaceAdmin.deleteNamespace(Id.Namespace.DEFAULT);
+  public static void tearDown() throws Exception {
+    namespaceAdmin.delete(Id.Namespace.DEFAULT);
   }
 
   /**

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/NamespaceHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/NamespaceHttpHandlerTest.java
@@ -384,18 +384,18 @@ public class NamespaceHttpHandlerTest extends AppFabricTestBase {
                                                             TEST_NAMESPACE_META2);
     Assert.assertEquals(expectedNamespaces, Sets.newHashSet(namespaces));
 
-    NamespaceMeta namespaceMeta = namespaceClient.get(TEST_NAMESPACE1);
+    NamespaceMeta namespaceMeta = namespaceClient.get(Id.Namespace.from(TEST_NAMESPACE1));
     Assert.assertEquals(TEST_NAMESPACE_META1, namespaceMeta);
 
     try {
-      namespaceClient.get("nonExistentNamespace");
+      namespaceClient.get(Id.Namespace.from("nonExistentNamespace"));
       Assert.fail("Did not expect namespace 'nonExistentNamespace' to exist.");
     } catch (NotFoundException expected) {
       // expected
     }
 
     // test create and get
-    String fooNamespace = "fooNamespace";
+    Id.Namespace fooNamespace = Id.Namespace.from("fooNamespace");
     NamespaceMeta toCreate = new NamespaceMeta.Builder().setName(fooNamespace).build();
     namespaceClient.create(toCreate);
     NamespaceMeta receivedMeta = namespaceClient.get(fooNamespace);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/DefaultStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/DefaultStoreTest.java
@@ -52,12 +52,11 @@ import co.cask.cdap.app.DefaultApplicationContext;
 import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.common.app.RunIds;
-import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.internal.AppFabricTestHelper;
 import co.cask.cdap.internal.DefaultId;
 import co.cask.cdap.internal.app.Specifications;
-import co.cask.cdap.internal.app.namespace.NamespaceAdmin;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.ProgramRunStatus;
@@ -106,7 +105,7 @@ public class DefaultStoreTest {
       AppFabricTestHelper.getInjector().getInstance(NamespacedLocationFactory.class);
     namespacedLocationFactory.get(Id.Namespace.DEFAULT).delete(true);
     NamespaceAdmin admin = AppFabricTestHelper.getInjector().getInstance(NamespaceAdmin.class);
-    admin.createNamespace(NamespaceMeta.DEFAULT);
+    admin.create(NamespaceMeta.DEFAULT);
   }
 
   @Test

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/runtime/FlowTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/runtime/FlowTest.java
@@ -28,12 +28,11 @@ import co.cask.cdap.api.metrics.MetricTimeSeries;
 import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.app.runtime.ProgramRunner;
-import co.cask.cdap.common.AlreadyExistsException;
-import co.cask.cdap.common.NamespaceCannotBeCreatedException;
 import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.discovery.EndpointStrategy;
 import co.cask.cdap.common.discovery.RandomEndpointStrategy;
+import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.common.queue.QueueName;
 import co.cask.cdap.common.stream.StreamEventCodec;
 import co.cask.cdap.data2.queue.QueueClientFactory;
@@ -42,7 +41,6 @@ import co.cask.cdap.data2.queue.QueueProducer;
 import co.cask.cdap.internal.AppFabricTestHelper;
 import co.cask.cdap.internal.DefaultId;
 import co.cask.cdap.internal.app.deploy.pipeline.ApplicationWithPrograms;
-import co.cask.cdap.internal.app.namespace.NamespaceAdmin;
 import co.cask.cdap.internal.app.runtime.BasicArguments;
 import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
 import co.cask.cdap.internal.app.runtime.ProgramRunnerFactory;
@@ -114,9 +112,9 @@ public class FlowTest {
 
 
   @BeforeClass
-  public static void init() throws AlreadyExistsException, NamespaceCannotBeCreatedException {
+  public static void init() throws Exception {
     NamespaceAdmin namespaceAdmin = AppFabricTestHelper.getInjector().getInstance(NamespaceAdmin.class);
-    namespaceAdmin.createNamespace(NamespaceMeta.DEFAULT);
+    namespaceAdmin.create(NamespaceMeta.DEFAULT);
     metricStore = AppFabricTestHelper.getInjector().getInstance(MetricStore.class);
   }
 

--- a/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
+++ b/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
@@ -207,7 +207,6 @@ public class CLIMainTest {
   @Test
   public void testStream() throws Exception {
     String streamId = PREFIX + "sdf123";
-    Id.Stream stream = Id.Stream.from(Id.Namespace.DEFAULT, streamId);
 
     testCommandOutputContains(cli, "create stream " + streamId, "Successfully created stream");
     testCommandOutputContains(cli, "list streams", streamId);

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeleteNamespaceCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeleteNamespaceCommand.java
@@ -57,7 +57,7 @@ public class DeleteNamespaceCommand extends AbstractCommand {
                                     namespaceId.getId());
       String userConfirm = consoleReader.readLine(prompt);
       if ("y".equalsIgnoreCase(userConfirm)) {
-        namespaceClient.delete(namespaceId.getId());
+        namespaceClient.delete(namespaceId);
         out.printf("Contents of namespace '%s' were deleted successfully", namespaceId.getId());
         out.println();
       }
@@ -67,7 +67,7 @@ public class DeleteNamespaceCommand extends AbstractCommand {
                                     namespaceId.getId());
       String userConfirm = consoleReader.readLine(prompt);
       if ("y".equalsIgnoreCase(userConfirm)) {
-        namespaceClient.delete(namespaceId.getId());
+        namespaceClient.delete(namespaceId);
         out.println(String.format(SUCCESS_MSG, namespaceId));
         if (cliConfig.getCurrentNamespace().equals(namespaceId)) {
           cliConfig.setNamespace(Id.Namespace.DEFAULT);

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/DescribeNamespaceCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/DescribeNamespaceCommand.java
@@ -51,7 +51,7 @@ public class DescribeNamespaceCommand extends AbstractCommand {
   @Override
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     Id.Namespace namespace = Id.Namespace.from(arguments.get(ArgumentName.NAMESPACE_NAME.getName()));
-    NamespaceMeta namespaceMeta = namespaceClient.get(namespace.getId());
+    NamespaceMeta namespaceMeta = namespaceClient.get(namespace);
     Table table = Table.builder()
       .setHeader("name", "description")
       .setRows(Lists.newArrayList(namespaceMeta), new RowMaker<NamespaceMeta>() {

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/UseNamespaceCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/UseNamespaceCommand.java
@@ -47,7 +47,7 @@ public class UseNamespaceCommand extends AbstractAuthCommand {
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     Id.Namespace namespace = Id.Namespace.from(arguments.get(ArgumentName.NAMESPACE_NAME.toString()));
     // Check if namespace exists; throws exception if namespace doesn't exist.
-    namespaceClient.get(namespace.getId());
+    namespaceClient.get(namespace);
     cliConfig.setNamespace(namespace);
     output.printf("Now using namespace '%s'\n", namespace);
   }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/completer/element/NamespaceNameCompleter.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/completer/element/NamespaceNameCompleter.java
@@ -18,13 +18,11 @@ package co.cask.cdap.cli.completer.element;
 
 import co.cask.cdap.cli.completer.StringsCompleter;
 import co.cask.cdap.client.NamespaceClient;
-import co.cask.cdap.common.UnauthorizedException;
 import co.cask.cdap.proto.NamespaceMeta;
 import com.google.common.base.Supplier;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -44,9 +42,7 @@ public class NamespaceNameCompleter extends StringsCompleter {
           for (NamespaceMeta namespaceMeta : namespaceClient.list()) {
             namespaceIds.add(namespaceMeta.getName());
           }
-        } catch (IOException e) {
-          return Lists.newArrayList();
-        } catch (UnauthorizedException e) {
+        } catch (Exception e) {
           return Lists.newArrayList();
         }
         return namespaceIds;

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/DatasetClientTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/DatasetClientTestRun.java
@@ -77,8 +77,8 @@ public class DatasetClientTestRun extends ClientTestBase {
   @After
   public void tearDown() throws Exception {
     NamespaceClient namespaceClient = new NamespaceClient(clientConfig);
-    namespaceClient.delete(TEST_NAMESPACE.getId());
-    namespaceClient.delete(OTHER_NAMESPACE.getId());
+    namespaceClient.delete(TEST_NAMESPACE);
+    namespaceClient.delete(OTHER_NAMESPACE);
   }
 
   @Test

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/NamespaceClientTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/NamespaceClientTestRun.java
@@ -19,7 +19,6 @@ package co.cask.cdap.client;
 import co.cask.cdap.client.common.ClientTestBase;
 import co.cask.cdap.common.AlreadyExistsException;
 import co.cask.cdap.common.BadRequestException;
-import co.cask.cdap.common.CannotBeDeletedException;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.UnauthorizedException;
 import co.cask.cdap.proto.Id;
@@ -61,12 +60,12 @@ public class NamespaceClientTestRun extends ClientTestBase {
     NamespaceMeta.Builder builder = new NamespaceMeta.Builder();
     builder.setName(TEST_NAMESPACE_NAME).setDescription(TEST_DESCRIPTION);
     namespaceClient.create(builder.build());
-    waitForNamespaceCreation(TEST_NAMESPACE_NAME.getId());
+    waitForNamespaceCreation(TEST_NAMESPACE_NAME);
 
     // verify that the namespace got created correctly
     namespaces = namespaceClient.list();
     Assert.assertEquals(initialNamespaceCount + 1, namespaces.size());
-    NamespaceMeta meta = namespaceClient.get(TEST_NAMESPACE_NAME.getId());
+    NamespaceMeta meta = namespaceClient.get(TEST_NAMESPACE_NAME);
     Assert.assertEquals(TEST_NAMESPACE_NAME.getId(), meta.getName());
     Assert.assertEquals(TEST_DESCRIPTION, meta.getDescription());
 
@@ -79,7 +78,7 @@ public class NamespaceClientTestRun extends ClientTestBase {
       // expected
     }
     // verify that the existing namespace was not updated
-    meta = namespaceClient.get(TEST_NAMESPACE_NAME.getId());
+    meta = namespaceClient.get(TEST_NAMESPACE_NAME);
     Assert.assertEquals(TEST_NAMESPACE_NAME.getId(), meta.getName());
     Assert.assertEquals(TEST_DESCRIPTION, meta.getDescription());
 
@@ -89,13 +88,13 @@ public class NamespaceClientTestRun extends ClientTestBase {
     namespaceClient.create(builder.build());
     namespaces = namespaceClient.list();
     Assert.assertEquals(initialNamespaceCount + 2, namespaces.size());
-    meta = namespaceClient.get(TEST_DEFAULT_FIELDS.getId());
+    meta = namespaceClient.get(TEST_DEFAULT_FIELDS);
     Assert.assertEquals(TEST_DEFAULT_FIELDS.getId(), meta.getName());
     Assert.assertEquals("", meta.getDescription());
 
     // cleanup
-    namespaceClient.delete(TEST_NAMESPACE_NAME.getId());
-    namespaceClient.delete(TEST_DEFAULT_FIELDS.getId());
+    namespaceClient.delete(TEST_NAMESPACE_NAME);
+    namespaceClient.delete(TEST_DEFAULT_FIELDS);
 
     Assert.assertEquals(initialNamespaceCount, namespaceClient.list().size());
   }
@@ -106,13 +105,13 @@ public class NamespaceClientTestRun extends ClientTestBase {
     NamespaceMeta.Builder builder = new NamespaceMeta.Builder();
     builder.setName(TEST_NAMESPACE_NAME).setDescription(TEST_DESCRIPTION);
     namespaceClient.create(builder.build());
-    waitForNamespaceCreation(TEST_NAMESPACE_NAME.getId());
+    waitForNamespaceCreation(TEST_NAMESPACE_NAME);
 
     // create another namespace
     builder = new NamespaceMeta.Builder();
     builder.setName(TEST_DEFAULT_FIELDS);
     namespaceClient.create(builder.build());
-    waitForNamespaceCreation(TEST_DEFAULT_FIELDS.getId());
+    waitForNamespaceCreation(TEST_DEFAULT_FIELDS);
 
     // cleanup
     namespaceClient.deleteAll();
@@ -123,17 +122,17 @@ public class NamespaceClientTestRun extends ClientTestBase {
   }
 
   private void verifyDoesNotExist(Id.Namespace namespaceId)
-    throws IOException, UnauthorizedException, CannotBeDeletedException {
+    throws Exception {
 
     try {
-      namespaceClient.get(namespaceId.getId());
+      namespaceClient.get(namespaceId);
       Assert.fail(String.format("Namespace '%s' must not be found", namespaceId));
     } catch (NotFoundException e) {
       // expected
     }
 
     try {
-      namespaceClient.delete(namespaceId.getId());
+      namespaceClient.delete(namespaceId);
       Assert.fail(String.format("Namespace '%s' must not be found", namespaceId));
     } catch (NotFoundException e) {
       // expected
@@ -161,17 +160,17 @@ public class NamespaceClientTestRun extends ClientTestBase {
   private void verifyReservedDelete() throws Exception {
     // For the purposes of NamespaceClientTestRun, deleting default namespace has no effect.
     // Its lifecycle is already tested in NamespaceHttpHandlerTest
-    namespaceClient.delete(Id.Namespace.DEFAULT.getId());
-    namespaceClient.get(Id.Namespace.DEFAULT.getId());
+    namespaceClient.delete(Id.Namespace.DEFAULT);
+    namespaceClient.get(Id.Namespace.DEFAULT);
     try {
-      namespaceClient.delete(Id.Namespace.SYSTEM.getId());
+      namespaceClient.delete(Id.Namespace.SYSTEM);
       Assert.fail(String.format("'%s' namespace must not exist", Id.Namespace.SYSTEM.getId()));
     } catch (NotFoundException e) {
       // expected
     }
   }
 
-  private void waitForNamespaceCreation(String namespace) throws IOException, UnauthorizedException,
+  private void waitForNamespaceCreation(Id.Namespace namespace) throws IOException, UnauthorizedException,
     InterruptedException {
     int count = 0;
     while (count < 10) {

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/PreferencesClientTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/PreferencesClientTestRun.java
@@ -22,7 +22,6 @@ import co.cask.cdap.client.common.ClientTestBase;
 import co.cask.cdap.common.ApplicationNotFoundException;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.ProgramNotFoundException;
-import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.ProgramType;
@@ -244,7 +243,7 @@ public class PreferencesClientTestRun extends ClientTestBase {
       } catch (ApplicationNotFoundException e) {
         // ok if this happens, means its already deleted.
       }
-      namespaceClient.delete(invalidNamespace.getId());
+      namespaceClient.delete(invalidNamespace);
     }
   }
 
@@ -260,12 +259,12 @@ public class PreferencesClientTestRun extends ClientTestBase {
     Assert.assertEquals(propMap, client.getNamespacePreferences(myspace, false));
     Assert.assertEquals(propMap, client.getNamespacePreferences(myspace, true));
 
-    namespaceClient.delete(myspace.getId());
+    namespaceClient.delete(myspace);
     namespaceClient.create(new NamespaceMeta.Builder().setName(myspace.getId()).build());
     Assert.assertTrue(client.getNamespacePreferences(myspace, false).isEmpty());
     Assert.assertTrue(client.getNamespacePreferences(myspace, true).isEmpty());
 
-    namespaceClient.delete(myspace.getId());
+    namespaceClient.delete(myspace);
   }
 
   @Test(expected = NotFoundException.class)

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/QueryClientTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/QueryClientTestRun.java
@@ -93,6 +93,7 @@ public class QueryClientTestRun extends ClientTestBase {
         queryClient.execute(dataset.getNamespace(), "select * from " + FakeApp.DS_NAME).get();
         Assert.fail("Explore Query should have thrown an ExecutionException since explore is disabled");
       } catch (ExecutionException e) {
+        // ignored
       }
 
       exploreClient.enableExploreDataset(dataset).get();

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/StreamClientTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/StreamClientTestRun.java
@@ -20,8 +20,6 @@ import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.flow.flowlet.StreamEvent;
 import co.cask.cdap.client.common.ClientTestBase;
 import co.cask.cdap.common.BadRequestException;
-import co.cask.cdap.common.CannotBeDeletedException;
-import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.StreamNotFoundException;
 import co.cask.cdap.common.UnauthorizedException;
 import co.cask.cdap.proto.Id;
@@ -241,7 +239,7 @@ public class StreamClientTestRun extends ClientTestBase {
   }
 
   @After
-  public void tearDown() throws CannotBeDeletedException, UnauthorizedException, NotFoundException, IOException {
-    namespaceClient.delete(namespaceId.getId());
+  public void tearDown() throws Exception {
+    namespaceClient.delete(namespaceId);
   }
 }

--- a/cdap-client/src/main/java/co/cask/cdap/client/NamespaceClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/NamespaceClient.java
@@ -31,7 +31,7 @@ import java.net.URL;
 import javax.inject.Inject;
 
 /**
- * Client to interact with CDAP namespaces
+ * Client that uses the specified {@link ClientConfig} to interact with CDAP namespaces
  */
 @Beta
 public class NamespaceClient extends AbstractNamespaceClient {

--- a/cdap-common/src/main/java/co/cask/cdap/common/namespace/AbstractNamespaceClient.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/namespace/AbstractNamespaceClient.java
@@ -18,7 +18,6 @@ package co.cask.cdap.common.namespace;
 
 import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.common.NamespaceAlreadyExistsException;
-import co.cask.cdap.common.NamespaceCannotBeCreatedException;
 import co.cask.cdap.common.NamespaceCannotBeDeletedException;
 import co.cask.cdap.common.NamespaceNotFoundException;
 import co.cask.cdap.common.UnauthorizedException;
@@ -27,6 +26,7 @@ import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.common.http.HttpRequest;
 import co.cask.common.http.HttpResponse;
 import co.cask.common.http.ObjectResponse;
+import com.google.common.base.Charsets;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 
@@ -36,63 +36,69 @@ import java.net.URL;
 import java.util.List;
 
 /**
- * Common implementation of methods to interact with namespace service.
+ * Common implementation of methods to interact with namespaces over HTTP.
  */
-public abstract class AbstractNamespaceClient {
+public abstract class AbstractNamespaceClient implements NamespaceAdmin {
   private static final Gson GSON = new Gson();
 
+  /**
+   * Executes an HTTP request.
+   */
   protected abstract HttpResponse execute(HttpRequest request) throws IOException, UnauthorizedException;
+
+  /**
+   * Resolves the specified URL.
+   */
   protected abstract URL resolve(String resource) throws IOException;
 
-  public List<NamespaceMeta> list() throws IOException, UnauthorizedException {
+  @Override
+  public List<NamespaceMeta> list() throws Exception {
     HttpRequest request = HttpRequest.get(resolve("namespaces")).build();
     HttpResponse response = execute(request);
     if (response.getResponseCode() == HttpURLConnection.HTTP_OK) {
       return ObjectResponse.fromJsonBody(response, new TypeToken<List<NamespaceMeta>>() { })
         .getResponseObject();
     }
-    throw new IOException(String.format("Cannot list namespaces. Reason: %s", response));
+    throw new IOException(String.format("Cannot list namespaces. Reason: %s", response.getResponseBodyAsString()));
   }
 
-  public NamespaceMeta get(String namespaceId) throws NamespaceNotFoundException, IOException, UnauthorizedException {
-    Id.Namespace namespace = Id.Namespace.from(namespaceId);
-    HttpResponse response = execute(HttpRequest.get(resolve(String.format("namespaces/%s", namespaceId))).build());
+  @Override
+  public NamespaceMeta get(Id.Namespace namespaceId) throws Exception {
+    HttpResponse response =
+      execute(HttpRequest.get(resolve(String.format("namespaces/%s", namespaceId.getId()))).build());
     if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
-      throw new NamespaceNotFoundException(namespace);
+      throw new NamespaceNotFoundException(namespaceId);
     } else if (response.getResponseCode() == HttpURLConnection.HTTP_OK) {
       return ObjectResponse.fromJsonBody(response, NamespaceMeta.class).getResponseObject();
     }
-    throw new IOException("Cannot get namespace. Reason: " + response);
+    throw new IOException(String.format("Cannot get namespace %s. Reason: %s",
+                                        namespaceId, response.getResponseBodyAsString()));
   }
 
-  public void delete(String namespaceId)
-    throws NamespaceNotFoundException, NamespaceCannotBeDeletedException, IOException, UnauthorizedException {
-
-    Id.Namespace namespace = Id.Namespace.from(namespaceId);
-    URL url = resolve(String.format("unrecoverable/namespaces/%s", namespaceId));
+  @Override
+  public void delete(Id.Namespace namespaceId) throws Exception {
+    URL url = resolve(String.format("unrecoverable/namespaces/%s", namespaceId.getId()));
     HttpResponse response = execute(HttpRequest.delete(url).build());
 
     if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
-      throw new NamespaceNotFoundException(namespace);
+      throw new NamespaceNotFoundException(namespaceId);
     } else if (HttpURLConnection.HTTP_FORBIDDEN == response.getResponseCode()) {
-      throw new NamespaceCannotBeDeletedException(namespace, response.getResponseBodyAsString());
+      throw new NamespaceCannotBeDeletedException(namespaceId, response.getResponseBodyAsString());
     } else if (response.getResponseCode() == HttpURLConnection.HTTP_OK) {
       return;
     }
-    throw new IOException("Cannot delete namespace. Reason: " + response);
+    throw new IOException(String.format("Cannot delete namespace %s. Reason: %s",
+                                        namespaceId, response.getResponseBodyAsString()));
   }
 
-  public void create(NamespaceMeta namespaceMeta)
-    throws NamespaceAlreadyExistsException, BadRequestException, IOException, UnauthorizedException,
-    NamespaceCannotBeCreatedException {
-
-    Id.Namespace namespace = Id.Namespace.from(namespaceMeta.getName());
+  @Override
+  public void create(NamespaceMeta metadata) throws Exception {
+    Id.Namespace namespace = Id.Namespace.from(metadata.getName());
     URL url = resolve(String.format("namespaces/%s", namespace.getId()));
-    HttpResponse response = execute(HttpRequest.put(url).withBody(GSON.toJson(namespaceMeta)).build());
+    HttpResponse response = execute(HttpRequest.put(url).withBody(GSON.toJson(metadata)).build());
     String responseBody = response.getResponseBodyAsString();
     if (response.getResponseCode() == HttpURLConnection.HTTP_OK) {
-      if (responseBody != null && responseBody.equals(String.format("Namespace '%s' already exists.",
-                                                                    namespaceMeta.getName()))) {
+      if (responseBody.equals(String.format("Namespace '%s' already exists.", metadata.getName()))) {
         throw new NamespaceAlreadyExistsException(namespace);
       }
       return;
@@ -100,13 +106,47 @@ public abstract class AbstractNamespaceClient {
     if (response.getResponseCode() == HttpURLConnection.HTTP_BAD_REQUEST) {
       throw new BadRequestException("Bad request: " + responseBody);
     }
-    throw new IOException(String.format("Cannot create namespace %s. Reason: %s", namespaceMeta.getName(), response));
+    throw new IOException(String.format("Cannot create namespace %s. Reason: %s", metadata.getName(), responseBody));
   }
 
-  public void deleteAll() throws
-    IOException, UnauthorizedException, NamespaceNotFoundException, NamespaceCannotBeDeletedException {
+  @Override
+  public boolean exists(Id.Namespace namespaceId) throws Exception {
+    return get(namespaceId) != null;
+  }
+
+  @Override
+  public void updateProperties(Id.Namespace namespaceId, NamespaceMeta metadata) throws Exception {
+    URL url = resolve(String.format("namespaces/%s/properties", namespaceId.getId()));
+    HttpResponse response = execute(HttpRequest.put(url).withBody(GSON.toJson(metadata)).build());
+    String responseBody = response.getResponseBodyAsString();
+    if (response.getResponseCode() == HttpURLConnection.HTTP_OK) {
+      return;
+    }
+    if (response.getResponseCode() == HttpURLConnection.HTTP_BAD_REQUEST) {
+      throw new BadRequestException("Bad request: " + responseBody);
+    }
+    throw new IOException(String.format("Cannot update namespace %s. Reason: %s", namespaceId, responseBody));
+  }
+
+  @Override
+  public void deleteDatasets(Id.Namespace namespaceId) throws Exception {
+    URL url = resolve(String.format("unrecoverable/namespaces/%s/datasets", namespaceId.getId()));
+    HttpResponse response = execute(HttpRequest.delete(url).build());
+
+    if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
+      throw new NamespaceNotFoundException(namespaceId);
+    } else if (HttpURLConnection.HTTP_FORBIDDEN == response.getResponseCode()) {
+      throw new NamespaceCannotBeDeletedException(namespaceId, response.getResponseBodyAsString());
+    } else if (response.getResponseCode() == HttpURLConnection.HTTP_OK) {
+      return;
+    }
+    throw new IOException(String.format("Cannot delete datasets in namespace %s. Reason: %s",
+                                        namespaceId, response.getResponseBodyAsString()));
+  }
+
+  public void deleteAll() throws Exception {
     for (NamespaceMeta meta : list()) {
-      delete(meta.getName());
+      delete(Id.Namespace.from(meta.getName()));
     }
   }
 }

--- a/cdap-common/src/main/java/co/cask/cdap/common/namespace/DiscoveryNamespaceClient.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/namespace/DiscoveryNamespaceClient.java
@@ -14,12 +14,11 @@
  * the License.
  */
 
-package co.cask.cdap.data2.util;
+package co.cask.cdap.common.namespace;
 
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.discovery.EndpointStrategy;
 import co.cask.cdap.common.discovery.RandomEndpointStrategy;
-import co.cask.cdap.common.namespace.AbstractNamespaceClient;
 import co.cask.common.http.HttpRequest;
 import co.cask.common.http.HttpRequests;
 import co.cask.common.http.HttpResponse;

--- a/cdap-common/src/main/java/co/cask/cdap/common/namespace/NamespaceAdmin.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/namespace/NamespaceAdmin.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package co.cask.cdap.internal.app.namespace;
+package co.cask.cdap.common.namespace;
 
 import co.cask.cdap.common.NamespaceAlreadyExistsException;
 import co.cask.cdap.common.NamespaceCannotBeCreatedException;
@@ -32,57 +32,55 @@ import java.util.List;
 public interface NamespaceAdmin {
 
   /**
-   * Lists all namespaces
+   * Lists all namespaces.
    *
    * @return a list of {@link NamespaceMeta} for all namespaces
    */
-  List<NamespaceMeta> listNamespaces();
+  List<NamespaceMeta> list() throws Exception;
 
   /**
-   * Gets details of a namespace
+   * Gets details of a namespace.
    *
    * @param namespaceId the {@link Id.Namespace} of the requested namespace
    * @return the {@link NamespaceMeta} of the requested namespace
    * @throws NamespaceNotFoundException if the requested namespace is not found
    */
-  NamespaceMeta getNamespace(Id.Namespace namespaceId) throws NamespaceNotFoundException;
+  NamespaceMeta get(Id.Namespace namespaceId) throws Exception;
 
   /**
-   * Checks if the specified namespace exists
+   * Checks if the specified namespace exists.
    *
    * @param namespaceId the {@link Id.Namespace} to check for existence
    * @return true, if the specifed namespace exists, false otherwise
    */
-  boolean hasNamespace(Id.Namespace namespaceId);
+  boolean exists(Id.Namespace namespaceId) throws Exception;
 
   /**
-   * Creates a new namespace
+   * Creates a new namespace.
    *
    * @param metadata the {@link NamespaceMeta} for the new namespace to be created
    * @throws NamespaceAlreadyExistsException if the specified namespace already exists
    * @throws NamespaceCannotBeCreatedException if the creation operation was unsuccessful
    */
-  void createNamespace(NamespaceMeta metadata)
-    throws NamespaceAlreadyExistsException, NamespaceCannotBeCreatedException;
+  void create(NamespaceMeta metadata) throws Exception;
 
   /**
-   * Deletes the specified namespace
+   * Deletes the specified namespace.
    *
    * @param namespaceId the {@link Id.Namespace} of the specified namespace
    * @throws NamespaceNotFoundException if the specified namespace does not exist
    * @throws NamespaceCannotBeDeletedException if the deletion operation was unsuccessful
    */
-  void deleteNamespace(Id.Namespace namespaceId)
-    throws NamespaceNotFoundException, NamespaceCannotBeDeletedException;
+  void delete(Id.Namespace namespaceId) throws Exception;
 
   /**
-   * Deletes all datasets in the specified namespace
+   * Deletes all datasets in the specified namespace.
    *
    * @param namespaceId the {@link Id.Namespace} of the specified namespace
    * @throws NotFoundException if the specified namespace does not exist
    * @throws NamespaceCannotBeDeletedException if the deletion operation was unsuccessful
    */
-  void deleteDatasets(Id.Namespace namespaceId) throws NotFoundException, NamespaceCannotBeDeletedException;
+  void deleteDatasets(Id.Namespace namespaceId) throws Exception;
 
   /**
    * Update namespace properties for a given namespace.
@@ -91,5 +89,5 @@ public interface NamespaceAdmin {
    * @param namespaceMeta namespacemeta to update
    * @throws NotFoundException if the specified namespace is not found
    */
-  void updateProperties(Id.Namespace namespaceId, NamespaceMeta namespaceMeta) throws NotFoundException;
+  void updateProperties(Id.Namespace namespaceId, NamespaceMeta namespaceMeta) throws Exception;
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamHandler.java
@@ -183,9 +183,8 @@ public final class StreamHandler extends AbstractHttpHandler {
   public void create(HttpRequest request, HttpResponder responder,
                      @PathParam("namespace-id") String namespaceId,
                      @PathParam("stream") String stream) throws Exception {
-
     // Check for namespace existence. Throws NotFoundException if namespace doesn't exist
-    namespaceClient.get(namespaceId);
+    namespaceClient.get(Id.Namespace.from(namespaceId));
 
     Id.Stream streamId;
     try {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamServiceRuntimeModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamServiceRuntimeModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,10 +17,10 @@ package co.cask.cdap.data.stream.service;
 
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.namespace.AbstractNamespaceClient;
+import co.cask.cdap.common.namespace.DiscoveryNamespaceClient;
 import co.cask.cdap.common.runtime.RuntimeModule;
 import co.cask.cdap.data.stream.service.heartbeat.HeartbeatPublisher;
 import co.cask.cdap.data.stream.service.heartbeat.NotificationHeartbeatPublisher;
-import co.cask.cdap.data2.util.DiscoveryNamespaceClient;
 import co.cask.cdap.gateway.handlers.CommonHandlers;
 import co.cask.http.HttpHandler;
 import com.google.common.base.Supplier;

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/GatewayTestBase.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/GatewayTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -19,6 +19,7 @@ package co.cask.cdap.gateway;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.common.utils.Networks;
 import co.cask.cdap.data.runtime.LocationStreamFileWriterFactory;
 import co.cask.cdap.data.stream.StreamFileWriterFactory;
@@ -34,7 +35,6 @@ import co.cask.cdap.data2.transaction.stream.leveldb.LevelDBStreamConsumerStateS
 import co.cask.cdap.data2.transaction.stream.leveldb.LevelDBStreamFileConsumerFactory;
 import co.cask.cdap.gateway.handlers.log.MockLogReader;
 import co.cask.cdap.gateway.router.NettyRouter;
-import co.cask.cdap.internal.app.namespace.NamespaceAdmin;
 import co.cask.cdap.internal.app.services.AppFabricServer;
 import co.cask.cdap.internal.guice.AppFabricTestModule;
 import co.cask.cdap.logging.read.LogReader;
@@ -191,8 +191,8 @@ public abstract class GatewayTestBase {
     streamService.startAndWait();
 
     namespaceAdmin = injector.getInstance(NamespaceAdmin.class);
-    namespaceAdmin.createNamespace(TEST_NAMESPACE_META1);
-    namespaceAdmin.createNamespace(TEST_NAMESPACE_META2);
+    namespaceAdmin.create(TEST_NAMESPACE_META1);
+    namespaceAdmin.create(TEST_NAMESPACE_META2);
 
     // Restart handlers to check if they are resilient across restarts.
     router = injector.getInstance(NettyRouter.class);
@@ -207,9 +207,9 @@ public abstract class GatewayTestBase {
   }
 
   public static void stopGateway(CConfiguration conf) throws Exception {
-    namespaceAdmin.deleteNamespace(Id.Namespace.from(TEST_NAMESPACE1));
-    namespaceAdmin.deleteNamespace(Id.Namespace.from(TEST_NAMESPACE2));
-    namespaceAdmin.deleteNamespace(Id.Namespace.DEFAULT);
+    namespaceAdmin.delete(Id.Namespace.from(TEST_NAMESPACE1));
+    namespaceAdmin.delete(Id.Namespace.from(TEST_NAMESPACE2));
+    namespaceAdmin.delete(Id.Namespace.DEFAULT);
     streamService.stopAndWait();
     notificationService.stopAndWait();
     appFabricServer.stopAndWait();

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/StreamHandlerTest.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/StreamHandlerTest.java
@@ -288,7 +288,7 @@ public class StreamHandlerTest extends GatewayTestBase {
     Assert.assertEquals(HttpResponseStatus.NOT_FOUND.getCode(), response.getResponseCode());
 
     // once the namespace exists, the same stream create works.
-    namespaceAdmin.createNamespace(new NamespaceMeta.Builder().setName(originallyNonExistentNamespace).build());
+    namespaceAdmin.create(new NamespaceMeta.Builder().setName(originallyNonExistentNamespace).build());
     createStream(streamId);
   }
 

--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestManager.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestManager.java
@@ -325,7 +325,7 @@ public class IntegrationTestManager implements TestManager {
 
   @Override
   public void deleteNamespace(Id.Namespace namespace) throws Exception {
-    namespaceClient.delete(namespace.getId());
+    namespaceClient.delete(namespace);
   }
 
   @Override

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/HBaseQueueDebugger.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/HBaseQueueDebugger.java
@@ -35,6 +35,7 @@ import co.cask.cdap.common.guice.KafkaClientModule;
 import co.cask.cdap.common.guice.LocationRuntimeModule;
 import co.cask.cdap.common.guice.TwillModule;
 import co.cask.cdap.common.guice.ZKClientModule;
+import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.common.queue.QueueName;
 import co.cask.cdap.common.utils.ImmutablePair;
@@ -63,7 +64,6 @@ import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
 import co.cask.cdap.data2.util.hbase.ScanBuilder;
 import co.cask.cdap.explore.guice.ExploreClientModule;
-import co.cask.cdap.internal.app.namespace.NamespaceAdmin;
 import co.cask.cdap.internal.app.queue.SimpleQueueSpecificationGenerator;
 import co.cask.cdap.internal.app.runtime.flow.FlowUtils;
 import co.cask.cdap.internal.app.store.DefaultStore;
@@ -154,7 +154,7 @@ public class HBaseQueueDebugger extends AbstractIdleService {
   public void scanAllQueues() throws Exception {
     QueueStatistics totalStats = new QueueStatistics();
 
-    List<NamespaceMeta> namespaceMetas = namespaceAdmin.listNamespaces();
+    List<NamespaceMeta> namespaceMetas = namespaceAdmin.list();
     for (NamespaceMeta namespaceMeta : namespaceMetas) {
       Id.Namespace namespaceId = Id.Namespace.from(namespaceMeta.getName());
 
@@ -485,6 +485,7 @@ public class HBaseQueueDebugger extends AbstractIdleService {
         @Provides
         @Singleton
         @Named("defaultStore")
+        @SuppressWarnings("unused")
         public Store getStore(DatasetFramework dsFramework,
                               CConfiguration cConf, LocationFactory locationFactory,
                               NamespacedLocationFactory namespacedLocationFactory,
@@ -497,6 +498,7 @@ public class HBaseQueueDebugger extends AbstractIdleService {
         @Provides
         @Singleton
         @Named("datasetMDS")
+        @SuppressWarnings("unused")
         public DatasetFramework getInDsFramework(DatasetFramework dsFramework) {
           return dsFramework;
         }

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
@@ -179,6 +179,7 @@ public class UpgradeTool {
         @Provides
         @Singleton
         @Named("mdsDatasetsRegistry")
+        @SuppressWarnings("unused")
         public MDSDatasetsRegistry getMDSDatasetsRegistry(TransactionSystemClient txClient,
                                                           @Named("datasetMDS") DatasetFramework framework) {
           return new MDSDatasetsRegistry(txClient, framework);
@@ -187,6 +188,7 @@ public class UpgradeTool {
         @Provides
         @Singleton
         @Named("datasetInstanceManager")
+        @SuppressWarnings("unused")
         public DatasetInstanceManager getDatasetInstanceManager(@Named("mdsDatasetsRegistry")
                                                                 MDSDatasetsRegistry mdsDatasetsRegistry) {
           return new DatasetInstanceManager(mdsDatasetsRegistry);
@@ -197,6 +199,7 @@ public class UpgradeTool {
         @Provides
         @Singleton
         @Named("datasetMDS")
+        @SuppressWarnings("unused")
         public DatasetFramework getInDsFramework(DatasetFramework dsFramework) {
           return dsFramework;
         }

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/flow/FlowQueuePendingCorrector.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/flow/FlowQueuePendingCorrector.java
@@ -42,6 +42,7 @@ import co.cask.cdap.common.guice.KafkaClientModule;
 import co.cask.cdap.common.guice.LocationRuntimeModule;
 import co.cask.cdap.common.guice.TwillModule;
 import co.cask.cdap.common.guice.ZKClientModule;
+import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.common.queue.QueueName;
 import co.cask.cdap.data.runtime.DataFabricDistributedModule;
@@ -57,7 +58,6 @@ import co.cask.cdap.data2.transaction.queue.hbase.HBaseQueueClientFactory;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
 import co.cask.cdap.explore.guice.ExploreClientModule;
-import co.cask.cdap.internal.app.namespace.NamespaceAdmin;
 import co.cask.cdap.internal.app.queue.SimpleQueueSpecificationGenerator;
 import co.cask.cdap.internal.app.runtime.flow.FlowUtils;
 import co.cask.cdap.internal.app.store.DefaultStore;
@@ -142,7 +142,7 @@ public class FlowQueuePendingCorrector extends AbstractIdleService {
    */
   public void run() throws Exception {
     System.out.println("Running queue.pending correction");
-    List<NamespaceMeta> namespaceMetas = namespaceAdmin.listNamespaces();
+    List<NamespaceMeta> namespaceMetas = namespaceAdmin.list();
     for (NamespaceMeta namespaceMeta : namespaceMetas) {
       run(Id.Namespace.from(namespaceMeta.getName()));
     }
@@ -352,6 +352,7 @@ public class FlowQueuePendingCorrector extends AbstractIdleService {
         @Provides
         @Singleton
         @Named("defaultStore")
+        @SuppressWarnings("unused")
         public Store getStore(DatasetFramework dsFramework,
                               CConfiguration cConf, LocationFactory locationFactory,
                               NamespacedLocationFactory namespacedLocationFactory,
@@ -364,6 +365,7 @@ public class FlowQueuePendingCorrector extends AbstractIdleService {
         @Provides
         @Singleton
         @Named("datasetMDS")
+        @SuppressWarnings("unused")
         public DatasetFramework getInDsFramework(DatasetFramework dsFramework) {
           return dsFramework;
         }

--- a/cdap-master/src/test/java/co/cask/cdap/data/tools/flow/FlowQueuePendingCorrectorTest.java
+++ b/cdap-master/src/test/java/co/cask/cdap/data/tools/flow/FlowQueuePendingCorrectorTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 public class FlowQueuePendingCorrectorTest {
   @Test
   public void testInjector() throws Exception {
-    FlowQueuePendingCorrector corrector = FlowQueuePendingCorrector.createCorrector();
+    FlowQueuePendingCorrector.createCorrector();
     // should not throw exception
   }
 }

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/ConfigurableTestBase.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/ConfigurableTestBase.java
@@ -31,8 +31,6 @@ import co.cask.cdap.api.templates.plugins.PluginPropertyField;
 import co.cask.cdap.app.guice.AppFabricServiceRuntimeModule;
 import co.cask.cdap.app.guice.InMemoryProgramRunnerModule;
 import co.cask.cdap.app.guice.ServiceStoreModules;
-import co.cask.cdap.common.NamespaceCannotBeDeletedException;
-import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
@@ -40,6 +38,7 @@ import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
 import co.cask.cdap.common.guice.IOModule;
 import co.cask.cdap.common.guice.LocationRuntimeModule;
 import co.cask.cdap.common.namespace.AbstractNamespaceClient;
+import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.common.utils.Networks;
 import co.cask.cdap.common.utils.OSDetector;
 import co.cask.cdap.data.runtime.DataFabricModules;
@@ -69,7 +68,6 @@ import co.cask.cdap.explore.executor.ExploreExecutorService;
 import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.explore.guice.ExploreRuntimeModule;
 import co.cask.cdap.internal.LocalNamespaceClient;
-import co.cask.cdap.internal.app.namespace.NamespaceAdmin;
 import co.cask.cdap.internal.app.runtime.schedule.SchedulerService;
 import co.cask.cdap.logging.guice.LoggingModules;
 import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
@@ -289,7 +287,7 @@ public class ConfigurableTestBase {
     RuntimeStats.metricStore = injector.getInstance(MetricStore.class);
     metricsManager = injector.getInstance(MetricsManager.class);
     namespaceAdmin = injector.getInstance(NamespaceAdmin.class);
-    namespaceAdmin.createNamespace(NamespaceMeta.DEFAULT);
+    namespaceAdmin.create(NamespaceMeta.DEFAULT);
   }
 
   private static class MetricsManagerProvider implements Provider<MetricsManager> {
@@ -371,12 +369,12 @@ public class ConfigurableTestBase {
   }
 
   @AfterClass
-  public static void finish() throws NotFoundException, NamespaceCannotBeDeletedException {
+  public static void finish() throws Exception {
     if (--startCount != 0) {
       return;
     }
 
-    namespaceAdmin.deleteNamespace(Id.Namespace.DEFAULT);
+    namespaceAdmin.delete(Id.Namespace.DEFAULT);
     streamCoordinatorClient.stopAndWait();
     metricsQueryService.stopAndWait();
     metricsCollectionService.startAndWait();

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/UnitTestManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/UnitTestManager.java
@@ -32,11 +32,11 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.discovery.StickyEndpointStrategy;
 import co.cask.cdap.common.io.Locations;
+import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.common.utils.DirUtils;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.explore.jdbc.ExploreDriver;
 import co.cask.cdap.internal.AppFabricClient;
-import co.cask.cdap.internal.app.namespace.NamespaceAdmin;
 import co.cask.cdap.internal.app.runtime.artifact.ArtifactDetail;
 import co.cask.cdap.internal.app.runtime.artifact.ArtifactRepository;
 import co.cask.cdap.internal.test.AppJarHelper;
@@ -431,12 +431,12 @@ public class UnitTestManager implements TestManager {
 
   @Override
   public void createNamespace(NamespaceMeta namespaceMeta) throws Exception {
-    namespaceAdmin.createNamespace(namespaceMeta);
+    namespaceAdmin.create(namespaceMeta);
   }
 
   @Override
   public void deleteNamespace(Id.Namespace namespace) throws Exception {
-    namespaceAdmin.deleteNamespace(namespace);
+    namespaceAdmin.delete(namespace);
   }
 
   @Override


### PR DESCRIPTION
…ce that both DefaultNamespaceAdmin (which interacts directly with namespaces) as well as AbstractNamespaceClient (which interacts with namespaces over HTTP) implement.

This is a pre-requisite for [CDAP-1864](https://issues.cask.co/browse/CDAP-1864).
This will also in turn help interact with namespaces similarly in the Metadata Service as well.

Build: http://builds.cask.co/browse/CDAP-DUT2662