### PR TITLE
CDAP-3591 ability to write to multiple sinks in etl realtime

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/common/Constants.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/common/Constants.java
@@ -45,7 +45,9 @@ public final class Constants {
    * Constants related to Sink.
    */
   public static final class Sink {
+    // keeping plugin id (singular) here temporarily until templates are removed
     public static final String PLUGINID = "sinkId";
+    public static final String PLUGINIDS = "sinkIds";
     public static final String PLUGINTYPE = "sink";
 
     private Sink() {

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/common/ETLConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/common/ETLConfig.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.Config;
 import co.cask.cdap.api.Resources;
 import com.google.common.collect.Lists;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -27,13 +28,25 @@ import java.util.List;
  */
 public class ETLConfig extends Config {
   private final ETLStage source;
+  // here for backwards compatibility
   private final ETLStage sink;
+  private final List<ETLStage> sinks;
   private final List<ETLStage> transforms;
   private final Resources resources;
+
+  public ETLConfig(ETLStage source, List<ETLStage> sinks, List<ETLStage> transforms, Resources resources) {
+    this.source = source;
+    this.sinks = sinks;
+    this.sink = null;
+    this.transforms = transforms;
+    this.resources = resources;
+  }
 
   public ETLConfig(ETLStage source, ETLStage sink, List<ETLStage> transforms, Resources resources) {
     this.source = source;
     this.sink = sink;
+    this.sinks = new ArrayList<>();
+    this.sinks.add(sink);
     this.transforms = transforms;
     this.resources = resources;
   }
@@ -42,8 +55,13 @@ public class ETLConfig extends Config {
     return source;
   }
 
+  // keeping here temporarily until templates are removed.
   public ETLStage getSink() {
     return sink;
+  }
+
+  public List<ETLStage> getSinks() {
+    return sinks;
   }
 
   public List<ETLStage> getTransforms() {

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/common/ETLTemplate.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/common/ETLTemplate.java
@@ -111,7 +111,7 @@ public abstract class ETLTemplate<T extends ETLConfig> extends ApplicationTempla
     }
 
     // Validate Source -> Transform -> Sink hookup
-    PipelineRegisterer.validateStages(source, sink, transforms);
+    PipelineRegisterer.validateStages(source, Lists.newArrayList(sink), transforms);
 
     configure(source, configurer, sourcePluginId);
     configure(sink, configurer, sinkPluginId);

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/common/Pipeline.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/common/Pipeline.java
@@ -23,12 +23,12 @@ import java.util.List;
  */
 public class Pipeline {
   private final String source;
-  private final String sink;
+  private final List<String> sinks;
   private final List<TransformInfo> transforms;
 
-  public Pipeline(String source, String sink, List<TransformInfo> transforms) {
+  public Pipeline(String source, List<String> sinks, List<TransformInfo> transforms) {
     this.source = source;
-    this.sink = sink;
+    this.sinks = sinks;
     this.transforms = transforms;
   }
 
@@ -36,8 +36,8 @@ public class Pipeline {
     return source;
   }
 
-  public String getSink() {
-    return sink;
+  public List<String> getSinks() {
+    return sinks;
   }
 
   public List<TransformInfo> getTransforms() {

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/common/PipelineRegisterer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/common/PipelineRegisterer.java
@@ -57,39 +57,47 @@ public class PipelineRegisterer {
    */
   public Pipeline registerPlugins(ETLConfig config, Class errorDatasetType, DatasetProperties datasetProperties) {
     ETLStage sourceConfig = config.getSource();
-    ETLStage sinkConfig = config.getSink();
     List<ETLStage> transformConfigs = config.getTransforms();
-    String sourcePluginId = PluginID.from(Constants.Source.PLUGINTYPE, sourceConfig.getName(), 1).getID();
-    // 2 + since we start at 1, and there is always a source.  For example, if there are 0 transforms, sink is stage 2.
-    String sinkPluginId =
-      PluginID.from(Constants.Sink.PLUGINTYPE, sinkConfig.getName(), 2 + transformConfigs.size()).getID();
+    List<ETLStage> sinkConfigs = config.getSinks();
+    // temporary for backwards compatibility
+    if (sinkConfigs == null) {
+      ETLStage sink = config.getSink();
+      if (sink == null) {
+        throw new IllegalArgumentException("At least one sink must be specified.");
+      }
+      sinkConfigs = Lists.newArrayList(sink);
+    }
+    if (sourceConfig == null) {
+      throw new IllegalArgumentException("A source must be specified.");
+    }
+    if (sinkConfigs.isEmpty()) {
+      throw new IllegalArgumentException("At least one sink must be specified.");
+    }
 
-    // Instantiate Source, Transforms, Sink stages.
-    // Use the plugin name as the plugin id for source and sink stages since there can be only one source and one sink.
+    // plugin num starts at 1 and increments for each stage in the pipeline
+    int pluginNum = 1;
+    String sourcePluginId = PluginID.from(Constants.Source.PLUGINTYPE, sourceConfig.getName(), pluginNum).getID();
+    pluginNum++;
+
+    // instantiate source
     PipelineConfigurable source = configurer.usePlugin(Constants.Source.PLUGINTYPE, sourceConfig.getName(),
                                                        sourcePluginId, getPluginProperties(sourceConfig));
     if (source == null) {
       throw new IllegalArgumentException(String.format("No Plugin of type '%s' named '%s' was found.",
                                                        Constants.Source.PLUGINTYPE, sourceConfig.getName()));
     }
+    // configure source, allowing it to add datasets, streams, etc
+    PipelineConfigurer sourceConfigurer = new DefaultPipelineConfigurer(configurer, sourcePluginId);
+    source.configurePipeline(sourceConfigurer);
 
-    PipelineConfigurable sink = configurer.usePlugin(Constants.Sink.PLUGINTYPE, sinkConfig.getName(),
-                                                     sinkPluginId, getPluginProperties(sinkConfig));
-    if (sink == null) {
-      throw new IllegalArgumentException(String.format("No Plugin of type '%s' named '%s' was found.",
-                                                       Constants.Sink.PLUGINTYPE, sinkConfig.getName()));
-    }
-
-    // Store transform id list to be serialized and passed to the driver program
-    List<TransformInfo> transformIds = new ArrayList<>(transformConfigs.size());
+    // transform id list will eventually be serialized and passed to the driver program
+    List<TransformInfo> transformInfos = new ArrayList<>(transformConfigs.size());
     List<Transformation> transforms = new ArrayList<>(transformConfigs.size());
-    for (int i = 0; i < transformConfigs.size(); i++) {
-      ETLStage transformConfig = transformConfigs.get(i);
+    for (ETLStage transformConfig : transformConfigs) {
 
       // Generate a transformId based on transform name and the array index (since there could
       // multiple transforms - ex, N filter transforms in the same pipeline)
-      // stage number starts from 1, plus source is always #1, so add 2 for stage number.
-      String transformId = PluginID.from(Constants.Transform.PLUGINTYPE, transformConfig.getName(), 2 + i).getID();
+      String transformId = PluginID.from(Constants.Transform.PLUGINTYPE, transformConfig.getName(), pluginNum).getID();
       PluginProperties transformProperties = getPluginProperties(transformConfig);
       Transform transformObj = configurer.usePlugin(Constants.Transform.PLUGINTYPE, transformConfig.getName(),
                                                     transformId, transformProperties);
@@ -106,22 +114,42 @@ public class PipelineRegisterer {
       }
       PipelineConfigurer transformConfigurer = new DefaultPipelineConfigurer(configurer, transformId);
       transformObj.configurePipeline(transformConfigurer);
-      transformIds.add(new TransformInfo(transformId, transformConfig.getErrorDatasetName()));
+      transformInfos.add(new TransformInfo(transformId, transformConfig.getErrorDatasetName()));
       transforms.add(transformObj);
+
+      pluginNum++;
+    }
+
+    List<String> sinkPluginIds = new ArrayList<>();
+    List<PipelineConfigurable> sinks = new ArrayList<>();
+    for (ETLStage sinkConfig : sinkConfigs) {
+      String sinkPluginId = PluginID.from(Constants.Sink.PLUGINTYPE, sinkConfig.getName(), pluginNum).getID();
+      sinkPluginIds.add(sinkPluginId);
+
+      // try to instantiate the sink
+      PipelineConfigurable sink = configurer.usePlugin(Constants.Sink.PLUGINTYPE, sinkConfig.getName(),
+        sinkPluginId, getPluginProperties(sinkConfig));
+      if (sink == null) {
+        throw new IllegalArgumentException(String.format("No Plugin of type '%s' named '%s' was found. " +
+            "Please check that an artifact containing the plugin exists, and that it extends the etl application.",
+          Constants.Sink.PLUGINTYPE, sinkConfig.getName()));
+      }
+      // run configure pipeline on sink to let it add datasets, etc.
+      PipelineConfigurer sinkConfigurer = new DefaultPipelineConfigurer(configurer, sinkPluginId);
+      sink.configurePipeline(sinkConfigurer);
+      sinks.add(sink);
+
+      pluginNum++;
     }
 
     // Validate Source -> Transform -> Sink hookup
     try {
-      validateStages(source, sink, transforms);
-      PipelineConfigurer sourceConfigurer = new DefaultPipelineConfigurer(configurer, sourcePluginId);
-      PipelineConfigurer sinkConfigurer = new DefaultPipelineConfigurer(configurer, sinkPluginId);
-      source.configurePipeline(sourceConfigurer);
-      sink.configurePipeline(sinkConfigurer);
+      validateStages(source, sinks, transforms);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
 
-    return new Pipeline(sourcePluginId, sinkPluginId, transformIds);
+    return new Pipeline(sourcePluginId, sinkPluginIds, transformInfos);
   }
 
   private PluginProperties getPluginProperties(ETLStage config) {
@@ -132,7 +160,7 @@ public class PipelineRegisterer {
     return builder.build();
   }
 
-  public static void validateStages(PipelineConfigurable source, PipelineConfigurable sink,
+  public static void validateStages(PipelineConfigurable source, List<PipelineConfigurable> sinks,
                                     List<Transformation> transforms) throws Exception {
     ArrayList<Type> unresTypeList = Lists.newArrayListWithCapacity(transforms.size() + 2);
     Type inType = Transformation.class.getTypeParameters()[0];
@@ -140,9 +168,7 @@ public class PipelineRegisterer {
 
     // Load the classes using the class names provided
     Class<?> sourceClass = source.getClass();
-    Class<?> sinkClass = sink.getClass();
     TypeToken sourceToken = TypeToken.of(sourceClass);
-    TypeToken sinkToken = TypeToken.of(sinkClass);
 
     // Extract the source's output type
     if (RealtimeSource.class.isAssignableFrom(sourceClass)) {
@@ -161,15 +187,23 @@ public class PipelineRegisterer {
     }
 
     // Extract the sink's input type
-    if (RealtimeSink.class.isAssignableFrom(sinkClass)) {
-      Type type = RealtimeSink.class.getTypeParameters()[0];
-      unresTypeList.add(sinkToken.resolveType(type).getType());
-    } else {
-      unresTypeList.add(sinkToken.resolveType(inType).getType());
+    for (PipelineConfigurable sink : sinks) {
+      Class<?> sinkClass = sink.getClass();
+      TypeToken sinkToken = TypeToken.of(sinkClass);
+      // some inefficiency if there are multiple sinks since the source and transform types will be re-validated
+      // each time. this only happens when the app is created though, and logic is easier to follow if its
+      // always one stage followed by another, rather than having a fork at the very end.
+      List<Type> pipelineTypes = Lists.newArrayList(unresTypeList);
+      if (RealtimeSink.class.isAssignableFrom(sinkClass)) {
+        Type type = RealtimeSink.class.getTypeParameters()[0];
+        pipelineTypes.add(sinkToken.resolveType(type).getType());
+      } else {
+        pipelineTypes.add(sinkToken.resolveType(inType).getType());
+      }
+      // Invoke validation method with list of unresolved types
+      validateTypes(pipelineTypes);
     }
 
-    // Invoke validation method with list of unresolved types
-    validateTypes(unresTypeList);
   }
 
   /**
@@ -180,7 +214,7 @@ public class PipelineRegisterer {
    *     which is true in the case above.
    */
   @VisibleForTesting
-  static void validateTypes(ArrayList<Type> unresTypeList) {
+  static void validateTypes(List<Type> unresTypeList) {
     Preconditions.checkArgument(unresTypeList.size() % 2 == 0, "ETL Stages validation expects even number of types");
     List<Type> resTypeList = Lists.newArrayListWithCapacity(unresTypeList.size());
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-realtime-app/src/main/java/co/cask/cdap/app/etl/realtime/config/ETLRealtimeConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-realtime-app/src/main/java/co/cask/cdap/app/etl/realtime/config/ETLRealtimeConfig.java
@@ -29,6 +29,12 @@ import java.util.List;
 public final class ETLRealtimeConfig extends ETLConfig {
   private final Integer instances;
 
+  public ETLRealtimeConfig(Integer instances, ETLStage source, List<ETLStage> sinks,
+                           List<ETLStage> transforms, Resources resources) {
+    super(source, sinks, transforms, resources);
+    this.instances = instances;
+  }
+
   public ETLRealtimeConfig(Integer instances, ETLStage source, ETLStage sink, List<ETLStage> transforms,
                            Resources resources) {
     super(source, sink, transforms, resources);


### PR DESCRIPTION
Adding the ability to write to multiple sinks in the etl realtime
application. The exact same data will be written to all sinks.
If transactional sinks are used, a failure to write to one sink
will cause that write to other sinks to fail. If non-transactional
sinks are used, a write to one sink can succeed while a write to
another sink can fail.