### PR TITLE
(CDAP-3387) Store the stream format specification as part of SerDe property

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -693,6 +693,7 @@ public final class Constants {
     public static final String TX_QUERY_KEY = "explore.hive.query.tx.id";
     public static final String TX_QUERY_CLOSED = "explore.hive.query.tx.commited";
     public static final String QUERY_ID = "explore.query.id";
+    public static final String FORMAT_SPEC = "explore.format.specification";
 
     public static final String START_ON_DEMAND = "explore.start.on.demand";
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamDataFileReader.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamDataFileReader.java
@@ -42,6 +42,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
@@ -86,9 +87,9 @@ public final class StreamDataFileReader implements FileReader<PositionStreamEven
    * @param startTime Timestamp in milliseconds for the event time to start reading with.
    * @return A new instance of {@link StreamDataFileReader}.
    */
-  public static StreamDataFileReader createByStartTime(InputSupplier<? extends SeekableInputStream> eventInputSupplier,
-                                                       InputSupplier<? extends InputStream> indexInputSupplier,
-                                                       long startTime) {
+  public static StreamDataFileReader createByStartTime(
+    InputSupplier<? extends SeekableInputStream> eventInputSupplier,
+    @Nullable InputSupplier<? extends InputStream> indexInputSupplier, long startTime) {
     return new StreamDataFileReader(eventInputSupplier, indexInputSupplier, startTime, 0L);
   }
 
@@ -102,13 +103,13 @@ public final class StreamDataFileReader implements FileReader<PositionStreamEven
    * @return A new instance of {@link StreamDataFileReader}.
    */
   public static StreamDataFileReader createWithOffset(InputSupplier<? extends SeekableInputStream> eventInputSupplier,
-                                                      InputSupplier<? extends InputStream> indexInputSupplier,
+                                                      @Nullable InputSupplier<? extends InputStream> indexInputSupplier,
                                                       long offset) {
     return new StreamDataFileReader(eventInputSupplier, indexInputSupplier, 0L, offset);
   }
 
   private StreamDataFileReader(InputSupplier<? extends SeekableInputStream> eventInputSupplier,
-                               InputSupplier<? extends InputStream> indexInputSupplier,
+                               @Nullable InputSupplier<? extends InputStream> indexInputSupplier,
                                long startTime, long offset) {
     this.eventInputSupplier = eventInputSupplier;
     this.indexInputSupplier = indexInputSupplier;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamInputFormat.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamInputFormat.java
@@ -89,9 +89,9 @@ public class StreamInputFormat<K, V> extends InputFormat<K, V> {
     .create();
   private static final StreamInputSplitFactory<InputSplit> splitFactory = new StreamInputSplitFactory<InputSplit>() {
     @Override
-    public InputSplit createSplit(Path path, Path indexPath, long startTime, long endTime,
+    public InputSplit createSplit(Path eventPath, Path indexPath, long startTime, long endTime,
                                   long start, long length, @Nullable String[] locations) {
-      return new StreamInputSplit(path, indexPath, startTime, endTime, start, length, locations);
+      return new StreamInputSplit(eventPath, indexPath, startTime, endTime, start, length, locations);
     }
   };
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamInputSplit.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamInputSplit.java
@@ -53,7 +53,7 @@ public final class StreamInputSplit extends FileSplit implements Writable {
    * @param length Size of this split.
    * @param locations List of hosts containing this split.
    */
-  StreamInputSplit(Path path, Path indexPath, long startTime, long endTime,
+  StreamInputSplit(Path path, @Nullable Path indexPath, long startTime, long endTime,
                    long start, long length, @Nullable String[] locations) {
     super(path, start, length, locations);
     this.indexPath = indexPath;
@@ -64,6 +64,7 @@ public final class StreamInputSplit extends FileSplit implements Writable {
   /**
    * Returns the path for index file.
    */
+  @Nullable
   public Path getIndexPath() {
     return indexPath;
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamInputSplitFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamInputSplitFactory.java
@@ -30,7 +30,7 @@ public interface StreamInputSplitFactory<T> {
   /**
    * Create a stream input split.
    *
-   * @param path path of the split
+   * @param eventPath path of the event file for the split
    * @param indexPath path to the index file for the split
    * @param startTime start timestamp for the split
    * @param endTime end timestamp for the split
@@ -39,6 +39,6 @@ public interface StreamInputSplitFactory<T> {
    * @param locations locations
    * @return stream input split
    */
-  T createSplit(Path path, Path indexPath, long startTime, long endTime,
+  T createSplit(Path eventPath, Path indexPath, long startTime, long endTime,
                 long start, long length, @Nullable String[] locations);
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamRecordReader.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamRecordReader.java
@@ -112,8 +112,9 @@ final class StreamRecordReader<K, V> extends RecordReader<K, V> {
    * @return A {@link StreamRecordReader} that is ready for reading events as specified by the input split.
    */
   private StreamDataFileReader createReader(FileSystem fs, StreamInputSplit inputSplit) {
-    return StreamDataFileReader.createWithOffset(Locations.newInputSupplier(fs, inputSplit.getPath()),
-                                                 Locations.newInputSupplier(fs, inputSplit.getIndexPath()),
-                                                 inputSplit.getStart());
+    return StreamDataFileReader.createWithOffset(
+      Locations.newInputSupplier(fs, inputSplit.getPath()),
+      inputSplit.getIndexPath() == null ? null : Locations.newInputSupplier(fs, inputSplit.getIndexPath()),
+      inputSplit.getStart());
   }
 }

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/executor/ExploreExecutorHttpHandler.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/executor/ExploreExecutorHttpHandler.java
@@ -40,7 +40,6 @@ import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.inject.Inject;
-import org.apache.twill.filesystem.Location;
 import org.jboss.netty.buffer.ChannelBufferInputStream;
 import org.jboss.netty.handler.codec.http.HttpRequest;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
@@ -89,11 +88,6 @@ public class ExploreExecutorHttpHandler extends AbstractHttpHandler {
     StreamConfig streamConfig;
     try {
       streamConfig = streamAdmin.getConfig(streamId);
-      Location streamLocation = streamConfig.getLocation();
-      if (streamLocation == null) {
-        responder.sendString(HttpResponseStatus.NOT_FOUND, "Could not find location of stream " + streamName);
-        return;
-      }
     } catch (IOException e) {
       LOG.info("Could not find stream {} to enable explore on.", streamName, e);
       responder.sendString(HttpResponseStatus.NOT_FOUND, "Could not find stream " + streamName);
@@ -101,7 +95,7 @@ public class ExploreExecutorHttpHandler extends AbstractHttpHandler {
     }
 
     try {
-      QueryHandle handle = exploreTableManager.enableStream(streamId, streamConfig);
+      QueryHandle handle = exploreTableManager.enableStream(streamId, streamConfig.getFormat());
       JsonObject json = new JsonObject();
       json.addProperty("handle", handle.getHandle());
       responder.sendJson(HttpResponseStatus.OK, json);

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/BaseHiveExploreService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/BaseHiveExploreService.java
@@ -28,6 +28,7 @@ import co.cask.cdap.data.dataset.SystemDatasetInstantiator;
 import co.cask.cdap.data.dataset.SystemDatasetInstantiatorFactory;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
+import co.cask.cdap.data2.transaction.stream.StreamConfig;
 import co.cask.cdap.explore.service.Explore;
 import co.cask.cdap.explore.service.ExploreException;
 import co.cask.cdap.explore.service.ExploreService;
@@ -1121,7 +1122,8 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
 
     // enable the table in the default namespace
     LOG.info("Enabling exploration on stream {}", streamID);
-    QueryHandle enableHandle = exploreTableManager.enableStream(streamID, streamAdmin.getConfig(streamID));
+    StreamConfig streamConfig = streamAdmin.getConfig(streamID);
+    QueryHandle enableHandle = exploreTableManager.enableStream(streamID, streamConfig.getFormat());
     // wait til enable is done
     QueryStatus status = waitForCompletion(enableHandle);
     // if enable failed, stop

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/stream/StreamRecordReader.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/stream/StreamRecordReader.java
@@ -115,8 +115,8 @@ final class StreamRecordReader implements RecordReader<Void, ObjectWritable> {
    */
   private StreamDataFileReader createReader(FileSystem fs, StreamInputSplit inputSplit) throws IOException {
     StreamDataFileReader reader = StreamDataFileReader.createWithOffset(
-      Locations.newInputSupplier(fs, inputSplit.getPath()),
-      Locations.newInputSupplier(fs, inputSplit.getIndexPath()),
+      Locations.newInputSupplier(fs, inputSplit.getEventPath()),
+      inputSplit.getIndexPath() == null ? null : Locations.newInputSupplier(fs, inputSplit.getIndexPath()),
       inputSplit.getStart());
     try {
       reader.initialize();

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/BaseHiveExploreServiceTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/BaseHiveExploreServiceTest.java
@@ -52,6 +52,7 @@ import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
 import co.cask.cdap.notifications.feeds.NotificationFeedManager;
 import co.cask.cdap.notifications.feeds.service.NoOpNotificationFeedManager;
 import co.cask.cdap.notifications.guice.NotificationServiceRuntimeModule;
+import co.cask.cdap.notifications.service.NotificationService;
 import co.cask.cdap.proto.ColumnDesc;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.QueryHandle;
@@ -129,6 +130,7 @@ public class BaseHiveExploreServiceTest {
   protected static DatasetService datasetService;
   protected static ExploreExecutorService exploreExecutorService;
   protected static ExploreService exploreService;
+  protected static NotificationService notificationService;
   protected static StreamHttpService streamHttpService;
   protected static StreamService streamService;
   protected static ExploreClient exploreClient;
@@ -173,6 +175,10 @@ public class BaseHiveExploreServiceTest {
     exploreClient = injector.getInstance(ExploreClient.class);
     exploreService = injector.getInstance(ExploreService.class);
     Assert.assertTrue(exploreClient.isServiceAvailable());
+
+    notificationService = injector.getInstance(NotificationService.class);
+    notificationService.startAndWait();
+
     streamService = injector.getInstance(StreamService.class);
     streamService.startAndWait();
     streamHttpService = injector.getInstance(StreamHttpService.class);
@@ -205,6 +211,7 @@ public class BaseHiveExploreServiceTest {
     Locations.deleteQuietly(namespacedLocationFactory.get(OTHER_NAMESPACE_ID), true);
     streamHttpService.stopAndWait();
     streamService.stopAndWait();
+    notificationService.stopAndWait();
     exploreClient.close();
     exploreExecutorService.stopAndWait();
     datasetService.stopAndWait();


### PR DESCRIPTION
- Detach it from StreamConfig so that different stream table view can have different format spec
- Modify the InputFormat/RecordRecord to use the FormatSpecification from the SerDe instead of reading from StreamConfig.