### PR TITLE
CDAP-3560 change isSystem to a scope enum

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/artifact/ArtifactDescriptor.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/artifact/ArtifactDescriptor.java
@@ -18,35 +18,21 @@ package co.cask.cdap.api.artifact;
 
 import org.apache.twill.filesystem.Location;
 
-import java.util.Objects;
-
 /**
- * Uniquely describes an artifact. Artifact descriptors are ordered by whether or not they are system artifacts,
+ * Uniquely describes an artifact. Artifact descriptors are ordered by scope,
  * then by name, and finally by version.
  */
 public final class ArtifactDescriptor implements Comparable<ArtifactDescriptor> {
-  private final String name;
-  private final ArtifactVersion version;
-  private final boolean isSystem;
+  private final ArtifactId artifactId;
   private final Location location;
 
-  public ArtifactDescriptor(String name, ArtifactVersion version, boolean isSystem, Location location) {
-    this.name = name;
-    this.version = version;
-    this.isSystem = isSystem;
+  public ArtifactDescriptor(ArtifactId artifactId, Location location) {
+    this.artifactId = artifactId;
     this.location = location;
   }
 
-  public String getName() {
-    return name;
-  }
-
-  public ArtifactVersion getVersion() {
-    return version;
-  }
-
-  public boolean isSystem() {
-    return isSystem;
+  public ArtifactId getArtifactId() {
+    return artifactId;
   }
 
   public Location getLocation() {
@@ -56,9 +42,7 @@ public final class ArtifactDescriptor implements Comparable<ArtifactDescriptor> 
   @Override
   public String toString() {
     return "ArtifactDescriptor{" +
-      "name='" + name + '\'' +
-      ", version=" + version +
-      ", isSystem=" + isSystem +
+      "artifactId=" + artifactId +
       ", location=" + location +
       '}';
   }
@@ -78,19 +62,19 @@ public final class ArtifactDescriptor implements Comparable<ArtifactDescriptor> 
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, version, isSystem);
+    return artifactId.hashCode();
   }
 
   @Override
   public int compareTo(ArtifactDescriptor other) {
-    // system artifacts are 'less than' other artifacts
-    if (isSystem != other.isSystem) {
-      return isSystem ? -1 : 1;
-    }
-    int cmp = name.compareTo(other.name);
+    int cmp = artifactId.getScope().compareTo(other.getArtifactId().getScope());
     if (cmp != 0) {
       return cmp;
     }
-    return version.compareTo(other.version);
+    cmp = artifactId.getName().compareTo(other.getArtifactId().getName());
+    if (cmp != 0) {
+      return cmp;
+    }
+    return artifactId.getVersion().compareTo(other.getArtifactId().getVersion());
   }
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/artifact/ArtifactId.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/artifact/ArtifactId.java
@@ -27,12 +27,12 @@ import java.util.Objects;
 public final class ArtifactId {
   private final String name;
   private final ArtifactVersion version;
-  private final boolean isSystem;
+  private final ArtifactScope scope;
 
-  public ArtifactId(String name, ArtifactVersion version, boolean isSystem) {
+  public ArtifactId(String name, ArtifactVersion version, ArtifactScope scope) {
     this.name = name;
     this.version = version;
-    this.isSystem = isSystem;
+    this.scope = scope;
   }
 
   public String getName() {
@@ -43,16 +43,16 @@ public final class ArtifactId {
     return version;
   }
 
-  public boolean isSystem() {
-    return isSystem;
+  public ArtifactScope getScope() {
+    return scope;
   }
 
   @Override
   public String toString() {
-    return "ArtifactDescriptor{" +
+    return "ArtifactId{" +
       "name='" + name + '\'' +
       ", version=" + version +
-      ", isSystem=" + isSystem +
+      ", scope='" + scope + '\'' +
       '}';
   }
 
@@ -68,12 +68,12 @@ public final class ArtifactId {
     ArtifactId that = (ArtifactId) o;
     return Objects.equals(name, that.name) &&
       Objects.equals(version, that.version) &&
-      isSystem == that.isSystem;
+      Objects.equals(scope, that.scope);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, version, isSystem);
+    return Objects.hash(name, version, scope);
   }
 
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/artifact/ArtifactScope.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/artifact/ArtifactScope.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.api.artifact;
+
+import co.cask.cdap.api.annotation.Beta;
+
+/**
+ * The scope of an artifact.
+ */
+@Beta
+public enum ArtifactScope {
+  SYSTEM,
+  USER
+}

--- a/cdap-api/src/main/java/co/cask/cdap/api/artifact/Plugin.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/artifact/Plugin.java
@@ -26,39 +26,24 @@ import java.util.Objects;
  * A container class for holding plugin information.
  */
 public final class Plugin {
-  private final String artifactName;
-  private final ArtifactVersion artifactVersion;
-  private final Boolean isSystem;
+  private final ArtifactId artifactId;
   private final URI locationURI;
   private final PluginClass pluginClass;
   private final PluginProperties properties;
 
-  public Plugin(String artifactName, ArtifactVersion artifactVersion, boolean isSystem, URI locationURI,
+  public Plugin(ArtifactId artifactId, URI locationURI,
                 PluginClass pluginClass, PluginProperties properties) {
-    this.artifactName = artifactName;
-    this.artifactVersion = artifactVersion;
-    this.isSystem = isSystem;
+    this.artifactId = artifactId;
     this.locationURI = locationURI;
     this.pluginClass = pluginClass;
     this.properties = properties;
   }
 
-  public String getArtifactName() {
-    return artifactName;
-  }
-
   /**
-   * @return {@link ArtifactVersion}
+   * @return the artifact id
    */
-  public ArtifactVersion getArtifactVersion() {
-    return artifactVersion;
-  }
-
-  /**
-   * @return true if the plugin is part of a system artifact
-   */
-  public boolean isSystem() {
-    return isSystem;
+  public ArtifactId getArtifactId() {
+    return artifactId;
   }
 
   /**
@@ -92,9 +77,7 @@ public final class Plugin {
     }
 
     Plugin that = (Plugin) o;
-    return Objects.equals(artifactName, that.artifactName)
-      && Objects.equals(artifactVersion, that.artifactVersion)
-      && Objects.equals(isSystem, that.isSystem)
+    return Objects.equals(artifactId, that.artifactId)
       && Objects.equals(locationURI, that.locationURI)
       && Objects.equals(pluginClass, that.pluginClass)
       && Objects.equals(properties, that.properties);
@@ -102,15 +85,13 @@ public final class Plugin {
 
   @Override
   public int hashCode() {
-    return Objects.hash(artifactName, artifactVersion, isSystem, locationURI, pluginClass, properties);
+    return Objects.hash(artifactId, locationURI, pluginClass, properties);
   }
 
   @Override
   public String toString() {
     return "AdapterPlugin{" +
-      "artifactName=" + artifactName +
-      ",artifactVersion=" + artifactVersion +
-      ",isSystem=" + isSystem +
+      "artifactId=" + artifactId +
       ",locationURI=" + locationURI +
       ",pluginClass=" + pluginClass +
       ",properties=" + properties +

--- a/cdap-api/src/main/java/co/cask/cdap/api/artifact/package-info.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/artifact/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Classes related to artifacts. An artifact is a jar file that contains classes that can be used by CDAP. For
+ * example, an artifact can contain an Application class to create applications from, or it can contain plugins that
+ * can be used by programs.
+ */
+package co.cask.cdap.api.artifact;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/DefaultAppConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/DefaultAppConfigurer.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.app.Application;
 import co.cask.cdap.api.app.ApplicationConfigurer;
 import co.cask.cdap.api.app.ApplicationSpecification;
 import co.cask.cdap.api.artifact.ArtifactId;
+import co.cask.cdap.api.artifact.ArtifactScope;
 import co.cask.cdap.api.flow.AbstractFlow;
 import co.cask.cdap.api.flow.Flow;
 import co.cask.cdap.api.flow.FlowSpecification;
@@ -223,7 +224,7 @@ public class DefaultAppConfigurer extends DefaultPluginConfigurer implements App
     // can be null only for apps before 3.2 that were not upgraded
     ArtifactId id = artifactId == null ? null :
       new ArtifactId(artifactId.getName(), artifactId.getVersion(),
-                     artifactId.getNamespace().equals(Id.Namespace.SYSTEM));
+                     artifactId.getNamespace().equals(Id.Namespace.SYSTEM) ? ArtifactScope.SYSTEM : ArtifactScope.USER);
     return new DefaultApplicationSpecification(name, description, configuration, id, getStreams(),
                                                getDatasetModules(), getDatasetSpecs(),
                                                flows, mapReduces, sparks, workflows, services,

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppLifecycleHttpHandler.java
@@ -18,6 +18,7 @@ package co.cask.cdap.gateway.handlers;
 
 import co.cask.cdap.api.ProgramSpecification;
 import co.cask.cdap.api.app.ApplicationSpecification;
+import co.cask.cdap.api.artifact.ArtifactScope;
 import co.cask.cdap.api.data.stream.StreamSpecification;
 import co.cask.cdap.api.schedule.SchedulableProgramType;
 import co.cask.cdap.app.runtime.ProgramController;
@@ -319,7 +320,8 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
 
           AppRequest<?> appRequest = GSON.fromJson(fileReader, AppRequest.class);
           ArtifactSummary artifactSummary = appRequest.getArtifact();
-          Id.Namespace artifactNamespace = artifactSummary.isSystem() ? Id.Namespace.SYSTEM : namespace;
+          Id.Namespace artifactNamespace =
+            ArtifactScope.SYSTEM.equals(artifactSummary.getScope()) ? Id.Namespace.SYSTEM : namespace;
           Id.Artifact artifactId =
             Id.Artifact.from(artifactNamespace, artifactSummary.getName(), artifactSummary.getVersion());
 
@@ -523,7 +525,7 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
     // the upgrade to v3.2 for some reason. In those cases artifact id will be null until they re-deploy the app.
     // in the meantime, we don't want this api call to null pointer exception.
     ArtifactSummary summary = spec.getArtifactId() == null ?
-      new ArtifactSummary(spec.getName(), null, false) : ArtifactSummary.from(spec.getArtifactId());
+      new ArtifactSummary(spec.getName(), null) : ArtifactSummary.from(spec.getArtifactId());
     return new ApplicationDetail(spec.getName(), spec.getDescription(), spec.getConfiguration(),
       streams, datasets, programs, summary);
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ArtifactHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ArtifactHttpHandler.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.gateway.handlers;
 
 import co.cask.cdap.api.artifact.ArtifactDescriptor;
+import co.cask.cdap.api.artifact.ArtifactScope;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.templates.plugins.PluginClass;
 import co.cask.cdap.app.program.ManifestFields;
@@ -74,6 +75,7 @@ import java.util.jar.Attributes;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 import java.util.zip.ZipException;
+import javax.annotation.Nullable;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
@@ -135,13 +137,19 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
   @Path("/namespaces/{namespace-id}/artifacts")
   public void getArtifacts(HttpRequest request, HttpResponder responder,
                            @PathParam("namespace-id") String namespaceId,
-                           @QueryParam("includeSystem") @DefaultValue("true") boolean includeSystem)
-    throws NamespaceNotFoundException {
+                           @Nullable @QueryParam("scope") String scope)
+    throws NamespaceNotFoundException, BadRequestException {
 
     Id.Namespace namespace = validateAndGetNamespace(namespaceId);
 
     try {
-      responder.sendJson(HttpResponseStatus.OK, artifactRepository.getArtifacts(namespace, includeSystem));
+      if (scope == null) {
+        responder.sendJson(HttpResponseStatus.OK, artifactRepository.getArtifacts(namespace, true));
+      } else {
+        ArtifactScope artifactScope = validateScope(scope);
+        Id.Namespace queryNamespace = artifactScope.equals(ArtifactScope.SYSTEM) ? Id.Namespace.SYSTEM : namespace;
+        responder.sendJson(HttpResponseStatus.OK, artifactRepository.getArtifacts(queryNamespace, false));
+      }
     } catch (IOException e) {
       LOG.error("Exception reading artifact metadata for namespace {} from the store.", namespaceId, e);
       responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, "Error reading artifact metadata from the store.");
@@ -153,10 +161,10 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
   public void getArtifactVersions(HttpRequest request, HttpResponder responder,
                                   @PathParam("namespace-id") String namespaceId,
                                   @PathParam("artifact-name") String artifactName,
-                                  @QueryParam("isSystem") @DefaultValue("false") boolean isSystem)
-    throws NamespaceNotFoundException {
+                                  @QueryParam("scope") @DefaultValue("user") String scope)
+    throws NamespaceNotFoundException, BadRequestException {
 
-    Id.Namespace namespace = validateAndGetNamespace(namespaceId, isSystem);
+    Id.Namespace namespace = validateAndGetNamespace(namespaceId, scope);
 
     try {
       responder.sendJson(HttpResponseStatus.OK, artifactRepository.getArtifacts(namespace, artifactName));
@@ -174,21 +182,17 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
                               @PathParam("namespace-id") String namespaceId,
                               @PathParam("artifact-name") String artifactName,
                               @PathParam("artifact-version") String artifactVersion,
-                              @QueryParam("isSystem") @DefaultValue("false") boolean isSystem)
+                              @QueryParam("scope") @DefaultValue("user") String scope)
     throws NamespaceNotFoundException, BadRequestException {
 
-    Id.Namespace namespace = validateAndGetNamespace(namespaceId, isSystem);
+    Id.Namespace namespace = validateAndGetNamespace(namespaceId, scope);
     Id.Artifact artifactId = validateAndGetArtifactId(namespace, artifactName, artifactVersion);
 
     try {
       ArtifactDetail detail = artifactRepository.getArtifact(artifactId);
       ArtifactDescriptor descriptor = detail.getDescriptor();
       // info hides some fields that are available in detail, such as the location of the artifact
-      ArtifactInfo info = new ArtifactInfo(
-        descriptor.getName(),
-        descriptor.getVersion().getVersion(),
-        descriptor.isSystem(),
-        detail.getMeta().getClasses());
+      ArtifactInfo info = new ArtifactInfo(descriptor.getArtifactId(), detail.getMeta().getClasses());
       responder.sendJson(HttpResponseStatus.OK, info, ArtifactInfo.class, GSON);
     } catch (ArtifactNotFoundException e) {
       responder.sendString(HttpResponseStatus.NOT_FOUND, "Artifact " + artifactId + " not found.");
@@ -204,10 +208,10 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
                                      @PathParam("namespace-id") String namespaceId,
                                      @PathParam("artifact-name") String artifactName,
                                      @PathParam("artifact-version") String artifactVersion,
-                                     @QueryParam("isSystem") @DefaultValue("false") boolean isSystem)
+                                     @QueryParam("scope") @DefaultValue("user") String scope)
     throws NamespaceNotFoundException, BadRequestException {
 
-    Id.Namespace namespace = validateAndGetNamespace(namespaceId, isSystem);
+    Id.Namespace namespace = validateAndGetNamespace(namespaceId, scope);
     Id.Artifact artifactId = validateAndGetArtifactId(namespace, artifactName, artifactVersion);
 
     try {
@@ -233,10 +237,10 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
                                  @PathParam("artifact-name") String artifactName,
                                  @PathParam("artifact-version") String artifactVersion,
                                  @PathParam("plugin-type") String pluginType,
-                                 @QueryParam("isSystem") @DefaultValue("false") boolean isSystem)
+                                 @QueryParam("scope") @DefaultValue("user") String scope)
     throws NamespaceNotFoundException, BadRequestException {
 
-    Id.Namespace namespace = validateAndGetNamespace(namespaceId, isSystem);
+    Id.Namespace namespace = validateAndGetNamespace(namespaceId, scope);
     Id.Artifact artifactId = validateAndGetArtifactId(namespace, artifactName, artifactVersion);
 
     try {
@@ -245,7 +249,7 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
       // flatten the map
       for (Map.Entry<ArtifactDescriptor, List<PluginClass>> pluginsEntry : plugins.entrySet()) {
         ArtifactDescriptor pluginArtifact = pluginsEntry.getKey();
-        ArtifactSummary pluginArtifactSummary = ArtifactSummary.from(pluginArtifact);
+        ArtifactSummary pluginArtifactSummary = ArtifactSummary.from(pluginArtifact.getArtifactId());
 
         for (PluginClass pluginClass : pluginsEntry.getValue()) {
           pluginSummaries.add(new PluginSummary(
@@ -270,10 +274,10 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
                                 @PathParam("artifact-version") String artifactVersion,
                                 @PathParam("plugin-type") String pluginType,
                                 @PathParam("plugin-name") String pluginName,
-                                @QueryParam("isSystem") @DefaultValue("false") boolean isSystem)
+                                @QueryParam("scope") @DefaultValue("user") String scope)
     throws NamespaceNotFoundException, BadRequestException {
 
-    Id.Namespace namespace = validateAndGetNamespace(namespaceId, isSystem);
+    Id.Namespace namespace = validateAndGetNamespace(namespaceId, scope);
     Id.Artifact artifactId = validateAndGetArtifactId(namespace, artifactName, artifactVersion);
 
     try {
@@ -284,7 +288,7 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
       // flatten the map
       for (Map.Entry<ArtifactDescriptor, PluginClass> pluginsEntry : plugins.entrySet()) {
         ArtifactDescriptor pluginArtifact = pluginsEntry.getKey();
-        ArtifactSummary pluginArtifactSummary = ArtifactSummary.from(pluginArtifact);
+        ArtifactSummary pluginArtifactSummary = ArtifactSummary.from(pluginArtifact.getArtifactId());
 
         PluginClass pluginClass = pluginsEntry.getValue();
         pluginInfos.add(new PluginInfo(
@@ -305,14 +309,21 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
   @Path("/namespaces/{namespace-id}/classes/apps")
   public void getApplicationClasses(HttpRequest request, HttpResponder responder,
                                     @PathParam("namespace-id") String namespaceId,
-                                    @QueryParam("includeSystem") @DefaultValue("true") boolean includeSystem)
-    throws NamespaceNotFoundException {
+                                    @Nullable @QueryParam("scope") String scope)
+    throws NamespaceNotFoundException, BadRequestException {
 
     Id.Namespace namespace = validateAndGetNamespace(namespaceId);
 
     try {
-      responder.sendJson(HttpResponseStatus.OK, artifactRepository.getApplicationClasses(namespace, includeSystem),
-                         APPCLASS_SUMMARIES_TYPE, GSON);
+      if (scope == null) {
+        responder.sendJson(HttpResponseStatus.OK, artifactRepository.getApplicationClasses(namespace, true),
+          APPCLASS_SUMMARIES_TYPE, GSON);
+      } else {
+        ArtifactScope artifactScope = validateScope(scope);
+        Id.Namespace queryNamespace = ArtifactScope.SYSTEM.equals(artifactScope) ? Id.Namespace.SYSTEM : namespace;
+        responder.sendJson(HttpResponseStatus.OK, artifactRepository.getApplicationClasses(queryNamespace, false),
+          APPCLASS_SUMMARIES_TYPE, GSON);
+      }
     } catch (IOException e) {
       LOG.error("Error getting app classes for namespace {}.", namespaceId, e);
       responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR,
@@ -325,10 +336,10 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
   public void getApplicationClasses(HttpRequest request, HttpResponder responder,
                                     @PathParam("namespace-id") String namespaceId,
                                     @PathParam("classname") String className,
-                                    @QueryParam("isSystem") @DefaultValue("true") boolean isSystem)
-    throws NamespaceNotFoundException {
+                                    @QueryParam("scope") @DefaultValue("user") String scope)
+    throws NamespaceNotFoundException, BadRequestException {
 
-    Id.Namespace namespace = validateAndGetNamespace(namespaceId, isSystem);
+    Id.Namespace namespace = validateAndGetNamespace(namespaceId, scope);
 
     try {
       responder.sendJson(HttpResponseStatus.OK, artifactRepository.getApplicationClasses(namespace, className),
@@ -457,13 +468,31 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
     }
   }
 
+  private ArtifactScope validateScope(String scope) throws BadRequestException {
+    try {
+      return ArtifactScope.valueOf(scope.toUpperCase());
+    } catch (IllegalArgumentException e) {
+      throw new BadRequestException("Invalid scope " + scope);
+    }
+  }
+
   private Id.Namespace validateAndGetNamespace(String namespaceId) throws NamespaceNotFoundException {
-    return validateAndGetNamespace(namespaceId, false);
+    return validateAndGetNamespace(namespaceId, ArtifactScope.USER);
+  }
+
+  private Id.Namespace validateAndGetNamespace(String namespaceId, String scope)
+    throws NamespaceNotFoundException, BadRequestException {
+    if (scope != null) {
+      return validateAndGetNamespace(namespaceId, validateScope(scope));
+    }
+    return validateAndGetNamespace(namespaceId, ArtifactScope.USER);
   }
 
   // check that the namespace exists, and check if the request is only supposed to include system artifacts,
   // and returning the system namespace if so.
-  private Id.Namespace validateAndGetNamespace(String namespaceId, boolean isSystem) throws NamespaceNotFoundException {
+  private Id.Namespace validateAndGetNamespace(String namespaceId, ArtifactScope scope)
+    throws NamespaceNotFoundException {
+
     Id.Namespace namespace = Id.Namespace.from(namespaceId);
     try {
       namespaceAdmin.get(namespace);
@@ -476,7 +505,7 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
       throw Throwables.propagate(e);
     }
 
-    return isSystem ? Id.Namespace.SYSTEM : namespace;
+    return ArtifactScope.SYSTEM.equals(scope) ? Id.Namespace.SYSTEM : namespace;
   }
 
   private Id.Artifact validateAndGetArtifactId(Id.Namespace namespace, String name,

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ArtifactHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ArtifactHttpHandler.java
@@ -140,15 +140,13 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
                            @Nullable @QueryParam("scope") String scope)
     throws NamespaceNotFoundException, BadRequestException {
 
-    Id.Namespace namespace = validateAndGetNamespace(namespaceId);
-
     try {
       if (scope == null) {
+        Id.Namespace namespace = validateAndGetNamespace(namespaceId);
         responder.sendJson(HttpResponseStatus.OK, artifactRepository.getArtifacts(namespace, true));
       } else {
-        ArtifactScope artifactScope = validateScope(scope);
-        Id.Namespace queryNamespace = artifactScope.equals(ArtifactScope.SYSTEM) ? Id.Namespace.SYSTEM : namespace;
-        responder.sendJson(HttpResponseStatus.OK, artifactRepository.getArtifacts(queryNamespace, false));
+        Id.Namespace namespace = validateAndGetNamespace(namespaceId, scope);
+        responder.sendJson(HttpResponseStatus.OK, artifactRepository.getArtifacts(namespace, false));
       }
     } catch (IOException e) {
       LOG.error("Exception reading artifact metadata for namespace {} from the store.", namespaceId, e);
@@ -312,16 +310,14 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
                                     @Nullable @QueryParam("scope") String scope)
     throws NamespaceNotFoundException, BadRequestException {
 
-    Id.Namespace namespace = validateAndGetNamespace(namespaceId);
-
     try {
       if (scope == null) {
+        Id.Namespace namespace = validateAndGetNamespace(namespaceId);
         responder.sendJson(HttpResponseStatus.OK, artifactRepository.getApplicationClasses(namespace, true),
           APPCLASS_SUMMARIES_TYPE, GSON);
       } else {
-        ArtifactScope artifactScope = validateScope(scope);
-        Id.Namespace queryNamespace = ArtifactScope.SYSTEM.equals(artifactScope) ? Id.Namespace.SYSTEM : namespace;
-        responder.sendJson(HttpResponseStatus.OK, artifactRepository.getApplicationClasses(queryNamespace, false),
+        Id.Namespace namespace = validateAndGetNamespace(namespaceId, scope);
+        responder.sendJson(HttpResponseStatus.OK, artifactRepository.getApplicationClasses(namespace, false),
           APPCLASS_SUMMARIES_TYPE, GSON);
       }
     } catch (IOException e) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/util/AbstractAppFabricHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/util/AbstractAppFabricHttpHandler.java
@@ -19,6 +19,7 @@ package co.cask.cdap.gateway.handlers.util;
 import co.cask.cdap.api.ProgramSpecification;
 import co.cask.cdap.api.app.ApplicationSpecification;
 import co.cask.cdap.api.artifact.ArtifactId;
+import co.cask.cdap.api.artifact.ArtifactScope;
 import co.cask.cdap.app.runtime.ProgramRuntimeService;
 import co.cask.cdap.app.store.Store;
 import co.cask.cdap.common.NamespaceNotFoundException;
@@ -185,11 +186,10 @@ public abstract class AbstractAppFabricHttpHandler extends AbstractHttpHandler {
 
     List<ApplicationRecord> appRecords = new ArrayList<>();
     for (ApplicationSpecification appSpec : store.getApplications(namespace, artifactName, artifactVersion)) {
-      // null artifact id means its an application template
-      // TODO: (CDAP-3359) remove generated artifact summary when ApplicationTemplates are removed
+      // possible if this particular app was deploy prior to v3.2 and upgrade failed for some reason.
       ArtifactId artifactId = appSpec.getArtifactId();
       ArtifactSummary artifactSummary = artifactId == null ?
-        new ArtifactSummary(appSpec.getName(), null, true) : ArtifactSummary.from(artifactId);
+        new ArtifactSummary(appSpec.getName(), null) : ArtifactSummary.from(artifactId);
       appRecords.add(new ApplicationRecord(artifactSummary, appSpec.getName(), appSpec.getDescription()));
     }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/DefaultPluginConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/DefaultPluginConfigurer.java
@@ -155,8 +155,7 @@ public class DefaultPluginConfigurer extends DefaultDatasetConfigurer implements
    */
   private void registerPlugin(String pluginId, ArtifactDescriptor artifactDescriptor, PluginClass pluginClass,
                               PluginProperties properties) {
-    plugins.put(pluginId, new Plugin(artifactDescriptor.getName(), artifactDescriptor.getVersion(),
-                                     artifactDescriptor.isSystem(), artifactDescriptor.getLocation().toURI(),
+    plugins.put(pluginId, new Plugin(artifactDescriptor.getArtifactId(), artifactDescriptor.getLocation().toURI(),
                                      pluginClass, properties));
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractContext.java
@@ -335,8 +335,7 @@ public abstract class AbstractContext extends AbstractServiceDiscoverer
     Plugin plugin = getPlugin(pluginId);
     try {
       URI locationURI = plugin.getLocationURI();
-      ArtifactDescriptor artifactDescriptor = new ArtifactDescriptor(plugin.getArtifactName(),
-                                                                     plugin.getArtifactVersion(), plugin.isSystem(),
+      ArtifactDescriptor artifactDescriptor = new ArtifactDescriptor(plugin.getArtifactId(),
                                                                      locationFactory.create(locationURI));
       return artifactPluginInstantiator.loadClass(artifactDescriptor, plugin.getPluginClass());
     } catch (ClassNotFoundException e) {
@@ -356,8 +355,7 @@ public abstract class AbstractContext extends AbstractServiceDiscoverer
     Plugin plugin = getPlugin(pluginId);
     try {
       URI locationURI = plugin.getLocationURI();
-      ArtifactDescriptor artifactDescriptor = new ArtifactDescriptor(plugin.getArtifactName(),
-                                                                     plugin.getArtifactVersion(), plugin.isSystem(),
+      ArtifactDescriptor artifactDescriptor = new ArtifactDescriptor(plugin.getArtifactId(),
                                                                      locationFactory.create(locationURI));
       return artifactPluginInstantiator.newInstance(artifactDescriptor, plugin.getPluginClass(),
                                                     plugin.getProperties());

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/PluginInstantiator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/adapter/PluginInstantiator.java
@@ -18,6 +18,8 @@ package co.cask.cdap.internal.app.runtime.adapter;
 
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.artifact.ArtifactDescriptor;
+import co.cask.cdap.api.artifact.ArtifactId;
+import co.cask.cdap.api.artifact.ArtifactScope;
 import co.cask.cdap.api.artifact.ArtifactVersion;
 import co.cask.cdap.api.data.schema.UnsupportedTypeException;
 import co.cask.cdap.api.templates.plugins.PluginClass;
@@ -381,8 +383,9 @@ public class PluginInstantiator implements Closeable {
 
   private ArtifactDescriptor getDescriptor(PluginInfo pluginInfo) {
     File file = new File(pluginDir, pluginInfo.getFileName());
-    return new ArtifactDescriptor(
-      pluginInfo.getName(), new ArtifactVersion(pluginInfo.getVersion().getVersion()), true, Locations.toLocation(file)
-    );
+    ArtifactId artifactId = new ArtifactId(pluginInfo.getName(),
+                                           new ArtifactVersion(pluginInfo.getVersion().getVersion()),
+                                           ArtifactScope.SYSTEM);
+    return new ArtifactDescriptor(artifactId, Locations.toLocation(file));
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactInspector.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactInspector.java
@@ -215,10 +215,8 @@ public class ArtifactInspector {
     }
 
     // Load the plugin class and inspect the config field.
-    ArtifactDescriptor artifactDescriptor = new ArtifactDescriptor(
-      artifactId.getName(), artifactId.getVersion(),
-      Id.Namespace.SYSTEM.equals(artifactId.getNamespace()),
-      Locations.toLocation(artifactFile));
+    ArtifactDescriptor artifactDescriptor = new ArtifactDescriptor(artifactId.toArtifactId(),
+                                                                   Locations.toLocation(artifactFile));
 
     try {
       ClassLoader pluginClassLoader = pluginInstantiator.getArtifactClassLoader(artifactDescriptor);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepository.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepository.java
@@ -169,7 +169,7 @@ public class ArtifactRepository {
     List<ApplicationClassInfo> infos = Lists.newArrayList();
     for (Map.Entry<ArtifactDescriptor, ApplicationClass> entry :
       artifactStore.getApplicationClasses(namespace, className).entrySet()) {
-      ArtifactSummary artifactSummary = ArtifactSummary.from(entry.getKey());
+      ArtifactSummary artifactSummary = ArtifactSummary.from(entry.getKey().getArtifactId());
       ApplicationClass appClass = entry.getValue();
       infos.add(new ApplicationClassInfo(artifactSummary, appClass.getClassName(), appClass.getConfigSchema()));
     }
@@ -465,7 +465,7 @@ public class ArtifactRepository {
   // convert details to summaries (to hide location and other unnecessary information)
   private List<ArtifactSummary> convertAndAdd(List<ArtifactSummary> summaries, Iterable<ArtifactDetail> details) {
     for (ArtifactDetail detail : details) {
-      summaries.add(ArtifactSummary.from(detail.getDescriptor()));
+      summaries.add(ArtifactSummary.from(detail.getDescriptor().getArtifactId()));
     }
     return summaries;
   }
@@ -507,9 +507,9 @@ public class ArtifactRepository {
         isInvalid = true;
         errMsg
           .append(" Parent '")
-          .append(parent.getDescriptor().getName())
+          .append(parent.getDescriptor().getArtifactId().getName())
           .append("-")
-          .append(parent.getDescriptor().getVersion().getVersion())
+          .append(parent.getDescriptor().getArtifactId().getVersion().getVersion())
           .append("' has parents.");
       }
     }
@@ -526,7 +526,7 @@ public class ArtifactRepository {
   private void addAppSummaries(List<ApplicationClassSummary> summaries, Id.Namespace namespace) {
     for (Map.Entry<ArtifactDescriptor, List<ApplicationClass>> classInfo :
       artifactStore.getApplicationClasses(namespace).entrySet()) {
-      ArtifactSummary artifactSummary = ArtifactSummary.from(classInfo.getKey());
+      ArtifactSummary artifactSummary = ArtifactSummary.from(classInfo.getKey().getArtifactId());
 
       for (ApplicationClass appClass : classInfo.getValue()) {
         summaries.add(new ApplicationClassSummary(artifactSummary, appClass.getClassName()));

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStore.java
@@ -216,8 +216,8 @@ public class ArtifactStore {
           if (range.versionIsInRange(new ArtifactVersion(version))) {
             ArtifactData data = gson.fromJson(Bytes.toString(columnEntry.getValue()), ArtifactData.class);
             Id.Artifact artifactId = Id.Artifact.from(artifactKey.namespace, artifactKey.name, version);
-            artifacts.add(
-              new ArtifactDetail(getDescriptor(artifactId, locationFactory.create(data.locationURI)), data.meta));
+            artifacts.add(new ArtifactDetail(new ArtifactDescriptor(
+              artifactId.toArtifactId(), locationFactory.create(data.locationURI)), data.meta));
           }
         }
         return Collections.unmodifiableList(artifacts);
@@ -279,7 +279,9 @@ public class ArtifactStore {
     if (data == null) {
       throw new ArtifactNotFoundException(artifactId);
     }
-    return new ArtifactDetail(getDescriptor(artifactId, locationFactory.create(data.locationURI)), data.meta);
+    return new ArtifactDetail(
+      new ArtifactDescriptor(artifactId.toArtifactId(), locationFactory.create(data.locationURI)),
+      data.meta);
   }
 
   /**
@@ -307,8 +309,8 @@ public class ArtifactStore {
               ArtifactColumn artifactColumn = ArtifactColumn.parse(column.getKey());
               AppData appData = gson.fromJson(Bytes.toString(column.getValue()), AppData.class);
 
-              ArtifactDescriptor artifactDescriptor =
-                getDescriptor(artifactColumn.artifactId, locationFactory.create(appData.artifactLocationURI));
+              ArtifactDescriptor artifactDescriptor = new ArtifactDescriptor(
+                artifactColumn.artifactId.toArtifactId(), locationFactory.create(appData.artifactLocationURI));
               List<ApplicationClass> existingAppClasses = result.get(artifactDescriptor);
               if (existingAppClasses == null) {
                 existingAppClasses = new ArrayList<>();
@@ -348,8 +350,8 @@ public class ArtifactStore {
               ArtifactColumn artifactColumn = ArtifactColumn.parse(column.getKey());
               AppData appData = gson.fromJson(Bytes.toString(column.getValue()), AppData.class);
 
-              ArtifactDescriptor artifactDescriptor =
-                getDescriptor(artifactColumn.artifactId, locationFactory.create(appData.artifactLocationURI));
+              ArtifactDescriptor artifactDescriptor = new ArtifactDescriptor(
+                artifactColumn.artifactId.toArtifactId(), locationFactory.create(appData.artifactLocationURI));
               result.put(artifactDescriptor, appData.appClass);
             }
           }
@@ -446,8 +448,8 @@ public class ArtifactStore {
               PluginData pluginData = gson.fromJson(Bytes.toString(column.getValue()), PluginData.class);
               // filter out plugins that don't extend this version of the parent artifact
               if (pluginData.usableBy.versionIsInRange(parentArtifactId.getVersion())) {
-                ArtifactDescriptor artifactInfo =
-                  getDescriptor(artifactColumn.artifactId, locationFactory.create(pluginData.artifactLocationURI));
+                ArtifactDescriptor artifactInfo = new ArtifactDescriptor(
+                  artifactColumn.artifactId.toArtifactId(), locationFactory.create(pluginData.artifactLocationURI));
                 result.put(artifactInfo, pluginData.pluginClass);
               }
             }
@@ -547,7 +549,7 @@ public class ArtifactStore {
       destination.delete();
       throw new IOException(e);
     }
-    return new ArtifactDetail(getDescriptor(artifactId, destination), artifactMeta);
+    return new ArtifactDetail(new ArtifactDescriptor(artifactId.toArtifactId(), destination), artifactMeta);
   }
 
   /**
@@ -710,7 +712,8 @@ public class ArtifactStore {
       ArtifactData data = gson.fromJson(Bytes.toString(columnVal.getValue()), ArtifactData.class);
       Id.Artifact artifactId = Id.Artifact.from(artifactKey.namespace, artifactKey.name, version);
       artifactDetails.add(new ArtifactDetail(
-        getDescriptor(artifactId, locationFactory.create(data.locationURI)), data.meta));
+        new ArtifactDescriptor(artifactId.toArtifactId(), locationFactory.create(data.locationURI)),
+        data.meta));
     }
   }
 
@@ -725,8 +728,8 @@ public class ArtifactStore {
 
       // filter out plugins that don't extend this version of the parent artifact
       if (pluginData.usableBy.versionIsInRange(parentArtifactId.getVersion())) {
-        ArtifactDescriptor artifactDescriptor =
-          getDescriptor(artifactColumn.artifactId, locationFactory.create(pluginData.artifactLocationURI));
+        ArtifactDescriptor artifactDescriptor = new ArtifactDescriptor(
+          artifactColumn.artifactId.toArtifactId(), locationFactory.create(pluginData.artifactLocationURI));
 
         if (!map.containsKey(artifactDescriptor)) {
           map.put(artifactDescriptor, Lists.<PluginClass>newArrayList());
@@ -734,11 +737,6 @@ public class ArtifactStore {
         map.get(artifactDescriptor).add(pluginData.pluginClass);
       }
     }
-  }
-
-  private ArtifactDescriptor getDescriptor(Id.Artifact artifactId, Location location) {
-    return new ArtifactDescriptor(artifactId.getName(), artifactId.getVersion(),
-                                  Id.Namespace.SYSTEM.equals(artifactId.getNamespace()), location);
   }
 
   private Scan scanArtifacts(Id.Namespace namespace) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceClassLoader.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceClassLoader.java
@@ -311,9 +311,7 @@ public class MapReduceClassLoader extends CombineClassLoader {
           locationFactory = (MapReduceTaskContextProvider.isLocal(hConf)) ? localLocationFactory : hdfsLocationFactory;
           List<ClassLoader> pluginClassLoaders = Lists.newArrayList();
           for (Plugin plugin : plugins.values()) {
-            ArtifactDescriptor artifactDescriptor = new ArtifactDescriptor(plugin.getArtifactName(),
-                                                                           plugin.getArtifactVersion(),
-                                                                           plugin.isSystem(),
+            ArtifactDescriptor artifactDescriptor = new ArtifactDescriptor(plugin.getArtifactId(),
                                                                            locationFactory.create(
                                                                              plugin.getLocationURI()));
             ClassLoader pluginClassLoader = artifactPluginInstantiator.getArtifactClassLoader(artifactDescriptor);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepositoryTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepositoryTest.java
@@ -165,13 +165,15 @@ public class ArtifactRepositoryTest {
       pluginNames.add(pluginClass.getName());
     }
     Assert.assertEquals(Sets.newHashSet("manual1", "manual2", "TestPlugin", "TestPlugin2"), pluginNames);
-    Assert.assertEquals(systemAppArtifactId.getName(), appArtifactDetail.getDescriptor().getName());
-    Assert.assertEquals(systemAppArtifactId.getVersion(), appArtifactDetail.getDescriptor().getVersion());
+    Assert.assertEquals(systemAppArtifactId.getName(), appArtifactDetail.getDescriptor().getArtifactId().getName());
+    Assert.assertEquals(systemAppArtifactId.getVersion(),
+                        appArtifactDetail.getDescriptor().getArtifactId().getVersion());
 
     // check plugin artifact added correctly
     ArtifactDetail pluginArtifactDetail = artifactRepository.getArtifact(pluginArtifactId);
-    Assert.assertEquals(pluginArtifactId.getName(), pluginArtifactDetail.getDescriptor().getName());
-    Assert.assertEquals(pluginArtifactId.getVersion(), pluginArtifactDetail.getDescriptor().getVersion());
+    Assert.assertEquals(pluginArtifactId.getName(), pluginArtifactDetail.getDescriptor().getArtifactId().getName());
+    Assert.assertEquals(pluginArtifactId.getVersion(),
+                        pluginArtifactDetail.getDescriptor().getArtifactId().getVersion());
     // check manually added plugins are there
     Assert.assertTrue(pluginArtifactDetail.getMeta().getClasses().getPlugins().containsAll(manuallyAddedPlugins));
   }
@@ -245,7 +247,7 @@ public class ArtifactRepositoryTest {
     Map.Entry<ArtifactDescriptor, PluginClass> plugin =
       artifactRepository.findPlugin(APP_ARTIFACT_ID, "plugin", "TestPlugin2", new PluginSelector());
     Assert.assertNotNull(plugin);
-    Assert.assertEquals(new ArtifactVersion("1.0"), plugin.getKey().getVersion());
+    Assert.assertEquals(new ArtifactVersion("1.0"), plugin.getKey().getArtifactId().getVersion());
     Assert.assertEquals("TestPlugin2", plugin.getValue().getName());
 
     // Create another plugin jar with later version and update the repository
@@ -256,7 +258,7 @@ public class ArtifactRepositoryTest {
     // Should select the latest version
     plugin = artifactRepository.findPlugin(APP_ARTIFACT_ID, "plugin", "TestPlugin2", new PluginSelector());
     Assert.assertNotNull(plugin);
-    Assert.assertEquals(new ArtifactVersion("2.0"), plugin.getKey().getVersion());
+    Assert.assertEquals(new ArtifactVersion("2.0"), plugin.getKey().getArtifactId().getVersion());
     Assert.assertEquals("TestPlugin2", plugin.getValue().getName());
 
     // Load the Plugin class from the classLoader.
@@ -272,7 +274,7 @@ public class ArtifactRepositoryTest {
       }
     });
     Assert.assertNotNull(plugin);
-    Assert.assertEquals(new ArtifactVersion("1.0"), plugin.getKey().getVersion());
+    Assert.assertEquals(new ArtifactVersion("1.0"), plugin.getKey().getArtifactId().getVersion());
     Assert.assertEquals("TestPlugin2", plugin.getValue().getName());
 
     // Load the Plugin class again from the current plugin selected

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStoreTest.java
@@ -20,6 +20,7 @@ import co.cask.cdap.WordCountApp;
 import co.cask.cdap.api.artifact.ApplicationClass;
 import co.cask.cdap.api.artifact.ArtifactClasses;
 import co.cask.cdap.api.artifact.ArtifactDescriptor;
+import co.cask.cdap.api.artifact.ArtifactScope;
 import co.cask.cdap.api.artifact.ArtifactVersion;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.templates.plugins.PluginClass;
@@ -181,7 +182,7 @@ public class ArtifactStoreTest {
     // shouldn't see it in the list
     List<ArtifactDetail> artifactList = artifactStore.getArtifacts(parentId.getNamespace());
     Assert.assertEquals(1, artifactList.size());
-    Assert.assertEquals(parentId.getName(), artifactList.get(0).getDescriptor().getName());
+    Assert.assertEquals(parentId.getName(), artifactList.get(0).getDescriptor().getArtifactId().getName());
     // shouldn't see any more plugins for parent
     Assert.assertTrue(artifactStore.getPluginClasses(parentId).isEmpty());
 
@@ -849,10 +850,10 @@ public class ArtifactStoreTest {
 
   private void assertEqual(Id.Artifact expectedId, ArtifactMeta expectedMeta,
                            String expectedContents, ArtifactDetail actual) throws IOException {
-    Assert.assertEquals(expectedId.getName(), actual.getDescriptor().getName());
-    Assert.assertEquals(expectedId.getVersion(), actual.getDescriptor().getVersion());
+    Assert.assertEquals(expectedId.getName(), actual.getDescriptor().getArtifactId().getName());
+    Assert.assertEquals(expectedId.getVersion(), actual.getDescriptor().getArtifactId().getVersion());
     Assert.assertEquals(expectedId.getNamespace().equals(Id.Namespace.SYSTEM),
-                        actual.getDescriptor().isSystem());
+                        actual.getDescriptor().getArtifactId().getScope().equals(ArtifactScope.SYSTEM));
     Assert.assertEquals(expectedMeta, actual.getMeta());
     Assert.assertEquals(expectedContents, CharStreams.toString(
       new InputStreamReader(actual.getDescriptor().getLocation().getInputStream(), Charsets.UTF_8)));

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/ApplicationLifecycleServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/ApplicationLifecycleServiceTest.java
@@ -20,6 +20,7 @@ import co.cask.cdap.AppWithMR;
 import co.cask.cdap.api.app.Application;
 import co.cask.cdap.api.app.ApplicationSpecification;
 import co.cask.cdap.api.artifact.ArtifactId;
+import co.cask.cdap.api.artifact.ArtifactScope;
 import co.cask.cdap.api.artifact.ArtifactVersion;
 import co.cask.cdap.app.DefaultAppConfigurer;
 import co.cask.cdap.app.DefaultApplicationContext;
@@ -83,13 +84,13 @@ public class ApplicationLifecycleServiceTest extends AppFabricTestBase {
 
       // app spec should now have an artifact id
       appSpec = store.getApplication(appId);
-      Assert.assertEquals(new ArtifactId(appSpec.getName(), new ArtifactVersion("3.1.0"), false),
+      Assert.assertEquals(new ArtifactId(appSpec.getName(), new ArtifactVersion("3.1.0"), ArtifactScope.USER),
                           appSpec.getArtifactId());
 
       // run upgrade again to make sure it doesn't break anything
       applicationLifecycleService.upgrade(false);
       appSpec = store.getApplication(appId);
-      Assert.assertEquals(new ArtifactId(appSpec.getName(), new ArtifactVersion("3.1.0"), false),
+      Assert.assertEquals(new ArtifactId(appSpec.getName(), new ArtifactVersion("3.1.0"), ArtifactScope.USER),
                           appSpec.getArtifactId());
     } finally {
       appJar.delete();
@@ -168,7 +169,7 @@ public class ApplicationLifecycleServiceTest extends AppFabricTestBase {
       // run upgrade
       applicationLifecycleService.upgrade(false);
       appSpec = store.getApplication(appId);
-      Assert.assertEquals(new ArtifactId(artifactId.getName(), artifactId.getVersion(), false),
+      Assert.assertEquals(new ArtifactId(artifactId.getName(), artifactId.getVersion(), ArtifactScope.USER),
                           appSpec.getArtifactId());
     } finally {
       appJar.delete();

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/AppLifecycleHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/AppLifecycleHttpHandlerTest.java
@@ -22,6 +22,7 @@ import co.cask.cdap.BloatedWordCountApp;
 import co.cask.cdap.ConfigTestApp;
 import co.cask.cdap.WordCountApp;
 import co.cask.cdap.api.Config;
+import co.cask.cdap.api.artifact.ArtifactScope;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.gateway.handlers.AppLifecycleHttpHandler;
 import co.cask.cdap.internal.app.services.http.AppFabricTestBase;
@@ -36,7 +37,6 @@ import org.apache.http.HttpResponse;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
@@ -80,7 +80,7 @@ public class AppLifecycleHttpHandlerTest extends AppFabricTestBase {
   public void testDeployUsingNonexistantArtifact404() throws Exception {
     Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "badapp");
     AppRequest<Config> appRequest =
-      new AppRequest<>(new ArtifactSummary("something", "1.0.0", false), null);
+      new AppRequest<>(new ArtifactSummary("something", "1.0.0"), null);
     HttpResponse response = deploy(appId, appRequest);
     Assert.assertEquals(404, response.getStatusLine().getStatusCode());
   }
@@ -93,7 +93,7 @@ public class AppLifecycleHttpHandlerTest extends AppFabricTestBase {
     Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "cfgApp");
     ConfigTestApp.ConfigClass config = new ConfigTestApp.ConfigClass("abc", "def");
     AppRequest<ConfigTestApp.ConfigClass> request = new AppRequest<>(
-      new ArtifactSummary(artifactId.getName(), artifactId.getVersion().getVersion(), false), config);
+      new ArtifactSummary(artifactId.getName(), artifactId.getVersion().getVersion()), config);
     Assert.assertEquals(200, deploy(appId, request).getStatusLine().getStatusCode());
 
     JsonObject appDetails = getAppDetails(Id.Namespace.DEFAULT.getId(), appId.getId());

--- a/cdap-app-templates/cdap-data-quality/src/test/java/co/cask/cdap/dq/DataQualityAppTest.java
+++ b/cdap-app-templates/cdap-data-quality/src/test/java/co/cask/cdap/dq/DataQualityAppTest.java
@@ -120,7 +120,7 @@ public class DataQualityAppTest extends TestBase {
       50, getStreamSource(), "avg", null);
 
     AppRequest<DataQualityApp.DataQualityConfig> appRequest = new AppRequest<>(
-      new ArtifactSummary(appArtifact.getName(), appArtifact.getVersion().getVersion(), false), config);
+      new ArtifactSummary(appArtifact.getName(), appArtifact.getVersion().getVersion()), config);
     deployApplication(appId, appRequest);
   }
 
@@ -136,7 +136,7 @@ public class DataQualityAppTest extends TestBase {
       WORKFLOW_SCHEDULE_MINUTES, getStreamSource(), "dataQuality", testMap);
     Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "newApp");
     AppRequest<DataQualityApp.DataQualityConfig> appRequest = new AppRequest<>(
-      new ArtifactSummary(appArtifact.getName(), appArtifact.getVersion().getVersion(), false), config);
+      new ArtifactSummary(appArtifact.getName(), appArtifact.getVersion().getVersion()), config);
     ApplicationManager applicationManager = deployApplication(appId, appRequest);
 
     MapReduceManager mrManager = applicationManager.getMapReduceManager("FieldAggregator").start();
@@ -180,7 +180,7 @@ public class DataQualityAppTest extends TestBase {
 
     Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "newApp2");
     AppRequest<DataQualityApp.DataQualityConfig> appRequest = new AppRequest<>(
-      new ArtifactSummary(appArtifact.getName(), appArtifact.getVersion().getVersion(), false), config);
+      new ArtifactSummary(appArtifact.getName(), appArtifact.getVersion().getVersion()), config);
     ApplicationManager applicationManager = deployApplication(appId, appRequest);
 
     MapReduceManager mrManager = applicationManager.getMapReduceManager("FieldAggregator").start();
@@ -223,7 +223,7 @@ public class DataQualityAppTest extends TestBase {
 
     Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "newApp3");
     AppRequest<DataQualityApp.DataQualityConfig> appRequest = new AppRequest<>(
-      new ArtifactSummary(appArtifact.getName(), appArtifact.getVersion().getVersion(), false), config);
+      new ArtifactSummary(appArtifact.getName(), appArtifact.getVersion().getVersion()), config);
     ApplicationManager applicationManager = deployApplication(appId, appRequest);
 
     MapReduceManager mrManager = applicationManager.getMapReduceManager("FieldAggregator").start();

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch-app/src/test/java/co/cask/cdap/app/etl/batch/BaseETLBatchTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch-app/src/test/java/co/cask/cdap/app/etl/batch/BaseETLBatchTest.java
@@ -75,7 +75,7 @@ public class BaseETLBatchTest extends TestBase {
   public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
 
   protected static final Id.Artifact APP_ARTIFACT_ID = Id.Artifact.from(Id.Namespace.DEFAULT, "etlbatch", "3.2.0");
-  protected static final ArtifactSummary ETLBATCH_ARTIFACT = new ArtifactSummary("etlbatch", "3.2.0", false);
+  protected static final ArtifactSummary ETLBATCH_ARTIFACT = new ArtifactSummary("etlbatch", "3.2.0");
   protected static final Id.Namespace NAMESPACE = Id.Namespace.DEFAULT;
   protected static final Id.ApplicationTemplate TEMPLATE_ID = Id.ApplicationTemplate.from("ETLBatch");
   protected static final Gson GSON = new Gson();

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/ApplicationClientTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/ApplicationClientTestRun.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.client;
 
 import co.cask.cdap.api.Config;
+import co.cask.cdap.api.artifact.ArtifactScope;
 import co.cask.cdap.client.app.AppReturnsArgs;
 import co.cask.cdap.client.app.ConfigTestApp;
 import co.cask.cdap.client.app.ConfigurableProgramsApp;
@@ -128,7 +129,7 @@ public class ApplicationClientTestRun extends ClientTestBase {
       verifyProgramRecords(FakeApp.ALL_PROGRAMS, appClient.listAllPrograms(Id.Namespace.DEFAULT));
 
       ApplicationDetail appDetail = appClient.get(app);
-      ArtifactSummary expected = new ArtifactSummary(FakeApp.NAME, "1.0.0-SNAPSHOT", false);
+      ArtifactSummary expected = new ArtifactSummary(FakeApp.NAME, "1.0.0-SNAPSHOT");
       Assert.assertEquals(expected, appDetail.getArtifact());
     } finally {
       // delete app
@@ -173,7 +174,7 @@ public class ApplicationClientTestRun extends ClientTestBase {
       ConfigurableProgramsApp.Programs conf =
         new ConfigurableProgramsApp.Programs(null, "worker1", "stream1", "dataset1");
       AppRequest<ConfigurableProgramsApp.Programs> request = new AppRequest<>(
-        new ArtifactSummary(artifactIdV1.getName(), artifactIdV1.getVersion().getVersion(), false), conf);
+        new ArtifactSummary(artifactIdV1.getName(), artifactIdV1.getVersion().getVersion()), conf);
       appClient.deploy(appId, request);
 
       // should only have the worker
@@ -183,7 +184,7 @@ public class ApplicationClientTestRun extends ClientTestBase {
       // update to use just the flow
       conf = new ConfigurableProgramsApp.Programs("flow1", null, "stream1", "dataset1");
       request = new AppRequest<>(
-        new ArtifactSummary(artifactIdV1.getName(), artifactIdV1.getVersion().getVersion(), false), conf);
+        new ArtifactSummary(artifactIdV1.getName(), artifactIdV1.getVersion().getVersion()), conf);
       appClient.update(appId, request);
 
       // should only have the flow
@@ -200,7 +201,7 @@ public class ApplicationClientTestRun extends ClientTestBase {
 
       // check different artifact name is invalid
       request = new AppRequest<>(
-        new ArtifactSummary("ghost", artifactIdV1.getVersion().getVersion(), false), conf);
+        new ArtifactSummary("ghost", artifactIdV1.getVersion().getVersion()), conf);
       try {
         appClient.update(appId, request);
         Assert.fail();
@@ -210,7 +211,7 @@ public class ApplicationClientTestRun extends ClientTestBase {
 
       // check nonexistent artifact is not found
       request = new AppRequest<>(
-        new ArtifactSummary(artifactIdV1.getName(), "0.0.1", false), conf);
+        new ArtifactSummary(artifactIdV1.getName(), "0.0.1"), conf);
       try {
         appClient.update(appId, request);
         Assert.fail();
@@ -222,7 +223,7 @@ public class ApplicationClientTestRun extends ClientTestBase {
       ConfigurableProgramsApp2.Programs conf2 =
         new ConfigurableProgramsApp2.Programs(null, null, "stream1", "dataset1", "service2");
       AppRequest<ConfigurableProgramsApp2.Programs> request2 = new AppRequest<>(
-        new ArtifactSummary(artifactIdV2.getName(), artifactIdV2.getVersion().getVersion(), false), conf2);
+        new ArtifactSummary(artifactIdV2.getName(), artifactIdV2.getVersion().getVersion()), conf2);
       appClient.update(appId, request2);
 
       // should only have a single service
@@ -249,9 +250,9 @@ public class ApplicationClientTestRun extends ClientTestBase {
       // app1 should end up with fake-1.0.0-SNAPSHOT
       appClient.deploy(Id.Namespace.DEFAULT, createAppJarFile(FakeApp.class, "fake", "1.0.0-SNAPSHOT"));
       // app2 should use fake-0.1.0-SNAPSHOT
-      appClient.deploy(appId2, new AppRequest<Config>(new ArtifactSummary("fake", "0.1.0-SNAPSHOT", false)));
+      appClient.deploy(appId2, new AppRequest<Config>(new ArtifactSummary("fake", "0.1.0-SNAPSHOT")));
       // app3 should use otherfake-1.0.0-SNAPSHOT
-      appClient.deploy(appId3, new AppRequest<Config>(new ArtifactSummary("otherfake", "1.0.0-SNAPSHOT", false)));
+      appClient.deploy(appId3, new AppRequest<Config>(new ArtifactSummary("otherfake", "1.0.0-SNAPSHOT")));
       appClient.waitForDeployed(appId1, 30, TimeUnit.SECONDS);
       appClient.waitForDeployed(appId2, 30, TimeUnit.SECONDS);
       appClient.waitForDeployed(appId3, 30, TimeUnit.SECONDS);
@@ -269,34 +270,34 @@ public class ApplicationClientTestRun extends ClientTestBase {
       // check filter by name only
       Set<ApplicationRecord> apps = Sets.newHashSet(appClient.list(Id.Namespace.DEFAULT, "fake", null));
       Set<ApplicationRecord> expected = ImmutableSet.of(
-        new ApplicationRecord(new ArtifactSummary("fake", "1.0.0-SNAPSHOT", false), appId1.getId(), ""),
-        new ApplicationRecord(new ArtifactSummary("fake", "0.1.0-SNAPSHOT", false), appId2.getId(), "")
+        new ApplicationRecord(new ArtifactSummary("fake", "1.0.0-SNAPSHOT"), appId1.getId(), ""),
+        new ApplicationRecord(new ArtifactSummary("fake", "0.1.0-SNAPSHOT"), appId2.getId(), "")
       );
       Assert.assertEquals(expected, apps);
 
       apps = Sets.newHashSet(appClient.list(Id.Namespace.DEFAULT, "otherfake", null));
       expected = ImmutableSet.of(
-        new ApplicationRecord(new ArtifactSummary("otherfake", "1.0.0-SNAPSHOT", false), appId3.getId(), ""));
+        new ApplicationRecord(new ArtifactSummary("otherfake", "1.0.0-SNAPSHOT"), appId3.getId(), ""));
       Assert.assertEquals(expected, apps);
 
       // check filter by version only
       apps = Sets.newHashSet(appClient.list(Id.Namespace.DEFAULT, null, "0.1.0-SNAPSHOT"));
       expected = ImmutableSet.of(
-        new ApplicationRecord(new ArtifactSummary("fake", "0.1.0-SNAPSHOT", false), appId2.getId(), "")
+        new ApplicationRecord(new ArtifactSummary("fake", "0.1.0-SNAPSHOT"), appId2.getId(), "")
       );
       Assert.assertEquals(expected, apps);
 
       apps = Sets.newHashSet(appClient.list(Id.Namespace.DEFAULT, null, "1.0.0-SNAPSHOT"));
       expected = ImmutableSet.of(
-        new ApplicationRecord(new ArtifactSummary("fake", "1.0.0-SNAPSHOT", false), appId1.getId(), ""),
-        new ApplicationRecord(new ArtifactSummary("otherfake", "1.0.0-SNAPSHOT", false), appId3.getId(), "")
+        new ApplicationRecord(new ArtifactSummary("fake", "1.0.0-SNAPSHOT"), appId1.getId(), ""),
+        new ApplicationRecord(new ArtifactSummary("otherfake", "1.0.0-SNAPSHOT"), appId3.getId(), "")
       );
       Assert.assertEquals(expected, apps);
 
       // check filter by both
       apps = Sets.newHashSet(appClient.list(Id.Namespace.DEFAULT, "fake", "0.1.0-SNAPSHOT"));
       expected = ImmutableSet.of(
-        new ApplicationRecord(new ArtifactSummary("fake", "0.1.0-SNAPSHOT", false), appId2.getId(), "")
+        new ApplicationRecord(new ArtifactSummary("fake", "0.1.0-SNAPSHOT"), appId2.getId(), "")
       );
       Assert.assertEquals(expected, apps);
     } finally {

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/ArtifactClientTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/ArtifactClientTestRun.java
@@ -18,6 +18,7 @@ package co.cask.cdap.client;
 
 import co.cask.cdap.api.artifact.ApplicationClass;
 import co.cask.cdap.api.artifact.ArtifactClasses;
+import co.cask.cdap.api.artifact.ArtifactScope;
 import co.cask.cdap.api.artifact.ArtifactVersion;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.templates.plugins.PluginClass;
@@ -42,7 +43,6 @@ import co.cask.cdap.proto.artifact.ArtifactSummary;
 import co.cask.cdap.proto.artifact.PluginInfo;
 import co.cask.cdap.proto.artifact.PluginSummary;
 import co.cask.cdap.test.XSlowTests;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
@@ -61,7 +61,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.jar.Manifest;
@@ -87,7 +86,7 @@ public class ArtifactClientTestRun extends ClientTestBase {
   public void setUp() throws Throwable {
     super.setUp();
     artifactClient = new ArtifactClient(clientConfig, new RESTClient(clientConfig));
-    for (ArtifactSummary artifactSummary : artifactClient.list(Id.Namespace.DEFAULT, false)) {
+    for (ArtifactSummary artifactSummary : artifactClient.list(Id.Namespace.DEFAULT)) {
       artifactClient.delete(
         Id.Artifact.from(Id.Namespace.DEFAULT, artifactSummary.getName(), artifactSummary.getVersion()));
     }
@@ -185,10 +184,9 @@ public class ArtifactClientTestRun extends ClientTestBase {
     artifactClient.add(pluginId.getNamespace(), pluginId.getName(), inputSupplier,
                        pluginId.getVersion().getVersion(), parents, additionalPlugins);
 
-    ArtifactSummary myapp1Summary = new ArtifactSummary(myapp1Id.getName(), myapp1Id.getVersion().getVersion(), false);
-    ArtifactSummary myapp2Summary = new ArtifactSummary(myapp2Id.getName(), myapp2Id.getVersion().getVersion(), false);
-    ArtifactSummary pluginArtifactSummary =
-      new ArtifactSummary(pluginId.getName(), pluginId.getVersion().getVersion(), false);
+    ArtifactSummary myapp1Summary = new ArtifactSummary(myapp1Id.getName(), myapp1Id.getVersion().getVersion());
+    ArtifactSummary myapp2Summary = new ArtifactSummary(myapp2Id.getName(), myapp2Id.getVersion().getVersion());
+    ArtifactSummary pluginArtifactSummary = new ArtifactSummary(pluginId.getName(), pluginId.getVersion().getVersion());
 
     Set<ArtifactSummary> artifacts = Sets.newHashSet(artifactClient.list(Id.Namespace.DEFAULT));
     Assert.assertEquals(Sets.newHashSet(myapp1Summary, myapp2Summary, pluginArtifactSummary), artifacts);
@@ -208,12 +206,12 @@ public class ArtifactClientTestRun extends ClientTestBase {
 
     // test get myapp-1.0.0
     ArtifactInfo myapp1Info =
-      new ArtifactInfo(myapp1Id.getName(), myapp1Id.getVersion().getVersion(), false, myAppClasses);
+      new ArtifactInfo(myapp1Id.getName(), myapp1Id.getVersion().getVersion(), ArtifactScope.USER, myAppClasses);
     Assert.assertEquals(myapp1Info, artifactClient.getArtifactInfo(myapp1Id));
 
     // test get myapp-2.0.0
     ArtifactInfo myapp2Info =
-      new ArtifactInfo(myapp2Id.getName(), myapp2Id.getVersion().getVersion(), false, myAppClasses);
+      new ArtifactInfo(myapp2Id.getName(), myapp2Id.getVersion().getVersion(), ArtifactScope.USER, myAppClasses);
     Assert.assertEquals(myapp2Info, artifactClient.getArtifactInfo(myapp2Id));
 
     // test get myapp-plugins-2.0.0
@@ -224,7 +222,7 @@ public class ArtifactClientTestRun extends ClientTestBase {
       .addPlugins(additionalPlugins)
       .build();
     ArtifactInfo pluginArtifactInfo =
-      new ArtifactInfo(pluginId.getName(), pluginId.getVersion().getVersion(), false, pluginClasses);
+      new ArtifactInfo(pluginId.getName(), pluginId.getVersion().getVersion(), ArtifactScope.USER, pluginClasses);
     Assert.assertEquals(pluginArtifactInfo, artifactClient.getArtifactInfo(pluginId));
 
     // test get all app classes in namespace

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/Id.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/Id.java
@@ -16,7 +16,8 @@
 
 package co.cask.cdap.proto;
 
-import co.cask.cdap.api.artifact.ArtifactDescriptor;
+import co.cask.cdap.api.artifact.ArtifactId;
+import co.cask.cdap.api.artifact.ArtifactScope;
 import co.cask.cdap.api.artifact.ArtifactVersion;
 import com.google.common.base.CharMatcher;
 import com.google.common.base.Charsets;
@@ -1314,6 +1315,11 @@ public abstract class Id {
       return String.format("%s-%s", name, version.getVersion());
     }
 
+    public ArtifactId toArtifactId() {
+      return new ArtifactId(name, version,
+                            Namespace.SYSTEM.equals(namespace) ? ArtifactScope.SYSTEM : ArtifactScope.USER);
+    }
+
     @Override
     public String toString() {
       return String.format("%s:%s-%s", namespace.getId(), name, version.getVersion());
@@ -1346,9 +1352,9 @@ public abstract class Id {
       return new Artifact(namespace, name, version);
     }
 
-    public static Artifact from(Id.Namespace namespace, ArtifactDescriptor descriptor) {
-      return new Artifact(descriptor.isSystem() ? Namespace.SYSTEM : namespace,
-                          descriptor.getName(), descriptor.getVersion());
+    public static Artifact from(Id.Namespace namespace, ArtifactId id) {
+      return new Artifact(ArtifactScope.SYSTEM.equals(id.getScope()) ? Namespace.SYSTEM : namespace,
+                          id.getName(), id.getVersion());
     }
 
     public static boolean isValidName(String name) {

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/artifact/ArtifactInfo.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/artifact/ArtifactInfo.java
@@ -18,6 +18,8 @@ package co.cask.cdap.proto.artifact;
 
 import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.artifact.ArtifactClasses;
+import co.cask.cdap.api.artifact.ArtifactId;
+import co.cask.cdap.api.artifact.ArtifactScope;
 
 import java.util.Objects;
 
@@ -28,8 +30,12 @@ import java.util.Objects;
 public class ArtifactInfo extends ArtifactSummary {
   private final ArtifactClasses classes;
 
-  public ArtifactInfo(String name, String version, boolean isSystem, ArtifactClasses classes) {
-    super(name, version, isSystem);
+  public ArtifactInfo(ArtifactId id, ArtifactClasses classes) {
+    this(id.getName(), id.getVersion().getVersion(), id.getScope(), classes);
+  }
+
+  public ArtifactInfo(String name, String version, ArtifactScope scope, ArtifactClasses classes) {
+    super(name, version, scope);
     this.classes = classes;
   }
 
@@ -62,7 +68,7 @@ public class ArtifactInfo extends ArtifactSummary {
     return "ArtifactInfo{" +
       "name='" + name + '\'' +
       ", version='" + version + '\'' +
-      ", isSystem=" + isSystem +
+      ", scope=" + scope +
       ", classes=" + classes +
       '}';
   }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/artifact/ArtifactSummary.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/artifact/ArtifactSummary.java
@@ -17,8 +17,8 @@
 package co.cask.cdap.proto.artifact;
 
 import co.cask.cdap.api.annotation.Beta;
-import co.cask.cdap.api.artifact.ArtifactDescriptor;
 import co.cask.cdap.api.artifact.ArtifactId;
+import co.cask.cdap.api.artifact.ArtifactScope;
 import co.cask.cdap.proto.Id;
 
 import java.util.Objects;
@@ -30,25 +30,26 @@ import java.util.Objects;
 public class ArtifactSummary {
   protected final String name;
   protected final String version;
-  protected final boolean isSystem;
+  protected final ArtifactScope scope;
 
   public static ArtifactSummary from(Id.Artifact artifactId) {
-    return new ArtifactSummary(artifactId.getName(), artifactId.getVersion().getVersion(),
-                               Id.Namespace.SYSTEM.equals(artifactId.getNamespace()));
+    ArtifactScope scope = Id.Namespace.SYSTEM.equals(artifactId.getNamespace()) ?
+      ArtifactScope.SYSTEM : ArtifactScope.USER;
+    return new ArtifactSummary(artifactId.getName(), artifactId.getVersion().getVersion(), scope);
   }
 
   public static ArtifactSummary from(ArtifactId artifactId) {
-    return new ArtifactSummary(artifactId.getName(), artifactId.getVersion().getVersion(), artifactId.isSystem());
+    return new ArtifactSummary(artifactId.getName(), artifactId.getVersion().getVersion(), artifactId.getScope());
   }
 
-  public static ArtifactSummary from(ArtifactDescriptor descriptor) {
-    return new ArtifactSummary(descriptor.getName(), descriptor.getVersion().getVersion(), descriptor.isSystem());
+  public ArtifactSummary(String name, String version) {
+    this(name, version, ArtifactScope.USER);
   }
 
-  public ArtifactSummary(String name, String version, boolean isSystem) {
+  public ArtifactSummary(String name, String version, ArtifactScope scope) {
     this.name = name;
     this.version = version;
-    this.isSystem = isSystem;
+    this.scope = scope;
   }
 
   public String getName() {
@@ -59,8 +60,8 @@ public class ArtifactSummary {
     return version;
   }
 
-  public boolean isSystem() {
-    return isSystem;
+  public ArtifactScope getScope() {
+    return scope;
   }
 
   @Override
@@ -74,12 +75,14 @@ public class ArtifactSummary {
 
     ArtifactSummary that = (ArtifactSummary) o;
 
-    return Objects.equals(name, that.name) && Objects.equals(version, that.version) && isSystem == that.isSystem;
+    return Objects.equals(name, that.name) &&
+      Objects.equals(version, that.version) &&
+      Objects.equals(scope, that.scope);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, version, isSystem);
+    return Objects.hash(name, version, scope);
   }
 
   @Override
@@ -87,7 +90,7 @@ public class ArtifactSummary {
     return "ArtifactSummary{" +
       "name='" + name + '\'' +
       ", version='" + version + '\'' +
-      ", isSystem=" + isSystem +
+      ", scope=" + scope +
       '}';
   }
 }

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/UnitTestManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/UnitTestManager.java
@@ -19,6 +19,7 @@ package co.cask.cdap.test;
 import co.cask.cdap.api.Config;
 import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.app.Application;
+import co.cask.cdap.api.artifact.ArtifactScope;
 import co.cask.cdap.api.dataset.DatasetAdmin;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.module.DatasetModule;
@@ -181,7 +182,8 @@ public class UnitTestManager implements TestManager {
     appFabricClient.deployApplication(appId, appRequest);
 
     ArtifactSummary requestedArtifact = appRequest.getArtifact();
-    Id.Artifact artifactId = Id.Artifact.from(requestedArtifact.isSystem() ? Id.Namespace.SYSTEM : appId.getNamespace(),
+    Id.Artifact artifactId = Id.Artifact.from(
+      ArtifactScope.SYSTEM.equals(requestedArtifact.getScope()) ? Id.Namespace.SYSTEM : appId.getNamespace(),
       requestedArtifact.getName(), requestedArtifact.getVersion());
     ArtifactDetail artifactDetail = artifactRepository.getArtifact(artifactId);
     return appManagerFactory.create(appId, artifactDetail.getDescriptor().getLocation());

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
@@ -18,6 +18,7 @@ package co.cask.cdap.test.app;
 
 import co.cask.cdap.ConfigTestApp;
 import co.cask.cdap.api.app.Application;
+import co.cask.cdap.api.artifact.ArtifactScope;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.lib.CloseableIterator;
@@ -205,7 +206,7 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
 
     Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "AppWithPlugin");
     AppRequest createRequest = new AppRequest(
-      new ArtifactSummary(artifactId.getName(), artifactId.getVersion().getVersion(), false));
+      new ArtifactSummary(artifactId.getName(), artifactId.getVersion().getVersion()));
 
     ApplicationManager appManager = deployApplication(appId, createRequest);
     WorkerManager workerManager = appManager.getWorkerManager(AppWithPlugin.WORKER);
@@ -238,7 +239,7 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
 
     Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "AppFromArtifact");
     AppRequest<ConfigTestApp.ConfigClass> createRequest = new AppRequest<>(
-      new ArtifactSummary(artifactId.getName(), artifactId.getVersion().getVersion(), false),
+      new ArtifactSummary(artifactId.getName(), artifactId.getVersion().getVersion()),
       new ConfigTestApp.ConfigClass("testStream", "testDataset")
     );
     ApplicationManager appManager = deployApplication(appId, createRequest);


### PR DESCRIPTION
Changing the isSystem boolean to an enum for artifact scope.
We will start out with system and user scopes, but this allows us
to add new scopes in the future and is consistent with other
concepts like metrics.

Also doing some cleanup so that ArtifactId is used in a few
classes instead of storing the individual id fields.

Also adding missing package-info file for artifacts.