### PR TITLE
CDAP-3479- Integrate error dataset transformation - ETL Realtime

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/template/etl/batch/ETLMapReduce.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/template/etl/batch/ETLMapReduce.java
@@ -22,7 +22,6 @@ import co.cask.cdap.api.mapreduce.AbstractMapReduce;
 import co.cask.cdap.api.mapreduce.MapReduceContext;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.template.etl.api.Transform;
-import co.cask.cdap.template.etl.api.Transformation;
 import co.cask.cdap.template.etl.api.batch.BatchSink;
 import co.cask.cdap.template.etl.api.batch.BatchSinkContext;
 import co.cask.cdap.template.etl.api.batch.BatchSource;
@@ -33,6 +32,7 @@ import co.cask.cdap.template.etl.common.Destroyables;
 import co.cask.cdap.template.etl.common.ETLStage;
 import co.cask.cdap.template.etl.common.PluginID;
 import co.cask.cdap.template.etl.common.StageMetrics;
+import co.cask.cdap.template.etl.common.TransformDetail;
 import co.cask.cdap.template.etl.common.TransformExecutor;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
@@ -46,6 +46,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -155,33 +156,32 @@ public class ETLMapReduce extends AbstractMapReduce {
       String sourcePluginId = runtimeArgs.get(Constants.Source.PLUGINID);
       String sinkPluginId = runtimeArgs.get(Constants.Sink.PLUGINID);
       List<String> transformIds = GSON.fromJson(runtimeArgs.get(Constants.Transform.PLUGINIDS), STRING_LIST_TYPE);
-
+      StageMetrics stageMetrics;
 
       List<ETLStage> stageList = etlConfig.getTransforms();
-      List<Transformation> pipeline = Lists.newArrayListWithCapacity(stageList.size() + 2);
-      List<StageMetrics> stageMetrics = Lists.newArrayListWithCapacity(stageList.size() + 2);
+      List<TransformDetail> pipeline = Lists.newArrayListWithCapacity(stageList.size() + 2);
       transforms = Lists.newArrayListWithCapacity(stageList.size());
 
       BatchSource source = context.newPluginInstance(sourcePluginId);
       BatchSourceContext batchSourceContext = new MapReduceSourceContext(context, mapperMetrics, sourcePluginId);
       source.initialize(batchSourceContext);
-      pipeline.add(source);
-      stageMetrics.add(new StageMetrics(mapperMetrics, PluginID.from(sourcePluginId)));
+      stageMetrics = new StageMetrics(mapperMetrics, PluginID.from(sourcePluginId));
+      pipeline.add(new TransformDetail(sourcePluginId, source, stageMetrics));
 
-      addTransforms(stageList, pipeline, stageMetrics, transformIds, context);
+
+      addTransforms(stageList, pipeline, transformIds, context);
 
       BatchSink sink = context.newPluginInstance(sinkPluginId);
       BatchSinkContext batchSinkContext = new MapReduceSinkContext(context, mapperMetrics, sinkPluginId);
       sink.initialize(batchSinkContext);
-      pipeline.add(sink);
-      stageMetrics.add(new StageMetrics(mapperMetrics, PluginID.from(sinkPluginId)));
+      stageMetrics = new StageMetrics(mapperMetrics, PluginID.from(sinkPluginId));
+      pipeline.add(new TransformDetail(sinkPluginId, sink, stageMetrics));
 
-      transformExecutor = new TransformExecutor<>(pipeline, stageMetrics);
+      transformExecutor = new TransformExecutor<>(pipeline);
     }
 
-    private void addTransforms(List<ETLStage> stageConfigs, List<Transformation> pipeline,
-                               List<StageMetrics> stageMetrics, List<String> transformIds,
-                               MapReduceContext context) throws Exception {
+    private void addTransforms(List<ETLStage> stageConfigs, List<TransformDetail> pipeline,
+                               List<String> transformIds, MapReduceContext context) throws Exception {
       Preconditions.checkArgument(stageConfigs.size() == transformIds.size());
 
       for (int i = 0; i < stageConfigs.size(); i++) {
@@ -192,9 +192,9 @@ public class ETLMapReduce extends AbstractMapReduce {
         LOG.debug("Transform Stage : {}", stageConfig.getName());
         LOG.debug("Transform Class : {}", transform.getClass().getName());
         transform.initialize(transformContext);
-        pipeline.add(transform);
+        StageMetrics stageMetrics = new StageMetrics(mapperMetrics, PluginID.from(transformId));
+        pipeline.add(new TransformDetail(transformId, transform, stageMetrics));
         transforms.add(transform);
-        stageMetrics.add(new StageMetrics(mapperMetrics, PluginID.from(transformId)));
       }
     }
 
@@ -202,7 +202,9 @@ public class ETLMapReduce extends AbstractMapReduce {
     public void map(Object key, Object value, Context context) throws IOException, InterruptedException {
       try {
         KeyValue input = new KeyValue(key, value);
-        for (KeyValue output : transformExecutor.runOneIteration(input)) {
+        Iterator<KeyValue> iterator = transformExecutor.runOneIteration(input).getEmittedRecords();
+        while (iterator.hasNext()) {
+          KeyValue output = iterator.next();
           context.write(output.getKey(), output.getValue());
         }
       } catch (Exception e) {

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/common/Constants.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/common/Constants.java
@@ -75,4 +75,13 @@ public final class Constants {
       throw new AssertionError("Suppress default constructor for noninstantiability");
     }
   }
+
+  /**
+   * Constants related to error dataset used in transform
+   */
+  public static final class ErrorDataset {
+    public static final String COLUMN_ERRCODE = "errCode";
+    public static final String COLUMN_ERRMSG = "errMsg";
+    public static final String COLUMN_INVALIDENTRY = "invalidRecord";
+  }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/common/DefaultEmitter.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/common/DefaultEmitter.java
@@ -21,6 +21,8 @@ import co.cask.cdap.template.etl.api.Emitter;
 import co.cask.cdap.template.etl.api.InvalidEntry;
 import com.google.common.collect.Lists;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
@@ -49,11 +51,16 @@ public class DefaultEmitter<T> implements Emitter<T>, Iterable<T> {
   @Override
   public void emitError(InvalidEntry<T> value) {
     errorList.add(value);
+    metrics.count("records.error", 1);
   }
 
   @Override
   public Iterator<T> iterator() {
     return entryList.iterator();
+  }
+
+  public Collection<InvalidEntry<T>> getErrors() {
+    return errorList;
   }
 
   public void reset() {

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/common/Pipeline.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/common/Pipeline.java
@@ -24,9 +24,9 @@ import java.util.List;
 public class Pipeline {
   private final String source;
   private final String sink;
-  private final List<String> transforms;
+  private final List<TransformInfo> transforms;
 
-  public Pipeline(String source, String sink, List<String> transforms) {
+  public Pipeline(String source, String sink, List<TransformInfo> transforms) {
     this.source = source;
     this.sink = sink;
     this.transforms = transforms;
@@ -40,7 +40,7 @@ public class Pipeline {
     return sink;
   }
 
-  public List<String> getTransforms() {
+  public List<TransformInfo> getTransforms() {
     return transforms;
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/common/PipelineRegisterer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/common/PipelineRegisterer.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.template.etl.common;
 
 import co.cask.cdap.api.artifact.PluginConfigurer;
+import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.templates.plugins.PluginProperties;
 import co.cask.cdap.template.etl.api.PipelineConfigurable;
 import co.cask.cdap.template.etl.api.PipelineConfigurer;
@@ -40,6 +41,7 @@ import java.util.List;
  * Registers plugins needed by an ETL pipeline.
  */
 public class PipelineRegisterer {
+
   private final PluginConfigurer configurer;
 
   public PipelineRegisterer(PluginConfigurer configurer) {
@@ -50,9 +52,10 @@ public class PipelineRegisterer {
    * Registers the plugins that will be used in the pipeline
    *
    * @param config the config containing pipeline information
+   * @param errorDatasetType error dataset type class
    * @return the ids of each plugin used in the pipeline
    */
-  public Pipeline registerPlugins(ETLConfig config) {
+  public Pipeline registerPlugins(ETLConfig config, Class errorDatasetType, DatasetProperties datasetProperties) {
     ETLStage sourceConfig = config.getSource();
     ETLStage sinkConfig = config.getSink();
     List<ETLStage> transformConfigs = config.getTransforms();
@@ -78,8 +81,8 @@ public class PipelineRegisterer {
     }
 
     // Store transform id list to be serialized and passed to the driver program
-    List<String> transformIds = Lists.newArrayListWithCapacity(transformConfigs.size());
-    List<Transformation> transforms = Lists.newArrayListWithCapacity(transformConfigs.size());
+    List<TransformInfo> transformIds = new ArrayList<>(transformConfigs.size());
+    List<Transformation> transforms = new ArrayList<>(transformConfigs.size());
     for (int i = 0; i < transformConfigs.size(); i++) {
       ETLStage transformConfig = transformConfigs.get(i);
 
@@ -94,9 +97,16 @@ public class PipelineRegisterer {
         throw new IllegalArgumentException(String.format("No Plugin of type '%s' named '%s' was found",
                                                          Constants.Transform.PLUGINTYPE, transformConfig.getName()));
       }
+      // if the transformation is configured to write filtered records to error dataset, we create that dataset.
+      if (transformConfig.getErrorDatasetName() != null) {
+        // TODO : can remove this after implementing CDAP-3480
+        if (errorDatasetType != null) {
+          configurer.createDataset(transformConfig.getErrorDatasetName(), errorDatasetType, datasetProperties);
+        }
+      }
       PipelineConfigurer transformConfigurer = new DefaultPipelineConfigurer(configurer, transformId);
       transformObj.configurePipeline(transformConfigurer);
-      transformIds.add(transformId);
+      transformIds.add(new TransformInfo(transformId, transformConfig.getErrorDatasetName()));
       transforms.add(transformObj);
     }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/common/TransformDetail.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/common/TransformDetail.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.template.etl.common;
+
+import co.cask.cdap.template.etl.api.Transformation;
+
+/**
+ * Class that encapsulates {@link co.cask.cdap.template.etl.api.Transform} and transformId
+ * and {@link co.cask.cdap.template.etl.common.StageMetrics}
+ */
+public class TransformDetail {
+
+  private final String transformId;
+  private final Transformation transformation;
+  private final StageMetrics metrics;
+
+  public TransformDetail(String transformId, Transformation transform, StageMetrics metrics) {
+    this.transformation = transform;
+    this.transformId = transformId;
+    this.metrics = metrics;
+  }
+
+  public TransformDetail(TransformDetail transformDetail, Transformation transformation) {
+    this.transformation = transformation;
+    this.transformId = transformDetail.getTransformId();
+    this.metrics = transformDetail.getMetrics();
+  }
+
+  public Transformation getTransformation() {
+    return transformation;
+  }
+
+  public String getTransformId() {
+    return transformId;
+  }
+
+  public StageMetrics getMetrics() {
+    return metrics;
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/common/TransformExecutor.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/common/TransformExecutor.java
@@ -18,12 +18,15 @@ package co.cask.cdap.template.etl.common;
 
 import co.cask.cdap.template.etl.api.Destroyable;
 import co.cask.cdap.template.etl.api.Transformation;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Executes Transforms one iteration at a time, tracking how many records were input into and output from
@@ -34,52 +37,73 @@ import java.util.List;
  */
 public class TransformExecutor<IN, OUT> implements Destroyable {
 
-  private final List<Transformation> transforms;
+
+  private static final Logger LOG = LoggerFactory.getLogger(TransformExecutor.class);
+
+  private final List<TransformDetail> transforms;
   private final List<DefaultEmitter> emitters;
 
-  public TransformExecutor(List<Transformation> transforms, List<StageMetrics> transformMetrics) {
-    int numTransforms = transforms.size();
-    Preconditions.checkArgument(numTransforms == transformMetrics.size());
-    this.transforms = Lists.newArrayListWithCapacity(numTransforms);
+
+  public TransformExecutor(List<TransformDetail> transformDetailList) {
+    int numTransforms = transformDetailList.size();
+    this.transforms = new ArrayList<>(numTransforms);
     this.emitters = Lists.newArrayListWithCapacity(numTransforms);
-    for (int i = 0; i < numTransforms; i++) {
-      StageMetrics stageMetrics = transformMetrics.get(i);
-      this.transforms.add(new TrackedTransform<>(transforms.get(i), stageMetrics));
-      this.emitters.add(new DefaultEmitter(stageMetrics));
+
+    for (TransformDetail transformDetail : transformDetailList) {
+      this.transforms.add(new TransformDetail(transformDetail,
+                                              new TrackedTransform(transformDetail.getTransformation(),
+                                                                   transformDetail.getMetrics())));
+      this.emitters.add(new DefaultEmitter(transformDetail.getMetrics()));
     }
   }
 
-  public Iterable<OUT> runOneIteration(IN input) throws Exception {
+  public TransformResponse<OUT> runOneIteration(IN input) throws Exception {
+
+    Map<String, Collection<OUT>> errorRecordsMap = new HashMap<>(transforms.size());
+
     if (transforms.isEmpty()) {
-      return Lists.newArrayList((OUT) input);
+      return new TransformResponse<>(Lists.newArrayList((OUT) input).iterator(), errorRecordsMap);
     }
 
-    Transformation transform = transforms.get(0);
+    TransformDetail transformDetail = transforms.get(0);
     DefaultEmitter currentEmitter = emitters.get(0);
     currentEmitter.reset();
+    Transformation transform = transformDetail.getTransformation();
     transform.transform(input, currentEmitter);
 
-    DefaultEmitter previousEmitter = currentEmitter;
+    if (!currentEmitter.getErrors().isEmpty()) {
+      errorRecordsMap.put(transformDetail.getTransformId(), currentEmitter.getErrors());
+    }
 
+    DefaultEmitter previousEmitter = currentEmitter;
     for (int i = 1; i < transforms.size(); i++) {
-      transform = transforms.get(i);
+      transformDetail = transforms.get(i);
+      transform = transformDetail.getTransformation();
       currentEmitter = emitters.get(i);
-      currentEmitter.reset();
       for (Object transformedVal : previousEmitter) {
         transform.transform(transformedVal, currentEmitter);
       }
-      previousEmitter.reset();
+      if (!currentEmitter.getErrors().isEmpty()) {
+        errorRecordsMap.put(transformDetail.getTransformId(), currentEmitter.getErrors());
+      }
       previousEmitter = currentEmitter;
     }
 
-    return previousEmitter;
+    return new TransformResponse<>(previousEmitter.iterator(), errorRecordsMap);
+  }
+
+  public void resetEmitters() {
+    for (DefaultEmitter<OUT> emitter : emitters) {
+      emitter.reset();
+    }
   }
 
   @Override
   public void destroy() {
-    for (Transformation transform : transforms) {
-      if (transform instanceof Destroyable) {
-        Destroyables.destroyQuietly((Destroyable) transform);
+    for (TransformDetail transformDetail : transforms) {
+      Transformation transformation = transformDetail.getTransformation();
+      if (transformation instanceof Destroyable) {
+        Destroyables.destroyQuietly((Destroyable) transformation);
       }
     }
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/common/TransformInfo.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/common/TransformInfo.java
@@ -16,44 +16,22 @@
 
 package co.cask.cdap.template.etl.common;
 
-import com.google.common.base.Objects;
-
-import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
- * ETL Stage Configuration.
+ * Class to encapsulate id of the transform and the error dataset used in that transform stage.
  */
-public final class ETLStage {
-  private final String name;
-  private final Map<String, String> properties;
+public class TransformInfo {
+  private final String transformId;
   private final String errorDatasetName;
 
-  public ETLStage(String name, Map<String, String> properties, @Nullable String errorDatasetName) {
-    this.name = name;
-    this.properties = properties;
+  public TransformInfo(String transformId, @Nullable String errorDatasetName) {
+    this.transformId = transformId;
     this.errorDatasetName = errorDatasetName;
   }
 
-  public ETLStage(String name, Map<String, String> properties) {
-    this(name, properties, null);
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  @Nullable
-  public Map<String, String> getProperties() {
-    return properties;
-  }
-
-  @Override
-  public String toString() {
-    return Objects.toStringHelper(this)
-      .add("name", name)
-      .add("properties", properties)
-      .toString();
+  public String getTransformId() {
+    return transformId;
   }
 
   @Nullable

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/common/TransformResponse.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/common/TransformResponse.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.template.etl.common;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * class representing transform response.
+ * @param <OUT> represents output type
+ */
+public class TransformResponse<OUT> {
+  private final Iterator<OUT> emittedRecords;
+  private final Map<String, Collection<OUT>> mapTransformIdToErrorEmitter;
+
+  public TransformResponse(Iterator<OUT> outIterator, Map<String, Collection<OUT>> mapTransformIdToErrorEmitter) {
+    this.emittedRecords = outIterator;
+    this.mapTransformIdToErrorEmitter = mapTransformIdToErrorEmitter;
+  }
+
+  public Iterator<OUT> getEmittedRecords() {
+    return emittedRecords;
+  }
+
+  public Map<String, Collection<OUT>> getMapTransformIdToErrorEmitter() {
+    return mapTransformIdToErrorEmitter;
+  }
+
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/template/etl/common/TransformExecutorTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/template/etl/common/TransformExecutorTest.java
@@ -17,13 +17,16 @@
 package co.cask.cdap.template.etl.common;
 
 import co.cask.cdap.template.etl.api.Emitter;
+import co.cask.cdap.template.etl.api.InvalidEntry;
 import co.cask.cdap.template.etl.api.Transform;
-import co.cask.cdap.template.etl.api.Transformation;
 import com.google.common.collect.Lists;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 /**
  */
@@ -32,44 +35,63 @@ public class TransformExecutorTest {
   @Test
   public void testEmptyTransforms() throws Exception {
     TransformExecutor<String, String> executor =
-      new TransformExecutor<>(Lists.<Transformation>newArrayList(), Lists.<StageMetrics>newArrayList());
-    List<String> results = Lists.newArrayList(executor.runOneIteration("foo"));
+      new TransformExecutor<>(Lists.<TransformDetail>newArrayList());
+    TransformResponse transformResponse = executor.runOneIteration("foo");
+    List<String> results = Lists.newArrayList(transformResponse.getEmittedRecords());
     Assert.assertEquals(1, results.size());
     Assert.assertEquals("foo", results.get(0));
+    executor.resetEmitters();
   }
 
   @Test
   public void testTransforms() throws Exception {
     MockMetrics mockMetrics = new MockMetrics();
-    List<Transformation> transforms = Lists.<Transformation>newArrayList(
-      new IntToDouble(), new Filter(100d), new DoubleToString());
-    List<StageMetrics> stageMetrics = Lists.newArrayList(
-      new StageMetrics(mockMetrics, PluginID.from(Constants.Source.PLUGINTYPE, "first", 1)),
-      new StageMetrics(mockMetrics, PluginID.from(Constants.Transform.PLUGINTYPE, "second", 2)),
-      new StageMetrics(mockMetrics, PluginID.from(Constants.Sink.PLUGINTYPE, "third", 3))
-    );
-    TransformExecutor<Integer, String> executor = new TransformExecutor<>(transforms, stageMetrics);
+    List<TransformDetail> transforms = Lists.<TransformDetail>newArrayList();
+    transforms.add(
+      new TransformDetail("intToDoubleTransform", new IntToDouble(),
+                                new StageMetrics(mockMetrics, PluginID.from(Constants.Source.PLUGINTYPE, "first", 1))));
 
-    List<String> results = Lists.newArrayList(executor.runOneIteration(1));
+    transforms.add(
+      new TransformDetail("filterTransform", new Filter(100d),
+                                new StageMetrics(mockMetrics,
+                                                 PluginID.from(Constants.Transform.PLUGINTYPE, "second", 2))));
+
+    transforms.add(
+      new TransformDetail("doubleToStringTransform", new DoubleToString(),
+                                new StageMetrics(mockMetrics, PluginID.from(Constants.Sink.PLUGINTYPE, "third", 3))));
+
+    TransformExecutor<Integer, String> executor = new TransformExecutor<>(transforms);
+
+    TransformResponse transformResponse = executor.runOneIteration(1);
+    List<String> results = Lists.newArrayList(transformResponse.getEmittedRecords());
     Assert.assertTrue(results.isEmpty());
+    Map<String, Collection> errorIteratorsMap = transformResponse.getMapTransformIdToErrorEmitter();
+
+    Assert.assertEquals(1, errorIteratorsMap.size());
+    Assert.assertEquals(3, Lists.newArrayList(errorIteratorsMap.get("filterTransform")).size());
+
     Assert.assertEquals(3, mockMetrics.getCount("source.first.1.records.out"));
     Assert.assertEquals(0, mockMetrics.getCount("transform.second.2.records.out"));
     Assert.assertEquals(0, mockMetrics.getCount("sink.third.3.records.out"));
 
-    results = Lists.newArrayList(executor.runOneIteration(10));
+    executor.resetEmitters();
+    results = Lists.newArrayList(executor.runOneIteration(10).getEmittedRecords());
     Assert.assertEquals(1, results.size());
     Assert.assertEquals("1000.0", results.get(0));
     Assert.assertEquals(6, mockMetrics.getCount("source.first.1.records.out"));
     Assert.assertEquals(1, mockMetrics.getCount("transform.second.2.records.out"));
     Assert.assertEquals(1, mockMetrics.getCount("sink.third.3.records.out"));
 
-    results = Lists.newArrayList(executor.runOneIteration(100));
+    executor.resetEmitters();
+    results = Lists.newArrayList(executor.runOneIteration(100).getEmittedRecords());
     Assert.assertEquals(2, results.size());
     Assert.assertEquals("1000.0", results.get(0));
     Assert.assertEquals("10000.0", results.get(1));
     Assert.assertEquals(9, mockMetrics.getCount("source.first.1.records.out"));
     Assert.assertEquals(3, mockMetrics.getCount("transform.second.2.records.out"));
     Assert.assertEquals(3, mockMetrics.getCount("sink.third.3.records.out"));
+
+    executor.resetEmitters();
   }
 
   private static class IntToDouble extends Transform<Integer, Double> {
@@ -92,6 +114,8 @@ public class TransformExecutorTest {
     public void transform(Double input, Emitter<Double> emitter) throws Exception {
       if (input > threshold) {
         emitter.emit(input);
+      } else {
+        emitter.emitError(new InvalidEntry<Double>(100, "less than threshold", input));
       }
     }
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-realtime-app/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-realtime-app/pom.xml
@@ -52,6 +52,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-etl-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>

--- a/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/main/java/co/cask/cdap/template/etl/realtime/ETLWorker.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/main/java/co/cask/cdap/template/etl/realtime/ETLWorker.java
@@ -26,7 +26,6 @@ import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.worker.AbstractWorker;
 import co.cask.cdap.api.worker.WorkerContext;
 import co.cask.cdap.template.etl.api.Transform;
-import co.cask.cdap.template.etl.api.Transformation;
 import co.cask.cdap.template.etl.api.realtime.RealtimeContext;
 import co.cask.cdap.template.etl.api.realtime.RealtimeSink;
 import co.cask.cdap.template.etl.api.realtime.RealtimeSource;
@@ -37,7 +36,9 @@ import co.cask.cdap.template.etl.common.Destroyables;
 import co.cask.cdap.template.etl.common.ETLStage;
 import co.cask.cdap.template.etl.common.PluginID;
 import co.cask.cdap.template.etl.common.StageMetrics;
+import co.cask.cdap.template.etl.common.TransformDetail;
 import co.cask.cdap.template.etl.common.TransformExecutor;
+import co.cask.cdap.template.etl.common.TransformResponse;
 import co.cask.cdap.template.etl.realtime.config.ETLRealtimeConfig;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
@@ -48,6 +49,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -59,11 +61,12 @@ public class ETLWorker extends AbstractWorker {
   private static final Type STRING_LIST_TYPE = new TypeToken<List<String>>() { }.getType();
   private static final Gson GSON = new Gson();
   private static final String SEPARATOR = ":";
+  private static final String ERROR_DATASET_IDENTIFIER = "errorDataset";
+  private static final String ERROR_DATASET_TYPE = "errorDatasetType";
 
   private String adapterName;
   private RealtimeSource source;
   private RealtimeSink sink;
-  private List<Metrics> transformMetrics;
   private TransformExecutor transformExecutor;
   private DefaultEmitter sourceEmitter;
   private String stateStoreKey;
@@ -82,7 +85,6 @@ public class ETLWorker extends AbstractWorker {
   public void initialize(final WorkerContext context) throws Exception {
     super.initialize(context);
     Map<String, String> runtimeArgs = context.getRuntimeArguments();
-
     Preconditions.checkArgument(runtimeArgs.containsKey(Constants.ADAPTER_NAME));
     Preconditions.checkArgument(runtimeArgs.containsKey(Constants.CONFIG_KEY));
     Preconditions.checkArgument(runtimeArgs.containsKey(Constants.Source.PLUGINID));
@@ -119,10 +121,10 @@ public class ETLWorker extends AbstractWorker {
     });
 
     initializeSource(context, config.getSource());
-    List<Transformation> transforms = initializeTransforms(context, config.getTransforms());
+    List<TransformDetail> transforms = initializeTransforms(context, config.getTransforms());
     initializeSink(context, config.getSink());
 
-    transformExecutor = new TransformExecutor(transforms, transformMetrics);
+    transformExecutor = new TransformExecutor(transforms);
   }
 
   private void initializeSource(WorkerContext context, ETLStage stage) throws Exception {
@@ -146,14 +148,14 @@ public class ETLWorker extends AbstractWorker {
     sink = new TrackedRealtimeSink(sink, metrics, PluginID.from(sinkPluginId));
   }
 
-  private List<Transformation> initializeTransforms(WorkerContext context, List<ETLStage> stages) throws Exception {
+  private List<TransformDetail> initializeTransforms(WorkerContext context,
+                                                           List<ETLStage> stages) throws Exception {
     List<String> transformIds = GSON.fromJson(context.getRuntimeArguments().get(Constants.Transform.PLUGINIDS),
                                               STRING_LIST_TYPE);
-    List<Transformation> transforms = Lists.newArrayList();
+    List<TransformDetail> transforms = new ArrayList<>();
 
     Preconditions.checkArgument(transformIds != null);
     Preconditions.checkArgument(stages.size() == transformIds.size());
-    transformMetrics = Lists.newArrayListWithCapacity(stages.size());
     for (int i = 0; i < stages.size(); i++) {
       ETLStage stage = stages.get(i);
       String transformId = transformIds.get(i);
@@ -163,8 +165,8 @@ public class ETLWorker extends AbstractWorker {
         LOG.debug("Transform Stage : {}", stage.getName());
         LOG.debug("Transform Class : {}", transform.getClass().getName());
         transform.initialize(transformContext);
-        transforms.add(transform);
-        transformMetrics.add(new StageMetrics(metrics, PluginID.from(transformId)));
+        transforms.add(new TransformDetail(transformId, transform,
+                                           new StageMetrics(metrics, PluginID.from(transformId))));
       } catch (InstantiationException e) {
         LOG.error("Unable to instantiate Transform : {}", stage.getName(), e);
         Throwables.propagate(e);
@@ -211,8 +213,9 @@ public class ETLWorker extends AbstractWorker {
       // to be persisted in the sink.
       for (Object sourceData : sourceEmitter) {
         try {
-          for (Object object : transformExecutor.runOneIteration(sourceData)) {
-            dataToSink.add(object);
+          TransformResponse transformResponse = transformExecutor.runOneIteration(sourceData);
+          while (transformResponse.getEmittedRecords().hasNext()) {
+            dataToSink.add(transformResponse.getEmittedRecords().next());
           }
         } catch (Exception e) {
           LOG.warn("Adapter {} : Exception thrown while processing data {}", adapterName, sourceData, e);


### PR DESCRIPTION
we want to user to be able to write to an error dataset from validator transform for invalid records. 
this PR contains implementation for ETL Realtime. 

JIRA: https://issues.cask.co/browse/CDAP-3479
Build: http://builds.cask.co/browse/CDAP-DUT2735-1