### PR TITLE
CDAP-3580 deserialize scope enum in a case insensitive way

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppLifecycleHttpHandler.java
@@ -33,6 +33,7 @@ import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.http.AbstractBodyConsumer;
+import co.cask.cdap.common.io.CaseInsensitiveEnumTypeAdapterFactory;
 import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.common.utils.DirUtils;
@@ -62,6 +63,7 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Lists;
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -96,7 +98,9 @@ import javax.ws.rs.core.MediaType;
 @Singleton
 @Path(Constants.Gateway.API_VERSION_3 + "/namespaces/{namespace-id}")
 public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
-  private static final Gson GSON = new Gson();
+  private static final Gson GSON = new GsonBuilder()
+    .registerTypeAdapterFactory(new CaseInsensitiveEnumTypeAdapterFactory())
+    .create();
   private static final Logger LOG = LoggerFactory.getLogger(AppLifecycleHttpHandler.class);
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/util/AbstractAppFabricHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/util/AbstractAppFabricHttpHandler.java
@@ -19,7 +19,6 @@ package co.cask.cdap.gateway.handlers.util;
 import co.cask.cdap.api.ProgramSpecification;
 import co.cask.cdap.api.app.ApplicationSpecification;
 import co.cask.cdap.api.artifact.ArtifactId;
-import co.cask.cdap.api.artifact.ArtifactScope;
 import co.cask.cdap.app.runtime.ProgramRuntimeService;
 import co.cask.cdap.app.store.Store;
 import co.cask.cdap.common.NamespaceNotFoundException;

--- a/cdap-common/src/main/java/co/cask/cdap/common/io/CaseInsensitiveEnumTypeAdapterFactory.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/io/CaseInsensitiveEnumTypeAdapterFactory.java
@@ -36,12 +36,13 @@ import java.util.Map;
  */
 public class CaseInsensitiveEnumTypeAdapterFactory implements TypeAdapterFactory {
   public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+    @SuppressWarnings("unchecked")
     Class<T> rawType = (Class<T>) type.getRawType();
     if (!rawType.isEnum()) {
       return null;
     }
 
-    final Map<String, T> lowercaseToConstant = new HashMap<String, T>();
+    final Map<String, T> lowercaseToConstant = new HashMap<>();
     for (T constant : rawType.getEnumConstants()) {
       lowercaseToConstant.put(toLowercase(constant), constant);
     }

--- a/cdap-common/src/main/java/co/cask/cdap/common/io/CaseInsensitiveEnumTypeAdapterFactory.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/io/CaseInsensitiveEnumTypeAdapterFactory.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.io;
+
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Type adapter that serializes enums in lowercase and deserializes enums in a case insensitive way.
+ * Taken straight from the example in TypeAdapterFactory javadocs except deserializes in a case insenstivie way
+ * instead of deserializing lowercase only.
+ */
+public class CaseInsensitiveEnumTypeAdapterFactory implements TypeAdapterFactory {
+  public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+    Class<T> rawType = (Class<T>) type.getRawType();
+    if (!rawType.isEnum()) {
+      return null;
+    }
+
+    final Map<String, T> lowercaseToConstant = new HashMap<String, T>();
+    for (T constant : rawType.getEnumConstants()) {
+      lowercaseToConstant.put(toLowercase(constant), constant);
+    }
+
+    return new TypeAdapter<T>() {
+      public void write(JsonWriter out, T value) throws IOException {
+        if (value == null) {
+          out.nullValue();
+        } else {
+          out.value(toLowercase(value));
+        }
+      }
+
+      public T read(JsonReader reader) throws IOException {
+        if (reader.peek() == JsonToken.NULL) {
+          reader.nextNull();
+          return null;
+        } else {
+          return lowercaseToConstant.get(toLowercase(reader.nextString()));
+        }
+      }
+    };
+  }
+
+  private String toLowercase(Object o) {
+    return o.toString().toLowerCase(Locale.US);
+  }
+}

--- a/cdap-common/src/test/java/co/cask/cdap/common/io/CaseInsensitiveEnumTypeAdapterFactoryTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/io/CaseInsensitiveEnumTypeAdapterFactoryTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.io;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ */
+public class CaseInsensitiveEnumTypeAdapterFactoryTest {
+  private static final Gson GSON = new GsonBuilder()
+    .registerTypeAdapterFactory(new CaseInsensitiveEnumTypeAdapterFactory())
+    .create();
+
+  @Test
+  public void testDeserialization() {
+    Assert.assertEquals(Suit.CLUB, GSON.fromJson("club", Suit.class));
+    Assert.assertEquals(Suit.CLUB, GSON.fromJson("CLUB", Suit.class));
+    Assert.assertEquals(Suit.CLUB, GSON.fromJson("cLub", Suit.class));
+  }
+
+  @Test
+  public void testSerialization() {
+    Assert.assertEquals("\"club\"", GSON.toJson(Suit.CLUB));
+  }
+
+  private enum Suit {
+    CLUB,
+    DIAMOND,
+    HEART,
+    SPADE
+  }
+}


### PR DESCRIPTION
Adding a type adapter factory for deserializing enums in a case
insensitive way and serializing enums in lowercase. This makes it
a little easier to use the deploy app api since artifact scope
no longer needs to be all caps.