### PR TITLE
CDAP-3605 Intercept entitiy deletion to also remove metadata.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ApplicationLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ApplicationLifecycleService.java
@@ -712,8 +712,9 @@ public class ApplicationLifecycleService extends AbstractIdleService {
 
     // Remove business metadata for the programs of the Application
     // TODO: Need to remove this we support prefix search of metadata type.
+    ApplicationSpecification appSpec = store.getApplication(appId);
     for (ProgramType programType : ProgramType.values()) {
-      deleteProgramBusinessMetadataForApp(programType, appId);
+      deleteProgramBusinessMetadataForApp(programType, appId, appSpec);
     }
   }
 
@@ -721,10 +722,9 @@ public class ApplicationLifecycleService extends AbstractIdleService {
    *  Delete the business metadata for a program type in an application.
    *  TODO: Need to remove this we support prefix search of metadata type.
    */
-  private void deleteProgramBusinessMetadataForApp(ProgramType programType, Id.Application appId) {
-    ApplicationSpecification appSpec = store.getApplication(appId);
+  private void deleteProgramBusinessMetadataForApp(ProgramType programType, Id.Application appId,
+                                                   ApplicationSpecification appSpec) {
     Set<String> programNames = null;
-
     switch (programType) {
       case FLOW:
         programNames = appSpec.getFlows().keySet();

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/FileStreamAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/FileStreamAdmin.java
@@ -28,6 +28,7 @@ import co.cask.cdap.data.stream.StreamFileOffset;
 import co.cask.cdap.data.stream.StreamUtils;
 import co.cask.cdap.data.stream.service.StreamMetaStore;
 import co.cask.cdap.data2.metadata.lineage.AccessType;
+import co.cask.cdap.data2.metadata.service.BusinessMetadataStore;
 import co.cask.cdap.data2.metadata.writer.LineageWriter;
 import co.cask.cdap.data2.registry.UsageRegistry;
 import co.cask.cdap.explore.client.ExploreFacade;
@@ -84,6 +85,7 @@ public class FileStreamAdmin implements StreamAdmin {
   private final StreamMetaStore streamMetaStore;
   private final ExploreTableNaming tableNaming;
   private ExploreFacade exploreFacade;
+  private final BusinessMetadataStore businessMds;
 
   @Inject
   public FileStreamAdmin(NamespacedLocationFactory namespacedLocationFactory,
@@ -94,7 +96,8 @@ public class FileStreamAdmin implements StreamAdmin {
                          UsageRegistry usageRegistry,
                          LineageWriter lineageWriter,
                          StreamMetaStore streamMetaStore,
-                         ExploreTableNaming tableNaming) {
+                         ExploreTableNaming tableNaming,
+                         BusinessMetadataStore businessMds) {
     this.namespacedLocationFactory = namespacedLocationFactory;
     this.cConf = cConf;
     this.notificationFeedManager = notificationFeedManager;
@@ -105,6 +108,7 @@ public class FileStreamAdmin implements StreamAdmin {
     this.lineageWriter = lineageWriter;
     this.streamMetaStore = streamMetaStore;
     this.tableNaming = tableNaming;
+    this.businessMds = businessMds;
   }
 
   @SuppressWarnings("unused")
@@ -415,6 +419,10 @@ public class FileStreamAdmin implements StreamAdmin {
           Locations.mkdirsIfNotExists(deleted);
           streamLocation.renameTo(deleted.append(streamId.getId() + System.currentTimeMillis()));
           streamMetaStore.removeStream(streamId);
+
+          // Remove metadata for the stream
+          businessMds.removeProperties(streamId);
+          businessMds.removeTags(streamId);
         } catch (Exception e) {
           throw Throwables.propagate(e);
         }


### PR DESCRIPTION
Intercept the entity deletion of App, Program, Dataset, and Stream so it also remove the corresponding business metadata (property and tags).