### PR TITLE
CDAP-3549 Enable SSH forwarding

### DIFF
--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu12.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu12.json
@@ -32,7 +32,8 @@
         ["modifyvm", "{{ .Name }}", "--memory", "4096"],
         ["modifyvm", "{{ .Name }}", "--clipboard", "bidirectional"],
         ["modifyvm", "{{ .Name }}", "--accelerate2dvideo", "on"],
-        ["modifyvm", "{{ .Name }}", "--accelerate3d", "on"]
+        ["modifyvm", "{{ .Name }}", "--accelerate3d", "on"],
+        ["modifyvm", "{{ .Name }}", "--natpf1", "guest_ssh,tcp,127.0.0.1,2222,,22" ]
       ],
       "vm_name": "cdap-standalone-vm-{{user `sdk_version`}}",
       "name": "cdap-sdk-vm"

--- a/cdap-distributions/src/packer/scripts/motd.sh
+++ b/cdap-distributions/src/packer/scripts/motd.sh
@@ -24,7 +24,7 @@ by clicking the icon at the bottom left. Included are the Eclipse and IntelliJ
 IDEs, Chromium Browser, Git, Subversion and the CDAP Standalone SDK.
 
 The login and password to the machine is 'cdap' and the user has sudo privileges
-without a password. SSH access can be enabled by 'sudo /etc/init.d/sshd start'.
+without a password.
 
 The SDK can be stopped/started/restarted using the /etc/init.d/cdap-sdk init
 script.


### PR DESCRIPTION
This maps `127.0.0.1:2222` on the host to `22` on the VM.