### PR TITLE
CDAP-3647 fix bug to allow deletion of system artifacts

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ArtifactHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ArtifactHttpHandler.java
@@ -451,7 +451,8 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
                              @PathParam("artifact-version") String artifactVersion)
     throws NamespaceNotFoundException, BadRequestException {
 
-    Id.Namespace namespace = validateAndGetNamespace(namespaceId);
+    Id.Namespace namespace = Id.Namespace.SYSTEM.getId().equalsIgnoreCase(namespaceId) ?
+      Id.Namespace.SYSTEM : validateAndGetNamespace(namespaceId);
     Id.Artifact artifactId = validateAndGetArtifactId(namespace, artifactName, artifactVersion);
 
     try {


### PR DESCRIPTION
This fixes a bug where system artifacts could never be deleted,
which is problematic if one is somehow deployed incorrectly.