### PR TITLE
Feature/cdap 2757 dynamic partitioning of mr output

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/DynamicPartitioner.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/DynamicPartitioner.java
@@ -35,7 +35,7 @@ public abstract class DynamicPartitioner<K, V> {
    *    on that instance.
    *  </p>
    *  @param mapReduceTaskContext the mapReduceTaskContext for the task that this DynamicPartitioner is running in.
-   *
+   *  Note that the hadoop context is not available on this MapReduceTaskContext.
    */
   public void initialize(MapReduceTaskContext<K, V> mapReduceTaskContext) {
     // do nothing by default

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/DynamicPartitioner.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/DynamicPartitioner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/DynamicPartitioner.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/DynamicPartitioner.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2014-2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.api.dataset.lib;
+
+import co.cask.cdap.api.mapreduce.MapReduceTaskContext;
+
+/**
+ * Responsible for dynamically determining a @{link PartitionKey}.
+ * For each K, V pair, the getPartitionKey(K, V) method is called to determine a PartitionKey.
+ *
+ * @param <K> Type of key
+ * @param <V> Type of value
+ */
+public abstract class DynamicPartitioner<K, V> {
+
+
+  /**
+   *  Initializes a DynamicPartitioner.
+   *  <p>
+   *    This method will be called only once per {@link DynamicPartitioner} instance. It is the first method call
+   *    on that instance.
+   *  </p>
+   *  @param mapReduceTaskContext the mapReduceTaskContext for the task that this DynamicPartitioner is running in.
+   *
+   */
+  public void initialize(MapReduceTaskContext<K, V> mapReduceTaskContext) {
+    // do nothing by default
+  }
+
+  /**
+   *  Destroys a DynamicPartitioner.
+   *  <p>
+   *    This method will be called only once per {@link DynamicPartitioner} instance. It is the last method call
+   *    on that instance.
+   *  </p>
+   */
+  public void destroy() {
+    // do nothing by default
+  }
+
+  /**
+   * Determine the PartitionKey for the key-value pair to be written to.
+   *
+   * @param key the key to be written
+   * @param value the value to be written
+   * @return the {@link PartitionKey} for the key-value pair to be written to.
+   */
+  public abstract PartitionKey getPartitionKey(K key, V value);
+}

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/FileSetArguments.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/FileSetArguments.java
@@ -78,6 +78,21 @@ public class FileSetArguments {
   }
 
   /**
+   * Sets the baseLocation of the file dataset as the output location in the runtime arguments for a file dataset.
+   */
+  public static void setBaseOutputPath(Map<String, String> arguments) {
+    // use null to indicate to use the base location of the file dataset as the output path
+    arguments.put(OUTPUT_PATH, null);
+  }
+
+  /**
+   * @return whether to use the base location of the file dataset as the output location.
+   */
+  public static boolean isBaseOutputPath(Map<String, String> arguments) {
+    return arguments.containsKey(OUTPUT_PATH) && arguments.get(OUTPUT_PATH) == null;
+  }
+
+  /**
    * Sets the output path in the runtime arguments for a file dataset.
    */
   public static void setOutputPath(Map<String, String> arguments, String path) {

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionedFileSetArguments.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionedFileSetArguments.java
@@ -31,6 +31,7 @@ public class PartitionedFileSetArguments {
 
   public static final String OUTPUT_PARTITION_KEY_PREFIX = "output.partition.key.";
   public static final String OUTPUT_PARTITION_METADATA_PREFIX = "output.partition.metadata.";
+  public static final String DYNAMIC_PARTITIONER_CLASS_NAME = "output.dynamic.partitioner.class.name";
   public static final String INPUT_PARTITION_LOWER_PREFIX = "input.filter.lower.";
   public static final String INPUT_PARTITION_UPPER_PREFIX = "input.filter.upper.";
   public static final String INPUT_PARTITION_VALUE_PREFIX = "input.filter.value.";
@@ -197,4 +198,36 @@ public class PartitionedFileSetArguments {
     FileSetArguments.addInputPath(arguments, partition.getRelativePath());
   }
 
+  /**
+   * Sets a DynamicPartitioner class to be used during the output of a PartitionedFileSet.
+   *
+   * @param arguments the runtime arguments for a partitioned dataset
+   * @param dynamicPartitionerClass the class to set
+   * @param <K> type of key
+   * @param <V> type of value
+   */
+  public static <K, V> void setDynamicPartitioner(Map<String, String> arguments,
+                                                  Class<? extends DynamicPartitioner<K, V>> dynamicPartitionerClass) {
+    setDynamicPartitioner(arguments, dynamicPartitionerClass.getName());
+  }
+
+  /**
+   * Sets a DynamicPartitioner class to be used during the output of a PartitionedFileSet.
+   *
+   * @param arguments the runtime arguments for a partitioned dataset
+   * @param dynamicPartitionerClassName the name of the class to set
+   */
+  public static void setDynamicPartitioner(Map<String, String> arguments, String dynamicPartitionerClassName) {
+    arguments.put(DYNAMIC_PARTITIONER_CLASS_NAME, dynamicPartitionerClassName);
+  }
+
+  /**
+   * Return the DynamicPartitioner class that was previously assigned onto runtime arguments.
+   *
+   * @param arguments the runtime arguments to get the class from
+   * @return name of the DynamicPartitioner class
+   */
+  public static String getDynamicPartitioner(Map<String, String> arguments) {
+    return arguments.get(DYNAMIC_PARTITIONER_CLASS_NAME);
+  }
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/flow/flowlet/Flowlet.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/flow/flowlet/Flowlet.java
@@ -46,7 +46,7 @@ public interface Flowlet extends ProgramLifecycle<FlowletContext> {
   /**
    *  Initializes a Flowlet.
    *  <p>
-   *    This method will be called only once per {@link Flowlet} instance..
+   *    This method will be called only once per {@link Flowlet} instance.
    *  </p>
    *  @param context An instance of {@link FlowletContext}
    *  @throws Exception If there is any error during initialization.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/metrics/MapReduceMetrics.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/metrics/MapReduceMetrics.java
@@ -16,6 +16,10 @@
 
 package co.cask.cdap.app.metrics;
 
+import org.apache.hadoop.mapreduce.TaskType;
+
+import javax.annotation.Nullable;
+
 /**
  * Metrics collector for MapReduce job.
  * todo: extract TaskType enum in its own class
@@ -48,6 +52,18 @@ public final class MapReduceMetrics {
 
     public String getId() {
       return id;
+    }
+
+    @Nullable
+    public static TaskType from(org.apache.hadoop.mapreduce.TaskType hadoopTaskType) {
+      switch (hadoopTaskType) {
+        case MAP:
+          return MapReduceMetrics.TaskType.Mapper;
+        case REDUCE:
+          return MapReduceMetrics.TaskType.Reducer;
+        default:
+          return null;
+      }
     }
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/AbstractMapReduceTaskContextBuilder.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/AbstractMapReduceTaskContextBuilder.java
@@ -59,7 +59,7 @@ public abstract class AbstractMapReduceTaskContextBuilder {
    * @param outputDataSetName name of the output dataset if specified for this mapreduce job, null otherwise
    * @return instance of {@link BasicMapReduceTaskContext}
    */
-  public BasicMapReduceTaskContext build(MapReduceMetrics.TaskType type,
+  public BasicMapReduceTaskContext build(@Nullable MapReduceMetrics.TaskType type,
                                          String runId,
                                          String taskId,
                                          long logicalStartTime,

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
@@ -31,11 +31,9 @@ import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.api.metrics.MetricsContext;
 import co.cask.cdap.api.plugin.Plugin;
 import co.cask.cdap.api.workflow.WorkflowToken;
-import co.cask.cdap.app.metrics.MapReduceMetrics;
 import co.cask.cdap.app.metrics.ProgramUserMetrics;
 import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.runtime.Arguments;
-import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.logging.LoggingContext;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.internal.app.runtime.AbstractContext;
@@ -79,8 +77,7 @@ public class BasicMapReduceContext extends AbstractContext implements MapReduceC
   private Resources reducerResources;
 
   public BasicMapReduceContext(Program program,
-                               MapReduceMetrics.TaskType type,
-                               RunId runId, String taskId,
+                               RunId runId,
                                Arguments runtimeArguments,
                                Set<String> datasets,
                                MapReduceSpecification spec,
@@ -93,9 +90,8 @@ public class BasicMapReduceContext extends AbstractContext implements MapReduceC
                                LocationFactory locationFactory,
                                @Nullable PluginInstantiator pluginInstantiator) {
     super(program, runId, runtimeArguments, datasets,
-          getMetricCollector(program, runId.getId(), taskId, metricsCollectionService, type),
-          dsFramework, discoveryServiceClient, locationFactory,
-          pluginInstantiator);
+          getMetricsCollector(program, runId.getId(), metricsCollectionService),
+          dsFramework, discoveryServiceClient, locationFactory, pluginInstantiator);
     this.logicalStartTime = logicalStartTime;
     this.programNameInWorkflow = programNameInWorkflow;
     this.workflowToken = workflowToken;
@@ -341,19 +337,14 @@ public class BasicMapReduceContext extends AbstractContext implements MapReduceC
   }
 
   @Nullable
-  private static MetricsContext getMetricCollector(Program program, String runId, String taskId,
-                                                   @Nullable MetricsCollectionService service,
-                                                   @Nullable MapReduceMetrics.TaskType type) {
+  private static MetricsContext getMetricsCollector(Program program, String runId,
+                                                    @Nullable MetricsCollectionService service) {
     if (service == null) {
       return null;
     }
 
     Map<String, String> tags = Maps.newHashMap();
     tags.putAll(getMetricsContext(program, runId));
-    if (type != null) {
-      tags.put(Constants.Metrics.Tag.MR_TASK_TYPE, type.getId());
-      tags.put(Constants.Metrics.Tag.INSTANCE_ID, taskId);
-    }
 
     return service.getContext(tags);
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceTaskContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceTaskContext.java
@@ -48,7 +48,6 @@ import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 
-
 /**
  * Mapreduce task runtime context which delegates to BasicMapReduceContext for non task-specific methods.
  * It currently also extends MapReduceContext to support backwards compatibility. Mapper and Reducer tasks could

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceTaskContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceTaskContext.java
@@ -72,7 +72,7 @@ public class BasicMapReduceTaskContext<KEYOUT, VALUEOUT> extends AbstractContext
   private TaskInputOutputContext<?, ?, KEYOUT, VALUEOUT> context;
 
   public BasicMapReduceTaskContext(Program program,
-                                   MapReduceMetrics.TaskType type,
+                                   @Nullable MapReduceMetrics.TaskType type,
                                    RunId runId, String taskId,
                                    Arguments runtimeArguments,
                                    Set<String> datasets,
@@ -139,9 +139,9 @@ public class BasicMapReduceTaskContext<KEYOUT, VALUEOUT> extends AbstractContext
     return (T) context;
   }
 
-  public void setHadoopContext(TaskInputOutputContext<?, ?, KEYOUT, VALUEOUT> flushingContext) {
-    this.multipleOutputs = new MultipleOutputs(flushingContext);
-    this.context = flushingContext;
+  public void setHadoopContext(TaskInputOutputContext<?, ?, KEYOUT, VALUEOUT> context) {
+    this.multipleOutputs = new MultipleOutputs(context);
+    this.context = context;
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/DynamicMapReduceContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/DynamicMapReduceContext.java
@@ -70,8 +70,7 @@ public class DynamicMapReduceContext extends BasicMapReduceContext implements Da
   private final DynamicDatasetContext dynamicDatasetContext;
 
   public DynamicMapReduceContext(Program program,
-                                 MapReduceMetrics.TaskType type,
-                                 RunId runId, String taskId,
+                                 RunId runId,
                                  Arguments runtimeArguments,
                                  MapReduceSpecification spec,
                                  long logicalStartTime, @Nullable String programNameInWorkflow,
@@ -82,7 +81,7 @@ public class DynamicMapReduceContext extends BasicMapReduceContext implements Da
                                  DatasetFramework dsFramework,
                                  LocationFactory locationFactory,
                                  @Nullable PluginInstantiator pluginInstantiator) {
-    super(program, type, runId, taskId, runtimeArguments, Collections.<String>emptySet(), spec,
+    super(program, runId, runtimeArguments, Collections.<String>emptySet(), spec,
           logicalStartTime, programNameInWorkflow, workflowToken, discoveryServiceClient, metricsCollectionService,
           dsFramework, locationFactory, pluginInstantiator);
     this.datasetsCache = CacheBuilder.newBuilder()

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
@@ -163,7 +163,7 @@ public class MapReduceProgramRunner implements ProgramRunner {
       closeables.add(pluginInstantiator);
 
       final DynamicMapReduceContext context =
-        new DynamicMapReduceContext(program, null, runId, null, options.getUserArguments(), spec,
+        new DynamicMapReduceContext(program, runId, options.getUserArguments(), spec,
                                     logicalStartTime, programNameInWorkflow, workflowToken, discoveryServiceClient,
                                     metricsCollectionService, txSystemClient, datasetFramework, locationFactory,
                                     pluginInstantiator);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceTaskContextProvider.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceTaskContextProvider.java
@@ -55,7 +55,7 @@ public final class MapReduceTaskContextProvider {
   private BasicMapReduceTaskContext context;
   private AbstractMapReduceTaskContextBuilder contextBuilder;
 
-  public MapReduceTaskContextProvider(TaskAttemptContext context, MapReduceMetrics.TaskType type) {
+  public MapReduceTaskContextProvider(TaskAttemptContext context, @Nullable MapReduceMetrics.TaskType type) {
     this.taskContext = context;
     this.type = type;
     this.contextConfig = new MapReduceContextConfig(context.getConfiguration());
@@ -71,7 +71,7 @@ public final class MapReduceTaskContextProvider {
    * inside cannot load program classes. It is used for the cases where only the application specification is needed,
    * but no need to load any class from it.
    */
-  public synchronized BasicMapReduceTaskContext get() {
+  public synchronized <K, V> BasicMapReduceTaskContext<K, V> get() {
     if (context == null) {
       CConfiguration cConf = contextConfig.getConf();
       context = getBuilder(cConf)

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/DataSetInputFormat.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/DataSetInputFormat.java
@@ -69,8 +69,7 @@ public final class DataSetInputFormat<KEY, VALUE> extends InputFormat<KEY, VALUE
     DataSetInputSplit inputSplit = (DataSetInputSplit) split;
 
     Configuration conf = context.getConfiguration();
-    // we don't currently allow datasets as the format between map and reduce stages, otherwise we'll have to
-    // pass in the stage here instead of hardcoding mapper.
+    // We know this is a mapper task because it is the input to the MR job.
     MapReduceTaskContextProvider contextProvider = new MapReduceTaskContextProvider(context,
                                                                                     MapReduceMetrics.TaskType.Mapper);
     BasicMapReduceTaskContext mrContext = contextProvider.get();

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/DataSetOutputFormat.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/DataSetOutputFormat.java
@@ -60,6 +60,9 @@ public final class DataSetOutputFormat<KEY, VALUE> extends OutputFormat<KEY, VAL
 
   @Override
   public void checkOutputSpecs(final JobContext context) throws IOException, InterruptedException {
+    if (getOutputDataSet(context.getConfiguration()) == null) {
+      throw new IllegalArgumentException("Dataset name not configured for job: " + context.getJobName());
+    }
     // TODO: validate out types? Or this is ensured by configuring job in "internal" code (i.e. not in user code)
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/DataSetOutputFormat.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/DataSetOutputFormat.java
@@ -41,10 +41,10 @@ public final class DataSetOutputFormat<KEY, VALUE> extends OutputFormat<KEY, VAL
   public RecordWriter<KEY, VALUE> getRecordWriter(final TaskAttemptContext context)
     throws IOException, InterruptedException {
     Configuration conf = context.getConfiguration();
-    // we don't currently allow datasets as the format between map and reduce stages, otherwise we'll have to
-    // pass in the stage here instead of hardcoding reducer.
-    MapReduceTaskContextProvider contextProvider = new MapReduceTaskContextProvider(context,
-                                                                                    MapReduceMetrics.TaskType.Reducer);
+    // we don't currently allow datasets as the format between map and reduce stages, but this can still be the output
+    // of a map-only job, so we need to determine the taskType
+    MapReduceMetrics.TaskType taskType = MapReduceMetrics.TaskType.from(context.getTaskAttemptID().getTaskType());
+    MapReduceTaskContextProvider contextProvider = new MapReduceTaskContextProvider(context, taskType);
     BasicMapReduceTaskContext mrContext = contextProvider.get();
     mrContext.getMetricsCollectionService().startAndWait();
     @SuppressWarnings("unchecked")

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/MultipleOutputs.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/MultipleOutputs.java
@@ -282,8 +282,19 @@ public class MultipleOutputs implements Closeable {
    */
   @SuppressWarnings("unchecked")
   public void close() {
+    closeRecordWriters(recordWriters.values(), context);
+  }
+
+  /**
+   * Closes a collection of RecordWriters, suppressing any exceptions until close is called on each of them.
+   *
+   * @param recordWriters The Collection of RecordWriters to close
+   * @param context The context to pass during close of each RecordWriter
+   */
+  public static void closeRecordWriters(Iterable<RecordWriter<?, ?>> recordWriters,
+                                        TaskAttemptContext context) {
     RuntimeException ex = null;
-    for (RecordWriter writer : recordWriters.values()) {
+    for (RecordWriter writer : recordWriters) {
       try {
         writer.close(context);
       } catch (IOException | InterruptedException e) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/partitioned/DynamicPartitioningOutputCommitter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/partitioned/DynamicPartitioningOutputCommitter.java
@@ -107,14 +107,6 @@ public class DynamicPartitioningOutputCommitter extends FileOutputCommitter {
       }
     }
 
-    try {
-      mrTaskContext.flushOperations();
-    } catch (Exception e) {
-      throw new IOException(e);
-    } finally {
-      mrTaskContext.close();
-    }
-
     // We need to copy to the parent of the FileOutputFormat's outputDir, since we added a _temporary_jobId suffix to
     // the original outputDir.
     Path finalOutput = FileOutputFormat.getOutputPath(context);
@@ -126,6 +118,14 @@ public class DynamicPartitioningOutputCommitter extends FileOutputCommitter {
     // create all the necessary partitions
     for (PartitionKey partitionKey : partitionsToAdd) {
       outputDataset.getPartitionOutput(partitionKey).addPartition();
+    }
+    // close the TaskContext, which flushes dataset operations
+    try {
+      mrTaskContext.flushOperations();
+    } catch (Exception e) {
+      throw new IOException(e);
+    } finally {
+      mrTaskContext.close();
     }
 
     // delete the job-specific _temporary folder and create a _done file in the o/p folder

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/partitioned/DynamicPartitioningOutputCommitter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/partitioned/DynamicPartitioningOutputCommitter.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.batch.dataset.partitioned;
+
+import co.cask.cdap.api.dataset.lib.Partition;
+import co.cask.cdap.api.dataset.lib.PartitionKey;
+import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
+import co.cask.cdap.api.dataset.lib.Partitioning;
+import co.cask.cdap.internal.app.runtime.batch.BasicMapReduceTaskContext;
+import co.cask.cdap.internal.app.runtime.batch.MapReduceTaskContextProvider;
+import com.google.common.collect.Lists;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.LocatedFileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathFilter;
+import org.apache.hadoop.fs.RemoteIterator;
+import org.apache.hadoop.mapred.FileAlreadyExistsException;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.lib.output.FileOutputCommitter;
+import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * An OutputCommitter which creates partitions in a configured PartitionedFileSet dataset for all of the partitions
+ * that were written to by a DynamicPartitioningOutputFormat
+ * It enables this by having each job write to a job-specific temporary path within that output directory.
+ * Then, upon commitJob, it moves the files to the final, parent directory if the final output directories do not
+ * already exist.
+ */
+public class DynamicPartitioningOutputCommitter extends FileOutputCommitter {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DynamicPartitioningOutputCommitter.class);
+
+  private final TaskAttemptContext taskContext;
+  private final Path jobSpecificOutputPath;
+
+  // Note that the outputPath passed in is treated as a temporary directory.
+  // The commitJob method moves the files from within this directory to an parent (final) directory.
+  // The cleanupJob method removes this directory.
+  public DynamicPartitioningOutputCommitter(Path outputPath, TaskAttemptContext context) throws IOException {
+    super(outputPath, context);
+    this.taskContext = context;
+    this.jobSpecificOutputPath = outputPath;
+  }
+
+  @Override
+  public void commitJob(JobContext context) throws IOException {
+    BasicMapReduceTaskContext mrTaskContext = new MapReduceTaskContextProvider(taskContext, null).get();
+    String outputDatasetName =
+      context.getConfiguration().get(DynamicPartitioningOutputFormat.HCONF_ATTR_OUTPUT_DATASET);
+    PartitionedFileSet outputDataset = mrTaskContext.getDataset(outputDatasetName);
+    Partitioning partitioning = outputDataset.getPartitioning();
+
+    Set<PartitionKey> partitionsToAdd = new HashSet<>();
+    // Go over all files in the temporary directory and keep track of partitions to add for them
+    FileStatus[] allCommittedTaskPaths = getAllCommittedTaskPaths(context);
+    for (FileStatus committedTaskPath : allCommittedTaskPaths) {
+      FileSystem fs = committedTaskPath.getPath().getFileSystem(context.getConfiguration());
+      RemoteIterator<LocatedFileStatus> fileIter = fs.listFiles(committedTaskPath.getPath(), true);
+      while (fileIter.hasNext()) {
+        Path path = fileIter.next().getPath();
+        String relativePath = getRelative(committedTaskPath.getPath(), path);
+
+        int lastPathSepIdx = relativePath.lastIndexOf(Path.SEPARATOR);
+        if (lastPathSepIdx == -1) {
+          // this shouldn't happen because each relative path should consist of at least one partition key and
+          // the output file name
+          LOG.warn("Skipping path '{}'. It's relative path '{}' has fewer than two parts", path, relativePath);
+          continue;
+        }
+        // relativePath = "../key1/key2/part-m-00000"
+        // relativeDir = "../key1/key2"
+        // fileName = "part-m-00000"
+        String relativeDir = relativePath.substring(0, lastPathSepIdx);
+        String fileName = relativePath.substring(lastPathSepIdx + 1);
+
+        Path finalDir = new Path(FileOutputFormat.getOutputPath(context), relativeDir);
+        Path finalPath = new Path(finalDir, fileName);
+        if (fs.exists(finalPath)) {
+          throw new FileAlreadyExistsException("Final output path " + finalPath + " already exists");
+        }
+        PartitionKey partitionKey = getPartitionKey(partitioning, relativeDir);
+        partitionsToAdd.add(partitionKey);
+      }
+    }
+
+    try {
+      mrTaskContext.flushOperations();
+    } catch (Exception e) {
+      throw new IOException(e);
+    } finally {
+      mrTaskContext.close();
+    }
+
+    // We need to copy to the parent of the FileOutputFormat's outputDir, since we added a _temporary_jobId suffix to
+    // the original outputDir.
+    Path finalOutput = FileOutputFormat.getOutputPath(context);
+    FileSystem fs = finalOutput.getFileSystem(context.getConfiguration());
+    for (FileStatus stat: getAllCommittedTaskPaths(context)) {
+      mergePaths(fs, stat, finalOutput);
+    }
+
+    // create all the necessary partitions
+    for (PartitionKey partitionKey : partitionsToAdd) {
+      outputDataset.getPartitionOutput(partitionKey).addPartition();
+    }
+
+    // delete the job-specific _temporary folder and create a _done file in the o/p folder
+    cleanupJob(context);
+    // True if the job requires output.dir marked on successful job.
+    // Note that by default it is set to true.
+    if (context.getConfiguration().getBoolean(SUCCESSFUL_JOB_OUTPUT_DIR_MARKER, true)) {
+      Path markerPath = new Path(finalOutput, SUCCEEDED_FILE_NAME);
+      fs.create(markerPath).close();
+    }
+  }
+
+  private PartitionKey getPartitionKey(Partitioning partitioning, String relativePath) {
+    List<String> pathParts = Lists.newArrayList(relativePath.split(Path.SEPARATOR));
+
+    PartitionKey.Builder builder = PartitionKey.builder();
+    int i = 0;
+    for (Map.Entry<String, Partitioning.FieldType> entry : partitioning.getFields().entrySet()) {
+      String keyName = entry.getKey();
+      Comparable keyValue = entry.getValue().parse(pathParts.get(i));
+      builder.addField(keyName, keyValue);
+      i++;
+    }
+    return builder.build();
+  }
+
+  @Override
+  public void cleanupJob(JobContext context) throws IOException {
+    FileSystem fs = jobSpecificOutputPath.getFileSystem(context.getConfiguration());
+    fs.delete(jobSpecificOutputPath, true);
+  }
+
+  // Copied from superclass to enable usage of it, because our 'from' and 'to' locations are different.
+  /**
+   * Merge two paths together.  Anything in from will be moved into to, if there
+   * are any name conflicts while merging the files or directories in from win.
+   * @param fs the File System to use
+   * @param from the path data is coming from.
+   * @param to the path data is going to.
+   * @throws IOException on any error
+   */
+  private void mergePaths(FileSystem fs, final FileStatus from, final Path to) throws IOException {
+    if (from.isFile()) {
+      if (fs.exists(to)) {
+        if (!fs.delete(to, true)) {
+          throw new IOException("Failed to delete " + to);
+        }
+      }
+
+      if (!fs.rename(from.getPath(), to)) {
+        throw new IOException("Failed to rename " + from + " to " + to);
+      }
+    } else if (from.isDirectory()) {
+      if (fs.exists(to)) {
+        FileStatus toStat = fs.getFileStatus(to);
+        if (!toStat.isDirectory()) {
+          if (!fs.delete(to, true)) {
+            throw new IOException("Failed to delete " + to);
+          }
+          if (!fs.rename(from.getPath(), to)) {
+            throw new IOException("Failed to rename " + from + " to " + to);
+          }
+        } else {
+          //It is a directory so merge everything in the directories
+          for (FileStatus subFrom: fs.listStatus(from.getPath())) {
+            Path subTo = new Path(to, subFrom.getPath().getName());
+            mergePaths(fs, subFrom, subTo);
+          }
+        }
+      } else {
+        //it does not exist just rename
+        if (!fs.rename(from.getPath(), to)) {
+          throw new IOException("Failed to rename " + from + " to " + to);
+        }
+      }
+    }
+  }
+
+  // copied from superclass
+  /**
+   * Get a list of all paths where output from committed tasks are stored.
+   * @param context the context of the current job
+   * @return the list of these Paths/FileStatuses.
+   * @throws IOException
+   */
+  private FileStatus[] getAllCommittedTaskPaths(JobContext context) throws IOException {
+    Path jobAttemptPath = getJobAttemptPath(context);
+    FileSystem fs = jobAttemptPath.getFileSystem(context.getConfiguration());
+    return fs.listStatus(jobAttemptPath, new CommittedTaskFilter());
+  }
+
+  class CommittedTaskFilter implements PathFilter {
+    @Override
+    public boolean accept(Path path) {
+      return !PENDING_DIR_NAME.equals(path.getName());
+    }
+  }
+
+
+  /**
+   * given two paths as input:
+   *    base: /my/base/path
+   *    file: /my/base/path/some/other/file
+   * return "some/other/file"
+   */
+  private String getRelative(Path base, Path file) {
+    return base.toUri().relativize(file.toUri()).getPath();
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/partitioned/DynamicPartitioningOutputCommitter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/partitioned/DynamicPartitioningOutputCommitter.java
@@ -16,7 +16,6 @@
 
 package co.cask.cdap.internal.app.runtime.batch.dataset.partitioned;
 
-import co.cask.cdap.api.dataset.lib.Partition;
 import co.cask.cdap.api.dataset.lib.PartitionKey;
 import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
 import co.cask.cdap.api.dataset.lib.Partitioning;
@@ -111,7 +110,7 @@ public class DynamicPartitioningOutputCommitter extends FileOutputCommitter {
     // the original outputDir.
     Path finalOutput = FileOutputFormat.getOutputPath(context);
     FileSystem fs = finalOutput.getFileSystem(context.getConfiguration());
-    for (FileStatus stat: getAllCommittedTaskPaths(context)) {
+    for (FileStatus stat : getAllCommittedTaskPaths(context)) {
       mergePaths(fs, stat, finalOutput);
     }
 
@@ -130,12 +129,7 @@ public class DynamicPartitioningOutputCommitter extends FileOutputCommitter {
 
     // delete the job-specific _temporary folder and create a _done file in the o/p folder
     cleanupJob(context);
-    // True if the job requires output.dir marked on successful job.
-    // Note that by default it is set to true.
-    if (context.getConfiguration().getBoolean(SUCCESSFUL_JOB_OUTPUT_DIR_MARKER, true)) {
-      Path markerPath = new Path(finalOutput, SUCCEEDED_FILE_NAME);
-      fs.create(markerPath).close();
-    }
+    // this commitJob() omits the marking with '_SUCCESS' file, because the output directory is shared across jobs.
   }
 
   private PartitionKey getPartitionKey(Partitioning partitioning, String relativePath) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/partitioned/DynamicPartitioningOutputFormat.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/partitioned/DynamicPartitioningOutputFormat.java
@@ -22,6 +22,7 @@ import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
 import co.cask.cdap.api.dataset.lib.PartitionedFileSetArguments;
 import co.cask.cdap.api.dataset.lib.Partitioning;
 import co.cask.cdap.app.metrics.MapReduceMetrics;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.lang.InstantiatorFactory;
 import co.cask.cdap.data2.dataset2.lib.partitioned.PartitionedFileSetDataset;
 import co.cask.cdap.internal.app.runtime.batch.BasicMapReduceTaskContext;
@@ -57,9 +58,6 @@ import static org.apache.hadoop.mapreduce.TaskType.MAP;
  */
 public class DynamicPartitioningOutputFormat<K, V> extends FileOutputFormat<K, V> {
 
-  public static final String HCONF_ATTR_OUTPUT_DATASET = "output.dataset.name";
-  public static final String HCONF_ATTR_OUTPUT_FORMAT_CLASS_NAME = "output.format.class.name";
-
   private FileOutputFormat<K, V> fileOutputFormat;
 
   /**
@@ -81,7 +79,7 @@ public class DynamicPartitioningOutputFormat<K, V> extends FileOutputFormat<K, V
 
     MapReduceMetrics.TaskType taskType = MapReduceMetrics.TaskType.from(job.getTaskAttemptID().getTaskType());
     final BasicMapReduceTaskContext<K, V> mrTaskContext = new MapReduceTaskContextProvider(job, taskType).get();
-    String outputDatasetName = job.getConfiguration().get(HCONF_ATTR_OUTPUT_DATASET);
+    String outputDatasetName = job.getConfiguration().get(Constants.Dataset.Partitioned.HCONF_ATTR_OUTPUT_DATASET);
     PartitionedFileSet outputDataset = mrTaskContext.getDataset(outputDatasetName);
     final Partitioning partitioning = outputDataset.getPartitioning();
 
@@ -142,8 +140,8 @@ public class DynamicPartitioningOutputFormat<K, V> extends FileOutputFormat<K, V
    */
   protected RecordWriter<K, V> getBaseRecordWriter(TaskAttemptContext job) throws IOException, InterruptedException {
     if (fileOutputFormat == null) {
-      Class<? extends FileOutputFormat> delegateOutputFormat =
-        job.getConfiguration().getClass(HCONF_ATTR_OUTPUT_FORMAT_CLASS_NAME, null, FileOutputFormat.class);
+      Class<? extends FileOutputFormat> delegateOutputFormat = job.getConfiguration()
+        .getClass(Constants.Dataset.Partitioned.HCONF_ATTR_OUTPUT_FORMAT_CLASS_NAME, null, FileOutputFormat.class);
 
       @SuppressWarnings("unchecked")
       FileOutputFormat<K, V> fileOutputFormat =
@@ -181,9 +179,9 @@ public class DynamicPartitioningOutputFormat<K, V> extends FileOutputFormat<K, V
     // paths within that directory. See createJobSpecificPath method and usages of it.
 
     // additionally check that output dataset and dynamic partitioner class name has been set in conf
-    if (job.getConfiguration().get(HCONF_ATTR_OUTPUT_DATASET) == null) {
+    if (job.getConfiguration().get(Constants.Dataset.Partitioned.HCONF_ATTR_OUTPUT_DATASET) == null) {
       throw new InvalidJobConfException("The job configuration does not contain required property: "
-                                          + HCONF_ATTR_OUTPUT_DATASET);
+                                          + Constants.Dataset.Partitioned.HCONF_ATTR_OUTPUT_DATASET);
     }
 
     Class<? extends DynamicPartitioner> className = job.getConfiguration()
@@ -193,11 +191,11 @@ public class DynamicPartitioningOutputFormat<K, V> extends FileOutputFormat<K, V
                                           + PartitionedFileSetArguments.DYNAMIC_PARTITIONER_CLASS_NAME);
     }
 
-    Class<? extends FileOutputFormat> delegateOutputFormatClassName =
-      job.getConfiguration().getClass(HCONF_ATTR_OUTPUT_FORMAT_CLASS_NAME, null, FileOutputFormat.class);
+    Class<? extends FileOutputFormat> delegateOutputFormatClassName = job.getConfiguration()
+      .getClass(Constants.Dataset.Partitioned.HCONF_ATTR_OUTPUT_FORMAT_CLASS_NAME, null, FileOutputFormat.class);
     if (delegateOutputFormatClassName == null) {
       throw new InvalidJobConfException("The job configuration does not contain required property: "
-                                          + HCONF_ATTR_OUTPUT_FORMAT_CLASS_NAME);
+                                          + Constants.Dataset.Partitioned.HCONF_ATTR_OUTPUT_FORMAT_CLASS_NAME);
     }
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/partitioned/DynamicPartitioningOutputFormat.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/partitioned/DynamicPartitioningOutputFormat.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.batch.dataset.partitioned;
+
+import co.cask.cdap.api.dataset.lib.DynamicPartitioner;
+import co.cask.cdap.api.dataset.lib.PartitionKey;
+import co.cask.cdap.api.dataset.lib.PartitionedFileSetArguments;
+import co.cask.cdap.common.lang.InstantiatorFactory;
+import co.cask.cdap.data2.dataset2.lib.partitioned.PartitionedFileSetDataset;
+import co.cask.cdap.internal.app.runtime.batch.BasicMapReduceTaskContext;
+import co.cask.cdap.internal.app.runtime.batch.MapReduceTaskContextProvider;
+import com.google.common.reflect.TypeToken;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapred.InvalidJobConfException;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.RecordWriter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.lib.output.FileOutputCommitter;
+import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
+import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
+import org.apache.hadoop.mapreduce.security.TokenCache;
+import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl;
+
+import java.io.IOException;
+import java.util.TreeMap;
+
+/**
+ * This class extends the FileOutputFormat and allows writing dynamically to multiple partitions of a PartitionedFileSet
+ * Dataset.
+ *
+ * @param <K> Type of key
+ * @param <V> Type of value
+ */
+public class DynamicPartitioningOutputFormat<K, V> extends FileOutputFormat<K, V> {
+//      TODO: Hive doesn't allow addPartition w/o the partition location existing. verify this?
+  public static final String HCONF_ATTR_OUTPUT_DATASET = "output.dataset.name";
+
+  // TODO: keep the limit to only FileOutputFormat and FileOutputCommitter?
+  private FileOutputFormat<K, V> fileOutputFormat;
+  private FileOutputCommitter committer;
+
+  /**
+   * Create a composite record writer that can write key/value data to different output files.
+   *
+   * @return a composite record writer
+   * @throws IOException
+   */
+  @Override
+  public RecordWriter<K, V> getRecordWriter(final TaskAttemptContext job) throws IOException {
+
+    final String outputName = FileOutputFormat.getOutputName(job);
+
+    Class<? extends DynamicPartitioner> className = job.getConfiguration()
+      .getClass(PartitionedFileSetArguments.DYNAMIC_PARTITIONER_CLASS_NAME, null, DynamicPartitioner.class);
+
+    @SuppressWarnings("unchecked")
+    final DynamicPartitioner<K, V> dynamicPartitioner =
+      new InstantiatorFactory(false).get(TypeToken.of(className)).create();
+
+    final BasicMapReduceTaskContext<K, V> mrTaskContext = new MapReduceTaskContextProvider(job, null).get();
+    dynamicPartitioner.initialize(mrTaskContext);
+
+    return new RecordWriter<K, V>() {
+
+      // a cache storing the record writers for different output files.
+      TreeMap<String, RecordWriter<K, V>> recordWriters = new TreeMap<>();
+
+      public void write(K key, V value) throws IOException, InterruptedException {
+        PartitionKey partitionKey = dynamicPartitioner.getPartitionKey(key, value);
+        String relativePath = PartitionedFileSetDataset.getOutputPath(partitionKey);
+        String finalPath = relativePath + "/" + outputName;
+
+        RecordWriter<K, V> rw = this.recordWriters.get(finalPath);
+        if (rw == null) {
+          // if we don't have the record writer yet for the final path, create one and add it to the cache
+          rw = getBaseRecordWriter(getTaskAttemptContext(job, finalPath));
+          this.recordWriters.put(finalPath, rw);
+        }
+        rw.write(key, value);
+      }
+
+      @Override
+      public void close(TaskAttemptContext context) throws IOException, InterruptedException {
+        try {
+          for (RecordWriter<K, V> recordWriter : this.recordWriters.values()) {
+            recordWriter.close(context);
+          }
+          this.recordWriters.clear();
+
+          mrTaskContext.flushOperations();
+        } catch (Exception e) {
+          throw new IOException(e);
+        } finally {
+          mrTaskContext.close();
+        }
+      }
+    };
+  }
+
+  private static TaskAttemptContext getTaskAttemptContext(TaskAttemptContext context,
+                                                          String newOutputName) throws IOException {
+    Job job = new Job(context.getConfiguration());
+    FileOutputFormat.setOutputName(job, newOutputName);
+
+    Path jobOutputPath = createJobSpecificPath(FileOutputFormat.getOutputPath(job), context);
+    FileOutputFormat.setOutputPath(job, jobOutputPath);
+
+    return new TaskAttemptContextImpl(job.getConfiguration(), context.getTaskAttemptID());
+  }
+
+  /**
+   * @return A RecordWriter object over the given file
+   * @throws IOException
+   */
+  protected RecordWriter<K, V> getBaseRecordWriter(TaskAttemptContext job) throws IOException, InterruptedException {
+    if (fileOutputFormat == null) {
+      // TODO: use the PFS's OutputFormat (encode in conf)
+      fileOutputFormat = new TextOutputFormat<>();
+    }
+    return fileOutputFormat.getRecordWriter(job);
+  }
+
+  // suffixes a Path with a job-specific string
+  private static Path createJobSpecificPath(Path path, JobContext jobContext) {
+    String outputPathSuffix = "_temporary_" + jobContext.getJobID().getId();
+    return new Path(path, outputPathSuffix);
+  }
+
+  @Override
+  public synchronized FileOutputCommitter getOutputCommitter(TaskAttemptContext context) throws IOException {
+    if (committer == null) {
+      final Path jobSpecificOutputPath = createJobSpecificPath(getOutputPath(context), context);
+      committer = new DynamicPartitioningOutputCommitter(jobSpecificOutputPath, context);
+    }
+    return committer;
+  }
+
+  @Override
+  public void checkOutputSpecs(JobContext job) throws IOException {
+    // Ensure that the output directory is set and not already there
+    Path outDir = getOutputPath(job);
+    if (outDir == null) {
+      throw new InvalidJobConfException("Output directory not set.");
+    }
+
+    // get delegation token for outDir's file system
+    TokenCache.obtainTokensForNamenodes(job.getCredentials(),
+                                        new Path[]{outDir}, job.getConfiguration());
+
+    // we permit multiple jobs writing to the same output directory. We handle this by each one writing to distinct
+    // paths within that directory. See createJobSpecificPath method and usages of it.
+
+    // additionally check that output dataset has been set in conf
+    if (job.getConfiguration().get(HCONF_ATTR_OUTPUT_DATASET) == null) {
+      throw new InvalidJobConfException("Output dataset not set");
+    }
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -205,6 +205,14 @@ public final class Constants {
     public static final String DATASET_UNCHECKED_UPGRADE = "dataset.unchecked.upgrade";
 
     /**
+     * Constants for PartitionedFileSet's DynamicPartitioner
+     */
+    public static final class Partitioned {
+      public static final String HCONF_ATTR_OUTPUT_DATASET = "output.dataset.name";
+      public static final String HCONF_ATTR_OUTPUT_FORMAT_CLASS_NAME = "output.format.class.name";
+    }
+
+    /**
      * DatasetManager service configuration.
      */
     public static final class Manager {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/file/FileSetDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/file/FileSetDataset.java
@@ -138,9 +138,11 @@ public final class FileSetDataset implements FileSet {
   }
 
   private Location determineOutputLocation() {
+    if (FileSetArguments.isBaseOutputPath(runtimeArguments)) {
+      return baseLocation;
+    }
     String outputPath = FileSetArguments.getOutputPath(runtimeArguments);
-    // TODO: think about all cases of this change (for instance, FileSet as output of MR)
-    return outputPath == null ? baseLocation : createLocation(outputPath);
+    return outputPath == null ? null : createLocation(outputPath);
   }
 
   private List<Location> determineInputLocations() {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/file/FileSetDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/file/FileSetDataset.java
@@ -139,7 +139,8 @@ public final class FileSetDataset implements FileSet {
 
   private Location determineOutputLocation() {
     String outputPath = FileSetArguments.getOutputPath(runtimeArguments);
-    return outputPath == null ? null : createLocation(outputPath);
+    // TODO: think about all cases of this change (for instance, FileSet as output of MR)
+    return outputPath == null ? baseLocation : createLocation(outputPath);
   }
 
   private List<Location> determineInputLocations() {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetDataset.java
@@ -41,6 +41,7 @@ import co.cask.cdap.api.dataset.lib.Partitioning.FieldType;
 import co.cask.cdap.api.dataset.table.Put;
 import co.cask.cdap.api.dataset.table.Row;
 import co.cask.cdap.api.dataset.table.Scanner;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.explore.client.ExploreFacade;
 import co.cask.cdap.proto.Id;
 import co.cask.tephra.Transaction;
@@ -603,11 +604,10 @@ public class PartitionedFileSetDataset extends AbstractDataset implements Partit
         throw new DataSetException(
           "Either a Partition key or a DynamicPartitioner class must be given as a runtime argument.");
       }
-      // also delegate to the files.getOutputFormatClassName()? (currently defaulting to TextOutputFormat)
       PartitionedFileSetArguments.setDynamicPartitioner(outputArgs, dynamicPartitionerClassName);
-      outputArgs.put("output.format.class.name", files.getOutputFormatClassName());
-      // need dependency on DynamicPartitioningOutputFormat to avoid inlining following string?
-      outputArgs.put("output.dataset.name", getName());
+      outputArgs.put(Constants.Dataset.Partitioned.HCONF_ATTR_OUTPUT_FORMAT_CLASS_NAME,
+                     files.getOutputFormatClassName());
+      outputArgs.put(Constants.Dataset.Partitioned.HCONF_ATTR_OUTPUT_DATASET, getName());
     }
     return ImmutableMap.copyOf(outputArgs);
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetDataset.java
@@ -45,7 +45,6 @@ import co.cask.cdap.explore.client.ExploreFacade;
 import co.cask.cdap.proto.Id;
 import co.cask.tephra.Transaction;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
@@ -590,12 +589,11 @@ public class PartitionedFileSetDataset extends AbstractDataset implements Partit
         "Output is not supported for external partitioned file set '" + spec.getName() + "'");
     }
 
-    // copy the output partition key to the output arguments of the embedded file set
-    // this will be needed by the output format to register the new partition.
+    // copy the output properties of the embedded file set to the output arguments
     Map<String, String> outputArgs = Maps.newHashMap(files.getOutputFormatConfiguration());
 
     // we set the file set's output path in the definition's getDataset(), so there is no need to configure it again.
-    // here we just want to validate that an output partition key was specified in the arguments.
+    // here we just want to validate that an output partition key or dynamic partitioner was specified in the arguments.
     PartitionKey outputKey = PartitionedFileSetArguments.getOutputPartitionKey(runtimeArguments, getPartitioning());
     if (outputKey != null) {
       PartitionedFileSetArguments.setOutputPartitionKey(outputArgs, outputKey);
@@ -621,7 +619,8 @@ public class PartitionedFileSetDataset extends AbstractDataset implements Partit
     if (outputPath == null) {
       return;
     }
-    // we know for sure there is an output partition key (checked in getOutputFormatConfig())
+    // its possible that there is no output key, if using the DynamicPartitioner, in which case
+    // DynamicPartitioningOutputFormat is responsible for registering the partitions
     PartitionKey outputKey = PartitionedFileSetArguments.getOutputPartitionKey(runtimeArguments, getPartitioning());
     if (outputKey != null) {
       Map<String, String> metadata = PartitionedFileSetArguments.getOutputPartitionMetadata(runtimeArguments);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetDataset.java
@@ -483,11 +483,23 @@ public class PartitionedFileSetDataset extends AbstractDataset implements Partit
     return Bytes.add(METADATA_PREFIX, Bytes.toBytes(metadataKey));
   }
 
+
   /**
    * Generate an output path for a given partition key.
    */
-  public static String getOutputPath(PartitionKey key) {
-    return Joiner.on("/").join(key.getFields().values());
+  // package visible for PartitionedFileSetDefinition
+  String getOutputPath(PartitionKey key) {
+    return getOutputPath(key, partitioning);
+  }
+
+  public static String getOutputPath(PartitionKey key, Partitioning partitioning) {
+    StringBuilder builder = new StringBuilder();
+    String sep = "";
+    for (String fieldName : partitioning.getFields().keySet()) {
+      builder.append(sep).append(key.getField(fieldName).toString());
+      sep = "/";
+    }
+    return builder.toString();
   }
 
   /**
@@ -569,7 +581,6 @@ public class PartitionedFileSetDataset extends AbstractDataset implements Partit
       return "co.cask.cdap.internal.app.runtime.batch.dataset.partitioned.DynamicPartitioningOutputFormat";
     }
     return files.getOutputFormatClassName();
-
   }
 
   @Override
@@ -582,7 +593,6 @@ public class PartitionedFileSetDataset extends AbstractDataset implements Partit
     // copy the output partition key to the output arguments of the embedded file set
     // this will be needed by the output format to register the new partition.
     Map<String, String> outputArgs = Maps.newHashMap(files.getOutputFormatConfiguration());
-
 
     // we set the file set's output path in the definition's getDataset(), so there is no need to configure it again.
     // here we just want to validate that an output partition key was specified in the arguments.

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetDataset.java
@@ -605,6 +605,7 @@ public class PartitionedFileSetDataset extends AbstractDataset implements Partit
       }
       // also delegate to the files.getOutputFormatClassName()? (currently defaulting to TextOutputFormat)
       PartitionedFileSetArguments.setDynamicPartitioner(outputArgs, dynamicPartitionerClassName);
+      outputArgs.put("output.format.class.name", files.getOutputFormatClassName());
       // need dependency on DynamicPartitioningOutputFormat to avoid inlining following string?
       outputArgs.put("output.dataset.name", getName());
     }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetDefinition.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetDefinition.java
@@ -124,6 +124,9 @@ public class PartitionedFileSetDefinition extends AbstractDatasetDefinition<Part
       if (key != null) {
         arguments = Maps.newHashMap(arguments);
         FileSetArguments.setOutputPath(arguments, PartitionedFileSetDataset.getOutputPath(key, partitioning));
+      } else if (PartitionedFileSetArguments.getDynamicPartitioner(arguments) != null) {
+        // when using DynamicPartitioner, use the baseLocation of the fileSet as the output location
+        FileSetArguments.setBaseOutputPath(arguments);
       }
     }
     return arguments;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetDefinition.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetDefinition.java
@@ -123,7 +123,7 @@ public class PartitionedFileSetDefinition extends AbstractDatasetDefinition<Part
       PartitionKey key = PartitionedFileSetArguments.getOutputPartitionKey(arguments, partitioning);
       if (key != null) {
         arguments = Maps.newHashMap(arguments);
-        FileSetArguments.setOutputPath(arguments, PartitionedFileSetDataset.getOutputPath(partitioning, key));
+        FileSetArguments.setOutputPath(arguments, PartitionedFileSetDataset.getOutputPath(key));
       }
     }
     return arguments;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetDefinition.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetDefinition.java
@@ -123,7 +123,7 @@ public class PartitionedFileSetDefinition extends AbstractDatasetDefinition<Part
       PartitionKey key = PartitionedFileSetArguments.getOutputPartitionKey(arguments, partitioning);
       if (key != null) {
         arguments = Maps.newHashMap(arguments);
-        FileSetArguments.setOutputPath(arguments, PartitionedFileSetDataset.getOutputPath(key));
+        FileSetArguments.setOutputPath(arguments, PartitionedFileSetDataset.getOutputPath(key, partitioning));
       }
     }
     return arguments;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetDataset.java
@@ -149,7 +149,7 @@ public class TimePartitionedFileSetDataset extends PartitionedFileSetDataset imp
         "Output is not supported for external time-partitioned file set '" + spec.getName() + "'");
     }
     PartitionKey key = partitionKeyForTime(time);
-    return new BasicTimePartitionOutput(this, getOutputPath(partitioning, key), key);
+    return new BasicTimePartitionOutput(this, getOutputPath(key), key);
   }
 
   @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/Transactions.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/Transactions.java
@@ -108,7 +108,7 @@ public final class Transactions {
       result = callable.call();
     } catch (Throwable t) {
       // Abort will always throw with the TransactionFailureException.
-      txContext.abort(new TransactionFailureException("Failed to execute method " + name + "inside a transaction", t));
+      txContext.abort(new TransactionFailureException("Failed to execute method " + name + " inside a transaction", t));
     }
 
     // If commit failed, the tx will be aborted and exception will be raised

--- a/cdap-examples/DataCleansing/src/main/java/co/cask/cdap/examples/datacleansing/DataCleansing.java
+++ b/cdap-examples/DataCleansing/src/main/java/co/cask/cdap/examples/datacleansing/DataCleansing.java
@@ -58,7 +58,7 @@ public class DataCleansing extends AbstractApplication {
 
     createDataset(CLEAN_RECORDS, PartitionedFileSet.class, PartitionedFileSetProperties.builder()
       // Properties for partitioning
-      .setPartitioning(Partitioning.builder().addLongField("time").build())
+      .setPartitioning(Partitioning.builder().addLongField("time").addIntField("zip").build())
       // Properties for file set
       .setOutputFormat(TextOutputFormat.class)
       // Properties for Explore (to create a partitioned Hive table)

--- a/cdap-examples/DataCleansing/src/main/java/co/cask/cdap/examples/datacleansing/DataCleansingMapReduce.java
+++ b/cdap-examples/DataCleansing/src/main/java/co/cask/cdap/examples/datacleansing/DataCleansingMapReduce.java
@@ -21,6 +21,7 @@ import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.dataset.lib.BatchPartitionConsumer;
+import co.cask.cdap.api.dataset.lib.DynamicPartitioner;
 import co.cask.cdap.api.dataset.lib.KeyValueTable;
 import co.cask.cdap.api.dataset.lib.PartitionKey;
 import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
@@ -29,6 +30,7 @@ import co.cask.cdap.api.mapreduce.AbstractMapReduce;
 import co.cask.cdap.api.mapreduce.MapReduceContext;
 import co.cask.cdap.api.mapreduce.MapReduceTaskContext;
 import co.cask.cdap.api.metrics.Metrics;
+import com.google.gson.JsonParser;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.io.Text;
@@ -80,12 +82,15 @@ public class DataCleansingMapReduce extends AbstractMapReduce {
     // Each run writes its output to a partition for the league
     Long timeKey = Long.valueOf(context.getRuntimeArguments().get(OUTPUT_PARTITION_KEY));
     PartitionKey outputKey = PartitionKey.builder().addLongField("time", timeKey).build();
-    Map<String, String> outputArgs = new HashMap<>();
-    PartitionedFileSetArguments.setOutputPartitionKey(outputArgs, outputKey);
 
     // set up two outputs - one for invalid records and one for valid records
-    context.addOutput(DataCleansing.CLEAN_RECORDS, outputArgs);
-    context.addOutput(DataCleansing.INVALID_RECORDS, outputArgs);
+    Map<String, String> invalidRecordsArgs = new HashMap<>();
+    PartitionedFileSetArguments.setOutputPartitionKey(invalidRecordsArgs, outputKey);
+    context.addOutput(DataCleansing.INVALID_RECORDS, invalidRecordsArgs);
+
+    Map<String, String> cleanRecordsArgs = new HashMap<>();
+    PartitionedFileSetArguments.setDynamicPartitioner(cleanRecordsArgs, TimeAndZipPartitioner.class);
+    context.addOutput(DataCleansing.CLEAN_RECORDS, cleanRecordsArgs);
 
     Job job = context.getHadoopJob();
     job.setMapperClass(SchemaMatchingFilter.class);
@@ -101,6 +106,27 @@ public class DataCleansingMapReduce extends AbstractMapReduce {
   public void onFinish(boolean succeeded, MapReduceContext context) throws Exception {
     if (succeeded) {
       partitionConsumer.persist(context);
+    }
+  }
+
+  /**
+   * Partitions the records based upon a runtime argument (time) and a field extracted from the text being written (zip)
+   */
+  public static final class TimeAndZipPartitioner extends DynamicPartitioner<NullWritable, Text> {
+
+    private Long time;
+    private JsonParser jsonParser;
+
+    @Override
+    public void initialize(MapReduceTaskContext<NullWritable, Text> mapReduceTaskContext) {
+      this.time = Long.valueOf(mapReduceTaskContext.getRuntimeArguments().get(OUTPUT_PARTITION_KEY));
+      this.jsonParser = new JsonParser();
+    }
+
+    @Override
+    public PartitionKey getPartitionKey(NullWritable key, Text value) {
+      int zip = jsonParser.parse(value.toString()).getAsJsonObject().get("zip").getAsInt();
+      return PartitionKey.builder().addLongField("time", time).addIntField("zip", zip).build();
     }
   }
 


### PR DESCRIPTION
Ability to dynamically write to multiple partitions of a PartitionedFileSet dataset, as the output of a MapReduce job.

This is implemented by having a DynamicParitioningOutputFormat which writes records to a relative path in the temporary directory of the MapReduce job, based upon the PartitionKey returned by a DynamicPartitioner class, which is implemented by the user. Then, in the commitJob of the OutputFormatCommitter, these paths are moved to the PartitionedFileSet's baseLocation, and Partitions are registered in the dataset for each of these.

https://issues.cask.co/browse/CDAP-2757
http://builds.cask.co/browse/CDAP-DUT2731-11