### PR TITLE
[CDAP-3524] Added mock APIs for managing business metadata for apps, …

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataSetServiceModules.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataSetServiceModules.java
@@ -36,6 +36,8 @@ import co.cask.cdap.data2.dataset2.DatasetDefinitionRegistryFactory;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.DefaultDatasetDefinitionRegistry;
 import co.cask.cdap.data2.dataset2.StaticDatasetFramework;
+import co.cask.cdap.data2.metadata.service.MetadataAdmin;
+import co.cask.cdap.data2.metadata.service.MockMetadataAdmin;
 import co.cask.cdap.data2.metrics.DatasetMetricsReporter;
 import co.cask.cdap.data2.metrics.HBaseDatasetMetricsReporter;
 import co.cask.cdap.data2.metrics.LevelDBDatasetMetricsReporter;
@@ -90,6 +92,9 @@ public class DataSetServiceModules extends RuntimeModule {
 
         bind(StorageProviderNamespaceAdmin.class).to(LocalStorageProviderNamespaceAdmin.class);
         expose(StorageProviderNamespaceAdmin.class);
+
+        bind(MetadataAdmin.class).to(MockMetadataAdmin.class);
+        expose(MetadataAdmin.class);
       }
     };
 
@@ -127,6 +132,9 @@ public class DataSetServiceModules extends RuntimeModule {
 
         bind(StorageProviderNamespaceAdmin.class).to(LocalStorageProviderNamespaceAdmin.class);
         expose(StorageProviderNamespaceAdmin.class);
+
+        bind(MetadataAdmin.class).to(MockMetadataAdmin.class);
+        expose(MetadataAdmin.class);
       }
     };
 
@@ -166,6 +174,9 @@ public class DataSetServiceModules extends RuntimeModule {
 
         bind(StorageProviderNamespaceAdmin.class).to(DistributedStorageProviderNamespaceAdmin.class);
         expose(StorageProviderNamespaceAdmin.class);
+
+        bind(MetadataAdmin.class).to(MockMetadataAdmin.class);
+        expose(MetadataAdmin.class);
       }
     };
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetService.java
@@ -27,6 +27,8 @@ import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetOpExecutor;
 import co.cask.cdap.data2.datafabric.dataset.service.mds.MDSDatasetsRegistry;
 import co.cask.cdap.data2.datafabric.dataset.type.DatasetTypeManager;
+import co.cask.cdap.data2.metadata.service.MetadataAdmin;
+import co.cask.cdap.data2.metadata.service.MetadataHttpHandler;
 import co.cask.cdap.data2.metrics.DatasetMetricsReporter;
 import co.cask.http.NettyHttpService;
 import com.google.common.base.Objects;
@@ -82,7 +84,8 @@ public class DatasetService extends AbstractExecutionThreadService {
                         Set<DatasetMetricsReporter> metricReporters,
                         DatasetInstanceService datasetInstanceService,
                         StorageProviderNamespaceAdmin storageProviderNamespaceAdmin,
-                        AbstractNamespaceClient namespaceClient) throws Exception {
+                        AbstractNamespaceClient namespaceClient,
+                        MetadataAdmin metadataAdmin) throws Exception {
 
     this.typeManager = typeManager;
     DatasetTypeHandler datasetTypeHandler = new DatasetTypeHandler(typeManager, cConf, namespacedLocationFactory,
@@ -90,10 +93,12 @@ public class DatasetService extends AbstractExecutionThreadService {
     DatasetInstanceHandler datasetInstanceHandler = new DatasetInstanceHandler(datasetInstanceService);
     StorageProviderNamespaceHandler storageProviderNamespaceHandler =
       new StorageProviderNamespaceHandler(storageProviderNamespaceAdmin);
+    MetadataHttpHandler metadataHandler = new MetadataHttpHandler(metadataAdmin);
     NettyHttpService.Builder builder = new CommonNettyHttpServiceBuilder(cConf);
     builder.addHttpHandlers(ImmutableList.of(datasetTypeHandler,
                                              datasetInstanceHandler,
-                                             storageProviderNamespaceHandler));
+                                             storageProviderNamespaceHandler,
+                                             metadataHandler));
 
     builder.setHandlerHooks(ImmutableList.of(new MetricsReporterHook(metricsCollectionService,
                                                                      Constants.Service.DATASET_MANAGER)));

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/service/MetadataAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/service/MetadataAdmin.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.metadata.service;
+
+import co.cask.cdap.common.ApplicationNotFoundException;
+import co.cask.cdap.common.DatasetNotFoundException;
+import co.cask.cdap.common.NamespaceNotFoundException;
+import co.cask.cdap.common.ProgramNotFoundException;
+import co.cask.cdap.common.StreamNotFoundException;
+import co.cask.cdap.proto.Id;
+
+import java.util.Map;
+
+/**
+ * Interface to interact with Metadata.
+ */
+public interface MetadataAdmin {
+
+  /**
+   * Adds the specified {@link Map} to the business metadata of the specified {@link Id.Application}.
+   * Existing keys are updated with new values, newer keys are appended to the metadata.
+   *
+   * @throws NamespaceNotFoundException if the namespace is not found
+   * @throws ApplicationNotFoundException if the application is not found
+   */
+  void add(Id.Application appId, Map<String, String> metadata)
+    throws NamespaceNotFoundException, ApplicationNotFoundException;
+
+  /**
+   * Adds the specified {@link Map} to the business metadata of the specified {@link Id.Program}.
+   * Existing keys are updated with new values, newer keys are appended to the metadata.
+   *
+   * @throws NamespaceNotFoundException if the namespace is not found
+   * @throws ApplicationNotFoundException if the application containing the program is not found
+   * @throws ProgramNotFoundException if the program is not found
+   */
+  void add(Id.Program programId, Map<String, String> metadata)
+    throws NamespaceNotFoundException, ApplicationNotFoundException, ProgramNotFoundException;
+
+  /**
+   * Adds the specified {@link Map} to the business metadata of the specified {@link Id.DatasetInstance}.
+   * Existing keys are updated with new values, newer keys are appended to the metadata.
+   *
+   * @throws NamespaceNotFoundException if the namespace is not found
+   * @throws DatasetNotFoundException if the dataset is not found
+   */
+  void add(Id.DatasetInstance datasetId, Map<String, String> metadata)
+    throws NamespaceNotFoundException, DatasetNotFoundException;
+
+  /**
+   * Adds the specified {@link Map} to the business metadata of the specified {@link Id.Stream}.
+   * Existing keys are updated with new values, newer keys are appended to the metadata.
+   *
+   * @throws NamespaceNotFoundException if the namespace is not found
+   * @throws StreamNotFoundException if the stream is not found
+   */
+  void add(Id.Stream streamId, Map<String, String> metadata)
+    throws NamespaceNotFoundException, StreamNotFoundException;
+
+  /**
+   * Adds the specified tags to specified {@link Id.Application}.
+   *
+   * @throws NamespaceNotFoundException if the namespace is not found
+   * @throws ApplicationNotFoundException if the application is not found
+   */
+  void addTags(Id.Application appId, String... tags)
+    throws NamespaceNotFoundException, ApplicationNotFoundException;
+
+  /**
+   * Adds the specified tags to specified {@link Id.Program}.
+   *
+   * @throws NamespaceNotFoundException if the namespace is not found
+   * @throws ApplicationNotFoundException if the application containing the program is not found
+   * @throws ProgramNotFoundException if the program is not found
+   */
+  void addTags(Id.Program programId, String... tags)
+    throws NamespaceNotFoundException, ApplicationNotFoundException, ProgramNotFoundException;
+
+  /**
+   * Adds the specified tags to specified {@link Id.DatasetInstance}.
+   *
+   * @throws NamespaceNotFoundException if the namespace is not found
+   * @throws DatasetNotFoundException if the dataset is not found
+   */
+  void addTags(Id.DatasetInstance datasetId, String... tags)
+    throws NamespaceNotFoundException, DatasetNotFoundException;
+
+  /**
+   * Adds the specified tags to specified {@link Id.Stream}.
+   *
+   * @throws NamespaceNotFoundException if the namespace is not found
+   * @throws StreamNotFoundException if the stream is not found
+   */
+  void addTags(Id.Stream streamId, String... tags)
+    throws NamespaceNotFoundException, StreamNotFoundException;
+
+  /**
+   * @return a {@link Map} representing the business metadata of the specified {@link Id.Application}.
+   * @throws NamespaceNotFoundException if the namespace is not found
+   * @throws ApplicationNotFoundException if the application is not found
+   */
+  Map<String, String> get(Id.Application appId) throws NamespaceNotFoundException, ApplicationNotFoundException;
+
+  /**
+   * @return a {@link Map} representing the business metadata of the specified {@link Id.Program}.
+   * @throws NamespaceNotFoundException if the namespace is not found
+   * @throws ApplicationNotFoundException if the application containing the program is not found
+   * @throws ProgramNotFoundException if the program is not found
+   */
+  Map<String, String> get(Id.Program appId)
+    throws NamespaceNotFoundException, ApplicationNotFoundException, ProgramNotFoundException;
+
+  /**
+   * @return a {@link Map} representing the business metadata of the specified {@link Id.DatasetInstance}.
+   * @throws NamespaceNotFoundException if the namespace is not found
+   * @throws DatasetNotFoundException if the dataset is not found
+   */
+  Map<String, String> get(Id.DatasetInstance datasetId) throws NamespaceNotFoundException, DatasetNotFoundException;
+
+  /**
+   * @return a {@link Map} representing the business metadata of the specified {@link Id.Stream}.
+   * @throws NamespaceNotFoundException if the namespace is not found
+   * @throws StreamNotFoundException if the stream is not found
+   */
+  Map<String, String> get(Id.Stream streamId) throws NamespaceNotFoundException, StreamNotFoundException;
+
+  /**
+   * @return all the tags for the specified {@link Id.Application}.
+   * @throws NamespaceNotFoundException if the namespace is not found
+   * @throws ApplicationNotFoundException if the application is not found
+   */
+  Iterable<String> getTags(Id.Application appId) throws NamespaceNotFoundException, ApplicationNotFoundException;
+
+  /**
+   * @return all the tags for the specified {@link Id.Program}.
+   * @throws NamespaceNotFoundException if the namespace is not found
+   * @throws ApplicationNotFoundException if the application containing the program is not found
+   * @throws ProgramNotFoundException if the program is not found
+   */
+  Iterable<String> getTags(Id.Program programId)
+    throws NamespaceNotFoundException, ApplicationNotFoundException, ProgramNotFoundException;
+
+  /**
+   * @return all the tags for the specified {@link Id.DatasetInstance}.
+   * @throws NamespaceNotFoundException if the namespace is not found
+   * @throws DatasetNotFoundException if the dataset is not found
+   */
+  Iterable<String> getTags(Id.DatasetInstance datasetId) throws NamespaceNotFoundException, DatasetNotFoundException;
+
+  /**
+   * @return all the tags for the specified {@link Id.Stream}.
+   * @throws NamespaceNotFoundException if the namespace is not found
+   * @throws StreamNotFoundException if the stream is not found
+   */
+  Iterable<String> getTags(Id.Stream streamId) throws NamespaceNotFoundException, StreamNotFoundException;
+
+  /**
+   * Removes the specified keys from the business metadata of the specified {@link Id.Application}.
+   *
+   * @throws NamespaceNotFoundException if the namespace is not found
+   * @throws ApplicationNotFoundException if the application is not found
+   */
+  void remove(Id.Application appId, String ... keys) throws NamespaceNotFoundException, ApplicationNotFoundException;
+
+  /**
+   * Removes the specified keys from the business metadata of the specified {@link Id.Program}.
+   *
+   * @throws NamespaceNotFoundException if the namespace is not found
+   * @throws ApplicationNotFoundException if the application containing the program is not found
+   * @throws ProgramNotFoundException if the program is not found
+   */
+  void remove(Id.Program programId, String ... keys)
+    throws NamespaceNotFoundException, ApplicationNotFoundException, ProgramNotFoundException;
+
+  /**
+   * Removes the specified keys from the business metadata of the specified {@link Id.DatasetInstance}.
+   *
+   * @throws NamespaceNotFoundException if the namespace is not found
+   * @throws DatasetNotFoundException if the dataset is not found
+   */
+  void remove(Id.DatasetInstance datasetInstance, String ... keys)
+    throws NamespaceNotFoundException, DatasetNotFoundException;
+
+  /**
+   * Removes the specified keys from the business metadata of the specified {@link Id.Stream}.
+   *
+   * @throws NamespaceNotFoundException if the namespace is not found
+   * @throws StreamNotFoundException if the stream is not found
+   */
+  void remove(Id.Stream streamId, String ... keys) throws NamespaceNotFoundException, StreamNotFoundException;
+
+  /**
+   * Removes the specified tags from the specified {@link Id.Application}.
+   *
+   * @throws NamespaceNotFoundException if the namespace is not found
+   * @throws ApplicationNotFoundException if the application is not found
+   */
+  void removeTags(Id.Application appId, String ... tags)
+    throws NamespaceNotFoundException, ApplicationNotFoundException;
+
+  /**
+   * Removes the specified tags from the specified {@link Id.Program}.
+   *
+   * @throws NamespaceNotFoundException if the namespace is not found
+   * @throws ApplicationNotFoundException if the application containing the program is not found
+   * @throws ProgramNotFoundException if the program is not found
+   */
+  void removeTags(Id.Program programId, String ... tags)
+    throws NamespaceNotFoundException, ApplicationNotFoundException, ProgramNotFoundException;
+
+  /**
+   * Removes the specified tags from the specified {@link Id.DatasetInstance}.
+   *
+   * @throws NamespaceNotFoundException if the namespace is not found
+   * @throws DatasetNotFoundException if the dataset is not found
+   */
+  void removeTags(Id.DatasetInstance datasetId, String ... tags)
+    throws NamespaceNotFoundException, DatasetNotFoundException;
+
+  /**
+   * Removes the specified tags from the specified {@link Id.Stream}.
+   *
+   * @throws NamespaceNotFoundException if the namespace is not found
+   * @throws StreamNotFoundException if the stream is not found
+   */
+  void removeTags(Id.Stream streamId, String ... tags) throws NamespaceNotFoundException, StreamNotFoundException;
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/service/MetadataHttpHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/service/MetadataHttpHandler.java
@@ -1,0 +1,344 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.metadata.service;
+
+import co.cask.cdap.common.BadRequestException;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.ProgramType;
+import co.cask.http.AbstractHttpHandler;
+import co.cask.http.HttpResponder;
+import com.google.common.base.Charsets;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import org.jboss.netty.buffer.ChannelBuffer;
+import org.jboss.netty.buffer.ChannelBufferInputStream;
+import org.jboss.netty.handler.codec.http.HttpRequest;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Map;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+/**
+ * HttpHandler for Metadata
+ */
+@Path(Constants.Gateway.API_VERSION_3)
+public class MetadataHttpHandler extends AbstractHttpHandler {
+  private static final Gson GSON = new Gson();
+  private static final Type MAP_STRING_STRING_TYPE = new TypeToken<Map<String, String>>() { }.getType();
+  private static final Type LIST_STRING_TYPE = new TypeToken<List<String>>() { }.getType();
+  private final MetadataAdmin metadataAdmin;
+
+  public MetadataHttpHandler(MetadataAdmin metadataAdmin) {
+    this.metadataAdmin = metadataAdmin;
+  }
+
+  @GET
+  @Path("/namespaces/{namespace-id}/apps/{app-id}/metadata")
+  public void getAppMetadata(HttpRequest request, HttpResponder responder,
+                             @PathParam("namespace-id") String namespaceId,
+                             @PathParam("app-id") String appId) throws Exception {
+    responder.sendJson(HttpResponseStatus.OK, metadataAdmin.get(Id.Application.from(namespaceId, appId)));
+  }
+
+  @GET
+  @Path("/namespaces/{namespace-id}/apps/{app-id}/{program-type}/{program-id}/metadata")
+  public void getProgramMetadata(HttpRequest request, HttpResponder responder,
+                             @PathParam("namespace-id") String namespaceId,
+                             @PathParam("app-id") String appId,
+                             @PathParam("program-type") String programType,
+                             @PathParam("program-id") String programId) throws Exception {
+    responder.sendJson(HttpResponseStatus.OK,
+                       metadataAdmin.get(Id.Program.from(Id.Application.from(namespaceId, appId),
+                                                         ProgramType.valueOfCategoryName(programType), programId)));
+  }
+
+  @GET
+  @Path("/namespaces/{namespace-id}/datasets/{dataset-id}/metadata")
+  public void getDatasetMetadata(HttpRequest request, HttpResponder responder,
+                                 @PathParam("namespace-id") String namespaceId,
+                                 @PathParam("dataset-id") String datasetId) throws Exception {
+    responder.sendJson(HttpResponseStatus.OK, metadataAdmin.get(Id.DatasetInstance.from(namespaceId, datasetId)));
+  }
+
+  @GET
+  @Path("/namespaces/{namespace-id}/streams/{stream-id}/metadata")
+  public void getStreamMetadata(HttpRequest request, HttpResponder responder,
+                                @PathParam("namespace-id") String namespaceId,
+                                @PathParam("stream-id") String streamId) throws Exception {
+    responder.sendJson(HttpResponseStatus.OK, metadataAdmin.get(Id.Stream.from(namespaceId, streamId)));
+  }
+
+  @POST
+  @Path("/namespaces/{namespace-id}/apps/{app-id}/metadata")
+  public void addAppMetadata(HttpRequest request, HttpResponder responder,
+                             @PathParam("namespace-id") String namespaceId,
+                             @PathParam("app-id") String appId) throws Exception {
+    Id.Application app = Id.Application.from(namespaceId, appId);
+    metadataAdmin.add(app, readMetadata(request));
+    responder.sendString(HttpResponseStatus.OK, "Metadata added successfully to " + app);
+  }
+
+  @POST
+  @Path("/namespaces/{namespace-id}/apps/{app-id}/{program-type}/{program-id}/metadata")
+  public void addProgramMetadata(HttpRequest request, HttpResponder responder,
+                                 @PathParam("namespace-id") String namespaceId,
+                                 @PathParam("app-id") String appId,
+                                 @PathParam("program-type") String programType,
+                                 @PathParam("program-id") String programId) throws Exception {
+    Id.Program program = Id.Program.from(Id.Application.from(namespaceId, appId),
+                                         ProgramType.valueOfCategoryName(programType), programId);
+    metadataAdmin.add(program, readMetadata(request));
+    responder.sendString(HttpResponseStatus.OK, "Metadata added successfully to " + program);
+  }
+
+  @POST
+  @Path("/namespaces/{namespace-id}/datasets/{dataset-id}/metadata")
+  public void addDatasetMetadata(HttpRequest request, HttpResponder responder,
+                                 @PathParam("namespace-id") String namespaceId,
+                                 @PathParam("dataset-id") String datasetId) throws Exception {
+    Id.DatasetInstance dataset = Id.DatasetInstance.from(namespaceId, datasetId);
+    metadataAdmin.add(dataset, readMetadata(request));
+    responder.sendString(HttpResponseStatus.OK, "Metadata added successfully to " + dataset);
+  }
+
+  @POST
+  @Path("/namespaces/{namespace-id}/streams/{stream-id}/metadata")
+  public void addStreamMetadata(HttpRequest request, HttpResponder responder,
+                                @PathParam("namespace-id") String namespaceId,
+                                @PathParam("stream-id") String streamId) throws Exception {
+    Id.Stream stream = Id.Stream.from(namespaceId, streamId);
+    metadataAdmin.add(stream, readMetadata(request));
+    responder.sendString(HttpResponseStatus.OK, "Metadata added successfully to " + stream);
+  }
+
+  @DELETE
+  @Path("/namespaces/{namespace-id}/apps/{app-id}/metadata")
+  public void removeAppMetadata(HttpRequest request, HttpResponder responder,
+                                @PathParam("namespace-id") String namespaceId,
+                                @PathParam("app-id") String appId) throws Exception {
+    Id.Application app = Id.Application.from(namespaceId, appId);
+    metadataAdmin.remove(app, readArray(request));
+    responder.sendString(HttpResponseStatus.OK,
+                         String.format("Metadata keys for app %s deleted successfully.", app));
+  }
+
+  @DELETE
+  @Path("/namespaces/{namespace-id}/apps/{app-id}/{program-type}/{program-id}/metadata")
+  public void removeProgramMetadata(HttpRequest request, HttpResponder responder,
+                                    @PathParam("namespace-id") String namespaceId,
+                                    @PathParam("app-id") String appId,
+                                    @PathParam("program-type") String programType,
+                                    @PathParam("program-id") String programId) throws Exception {
+    Id.Program program = Id.Program.from(Id.Application.from(namespaceId, appId),
+                                         ProgramType.valueOfCategoryName(programType), programId);
+    metadataAdmin.remove(program, readArray(request));
+    responder.sendString(HttpResponseStatus.OK,
+                         String.format("Metadata keys for program %s deleted successfully.", program));
+  }
+
+  @DELETE
+  @Path("/namespaces/{namespace-id}/datasets/{dataset-id}/metadata")
+  public void removeDatasetMetadata(HttpRequest request, HttpResponder responder,
+                                    @PathParam("namespace-id") String namespaceId,
+                                    @PathParam("dataset-id") String datasetId) throws Exception {
+    Id.DatasetInstance dataset = Id.DatasetInstance.from(namespaceId, datasetId);
+    metadataAdmin.remove(dataset, readArray(request));
+    responder.sendString(HttpResponseStatus.OK,
+                         String.format("Metadata keys for dataset %s deleted successfully.", dataset));
+  }
+
+  @DELETE
+  @Path("/namespaces/{namespace-id}/streams/{stream-id}/metadata")
+  public void removeStreamMetadata(HttpRequest request, HttpResponder responder,
+                                   @PathParam("namespace-id") String namespaceId,
+                                   @PathParam("stream-id") String streamId) throws Exception {
+    Id.Stream stream = Id.Stream.from(namespaceId, streamId);
+    metadataAdmin.remove(stream, readArray(request));
+    responder.sendString(HttpResponseStatus.OK,
+                         String.format("Metadata keys for stream %s deleted successfully.", stream));
+  }
+
+  @POST
+  @Path("/namespaces/{namespace-id}/apps/{app-id}/tags")
+  public void addAppTags(HttpRequest request, HttpResponder responder,
+                            @PathParam("namespace-id") String namespaceId,
+                            @PathParam("app-id") String appId) throws Exception {
+    Id.Application app = Id.Application.from(namespaceId, appId);
+    metadataAdmin.addTags(app, readArray(request));
+    responder.sendString(HttpResponseStatus.OK,
+                         String.format("Added tags to application %s successfully", app));
+  }
+
+  @POST
+  @Path("/namespaces/{namespace-id}/apps/{app-id}/{program-type}/{program-id}/tags")
+  public void addProgramTags(HttpRequest request, HttpResponder responder,
+                             @PathParam("namespace-id") String namespaceId,
+                             @PathParam("app-id") String appId,
+                             @PathParam("program-type") String programType,
+                             @PathParam("program-id") String programId) throws Exception {
+    Id.Program program = Id.Program.from(Id.Application.from(namespaceId, appId),
+                                         ProgramType.valueOfCategoryName(programType), programId);
+    metadataAdmin.addTags(program, readArray(request));
+    responder.sendString(HttpResponseStatus.OK,
+                         String.format("Added tags to program %s successfully", program));
+  }
+
+  @POST
+  @Path("/namespaces/{namespace-id}/datasets/{dataset-id}/tags")
+  public void addDatasetTags(HttpRequest request, HttpResponder responder,
+                            @PathParam("namespace-id") String namespaceId,
+                            @PathParam("dataset-id") String datasetId) throws Exception {
+    Id.DatasetInstance dataset = Id.DatasetInstance.from(namespaceId, datasetId);
+    metadataAdmin.addTags(dataset, readArray(request));
+    responder.sendString(HttpResponseStatus.OK,
+                         String.format("Added tags to dataset %s successfully", dataset));
+  }
+
+  @POST
+  @Path("/namespaces/{namespace-id}/streams/{stream-id}/tags")
+  public void addStreamTags(HttpRequest request, HttpResponder responder,
+                            @PathParam("namespace-id") String namespaceId,
+                            @PathParam("stream-id") String streamId) throws Exception {
+    Id.Stream stream = Id.Stream.from(namespaceId, streamId);
+    metadataAdmin.addTags(stream, readArray(request));
+    responder.sendString(HttpResponseStatus.OK,
+                         String.format("Added tags to stream %s successfully", stream));
+  }
+
+  @GET
+  @Path("/namespaces/{namespace-id}/apps/{app-id}/tags")
+  public void getAppTags(HttpRequest request, HttpResponder responder,
+                         @PathParam("namespace-id") String namespaceId,
+                         @PathParam("app-id") String appId) throws Exception {
+    Id.Application app = Id.Application.from(namespaceId, appId);
+    responder.sendJson(HttpResponseStatus.OK, metadataAdmin.getTags(app));
+  }
+
+  @GET
+  @Path("/namespaces/{namespace-id}/apps/{app-id}/{program-type}/{program-id}/tags")
+  public void getProgramTags(HttpRequest request, HttpResponder responder,
+                             @PathParam("namespace-id") String namespaceId,
+                             @PathParam("app-id") String appId,
+                             @PathParam("program-type") String programType,
+                             @PathParam("program-id") String programId) throws Exception {
+    Id.Program program = Id.Program.from(Id.Application.from(namespaceId, appId),
+                                         ProgramType.valueOfCategoryName(programType), programId);
+    responder.sendJson(HttpResponseStatus.OK, metadataAdmin.getTags(program));
+  }
+
+  @GET
+  @Path("/namespaces/{namespace-id}/datasets/{dataset-id}/tags")
+  public void getDatasetTags(HttpRequest request, HttpResponder responder,
+                             @PathParam("namespace-id") String namespaceId,
+                             @PathParam("dataset-id") String datasetId) throws Exception {
+    Id.DatasetInstance dataset = Id.DatasetInstance.from(namespaceId, datasetId);
+    responder.sendJson(HttpResponseStatus.OK, metadataAdmin.getTags(dataset));
+  }
+
+  @GET
+  @Path("/namespaces/{namespace-id}/streams/{stream-id}/tags")
+  public void getStreamTags(HttpRequest request, HttpResponder responder,
+                            @PathParam("namespace-id") String namespaceId,
+                            @PathParam("stream-id") String streamId) throws Exception {
+    Id.Stream stream = Id.Stream.from(namespaceId, streamId);
+    responder.sendJson(HttpResponseStatus.OK, metadataAdmin.getTags(stream));
+  }
+
+  @DELETE
+  @Path("/namespaces/{namespace-id}/apps/{app-id}/tags")
+  public void removeAppTags(HttpRequest request, HttpResponder responder,
+                            @PathParam("namespace-id") String namespaceId,
+                            @PathParam("app-id") String appId) throws Exception {
+    Id.Application app = Id.Application.from(namespaceId, appId);
+    metadataAdmin.removeTags(app, readArray(request));
+    responder.sendString(HttpResponseStatus.OK,
+                         String.format("Tags for app %s deleted successfully.", app));
+  }
+
+  @DELETE
+  @Path("/namespaces/{namespace-id}/apps/{app-id}/{program-type}/{program-id}/tags")
+  public void removeProgramTags(HttpRequest request, HttpResponder responder,
+                                @PathParam("namespace-id") String namespaceId,
+                                @PathParam("app-id") String appId,
+                                @PathParam("program-type") String programType,
+                                @PathParam("program-id") String programId) throws Exception {
+    Id.Program program = Id.Program.from(Id.Application.from(namespaceId, appId),
+                                         ProgramType.valueOfCategoryName(programType), programId);
+    metadataAdmin.removeTags(program, readArray(request));
+    responder.sendString(HttpResponseStatus.OK,
+                         String.format("Tags for program %s deleted successfully.", program));
+  }
+
+  @DELETE
+  @Path("/namespaces/{namespace-id}/datasets/{dataset-id}/tags")
+  public void removeDatasetTags(HttpRequest request, HttpResponder responder,
+                                @PathParam("namespace-id") String namespaceId,
+                                @PathParam("dataset-id") String datasetId) throws Exception {
+    Id.DatasetInstance dataset = Id.DatasetInstance.from(namespaceId, datasetId);
+    metadataAdmin.removeTags(dataset, readArray(request));
+    responder.sendString(HttpResponseStatus.OK,
+                         String.format("Tags for dataset %s deleted successfully.", dataset));
+  }
+
+  @DELETE
+  @Path("/namespaces/{namespace-id}/streams/{stream-id}/tags")
+  public void removeStreamTags(HttpRequest request, HttpResponder responder,
+                                   @PathParam("namespace-id") String namespaceId,
+                                   @PathParam("stream-id") String streamId) throws Exception {
+    Id.Stream stream = Id.Stream.from(namespaceId, streamId);
+    metadataAdmin.removeTags(stream, readArray(request));
+    responder.sendString(HttpResponseStatus.OK,
+                         String.format("Tags for stream %s deleted successfully.", stream));
+  }
+
+  private Map<String, String> readMetadata(HttpRequest request) throws BadRequestException, IOException {
+    ChannelBuffer content = request.getContent();
+    if (!content.readable()) {
+      throw new BadRequestException("Unable to read business metadata from request.");
+    }
+    try (Reader reader = new InputStreamReader(new ChannelBufferInputStream(content), Charsets.UTF_8)) {
+      return GSON.fromJson(reader, MAP_STRING_STRING_TYPE);
+    }
+  }
+
+  private String[] readArray(HttpRequest request) throws BadRequestException, IOException {
+    ChannelBuffer content = request.getContent();
+    if (!content.readable()) {
+      throw new BadRequestException("Unable to read business metadata from request.");
+    }
+    try (Reader reader = new InputStreamReader(new ChannelBufferInputStream(content), Charsets.UTF_8)) {
+      List<String> toReturn = GSON.fromJson(reader, LIST_STRING_TYPE);
+      return toReturn.toArray(new String[toReturn.size()]);
+    }
+  }
+
+  @POST
+  @Path("/metadata/history")
+  public void recordRun(HttpRequest request, HttpResponder responder) {
+    responder.sendString(HttpResponseStatus.OK, "Metadata recorded successfully");
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/service/MockMetadataAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/service/MockMetadataAdmin.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.metadata.service;
+
+import co.cask.cdap.common.ApplicationNotFoundException;
+import co.cask.cdap.common.DatasetNotFoundException;
+import co.cask.cdap.common.NamespaceNotFoundException;
+import co.cask.cdap.common.ProgramNotFoundException;
+import co.cask.cdap.common.StreamNotFoundException;
+import co.cask.cdap.proto.Id;
+import com.google.common.collect.ImmutableMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Mock implementation of {@link MetadataAdmin}
+ */
+public class MockMetadataAdmin implements MetadataAdmin {
+  private static final String NOT_FOUND = "notfound";
+  private static final String EMPTY = "empty";
+  private static final Logger LOG = LoggerFactory.getLogger(MockMetadataAdmin.class);
+
+  @Override
+  public void add(Id.Application appId, Map<String, String> metadata)
+    throws NamespaceNotFoundException, ApplicationNotFoundException {
+    verifyApp(appId);
+    LOG.info("Metadata for app '{}' added successfully.", appId);
+  }
+
+  @Override
+  public void add(Id.Program programId, Map<String, String> metadata)
+    throws NamespaceNotFoundException, ApplicationNotFoundException, ProgramNotFoundException {
+    verifyProgram(programId);
+    LOG.info("Metadata for program '{}' added successfully.", programId);
+  }
+
+  @Override
+  public void add(Id.DatasetInstance datasetId, Map<String, String> metadata)
+    throws NamespaceNotFoundException, DatasetNotFoundException {
+    verifyDataset(datasetId);
+    LOG.info("Metadata for dataset '{}' added successfully.", datasetId);
+  }
+
+  @Override
+  public void add(Id.Stream streamId, Map<String, String> metadata)
+    throws NamespaceNotFoundException, StreamNotFoundException {
+    verifyStream(streamId);
+    LOG.info("Metadata for stream '{}' added successfully.", streamId);
+  }
+
+  @Override
+  public Map<String, String> get(Id.Application appId) throws NamespaceNotFoundException, ApplicationNotFoundException {
+    verifyApp(appId);
+    Map<String, String> metadata;
+    if (EMPTY.equals(appId.getNamespaceId()) || EMPTY.equals(appId.getId())) {
+      metadata = ImmutableMap.of();
+    } else {
+      metadata = ImmutableMap.of("aKey", "aValue",
+                                 "aK", "aV",
+                                 "aK1", "aV1",
+                                 "tags", "counter,mr,visual");
+    }
+    return metadata;
+  }
+
+  @Override
+  public Map<String, String> get(Id.Program programId)
+    throws NamespaceNotFoundException, ApplicationNotFoundException, ProgramNotFoundException {
+    verifyProgram(programId);
+    Map<String, String> metadata;
+    if (EMPTY.equals(programId.getNamespaceId()) || EMPTY.equals(programId.getApplicationId()) ||
+      EMPTY.equals(programId.getId())) {
+      metadata = ImmutableMap.of();
+    } else {
+      metadata = ImmutableMap.of("aKey", "aValue",
+                                 "aK", "aV",
+                                 "aK1", "aV1",
+                                 "tags", "counter,mr,visual");
+    }
+    return metadata;
+  }
+
+  @Override
+  public Map<String, String> get(Id.DatasetInstance datasetId)
+    throws NamespaceNotFoundException, DatasetNotFoundException {
+    verifyDataset(datasetId);
+    Map<String, String> metadata;
+    if (EMPTY.equals(datasetId.getNamespaceId()) || EMPTY.equals(datasetId.getId())) {
+      metadata = ImmutableMap.of();
+    } else {
+      metadata = ImmutableMap.of("dKey", "dValue",
+                                 "dK", "dV",
+                                 "dK1", "dV1",
+                                 "tags", "reports,deviations,errors");
+    }
+    return metadata;
+  }
+
+  @Override
+  public Map<String, String> get(Id.Stream streamId) throws NamespaceNotFoundException, StreamNotFoundException {
+    verifyStream(streamId);
+    Map<String, String> metadata;
+    if (EMPTY.equals(streamId.getNamespaceId()) || EMPTY.equals(streamId.getId())) {
+      metadata = ImmutableMap.of();
+    } else {
+      metadata = ImmutableMap.of("sKey", "sValue",
+                                 "sK", "sV",
+                                 "sK1", "sV1",
+                                 "tags", "input,raw");
+    }
+    return metadata;
+  }
+
+  @Override
+  public void remove(Id.Application appId, String ... keys)
+    throws NamespaceNotFoundException, ApplicationNotFoundException {
+    verifyApp(appId);
+    LOG.info("Metadata for app '{}' added successfully.", appId);
+  }
+
+  @Override
+  public void remove(Id.Program programId, String ... keys)
+    throws NamespaceNotFoundException, ApplicationNotFoundException, ProgramNotFoundException {
+    verifyProgram(programId);
+    LOG.info("Metadata for program '{}' removed successfully.", programId);
+  }
+
+  @Override
+  public void remove(Id.DatasetInstance datasetId, String ... keys)
+    throws NamespaceNotFoundException, DatasetNotFoundException {
+    verifyDataset(datasetId);
+    LOG.info("Metadata for dataset '{}' removed successfully.", datasetId);
+  }
+
+  @Override
+  public void remove(Id.Stream streamId, String ... keys) throws NamespaceNotFoundException, StreamNotFoundException {
+    verifyStream(streamId);
+    LOG.info("Metadata for stream '{}' removed successfully.", streamId);
+  }
+
+  @Override
+  public void addTags(Id.Application appId, String... tags)
+    throws NamespaceNotFoundException, ApplicationNotFoundException {
+    verifyApp(appId);
+    LOG.info("Tags {} for app '{}' added successfully.", tags, appId);
+  }
+
+  @Override
+  public void addTags(Id.Program programId, String... tags)
+    throws NamespaceNotFoundException, ApplicationNotFoundException, ProgramNotFoundException {
+    verifyProgram(programId);
+    LOG.info("Tags {} for program '{}' added successfully.", tags, programId);
+  }
+
+  @Override
+  public void addTags(Id.DatasetInstance datasetId, String... tags)
+    throws NamespaceNotFoundException, DatasetNotFoundException {
+    verifyDataset(datasetId);
+    LOG.info("Tags {} for dataset '{}' added successfully.", tags, datasetId);
+  }
+
+  @Override
+  public void addTags(Id.Stream streamId, String... tags) throws NamespaceNotFoundException, StreamNotFoundException {
+    verifyStream(streamId);
+    LOG.info("Tags {} for stream '{}' added successfully.", tags, streamId);
+  }
+
+  @Override
+  public Iterable<String> getTags(Id.Application appId)
+    throws NamespaceNotFoundException, ApplicationNotFoundException {
+    verifyApp(appId);
+    List<String> tags = new ArrayList<>();
+    tags.add("aTag");
+    tags.add("aTag1");
+    return tags;
+  }
+
+  @Override
+  public Iterable<String> getTags(Id.Program programId)
+    throws NamespaceNotFoundException, ApplicationNotFoundException, ProgramNotFoundException {
+    verifyProgram(programId);
+    List<String> tags = new ArrayList<>();
+    tags.add("pTag");
+    tags.add("pTag10");
+    return tags;
+  }
+
+  @Override
+  public Iterable<String> getTags(Id.DatasetInstance datasetId)
+    throws NamespaceNotFoundException, DatasetNotFoundException {
+    verifyDataset(datasetId);
+    List<String> tags = new ArrayList<>();
+    tags.add("dTag");
+    tags.add("dTag1");
+    return tags;
+  }
+
+  @Override
+  public Iterable<String> getTags(Id.Stream streamId) throws NamespaceNotFoundException, StreamNotFoundException {
+    verifyStream(streamId);
+    List<String> tags = new ArrayList<>();
+    tags.add("sTag");
+    tags.add("sTag10");
+    return tags;
+  }
+
+  @Override
+  public void removeTags(Id.Application appId, String... tags)
+    throws NamespaceNotFoundException, ApplicationNotFoundException {
+    verifyApp(appId);
+    LOG.info("Tags {} removed from app {}.", tags, appId);
+  }
+
+  @Override
+  public void removeTags(Id.Program programId, String... tags)
+    throws NamespaceNotFoundException, ApplicationNotFoundException, ProgramNotFoundException {
+    verifyProgram(programId);
+    LOG.info("Tags {} removed from program {}.", tags, programId);
+  }
+
+  @Override
+  public void removeTags(Id.DatasetInstance datasetId, String... tags)
+    throws NamespaceNotFoundException, DatasetNotFoundException {
+    verifyDataset(datasetId);
+    LOG.info("Tags {} removed from dataset {}.", tags, datasetId);
+  }
+
+  @Override
+  public void removeTags(Id.Stream streamId, String... tags)
+    throws NamespaceNotFoundException, StreamNotFoundException {
+    verifyStream(streamId);
+    LOG.info("Tags {} removed from stream {}.", tags, streamId);
+  }
+
+  private void verifyNamespace(Id.Namespace namespaceId) throws NamespaceNotFoundException {
+    if (NOT_FOUND.equals(namespaceId.getId())) {
+      throw new NamespaceNotFoundException(namespaceId);
+    }
+  }
+
+  private void verifyApp(Id.Application appId) throws NamespaceNotFoundException, ApplicationNotFoundException {
+    verifyNamespace(appId.getNamespace());
+    if (NOT_FOUND.equals(appId.getId())) {
+      throw new ApplicationNotFoundException(appId);
+    }
+  }
+
+  private void verifyProgram(Id.Program programId)
+    throws NamespaceNotFoundException, ApplicationNotFoundException, ProgramNotFoundException {
+    verifyApp(programId.getApplication());
+    if (NOT_FOUND.equals(programId.getId())) {
+      throw new ProgramNotFoundException(programId);
+    }
+  }
+
+  private void verifyDataset(Id.DatasetInstance datasetId) throws NamespaceNotFoundException, DatasetNotFoundException {
+    verifyNamespace(datasetId.getNamespace());
+    if (NOT_FOUND.equals(datasetId.getId())) {
+      throw new DatasetNotFoundException(datasetId);
+    }
+  }
+
+  private void verifyStream(Id.Stream streamId) throws NamespaceNotFoundException, StreamNotFoundException {
+    verifyNamespace(streamId.getNamespace());
+    if (NOT_FOUND.equals(streamId.getId())) {
+      throw new StreamNotFoundException(streamId);
+    }
+  }
+}

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
@@ -42,6 +42,7 @@ import co.cask.cdap.data2.dataset2.SimpleKVTable;
 import co.cask.cdap.data2.dataset2.SingleTypeModule;
 import co.cask.cdap.data2.dataset2.lib.table.CoreDatasetsModule;
 import co.cask.cdap.data2.dataset2.module.lib.inmemory.InMemoryTableModule;
+import co.cask.cdap.data2.metadata.service.MockMetadataAdmin;
 import co.cask.cdap.data2.metrics.DatasetMetricsReporter;
 import co.cask.cdap.data2.registry.UsageRegistry;
 import co.cask.cdap.explore.client.DiscoveryExploreClient;
@@ -143,7 +144,9 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
                                  instanceService,
                                  new LocalStorageProviderNamespaceAdmin(cConf, namespacedLocationFactory,
                                                                         exploreFacade),
-                                 NAMESPACE_CLIENT);
+                                 NAMESPACE_CLIENT,
+                                 new MockMetadataAdmin()
+    );
     // Start dataset service, wait for it to be discoverable
     service.start();
     final CountDownLatch startLatch = new CountDownLatch(1);

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
@@ -43,6 +43,7 @@ import co.cask.cdap.data2.datafabric.dataset.type.DatasetTypeManager;
 import co.cask.cdap.data2.dataset2.DatasetDefinitionRegistryFactory;
 import co.cask.cdap.data2.dataset2.DefaultDatasetDefinitionRegistry;
 import co.cask.cdap.data2.dataset2.InMemoryDatasetFramework;
+import co.cask.cdap.data2.metadata.service.MockMetadataAdmin;
 import co.cask.cdap.data2.metrics.DatasetMetricsReporter;
 import co.cask.cdap.data2.registry.UsageRegistry;
 import co.cask.cdap.explore.client.DiscoveryExploreClient;
@@ -202,7 +203,9 @@ public abstract class DatasetServiceTestBase {
                                  instanceService,
                                  new LocalStorageProviderNamespaceAdmin(cConf, namespacedLocationFactory,
                                                                         exploreFacade),
-                                 namespaceClient);
+                                 namespaceClient,
+                                 new MockMetadataAdmin()
+    );
 
     // Start dataset service, wait for it to be discoverable
     service.start();

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterPathLookup.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterPathLookup.java
@@ -74,6 +74,16 @@ public final class RouterPathLookup extends AbstractHttpHandler {
     } else if (matches(uriParts, "v3", "system", "services", null, "logs")) {
       //Log Handler Path /v3/system/services/<service-id>/logs
       return Constants.Service.METRICS;
+    } else if (matches(uriParts, "v3", "namespaces", null, "apps", null, "metadata") ||
+      matches(uriParts, "v3", "namespaces", null, "apps", null, null, null, "metadata") ||
+      matches(uriParts, "v3", "namespaces", null, "datasets", null, "metadata") ||
+      matches(uriParts, "v3", "namespaces", null, "streams", null, "metadata") ||
+      matches(uriParts, "v3", "namespaces", null, "apps", null, "tags") ||
+      matches(uriParts, "v3", "namespaces", null, "apps", null, null, null, "tags") ||
+      matches(uriParts, "v3", "namespaces", null, "datasets", null, "tags") ||
+      matches(uriParts, "v3", "namespaces", null, "streams", null, "tags")) {
+      // all metadata REST APIs are currently exposed from Dataset service
+      return Constants.Service.DATASET_MANAGER;
     } else if ((matches(uriParts, "v3", "namespaces", null, "streams", null, "adapters")
       || matches(uriParts, "v3", "namespaces", null, "streams", null, "programs")
       || matches(uriParts, "v3", "namespaces", null, "data", "datasets", null, "adapters")

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/RouterPathTest.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/RouterPathTest.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.gateway.router;
 
 import co.cask.cdap.common.conf.Constants;
+import com.google.common.collect.ImmutableList;
 import org.jboss.netty.handler.codec.http.DefaultHttpRequest;
 import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.jboss.netty.handler.codec.http.HttpRequest;
@@ -322,5 +323,33 @@ public class RouterPathTest {
     HttpRequest httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("PUT"), namespacePath);
     String result = pathLookup.getRoutingService(FALLBACKSERVICE, namespacePath, httpRequest);
     Assert.assertEquals(null, result);
+  }
+
+  @Test
+  public void testMetadataPath() {
+    // app metadata
+    assertMetadataRouting("/v3/namespaces/default//apps/WordCount//////metadata");
+    // program metadata
+    assertMetadataRouting("/v3/namespaces/default//apps/WordCount/flows/WordCountFlow/metadata");
+    // dataset metadata
+    assertMetadataRouting("/v3/namespaces/default/////datasets/ds1/metadata");
+    // stream metadata
+    assertMetadataRouting("/v3/namespaces////default////streams//s1/metadata");
+    // app tags
+    assertMetadataRouting("/v3/namespaces/default//apps/WordCount//////tags");
+    // program metadata
+    assertMetadataRouting("/v3/namespaces/default//apps/WordCount/flows/WordCountFlow/tags");
+    // dataset metadata
+    assertMetadataRouting("/v3/namespaces/default/////datasets/ds1/tags");
+    // stream metadata
+    assertMetadataRouting("/v3/namespaces////default////streams//s1/tags");
+  }
+
+  private void assertMetadataRouting(String path) {
+    for (HttpMethod method : ImmutableList.of(HttpMethod.GET, HttpMethod.POST, HttpMethod.DELETE)) {
+      HttpRequest httpRequest = new DefaultHttpRequest(VERSION, method, path);
+      String result = pathLookup.getRoutingService(FALLBACKSERVICE, path, httpRequest);
+      Assert.assertEquals(Constants.Service.DATASET_MANAGER,  result);
+    }
   }
 }


### PR DESCRIPTION
…programs, datasets and streams

- [ x ] ``MetadataAdmin`` Interface
- [ x ] Mock implementation of ``MetadataAdmin`` - ``MockMetadataAdmin``
- [ x ] ``MetadataHttpHandler`` containing REST APIs defined at [Metadata Design](https://wiki.cask.co/display/CE/Metadata+and+Data+Discovery#MetadataandDataDiscovery-RESTAPIs)
- [ x ] ``MetadataHttpHandler`` currently runs inside Dataset Service, to quickly setup mock APIs for UI to integrate with, however, it may move to its own service later depending on timing/design issues.

Build: https://builds.cask.co/browse/CDAP-DUT2683