### PR TITLE
Allow RPM builds on OSX and other non-Linux systems

### DIFF
--- a/cdap-distributions/pom.xml
+++ b/cdap-distributions/pom.xml
@@ -88,6 +88,7 @@
                     -C "${stage.dir}"
                     --version "${package.version}"
                     --architecture all
+                    --rpm-os linux
                     --url "http://www.cask.co"
                     --template-value "project=cdap"
                     --after-install "${project.basedir}/src/rpm/scripts/common-postinst"

--- a/pom.xml
+++ b/pom.xml
@@ -1963,6 +1963,7 @@
                       --directories "/opt/cdap/${package.name}"
                       --version "${package.version}"
                       --architecture all
+                      --rpm-os linux
                       --url "http://cask.co"
                       --template-value "project=${package.name}"
                       --after-install "${project.parent.basedir}/cdap-distributions/src/rpm/scripts/postinst"


### PR DESCRIPTION
This tells `fpm` to send the `--target noarch-unknown-linux` option to `rpmbuild` which allows packages to be built on OSX and installed on Linux.