### PR TITLE
Fix Documentation Build

### DIFF
--- a/cdap-docs/_common/common-build.sh
+++ b/cdap-docs/_common/common-build.sh
@@ -378,6 +378,9 @@ function set_message() {
 }
 
 function consolidate_messages() {
+  if [[ "x${TMP_MESSAGES_FILE}" == "x" ]]; then
+    return
+  fi
   local m="Warning Messages for \"${MANUAL}\":"
   if [ "x${MESSAGES}" != "x" ]; then
     echo_red_bold "Consolidating messages" 

--- a/cdap-docs/application-templates/source/etl/templates/sinks/batch/index.rst
+++ b/cdap-docs/application-templates/source/etl/templates/sinks/batch/index.rst
@@ -12,6 +12,8 @@ Sinks: Batch
     Cube <cube>
     Database <database>
     KVTable <kvtable>
+    SnapshotAvro <snapshotavro>
+    SnapshotParquet <snapshotparquet>
     Table <table>
     TPFSAvro <tpfsavro>
     TPFSParquet <tpfsparquet>


### PR DESCRIPTION
Add missing SnapshotAvro and SnapshotParquet documents to the Sphinx index.

Adds a test to prevent confusing error messages when running the build in a manual sub-directory.