### PR TITLE
CDAP-3523 Implement REST APIs for searching Metadata.

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/service/DefaultMetadataAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/service/DefaultMetadataAdmin.java
@@ -20,6 +20,8 @@ import co.cask.cdap.common.NamespaceNotFoundException;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.namespace.AbstractNamespaceClient;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.MetadataSearchResultRecord;
+import co.cask.cdap.proto.MetadataSearchTargetType;
 import com.google.common.base.Throwables;
 import com.google.inject.Inject;
 
@@ -74,6 +76,14 @@ public class DefaultMetadataAdmin implements MetadataAdmin {
   public void removeTags(Id.NamespacedId entityId, String... tags) throws NotFoundException {
     ensureEntityExists(entityId);
     businessMds.removeTags(entityId, tags);
+  }
+
+  @Override
+  public Iterable<MetadataSearchResultRecord> searchMetadataOnType(String searchQuery, MetadataSearchTargetType type)
+    throws NotFoundException {
+    // TODO Add code
+
+    return null;
   }
 
   /**

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/service/MetadataAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/service/MetadataAdmin.java
@@ -20,6 +20,8 @@ import co.cask.cdap.common.ApplicationNotFoundException;
 import co.cask.cdap.common.NamespaceNotFoundException;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.MetadataSearchResultRecord;
+import co.cask.cdap.proto.MetadataSearchTargetType;
 
 import java.util.Map;
 
@@ -80,4 +82,16 @@ public interface MetadataAdmin {
    * @throws ApplicationNotFoundException if the application is not found
    */
   void removeTags(Id.NamespacedId appId, String ... tags) throws NotFoundException;
+
+  /**
+   * Execute search for metadata for particular type of CDAP object.
+   *
+   * @param searchQuery The query need to be executed for the search.
+   * @param type The particular type of CDAP object that the metadata need to be searched.
+   *
+   * @return a {@link Iterable} records for metadata search.
+   * @throws NotFoundException if there is not record found for particular query text.
+   */
+  Iterable<MetadataSearchResultRecord> searchMetadataOnType(String searchQuery, MetadataSearchTargetType type)
+    throws NotFoundException;
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/MetadataSearchResultRecord.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/MetadataSearchResultRecord.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.proto;
+
+import java.util.Objects;
+
+/**
+ * Represent the Metadata search result record.
+ */
+public class MetadataSearchResultRecord {
+  private final Id.NamespacedId id;
+  private final MetadataSearchTargetType type;
+  private final String key;
+  private final String value;
+
+  public MetadataSearchResultRecord(Id.NamespacedId id, MetadataSearchTargetType type, String key, String value) {
+    this.id = id;
+    this.type = type;
+    this.key = key;
+    this.value = value;
+  }
+
+  public Id.NamespacedId getId() {
+    return id;
+  }
+
+  public MetadataSearchTargetType getType() {
+    return type;
+  }
+
+  public String getKey() {
+    return key;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    MetadataSearchResultRecord that = (MetadataSearchResultRecord) o;
+
+    return Objects.equals(this.id, that.id) &&
+      Objects.equals(this.type, that.type) &&
+      Objects.equals(this.key, that.key) &&
+      Objects.equals(this.value, that.value);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, type, key, value);
+  }
+
+  @Override
+  public String toString() {
+    return "{" +
+      "id='" + id + '\'' +
+      "type='" + type + '\'' +
+      ", key='" + key + '\'' +
+      ", value='" + value + '\'' +
+      '}';
+  }
+}

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/MetadataSearchTargetType.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/MetadataSearchTargetType.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.proto;
+
+/**
+ * Supported types for metadata search.
+ */
+public enum MetadataSearchTargetType {
+  ALL,
+  Application,
+  Program,
+  DatasetInstance,
+  Stream
+}


### PR DESCRIPTION
First drop for REST API to support search on metadata based on query text and type.

Modify MetadataHttpHandler and MetadataHttpAdmin service to support GET /search?query="key=value"&type="Program"