### PR TITLE
CDAP-3592 refactoring to prepare for multiple sinks in etl batch.

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceTaskContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceTaskContext.java
@@ -39,7 +39,9 @@ public interface MapReduceTaskContext<KEYOUT, VALUEOUT> extends RuntimeContext, 
   ServiceDiscoverer, AdapterContext, PluginContext {
 
   /**
-   * Write key and value to the named output Dataset.
+   * Write key and value to the named output Dataset. This method must only be used if the MapReduce writes to
+   * more than one output. If there is a single output, {@link #write(Object, Object)} must be used, or else
+   * data may not be written correctly.
    *
    * @param namedOutput the name of the output Dataset
    * @param key         the key
@@ -48,7 +50,8 @@ public interface MapReduceTaskContext<KEYOUT, VALUEOUT> extends RuntimeContext, 
   <K, V> void write(String namedOutput, K key, V value) throws IOException, InterruptedException;
 
   /**
-   * Write key and value to the hadoop context.
+   * Write key and value to the hadoop context. This method must only be used in the MapReduce writes to a single
+   * output. If there is more than one outputs, {@link #write(String, Object, Object)} must be used.
    *
    * @param key         the key
    * @param value       the value

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/template/etl/api/TransformContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/template/etl/api/TransformContext.java
@@ -18,6 +18,7 @@ package co.cask.cdap.template.etl.api;
 
 import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.metrics.Metrics;
+import co.cask.cdap.api.templates.AdapterConfigurer;
 import co.cask.cdap.api.templates.plugins.PluginProperties;
 
 /**
@@ -32,6 +33,16 @@ public interface TransformContext {
    * @return the {@link PluginProperties}.
    */
   PluginProperties getPluginProperties();
+
+  /**
+   * Gets the {@link PluginProperties} associated with the given plugin id used by the stage.
+   *
+   * @param pluginId the unique identifier provided when declaring plugin usage at configure time.
+   * @return the {@link PluginProperties}.
+   * @throws IllegalArgumentException if no plugin for the given type and name
+   * @throws UnsupportedOperationException if the program is not running under the adapter context
+   */
+  PluginProperties getPluginProperties(String pluginId);
 
   /**
    * Get an instance of {@link Metrics}, used to collect metrics. Note that metric names are not scoped by
@@ -63,19 +74,13 @@ public interface TransformContext {
   <T> T newPluginInstance(String pluginId) throws InstantiationException;
 
   /**
-   * Creates a new instance of a plugin.
-   * The instance returned will have the {@link co.cask.cdap.api.templates.plugins.PluginConfig} setup with
-   * {@link PluginProperties} provided at the time when the
-   * {@link co.cask.cdap.api.artifact.PluginConfigurer#usePlugin(String, String, String, PluginProperties)}
-   * was called during the program configuration time.
+   * Loads and returns a plugin class as specified by the given type and name.
    *
-   * @param pluginId the unique identifier provide when declaring plugin usage in the program
+   * @param pluginId the unique identifier provide when declaring plugin usage in {@link AdapterConfigurer}.
    * @param <T> the class type of the plugin
-   * @return A new instance of the plugin being specified by the arguments
-   *
-   * @throws InstantiationException if failed create a new instance
-   * @throws IllegalArgumentException if pluginId is not found
-   * @throws UnsupportedOperationException if the program does not support plugin
+   * @return the resulting plugin {@link Class}.
+   * @throws IllegalArgumentException if no plugin for the given type and name
+   * @throws UnsupportedOperationException if the program is not running under the adapter context
    */
-  <T> T newInstance(String pluginId) throws InstantiationException;
+  <T> Class<T> loadPluginClass(String pluginId);
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/template/etl/api/batch/BatchRuntimeContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/template/etl/api/batch/BatchRuntimeContext.java
@@ -27,7 +27,7 @@ import java.util.Map;
  * Context passed to Batch Source and Sink.
  */
 @Beta
-public interface BatchContext extends DatasetContext, TransformContext {
+public interface BatchRuntimeContext extends DatasetContext, TransformContext {
 
   /**
    * Returns the logical start time of the Batch Job.  Logical start time is the time when this Batch
@@ -45,7 +45,4 @@ public interface BatchContext extends DatasetContext, TransformContext {
    */
   Map<String, String> getRuntimeArguments();
 
-  /**
-   */
-  <T> T getHadoopJob();
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/template/etl/api/batch/BatchSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/template/etl/api/batch/BatchSink.java
@@ -37,17 +37,17 @@ import co.cask.cdap.template.etl.api.Transformation;
  */
 @Beta
 public abstract class BatchSink<IN, KEY_OUT, VAL_OUT> extends BatchConfigurable<BatchSinkContext>
-  implements Transformation<IN, KeyValue<KEY_OUT, VAL_OUT>>, StageLifecycle<BatchSinkContext> {
+  implements Transformation<IN, KeyValue<KEY_OUT, VAL_OUT>>, StageLifecycle<BatchRuntimeContext> {
 
   /**
    * Initialize the Batch Sink stage. Executed inside the Batch Run. This method is guaranteed to be invoked
    * before any calls to {@link BatchSink#transform} are made.
    *
-   * @param context {@link BatchSinkContext}
+   * @param context {@link BatchRuntimeContext}
    * @throws Exception if there is any error during initialization
    */
   @Override
-  public void initialize(BatchSinkContext context) throws Exception {
+  public void initialize(BatchRuntimeContext context) throws Exception {
     // no-op
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/template/etl/api/batch/BatchSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/template/etl/api/batch/BatchSource.java
@@ -37,17 +37,17 @@ import co.cask.cdap.template.etl.api.Transformation;
  */
 @Beta
 public abstract class BatchSource<KEY_IN, VAL_IN, OUT> extends BatchConfigurable<BatchSourceContext>
-  implements Transformation<KeyValue<KEY_IN, VAL_IN>, OUT>, StageLifecycle<BatchSourceContext> {
+  implements Transformation<KeyValue<KEY_IN, VAL_IN>, OUT>, StageLifecycle<BatchRuntimeContext> {
 
   /**
    * Initialize the Batch Source stage. Executed inside the Batch Run. This method is guaranteed to be invoked
    * before any calls to {@link BatchSource#transform} are made.
    *
-   * @param context {@link BatchSourceContext}
+   * @param context {@link BatchRuntimeContext}
    * @throws Exception if there is any error during initialization
    */
   @Override
-  public void initialize(BatchSourceContext context) throws Exception {
+  public void initialize(BatchRuntimeContext context) throws Exception {
     // no-op
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch-app/src/main/java/co/cask/cdap/app/etl/batch/ETLMapReduce.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch-app/src/main/java/co/cask/cdap/app/etl/batch/ETLMapReduce.java
@@ -25,6 +25,7 @@ import co.cask.cdap.api.mapreduce.MapReduceTaskContext;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.app.etl.batch.config.ETLBatchConfig;
 import co.cask.cdap.template.etl.api.Transform;
+import co.cask.cdap.template.etl.api.batch.BatchConfigurable;
 import co.cask.cdap.template.etl.api.batch.BatchRuntimeContext;
 import co.cask.cdap.template.etl.api.batch.BatchSink;
 import co.cask.cdap.template.etl.api.batch.BatchSinkContext;
@@ -34,6 +35,7 @@ import co.cask.cdap.template.etl.batch.MapReduceRuntimeContext;
 import co.cask.cdap.template.etl.batch.MapReduceSinkContext;
 import co.cask.cdap.template.etl.batch.MapReduceSourceContext;
 import co.cask.cdap.template.etl.common.Constants;
+import co.cask.cdap.template.etl.common.DefaultEmitter;
 import co.cask.cdap.template.etl.common.Destroyables;
 import co.cask.cdap.template.etl.common.Pipeline;
 import co.cask.cdap.template.etl.common.PipelineRegisterer;
@@ -42,6 +44,8 @@ import co.cask.cdap.template.etl.common.StageMetrics;
 import co.cask.cdap.template.etl.common.TransformDetail;
 import co.cask.cdap.template.etl.common.TransformExecutor;
 import co.cask.cdap.template.etl.common.TransformInfo;
+import co.cask.cdap.template.etl.common.TransformResponse;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import com.google.common.reflect.TypeToken;
@@ -53,6 +57,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -65,11 +70,15 @@ import java.util.Set;
 public class ETLMapReduce extends AbstractMapReduce {
   public static final String NAME = ETLMapReduce.class.getSimpleName();
   private static final Logger LOG = LoggerFactory.getLogger(ETLMapReduce.class);
+  private static final String SINK_OUTPUTS_KEY = "cdap.etl.sink.outputs";
+  private static final Type SINK_OUTPUTS_TYPE = new TypeToken<Map<String, Set<String>>>() { }.getType();
   private static final Type STRING_LIST_TYPE = new TypeToken<List<String>>() { }.getType();
   private static final Gson GSON = new Gson();
 
-  private BatchSource batchSource;
-  private List<BatchSink> batchSinks;
+  private BatchConfigurable<BatchSourceContext> batchSource;
+  private List<BatchConfigurable<BatchSinkContext>> batchSinks;
+  // injected by CDAP
+  @SuppressWarnings("unused")
   private Metrics mrMetrics;
 
   // this is only visible at configure time, not at runtime
@@ -111,14 +120,21 @@ public class ETLMapReduce extends AbstractMapReduce {
     BatchSourceContext sourceContext = new MapReduceSourceContext(context, mrMetrics, sourcePluginId);
     batchSource.prepareRun(sourceContext);
 
-    List<String> sinkPluginIds = GSON.fromJson(properties.get(Constants.Sink.PLUGINIDS), STRING_LIST_TYPE);
+    Map<String, Set<String>> sinkOutputs = new HashMap<>();
+    String sinkPluginIdsStr = properties.get(Constants.Sink.PLUGINIDS);
+    // should never happen
+    Preconditions.checkNotNull(sinkPluginIdsStr, "sink plugin ids could not be found in program properties.");
+
+    List<String> sinkPluginIds = GSON.fromJson(sinkPluginIdsStr, STRING_LIST_TYPE);
     batchSinks = Lists.newArrayListWithCapacity(sinkPluginIds.size());
     for (String sinkPluginId : sinkPluginIds) {
-      BatchSink batchSink = context.newInstance(sinkPluginId);
-      BatchSinkContext sinkContext = new MapReduceSinkContext(context, mrMetrics, sinkPluginId);
+      BatchConfigurable<BatchSinkContext> batchSink = context.newInstance(sinkPluginId);
+      MapReduceSinkContext sinkContext = new MapReduceSinkContext(context, mrMetrics, sinkPluginId);
       batchSink.prepareRun(sinkContext);
       batchSinks.add(batchSink);
+      sinkOutputs.put(sinkPluginId, sinkContext.getOutputNames());
     }
+    job.getConfiguration().set(SINK_OUTPUTS_KEY, GSON.toJson(sinkOutputs));
 
     job.setMapperClass(ETLMapper.class);
     job.setNumReduceTasks(0);
@@ -143,10 +159,13 @@ public class ETLMapReduce extends AbstractMapReduce {
   }
 
   private void onRunFinishSink(MapReduceContext context, boolean succeeded) {
-    List<String> sinkPluginIds = GSON.fromJson(context.getSpecification().getProperty(Constants.Sink.PLUGINIDS),
-                                               STRING_LIST_TYPE);
+    String sinkPluginIdsStr = context.getSpecification().getProperty(Constants.Sink.PLUGINIDS);
+    // should never happen
+    Preconditions.checkNotNull(sinkPluginIdsStr, "sink plugin ids could not be found in program properties.");
+
+    List<String> sinkPluginIds = GSON.fromJson(sinkPluginIdsStr, STRING_LIST_TYPE);
     for (int i = 0; i < sinkPluginIds.size(); i++) {
-      BatchSink batchSink = batchSinks.get(i);
+      BatchConfigurable<BatchSinkContext> batchSink = batchSinks.get(i);
       String sinkPluginId = sinkPluginIds.get(i);
       BatchSinkContext sinkContext = new MapReduceSinkContext(context, mrMetrics, sinkPluginId);
       try {
@@ -165,39 +184,51 @@ public class ETLMapReduce extends AbstractMapReduce {
     private static final Gson GSON = new Gson();
     private static final Type TRANSFORMDETAILS_LIST_TYPE = new TypeToken<List<TransformInfo>>() { }.getType();
 
-    private TransformExecutor<KeyValue, KeyValue> transformExecutor;
+    private TransformExecutor<KeyValue, Object> transformExecutor;
+    // injected by CDAP
+    @SuppressWarnings("unused")
     private Metrics mapperMetrics;
-    private Map<String, Set<String>> sinkOutputs;
+    private List<WrappedSink<Object, Object, Object>> sinks;
 
     @Override
     public void initialize(MapReduceTaskContext context) throws Exception {
-
       // get source, transform, sink ids from program properties
       context.getSpecification().getProperties();
       Map<String, String> properties = context.getSpecification().getProperties();
 
       String sourcePluginId = properties.get(Constants.Source.PLUGINID);
-      List<TransformInfo> transformInfos = GSON.fromJson(properties.get(Constants.Transform.PLUGINIDS),
-        TRANSFORMDETAILS_LIST_TYPE);
+      // should never happen
+      String transformInfosStr = properties.get(Constants.Transform.PLUGINIDS);
+      Preconditions.checkNotNull(transformInfosStr, "Transform plugin ids not found in program properties.");
 
+      List<TransformInfo> transformInfos = GSON.fromJson(transformInfosStr, TRANSFORMDETAILS_LIST_TYPE);
       List<TransformDetail> pipeline = Lists.newArrayListWithCapacity(transformInfos.size() + 2);
 
       BatchSource source = context.newInstance(sourcePluginId);
       BatchRuntimeContext runtimeContext = new MapReduceRuntimeContext(context, mapperMetrics, sourcePluginId);
       source.initialize(runtimeContext);
       pipeline.add(new TransformDetail(sourcePluginId, source,
-                                             new StageMetrics(mapperMetrics, PluginID.from(sourcePluginId))));
+        new StageMetrics(mapperMetrics, PluginID.from(sourcePluginId))));
 
       addTransforms(pipeline, transformInfos, context);
 
-      List<String> sinkPluginIds = GSON.fromJson(properties.get(Constants.Sink.PLUGINIDS), STRING_LIST_TYPE);
-      // multi-output for mapreduce coming in a later PR
-      String sinkPluginId = sinkPluginIds.get(0);
-      BatchSink sink = context.newInstance(sinkPluginId);
-      runtimeContext = new MapReduceRuntimeContext(context, mapperMetrics, sinkPluginId);
-      sink.initialize(runtimeContext);
-      pipeline.add(new TransformDetail(sinkPluginId, sink,
-                                             new StageMetrics(mapperMetrics, PluginID.from(sinkPluginId))));
+      // get the list of sinks, and the names of the outputs each sink writes to
+      Context hadoopContext = (Context) context.getHadoopContext();
+      String sinkOutputsStr = hadoopContext.getConfiguration().get(SINK_OUTPUTS_KEY);
+      // should never happen, this is set in beforeSubmit
+      Preconditions.checkNotNull(sinkOutputsStr, "Sink outputs not found in hadoop conf.");
+
+      Map<String, Set<String>> sinkOutputs = GSON.fromJson(sinkOutputsStr, SINK_OUTPUTS_TYPE);
+      sinks = new ArrayList<>(sinkOutputs.size());
+      for (Map.Entry<String, Set<String>> sinkOutput : sinkOutputs.entrySet()) {
+        String sinkPluginId = sinkOutput.getKey();
+        Set<String> sinkOutputNames = sinkOutput.getValue();
+
+        BatchSink<Object, Object, Object> sink = context.newInstance(sinkPluginId);
+        runtimeContext = new MapReduceRuntimeContext(context, mapperMetrics, sinkPluginId);
+        sink.initialize(runtimeContext);
+        sinks.add(new WrappedSink<>(sinkPluginId, sink, sinkOutputNames, context, mapperMetrics));
+      }
 
       transformExecutor = new TransformExecutor<>(pipeline);
     }
@@ -220,11 +251,14 @@ public class ETLMapReduce extends AbstractMapReduce {
     @Override
     public void map(Object key, Object value, Context context) throws IOException, InterruptedException {
       try {
-        KeyValue input = new KeyValue(key, value);
-        Iterator<KeyValue> iterator = transformExecutor.runOneIteration(input).getEmittedRecords();
-        while (iterator.hasNext()) {
-          KeyValue output = iterator.next();
-          context.write(output.getKey(), output.getValue());
+        KeyValue<Object, Object> input = new KeyValue<>(key, value);
+        TransformResponse<Object> recordsAndErrors = transformExecutor.runOneIteration(input);
+        Iterator<Object> transformedRecords = recordsAndErrors.getEmittedRecords();
+        while (transformedRecords.hasNext()) {
+          Object transformedRecord = transformedRecords.next();
+          for (WrappedSink<Object, Object, Object> sink : sinks) {
+            sink.write(transformedRecord);
+          }
         }
         transformExecutor.resetEmitters();
       } catch (Exception e) {
@@ -237,6 +271,36 @@ public class ETLMapReduce extends AbstractMapReduce {
     public void destroy() {
       // Both BatchSource and BatchSink implements Transform, hence are inside the transformExecutor as well
       Destroyables.destroyQuietly(transformExecutor);
+    }
+  }
+
+  // wrapper around sinks to help writing sink output to the correct named output
+  private static class WrappedSink<IN, KEY_OUT, VAL_OUT> {
+    private final BatchSink<IN, KEY_OUT, VAL_OUT> sink;
+    private final DefaultEmitter<KeyValue<KEY_OUT, VAL_OUT>> emitter;
+    private final Set<String> outputNames;
+    private final MapReduceTaskContext context;
+
+    private WrappedSink(String sinkPluginId,
+                        BatchSink<IN, KEY_OUT, VAL_OUT> sink,
+                        Set<String> outputNames,
+                        MapReduceTaskContext context,
+                        Metrics metrics) {
+      this.sink = sink;
+      this.emitter = new DefaultEmitter<>(new StageMetrics(metrics, PluginID.from(sinkPluginId)));
+      this.outputNames = outputNames;
+      this.context = context;
+    }
+
+    private void write(IN input) throws Exception {
+      sink.transform(input, emitter);
+      for (KeyValue outputRecord : emitter) {
+        for (String outputName : outputNames) {
+          context.write(outputName, outputRecord.getKey(), outputRecord.getValue());
+        }
+      }
+      // TODO: write errors to error dataset
+      emitter.reset();
     }
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch-app/src/main/java/co/cask/cdap/app/etl/batch/ETLMapReduce.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch-app/src/main/java/co/cask/cdap/app/etl/batch/ETLMapReduce.java
@@ -220,6 +220,9 @@ public class ETLMapReduce extends AbstractMapReduce {
       Preconditions.checkNotNull(sinkOutputsStr, "Sink outputs not found in hadoop conf.");
 
       Map<String, Set<String>> sinkOutputs = GSON.fromJson(sinkOutputsStr, SINK_OUTPUTS_TYPE);
+      // should never happen, this is checked and set in beforeSubmit
+      Preconditions.checkArgument(!sinkOutputs.isEmpty(), "Sink outputs not found in hadoop conf.");
+
       boolean hasOneOutput = hasOneOutput(transformInfos, sinkOutputs);
       sinks = new ArrayList<>(sinkOutputs.size());
       for (Map.Entry<String, Set<String>> sinkOutput : sinkOutputs.entrySet()) {
@@ -315,6 +318,7 @@ public class ETLMapReduce extends AbstractMapReduce {
   }
 
   // need to write with a different method if there is only one output for the mapreduce
+  // TODO: remove if the fix to CDAP-3628 allows us to write using the same method
   private static class SingleOutputSink<IN, KEY_OUT, VAL_OUT> extends WrappedSink<IN, KEY_OUT, VAL_OUT> {
 
     protected SingleOutputSink(String sinkPluginId, BatchSink<IN, KEY_OUT, VAL_OUT> sink,

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch-app/src/main/java/co/cask/cdap/app/etl/batch/config/ETLBatchConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch-app/src/main/java/co/cask/cdap/app/etl/batch/config/ETLBatchConfig.java
@@ -30,6 +30,13 @@ public final class ETLBatchConfig extends ETLConfig {
   private final String schedule;
   private final List<ETLStage> actions;
 
+  public ETLBatchConfig(String schedule, ETLStage source, List<ETLStage> sinks, List<ETLStage> transforms,
+                        Resources resources, List<ETLStage> actions) {
+    super(source, sinks, transforms, resources);
+    this.schedule = schedule;
+    this.actions = actions;
+  }
+
   public ETLBatchConfig(String schedule, ETLStage source, ETLStage sink, List<ETLStage> transforms,
                         Resources resources, List<ETLStage> actions) {
     super(source, sink, transforms, resources);

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch-app/src/test/java/co/cask/cdap/app/etl/batch/BaseETLBatchTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch-app/src/test/java/co/cask/cdap/app/etl/batch/BaseETLBatchTest.java
@@ -124,8 +124,7 @@ public class BaseETLBatchTest extends TestBase {
           String locName = file.getName();
 
           if (locName.endsWith(".avro")) {
-            DataFileStream<GenericRecord> fileStream =
-              new DataFileStream<>(file.getInputStream(), datumReader);
+            DataFileStream<GenericRecord> fileStream = new DataFileStream<>(file.getInputStream(), datumReader);
             Iterables.addAll(records, fileStream);
             fileStream.close();
           }

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch-app/src/test/java/co/cask/cdap/app/etl/batch/ETLMapReduceTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch-app/src/test/java/co/cask/cdap/app/etl/batch/ETLMapReduceTest.java
@@ -272,7 +272,7 @@ public class ETLMapReduceTest extends BaseETLBatchTest {
     mrManager.start();
     mrManager.waitForFinish(2, TimeUnit.MINUTES);
 
-    for (String sinkName : new String[] { "fileSink1", "fileSink2" } ) {
+    for (String sinkName : new String[] { "fileSink1", "fileSink2" }) {
       DataSetManager<TimePartitionedFileSet> fileSetManager = getDataset(sinkName);
       TimePartitionedFileSet fileSet = fileSetManager.get();
       List<GenericRecord> records = readOutput(fileSet, FileBatchSource.DEFAULT_SCHEMA);

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch-app/src/test/java/co/cask/cdap/app/etl/batch/ETLMapReduceTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch-app/src/test/java/co/cask/cdap/app/etl/batch/ETLMapReduceTest.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.app.etl.batch;
 
+import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.dataset.lib.KeyValueTable;
@@ -231,7 +232,7 @@ public class ETLMapReduceTest extends BaseETLBatchTest {
   }
 
   @Test
-  public void testFiletoTPFS() throws Exception {
+  public void testFiletoMultipleTPFS() throws Exception {
     String filePath = "file:///tmp/test/text.txt";
     String testData = "String for testing purposes.";
 
@@ -248,11 +249,20 @@ public class ETLMapReduceTest extends BaseETLBatchTest {
       .put(Properties.File.PATH, filePath)
       .build());
 
-    ETLStage sink = new ETLStage("TPFSAvro",
-                                 ImmutableMap.of(Properties.TimePartitionedFileSetDataset.SCHEMA,
-                                                 FileBatchSource.DEFAULT_SCHEMA.toString(),
-                                                 Properties.TimePartitionedFileSetDataset.TPFS_NAME, "fileSink"));
-    ETLBatchConfig etlConfig = new ETLBatchConfig("* * * * *", source, sink, Lists.<ETLStage>newArrayList());
+    ETLStage sink1 = new ETLStage("TPFSAvro",
+                                  ImmutableMap.of(Properties.TimePartitionedFileSetDataset.SCHEMA,
+                                    FileBatchSource.DEFAULT_SCHEMA.toString(),
+                                    Properties.TimePartitionedFileSetDataset.TPFS_NAME, "fileSink1"));
+    ETLStage sink2 = new ETLStage("TPFSParquet",
+                                  ImmutableMap.of(Properties.TimePartitionedFileSetDataset.SCHEMA,
+                                    FileBatchSource.DEFAULT_SCHEMA.toString(),
+                                    Properties.TimePartitionedFileSetDataset.TPFS_NAME, "fileSink2"));
+    ETLBatchConfig etlConfig = new ETLBatchConfig("* * * * *",
+                                                  source,
+                                                  Lists.newArrayList(sink1, sink2),
+                                                  Lists.<ETLStage>newArrayList(),
+                                                  new Resources(),
+                                                  Lists.<ETLStage>newArrayList());
 
     AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(ETLBATCH_ARTIFACT, etlConfig);
     Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "FileToTPFS");
@@ -262,12 +272,14 @@ public class ETLMapReduceTest extends BaseETLBatchTest {
     mrManager.start();
     mrManager.waitForFinish(2, TimeUnit.MINUTES);
 
-    DataSetManager<TimePartitionedFileSet> fileSetManager = getDataset("fileSink");
-    TimePartitionedFileSet fileSet = fileSetManager.get();
-    List<GenericRecord> records = readOutput(fileSet, FileBatchSource.DEFAULT_SCHEMA);
-    Assert.assertEquals(1, records.size());
-    Assert.assertEquals(testData, records.get(0).get("body").toString());
-    fileSet.close();
+    for (String sinkName : new String[] { "fileSink1", "fileSink2" } ) {
+      DataSetManager<TimePartitionedFileSet> fileSetManager = getDataset(sinkName);
+      TimePartitionedFileSet fileSet = fileSetManager.get();
+      List<GenericRecord> records = readOutput(fileSet, FileBatchSource.DEFAULT_SCHEMA);
+      Assert.assertEquals(1, records.size());
+      Assert.assertEquals(testData, records.get(0).get("body").toString());
+      fileSet.close();
+    }
   }
 
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/batch/BatchTransformContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/batch/BatchTransformContext.java
@@ -20,21 +20,19 @@ import co.cask.cdap.api.mapreduce.MapReduceContext;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.templates.plugins.PluginProperties;
 import co.cask.cdap.template.etl.api.TransformContext;
-import co.cask.cdap.template.etl.common.Constants;
+import co.cask.cdap.template.etl.common.ScopedPluginContext;
 
 /**
  * Context for the Transform Stage.
  */
-public class BatchTransformContext implements TransformContext {
+public class BatchTransformContext extends ScopedPluginContext implements TransformContext {
   private final MapReduceContext context;
   private final Metrics metrics;
 
-  protected final String pluginId;
-
-  public BatchTransformContext(MapReduceContext context, Metrics metrics, String pluginId) {
+  public BatchTransformContext(MapReduceContext context, Metrics metrics, String stageId) {
+    super(stageId);
     this.context = context;
     this.metrics = metrics;
-    this.pluginId = pluginId;
   }
 
   @Override
@@ -43,26 +41,42 @@ public class BatchTransformContext implements TransformContext {
   }
 
   @Override
-  public <T> T newPluginInstance(String pluginId) throws InstantiationException {
-    return context.newPluginInstance(getPluginId(pluginId));
+  protected <T> T newScopedPluginInstance(String scopedPluginId) throws InstantiationException {
+    // temporary hack to let it support both templates and applications. Will be removed when templates are removed.
+    try {
+      return context.newPluginInstance(scopedPluginId);
+    } catch (UnsupportedOperationException e) {
+      return context.newInstance(scopedPluginId);
+    }
   }
 
   @Override
-  public <T> T newInstance(String pluginId) throws InstantiationException {
-    return context.newInstance(getPluginId(pluginId));
-  }
-
-  protected String getPluginId(String childPluginId) {
-    return String.format("%s%s%s", pluginId, Constants.ID_SEPARATOR, childPluginId);
+  protected <T> Class<T> loadScopedPluginClass(String scopedPluginId) {
+    // temporary hack until templates are removed, and to let this work for both apps and templates
+    try {
+      return context.loadPluginClass(scopedPluginId);
+    } catch (UnsupportedOperationException e) {
+      return context.loadClass(scopedPluginId);
+    }
   }
 
   @Override
   public PluginProperties getPluginProperties() {
     // temporary hack to let it support both templates and applications. Will be removed when templates are removed.
     try {
-      return context.getPluginProperties(pluginId);
+      return context.getPluginProperties(stageId);
     } catch (UnsupportedOperationException e) {
-      return context.getPluginProps(pluginId);
+      return context.getPluginProps(stageId);
+    }
+  }
+
+  @Override
+  public PluginProperties getScopedPluginProperties(String scopedPluginId) {
+    // temporary hack to let it support both templates and applications. Will be removed when templates are removed.
+    try {
+      return context.getPluginProperties(scopedPluginId);
+    } catch (UnsupportedOperationException e) {
+      return context.getPluginProps(scopedPluginId);
     }
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/batch/MapReduceBatchContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/batch/MapReduceBatchContext.java
@@ -61,42 +61,6 @@ public abstract class MapReduceBatchContext extends BatchTransformContext implem
     return mrContext.getDataset(name, arguments);
   }
 
-  @Nullable
-  @Override
-  public AdapterSpecification getAdapterSpecification() {
-    return mrContext.getAdapterSpecification();
-  }
-
-  @Override
-  public PluginProperties getPluginProperties(String pluginId) {
-    // temporary hack until templates are removed, and to let this work for both apps and templates
-    try {
-      return mrContext.getPluginProperties(getPluginId(pluginId));
-    } catch (UnsupportedOperationException e) {
-      return mrContext.getPluginProps(getPluginId(pluginId));
-    }
-  }
-
-  @Override
-  public <T> Class<T> loadPluginClass(String pluginId) {
-    // temporary hack until templates are removed, and to let this work for both apps and templates
-    try {
-      return mrContext.loadPluginClass(getPluginId(pluginId));
-    } catch (UnsupportedOperationException e) {
-      return mrContext.loadClass(getPluginId(pluginId));
-    }
-  }
-
-  @Override
-  public <T> T newPluginInstance(String pluginId) throws InstantiationException {
-    // temporary hack until templates are removed, and to let this work for both apps and templates
-    try {
-      return mrContext.newPluginInstance(getPluginId(pluginId));
-    } catch (UnsupportedOperationException e) {
-      return mrContext.newInstance(getPluginId(pluginId));
-    }
-  }
-
   @Override
   public Map<String, String> getRuntimeArguments() {
     return mrContext.getRuntimeArguments();

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/batch/MapReduceSinkContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/batch/MapReduceSinkContext.java
@@ -17,34 +17,48 @@
 package co.cask.cdap.template.etl.batch;
 
 import co.cask.cdap.api.data.batch.OutputFormatProvider;
-import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.mapreduce.MapReduceContext;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.template.etl.api.batch.BatchSinkContext;
 
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 /**
- * MapReduce Sink Context.
+ * MapReduce Sink Context. Delegates operations to MapReduceContext and also keeps track of which outputs
+ * were written to.
  */
 public class MapReduceSinkContext extends MapReduceBatchContext implements BatchSinkContext {
+  private final Set<String> outputNames;
 
-  public MapReduceSinkContext(MapReduceContext context, Metrics metrics, String prefixId) {
-    super(context, metrics, prefixId);
+  public MapReduceSinkContext(MapReduceContext context, Metrics metrics, String sinkId) {
+    super(context, metrics, sinkId);
+    this.outputNames = new HashSet<>();
   }
 
   @Override
   public void addOutput(String datasetName) {
     mrContext.addOutput(datasetName);
+    outputNames.add(datasetName);
   }
 
   @Override
   public void addOutput(String datasetName, Map<String, String> arguments) {
     mrContext.addOutput(datasetName, arguments);
+    outputNames.add(datasetName);
   }
 
   @Override
   public void addOutput(String outputName, OutputFormatProvider outputFormatProvider) {
     mrContext.addOutput(outputName, outputFormatProvider);
+    outputNames.add(outputName);
+  }
+
+  /**
+   * @return set of outputs that were added
+   */
+  public Set<String> getOutputNames() {
+    return outputNames;
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/batch/MapReduceSourceContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/batch/MapReduceSourceContext.java
@@ -30,8 +30,8 @@ import java.util.List;
  */
 public class MapReduceSourceContext extends MapReduceBatchContext implements BatchSourceContext {
 
-  public MapReduceSourceContext(MapReduceContext context, Metrics metrics, String prefixId) {
-    super(context, metrics, prefixId);
+  public MapReduceSourceContext(MapReduceContext context, Metrics metrics, String sourceId) {
+    super(context, metrics, sourceId);
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/common/ETLConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/common/ETLConfig.java
@@ -28,7 +28,7 @@ import java.util.List;
  */
 public class ETLConfig extends Config {
   private final ETLStage source;
-  // here for backwards compatibility
+  // here for backwards compatibility. This will remain until we remove the etl templates.
   private final ETLStage sink;
   private final List<ETLStage> sinks;
   private final List<ETLStage> transforms;

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/common/ScopedPluginContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/common/ScopedPluginContext.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.template.etl.common;
+
+import co.cask.cdap.api.templates.plugins.PluginProperties;
+import co.cask.cdap.template.etl.api.TransformContext;
+
+/**
+ * Context that scopes plugin ids by the id of the transform. This allows multiple transforms to use plugins with
+ * the same id without clobbering each other.
+ */
+public abstract class ScopedPluginContext implements TransformContext {
+  protected final String stageId;
+
+  public ScopedPluginContext(String stageId) {
+    this.stageId = stageId;
+  }
+
+  @Override
+  public PluginProperties getPluginProperties(String pluginId) {
+    return getScopedPluginProperties(scopePluginId(pluginId));
+  }
+
+  @Override
+  public <T> T newPluginInstance(String pluginId) throws InstantiationException {
+    return newScopedPluginInstance(scopePluginId(pluginId));
+  }
+
+  @Override
+  public <T> Class<T> loadPluginClass(String pluginId) {
+    return loadScopedPluginClass(scopePluginId(pluginId));
+  }
+
+  protected abstract <T> T newScopedPluginInstance(String scopedPluginId) throws InstantiationException;
+
+  protected abstract <T> Class<T> loadScopedPluginClass(String scopedPluginId);
+
+  protected abstract PluginProperties getScopedPluginProperties(String scopedPluginId);
+
+  private String scopePluginId(String childPluginId) {
+    return String.format("%s%s%s", stageId, Constants.ID_SEPARATOR, childPluginId);
+  }
+
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/realtime/WorkerRealtimeContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/template/etl/realtime/WorkerRealtimeContext.java
@@ -18,11 +18,9 @@ package co.cask.cdap.template.etl.realtime;
 
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.templates.AdapterSpecification;
-import co.cask.cdap.api.templates.plugins.PluginProperties;
 import co.cask.cdap.api.worker.Worker;
 import co.cask.cdap.api.worker.WorkerContext;
 import co.cask.cdap.template.etl.api.realtime.RealtimeContext;
-import co.cask.cdap.template.etl.common.Constants;
 
 import javax.annotation.Nullable;
 
@@ -53,18 +51,4 @@ public class WorkerRealtimeContext extends RealtimeTransformContext implements R
     return context.getAdapterSpecification();
   }
 
-  @Override
-  public PluginProperties getPluginProperties(String pluginId) {
-    return context.getPluginProperties(getPluginId(pluginId));
-  }
-
-  @Override
-  public <T> Class<T> loadPluginClass(String pluginId) {
-    return context.loadPluginClass(getPluginId(pluginId));
-  }
-
-  @Override
-  public <T> T newPluginInstance(String pluginId) throws InstantiationException {
-    return context.newPluginInstance(getPluginId(pluginId));
-  }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/sink/BatchCubeSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/sink/BatchCubeSink.java
@@ -24,8 +24,8 @@ import co.cask.cdap.api.dataset.lib.KeyValue;
 import co.cask.cdap.api.dataset.lib.cube.Cube;
 import co.cask.cdap.api.dataset.lib.cube.CubeFact;
 import co.cask.cdap.template.etl.api.Emitter;
+import co.cask.cdap.template.etl.api.batch.BatchRuntimeContext;
 import co.cask.cdap.template.etl.api.batch.BatchSink;
-import co.cask.cdap.template.etl.api.batch.BatchSinkContext;
 import co.cask.cdap.template.etl.common.CubeSinkConfig;
 import co.cask.cdap.template.etl.common.Properties;
 import co.cask.cdap.template.etl.common.StructuredRecordToCubeFact;
@@ -67,7 +67,7 @@ public class BatchCubeSink extends BatchWritableSink<StructuredRecord, byte[], C
   private StructuredRecordToCubeFact transform;
 
   @Override
-  public void initialize(BatchSinkContext context) throws Exception {
+  public void initialize(BatchRuntimeContext context) throws Exception {
     super.initialize(context);
     transform = new StructuredRecordToCubeFact(context.getPluginProperties().getProperties());
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/sink/DBSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/sink/DBSink.java
@@ -26,6 +26,7 @@ import co.cask.cdap.api.templates.plugins.PluginConfig;
 import co.cask.cdap.api.templates.plugins.PluginProperties;
 import co.cask.cdap.template.etl.api.Emitter;
 import co.cask.cdap.template.etl.api.PipelineConfigurer;
+import co.cask.cdap.template.etl.api.batch.BatchRuntimeContext;
 import co.cask.cdap.template.etl.api.batch.BatchSink;
 import co.cask.cdap.template.etl.api.batch.BatchSinkContext;
 import co.cask.cdap.template.etl.common.DBConfig;
@@ -102,7 +103,7 @@ public class DBSink extends BatchSink<StructuredRecord, DBRecord, NullWritable> 
   }
 
   @Override
-  public void initialize(BatchSinkContext context) throws Exception {
+  public void initialize(BatchRuntimeContext context) throws Exception {
     super.initialize(context);
     driverClass = context.loadPluginClass(getJDBCPluginId());
     setResultSetMetadata();

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/sink/TableSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/sink/TableSink.java
@@ -27,6 +27,7 @@ import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.etl.common.RecordPutTransformer;
 import co.cask.cdap.template.etl.api.Emitter;
 import co.cask.cdap.template.etl.api.PipelineConfigurer;
+import co.cask.cdap.template.etl.api.batch.BatchRuntimeContext;
 import co.cask.cdap.template.etl.api.batch.BatchSinkContext;
 import co.cask.cdap.template.etl.common.Properties;
 import co.cask.cdap.template.etl.common.TableSinkConfig;
@@ -60,12 +61,12 @@ public class TableSink extends BatchWritableSink<StructuredRecord, byte[], Put> 
   }
 
   @Override
-  public void initialize(BatchSinkContext context) throws Exception {
+  public void initialize(BatchRuntimeContext context) throws Exception {
     super.initialize(context);
     Schema outputSchema = null;
     // If a schema string is present in the properties, use that to construct the outputSchema and pass it to the
     // recordPutTransformer
-    String schemaString = context.getPluginProperties().getProperties().get(Properties.Table.PROPERTY_SCHEMA);
+    String schemaString = tableSinkConfig.getSchemaStr();
     if (schemaString != null) {
       outputSchema = Schema.parseJson(schemaString);
     }

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/sink/TimePartitionedFileSetDatasetAvroSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/sink/TimePartitionedFileSetDatasetAvroSink.java
@@ -25,6 +25,7 @@ import co.cask.cdap.api.dataset.lib.KeyValue;
 import co.cask.cdap.api.dataset.lib.TimePartitionedFileSet;
 import co.cask.cdap.template.etl.api.Emitter;
 import co.cask.cdap.template.etl.api.PipelineConfigurer;
+import co.cask.cdap.template.etl.api.batch.BatchRuntimeContext;
 import co.cask.cdap.template.etl.api.batch.BatchSink;
 import co.cask.cdap.template.etl.api.batch.BatchSinkContext;
 import co.cask.cdap.template.etl.common.StructuredToAvroTransformer;
@@ -84,7 +85,7 @@ public class TimePartitionedFileSetDatasetAvroSink extends
 
 
   @Override
-  public void initialize(BatchSinkContext context) throws Exception {
+  public void initialize(BatchRuntimeContext context) throws Exception {
     super.initialize(context);
     recordTransformer = new StructuredToAvroTransformer(config.schema);
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/sink/TimePartitionedFileSetDatasetAvroSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/sink/TimePartitionedFileSetDatasetAvroSink.java
@@ -31,11 +31,9 @@ import co.cask.cdap.template.etl.common.StructuredToAvroTransformer;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.mapred.AvroKey;
-import org.apache.avro.mapreduce.AvroJob;
 import org.apache.avro.mapreduce.AvroKeyInputFormat;
 import org.apache.avro.mapreduce.AvroKeyOutputFormat;
 import org.apache.hadoop.io.NullWritable;
-import org.apache.hadoop.mapreduce.MRJobConfig;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/sink/TimePartitionedFileSetDatasetAvroSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/sink/TimePartitionedFileSetDatasetAvroSink.java
@@ -27,7 +27,6 @@ import co.cask.cdap.template.etl.api.Emitter;
 import co.cask.cdap.template.etl.api.PipelineConfigurer;
 import co.cask.cdap.template.etl.api.batch.BatchRuntimeContext;
 import co.cask.cdap.template.etl.api.batch.BatchSink;
-import co.cask.cdap.template.etl.api.batch.BatchSinkContext;
 import co.cask.cdap.template.etl.common.StructuredToAvroTransformer;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
@@ -36,8 +35,10 @@ import org.apache.avro.mapreduce.AvroJob;
 import org.apache.avro.mapreduce.AvroKeyInputFormat;
 import org.apache.avro.mapreduce.AvroKeyOutputFormat;
 import org.apache.hadoop.io.NullWritable;
-import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.MRJobConfig;
 
+import java.util.HashMap;
+import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
@@ -76,13 +77,12 @@ public class TimePartitionedFileSetDatasetAvroSink extends
   }
 
   @Override
-  public void prepareRun(BatchSinkContext context) {
-    super.prepareRun(context);
+  protected Map<String, String> getAdditionalTPFSArguments() {
+    Map<String, String> args = new HashMap<>();
     Schema avroSchema = new Schema.Parser().parse(config.schema);
-    Job job = context.getHadoopJob();
-    AvroJob.setOutputKeySchema(job, avroSchema);
+    args.put(FileSetProperties.OUTPUT_PROPERTIES_PREFIX + "avro.schema.output.key", avroSchema.toString());
+    return args;
   }
-
 
   @Override
   public void initialize(BatchRuntimeContext context) throws Exception {

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/sink/TimePartitionedFileSetDatasetParquetSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/sink/TimePartitionedFileSetDatasetParquetSink.java
@@ -29,15 +29,15 @@ import co.cask.cdap.template.etl.api.Emitter;
 import co.cask.cdap.template.etl.api.PipelineConfigurer;
 import co.cask.cdap.template.etl.api.batch.BatchRuntimeContext;
 import co.cask.cdap.template.etl.api.batch.BatchSink;
-import co.cask.cdap.template.etl.api.batch.BatchSinkContext;
 import co.cask.cdap.template.etl.common.SchemaConverter;
 import co.cask.cdap.template.etl.common.StructuredToAvroTransformer;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.hadoop.mapreduce.Job;
 import parquet.avro.AvroParquetInputFormat;
 import parquet.avro.AvroParquetOutputFormat;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
@@ -81,11 +81,11 @@ public class TimePartitionedFileSetDatasetParquetSink extends
   }
 
   @Override
-  public void prepareRun(BatchSinkContext context) {
-    super.prepareRun(context);
+  protected Map<String, String> getAdditionalTPFSArguments() {
+    Map<String, String> args = new HashMap<>();
     org.apache.avro.Schema avroSchema = new org.apache.avro.Schema.Parser().parse(config.schema.toLowerCase());
-    Job job = context.getHadoopJob();
-    AvroParquetOutputFormat.setSchema(job, avroSchema);
+    args.put(FileSetProperties.OUTPUT_PROPERTIES_PREFIX + "parquet.avro.schema", avroSchema.toString());
+    return args;
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/sink/TimePartitionedFileSetDatasetParquetSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/sink/TimePartitionedFileSetDatasetParquetSink.java
@@ -27,6 +27,7 @@ import co.cask.cdap.api.dataset.lib.KeyValue;
 import co.cask.cdap.api.dataset.lib.TimePartitionedFileSet;
 import co.cask.cdap.template.etl.api.Emitter;
 import co.cask.cdap.template.etl.api.PipelineConfigurer;
+import co.cask.cdap.template.etl.api.batch.BatchRuntimeContext;
 import co.cask.cdap.template.etl.api.batch.BatchSink;
 import co.cask.cdap.template.etl.api.batch.BatchSinkContext;
 import co.cask.cdap.template.etl.common.SchemaConverter;
@@ -88,7 +89,7 @@ public class TimePartitionedFileSetDatasetParquetSink extends
   }
 
   @Override
-  public void initialize(BatchSinkContext context) throws Exception {
+  public void initialize(BatchRuntimeContext context) throws Exception {
     super.initialize(context);
     recordTransformer = new StructuredToAvroTransformer(config.schema);
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/sink/TimePartitionedFileSetSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/sink/TimePartitionedFileSetSink.java
@@ -17,7 +17,6 @@
 package co.cask.cdap.template.etl.batch.sink;
 
 import co.cask.cdap.api.data.format.StructuredRecord;
-import co.cask.cdap.api.dataset.lib.TimePartitionedFileSet;
 import co.cask.cdap.api.dataset.lib.TimePartitionedFileSetArguments;
 import co.cask.cdap.template.etl.api.PipelineConfigurer;
 import co.cask.cdap.template.etl.api.batch.BatchSink;
@@ -65,12 +64,20 @@ public abstract class TimePartitionedFileSetSink<KEY_OUT, VAL_OUT>
 
   @Override
   public void prepareRun(BatchSinkContext context) {
-    Map<String, String> sinkArgs = new HashMap<>();
+    Map<String, String> sinkArgs = getAdditionalTPFSArguments();
     TimePartitionedFileSetArguments.setOutputPartitionTime(sinkArgs, context.getLogicalStartTime());
     if (!Strings.isNullOrEmpty(tpfsSinkConfig.filePathFormat)) {
       TimePartitionedFileSetArguments.setOutputPathFormat(sinkArgs, tpfsSinkConfig.filePathFormat,
                                                           tpfsSinkConfig.timeZone);
     }
     context.addOutput(tpfsSinkConfig.name, sinkArgs);
+  }
+
+  /**
+   * @return any additional properties that need to be set for the sink. For example, avro sink requires
+   *         setting some schema output key.
+   */
+  protected Map<String, String> getAdditionalTPFSArguments() {
+    return new HashMap<>();
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/source/DBSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/source/DBSource.java
@@ -25,6 +25,7 @@ import co.cask.cdap.api.templates.plugins.PluginConfig;
 import co.cask.cdap.api.templates.plugins.PluginProperties;
 import co.cask.cdap.template.etl.api.Emitter;
 import co.cask.cdap.template.etl.api.PipelineConfigurer;
+import co.cask.cdap.template.etl.api.batch.BatchRuntimeContext;
 import co.cask.cdap.template.etl.api.batch.BatchSource;
 import co.cask.cdap.template.etl.api.batch.BatchSourceContext;
 import co.cask.cdap.template.etl.common.DBConfig;
@@ -109,7 +110,7 @@ public class DBSource extends BatchSource<LongWritable, DBRecord, StructuredReco
   }
 
   @Override
-  public void initialize(BatchSourceContext context) throws Exception {
+  public void initialize(BatchRuntimeContext context) throws Exception {
     super.initialize(context);
     driverClass = context.loadPluginClass(getJDBCPluginId());
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/source/ElasticsearchSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/source/ElasticsearchSource.java
@@ -24,6 +24,7 @@ import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.dataset.lib.KeyValue;
 import co.cask.cdap.api.templates.plugins.PluginConfig;
 import co.cask.cdap.template.etl.api.Emitter;
+import co.cask.cdap.template.etl.api.batch.BatchRuntimeContext;
 import co.cask.cdap.template.etl.api.batch.BatchSource;
 import co.cask.cdap.template.etl.api.batch.BatchSourceContext;
 import co.cask.cdap.template.etl.common.Properties;
@@ -72,7 +73,7 @@ public class ElasticsearchSource extends BatchSource<Text, MapWritable, Structur
   }
 
   @Override
-  public void initialize(BatchSourceContext context) {
+  public void initialize(BatchRuntimeContext context) {
     schema = parseSchema();
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/source/TableSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/source/TableSource.java
@@ -26,6 +26,7 @@ import co.cask.cdap.api.dataset.table.Row;
 import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.template.etl.api.Emitter;
 import co.cask.cdap.template.etl.api.PipelineConfigurer;
+import co.cask.cdap.template.etl.api.batch.BatchRuntimeContext;
 import co.cask.cdap.template.etl.api.batch.BatchSourceContext;
 import co.cask.cdap.template.etl.common.Properties;
 import co.cask.cdap.template.etl.common.RowRecordTransformer;
@@ -66,7 +67,7 @@ public class TableSource extends BatchReadableSource<byte[], Row, StructuredReco
   }
 
   @Override
-  public void initialize(BatchSourceContext context) throws Exception {
+  public void initialize(BatchRuntimeContext context) throws Exception {
     super.initialize(context);
     Schema schema = Schema.parseJson(tableConfig.getSchemaStr());
     rowRecordTransformer = new RowRecordTransformer(schema, tableConfig.getRowField());

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/transform/ValidatorTransform.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/transform/ValidatorTransform.java
@@ -108,11 +108,7 @@ public class ValidatorTransform extends Transform<StructuredRecord, StructuredRe
   public void initialize(TransformContext context) throws Exception {
     List<Validator> validators = new ArrayList<>();
     for (String pluginId : config.validators.split("\\s*,\\s*")) {
-      try {
-        validators.add((Validator) context.newPluginInstance(pluginId));
-      } catch (UnsupportedOperationException e) {
-        validators.add((Validator) context.newInstance(pluginId));
-      }
+      validators.add((Validator) context.newPluginInstance(pluginId));
     }
     try {
       setUpInitialScript(context, validators);

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/template/etl/common/MockRealtimeContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/template/etl/common/MockRealtimeContext.java
@@ -79,9 +79,4 @@ public class MockRealtimeContext implements RealtimeContext {
   public <T> T newPluginInstance(String pluginId) throws InstantiationException {
     return null;
   }
-
-  @Override
-  public <T> T newInstance(String pluginId) throws InstantiationException {
-    return null;
-  }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/template/etl/transform/MockTransformContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/template/etl/transform/MockTransformContext.java
@@ -44,6 +44,11 @@ public class MockTransformContext implements TransformContext {
   }
 
   @Override
+  public PluginProperties getPluginProperties(String pluginId) {
+    return null;
+  }
+
+  @Override
   public Metrics getMetrics() {
     return NoopMetrics.INSTANCE;
   }
@@ -54,7 +59,7 @@ public class MockTransformContext implements TransformContext {
   }
 
   @Override
-  public <T> T newInstance(String pluginId) throws InstantiationException {
+  public <T> Class<T> loadPluginClass(String pluginId) {
     return null;
   }
 }


### PR DESCRIPTION
Switching ETLMapper to implement ``ProgramLifecycle<MapReduceTaskContext>
instead of ProgramLifecycle<MapReduceContext>``. This will give access
to the new context.write(name, key, value) methods that will be
required to support multiple sinks.

In order to do this, introduced a BatchRuntimeContext class that is
passed to sources, transforms, and sinks at initialize time instead of
passing BatchContext. This is because BatchContext allows you to get
the Hadoop Job, add outputs, and set input - all of which really only
makes sense in the prepareRun (beforeSubmit) method. In addition,
MapReduceTaskContext has no way to get the Hadoop Job, so the change
is required. In the process also cleaning up the context classes to
remove duplicate code and remove usage of AdapterContext.