### PR TITLE
CDAP-3101 Added listener for the killed event when the program is sta…

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/ScheduleTaskRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/ScheduleTaskRunner.java
@@ -126,6 +126,11 @@ public final class ScheduleTaskRunner {
       }
 
       @Override
+      public void killed() {
+        latch.countDown();
+      }
+
+      @Override
       public void completed() {
         latch.countDown();
       }

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -149,7 +149,7 @@ public final class Constants {
    */
   public class Scheduler {
     public static final String CFG_SCHEDULER_MAX_THREAD_POOL_SIZE = "scheduler.max.thread.pool.size";
-    public static final int DEFAULT_THREAD_POOL_SIZE = 30;
+    public static final int DEFAULT_THREAD_POOL_SIZE = 100;
   }
 
   /**


### PR DESCRIPTION
…rted through scheduler and also increased the scheduler thread pool size to 100.

JIRA: https://issues.cask.co/browse/CDAP-3101
Build: http://builds.cask.co/browse/CDAP-DUT2830-1

When the program is started through scheduler service and stopped explicitly by the user, the thread which triggered the schedule remained in the ACTIVE state. 

In this PR, added listener for the `killed` event in the `ScheduleTaskRunner` so that if program is explicitly killed, the thread gets unblocked and goes to the completion.

Also increase the default thread pool size to 100.

Verified the fix on the cluster. Before the fix, if the program is killed, the thread running the method `DefaultSchedulerService$ScheduledJob.execute` remained in blocked state. After the fix, thread gets unblocked and goes to completion.