### PR TITLE
Added a way to serialize/deserialize Id.NamespacedId objects by seria…

### DIFF
--- a/cdap-proto/pom.xml
+++ b/cdap-proto/pom.xml
@@ -36,6 +36,11 @@
       <artifactId>cdap-api</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/Id.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/Id.java
@@ -642,6 +642,24 @@ public abstract class Id {
         .add("id", id).toString();
     }
 
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      Schedule that = (Schedule) o;
+      return Objects.equal(application, that.application) &&
+        Objects.equal(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(application, id);
+    }
+
     public static Schedule from(Application application, String id) {
       return new Schedule(application, id);
     }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/codec/NamespacedIdCodec.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/codec/NamespacedIdCodec.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.proto.codec;
+
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.ProgramType;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+
+import java.lang.reflect.Type;
+
+/**
+ * Codec for {@link Id.NamespacedId}. Currently only supports {@link Id.Application}, {@link Id.Program},
+ * {@link Id.DatasetInstance} and {@link Id.Stream}. Support for other {@link Id.NamespacedId} objects will be added
+ * later.
+ */
+public class NamespacedIdCodec extends AbstractSpecificationCodec<Id.NamespacedId> {
+  @Override
+  public JsonElement serialize(Id.NamespacedId src, Type typeOfSrc, JsonSerializationContext context) {
+    JsonObject jsonObj = new JsonObject();
+    jsonObj.add("type", new JsonPrimitive(src.getIdType()));
+    jsonObj.add("id", context.serialize(src));
+
+    return jsonObj;
+  }
+
+  @Override
+  public Id.NamespacedId deserialize(JsonElement json, Type typeOfT,
+                                     JsonDeserializationContext context) throws JsonParseException {
+    JsonObject jsonObj = json.getAsJsonObject();
+    JsonObject id = jsonObj.getAsJsonObject("id");
+    String type = jsonObj.get("type").getAsString();
+    switch (type) {
+      case "application":
+        return deserializeApplicationId(id);
+      case "program":
+        return deserializeProgramId(id);
+      case "flow":
+        return deserializeFlowId(id);
+      case "flowlet":
+        return deserializeFlowletId(id);
+      case "service":
+        return deserializeServiceId(id);
+      case "schedule":
+        return deserializeSchedule(id);
+      case "worker":
+        return deserializeWorkerId(id);
+      case "workflow":
+        return deserializeWorkflowId(id);
+      case "datasetinstance":
+        return deserializeDatasetInstanceId(id);
+      case "stream":
+        return deserializeStreamId(id);
+      default:
+        throw new UnsupportedOperationException(
+          String.format("Unsupported object of type %s found. Deserialization of only %s, %s, %s, %s, %s, %s, %s, " +
+                          "%s, %s, %s is supported.",
+                        type,
+                        Id.Application.class.getSimpleName(),
+                        Id.Program.class.getSimpleName(),
+                        Id.Flow.class.getSimpleName(),
+                        Id.Flow.Flowlet.class.getSimpleName(),
+                        Id.Service.class.getSimpleName(),
+                        Id.Schedule.class.getSimpleName(),
+                        Id.Worker.class.getSimpleName(),
+                        Id.Workflow.class.getSimpleName(),
+                        Id.DatasetInstance.class.getSimpleName(),
+                        Id.Stream.class.getSimpleName()
+          )
+        );
+    }
+  }
+
+  private Id.Application deserializeApplicationId(JsonObject id) {
+    Id.Namespace namespace = deserializeNamespace(id);
+    String applicationId = id.get("applicationId").getAsString();
+    return Id.Application.from(namespace, applicationId);
+  }
+
+  private Id.Namespace deserializeNamespace(JsonObject id) {
+    String namespace = id.getAsJsonObject("namespace").get("id").getAsString();
+    return Id.Namespace.from(namespace);
+  }
+
+  private Id.Program deserializeProgramId(JsonObject id) {
+    Id.Application app = deserializeApplicationId(id.getAsJsonObject("application"));
+    ProgramType programType = ProgramType.valueOf(id.get("type").getAsString().toUpperCase());
+    String programId = id.get("id").getAsString();
+    return Id.Program.from(app, programType, programId);
+  }
+
+  private Id.Flow deserializeFlowId(JsonObject id) {
+    Id.Program program = deserializeProgramId(id);
+    return Id.Flow.from(program.getApplication(), program.getId());
+  }
+
+  private Id.Flow.Flowlet deserializeFlowletId(JsonObject id) {
+    Id.Flow flow = deserializeFlowId(id.getAsJsonObject("flow"));
+    String flowletId = id.get("id").getAsString();
+    return Id.Flow.Flowlet.from(flow, flowletId);
+  }
+
+  private Id.Service deserializeServiceId(JsonObject id) {
+    Id.Program program = deserializeProgramId(id);
+    return Id.Service.from(program.getApplication(), program.getId());
+  }
+
+  private Id.Schedule deserializeSchedule(JsonObject id) {
+    Id.Application app = deserializeApplicationId(id.getAsJsonObject("application"));
+    String scheduleId = id.get("id").getAsString();
+    return Id.Schedule.from(app, scheduleId);
+  }
+
+  private Id.Worker deserializeWorkerId(JsonObject id) {
+    Id.Program program = deserializeProgramId(id);
+    return Id.Worker.from(program.getApplication(), program.getId());
+  }
+
+  private Id.Workflow deserializeWorkflowId(JsonObject id) {
+    Id.Program program = deserializeProgramId(id);
+    return Id.Workflow.from(program.getApplication(), program.getId());
+  }
+
+  private Id.DatasetInstance deserializeDatasetInstanceId(JsonObject id) {
+    Id.Namespace namespace = deserializeNamespace(id);
+    String instanceId = id.get("instanceId").getAsString();
+    return Id.DatasetInstance.from(namespace, instanceId);
+  }
+
+  private Id.Stream deserializeStreamId(JsonObject id) {
+    Id.Namespace namespace = deserializeNamespace(id);
+    String streamName = id.get("streamName").getAsString();
+    return Id.Stream.from(namespace, streamName);
+  }
+}

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/metadata/MetadataChangeRecord.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/metadata/MetadataChangeRecord.java
@@ -18,6 +18,7 @@ package co.cask.cdap.proto.metadata;
 
 import co.cask.cdap.proto.Id;
 
+import java.util.Objects;
 import javax.annotation.Nullable;
 
 /**
@@ -79,5 +80,47 @@ public final class MetadataChangeRecord {
     public MetadataRecord getDeletions() {
       return deletions;
     }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+
+      MetadataDiffRecord that = (MetadataDiffRecord) o;
+
+      return Objects.equals(additions, that.additions) &&
+        Objects.equals(deletions, that.deletions);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(additions, deletions);
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    MetadataChangeRecord that = (MetadataChangeRecord) o;
+
+    return Objects.equals(previous, that.previous) &&
+      Objects.equals(changes, that.changes) &&
+      updateTime == that.updateTime &&
+      Objects.equals(updater, that.updater);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(previous, changes, updateTime, updater);
   }
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/metadata/MetadataRecord.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/metadata/MetadataRecord.java
@@ -20,6 +20,7 @@ import co.cask.cdap.proto.Id;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Represents the complete metadata of a {@link Id.NamespacedId} including its properties and tags.
@@ -30,7 +31,7 @@ public class MetadataRecord {
   private final Map<String, String> properties;
   private final List<String> tags;
 
-  public MetadataRecord(Map<String, String> properties, List<String> tags, Id.NamespacedId targetId) {
+  public MetadataRecord(Id.NamespacedId targetId, Map<String, String> properties, List<String> tags) {
     this(targetId, MetadataScope.USER, properties, tags);
   }
 
@@ -56,5 +57,27 @@ public class MetadataRecord {
 
   public List<String> getTags() {
     return tags;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    MetadataRecord that = (MetadataRecord) o;
+
+    return Objects.equals(targetId, that.targetId) &&
+      scope == that.scope &&
+      Objects.equals(properties, that.properties) &&
+      Objects.equals(tags, that.tags);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(targetId, scope, properties, tags);
   }
 }

--- a/cdap-proto/src/test/java/co/cask/cdap/proto/codec/NamespacedIdCodecTest.java
+++ b/cdap-proto/src/test/java/co/cask/cdap/proto/codec/NamespacedIdCodecTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.proto.codec;
+
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.metadata.MetadataRecord;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Tests for {@link Id.NamespacedId}.
+ */
+public class NamespacedIdCodecTest {
+  private static final Gson GSON = new GsonBuilder()
+    .registerTypeAdapter(Id.NamespacedId.class, new NamespacedIdCodec())
+    .create();
+
+  private final Id.Namespace ns = Id.Namespace.from("ns");
+  private final Id.Application app = Id.Application.from(ns, "app");
+  private final Id.Program program = Id.Program.from(app, ProgramType.CUSTOM_ACTION, "action");
+  private final Id.Flow flow = Id.Flow.from(app, "flow");
+  private final Id.Flow.Flowlet flowlet = Id.Flow.Flowlet.from(flow, "flowlet");
+  private final Id.Service service = Id.Service.from(app, "service");
+  private final Id.Schedule schedule = Id.Schedule.from(app, "schedule");
+  private final Id.Worker worker = Id.Worker.from(app, "worker");
+  private final Id.Workflow workflow = Id.Workflow.from(app, "workflow");
+  private final Id.DatasetInstance dataset = Id.DatasetInstance.from(ns, "ds");
+  private final Id.Stream stream = Id.Stream.from(ns, "stream");
+
+  @Test
+  public void testNamespacedIdCodec() {
+    String nsJson = GSON.toJson(ns);
+    Assert.assertEquals(ns, GSON.fromJson(nsJson, Id.Namespace.class));
+    String appJson = GSON.toJson(app, Id.NamespacedId.class);
+    Assert.assertEquals(app, GSON.fromJson(appJson, Id.NamespacedId.class));
+    String programJson = GSON.toJson(program, Id.NamespacedId.class);
+    Assert.assertEquals(program, GSON.fromJson(programJson, Id.NamespacedId.class));
+    String flowJson = GSON.toJson(flow, Id.NamespacedId.class);
+    Assert.assertEquals(flow, GSON.fromJson(flowJson, Id.NamespacedId.class));
+    String flowletJson = GSON.toJson(flowlet, Id.NamespacedId.class);
+    Assert.assertEquals(flowlet, GSON.fromJson(flowletJson, Id.NamespacedId.class));
+    String serviceJson = GSON.toJson(service, Id.NamespacedId.class);
+    Assert.assertEquals(service, GSON.fromJson(serviceJson, Id.NamespacedId.class));
+    String scheduleJson = GSON.toJson(schedule, Id.NamespacedId.class);
+    Assert.assertEquals(schedule, GSON.fromJson(scheduleJson, Id.NamespacedId.class));
+    String workerJson = GSON.toJson(worker, Id.NamespacedId.class);
+    Assert.assertEquals(worker, GSON.fromJson(workerJson, Id.NamespacedId.class));
+    String workflowJson = GSON.toJson(workflow, Id.NamespacedId.class);
+    Assert.assertEquals(workflow, GSON.fromJson(workflowJson, Id.NamespacedId.class));
+    String datasetJson = GSON.toJson(dataset, Id.NamespacedId.class);
+    Assert.assertEquals(dataset, GSON.fromJson(datasetJson, Id.NamespacedId.class));
+    String streamJson = GSON.toJson(stream, Id.NamespacedId.class);
+    Assert.assertEquals(stream, GSON.fromJson(streamJson, Id.NamespacedId.class));
+  }
+
+  @Test
+  public void testWithMetadataRecord() {
+    Map<String, String> properties = ImmutableMap.of("key1", "value1", "k1", "v1");
+    List<String> tags = ImmutableList.of("tag1", "t1");
+    // verify with Id.Application
+    MetadataRecord appRecord = new MetadataRecord(app, properties, tags);
+    String appRecordJson = GSON.toJson(appRecord);
+    Assert.assertEquals(appRecord, GSON.fromJson(appRecordJson, MetadataRecord.class));
+    // verify with Id.Program
+    MetadataRecord programRecord = new MetadataRecord(program, properties, tags);
+    String programRecordJson = GSON.toJson(programRecord);
+    Assert.assertEquals(programRecord, GSON.fromJson(programRecordJson, MetadataRecord.class));
+    // verify with Id.Flow
+    MetadataRecord flowRecord = new MetadataRecord(flow, properties, tags);
+    String flowRecordJson = GSON.toJson(flowRecord);
+    Assert.assertEquals(flowRecord, GSON.fromJson(flowRecordJson, MetadataRecord.class));
+    // verify with Id.Flow.Flowlet
+    MetadataRecord flowletRecord = new MetadataRecord(flowlet, properties, tags);
+    String flowletRecordJson = GSON.toJson(flowletRecord);
+    Assert.assertEquals(flowletRecord, GSON.fromJson(flowletRecordJson, MetadataRecord.class));
+    // verify with Id.Service
+    MetadataRecord serviceRecord = new MetadataRecord(service, properties, tags);
+    String serviceRecordJson = GSON.toJson(serviceRecord);
+    Assert.assertEquals(serviceRecord, GSON.fromJson(serviceRecordJson, MetadataRecord.class));
+    // verify with Id.Schedule
+    MetadataRecord scheduleRecord = new MetadataRecord(schedule, properties, tags);
+    String scheduleRecordJson = GSON.toJson(scheduleRecord);
+    Assert.assertEquals(scheduleRecord, GSON.fromJson(scheduleRecordJson, MetadataRecord.class));
+    // verify with Id.Worker
+    MetadataRecord workerRecord = new MetadataRecord(worker, properties, tags);
+    String workerRecordJson = GSON.toJson(workerRecord);
+    Assert.assertEquals(workerRecord, GSON.fromJson(workerRecordJson, MetadataRecord.class));
+    // verify with Id.Workflow
+    MetadataRecord workflowRecord = new MetadataRecord(workflow, properties, tags);
+    String workflowRecordJson = GSON.toJson(workflowRecord);
+    Assert.assertEquals(workflowRecord, GSON.fromJson(workflowRecordJson, MetadataRecord.class));
+    // verify with Id.DatasetInstance
+    MetadataRecord datasetRecord = new MetadataRecord(dataset, properties, tags);
+    String datasetRecordJson = GSON.toJson(datasetRecord);
+    Assert.assertEquals(datasetRecord, GSON.fromJson(datasetRecordJson, MetadataRecord.class));
+    // verify with Id.Stream
+    MetadataRecord streamRecord = new MetadataRecord(stream, properties, tags);
+    String streamRecordJson = GSON.toJson(streamRecord);
+    Assert.assertEquals(streamRecord, GSON.fromJson(streamRecordJson, MetadataRecord.class));
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void testUnsupported() {
+    Id.DatasetModule module = Id.DatasetModule.from(ns, "module");
+    String moduleJson = GSON.toJson(module, Id.NamespacedId.class);
+    GSON.fromJson(moduleJson, Id.NamespacedId.class);
+  }
+}


### PR DESCRIPTION
…lizing a 'type' key for use during deserialization. Currently only supports subclasses of Id.NamespacedId that are supported in the metadata system.

This will be used at multiple places in the metadata system.

Build: http://builds.cask.co/browse/CDAP-DUT2839