### PR TITLE
Support for adding OutputFormatProvider as output of MR

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceContext.java
@@ -132,7 +132,7 @@ public interface MapReduceContext extends RuntimeContext, DatasetContext, Servic
   void addOutput(String datasetName);
 
   /**
-   * Overrides the output configuration of this MapReduce job to also allow writing to the specified dataset.
+   * Updates the output configuration of this MapReduce job to also allow writing to the specified dataset.
    * Currently, the dataset specified in must be an {@link OutputFormatProvider}.
    * You may want to use this method instead of {@link #addOutput(String)} if your output dataset uses runtime
    * arguments set in your own program logic.
@@ -142,6 +142,15 @@ public interface MapReduceContext extends RuntimeContext, DatasetContext, Servic
    * @throws IllegalArgumentException if the specified dataset is not an OutputFormatProvider.
    */
   void addOutput(String datasetName, Map<String, String> arguments);
+
+  /**
+   * Updates the output configuration of this MapReduce job to also allow writing using the given OutputFormatProvider.
+   *
+   * @param outputName the name of the output
+   * @param outputFormatProvider the outputFormatProvider which specifies an OutputFormat and configuration to be used
+   *                             when writing to this output
+   */
+  void addOutput(String outputName, OutputFormatProvider outputFormatProvider);
 
   /**
    * Overrides the resources, such as memory and virtual cores, to use for each mapper of this MapReduce job.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceLifecycleContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceLifecycleContext.java
@@ -19,6 +19,7 @@ package co.cask.cdap.internal.app.runtime.batch;
 import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.app.ApplicationSpecification;
 import co.cask.cdap.api.data.DatasetInstantiationException;
+import co.cask.cdap.api.data.batch.OutputFormatProvider;
 import co.cask.cdap.api.data.batch.Split;
 import co.cask.cdap.api.data.stream.StreamBatchReadable;
 import co.cask.cdap.api.dataset.Dataset;
@@ -206,6 +207,11 @@ public class MapReduceLifecycleContext<KEYOUT, VALUEOUT> implements MapReduceTas
 
   @Override
   public void addOutput(String datasetName, Map<String, String> arguments) {
+    LOG.warn(UNSUPPORTED_OPERATION_MESSAGE);
+  }
+
+  @Override
+  public void addOutput(String outputName, OutputFormatProvider outputFormatProvider) {
     LOG.warn(UNSUPPORTED_OPERATION_MESSAGE);
   }
 


### PR DESCRIPTION
This allows adding an OutputFormatProvider as an output onto the MapReduceContext.
Previously, only Datasets were allowed.

http://builds.cask.co/browse/CDAP-DUT2743-4