### PR TITLE
Clean up scripts, simplify coding, use more bash internals

### DIFF
--- a/cdap-common/bin/common-env.sh
+++ b/cdap-common/bin/common-env.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -17,8 +17,8 @@
 
 # Set environment variables here.
 
-# The java implementation to use.  Java 1.6 required.
-# export JAVA_HOME=/usr/java/jdk1.6.0/
+# The java implementation to use.  Java 1.7 required.
+# export JAVA_HOME=/usr/java/jdk1.7.0/
 
 # The maximum amount of heap to use, in MB. Default is 1000.
 # export HEAPSIZE=1000
@@ -38,8 +38,8 @@ export OPTS="-XX:+UseConcMarkSweepGC"
 # Where log files are stored.  $CDAP_HOME/logs by default.
 export LOG_DIR=/var/log/cdap
 
-# A string representing this instance of hbase. $USER by default.
-export IDENT_STRING=$USER
+# A string representing this instance of CDAP. $USER by default.
+export IDENT_STRING=${USER}
 
 # The scheduling priority for daemon processes.  See 'man nice'.
 # export NICENESS=10

--- a/cdap-common/bin/common.sh
+++ b/cdap-common/bin/common.sh
@@ -16,135 +16,138 @@
 # the License.
 
 # checks if there exists a PID that is already running. return 0 idempotently
-check_before_start()
-{
-  if [ ! -d "$PID_DIR" ]; then
-    mkdir -p "$PID_DIR"
-  fi
-  if [ -f $pid ]; then
-    if kill -0 `cat $pid` > /dev/null 2>&1; then
-      #echo "$APP $SERVICE running as process `cat $pid`. Stop it first."
-      echo "$APP running as process `cat $pid`. Stop it first."
-      exit 0
+check_before_start() {
+  if [ -f ${pid} ]; then
+    if kill -0 $(<${pid}) > /dev/null 2>&1; then
+      echo "${APP} running as process $(<${pid}). Stop it first."
+      return 1
     fi
   fi
+  return 0
+}
+
+create_pid_dir() {
+  mkdir -p "${PID_DIR}"
 }
 
 # Rotates the basic start/stop logs
-rotate_log ()
-{
-    log=$1;
-    num=5;
-    if [ -n "$2" ]; then
-    num=$2
-    fi
-    if [ -f "$log" ]; then # rotate logs
-    while [ $num -gt 1 ]; do
-        prev=`expr $num - 1`
-        [ -f "$log.$prev" ] && mv -f "$log.$prev" "$log.$num"
-        num=$prev
+rotate_log () {
+  local log=${1} num=5 prev=0
+  [[ -n "${2}" ]] && num=${2}
+  if [ -f "${log}" ]; then # rotate logs
+    while [ ${num} -gt 1 ]; do
+      prev=$((${num} - 1))
+      [ -f "${log}.${prev}" ] && mv -f "${log}.${prev}" "${log}.${num}"
+      num=${prev}
     done
-    mv -f "$log" "$log.$num";
-    fi
+    mv -f "${log}" "${log}.${num}"
+  fi
 }
 
 # Attempts to find JAVA in few ways.
-set_java ()
-{
+set_java () {
   # Determine the Java command to use to start the JVM.
-  if [ -n "$JAVA_HOME" ] ; then
-    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
-        # IBM's JDK on AIX uses strange locations for the executables
-        export JAVA="$JAVA_HOME/jre/sh/java"
+  if [ -n "${JAVA_HOME}" ] ; then
+    if [ -x "${JAVA_HOME}/jre/sh/java" ] ; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      export JAVA="${JAVA_HOME}/jre/sh/java"
     else
-        export JAVA="$JAVA_HOME/bin/java"
+      export JAVA="${JAVA_HOME}/bin/java"
     fi
-    if [ ! -x "$JAVA" ] ; then
-        echo "ERROR: JAVA_HOME is set to an invalid directory: $JAVA_HOME
+    if [ ! -x "${JAVA}" ] ; then
+      echo "ERROR: JAVA_HOME is set to an invalid directory: ${JAVA_HOME}
 
 Please set the JAVA_HOME variable in your environment to match the
 location of your Java installation." >&2
-        exit 1
+      return 1
     fi
-else
+  else
     export JAVA="java"
-    which java >/dev/null 2>&1 || { echo "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+    which java >/dev/null 2>&1 && return 0
+    # If we get here, we've failed this city
+    echo "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
 Please set the JAVA_HOME variable in your environment to match the
-location of your Java installation." >&2 ; exit 1; }
-fi
+location of your Java installation." >&2
+    return 1
+  fi
+  return 0
 }
 
 # Sets the correct HBase support library to use, based on what version exists in the classpath
-set_hbase()
-{
-  if [ -z "$JAVA" ]; then
+set_hbase() {
+  # Why is this here? Is this not redundant?
+  if [ -z "${JAVA}" ]; then
     echo "ERROR: JAVA is not yet set, cannot determine HBase version"
-    exit 1
+    return 1
   fi
 
-  if [ -z "$HBASE_VERSION" ]; then
-    HBASE_VERSION=`$JAVA -cp $CLASSPATH co.cask.tephra.util.HBaseVersion 2> /dev/null`
+  retvalue=1
+  if [ -z "${HBASE_VERSION}" ]; then
+    HBASE_VERSION=$(${JAVA} -cp ${CLASSPATH} co.cask.tephra.util.HBaseVersion 2> /dev/null)
     retvalue=$?
   else
     retvalue=0
   fi
 
   # only set HBase version if previous call succeeded (may fail for components that don't use HBase)
-  if [ $retvalue == 0 ]; then
-    case "$HBASE_VERSION" in
+  if [ ${retvalue} == 0 ]; then
+    case ${HBASE_VERSION} in
       0.96*)
-        hbasecompat="$CDAP_HOME/hbase-compat-0.96/lib/*"
+        hbasecompat="${CDAP_HOME}/hbase-compat-0.96/lib/*"
         ;;
       0.98*)
-        hbasecompat="$CDAP_HOME/hbase-compat-0.98/lib/*"
+        hbasecompat="${CDAP_HOME}/hbase-compat-0.98/lib/*"
         ;;
       1.0-cdh*)
-        hbasecompat="$CDAP_HOME/hbase-compat-1.0-cdh/lib/*"
+        hbasecompat="${CDAP_HOME}/hbase-compat-1.0-cdh/lib/*"
         ;;
       1.0*)
-        hbasecompat="$CDAP_HOME/hbase-compat-1.0/lib/*"
+        hbasecompat="${CDAP_HOME}/hbase-compat-1.0/lib/*"
         ;;
       *)
-        echo "ERROR: Unknown/unsupported version of HBase found: $HBASE_VERSION"
-        exit 1
+        echo "ERROR: Unknown/unsupported version of HBase found: ${HBASE_VERSION}"
+        return 1
         ;;
     esac
-    if [ -n "$hbasecompat" ]; then
-      CLASSPATH=$hbasecompat:$CLASSPATH
+    if [ -n "${hbasecompat}" ]; then
+      CLASSPATH="${hbasecompat}:${CLASSPATH}"
     else
-      echo "ERROR: Failed to find installed hbase-compat jar for version $HBASE_VERSION."
+      # When will we ever hit this case?
+      echo "ERROR: Failed to find installed hbase-compat jar for version ${HBASE_VERSION}."
       echo "       Is the hbase-compat-* package installed?"
+      return 1
     fi
   fi
   export CLASSPATH
+  return 0
 }
 
 # set the classpath to include hadoop and hbase dependencies
-set_classpath()
-{
-  COMP_HOME=$1
-  CCONF=$2
-  if [ -n "$HBASE_HOME" ]; then
-    HBASE_CP=`$HBASE_HOME/bin/hbase classpath`
-  elif [ `which hbase` ]; then
-    HBASE_CP=`hbase classpath`
+set_classpath() {
+  COMP_HOME=${1}
+  CCONF=${2}
+  if [ -n "${HBASE_HOME}" ]; then
+    HBASE_CP=$(${HBASE_HOME}/bin/hbase classpath)
+  elif [[ $(which hbase 2>/dev/null) ]]; then
+    HBASE_CP=$(hbase classpath)
   fi
 
+  # Where is this used outside this function?
   export HBASE_CP
 
-  if [ -n "$HBASE_CP" ]; then
-    CP=$COMP_HOME/lib/*:$HBASE_CP:$CCONF/:$COMP_HOME/conf/:$EXTRA_CLASSPATH
+  if [ -n "${HBASE_CP}" ]; then
+    CP="${COMP_HOME}/lib/*:${HBASE_CP}:${CCONF}/:${COMP_HOME}/conf/:${EXTRA_CLASSPATH}"
   else
     # assume Hadoop/HBase libs are included via EXTRA_CLASSPATH
     echo "WARN: could not find Hadoop and HBase libraries"
-    CP=$COMP_HOME/lib/*:$CCONF/:$COMP_HOME/conf/:$EXTRA_CLASSPATH
+    CP="${COMP_HOME}/lib/*:${CCONF}/:${COMP_HOME}/conf/:${EXTRA_CLASSPATH}"
   fi
 
   # Setup classpaths.
-  if [ -n "$CLASSPATH" ]; then
-    CLASSPATH=$CLASSPATH:$CP
+  if [ -n "${CLASSPATH}" ]; then
+    CLASSPATH="${CLASSPATH}:${CP}"
   else
-    CLASSPATH=$CP
+    CLASSPATH="${CP}"
   fi
 
   export CLASSPATH
@@ -154,100 +157,56 @@ set_classpath()
 # Hive classpath is not added as part of system classpath as hive jars bundle unrelated jars like guava,
 # and hence need to be isolated.
 set_hive_classpath() {
-  if [ "x$HIVE_HOME" = "x" ] || [ "x$HIVE_CONF_DIR" = "x" ]; then
-    if [ `which hive 2>/dev/null` ]; then
-      HIVE_VAR_OUT=`hive -e 'set -v' 2>/dev/null`
-
-      if [ "x$HIVE_HOME" = "x" ]; then
-        HIVE_HOME=`echo $HIVE_VAR_OUT | tr ' ' '\n' | grep '^env:HIVE_HOME=' | cut -f 2 -d '='`
-      fi
-
-      if [ "x$HIVE_CONF_DIR" = "x" ]; then
-        HIVE_CONF_DIR=`echo $HIVE_VAR_OUT | tr ' ' '\n' | grep '^env:HIVE_CONF_DIR=' | cut -f 2 -d '='`
-      fi
-
-      if [ "x$HADOOP_CONF_DIR" = "x" ]; then
-        HADOOP_CONF_DIR=`echo $HIVE_VAR_OUT | tr ' ' '\n' | grep '^env:HADOOP_CONF_DIR=' | cut -f 2 -d '='`
-      fi
+  if [ -z "${HIVE_HOME}" -o -z "${HIVE_CONF_DIR}" -o -z "${HADOOP_CONF_DIR}" ]; then
+    if [[ $(which hive 2>/dev/null) ]]; then
+      HIVE_VAR_OUT=$(hive -e 'set -v' 2>/dev/null)
+      HIVE_VARS=$(echo ${HIVE_VAR_OUT} | tr ' ' '\n')
+      # Quotes preserve whitespace
+      HIVE_HOME=${HIVE_HOME:-$(echo -e "${HIVE_VARS}" | grep '^env:HIVE_HOME=' | cut -d= -f2)}
+      HIVE_CONF_DIR=${HIVE_CONF_DIR:-$(echo -e "${HIVE_VARS}" | grep '^env:HIVE_CONF_DIR=' | cut -d= -f2)}
+      HADOOP_CONF_DIR=${HADOOP_CONF_DIR:-$(echo -e "${HIVE_VARS}" | grep '^env:HADOOP_CONF_DIR=' | cut -d= -f2)}
     fi
   fi
 
   # If Hive classpath is successfully determined, derive explore
   # classpath from it and export it to use it in the launch command
-  if [ "x$HIVE_HOME" != "x" -a "x$HIVE_CONF_DIR" != "x" -a "x$HADOOP_CONF_DIR" != "x" ]; then
-    # Reference the conf files needed by Explore
-    EXPLORE_CONF_FILES=''
-    for a in `ls $HIVE_CONF_DIR`; do
-      EXPLORE_CONF_FILES=$EXPLORE_CONF_FILES:$HIVE_CONF_DIR/$a;
-    done
-    for a in `ls $HADOOP_CONF_DIR`; do
-      EXPLORE_CONF_FILES=$EXPLORE_CONF_FILES:$HADOOP_CONF_DIR/$a;
-    done
-    # Remove leading ':'
-    EXPLORE_CONF_FILES=${EXPLORE_CONF_FILES:1:${#EXPLORE_CONF_FILES}-1}
-    export EXPLORE_CONF_FILES
-
-    # Hive exec has a HiveConf class that needs to be loaded before the HiveConf class from
-    # hive-common for joins operations to work
-    HIVE_EXEC=`ls $HIVE_HOME/lib/hive-exec-*`
-    OTHER_HIVE_JARS=`ls $HIVE_HOME/lib/*.jar | tr '\n' ':'`
-
-    # We put in the explore classpath all the jars that are not in the regular classpath.
-    EXPLORE_CLASSPATH=$HIVE_EXEC:$OTHER_HIVE_JARS
-
-    export EXPLORE_CLASSPATH
+  if [ -n "${HIVE_HOME}" -a -n "${HIVE_CONF_DIR}" -a -n "${HADOOP_CONF_DIR}" ]; then
+    EXPLORE_CONF_FILES=$(ls -1 ${HIVE_CONF_DIR}/* ${HADOOP_CONF_DIR}/* | tr '\n' ':')
+    EXPLORE_CLASSPATH=$(ls -1 ${HIVE_HOME}/lib/hive-exec-* ${HIVE_HOME}/lib/*.jar | tr '\n' ':')
+    export EXPLORE_CONF_FILES EXPLORE_CLASSPATH
   fi
 }
 
 # Check that directory /var/tmp/cdap exists in the master node, or create it
 check_or_create_master_local_dir() {
-  if [ ! -d "$LOCAL_DIR" ]; then
-    mkdir -p "$LOCAL_DIR"
-  fi
+  mkdir -p "${LOCAL_DIR}"
 }
 
 # check and set classpath if in development enviroment
-check_and_set_classpath_for_dev_environment ()
-{
-  APP_HOME=$1
+check_and_set_classpath_for_dev_environment () {
+  APP_HOME=${1}
 
   # Detect if we are in development.
-  in_dev_env=false
-  if [ -n "$IN_DEV_ENVIRONMENT" ]; then
-    in_dev_env=true
-  fi
+  IN_DEV_ENVIRONMENT=${IN_DEV_ENVIRONMENT:-false}
 
   # for developers only, add flow and flow related stuff to class path.
-  if $in_dev_env; then
+  if [[ ${IN_DEV_ENVIRONMENT} ]]; then
     echo "Constructing classpath for development environment ..."
-    if [ -f "$APP_HOME/build/generated-classpath" ]; then
-      CLASSPATH=${CLASSPATH}:`cat $APP_HOME/build/generated-classpath`
-    fi
-    if [ -d "$APP_HOME/build/classes" ]; then
-      CLASSPATH=${CLASSPATH}:$APP_HOME/build/classes/main
-      CLASSPATH=${CLASSPATH}:$APP_HOME/conf/*
-    fi
-    if [ -d "$APP_HOME/../data-fabric/build/classes" ]; then
-      CLASSPATH=${CLASSPATH}:$APP_HOME/../data-fabric/build/classes/main
-    fi
-    if [ -d "$APP_HOME/../common/build/classes" ]; then
-      CLASSPATH=${CLASSPATH}:$APP_HOME/../common/build/classes/main
-    fi
-    if [ -d "$APP_HOME/../gateway/build/classes" ]; then
-      CLASSPATH=${CLASSPATH}:$APP_HOME/../common/build/classes/main
-    fi
+    [[ -f "${APP_HOME}"/build/generated-classpath ]] && CLASSPATH+=":$(<${APP_HOME}/build/generated-classpath)"
+    [[ -d "${APP_HOME}"/build/classes ]] && CLASSPATH+=":${APP_HOME}/build/classes/main:${APP_HOME}/conf/*"
+    [[ -d "${APP_HOME}"/../data-fabric/build/classes ]] && CLASSPATH+=":${APP_HOME}/../data-fabric/build/classes/main"
+    [[ -d "${APP_HOME}"/../common/build/classes ]] && CLASSPATH+=":${APP_HOME}/../common/build/classes/main"
+    [[ -d "${APP_HOME}"/../gateway/build/classes ]] && CLASSPATH+=":${APP_HOME}/../gateway/build/classes/main"
     export CLASSPATH
   fi
 }
 
-#export LOG_PREFIX=$SERVICE-$IDENT_STRING-$HOSTNAME
-export LOG_PREFIX=$APP-$IDENT_STRING-$HOSTNAME
-export LOGFILE=$LOG_PREFIX.log
+HOSTNAME=$(hostname -f)
+export LOG_PREFIX=${APP}-${IDENT_STRING}-${HOSTNAME}
+export LOGFILE=${LOG_PREFIX}.log
 loglog="${LOG_DIR}/${LOGFILE}"
 
-pid=$PID_DIR/$APP-${IDENT_STRING}.pid
-loggc=$LOG_DIR/$LOG_PREFIX.gc
+pid=${PID_DIR}/${APP}-${IDENT_STRING}.pid
+loggc="${LOG_DIR}/${LOG_PREFIX}.gc"
 
-if [ "$NICENESS" = "" ]; then
- export NICENESS=0
-fi
+export NICENESS=${NICENESS:-0}

--- a/cdap-common/bin/service
+++ b/cdap-common/bin/service
@@ -30,7 +30,7 @@ SVCNAME=${0##*/}
 
 if [[ "${SVCNAME}" == "service" ]]; then
   echo "Create a soft link to this script as svc-<component>"
-  echo "E.g. ln -s service svc-<component>"
+  echo "Example: ln -s service svc-<component>"
   exit 1
 fi
 
@@ -42,7 +42,7 @@ export APP
 TARGET=$(readlink ${0}) # TODO: readlink isn't always available
 if [[ $? -ne 0 ]]; then
   echo "Create a soft link to this script as svc-<component>"
-  echo "E.g. ln -s service svc-<component>"
+  echo "Example: ln -s service svc-<component>"
   exit 1
 fi
 
@@ -52,7 +52,7 @@ COMPONENT_BIN="${COMPONENT_HOME}"/bin
 PKGNAME=${COMPONENT_HOME##*/}
 if [[ -z "${PKGNAME}" ]]; then
   echo "Create a soft link to this script as svc-<component>"
-  echo "E.g. ln -s service svc-<component>"
+  echo "Example: ln -s service svc-<component>"
   exit 1
 fi
 

--- a/cdap-common/bin/service
+++ b/cdap-common/bin/service
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -15,30 +15,31 @@
 # the License.
 
 # Source function library. used for "status" use case
-if [ -f "/etc/rc.d/init.d/functions" ]; then
+if [ -f /etc/rc.d/init.d/functions ]; then
   PLATFORM="RHEL"
-  . /etc/rc.d/init.d/functions
+  source /etc/rc.d/init.d/functions
 elif [ -f /lib/lsb/init-functions ] ; then
   PLATFORM="UBUNTU"
-  . /lib/lsb/init-functions
+  source /lib/lsb/init-functions
 else
   echo "Platform is unsupported."
-  exit 0
+  exit 1
 fi
 
-SVCNAME=`basename $0`
+SVCNAME=${0##*/}
 
-if [[ "X$SVCNAME" == "Xsvc" ]]; then
+if [[ "${SVCNAME}" == "service" ]]; then
   echo "Create a soft link to this script as svc-<component>"
   echo "E.g. ln -s service svc-<component>"
   exit 1
 fi
 
 # APP is shortened SVCNAME
-APP=`echo $SVCNAME | cut -d'-' -f2-`; export APP
+APP=${SVCNAME##svc-}
+export APP
 
 # Determine symlink target (full path)
-TARGET=`readlink $0`
+TARGET=$(readlink ${0}) # TODO: readlink isn't always available
 if [[ $? -ne 0 ]]; then
   echo "Create a soft link to this script as svc-<component>"
   echo "E.g. ln -s service svc-<component>"
@@ -46,243 +47,194 @@ if [[ $? -ne 0 ]]; then
 fi
 
 # Determine package name by applying regex to the target of the symlink being run
-D1=`dirname $TARGET`; D2=`dirname $D1`
-PKGNAME=`basename $D2`
-if [[ "X$PKGNAME" == "X" ]]; then
+COMPONENT_HOME=${TARGET%/*/*}
+COMPONENT_BIN="${COMPONENT_HOME}"/bin
+PKGNAME=${COMPONENT_HOME##*/}
+if [[ -z "${PKGNAME}" ]]; then
   echo "Create a soft link to this script as svc-<component>"
   echo "E.g. ln -s service svc-<component>"
   exit 1
 fi
 
-# Default CDAP_HOME to /opt/cdap (package default)
-CDAP_HOME=${CDAP_HOME:-/opt/cdap}
+# Set CDAP_HOME from COMPONENT_HOME if not set
+CDAP_HOME="${CDAP_HOME:-${COMPONENT_HOME%/*}}"
 
-# Default CDAP_CONF to /etc/cdap (package default)
+# Default CDAP_CONF to /etc/cdap/conf (package default)
 CDAP_CONF=${CDAP_CONF:-/etc/cdap/conf}
 
-# construct COMPONENT_HOME and COMPONENT_BIN
-COMPONENT_HOME="$CDAP_HOME"/"$PKGNAME"; export COMPONENT_HOME
-COMPONENT_BIN="$COMPONENT_HOME"/bin
+export CDAP_HOME CDAP_CONF COMPONENT_HOME
 
-# Load component common.sh
-source $COMPONENT_BIN/common.sh
-
-# Load component common environment file too
-source $COMPONENT_BIN/common-env.sh
-
-# Load app specific configuration.
-SERVICE_ENVIRONMENT_FILE="$COMPONENT_HOME"/conf/"$APP"-env.sh
-if [ -f "$SERVICE_ENVIRONMENT_FILE" ]; then 
- . "$SERVICE_ENVIRONMENT_FILE"
-fi
+# Load variables/functions from COMPONENT_HOME
+for i in bin/common-env.sh bin/common.sh conf/${APP}-env.sh; do
+  test -f "${COMPONENT_HOME}"/${i} && source ${COMPONENT_HOME}/${i}
+done
 
 # Load user-modifiable configuration
-if [ -f "${CDAP_CONF}/cdap-env.sh" ]; then
- . "${CDAP_CONF}/cdap-env.sh"
-fi
+test -f "${CDAP_CONF}"/cdap-env.sh && source "${CDAP_CONF}"/cdap-env.sh
 
-# Set Log location
-export LOG_PREFIX=$APP-$IDENT_STRING-$HOSTNAME
-export LOGFILE=$LOG_PREFIX.log
-loglog="${LOG_DIR}/${LOGFILE}"
+die() {
+  echo "ERROR: ${*}"
+  exit 1
+}
 
-# Set PID location
-pid=$PID_DIR/$APP-${IDENT_STRING}.pid
-loggc=$LOG_DIR/$LOG_PREFIX.gc
+logecho() {
+  echo ${*} | tee -a ${loglog}
+}
 
-# Set Niceness
-if [ "$NICENESS" = "" ]; then
- export NICENESS=0
-fi
+# Start a non-Java application with arguments in the background
+_start_bin() {
+  check_before_start || exit 1 # Error output is done in function
+  create_pid_dir || die "Could not create PID dir: ${PID_DIR}"
+  logecho "$(date) Starting ${APP} service on ${HOSTNAME}"
+  ulimit -a >>${loglog} 2>&1
+  nohup nice -n ${NICENESS} ${MAIN_CMD} ${MAIN_CMD_ARGS} </dev/null >>${loglog} 2>&1 &
+  echo $! >${pid}
+  kill -0 $(<${pid}) 2>/dev/null
+  return $?
+}
+
+# Start a Java application from class name with arguments in the background
+_start_java() {
+  # Check and set classpath if in development environment. 
+  check_and_set_classpath_for_dev_environment "${CDAP_HOME}"
+  # Setup classpaths.
+  set_classpath "${COMPONENT_HOME}" "${CDAP_CONF}"
+  set_hive_classpath
+  # Setup Java
+  set_java || exit 1
+  # Add proper HBase compatibility to CLASSPATH
+  set_hbase || exit 1
+  # Master requires this local directory
+  if [ "${PKGNAME}" == "master" ]; then
+    check_or_create_master_local_dir || die "Could not create Master local directory"
+  fi
+  check_before_start || exit 1
+  create_pid_dir || die "Could not create PID dir: ${PID_DIR}"
+  logecho "$(date) Starting Java ${APP} service on ${HOSTNAME}"
+  "${JAVA}" -version 2>>${loglog}
+  ulimit -a >>${loglog}
+  echo "CLASSPATH=${CLASSPATH}" >>${loglog}
+  # Start our JVM
+  local __defines="-Dcdap.service=${APP} ${JAVA_HEAPMAX} -Duser.dir=${LOCAL_DIR}"
+  __defines+=" -Dexplore.conf.files=${EXPLORE_CONF_FILES} -Dexplore.classpath=${EXPLORE_CLASSPATH}"
+  __defines+=" ${OPTS}"
+  nohup nice -n ${NICENESS} "${JAVA}" ${__defines} -cp ${CLASSPATH} ${MAIN_CLASS} ${MAIN_CLASS_ARGS} ${@} </dev/null >>${loglog} 2>&1 &
+  echo $! >${pid}
+  # Now, wait for JVM spinup
+  sleep 2
+  kill -0 $(<${pid}) >/dev/null 2>&1
+  return $?
+}
 
 start() {
-    if [ $MAIN_CMD ]; then
-      # This app is configured as a NON-JAVA app
-
-      check_before_start
-
-      echo "`date` Starting $APP service on `hostname`"
-      echo "`date` Starting $APP service on `hostname`" >> $loglog
-      echo "`ulimit -a`" >> $loglog 2>&1
-
-      nohup nice -n $NICENESS $MAIN_CMD $MAIN_CMD_ARGS </dev/null >>$loglog 2>&1 &
-
-      echo $! >$pid
-    elif [ $MAIN_CLASS ]; then
-      # This app is configured as a JAVA app (default)
-
-      # Check and set classpath if in development environment. 
-      check_and_set_classpath_for_dev_environment $CDAP_HOME
-
-      # Setup classpaths.
-      set_classpath $COMPONENT_HOME $CDAP_CONF
-
-      # Setup hive classpath if hive is installed, this has to be run after HBASE_CP is setup by set_classpath.
-      set_hive_classpath
-
-      # sets the JAVA variable.
-      set_java
-
-      # Adds the correct HBase support lib to the classpath
-      set_hbase
-
-      check_or_create_master_local_dir
-
-      check_before_start
-
-      echo "`date` Starting Java $APP service on `hostname`"
-      echo "`date` Starting Java $APP service on `hostname`" >> $loglog
-      "$JAVA" -version 2>> $loglog
-      echo "`ulimit -a`" >> $loglog 2>&1
-
-      nohup nice -n $NICENESS "$JAVA" -Dcdap.service=$APP "$JAVA_HEAPMAX" \
-        -Dexplore.conf.files=$EXPLORE_CONF_FILES \
-        -Dexplore.classpath=$EXPLORE_CLASSPATH $OPTS \
-        -Duser.dir=$LOCAL_DIR \
-        -cp $CLASSPATH $MAIN_CLASS $MAIN_CLASS_ARGS </dev/null >>$loglog 2>&1 &
-      echo $! >$pid
-
-    else
-      echo "Error: Neither MAIN_CLASS or MAIN_CMD are set.  Please set one in $SERVICE_ENVIRONMENT_FILE"
-      exit -1
-    fi
-}
-
-stop() {
-    if [ -f $pid ]; then
-      pidToKill=`cat $pid`
-      # kill -0 == see if the PID exists
-      if kill -0 $pidToKill > /dev/null 2>&1; then
-        echo -n stopping $command
-        echo "`date` Terminating $command" >> $loglog
-        kill $pidToKill > /dev/null 2>&1
-        while kill -0 $pidToKill > /dev/null 2>&1;
-        do
-          echo -n "."
-          sleep 1;
-        done
-        rm $pid
-        echo
-      else
-        retval=$?
-        echo nothing to stop because kill -0 of pid $pidToKill failed with status $retval
-      fi
-      rm -f $pid
-    else
-      echo nothing to stop because no pid file $pid
-    fi
-}
-
-restart() {
-    stop
-    start
-}
-
-condrestart(){
-    case "$PLATFORM" in
-      "RHEL")
-        rh_status > /dev/null 2>&1
-        retval=$?
-      ;;
-      "UBUNTU")
-        ub_status > /dev/null 2>&1
-        retval=$?
-      ;;
-    esac
-
-  if [[ $retval -eq 0 ]]; then
-    restart
+  if [ ${MAIN_CMD} ]; then
+    _start_bin || die "Failed to start ${APP} service"
+  elif [ ${MAIN_CLASS} ]; then
+    _start_java || die "Failed to start Java ${APP} service"
+  else
+    die "Neither MAIN_CLASS or MAIN_CMD are set.  Please set one in ${CDAP_CONF}/cdap-env.sh"
   fi
 }
 
+stop() {
+  if [ -f ${pid} ]; then
+    pidToKill=$(<${pid})
+    # kill -0 == see if the PID exists
+    if kill -0 ${pidToKill} > /dev/null 2>&1; then
+      echo -n "Stopping ${APP}"
+      echo "$(date) Stopping ${APP}" >>${loglog}
+      kill ${pidToKill} > /dev/null 2>&1
+      # TODO: infinite loops are bad, mm'kay?
+      while kill -0 ${pidToKill} > /dev/null 2>&1; do
+        echo -n "."
+        sleep 1
+      done
+    else
+      retval=$?
+      echo "Nothing to stop because kill -0 of pid ${pidToKill} failed with status ${retval}"
+    fi
+    rm -f $pid
+  else
+    echo "Nothing to stop because no pid file ${pid}"
+  fi
+}
+
+restart() {
+  stop
+  start
+}
+
+_status() {
+  case ${PLATFORM} in
+    RHEL)
+      rh_status > /dev/null 2>&1
+      retval=$?
+    ;;
+    UBUNTU)
+      ub_status > /dev/null 2>&1
+      retval=$?
+    ;;
+  esac
+  return ${retval}
+}
+
 rh_status() {
-    echo "checking status"
-    # call sourced status function
-    status -p $pid 
+  echo "Checking status"
+  # call sourced status function
+  status -p ${pid}
 }
 
 ub_status() {
-    echo "checking status"
-    # call sourced status function
-    status_of_proc -p $pid "$0" "$APP"
+  echo "Checking status"
+  # call sourced status function
+  status_of_proc -p ${pid} ${0} ${APP}
 }
 
 # Executes a specific class' main method with the classpath and environment setup
 run() {
-    classname=$1
-    shift
-    if [ -z "$classname" ]; then
-        echo "ERROR: No classname was given!"
-        echo "Usage: $0 run <fully qualified classname> [arguments]"
-        exit 1
-    fi
-    # Check and set classpath if in development environment. 
-    check_and_set_classpath_for_dev_environment $CDAP_HOME
+  MAIN_CLASS=${1}
+  shift
+  if [ -z "${MAIN_CLASS}" ]; then
+    echo "Error: No classname given!"
+    die "Usage: ${0} run <fully qualified classname> [arguments]"
+  fi
 
-    # Setup classpaths.
-    set_classpath $COMPONENT_HOME $CDAP_CONF
+  # TODO: why can't we use _start_java and pass arguments?
 
-    # Setup hive classpath if hive is installed.
-    set_hive_classpath
+  # Check and set classpath if in development environment. 
+  check_and_set_classpath_for_dev_environment "${CDAP_HOME}"
+  # Setup classpaths.
+  set_classpath "${COMPONENT_HOME}" "${CDAP_CONF}"
+  set_hive_classpath
+  # Setup Java
+  set_java || exit 1
+  # Add proper HBase compatibility to CLASSPATH
+  set_hbase || exit 1
+  # Master requires this local directory
+  if [ "${PKGNAME}" == "master" ]; then
+    check_or_create_master_local_dir || die "Could not create Master local directory"
+  fi
 
-    # sets the JAVA variable.
-    set_java
-
-    # Adds the correct HBase support lib to the classpath
-    set_hbase
-
-    check_or_create_master_local_dir
-
-    echo "Running class $classname"
-    "$JAVA" "$JAVA_HEAPMAX" -Dhive.classpath=$HIVE_CLASSPATH -Duser.dir=$LOCAL_DIR $OPTS -cp $CLASSPATH $classname $@
+  if [ ${#@} -ne 0 ]; then
+    echo "Running class ${MAIN_CLASS} with arguments: ${@}"
+  else
+    echo "Running class ${MAIN_CLASS}"
+  fi
+  "${JAVA}" "${JAVA_HEAPMAX}" -Dhive.classpath=${HIVE_CLASSPATH} -Duser.dir=${LOCAL_DIR} ${OPTS} -cp ${CLASSPATH} ${MAIN_CLASS} ${@}
 }
 
-case "$1" in
-  start)
-    $1  
-  ;;
-  
-  stop)
-    $1
-  ;;
-
-  restart)
-    $1
-  ;;
-
-  condrestart)
-    $1
-  ;;
-
-  status)
-    case "$PLATFORM" in
-      "RHEL")
-        rh_status
-      ;;
-      "UBUNTU")
-        ub_status
-      ;;
-    esac 
-  ;;
-
+case ${1} in
+  start|stop|restart) ${1} ;;
+  status) _status && echo "CDAP ${APP} ($(<${pid})) is running" ;;
+  condrestart) _status && restart ;;  
+  run) shift; run ${@} ;;
   classpath)
-    set_classpath $COMPONENT_HOME $CDAP_CONF
-    set_java
-    set_hbase
-    echo $CLASSPATH
+    set_classpath "${COMPONENT_HOME}" "${CDAP_CONF}"
+    set_java || exit 1
+    set_hbase || exit 1
+    echo "${CLASSPATH}"
   ;;
 
-  run)
-    shift
-    run $@
-  ;;
-
-  *)
-    echo "Usage: $0 {start|stop|restart|status|run}"
-    exit 1
-  ;;
-
-
+  *) die "Usage: $0 {start|stop|restart|status|condrestart|run}" ;;
 esac
 exit $? 
-


### PR DESCRIPTION
This is mostly a style/syntax update. There's not much refactoring done and little functionality change. It's mostly the following:

- Adding braces to variables
- Simplify setting variables
- Use Bash variable expansion capabilities
- Reduce shell-outs (cat/grep)
- Functions `return` instead of `exit`
- Use `$( )` rather than backticks