### PR TITLE
CDAP-3559 dont delete the app archive when deleting an app

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ApplicationLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ApplicationLifecycleService.java
@@ -363,11 +363,6 @@ public class ApplicationLifecycleService extends AbstractIdleService {
     }
     deleteProgramLocations(appId);
 
-    Location appArchive = store.getApplicationArchiveLocation(appId);
-    Preconditions.checkNotNull(appArchive, "Could not find the location of application", appId.getId());
-    if (!appArchive.delete()) {
-      LOG.debug("Could not delete application archive");
-    }
     store.removeApplication(appId);
 
     try {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/AppLifecycleHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/AppLifecycleHttpHandlerTest.java
@@ -31,10 +31,12 @@ import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.artifact.ArtifactSummary;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import com.google.gson.reflect.TypeToken;
 import org.apache.http.HttpResponse;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
@@ -265,5 +267,13 @@ public class AppLifecycleHttpHandlerTest extends AppFabricTestBase {
     response = doDelete(getVersionedAPIPath("apps/WordCountApp/", Constants.Gateway.API_VERSION_3_TOKEN,
                                             TEST_NAMESPACE1));
     Assert.assertEquals(404, response.getStatusLine().getStatusCode());
+
+    // deleting the app should not delete the artifact
+    response = doGet(getVersionedAPIPath("artifacts/WordCountApp", Constants.Gateway.API_VERSION_3_TOKEN,
+                                         TEST_NAMESPACE1));
+    Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+
+    List<ArtifactSummary> summaries = readResponse(response, new TypeToken<List<ArtifactSummary>>() { }.getType());
+    Assert.assertFalse(summaries.isEmpty());
   }
 }


### PR DESCRIPTION
Now that apps are created from artifacts, this is bad behavior.
We don't have to delete the app jar since other apps may be using
it, and since futures apps may want to use it.