### PR TITLE
Fix Doc Build: example includes

### DIFF
--- a/cdap-docs/_common/common-build.sh
+++ b/cdap-docs/_common/common-build.sh
@@ -366,15 +366,6 @@ function set_message() {
   else
     MESSAGES="${MESSAGES}\n\n${*}"
   fi
-  if [ "x${TMP_MESSAGES_FILE}" != "x" ]; then
-    if [ -e ${TMP_MESSAGES_FILE} ]; then
-      # As TMP_MESSAGES_FILE exists, add a blank line to start new message
-      echo >> ${TMP_MESSAGES_FILE}
-    fi
-    echo_red_bold "Warning Message for \"${MANUAL}\":" >> ${TMP_MESSAGES_FILE}
-    echo >> ${TMP_MESSAGES_FILE}
-    printf "${*}\n" >> ${TMP_MESSAGES_FILE}
-  fi
 }
 
 function consolidate_messages() {
@@ -382,9 +373,13 @@ function consolidate_messages() {
     return
   fi
   local m="Warning Messages for \"${MANUAL}\":"
+  local l="--------------------------------------------------------"
   if [ "x${MESSAGES}" != "x" ]; then
     echo_red_bold "Consolidating messages" 
+    echo >> ${TMP_MESSAGES_FILE}
     echo_red_bold "${m}" >> ${TMP_MESSAGES_FILE}
+    echo ${l} >> ${TMP_MESSAGES_FILE}
+    echo >> ${TMP_MESSAGES_FILE}
     printf "${MESSAGES}\n" >> ${TMP_MESSAGES_FILE}
     unset -v MESSAGES
   fi
@@ -393,6 +388,7 @@ function consolidate_messages() {
     m="Sphinx ${m}"
     echo >> ${TMP_MESSAGES_FILE}
     echo_red_bold "${m}" >> ${TMP_MESSAGES_FILE}
+    echo ${l} >> ${TMP_MESSAGES_FILE}
     echo >> ${TMP_MESSAGES_FILE}
     cat ${TARGET}/${SPHINX_MESSAGES} | while read line
     do
@@ -417,6 +413,7 @@ function display_messages_file() {
     echo "--------------------------------------------------------"
     echo_red_bold "End Warning Messages"
     echo "--------------------------------------------------------"
+    echo
     warnings=1 # Indicates warning messages present
   fi
   return ${warnings}

--- a/cdap-docs/developers-manual/build.sh
+++ b/cdap-docs/developers-manual/build.sh
@@ -82,7 +82,7 @@ function download_includes() {
   download_readme_file_and_test ${includes_dir} ${ingest_url} 5fc88ec3a658062775403f5be30afbe9 cdap-stream-clients/ruby
 
   echo_red_bold "Check included example files for changes"
-  test_an_include 12e10950a1c42401d229f549b77c5b7d ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryBuilder.java
+  test_an_include f03add3234d3f30b7994506baf1de085 ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryBuilder.java
   test_an_include 80216a08a2b3d480e4a081722408222f ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryService.java
   test_an_include 29fe1471372678115e643b0ad431b28d ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseStore.java
   test_an_include 57d7e810f37e2bd9fdcb4e25cd9d9150 ../../cdap-examples/SparkPageRank/src/main/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankApp.java

--- a/cdap-docs/developers-manual/source/building-blocks/mapreduce-programs.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/mapreduce-programs.rst
@@ -180,7 +180,7 @@ are set:
 
 .. literalinclude:: /../../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryBuilder.java
    :language: java
-   :lines: 45-56
+   :lines: 44-55
 
 The Resources API, if called with two arguments, sets both the memory used in megabytes
 and the number of virtual cores used.

--- a/cdap-docs/examples-manual/build.sh
+++ b/cdap-docs/examples-manual/build.sh
@@ -141,8 +141,7 @@ function download_includes() {
   test_an_include 77d244f968d508d9ea2d91e463065b68 ../../cdap-examples/CountRandom/src/main/java/co/cask/cdap/examples/countrandom/NumberSplitter.java
   test_an_include 9f963a17090976d2c15a4d092bd9e8de ../../cdap-examples/CountRandom/src/main/java/co/cask/cdap/examples/countrandom/NumberCounter.java
   
-  test_an_include 64599f425033bbf0537dacd1f2d615d8 ../../cdap-examples/DataCleansing/src/main/java/co/cask/cdap/examples/datacleansing/DataCleansing.java
-  test_an_include d807b8ed114c25b8af546e0309089478 ../../cdap-examples/DataCleansing/src/main/java/co/cask/cdap/examples/datacleansing/DataCleansingMapReduce.java
+  test_an_include 1064c8ce80d70df4bb8d4c62a4549e64 ../../cdap-examples/DataCleansing/src/main/java/co/cask/cdap/examples/datacleansing/DataCleansingMapReduce.java
 
   test_an_include 8a7b4aacee88800cd82d96b07280cc64 ../../cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetExample.java
   test_an_include 2ad024c8093bea2b3cb9b5fa14f1224b ../../cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetService.java
@@ -154,7 +153,7 @@ function download_includes() {
   
   test_an_include cdd3edfefe86857da8f41889d433d434 ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseApp.java
   test_an_include 29fe1471372678115e643b0ad431b28d ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseStore.java
-  test_an_include 12e10950a1c42401d229f549b77c5b7d ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryBuilder.java
+  test_an_include f03add3234d3f30b7994506baf1de085 ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryBuilder.java
   test_an_include 80216a08a2b3d480e4a081722408222f ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryService.java
 
   test_an_include 050cde0eb54b20803e65aae63b11143d ../../cdap-examples/SparkKMeans/src/main/java/co/cask/cdap/examples/sparkkmeans/SparkKMeansApp.java

--- a/cdap-docs/examples-manual/source/examples/data-cleansing.rst
+++ b/cdap-docs/examples-manual/source/examples/data-cleansing.rst
@@ -111,7 +111,7 @@ Otherwise, the default schema that is matched against the records:
 
 .. literalinclude:: /../../../cdap-examples/DataCleansing/src/main/java/co/cask/cdap/examples/datacleansing/DataCleansingMapReduce.java
     :language: java
-    :lines: 112-116
+    :lines: 138-142
 
 Querying the Results
 --------------------

--- a/cdap-docs/examples-manual/source/examples/purchase.rst
+++ b/cdap-docs/examples-manual/source/examples/purchase.rst
@@ -99,9 +99,7 @@ default values used in configuration and as runtime arguments:
 
 .. literalinclude:: /../../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryBuilder.java
    :language: java
-   :lines: 40-75
-   :start-after: */
-   :end-before: /**
+   :lines: 44-73
 
 ``PurchaseHistoryService`` Service
 ----------------------------------


### PR DESCRIPTION
Removes duplicate messages in the warnings in the doc build log.
Fixes the included files, both for line numbers and MD5 hashes.

Built successfully: http://builds.cask.co/browse/CDAP-DDBD571-1