### PR TITLE
Change the word "file" to "product" in the license description.

### DIFF
--- a/cdap-docs/reference-manual/source/licenses/index.rst
+++ b/cdap-docs/reference-manual/source/licenses/index.rst
@@ -161,7 +161,7 @@ The Cask Data Application Platform (CDAP) product is copyright and licensed as f
    Copyright © |copyright|
 
    Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
+   you may not use this product except in compliance with the License.
    You may obtain a copy of the License at
 
        http://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION
This is a one-word change to the license file included in the documentation. This license is the standard text used in the Apache License, which was intended to be placed at the top of a source code *file*; and so it uses the word *file*.

But our usage here is slightly different; we are referring to the CDAP *product*, and hence the one-word change.