### PR TITLE
CDAP-3527 Add first drop of Business Metadata dataset.

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/SystemDatasetRuntimeModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/SystemDatasetRuntimeModule.java
@@ -31,6 +31,7 @@ import co.cask.cdap.data2.dataset2.module.lib.inmemory.InMemoryMetricsTableModul
 import co.cask.cdap.data2.dataset2.module.lib.inmemory.InMemoryTableModule;
 import co.cask.cdap.data2.dataset2.module.lib.leveldb.LevelDBMetricsTableModule;
 import co.cask.cdap.data2.dataset2.module.lib.leveldb.LevelDBTableModule;
+import co.cask.cdap.data2.metadata.dataset.BusinessMetadataDatasetModule;
 import co.cask.cdap.data2.registry.UsageDatasetModule;
 import co.cask.cdap.data2.transaction.queue.hbase.HBaseQueueDatasetModule;
 import com.google.inject.AbstractModule;
@@ -105,5 +106,6 @@ public class SystemDatasetRuntimeModule extends RuntimeModule {
     mapBinder.addBinding("objectMappedTable").toInstance(new ObjectMappedTableModule());
     mapBinder.addBinding("cube").toInstance(new CubeModule());
     mapBinder.addBinding("usage").toInstance(new UsageDatasetModule());
+    mapBinder.addBinding("businessMetadata").toInstance(new BusinessMetadataDatasetModule());
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/BusinessMetadataDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/BusinessMetadataDataset.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.data2.metadata.dataset;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.dataset.lib.AbstractDataset;
+import co.cask.cdap.api.dataset.lib.IndexedTable;
+import co.cask.cdap.api.dataset.table.Put;
+import co.cask.cdap.api.dataset.table.Row;
+import co.cask.cdap.data2.dataset2.lib.table.MDSKey;
+import co.cask.cdap.proto.Id;
+
+import com.google.common.base.Throwables;
+import com.google.common.collect.Lists;
+
+import java.util.Collection;
+
+/**
+ * Implementation of Business Metadata on top of {@link IndexedTable}.
+ */
+public class BusinessMetadataDataset extends AbstractDataset {
+  // column keys
+  public static final String KEYVALUE_COLUMN = "kv";
+  public static final String VALUE_COLUMN = "v";
+
+  private final IndexedTable indexedTable;
+
+  public BusinessMetadataDataset(IndexedTable indexedTable) {
+    super("ignore", indexedTable);
+    this.indexedTable = indexedTable;
+  }
+
+  /**
+   * Add new business metadata.
+   *
+   * @param metadataRecord The value of the metadata to be saved.
+   */
+  public void createBusinessMetadata(BusinessMetadataRecord metadataRecord) {
+    String targetType = getTargetType(metadataRecord.getTargetId());
+    Id.NamespacedId targetId = metadataRecord.getTargetId();
+    String key = metadataRecord.getKey();
+    MDSKey mdsKey = getInstanceKey(targetType, targetId, key);
+
+    // Put to the default column.
+    write(mdsKey, metadataRecord);
+  }
+
+  /**
+   * Add new business metadata.
+   *
+   * @param targetId The target Id: app-id(ns+app) / program-id(ns+app+pgtype+pgm) /
+   *                 dataset-id(ns+dataset)/stream-id(ns+stream).
+   * @param key The metadata key to be added.
+   * @param value The metadata value to be added.
+   */
+  public void createBusinessMetadata(Id.NamespacedId targetId, String key, String value) {
+    createBusinessMetadata(new BusinessMetadataRecord(targetId, key, value));
+  }
+
+  /**
+   * Return business metadata based on type, target id, and key.
+   *
+   * @param targetId The id of the target.
+   * @param key The metadata key to get.
+   * @return instance of {@link BusinessMetadataRecord} for the target type, id, and key.
+   */
+  public BusinessMetadataRecord getBusinessMetadata(Id.NamespacedId targetId, String key) {
+    String targetType = getTargetType(targetId);
+    MDSKey mdsKey = getInstanceKey(targetType, targetId, key);
+    Row row = indexedTable.get(mdsKey.getKey());
+    if (row.isEmpty()) {
+      return null;
+    }
+
+    byte[] keyvalue = row.get(KEYVALUE_COLUMN);
+    byte[] value = row.get(VALUE_COLUMN);
+
+    return new BusinessMetadataRecord(targetId, key, Bytes.toString(value));
+  }
+
+  private static Id.NamespacedId fromString(String type, String id) {
+    if (type.equals(Id.Program.class.getSimpleName())) {
+      return Id.Program.fromStrings(id.split("/"));
+    } else if (type.equals(Id.Application.class.getSimpleName())) {
+      return Id.Application.fromStrings(id.split("/"));
+    } else if (type.equals(Id.DatasetInstance.class.getSimpleName())) {
+      // TODO Add code
+    } else if (type.equals(Id.Stream.class.getSimpleName())) {
+      return Id.Stream.fromId(id);
+    }
+    throw new IllegalArgumentException("Illegal Type of metadata source.");
+  }
+
+  /**
+   * Find the instance of {@link BusinessMetadataRecord} based on key.
+   *
+   * @param key The metadata value to be found.
+   * @return Collection of {@link BusinessMetadataRecord} fits the key.
+   */
+  public Collection<BusinessMetadataRecord> findBusinessMetadataOnKey(String key) {
+
+    // TODO ADD CODE
+
+    return Lists.newArrayList();
+  }
+
+  private void write(MDSKey id, BusinessMetadataRecord record) {
+    try {
+      Put put = new Put(id.getKey());
+
+      // Now add the index columns.
+      put.add(Bytes.toBytes(KEYVALUE_COLUMN), Bytes.toBytes(record.getKey() + ":" + record.getValue()));
+      put.add(Bytes.toBytes(VALUE_COLUMN), Bytes.toBytes(record.getValue()));
+
+      indexedTable.put(put);
+    } catch (Exception e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  // Helper method to generate key.
+  private MDSKey getInstanceKey(String targetType, Id.NamespacedId targetId, String key) {
+    MDSKey.Builder builder = new MDSKey.Builder();
+    builder.add(targetType);
+    builder.add(targetId.toString());
+    builder.add(key);
+
+    return builder.build();
+  }
+
+  private String getTargetType(Id.NamespacedId namespacedId) {
+    if (namespacedId instanceof Id.Program) {
+      return Id.Program.class.getSimpleName();
+    }
+    return namespacedId.getClass().getSimpleName();
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/BusinessMetadataDatasetModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/BusinessMetadataDatasetModule.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.data2.metadata.dataset;
+
+import co.cask.cdap.api.dataset.DatasetAdmin;
+import co.cask.cdap.api.dataset.DatasetDefinition;
+import co.cask.cdap.api.dataset.lib.IndexedTable;
+import co.cask.cdap.api.dataset.module.DatasetDefinitionRegistry;
+import co.cask.cdap.api.dataset.module.DatasetModule;
+
+/**
+ * {@link co.cask.cdap.api.dataset.module.DatasetModule} for {@link BusinessMetadataDataset}.
+ */
+public class BusinessMetadataDatasetModule implements DatasetModule {
+
+  @Override
+  public void register(DatasetDefinitionRegistry registry) {
+    DatasetDefinition<IndexedTable, ? extends DatasetAdmin> indexedTableDef =
+      registry.get(IndexedTable.class.getName());
+    registry.add(new BusinessMetadataDefinition("businessMetadataDataset", indexedTableDef));
+    registry.add(new BusinessMetadataDefinition(BusinessMetadataDataset.class.getSimpleName(), indexedTableDef));
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/BusinessMetadataDefinition.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/BusinessMetadataDefinition.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.data2.metadata.dataset;
+
+import co.cask.cdap.api.dataset.DatasetAdmin;
+import co.cask.cdap.api.dataset.DatasetContext;
+import co.cask.cdap.api.dataset.DatasetDefinition;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.DatasetSpecification;
+import co.cask.cdap.api.dataset.lib.AbstractDatasetDefinition;
+import co.cask.cdap.api.dataset.lib.CompositeDatasetAdmin;
+import co.cask.cdap.api.dataset.lib.IndexedTable;
+import co.cask.cdap.api.dataset.lib.IndexedTableDefinition;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Define the Dataset for metadata.
+ */
+public class BusinessMetadataDefinition extends AbstractDatasetDefinition<BusinessMetadataDataset, DatasetAdmin> {
+
+  public static final String METADATA_INDEX_TABLE_NAME = "metadata_index";
+  public static final String INDEXED_COLS = BusinessMetadataDataset.KEYVALUE_COLUMN + "," +
+    BusinessMetadataDataset.VALUE_COLUMN;
+
+  private final DatasetDefinition<? extends IndexedTable, ?> indexedTableDef;
+
+  public BusinessMetadataDefinition(String name, DatasetDefinition<? extends IndexedTable, ?> indexedTableDef) {
+    super(name);
+    this.indexedTableDef = indexedTableDef;
+  }
+
+  // Implementation of DatasetDefinition interface methods.
+
+  @Override
+  public DatasetSpecification configure(String instanceName, DatasetProperties properties) {
+    // Define the columns for indexing on the partitionsTable
+    DatasetProperties indexedTableProperties = DatasetProperties.builder()
+      .addAll(properties.getProperties())
+      .add(IndexedTableDefinition.INDEX_COLUMNS_CONF_KEY, INDEXED_COLS)
+      .build();
+    return DatasetSpecification.builder(instanceName, getName())
+      .properties(properties.getProperties())
+      .datasets(indexedTableDef.configure(METADATA_INDEX_TABLE_NAME, indexedTableProperties))
+      .build();
+  }
+
+  @Override
+  public DatasetAdmin getAdmin(DatasetContext datasetContext, DatasetSpecification spec,
+                               ClassLoader classLoader) throws IOException {
+    return new CompositeDatasetAdmin(indexedTableDef.getAdmin(datasetContext,
+                                                              spec.getSpecification(METADATA_INDEX_TABLE_NAME),
+                                                              classLoader));
+  }
+
+  @Override
+  public BusinessMetadataDataset getDataset(DatasetContext datasetContext, DatasetSpecification spec,
+                                 Map<String, String> arguments, ClassLoader classLoader) throws IOException {
+
+    IndexedTable indexedTable  = indexedTableDef.getDataset(datasetContext,
+                                                            spec.getSpecification(METADATA_INDEX_TABLE_NAME),
+                                                            arguments, classLoader);
+
+    return new BusinessMetadataDataset(indexedTable);
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/BusinessMetadataRecord.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/BusinessMetadataRecord.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.data2.metadata.dataset;
+
+import co.cask.cdap.proto.Id;
+
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+/**
+ * Represent Busineess Metadata for CDAP.
+ */
+public class BusinessMetadataRecord {
+  private final Id.NamespacedId  targetId;
+  private final String key;
+  private final String value;
+  private final String schema;
+
+  public BusinessMetadataRecord(Id.NamespacedId targetId, String key, String value) {
+    this(targetId, key, value, null);
+  }
+
+  public BusinessMetadataRecord(Id.NamespacedId targetId, String key, String value,
+                                @Nullable String schema) {
+    this.targetId = targetId;
+    this.key = key;
+    this.value = value;
+    this.schema = schema;
+  }
+
+  public Id.NamespacedId  getTargetId() {
+    return targetId;
+  }
+
+  public String getKey() {
+    return key;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public String getSchema() {
+    return schema;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    BusinessMetadataRecord that = (BusinessMetadataRecord) o;
+
+    return Objects.equals(targetId, that.targetId) &&
+      Objects.equals(key, that.key) &&
+      Objects.equals(value, that.value) &&
+      Objects.equals(schema, that.schema);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(targetId, key, value, schema);
+  }
+
+  @Override
+  public String toString() {
+    return "{" +
+      "targetId='" + targetId + '\'' +
+      ", key='" + key + '\'' +
+      ", value='" + value + '\'' +
+      ", schema='" + (schema != null ? schema : 0) +
+      '}';
+  }
+}

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/dataset/BusinessMetadataDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/dataset/BusinessMetadataDatasetTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.data2.metadata.dataset;
+
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
+import co.cask.cdap.data2.dataset2.DatasetFrameworkTestUtil;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.ProgramType;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Test class for {@link BusinessMetadataDataset} class.
+ */
+public class BusinessMetadataDatasetTest {
+
+  @ClassRule
+  public static TemporaryFolder tmpFolder = new TemporaryFolder();
+
+  @ClassRule
+  public static DatasetFrameworkTestUtil dsFrameworkUtil = new DatasetFrameworkTestUtil();
+
+  private static final Id.DatasetInstance datasetInstance =
+    Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "meta");
+
+  BusinessMetadataDataset dataset;
+
+  @Before
+  public void before() throws Exception {
+    dataset = getDataset();
+  }
+
+  @After
+  public void after() throws Exception {
+    dataset = null;
+  }
+
+  @Test
+  public void testAddOneMetadata() throws Exception {
+
+    Id.Program flow21 = Id.Program.from("ns1", "app2", ProgramType.FLOW, "flow21");
+
+    // Create record
+    final BusinessMetadataRecord record = new BusinessMetadataRecord(
+      flow21, "key1", "value1");
+
+    // Save it
+    dataset.createBusinessMetadata(record);
+
+    // Get that record
+    final BusinessMetadataRecord result = dataset.getBusinessMetadata(flow21, "key1");
+
+    // Assert check
+    Assert.assertEquals(record, result);
+  }
+
+  private static BusinessMetadataDataset getDataset() throws Exception {
+    return DatasetsUtil.getOrCreateDataset(dsFrameworkUtil.getFramework(), datasetInstance,
+                                           BusinessMetadataDataset.class.getSimpleName(),
+                                           DatasetProperties.EMPTY, null, null);
+  }
+}


### PR DESCRIPTION
This PR is created to help share internally about the new datasets for Business Metadata.

Added new system dataset for Business Metadata called BusinessMetadataDataset that internally backed by IndexedTable to support inverted index search for value and key:value columns.