### PR TITLE
CDAP-3593 move sinks to new addOutput() apis in cdap mapreduce

### DIFF
--- a/cdap-app-templates/cdap-data-quality/src/main/java/co/cask/cdap/dq/DataQualityApp.java
+++ b/cdap-app-templates/cdap-data-quality/src/main/java/co/cask/cdap/dq/DataQualityApp.java
@@ -18,6 +18,7 @@ package co.cask.cdap.dq;
 
 import co.cask.cdap.api.Config;
 import co.cask.cdap.api.ProgramLifecycle;
+import co.cask.cdap.api.annotation.Property;
 import co.cask.cdap.api.app.AbstractApplication;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.data.format.StructuredRecord;
@@ -161,10 +162,10 @@ public class DataQualityApp extends AbstractApplication<DataQualityApp.DataQuali
       // We use pluginId as the prefixId
       batchSource.configurePipeline(new MapReducePipelineConfigurer(mrConfigurer, PLUGIN_ID));
       setName("FieldAggregator");
-      setOutputDataset(datasetName);
       setProperties(ImmutableMap.<String, String>builder()
                       .put("fieldAggregations", GSON.toJson(fieldAggregations))
                       .put("sourceId", source.getId())
+                      .put("datasetName", datasetName)
                       .build());
     }
 
@@ -177,6 +178,7 @@ public class DataQualityApp extends AbstractApplication<DataQualityApp.DataQuali
       // TODO: Figure out metrics to be passed in
       BatchSourceContext sourceContext = new MapReduceSourceContext(context, null, PLUGIN_ID);
       batchSource.prepareRun(sourceContext);
+      context.addOutput(context.getSpecification().getProperty("datasetName"));
     }
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/template/etl/api/batch/BatchSinkContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/template/etl/api/batch/BatchSinkContext.java
@@ -20,6 +20,8 @@ import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.data.batch.OutputFormatProvider;
 import co.cask.cdap.api.dataset.Dataset;
 
+import java.util.Map;
+
 /**
  * Context of a Batch Sink.
  */
@@ -27,20 +29,31 @@ import co.cask.cdap.api.dataset.Dataset;
 public interface BatchSinkContext extends BatchContext {
 
   /**
-   * Overrides the output configuration of this Batch job to write to the specified dataset by its name.
+   * Overrides the output configuration of this MapReduce job to also allow writing to the specified dataset by
+   * its name.
    *
    * @param datasetName the name of the output dataset
    */
-  void setOutput(String datasetName);
+  void addOutput(String datasetName);
 
   /**
-   * Overrides the output configuration of this Batch job to write to the specified dataset instance.
-   * Currently, the dataset passed in must either be an {@link OutputFormatProvider}.
-   * You may want to use this method instead of {@link #setOutput(String)} if your output dataset uses runtime
+   * Updates the output configuration of this MapReduce job to also allow writing to the specified dataset.
+   * Currently, the dataset specified in must be an {@link OutputFormatProvider}.
+   * You may want to use this method instead of {@link #addOutput(String)} if your output dataset uses runtime
    * arguments set in your own program logic.
    *
    * @param datasetName the name of the output dataset
-   * @param dataset the output dataset
+   * @param arguments the arguments to use when instantiating the dataset
+   * @throws IllegalArgumentException if the specified dataset is not an OutputFormatProvider.
    */
-  void setOutput(String datasetName, Dataset dataset);
+  void addOutput(String datasetName, Map<String, String> arguments);
+
+  /**
+   * Updates the output configuration of this MapReduce job to also allow writing using the given OutputFormatProvider.
+   *
+   * @param outputName the name of the output
+   * @param outputFormatProvider the outputFormatProvider which specifies an OutputFormat and configuration to be used
+   *                             when writing to this output
+   */
+  void addOutput(String outputName, OutputFormatProvider outputFormatProvider);
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/batch/MapReduceSinkContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/batch/MapReduceSinkContext.java
@@ -16,10 +16,13 @@
 
 package co.cask.cdap.template.etl.batch;
 
+import co.cask.cdap.api.data.batch.OutputFormatProvider;
 import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.mapreduce.MapReduceContext;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.template.etl.api.batch.BatchSinkContext;
+
+import java.util.Map;
 
 /**
  * MapReduce Sink Context.
@@ -31,12 +34,17 @@ public class MapReduceSinkContext extends MapReduceBatchContext implements Batch
   }
 
   @Override
-  public void setOutput(String datasetName) {
-    mrContext.setOutput(datasetName);
+  public void addOutput(String datasetName) {
+    mrContext.addOutput(datasetName);
   }
 
   @Override
-  public void setOutput(String datasetName, Dataset dataset) {
-    mrContext.setOutput(datasetName, dataset);
+  public void addOutput(String datasetName, Map<String, String> arguments) {
+    mrContext.addOutput(datasetName, arguments);
+  }
+
+  @Override
+  public void addOutput(String outputName, OutputFormatProvider outputFormatProvider) {
+    mrContext.addOutput(outputName, outputFormatProvider);
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/sink/BatchWritableSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/sink/BatchWritableSink.java
@@ -60,6 +60,6 @@ public abstract class BatchWritableSink<IN, KEY_OUT, VAL_OUT> extends BatchSink<
   @Override
   public void prepareRun(BatchSinkContext context) {
     PluginProperties pluginProperties = context.getPluginProperties();
-    context.setOutput(pluginProperties.getProperties().get(Properties.BatchReadableWritable.NAME));
+    context.addOutput(pluginProperties.getProperties().get(Properties.BatchReadableWritable.NAME));
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/sink/DBSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/sink/DBSink.java
@@ -19,6 +19,7 @@ package co.cask.cdap.template.etl.batch.sink;
 import co.cask.cdap.api.annotation.Description;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.data.batch.OutputFormatProvider;
 import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.api.dataset.lib.KeyValue;
 import co.cask.cdap.api.templates.plugins.PluginConfig;
@@ -33,17 +34,12 @@ import co.cask.cdap.template.etl.common.DBUtils;
 import co.cask.cdap.template.etl.common.ETLDBOutputFormat;
 import co.cask.cdap.template.etl.common.JDBCDriverShim;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Splitter;
 import com.google.common.base.Throwables;
-import com.google.common.collect.Lists;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.mapred.lib.db.DBConfiguration;
-import org.apache.hadoop.mapreduce.Job;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.DriverManager;
@@ -51,7 +47,8 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Sink that can be configured to export data to a database table.
@@ -99,24 +96,9 @@ public class DBSink extends BatchSink<StructuredRecord, DBRecord, NullWritable> 
               dbSinkConfig.tableName, dbSinkConfig.jdbcPluginType, dbSinkConfig.jdbcPluginName,
               dbSinkConfig.connectionString, dbSinkConfig.columns);
 
-    Job job = context.getHadoopJob();
-    Configuration hConf = job.getConfiguration();
-
     // Load the plugin class to make sure it is available.
     Class<? extends Driver> driverClass = context.loadPluginClass(getJDBCPluginId());
-    if (dbSinkConfig.user == null && dbSinkConfig.password == null) {
-      DBConfiguration.configureDB(hConf, driverClass.getName(), dbSinkConfig.connectionString);
-    } else {
-      DBConfiguration.configureDB(hConf, driverClass.getName(), dbSinkConfig.connectionString,
-                                  dbSinkConfig.user, dbSinkConfig.password);
-    }
-    List<String> fields = Lists.newArrayList(Splitter.on(",").omitEmptyStrings().split(dbSinkConfig.columns));
-    try {
-      ETLDBOutputFormat.setOutput(job, dbSinkConfig.tableName, fields.toArray(new String[fields.size()]));
-    } catch (IOException e) {
-      throw Throwables.propagate(e);
-    }
-    job.setOutputFormatClass(ETLDBOutputFormat.class);
+    context.addOutput(dbSinkConfig.tableName, new DBOutputFormatProvider(dbSinkConfig, driverClass));
   }
 
   @Override
@@ -198,5 +180,32 @@ public class DBSink extends BatchSink<StructuredRecord, DBRecord, NullWritable> 
 
     @Description("Name of the table to export to.")
     public String tableName;
+  }
+
+  private static class DBOutputFormatProvider implements OutputFormatProvider {
+    private final Map<String, String> conf;
+
+    public DBOutputFormatProvider(DBSinkConfig dbSinkConfig, Class<? extends Driver> driverClass) {
+      this.conf = new HashMap<>();
+
+      conf.put(DBConfiguration.DRIVER_CLASS_PROPERTY, driverClass.getName());
+      conf.put(DBConfiguration.URL_PROPERTY, dbSinkConfig.connectionString);
+      if (dbSinkConfig.user != null && dbSinkConfig.password != null) {
+        conf.put(DBConfiguration.USERNAME_PROPERTY, dbSinkConfig.user);
+        conf.put(DBConfiguration.PASSWORD_PROPERTY, dbSinkConfig.password);
+      }
+      conf.put(DBConfiguration.OUTPUT_TABLE_NAME_PROPERTY, dbSinkConfig.tableName);
+      conf.put(DBConfiguration.OUTPUT_FIELD_NAMES_PROPERTY, dbSinkConfig.columns);
+    }
+
+    @Override
+    public String getOutputFormatClassName() {
+      return ETLDBOutputFormat.class.getName();
+    }
+
+    @Override
+    public Map<String, String> getOutputFormatConfiguration() {
+      return conf;
+    }
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/sink/TimePartitionedFileSetSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/sink/TimePartitionedFileSetSink.java
@@ -71,7 +71,6 @@ public abstract class TimePartitionedFileSetSink<KEY_OUT, VAL_OUT>
       TimePartitionedFileSetArguments.setOutputPathFormat(sinkArgs, tpfsSinkConfig.filePathFormat,
                                                           tpfsSinkConfig.timeZone);
     }
-    TimePartitionedFileSet sink = context.getDataset(tpfsSinkConfig.name, sinkArgs);
-    context.setOutput(tpfsSinkConfig.name, sink);
+    context.addOutput(tpfsSinkConfig.name, sinkArgs);
   }
 }


### PR DESCRIPTION
This changes the sink contexts to use addOutput() instead of
setOutput() in preparation of allowing multiple output sinks.