### PR TITLE
CDAP-3561: PluginProperties should be in PluginConfig

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/Config.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/Config.java
@@ -17,19 +17,10 @@
 package co.cask.cdap.api;
 
 import co.cask.cdap.api.app.Application;
-import co.cask.cdap.api.templates.plugins.PluginProperties;
 
 /**
  * Configuration class of an configurable entity, such as {@link Application}.
  */
 public class Config {
 
-  private PluginProperties properties;
-
-  /**
-   * Returns the {@link PluginProperties}.
-   */
-  public final PluginProperties getProperties() {
-    return properties;
-  }
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/templates/plugins/PluginConfig.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/templates/plugins/PluginConfig.java
@@ -25,4 +25,12 @@ import co.cask.cdap.api.annotation.Beta;
 @Beta
 public abstract class PluginConfig extends Config {
 
+  private PluginProperties properties;
+
+  /**
+   * Returns the {@link PluginProperties}.
+   */
+  public final PluginProperties getProperties() {
+    return properties;
+  }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/PluginInstantiator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/PluginInstantiator.java
@@ -16,7 +16,6 @@
 
 package co.cask.cdap.internal.app.runtime.adapter;
 
-import co.cask.cdap.api.Config;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.artifact.ArtifactDescriptor;
 import co.cask.cdap.api.artifact.ArtifactVersion;
@@ -327,7 +326,7 @@ public class PluginInstantiator implements Closeable {
     public void visit(Object instance, Type inspectType, Type declareType, Field field) throws Exception {
       TypeToken<?> declareTypeToken = TypeToken.of(declareType);
 
-      if (Config.class.equals(declareTypeToken.getRawType())) {
+      if (PluginConfig.class.equals(declareTypeToken.getRawType())) {
         if (field.getName().equals("properties")) {
           field.set(instance, properties);
         }


### PR DESCRIPTION
Moving PluginProperties to ``PluginConfig`` from ``Config``

Build : http://builds.cask.co/browse/CDAP-DUT2682