### PR TITLE
CDAP-3189 Avoid adding cdap-default.xml multiple times to the configuration.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextConfig.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextConfig.java
@@ -265,7 +265,7 @@ public final class MapReduceContextConfig {
   }
 
   public CConfiguration getConf() {
-    CConfiguration conf = CConfiguration.create();
+    CConfiguration conf = CConfiguration.createEmpty();
     conf.addResource(new ByteArrayInputStream(hConf.get(HCONF_ATTR_CCONF).getBytes()));
     return conf;
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextConfig.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextConfig.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.internal.app.runtime.batch;
 
 import co.cask.cdap.api.artifact.Plugin;
+import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.data.batch.SimpleSplit;
 import co.cask.cdap.api.data.batch.Split;
 import co.cask.cdap.api.workflow.WorkflowToken;
@@ -265,9 +266,7 @@ public final class MapReduceContextConfig {
   }
 
   public CConfiguration getConf() {
-    CConfiguration conf = CConfiguration.createEmpty();
-    conf.addResource(new ByteArrayInputStream(hConf.get(HCONF_ATTR_CCONF).getBytes()));
-    return conf;
+    return CConfiguration.create(new ByteArrayInputStream(Bytes.toBytes(hConf.get(HCONF_ATTR_CCONF))));
   }
 
   private void setTx(Transaction tx) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractProgramTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractProgramTwillRunnable.java
@@ -193,7 +193,7 @@ public abstract class AbstractProgramTwillRunnable<T extends ProgramRunner> impl
 
       UserGroupInformation.setConfiguration(hConf);
 
-      cConf = CConfiguration.create(new File(configs.get("cConf")).toURI().toURL());
+      cConf = CConfiguration.create(new File(configs.get("cConf")));
 
       // Alter the template directory to only the name part in the container directory.
       // It works in pair with the ProgramRunner.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractProgramTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractProgramTwillRunnable.java
@@ -193,9 +193,7 @@ public abstract class AbstractProgramTwillRunnable<T extends ProgramRunner> impl
 
       UserGroupInformation.setConfiguration(hConf);
 
-      cConf = CConfiguration.create();
-      cConf.clear();
-      cConf.addResource(new File(configs.get("cConf")).toURI().toURL());
+      cConf = CConfiguration.create(new File(configs.get("cConf")).toURI().toURL());
 
       // Alter the template directory to only the name part in the container directory.
       // It works in pair with the ProgramRunner.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkContextProvider.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkContextProvider.java
@@ -164,10 +164,7 @@ public final class SparkContextProvider {
   }
 
   private static CConfiguration createCConf() throws MalformedURLException {
-    CConfiguration cConf = CConfiguration.create();
-    cConf.clear();
-    cConf.addResource(new File(CCONF_FILE_NAME).toURI().toURL());
-    return cConf;
+    return CConfiguration.create(new File(CCONF_FILE_NAME).toURI().toURL());
   }
 
   private static Configuration createHConf() throws MalformedURLException {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkContextProvider.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkContextProvider.java
@@ -164,7 +164,7 @@ public final class SparkContextProvider {
   }
 
   private static CConfiguration createCConf() throws MalformedURLException {
-    return CConfiguration.create(new File(CCONF_FILE_NAME).toURI().toURL());
+    return CConfiguration.create(new File(CCONF_FILE_NAME));
   }
 
   private static Configuration createHConf() throws MalformedURLException {

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/CConfiguration.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/CConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -18,6 +18,9 @@ package co.cask.cdap.common.conf;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.InputStream;
+import java.net.URL;
 
 /**
  * CConfiguration is an extension of the Hadoop Configuration class. By default,
@@ -57,12 +60,30 @@ public class CConfiguration extends Configuration {
   }
 
   /**
-   * Creates an instance of empty configuration.
-   *
+   * Creates an instance of configuration.
+   * @param resource the URL to be added to the configuration
+   * @param moreResources the list of URL's to be added to the configuration
+   * @return an instance of CConfiguration
+   * @throws IllegalArgumentException when the resource cannot be converted to the URL
+   */
+  public static CConfiguration create(URL resource, URL...moreResources) {
+    CConfiguration conf = new CConfiguration();
+    conf.addResource(resource);
+    for (URL resourceURL : moreResources) {
+      conf.addResource(resourceURL);
+    }
+    return conf;
+  }
+
+  /**
+   * Creates an instance of configuration.
+   * @param resource the resource to be added to the configuration
    * @return an instance of CConfiguration
    */
-  public static CConfiguration createEmpty() {
-    return new CConfiguration();
+  public static CConfiguration create(InputStream resource) {
+    CConfiguration conf = new CConfiguration();
+    conf.addResource(resource);
+    return conf;
   }
 
   /**

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/CConfiguration.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/CConfiguration.java
@@ -19,7 +19,9 @@ package co.cask.cdap.common.conf;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.io.InputStream;
+import java.net.MalformedURLException;
 import java.net.URL;
 
 /**
@@ -56,6 +58,22 @@ public class CConfiguration extends Configuration {
     CConfiguration conf = new CConfiguration();
     conf.addResource("cdap-default.xml");
     conf.addResource("cdap-site.xml");
+    return conf;
+  }
+
+  /**
+   * Creates an instance of configuration.
+   * @param file the file to be added to the configuration
+   * @param moreFiles the list of more files to be added to the configuration
+   * @return an instance of CConfiguration
+   * @throws MalformedURLException if the error occurred while constructing the URL
+   */
+  public static CConfiguration create(File file, File...moreFiles) throws MalformedURLException {
+    CConfiguration conf = new CConfiguration();
+    conf.addResource(file.toURI().toURL());
+    for (File anotherFile : moreFiles) {
+      conf.addResource(anotherFile.toURI().toURL());
+    }
     return conf;
   }
 

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/CConfiguration.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/CConfiguration.java
@@ -57,6 +57,15 @@ public class CConfiguration extends Configuration {
   }
 
   /**
+   * Creates an instance of empty configuration.
+   *
+   * @return an instance of CConfiguration
+   */
+  public static CConfiguration createEmpty() {
+    return new CConfiguration();
+  }
+
+  /**
    * Creates a new instance which clones all configurations from another {@link CConfiguration}.
    */
   public static CConfiguration copy(CConfiguration other) {

--- a/cdap-common/src/main/java/co/cask/cdap/common/twill/AbstractMasterTwillRunnable.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/twill/AbstractMasterTwillRunnable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -82,9 +82,7 @@ public abstract class AbstractMasterTwillRunnable extends AbstractTwillRunnable 
 
       UserGroupInformation.setConfiguration(hConf);
 
-      cConf = CConfiguration.create();
-      cConf.clear();
-      cConf.addResource(new File(configs.get("cConf")).toURI().toURL());
+      cConf = CConfiguration.create(new File(configs.get("cConf")).toURI().toURL());
 
       LOG.debug("{} cConf {}", name, cConf);
       LOG.debug("{} HBase conf {}", name, hConf);

--- a/cdap-common/src/main/java/co/cask/cdap/common/twill/AbstractMasterTwillRunnable.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/twill/AbstractMasterTwillRunnable.java
@@ -82,7 +82,7 @@ public abstract class AbstractMasterTwillRunnable extends AbstractTwillRunnable 
 
       UserGroupInformation.setConfiguration(hConf);
 
-      cConf = CConfiguration.create(new File(configs.get("cConf")).toURI().toURL());
+      cConf = CConfiguration.create(new File(configs.get("cConf")));
 
       LOG.debug("{} cConf {}", name, cConf);
       LOG.debug("{} HBase conf {}", name, hConf);

--- a/cdap-common/src/test/java/co/cask/cdap/gateway/handlers/ConfigServiceTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/gateway/handlers/ConfigServiceTest.java
@@ -33,11 +33,6 @@ public class ConfigServiceTest {
 
   @Test
   public void testConfig() {
-
-    // cConf
-    CConfiguration cConf = CConfiguration.create();
-    cConf.clear();
-
     String cConfResourceString =
       "<configuration>\n" +
         "\n" +
@@ -49,7 +44,7 @@ public class ConfigServiceTest {
         "\n" +
         "</configuration>";
     ReaderInputStream cConfResource = new ReaderInputStream(new StringReader(cConfResourceString));
-    cConf.addResource(cConfResource);
+    CConfiguration cConf = CConfiguration.create(cConfResource);
 
     ConfigEntry cConfEntry = new ConfigEntry(
       "stream.zz.threshold", "1", cConfResource.toString());

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/context/CConfCodec.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/context/CConfCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -48,9 +48,6 @@ public class CConfCodec implements Codec<CConfiguration> {
     }
 
     ByteArrayInputStream bin = new ByteArrayInputStream(data);
-    CConfiguration cConfiguration = CConfiguration.create();
-    cConfiguration.clear();
-    cConfiguration.addResource(bin);
-    return cConfiguration;
+    return CConfiguration.create(bin);
   }
 }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/run/LogSaverTwillRunnable.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/run/LogSaverTwillRunnable.java
@@ -107,7 +107,7 @@ public final class LogSaverTwillRunnable extends AbstractTwillRunnable {
 
       UserGroupInformation.setConfiguration(hConf);
 
-      CConfiguration cConf = CConfiguration.create(new File(configs.get("cConf")).toURI().toURL());
+      CConfiguration cConf = CConfiguration.create(new File(configs.get("cConf")));
 
       cConf.set(Constants.LogSaver.ADDRESS, context.getHost().getCanonicalHostName());
 

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/run/LogSaverTwillRunnable.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/run/LogSaverTwillRunnable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -107,9 +107,8 @@ public final class LogSaverTwillRunnable extends AbstractTwillRunnable {
 
       UserGroupInformation.setConfiguration(hConf);
 
-      CConfiguration cConf = CConfiguration.create();
-      cConf.clear();
-      cConf.addResource(new File(configs.get("cConf")).toURI().toURL());
+      CConfiguration cConf = CConfiguration.create(new File(configs.get("cConf")).toURI().toURL());
+
       cConf.set(Constants.LogSaver.ADDRESS, context.getHost().getCanonicalHostName());
 
       // Initialize ZK client


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-3189

In order to pass the cdap configurations (cdap-default.xml and cdap-site.xml) to the mapper and reducer tasks, they are serialized into the hConf under property name "hconf.cconf".

While deserializing, we first create the new `CConfiguration` object which includes the cdap-default.xml and cdap-site.xml. Then to this object we add the value of "hconf.cconf" property as a new resource. This results in the `CConfiguration` object to contain duplicate configurations. 

As a result we see lot of warning messages when the MapReduce program is run:
```java
2015-09-11 09:23:00,407 - WARN  [LocalJobRunner Map Task Executor #5:c.c.c.c.c.Configuration@1748] - java.io.ByteArrayInputStream@6158ab02:an attempt to override final parameter: app.template.plugin.dir;  Ignoring.
2015-09-11 09:23:00,407 - WARN  [LocalJobRunner Map Task Executor #4:c.c.c.c.c.Configuration@1748] - java.io.ByteArrayInputStream@11b48062:an attempt to override final parameter: app.template.plugin.dir;  Ignoring.
2015-09-11 09:23:00,409 - WARN  [LocalJobRunner Map Task Executor #2:c.c.c.c.c.Configuration@1748] - java.io.ByteArrayInputStream@5f8ce5e:an attempt to override final parameter: stream.instance.file.prefix;  Ignoring.
2015-09-11 09:23:00,409 - WARN  [LocalJobRunner Map Task Executor #5:c.c.c.c.c.Configuration@1748] - java.io.ByteArrayInputStream@6158ab02:an attempt to override final parameter: stream.instance.file.prefix;  Ignoring.
``` 

In this PR, while deserializing, we create an empty `CConfiguration` object which will have no resource added to it and then to this object we add the value of "hconf.cconf" property as a new resource.

 Tested on standalone and I no longer see those warning messages for `app.template.plugin.dir` and `stream.instance.file.prefix`

Will run the integration tests on cluster as well.