### PR TITLE
CDAP-3521 Recording lineage information for a dataset accessed by a flowlet

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowletProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowletProgramRunner.java
@@ -55,6 +55,7 @@ import co.cask.cdap.common.utils.ImmutablePair;
 import co.cask.cdap.data.stream.StreamCoordinatorClient;
 import co.cask.cdap.data.stream.StreamPropertyListener;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.metadata.writer.ProgramContextAware;
 import co.cask.cdap.data2.queue.ConsumerConfig;
 import co.cask.cdap.data2.queue.ConsumerGroupConfig;
 import co.cask.cdap.data2.queue.DequeueStrategy;
@@ -199,6 +200,13 @@ public final class FlowletProgramRunner implements ProgramRunner {
       Class<?> clz = Class.forName(flowletDef.getFlowletSpec().getClassName(), true,
                                    program.getClassLoader());
       Preconditions.checkArgument(Flowlet.class.isAssignableFrom(clz), "%s is not a Flowlet.", clz);
+
+      // Setup dataset framework context, if required
+      if (dsFramework instanceof ProgramContextAware) {
+        Id.Program programId = program.getId();
+        Id.Flow.Flowlet flowletId = Id.Flow.Flowlet.from(programId.getApplication(), programId.getId(), flowletName);
+        ((ProgramContextAware) dsFramework).initContext(new Id.Run(programId, runId.getId()), flowletId);
+      }
 
       Class<? extends Flowlet> flowletClass = (Class<? extends Flowlet>) clz;
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/LineageHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/LineageHandler.java
@@ -20,6 +20,7 @@ import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.metadata.lineage.Lineage;
 import co.cask.cdap.data2.metadata.lineage.LineageService;
+import co.cask.cdap.metadata.serialize.LineageProto;
 import co.cask.cdap.proto.Id;
 import co.cask.http.AbstractHttpHandler;
 import co.cask.http.HttpResponder;
@@ -58,7 +59,7 @@ public class LineageHandler extends AbstractHttpHandler {
 
     Id.DatasetInstance datasetInstance = Id.DatasetInstance.from(namespaceId, datasetId);
     Lineage lineage = lineageService.computeLineage(datasetInstance, start, end, levels);
-    responder.sendJson(HttpResponseStatus.OK, lineage);
+    responder.sendJson(HttpResponseStatus.OK, new LineageProto(start, end, lineage.getRelations()));
   }
 
   private void checkArguments(long start, long end, int levels) throws BadRequestException {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/serialize/DataProto.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/serialize/DataProto.java
@@ -14,25 +14,22 @@
  * the License.
  */
 
-package co.cask.cdap.data2.metadata.lineage;
-
-import com.google.common.collect.ImmutableSet;
+package co.cask.cdap.metadata.serialize;
 
 import java.util.Objects;
-import java.util.Set;
 
 /**
- * Represents the data access relations between Programs and Datasets.
+ * Class to serialize {@link co.cask.cdap.proto.Id.DatasetInstance} and {@link co.cask.cdap.proto.Id.Stream}.
  */
-public class Lineage {
-  private final Set<Relation> relations;
+public class DataProto {
+  private final String namespace;
+  private final String type;
+  private final String id;
 
-  public Lineage(Set<Relation> relations) {
-    this.relations = ImmutableSet.copyOf(relations);
-  }
-
-  public Set<Relation> getRelations() {
-    return relations;
+  public DataProto(String namespace, String type, String id) {
+    this.namespace = namespace;
+    this.type = type;
+    this.id = id;
   }
 
   @Override
@@ -43,19 +40,23 @@ public class Lineage {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    Lineage lineage = (Lineage) o;
-    return Objects.equals(relations, lineage.relations);
+    DataProto data = (DataProto) o;
+    return Objects.equals(namespace, data.namespace) &&
+      Objects.equals(type, data.type) &&
+      Objects.equals(id, data.id);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(relations);
+    return Objects.hash(namespace, type, id);
   }
 
   @Override
   public String toString() {
-    return "Lineage{" +
-      "relations=" + relations +
+    return "DataProto{" +
+      "namespace='" + namespace + '\'' +
+      ", type='" + type + '\'' +
+      ", id='" + id + '\'' +
       '}';
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/serialize/LineageProto.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/serialize/LineageProto.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.metadata.serialize;
+
+import co.cask.cdap.data2.metadata.lineage.Relation;
+import co.cask.cdap.proto.Id;
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
+import org.apache.twill.api.RunId;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+/**
+ * Class to serialize {@link co.cask.cdap.data2.metadata.lineage.Lineage}.
+ */
+public class LineageProto {
+  private static final Function<RunId, String> RUN_ID_STRING_FUNCTION =
+    new Function<RunId, String>() {
+      @Override
+      public String apply(RunId input) {
+        return input.getId();
+      }
+    };
+  private static final Function<Id.NamespacedId, String> ID_STRING_FUNCTION =
+    new Function<Id.NamespacedId, String>() {
+      @Nullable
+      @Override
+      public String apply(Id.NamespacedId input) {
+        return input.getId();
+      }
+    };
+
+  private final long start;
+  private final long end;
+  private final Set<RelationProto> relations;
+  private final Map<String, Map<String, ProgramProto>> programs;
+  private final Map<String, Map<String, DataProto>> data;
+
+  public LineageProto(long start, long end, Set<Relation> lineageRelations) {
+    this.start = start;
+    this.end = end;
+    this.relations = new HashSet<>();
+    this.programs = new HashMap<>();
+    this.data = new HashMap<>();
+
+    addRelations(lineageRelations);
+  }
+
+  private void addRelations(Set<Relation> lineageRelations) {
+    for (Relation relation : lineageRelations) {
+      String dataKey = makeDataKey(relation.getData());
+      String programKey = makeProgramKey(relation.getProgram());
+      RelationProto relationProto = new RelationProto(dataKey, programKey,
+                                                      relation.getAccess().toString().toLowerCase(),
+                                                      convertRuns(relation.getRuns()),
+                                                      convertComponents(relation.getComponents()));
+      relations.add(relationProto);
+      programs.put(programKey, ImmutableMap.of("id", toProgramProto(relation.getProgram())));
+      data.put(dataKey, ImmutableMap.of("id", toDataProto(relation.getData())));
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    LineageProto that = (LineageProto) o;
+    return Objects.equals(start, that.start) &&
+      Objects.equals(end, that.end) &&
+      Objects.equals(relations, that.relations) &&
+      Objects.equals(programs, that.programs) &&
+      Objects.equals(data, that.data);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(start, end, relations, programs, data);
+  }
+
+  @Override
+  public String toString() {
+    return "LineageProto{" +
+      "start=" + start +
+      ", end=" + end +
+      ", relations=" + relations +
+      ", programs=" + programs +
+      ", data=" + data +
+      '}';
+  }
+
+  private Set<String> convertRuns(Set<RunId> runIds) {
+    return Sets.newHashSet(Iterables.transform(runIds, RUN_ID_STRING_FUNCTION));
+  }
+
+  private Set<String> convertComponents(Set<Id.NamespacedId> components) {
+    return Sets.newHashSet(Iterables.transform(components, ID_STRING_FUNCTION));
+  }
+
+  private String makeProgramKey(Id.Program program) {
+    return Joiner.on('.').join(program.getType().getCategoryName().toLowerCase(), program.getNamespaceId(),
+                               program.getApplicationId(), program.getId());
+  }
+
+  private ProgramProto toProgramProto(Id.Program program) {
+    return new ProgramProto(program.getNamespaceId(), program.getApplicationId(),
+                            program.getType().getCategoryName().toLowerCase(), program.getId());
+  }
+
+  private String makeDataKey(Id.NamespacedId data) {
+    if (data instanceof Id.DatasetInstance) {
+      return makeDatasetKey((Id.DatasetInstance) data);
+    }
+
+    if (data instanceof  Id.Stream) {
+      return makeStreamKey((Id.Stream) data);
+    }
+
+    throw new IllegalArgumentException("Unknown data object " + data);
+  }
+
+  private DataProto toDataProto(Id.NamespacedId data) {
+    if (data instanceof Id.DatasetInstance) {
+      return new DataProto(((Id.DatasetInstance) data).getNamespaceId(), "dataset", data.getId());
+    }
+
+    if (data instanceof Id.Stream) {
+      return new DataProto(((Id.Stream) data).getNamespaceId(), "stream", data.getId());
+    }
+
+    throw new IllegalArgumentException("Unknown data object " + data);
+  }
+
+  private String makeDatasetKey(Id.DatasetInstance datasetInstance) {
+    return Joiner.on('.').join("dataset", datasetInstance.getNamespaceId(), datasetInstance.getId());
+  }
+
+  private String makeStreamKey(Id.Stream stream) {
+    return Joiner.on('.').join("stream", stream.getNamespaceId(), stream.getId());
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/serialize/ProgramProto.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/serialize/ProgramProto.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.metadata.serialize;
+
+import java.util.Objects;
+
+/**
+ * Class to serialize {@link co.cask.cdap.proto.Id.Program}.
+ */
+public class ProgramProto {
+  private final String namespace;
+  private final String application;
+  private final String type;
+  private final String id;
+
+  public ProgramProto(String namespace, String application, String type, String id) {
+    this.namespace = namespace;
+    this.application = application;
+    this.type = type;
+    this.id = id;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ProgramProto program = (ProgramProto) o;
+    return Objects.equals(namespace, program.namespace) &&
+      Objects.equals(application, program.application) &&
+      Objects.equals(type, program.type) &&
+      Objects.equals(id, program.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(namespace, application, type, id);
+  }
+
+  @Override
+  public String toString() {
+    return "ProgramProto{" +
+      "namespace='" + namespace + '\'' +
+      ", application='" + application + '\'' +
+      ", type='" + type + '\'' +
+      ", id='" + id + '\'' +
+      '}';
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/serialize/RelationProto.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/serialize/RelationProto.java
@@ -14,52 +14,27 @@
  * the License.
  */
 
-package co.cask.cdap.data2.metadata.lineage;
-
-import co.cask.cdap.proto.Id;
-import com.google.common.collect.ImmutableSet;
-import org.apache.twill.api.RunId;
+package co.cask.cdap.metadata.serialize;
 
 import java.util.Objects;
 import java.util.Set;
 
 /**
- * Represents a Dataset access by a Program.
+ * Class to serialize {@link co.cask.cdap.data2.metadata.lineage.Relation}.
  */
-public class Relation {
-  private final Id.NamespacedId data;
-  private final Id.Program program;
-  private final AccessType access;
-  private final Set<RunId> runs;
-  private final Set<Id.NamespacedId> components;
+public class RelationProto {
+  private final String data;
+  private final String program;
+  private final String access;
+  private final Set<String> runs;
+  private final Set<String> components;
 
-  public Relation(Id.DatasetInstance data, Id.Program program, AccessType access, Set<RunId> runs,
-                  Set<? extends Id.NamespacedId> components) {
+  public RelationProto(String data, String program, String access, Set<String> runs, Set<String> components) {
     this.data = data;
     this.program = program;
     this.access = access;
-    this.runs = ImmutableSet.copyOf(runs);
-    this.components = ImmutableSet.copyOf(components);
-  }
-
-  public Id.NamespacedId getData() {
-    return data;
-  }
-
-  public Id.Program getProgram() {
-    return program;
-  }
-
-  public AccessType getAccess() {
-    return access;
-  }
-
-  public Set<RunId> getRuns() {
-    return runs;
-  }
-
-  public Set<Id.NamespacedId> getComponents() {
-    return components;
+    this.runs = runs;
+    this.components = components;
   }
 
   @Override
@@ -70,7 +45,7 @@ public class Relation {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    Relation relation = (Relation) o;
+    RelationProto relation = (RelationProto) o;
     return Objects.equals(data, relation.data) &&
       Objects.equals(program, relation.program) &&
       Objects.equals(access, relation.access) &&
@@ -85,10 +60,10 @@ public class Relation {
 
   @Override
   public String toString() {
-    return "Relation{" +
-      "data=" + data +
-      ", program=" + program +
-      ", access=" + access +
+    return "RelationProto{" +
+      "data='" + data + '\'' +
+      ", program='" + program + '\'' +
+      ", access='" + access + '\'' +
       ", runs=" + runs +
       ", components=" + components +
       '}';

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/LineageTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/LineageTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.metadata;
+
+import co.cask.cdap.AllProgramsApp;
+import co.cask.cdap.common.app.RunIds;
+import co.cask.cdap.data2.metadata.lineage.AccessType;
+import co.cask.cdap.data2.metadata.lineage.Relation;
+import co.cask.cdap.metadata.serialize.LineageProto;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.ProgramRunStatus;
+import co.cask.cdap.proto.RunRecord;
+import co.cask.cdap.test.SlowTests;
+import co.cask.common.http.HttpResponse;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.gson.Gson;
+import org.apache.twill.api.RunId;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tests lineage recording and query.
+ */
+@Category(SlowTests.class)
+public class LineageTest extends MetadataTestBase {
+  private static final Gson GSON = new Gson();
+  private static final String STOPPED = "STOPPED";
+
+  @Test
+  public void testLineage() throws Exception {
+    final Id.Application app = Id.Application.from("default", AllProgramsApp.NAME);
+    final Id.Flow flow = Id.Flow.from(app, AllProgramsApp.NoOpFlow.NAME);
+    final Id.Stream stream = Id.Stream.from("default", AllProgramsApp.STREAM_NAME);
+    final Id.DatasetInstance dataset = Id.DatasetInstance.from("default", AllProgramsApp.DATASET_NAME);
+
+    deploy(AllProgramsApp.class);
+    try {
+      addProperties(dataset, ImmutableMap.of("data-key1", "data-value1"));
+      Assert.assertEquals(ImmutableMap.of("data-key1", "data-value1"), getProperties(dataset));
+
+      startProgram(flow);
+      waitState(flow, ProgramRunStatus.RUNNING.toString());
+      RunId flowRunId = getRunId(flow);
+      stopProgram(flow);
+      waitState(flow, STOPPED);
+
+      long now = System.currentTimeMillis();
+      long oneHourMillis = TimeUnit.HOURS.toMillis(1);
+      HttpResponse httpResponse = fetchLineage(dataset, now - oneHourMillis, now + oneHourMillis, 10);
+      LineageProto lineage = GSON.fromJson(httpResponse.getResponseBodyAsString(), LineageProto.class);
+
+      LineageProto expected =
+        new LineageProto(now - oneHourMillis, now + oneHourMillis,
+                         ImmutableSet.of(
+                           new Relation(dataset, flow, AccessType.UNKNOWN,
+                                        ImmutableSet.of(flowRunId),
+                                        ImmutableSet.of(Id.Flow.Flowlet.from(flow, AllProgramsApp.A.NAME)))
+                         ));
+      Assert.assertEquals(expected, lineage);
+    } finally {
+      deleteApp(app, 200);
+    }
+  }
+
+  private RunId getRunId(Id.Program program) throws Exception {
+    List<RunRecord> runRecords = getProgramRuns(program, "RUNNING");
+    Assert.assertEquals(1, runRecords.size());
+    return RunIds.fromString(runRecords.iterator().next().getPid());
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataTestBase.java
@@ -1,0 +1,349 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.metadata;
+
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.discovery.EndpointStrategy;
+import co.cask.cdap.common.discovery.RandomEndpointStrategy;
+import co.cask.cdap.internal.app.services.http.AppFabricTestBase;
+import co.cask.cdap.proto.Id;
+import co.cask.common.http.HttpRequest;
+import co.cask.common.http.HttpRequests;
+import co.cask.common.http.HttpResponse;
+import com.google.common.reflect.TypeToken;
+import com.google.gson.Gson;
+import org.apache.twill.discovery.Discoverable;
+import org.apache.twill.discovery.DiscoveryServiceClient;
+import org.apache.twill.discovery.ServiceDiscovered;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+
+/**
+ * Base class for metadata tests.
+ */
+public abstract class MetadataTestBase extends AppFabricTestBase {
+  private static final Gson GSON = new Gson();
+  private static final Type LIST_STRING_TYPE = new TypeToken<List<String>>() { }.getType();
+  private static String metadataServiceUrl;
+
+  @BeforeClass
+  public static void setup() throws MalformedURLException {
+    DiscoveryServiceClient discoveryClient = getInjector().getInstance(DiscoveryServiceClient.class);
+    ServiceDiscovered metadataHttpDiscovered = discoveryClient.discover(Constants.Service.METADATA_SERVICE);
+    EndpointStrategy endpointStrategy = new RandomEndpointStrategy(metadataHttpDiscovered);
+    Discoverable discoverable = endpointStrategy.pick(1, TimeUnit.SECONDS);
+    Assert.assertNotNull(discoverable);
+    int port = discoverable.getSocketAddress().getPort();
+    metadataServiceUrl = String.format("http://127.0.0.1:%d", port);
+  }
+
+  protected HttpResponse addProperties(Id.Application app, @Nullable Map<String, String> properties)
+    throws IOException {
+    String path = getVersionedAPIPath(String.format("apps/%s/metadata/properties", app.getId()), app.getNamespaceId());
+    if (properties == null) {
+      return makePostRequest(path);
+    }
+    return makePostRequest(path, GSON.toJson(properties));
+  }
+
+  protected HttpResponse addProperties(Id.Program program, @Nullable Map<String, String> properties)
+    throws IOException {
+    String path = getVersionedAPIPath(String.format("apps/%s/%s/%s/metadata/properties", program.getApplicationId(),
+                                                    program.getType().getCategoryName(), program.getId()),
+                                      program.getNamespaceId());
+    if (properties == null) {
+      return makePostRequest(path);
+    }
+    return makePostRequest(path, GSON.toJson(properties));
+  }
+
+  protected HttpResponse addProperties(Id.DatasetInstance dataset,
+                                       @Nullable Map<String, String> properties) throws IOException {
+    String path = getVersionedAPIPath(String.format("datasets/%s/metadata/properties",
+                                                    dataset.getId()), dataset.getNamespaceId());
+    if (properties == null) {
+      return makePostRequest(path);
+    }
+    return makePostRequest(path, GSON.toJson(properties));
+  }
+
+  protected HttpResponse addProperties(Id.Stream stream, @Nullable Map<String, String> properties) throws IOException {
+    String path = getVersionedAPIPath(String.format("streams/%s/metadata/properties",
+                                                    stream.getId()), stream.getNamespaceId());
+    if (properties == null) {
+      return makePostRequest(path);
+    }
+    return makePostRequest(path, GSON.toJson(properties));
+  }
+
+  protected Map<String, String> getProperties(Id.Application app) throws IOException {
+    String path = getVersionedAPIPath(String.format("apps/%s/metadata/properties", app.getId()), app.getNamespaceId());
+    HttpResponse response = makeGetRequest(path);
+    Assert.assertEquals(200, response.getResponseCode());
+    return GSON.fromJson(response.getResponseBodyAsString(), MAP_STRING_STRING_TYPE);
+  }
+
+  protected Map<String, String> getProperties(Id.Program program) throws IOException {
+    String path = getVersionedAPIPath(String.format("apps/%s/%s/%s/metadata/properties", program.getApplicationId(),
+                                                    program.getType().getCategoryName(), program.getId()),
+                                      program.getNamespaceId());
+    HttpResponse response = makeGetRequest(path);
+    Assert.assertEquals(200, response.getResponseCode());
+    return GSON.fromJson(response.getResponseBodyAsString(), MAP_STRING_STRING_TYPE);
+  }
+
+  protected Map<String, String> getProperties(Id.DatasetInstance dataset) throws IOException {
+    String path = getVersionedAPIPath(String.format("datasets/%s/metadata/properties",
+                                                    dataset.getId()), dataset.getNamespaceId());
+    HttpResponse response = makeGetRequest(path);
+    Assert.assertEquals(200, response.getResponseCode());
+    return GSON.fromJson(response.getResponseBodyAsString(), MAP_STRING_STRING_TYPE);
+  }
+
+  protected Map<String, String> getProperties(Id.Stream stream) throws IOException {
+    String path = getVersionedAPIPath(String.format("streams/%s/metadata/properties",
+                                                    stream.getId()), stream.getNamespaceId());
+    HttpResponse response = makeGetRequest(path);
+    Assert.assertEquals(200, response.getResponseCode());
+    return GSON.fromJson(response.getResponseBodyAsString(), MAP_STRING_STRING_TYPE);
+  }
+
+  protected void removeProperties(Id.Application app) throws IOException {
+    removeProperties(app, null);
+  }
+
+  private void removeProperties(Id.Application app, @Nullable String propertyToRemove) throws IOException {
+    String path = getVersionedAPIPath(String.format("apps/%s/metadata/properties", app.getId()), app.getNamespaceId());
+    if (propertyToRemove != null) {
+      path = String.format("%s/%s", path, propertyToRemove);
+    }
+    HttpResponse response = makeDeleteRequest(path);
+    Assert.assertEquals(200, response.getResponseCode());
+  }
+
+  protected void removeProperties(Id.Program program) throws IOException {
+    removeProperties(program, null);
+  }
+
+  protected void removeProperties(Id.Program program, @Nullable String propertyToRemove) throws IOException {
+    String path = getVersionedAPIPath(String.format("apps/%s/%s/%s/metadata/properties", program.getApplicationId(),
+                                                    program.getType().getCategoryName(), program.getId()),
+                                      program.getNamespaceId());
+    if (propertyToRemove != null) {
+      path = String.format("%s/%s", path, propertyToRemove);
+    }
+    HttpResponse response = makeDeleteRequest(path);
+    Assert.assertEquals(200, response.getResponseCode());
+  }
+
+  protected void removeProperties(Id.DatasetInstance dataset) throws IOException {
+    removeProperties(dataset, null);
+  }
+
+  protected void removeProperties(Id.DatasetInstance dataset, @Nullable String propertyToRemove) throws IOException {
+    String path = getVersionedAPIPath(String.format("datasets/%s/metadata/properties",
+                                                    dataset.getId()), dataset.getNamespaceId());
+    if (propertyToRemove != null) {
+      path = String.format("%s/%s", path, propertyToRemove);
+    }
+    HttpResponse response = makeDeleteRequest(path);
+    Assert.assertEquals(200, response.getResponseCode());
+  }
+
+  protected void removeProperties(Id.Stream stream) throws IOException {
+    removeProperties(stream, null);
+  }
+
+  protected void removeProperties(Id.Stream stream, @Nullable String propertyToRemove) throws IOException {
+    String path = getVersionedAPIPath(String.format("streams/%s/metadata/properties",
+                                                    stream.getId()), stream.getNamespaceId());
+    if (propertyToRemove != null) {
+      path = String.format("%s/%s", path, propertyToRemove);
+    }
+    HttpResponse response = makeDeleteRequest(path);
+    Assert.assertEquals(200, response.getResponseCode());
+  }
+
+  protected HttpResponse addTags(Id.Application app, @Nullable List<String> tags) throws IOException {
+    String path = getVersionedAPIPath(String.format("apps/%s/metadata/tags", app.getId()), app.getNamespaceId());
+    if (tags == null) {
+      return makePostRequest(path);
+    }
+    return makePostRequest(path, GSON.toJson(tags));
+  }
+
+  protected HttpResponse addTags(Id.Program program, @Nullable List<String> tags) throws IOException {
+    String path = getVersionedAPIPath(String.format("apps/%s/%s/%s/metadata/tags", program.getApplicationId(),
+                                                    program.getType().getCategoryName(), program.getId()),
+                                      program.getNamespaceId());
+    if (tags == null) {
+      return makePostRequest(path);
+    }
+    return makePostRequest(path, GSON.toJson(tags));
+  }
+
+  protected HttpResponse addTags(Id.DatasetInstance dataset, @Nullable List<String> tags) throws IOException {
+    String path = getVersionedAPIPath(String.format("datasets/%s/metadata/tags",
+                                                    dataset.getId()), dataset.getNamespaceId());
+    if (tags == null) {
+      return makePostRequest(path);
+    }
+    return makePostRequest(path, GSON.toJson(tags));
+  }
+
+  protected HttpResponse addTags(Id.Stream stream, @Nullable List<String> tags) throws IOException {
+    String path = getVersionedAPIPath(String.format("streams/%s/metadata/tags",
+                                                    stream.getId()), stream.getNamespaceId());
+    if (tags == null) {
+      return makePostRequest(path);
+    }
+    return makePostRequest(path, GSON.toJson(tags));
+  }
+
+  protected List<String> getTags(Id.Application app) throws IOException {
+    String path = getVersionedAPIPath(String.format("apps/%s/metadata/tags", app.getId()), app.getNamespaceId());
+    HttpResponse response = makeGetRequest(path);
+    Assert.assertEquals(200, response.getResponseCode());
+    return GSON.fromJson(response.getResponseBodyAsString(), LIST_STRING_TYPE);
+  }
+
+  protected List<String> getTags(Id.Program program) throws IOException {
+    String path = getVersionedAPIPath(String.format("apps/%s/%s/%s/metadata/tags", program.getApplicationId(),
+                                                    program.getType().getCategoryName(), program.getId()),
+                                      program.getNamespaceId());
+    HttpResponse response = makeGetRequest(path);
+    Assert.assertEquals(200, response.getResponseCode());
+    return GSON.fromJson(response.getResponseBodyAsString(), LIST_STRING_TYPE);
+  }
+
+  protected List<String> getTags(Id.DatasetInstance dataset) throws IOException {
+    String path = getVersionedAPIPath(String.format("datasets/%s/metadata/tags",
+                                                    dataset.getId()), dataset.getNamespaceId());
+    HttpResponse response = makeGetRequest(path);
+    Assert.assertEquals(200, response.getResponseCode());
+    return GSON.fromJson(response.getResponseBodyAsString(), LIST_STRING_TYPE);
+  }
+
+  protected List<String> getTags(Id.Stream stream) throws IOException {
+    String path = getVersionedAPIPath(String.format("streams/%s/metadata/tags",
+                                                    stream.getId()), stream.getNamespaceId());
+    HttpResponse response = makeGetRequest(path);
+    Assert.assertEquals(200, response.getResponseCode());
+    return GSON.fromJson(response.getResponseBodyAsString(), LIST_STRING_TYPE);
+  }
+
+  protected void removeTags(Id.Application app) throws IOException {
+    removeTags(app, null);
+  }
+
+  protected void removeTags(Id.Application app, @Nullable String tagToRemove) throws IOException {
+    String path = getVersionedAPIPath(String.format("apps/%s/metadata/tags", app.getId()), app.getNamespaceId());
+    if (tagToRemove != null) {
+      path = String.format("%s/%s", path, tagToRemove);
+    }
+    HttpResponse response = makeDeleteRequest(path);
+    Assert.assertEquals(200, response.getResponseCode());
+  }
+
+  protected void removeTags(Id.Program program) throws IOException {
+    removeTags(program, null);
+  }
+
+  private void removeTags(Id.Program program, @Nullable String tagToRemove) throws IOException {
+    String path = getVersionedAPIPath(String.format("apps/%s/%s/%s/metadata/tags", program.getApplicationId(),
+                                                    program.getType().getCategoryName(), program.getId()),
+                                      program.getNamespaceId());
+    if (tagToRemove != null) {
+      path = String.format("%s/%s", path, tagToRemove);
+    }
+    HttpResponse response = makeDeleteRequest(path);
+    Assert.assertEquals(200, response.getResponseCode());
+  }
+
+  protected void removeTags(Id.DatasetInstance dataset) throws IOException {
+    removeTags(dataset, null);
+  }
+
+  protected void removeTags(Id.DatasetInstance dataset, @Nullable String tagToRemove) throws IOException {
+    String path = getVersionedAPIPath(String.format("datasets/%s/metadata/tags",
+                                                    dataset.getId()), dataset.getNamespaceId());
+    if (tagToRemove != null) {
+      path = String.format("%s/%s", path, tagToRemove);
+    }
+    HttpResponse response = makeDeleteRequest(path);
+    Assert.assertEquals(200, response.getResponseCode());
+  }
+
+  protected void removeTags(Id.Stream stream) throws IOException {
+    removeTags(stream, null);
+  }
+
+  protected void removeTags(Id.Stream stream, @Nullable String tagToRemove) throws IOException {
+    String path = getVersionedAPIPath(String.format("streams/%s/metadata/tags",
+                                                    stream.getId()), stream.getNamespaceId());
+    if (tagToRemove != null) {
+      path = String.format("%s/%s", path, tagToRemove);
+    }
+    HttpResponse response = makeDeleteRequest(path);
+    Assert.assertEquals(200, response.getResponseCode());
+  }
+
+  protected HttpResponse fetchLineage(Id.DatasetInstance datasetInstance, long start, long end, int levels)
+    throws IOException {
+    String path = getVersionedAPIPath(
+      String.format("datasets/%s/lineage?start=%d&end=%d&levels=%d", datasetInstance.getId(), start, end, levels),
+      datasetInstance.getNamespaceId());
+    return makePostRequest(path);
+  }
+
+  // The following methods are needed because AppFabricTestBase's doGet, doPost, doPut, doDelete are hardwired to
+  // AppFabric Service
+  private HttpResponse makePostRequest(String resource) throws IOException {
+    return makePostRequest(resource, null);
+  }
+
+  private HttpResponse makePostRequest(String resource, @Nullable String body) throws IOException {
+    HttpRequest.Builder postBuilder = HttpRequest.post(getMetadataUrl(resource));
+    if (body != null) {
+      postBuilder.withBody(body);
+    }
+    return HttpRequests.execute(postBuilder.build());
+  }
+
+  private HttpResponse makeGetRequest(String resource) throws IOException {
+    HttpRequest request = HttpRequest.get(getMetadataUrl(resource)).build();
+    return HttpRequests.execute(request);
+  }
+
+  private HttpResponse makeDeleteRequest(String resource) throws IOException {
+    HttpRequest request = HttpRequest.delete(getMetadataUrl(resource)).build();
+    return HttpRequests.execute(request);
+  }
+
+  private URL getMetadataUrl(String resource) throws MalformedURLException {
+    return new URL(String.format("%s%s", metadataServiceUrl, resource));
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataSetsModules.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataSetsModules.java
@@ -23,15 +23,21 @@ import co.cask.cdap.data2.dataset2.DatasetDefinitionRegistryFactory;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.DefaultDatasetDefinitionRegistry;
 import co.cask.cdap.data2.dataset2.InMemoryDatasetFramework;
+import co.cask.cdap.data2.metadata.writer.BasicLineageWriter;
+import co.cask.cdap.data2.metadata.writer.LineageWriter;
+import co.cask.cdap.data2.metadata.writer.LineageWriterDatasetFramework;
 import com.google.inject.Module;
 import com.google.inject.PrivateModule;
 import com.google.inject.Scopes;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
+import com.google.inject.name.Names;
 
 /**
  * DataSets framework bindings
  */
 public class DataSetsModules extends RuntimeModule {
+
+  public static final String BASIC_DATASET_FRAMEWORK = "basicDatasetFramework";
 
   @Override
   public Module getInMemoryModules() {
@@ -41,7 +47,14 @@ public class DataSetsModules extends RuntimeModule {
         install(new FactoryModuleBuilder()
                   .implement(DatasetDefinitionRegistry.class, DefaultDatasetDefinitionRegistry.class)
                   .build(DatasetDefinitionRegistryFactory.class));
-        bind(DatasetFramework.class).to(InMemoryDatasetFramework.class).in(Scopes.SINGLETON);
+
+        bind(DatasetFramework.class)
+          .annotatedWith(Names.named(BASIC_DATASET_FRAMEWORK))
+          .to(InMemoryDatasetFramework.class).in(Scopes.SINGLETON);
+        expose(DatasetFramework.class).annotatedWith(Names.named(BASIC_DATASET_FRAMEWORK));
+
+        bind(LineageWriter.class).to(BasicLineageWriter.class);
+        bind(DatasetFramework.class).to(LineageWriterDatasetFramework.class);
         expose(DatasetFramework.class);
       }
     };
@@ -55,7 +68,14 @@ public class DataSetsModules extends RuntimeModule {
         install(new FactoryModuleBuilder()
                   .implement(DatasetDefinitionRegistry.class, DefaultDatasetDefinitionRegistry.class)
                   .build(DatasetDefinitionRegistryFactory.class));
-        bind(DatasetFramework.class).to(RemoteDatasetFramework.class);
+
+        bind(DatasetFramework.class)
+          .annotatedWith(Names.named(BASIC_DATASET_FRAMEWORK))
+          .to(RemoteDatasetFramework.class);
+        expose(DatasetFramework.class).annotatedWith(Names.named(BASIC_DATASET_FRAMEWORK));
+
+        bind(LineageWriter.class).to(BasicLineageWriter.class);
+        bind(DatasetFramework.class).to(LineageWriterDatasetFramework.class);
         expose(DatasetFramework.class);
       }
     };
@@ -70,7 +90,14 @@ public class DataSetsModules extends RuntimeModule {
         install(new FactoryModuleBuilder()
                   .implement(DatasetDefinitionRegistry.class, DefaultDatasetDefinitionRegistry.class)
                   .build(DatasetDefinitionRegistryFactory.class));
-        bind(DatasetFramework.class).to(RemoteDatasetFramework.class);
+
+        bind(DatasetFramework.class)
+          .annotatedWith(Names.named(BASIC_DATASET_FRAMEWORK))
+          .to(RemoteDatasetFramework.class);
+        expose(DatasetFramework.class).annotatedWith(Names.named(BASIC_DATASET_FRAMEWORK));
+
+        bind(LineageWriter.class).to(BasicLineageWriter.class);
+        bind(DatasetFramework.class).to(LineageWriterDatasetFramework.class);
         expose(DatasetFramework.class);
       }
     };

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/lineage/LineageStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/lineage/LineageStore.java
@@ -18,6 +18,7 @@ package co.cask.cdap.data2.metadata.lineage;
 
 import co.cask.cdap.api.dataset.DatasetDefinition;
 import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.transaction.Transactions;
@@ -27,6 +28,7 @@ import co.cask.tephra.TransactionExecutorFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 import com.google.inject.Inject;
+import com.google.inject.name.Named;
 
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -42,7 +44,8 @@ public class LineageStore {
   private final Id.DatasetInstance lineageDatasetId;
 
   @Inject
-  LineageStore(TransactionExecutorFactory executorFactory, DatasetFramework datasetFramework) {
+  LineageStore(TransactionExecutorFactory executorFactory,
+               @Named(DataSetsModules.BASIC_DATASET_FRAMEWORK) DatasetFramework datasetFramework) {
     this(executorFactory, datasetFramework, LINEAGE_DATASET_ID);
   }
 
@@ -76,7 +79,7 @@ public class LineageStore {
    * @param component program component such as flowlet id, etc.
    */
   public void addAccess(final Id.Run run, final Id.DatasetInstance datasetInstance,
-                        final AccessType accessType, final String metadata, @Nullable final Id component) {
+                        final AccessType accessType, final String metadata, @Nullable final Id.NamespacedId component) {
     execute(new TransactionExecutor.Procedure<LineageDataset>() {
       @Override
       public void apply(LineageDataset input) throws Exception {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/service/BusinessMetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/service/BusinessMetadataStore.java
@@ -18,6 +18,7 @@ package co.cask.cdap.data2.metadata.service;
 
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.common.ServiceUnavailableException;
+import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.DatasetManagementException;
@@ -25,7 +26,6 @@ import co.cask.cdap.data2.dataset2.tx.Transactional;
 import co.cask.cdap.data2.metadata.dataset.BusinessMetadataDataset;
 import co.cask.cdap.data2.metadata.dataset.BusinessMetadataRecord;
 import co.cask.cdap.proto.Id;
-import co.cask.cdap.proto.MetadataSearchResultRecord;
 import co.cask.cdap.proto.MetadataSearchTargetType;
 import co.cask.tephra.TransactionExecutor;
 import co.cask.tephra.TransactionExecutorFactory;
@@ -33,6 +33,7 @@ import com.google.common.base.Supplier;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Iterators;
 import com.google.inject.Inject;
+import com.google.inject.name.Named;
 
 import java.io.IOException;
 import java.util.Iterator;
@@ -49,7 +50,8 @@ public class BusinessMetadataStore {
   private final Transactional<BusinessMdsIterable, BusinessMetadataDataset> txnl;
 
   @Inject
-  public BusinessMetadataStore(TransactionExecutorFactory txExecutorFactory, final DatasetFramework dsFramework) {
+  public BusinessMetadataStore(TransactionExecutorFactory txExecutorFactory,
+                               @Named(DataSetsModules.BASIC_DATASET_FRAMEWORK) final DatasetFramework dsFramework) {
     this.txnl = Transactional.of(txExecutorFactory, new Supplier<BusinessMdsIterable>() {
       @Override
       public BusinessMdsIterable get() {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/BasicLineageWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/BasicLineageWriter.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.metadata.writer;
+
+import co.cask.cdap.data2.metadata.lineage.AccessType;
+import co.cask.cdap.data2.metadata.lineage.LineageStore;
+import co.cask.cdap.data2.metadata.service.BusinessMetadataStore;
+import co.cask.cdap.proto.Id;
+import com.google.gson.Gson;
+import com.google.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+/**
+ * Writes program-dataset access information along with metadata  into {@link LineageStore}.
+ */
+public class BasicLineageWriter implements LineageWriter {
+  private static final Logger LOG = LoggerFactory.getLogger(BasicLineageWriter.class);
+  private static final Gson GSON = new Gson();
+
+  private final BusinessMetadataStore businessMetadataStore;
+  private final LineageStore lineageStore;
+
+  @Inject
+  public BasicLineageWriter(BusinessMetadataStore businessMetadataStore, LineageStore lineageStore) {
+    this.businessMetadataStore = businessMetadataStore;
+    this.lineageStore = lineageStore;
+  }
+
+  @Override
+  public void addAccess(Id.Run run, Id.DatasetInstance datasetInstance, AccessType accessType) {
+    addAccess(run, datasetInstance, accessType, null);
+  }
+
+  @Override
+  public void addAccess(Id.Run run, Id.DatasetInstance datasetInstance, AccessType accessType,
+                        Id.NamespacedId component) {
+    // TODO: avoid duplicate writes for a dataset instance
+    String metadata = gatherMetadata(run, datasetInstance);
+    LOG.debug("Writing access for run {}, dataset {}, accessType {}, component {}, metadata = {}",
+              run, datasetInstance, accessType, component, metadata);
+    lineageStore.addAccess(run, datasetInstance, accessType, metadata, component);
+  }
+
+  private String gatherMetadata(Id.Run run, Id.DatasetInstance datasetInstance) {
+    // TODO: add app metadata and tags
+    Map<String, String> datasetMetadata = businessMetadataStore.getProperties(datasetInstance);
+    return GSON.toJson(datasetMetadata);
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/LineageWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/LineageWriter.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.metadata.writer;
+
+import co.cask.cdap.data2.metadata.lineage.AccessType;
+import co.cask.cdap.proto.Id;
+
+/**
+ * Defines an interface to record program-dataset access records.
+ */
+public interface LineageWriter {
+  /**
+   * Add a program-dataset access.
+   *
+   * @param run program run information
+   * @param datasetInstance dataset accessed by the program
+   * @param accessType access type
+   */
+  void addAccess(Id.Run run, Id.DatasetInstance datasetInstance, AccessType accessType);
+
+  /**
+   * Add a program-dataset access.
+   *
+   * @param run program run information
+   * @param datasetInstance dataset accessed by the program
+   * @param accessType access type
+   * @param component program component such as flowlet id, etc.
+   */
+  void addAccess(Id.Run run, Id.DatasetInstance datasetInstance,
+                 AccessType accessType, Id.NamespacedId component);
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/LineageWriterDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/LineageWriterDatasetFramework.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.metadata.writer;
+
+import co.cask.cdap.api.dataset.Dataset;
+import co.cask.cdap.api.dataset.DatasetAdmin;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.DatasetSpecification;
+import co.cask.cdap.api.dataset.module.DatasetModule;
+import co.cask.cdap.common.ServiceUnavailableException;
+import co.cask.cdap.data.runtime.DataSetsModules;
+import co.cask.cdap.data2.datafabric.dataset.type.DatasetClassLoaderProvider;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.dataset2.DatasetManagementException;
+import co.cask.cdap.data2.metadata.lineage.AccessType;
+import co.cask.cdap.proto.DatasetSpecificationSummary;
+import co.cask.cdap.proto.Id;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
+
+/**
+ * {@link DatasetFramework} that also records lineage (program-dataset access) records.
+ */
+public class LineageWriterDatasetFramework implements DatasetFramework, ProgramContextAware {
+  private final DatasetFramework delegate;
+  private final LineageWriter lineageWriter;
+
+  private final AtomicReference<Id.Run> runRef = new AtomicReference<>();
+  private final AtomicReference<Id.NamespacedId> componentIdRef = new AtomicReference<>();
+
+  @Inject
+  public LineageWriterDatasetFramework(
+    @Named(DataSetsModules.BASIC_DATASET_FRAMEWORK) DatasetFramework datasetFramework, LineageWriter lineageWriter) {
+    this.delegate = datasetFramework;
+    this.lineageWriter = lineageWriter;
+  }
+
+  @Override
+  public void initContext(Id.Run run) {
+    runRef.set(run);
+  }
+
+  @Override
+  public void initContext(Id.Run run, Id.NamespacedId componentId) {
+    runRef.set(run);
+    componentIdRef.set(componentId);
+  }
+
+  @Override
+  public void addModule(Id.DatasetModule moduleId, DatasetModule module)
+    throws DatasetManagementException, ServiceUnavailableException {
+    delegate.addModule(moduleId, module);
+  }
+
+  @Override
+  public void deleteModule(Id.DatasetModule moduleId) throws DatasetManagementException, ServiceUnavailableException {
+    delegate.deleteModule(moduleId);
+  }
+
+  @Override
+  public void deleteAllModules(Id.Namespace namespaceId)
+    throws DatasetManagementException, ServiceUnavailableException {
+    delegate.deleteAllModules(namespaceId);
+  }
+
+  @Override
+  public void addInstance(String datasetTypeName, Id.DatasetInstance datasetInstanceId, DatasetProperties props)
+    throws DatasetManagementException, IOException, ServiceUnavailableException {
+    delegate.addInstance(datasetTypeName, datasetInstanceId, props);
+  }
+
+  @Override
+  public void updateInstance(Id.DatasetInstance datasetInstanceId, DatasetProperties props)
+    throws DatasetManagementException, IOException, ServiceUnavailableException {
+    delegate.updateInstance(datasetInstanceId, props);
+  }
+
+  @Override
+  public Collection<DatasetSpecificationSummary> getInstances(Id.Namespace namespaceId)
+    throws DatasetManagementException, ServiceUnavailableException {
+    return delegate.getInstances(namespaceId);
+  }
+
+  @Override
+  @Nullable
+  public DatasetSpecification getDatasetSpec(Id.DatasetInstance datasetInstanceId)
+    throws DatasetManagementException, ServiceUnavailableException {
+    return delegate.getDatasetSpec(datasetInstanceId);
+  }
+
+  @Override
+  public boolean hasInstance(Id.DatasetInstance datasetInstanceId)
+    throws DatasetManagementException, ServiceUnavailableException {
+    return delegate.hasInstance(datasetInstanceId);
+  }
+
+  @Override
+  public boolean hasSystemType(String typeName) throws DatasetManagementException, ServiceUnavailableException {
+    return delegate.hasSystemType(typeName);
+  }
+
+  @Override
+  @VisibleForTesting
+  public boolean hasType(Id.DatasetType datasetTypeId) throws DatasetManagementException, ServiceUnavailableException {
+    return delegate.hasType(datasetTypeId);
+  }
+
+  @Override
+  public void deleteInstance(Id.DatasetInstance datasetInstanceId)
+    throws DatasetManagementException, IOException, ServiceUnavailableException {
+    delegate.deleteInstance(datasetInstanceId);
+  }
+
+  @Override
+  public void deleteAllInstances(Id.Namespace namespaceId)
+    throws DatasetManagementException, IOException, ServiceUnavailableException {
+    delegate.deleteAllInstances(namespaceId);
+  }
+
+  @Override
+  @Nullable
+  public <T extends DatasetAdmin> T getAdmin(Id.DatasetInstance datasetInstanceId, @Nullable ClassLoader classLoader)
+    throws DatasetManagementException, IOException, ServiceUnavailableException {
+    return delegate.getAdmin(datasetInstanceId, classLoader);
+  }
+
+  @Override
+  @Nullable
+  public <T extends DatasetAdmin> T getAdmin(Id.DatasetInstance datasetInstanceId, @Nullable ClassLoader classLoader,
+                                             DatasetClassLoaderProvider classLoaderProvider)
+    throws DatasetManagementException, IOException, ServiceUnavailableException {
+    return delegate.getAdmin(datasetInstanceId, classLoader, classLoaderProvider);
+  }
+
+  @Override
+  @Nullable
+  public <T extends Dataset> T getDataset(Id.DatasetInstance datasetInstanceId,
+                                          @Nullable Map<String, String> arguments, @Nullable ClassLoader classLoader,
+                                          @Nullable Iterable<? extends Id> owners)
+    throws DatasetManagementException, IOException, ServiceUnavailableException {
+    T dataset = delegate.getDataset(datasetInstanceId, arguments, classLoader, owners);
+    writeLineage(datasetInstanceId, dataset);
+    return dataset;
+  }
+
+  @Override
+  @Nullable
+  public <T extends Dataset> T getDataset(Id.DatasetInstance datasetInstanceId,
+                                          @Nullable Map<String, String> arguments, @Nullable ClassLoader classLoader)
+    throws DatasetManagementException, IOException, ServiceUnavailableException {
+    T dataset = delegate.getDataset(datasetInstanceId, arguments, classLoader);
+    writeLineage(datasetInstanceId, dataset);
+    return dataset;
+  }
+
+  @Override
+  @Nullable
+  public <T extends Dataset> T getDataset(Id.DatasetInstance datasetInstanceId,
+                                          @Nullable Map<String, String> arguments, @Nullable ClassLoader classLoader,
+                                          DatasetClassLoaderProvider classLoaderProvider,
+                                          @Nullable Iterable<? extends Id> owners)
+    throws DatasetManagementException, IOException, ServiceUnavailableException {
+    T dataset = delegate.getDataset(datasetInstanceId, arguments, classLoader, classLoaderProvider, owners);
+    writeLineage(datasetInstanceId, dataset);
+    return dataset;
+  }
+
+  @Override
+  public void createNamespace(Id.Namespace namespaceId)
+    throws DatasetManagementException, ServiceUnavailableException {
+    delegate.createNamespace(namespaceId);
+  }
+
+  @Override
+  public void deleteNamespace(Id.Namespace namespaceId)
+    throws DatasetManagementException, ServiceUnavailableException {
+    delegate.deleteNamespace(namespaceId);
+  }
+
+  private <T extends Dataset> void writeLineage(Id.DatasetInstance datasetInstanceId, T dataset) {
+    if (dataset != null && runRef.get() != null) {
+      lineageWriter.addAccess(runRef.get(), datasetInstanceId, AccessType.UNKNOWN, componentIdRef.get());
+    }
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/ProgramContextAware.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/ProgramContextAware.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.metadata.writer;
+
+import co.cask.cdap.proto.Id;
+
+/**
+ * Interface implemented by classes that need program context information.
+ */
+public interface ProgramContextAware {
+  /**
+   * Initalize with program run information.
+
+   * @param run program run
+   */
+  void initContext(Id.Run run);
+
+  /**
+   * Intialize with program run and program component (i.e, flowet Id, etc.) information.
+
+   * @param run program run
+   * @param componentId program component
+   */
+  void initContext(Id.Run run, Id.NamespacedId componentId);
+}

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/lineage/LineageServiceTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/lineage/LineageServiceTest.java
@@ -88,9 +88,7 @@ public class LineageServiceTest {
         new Relation(dataset2, program1, AccessType.READ, toSet(twillRunId(run1)), toSet(flowlet1)),
         new Relation(dataset2, program2, AccessType.WRITE, toSet(twillRunId(run2)), toSet(flowlet2)),
         new Relation(dataset3, program2, AccessType.READ, toSet(twillRunId(run2)), toSet(flowlet2))
-      ),
-      ImmutableSet.of(program1, program2),
-      ImmutableSet.of(dataset1, dataset2, dataset3)
+      )
     );
 
     // Lineage for D1
@@ -101,9 +99,6 @@ public class LineageServiceTest {
 
     // Lineage for D1 for one level should be D2 -> P1 -> D1
     Lineage oneLevelLineage = lineageService.computeLineage(dataset1, 500, 20000, 1);
-
-    Assert.assertEquals(ImmutableSet.of(program1), oneLevelLineage.getPrograms());
-    Assert.assertEquals(ImmutableSet.of(dataset1, dataset2), oneLevelLineage.getData());
 
     Assert.assertEquals(
       ImmutableSet.of(
@@ -145,10 +140,8 @@ public class LineageServiceTest {
         new Relation(dataset3, program2, AccessType.WRITE, toSet(twillRunId(run2)), toSet(flowlet2)),
         new Relation(dataset4, program3, AccessType.WRITE, toSet(twillRunId(run3)), emptySet()),
         new Relation(dataset3, program3, AccessType.READ, toSet(twillRunId(run3)), emptySet())
-      ),
-      ImmutableSet.of(program1, program2, program3),
-      ImmutableSet.of(dataset1, dataset2, dataset3, dataset4)
-      );
+      )
+    );
 
     // Lineage for D1
     Assert.assertEquals(expectedLineage, lineageService.computeLineage(dataset1, 500, 20000, 100));
@@ -162,9 +155,6 @@ public class LineageServiceTest {
     //                              |<-----------------
     //
     Lineage oneLevelLineage = lineageService.computeLineage(dataset1, 500, 20000, 1);
-
-    Assert.assertEquals(ImmutableSet.of(program1, program2), oneLevelLineage.getPrograms());
-    Assert.assertEquals(ImmutableSet.of(dataset1, dataset2, dataset3), oneLevelLineage.getData());
 
     Assert.assertEquals(
       ImmutableSet.of(
@@ -195,9 +185,7 @@ public class LineageServiceTest {
       ImmutableSet.of(
         new Relation(dataset1, program1, AccessType.READ, toSet(twillRunId(run1)), toSet(flowlet1)),
         new Relation(dataset1, program1, AccessType.WRITE, toSet(twillRunId(run1)), toSet(flowlet1))
-      ),
-      ImmutableSet.of(program1),
-      ImmutableSet.of(dataset1)
+      )
     );
 
     Assert.assertEquals(expectedLineage, lineageService.computeLineage(dataset1, 500, 20000, 100));
@@ -225,9 +213,7 @@ public class LineageServiceTest {
       ImmutableSet.of(
         new Relation(dataset1, program1, AccessType.READ, toSet(twillRunId(run1)), toSet(flowlet1)),
         new Relation(dataset1, program1, AccessType.WRITE, toSet(twillRunId(run2)), toSet(flowlet1))
-      ),
-      ImmutableSet.of(program1),
-      ImmutableSet.of(dataset1)
+      )
     );
 
     Assert.assertEquals(expectedLineage, lineageService.computeLineage(dataset1, 500, 20000, 100));
@@ -283,9 +269,7 @@ public class LineageServiceTest {
         new Relation(dataset2, program4, AccessType.READ, toSet(twillRunId(run4)), emptySet()),
         new Relation(dataset3, program4, AccessType.READ, toSet(twillRunId(run4)), emptySet()),
         new Relation(dataset7, program4, AccessType.WRITE, toSet(twillRunId(run4)), emptySet())
-      ),
-      ImmutableSet.of(program1, program2, program3, program4),
-      ImmutableSet.of(dataset0, dataset1, dataset2, dataset3, dataset4, dataset5, dataset6, dataset7)
+      )
     );
 
     // Lineage for D7
@@ -357,9 +341,7 @@ public class LineageServiceTest {
         new Relation(dataset3, program5, AccessType.READ, toSet(twillRunId(run5)), emptySet()),
         new Relation(dataset6, program5, AccessType.READ, toSet(twillRunId(run5)), emptySet()),
         new Relation(dataset1, program5, AccessType.WRITE, toSet(twillRunId(run5)), emptySet())
-      ),
-      ImmutableSet.of(program1, program2, program3, program4, program5),
-      ImmutableSet.of(dataset0, dataset1, dataset2, dataset3, dataset4, dataset5, dataset6, dataset7)
+      )
     );
 
     // Lineage for D1
@@ -377,9 +359,6 @@ public class LineageServiceTest {
     //                   |
     //             D2 -> P2 -> D3
     Lineage oneLevelLineage = lineageService.computeLineage(dataset5, 500, 20000, 1);
-
-    Assert.assertEquals(ImmutableSet.of(program2, program3), oneLevelLineage.getPrograms());
-    Assert.assertEquals(ImmutableSet.of(dataset2, dataset3, dataset5, dataset6), oneLevelLineage.getData());
 
     Assert.assertEquals(
       ImmutableSet.of(


### PR DESCRIPTION
Only recording lineage for datasets from flowlets in this PR to keep changes minimal. I'll add recording for streams and other program types in an upcoming PR.

Also, the following TODOs will be fixed in an upcoming PR:
1. Avoid duplicate writes of lineage for a dataset instance.
2. Add complete metadata and tags when recording lineage.

The PR looks big due to refactoring of tests and new classes for serializing lineage over HTTP.