### PR TITLE
CDAP-3625: Improved table naming for stream views

### DIFF
--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/stream/view/DescribeStreamViewCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/stream/view/DescribeStreamViewCommand.java
@@ -59,11 +59,12 @@ public class DescribeStreamViewCommand extends AbstractAuthCommand {
     ViewDetail detail = client.get(Id.Stream.View.from(streamId, arguments.get(ArgumentName.VIEW.toString())));
 
     Table table = Table.builder()
-      .setHeader("id", "format", "schema", "settings")
+      .setHeader("id", "format", "table", "schema", "settings")
       .setRows(Collections.singletonList(detail), new RowMaker<ViewDetail>() {
         @Override
         public List<?> makeRow(ViewDetail object) {
           return Lists.newArrayList(object.getId(), object.getFormat().getName(),
+                                    object.getTableName(),
                                     GSON.toJson(object.getFormat().getSchema()),
                                     GSON.toJson(object.getFormat().getSettings()));
         }

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/StreamViewClientTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/StreamViewClientTestRun.java
@@ -93,7 +93,7 @@ public class StreamViewClientTestRun extends ClientTestBase {
           Schema.Field.of("one", Schema.of(Schema.Type.STRING)),
           Schema.Field.of("two", Schema.of(Schema.Type.STRING)),
           Schema.Field.of("three", Schema.of(Schema.Type.STRING))));
-      ViewSpecification viewSpecification = new ViewSpecification(format);
+      ViewSpecification viewSpecification = new ViewSpecification(format, "firsttable");
       LOG.info("Creating view {} with config {}", view1, GSON.toJson(viewSpecification));
       Assert.assertEquals(true, streamViewClient.createOrUpdate(view1, viewSpecification));
 
@@ -108,16 +108,16 @@ public class StreamViewClientTestRun extends ClientTestBase {
           Schema.Field.of("one", Schema.of(Schema.Type.STRING)),
           Schema.Field.of("two", Schema.of(Schema.Type.STRING)),
           Schema.Field.of("three", Schema.of(Schema.Type.STRING))));
-      ViewSpecification newViewSpecification = new ViewSpecification(newFormat);
+      ViewSpecification newViewSpecification = new ViewSpecification(newFormat, "sometable");
       LOG.info("Updating view {} with config {}", view1, GSON.toJson(newViewSpecification));
-      Assert.assertEquals(false, streamViewClient.createOrUpdate(view1, viewSpecification));
+      Assert.assertEquals(false, streamViewClient.createOrUpdate(view1, newViewSpecification));
 
       LOG.info("Verifying that view {} has been updated", view1);
-      Assert.assertEquals(new ViewDetail(view1.getId(), viewSpecification), streamViewClient.get(view1));
+      Assert.assertEquals(new ViewDetail(view1.getId(), newViewSpecification), streamViewClient.get(view1));
       Assert.assertEquals(ImmutableList.of(view1.getId()), streamViewClient.list(stream));
 
       ExploreExecutionResult executionResult = queryClient.execute(
-        view1.getNamespace(), "select one,two,three from stream_foo_view_view1").get();
+        view1.getNamespace(), "select one,two,three from sometable").get();
       Assert.assertNotNull(executionResult.getResultSchema());
       Assert.assertEquals(3, executionResult.getResultSchema().size());
       Assert.assertEquals("one", executionResult.getResultSchema().get(0).getName());

--- a/cdap-common/src/main/java/co/cask/cdap/internal/explore/ExploreTableNaming.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/explore/ExploreTableNaming.java
@@ -32,7 +32,7 @@ public final class ExploreTableNaming {
   }
 
   public String getTableName(Id.Stream.View viewId) {
-    return String.format("stream_%s_view_%s", cleanTableName(viewId.getStreamId()), cleanTableName(viewId.getId()));
+    return String.format("stream_%s_%s", cleanTableName(viewId.getStreamId()), cleanTableName(viewId.getId()));
   }
 
   public String cleanTableName(String name) {

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data/stream/view/StreamViewHttpHandlerTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data/stream/view/StreamViewHttpHandlerTest.java
@@ -109,7 +109,8 @@ public class StreamViewHttpHandlerTest {
       200,
       HttpRequest.get(resolve("/v3/namespaces/default/streams/foo/views/view1")).build(),
       ViewDetail.class);
-    Assert.assertEquals(new ViewDetail("view1", config), actualDetail);
+    Assert.assertEquals(
+      new ViewDetail("view1", new ViewSpecification(config.getFormat(), "stream_foo_view1")), actualDetail);
 
     views = execute(
       200, HttpRequest.get(resolve("/v3/namespaces/default/streams/foo/views")).build(),
@@ -126,7 +127,8 @@ public class StreamViewHttpHandlerTest {
       200,
       HttpRequest.get(resolve("/v3/namespaces/default/streams/foo/views/view2")).build(),
       ViewDetail.class);
-    Assert.assertEquals(new ViewDetail("view2", config), actualDetail);
+    Assert.assertEquals(
+      new ViewDetail("view2", new ViewSpecification(config.getFormat(), "stream_foo_view2")), actualDetail);
 
     views = execute(
       200, HttpRequest.get(resolve("/v3/namespaces/default/streams/foo/views")).build(),

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/ViewSpecification.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/ViewSpecification.java
@@ -18,6 +18,7 @@ package co.cask.cdap.proto;
 import co.cask.cdap.api.data.format.FormatSpecification;
 
 import java.util.Objects;
+import javax.annotation.Nullable;
 
 /**
  * Represents the configuration of a stream view, used when creating or updating a view.
@@ -26,16 +27,32 @@ public class ViewSpecification {
 
   private final FormatSpecification format;
 
-  public ViewSpecification(FormatSpecification format) {
+  /**
+   * The Hive table name to use. If null in the creation or update request,
+   * use default name generated from {@link Id.Stream.View} before persisting this.
+   */
+  private final String tableName;
+
+  public ViewSpecification(FormatSpecification format, String tableName) {
     this.format = format;
+    this.tableName = tableName;
   }
 
-  public ViewSpecification(ViewSpecification existing) {
-    this(existing.format);
+  public ViewSpecification(FormatSpecification format) {
+    this(format, null);
+  }
+
+  public ViewSpecification(ViewSpecification other) {
+    this(other.format, other.tableName);
   }
 
   public FormatSpecification getFormat() {
     return format;
+  }
+
+  @Nullable
+  public String getTableName() {
+    return tableName;
   }
 
   @Override
@@ -47,11 +64,20 @@ public class ViewSpecification {
       return false;
     }
     ViewSpecification that = (ViewSpecification) o;
-    return Objects.equals(format, that.format);
+    return Objects.equals(format, that.format) && Objects.equals(tableName, that.tableName);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(format);
+    return Objects.hash(format, tableName);
+  }
+
+  @Override
+  public String toString() {
+    final StringBuilder sb = new StringBuilder("ViewSpecification{");
+    sb.append("format=").append(format);
+    sb.append(", tableName='").append(tableName).append('\'');
+    sb.append('}');
+    return sb.toString();
   }
 }


### PR DESCRIPTION
- "tableName" can now be passed into the HTTP endpoint for
  creating/updating a stream view so the user can specify what
  the name of the Hive table will be
- default table name for stream views changed from
  `streams_<stream-id>_views_<view-id>` to
  `stream_<stream-id>_<view_id>`

https://issues.cask.co/browse/CDAP-3625
http://builds.cask.co/browse/CDAP-DUT2775