### PR TITLE
CDAP-3432: CLI prompt doesn't show the namespace name when passed from URI

### DIFF
--- a/cdap-cli/src/main/java/co/cask/cdap/cli/CLIMain.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/CLIMain.java
@@ -288,7 +288,8 @@ public class CLIMain {
         }
 
         CLIConnectionConfig connectionConfig = new CLIConnectionConfig(
-          cliConfig.getClientConfig().getConnectionConfig(), Id.Namespace.DEFAULT, null);
+          cliConfig.getClientConfig().getConnectionConfig(),
+          cliConfig.getCurrentNamespace(), null);
         cliMain.updateCLIPrompt(connectionConfig);
 
         if (hasScriptFile) {


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-3432
http://builds.cask.co/browse/CDAP-DUT2675