### PR TITLE
CDAP-3599 Breadcrumb namespace width to 24

### DIFF
--- a/cdap-ui/app/directives/breadcrumbs/breadcrumbs.html
+++ b/cdap-ui/app/directives/breadcrumbs/breadcrumbs.html
@@ -20,7 +20,7 @@
       <li class="dropdown">
         <a href="" class="ns-dropdown-toggle">
           <span class="fa fa-align-justify"></span>
-          <span ng-bind="namespace| myEllipsis: 10"></span>
+          <span ng-bind="namespace| myEllipsis: 21"></span>
         </a>
       </li>
     </ul>

--- a/cdap-ui/app/directives/breadcrumbs/breadcrumbs.less
+++ b/cdap-ui/app/directives/breadcrumbs/breadcrumbs.less
@@ -88,7 +88,7 @@ my-breadcrumbs, my-breadcrumb {
     }
 
     ul.dropdown-menu {
-      width: 120px;
+      max-width: 400px;
       height: auto;
       max-height: 290px;
       min-width: 0;

--- a/cdap-ui/app/directives/breadcrumbs/namespace.html
+++ b/cdap-ui/app/directives/breadcrumbs/namespace.html
@@ -15,7 +15,7 @@
 --> 
 
 <ul class="dropdown-menu" role="menu">
-  <li ng-if="!$state.includes('dashboard.**')" ng-repeat="ns in namespaces">
+  <li ng-if="!$state.includes('dashboard.**')" ng-repeat="ns in namespaces | orderBy : 'name'">
     <a role="menuitem" ng-class="{'active': ns.name === namespace}" ui-sref="overview({namespace: ns.name})" tabindex="-1">
       <i ng-class="{'fa fa-check': ns.name === namespace}"></i>
       <span ng-bind="ns.name | myEllipsis: 24"></span>

--- a/cdap-ui/app/directives/breadcrumbs/namespace.html
+++ b/cdap-ui/app/directives/breadcrumbs/namespace.html
@@ -18,13 +18,13 @@
   <li ng-if="!$state.includes('dashboard.**')" ng-repeat="ns in namespaces">
     <a role="menuitem" ng-class="{'active': ns.name === namespace}" ui-sref="overview({namespace: ns.name})" tabindex="-1">
       <i ng-class="{'fa fa-check': ns.name === namespace}"></i>
-      <span ng-bind="ns.name | myEllipsis: 8"></span>
+      <span ng-bind="ns.name | myEllipsis: 24"></span>
     </a>
   </li>
   <li ng-if="$state.includes('dashboard.**')" ng-repeat="ns in namespaces">
     <a role="menuitem" ui-sref="dashboard.standard.cdap({namespace: ns.name})" tabindex="-1">
       <i ng-class="{'fa fa-check': ns.name === namespace}"></i>
-      <span ng-class="{'active': ns.name === namespace}" ng-bind="ns.name | myEllipsis: 8"></span>
+      <span ng-class="{'active': ns.name === namespace}" ng-bind="ns.name | myEllipsis: 24"></span>
     </a>
   </li>
 </ul>


### PR DESCRIPTION
1. Limit namespace in breadcrumb to 24.
2. Adjust the drop down size to 24
3. Sort the namespace list. 