### PR TITLE
Feature/package maintainer scripts update

### DIFF
--- a/cdap-distributions/src/debian/scripts/common-postinst
+++ b/cdap-distributions/src/debian/scripts/common-postinst
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-distributions/src/debian/scripts/common-postinst
+++ b/cdap-distributions/src/debian/scripts/common-postinst
@@ -16,7 +16,7 @@
 # the License.
 #
 
-#COMMON  post install script for <%= project %>
+# postinstall script for <%= project %>
 set -e
 
 package_name="<%= project %>"

--- a/cdap-distributions/src/debian/scripts/common-preinst
+++ b/cdap-distributions/src/debian/scripts/common-preinst
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-distributions/src/debian/scripts/common-preinst
+++ b/cdap-distributions/src/debian/scripts/common-preinst
@@ -16,7 +16,7 @@
 # the License.
 #
 
-#COMMON  post install script for <%= project %>
+# preinstall script for <%= project %>
 set -e
 
 package_name="<%= project %>"

--- a/cdap-distributions/src/debian/scripts/common-prerm
+++ b/cdap-distributions/src/debian/scripts/common-prerm
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-distributions/src/debian/scripts/common-prerm
+++ b/cdap-distributions/src/debian/scripts/common-prerm
@@ -16,8 +16,7 @@
 # the License.
 #
 
-
-#COMMON  pre remove script for <%= project %>
+# prerm script for <%= project %>
 set -e
 
 package_name="<%= project %>"

--- a/cdap-distributions/src/debian/scripts/postinst
+++ b/cdap-distributions/src/debian/scripts/postinst
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-distributions/src/debian/scripts/postinst
+++ b/cdap-distributions/src/debian/scripts/postinst
@@ -33,7 +33,7 @@ case "$1" in
     chmod +x /opt/cdap/$package_name/bin/service
 
     if stat -t /opt/cdap/$package_name/conf/*-env.sh >/dev/null 2>&1 ; then
-      find /opt/cdap/$package_name/conf -name '*-env.sh' | xargs -n1 basename | sed 's/-env.sh//' | while read svcname; do
+      find -L /opt/cdap/$package_name/conf -name '*-env.sh' | xargs -n1 basename | sed 's/-env.sh//' | while read svcname; do
         # refresh internal symlinks
         if [ -h "/opt/cdap/$package_name/bin/svc-$svcname" ]; then
           unlink /opt/cdap/$package_name/bin/svc-$svcname

--- a/cdap-distributions/src/debian/scripts/postinst
+++ b/cdap-distributions/src/debian/scripts/postinst
@@ -16,8 +16,7 @@
 # the License.
 #
 
-
-# post install script for <%= project %>
+# postinstall script for <%= project %>
 set -e
 
 package_name="<%= project %>"

--- a/cdap-distributions/src/debian/scripts/postrm
+++ b/cdap-distributions/src/debian/scripts/postrm
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-distributions/src/debian/scripts/postrm
+++ b/cdap-distributions/src/debian/scripts/postrm
@@ -16,7 +16,7 @@
 # the License.
 #
 
-# post remove script for <%= project %>
+# postrm script for <%= project %>
 set -e
 
 package_name="<%= project %>"

--- a/cdap-distributions/src/debian/scripts/prerm
+++ b/cdap-distributions/src/debian/scripts/prerm
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-distributions/src/debian/scripts/prerm
+++ b/cdap-distributions/src/debian/scripts/prerm
@@ -16,7 +16,7 @@
 # the License.
 #
 
-# pre remove script for <%= project %>
+# prerm script for <%= project %>
 set -e
 
 package_name="<%= project %>"

--- a/cdap-distributions/src/debian/scripts/prerm
+++ b/cdap-distributions/src/debian/scripts/prerm
@@ -25,7 +25,7 @@ version="<%= @version %>"
 case "$1" in
     remove)
       if stat -t /opt/cdap/$package_name/conf/*-env.sh >/dev/null 2>&1 ; then
-        find /opt/cdap/$package_name/conf -name '*-env.sh' | xargs -n1 basename | sed 's/-env.sh//' | while read svcname; do
+        find -L /opt/cdap/$package_name/conf -name '*-env.sh' | xargs -n1 basename | sed 's/-env.sh//' | while read svcname; do
           # stop each service
           if [ -x "/etc/init.d/cdap-$svcname" ]; then
             invoke-rc.d cdap-$svcname stop || :
@@ -40,7 +40,7 @@ case "$1" in
 
     upgrade|deconfigure)
       if stat -t /opt/cdap/$package_name/conf/*-env.sh >/dev/null 2>&1 ; then
-        find /opt/cdap/$package_name/conf -name '*-env.sh' | xargs -n1 basename | sed 's/-env.sh//' | while read svcname; do
+        find -L /opt/cdap/$package_name/conf -name '*-env.sh' | xargs -n1 basename | sed 's/-env.sh//' | while read svcname; do
           if [ -h "/opt/cdap/$package_name/bin/svc-$svcname" ]; then
             unlink /opt/cdap/$package_name/bin/svc-$svcname > /dev/null 2>&1 ||:
           fi

--- a/cdap-distributions/src/rpm/scripts/common-postinst
+++ b/cdap-distributions/src/rpm/scripts/common-postinst
@@ -14,7 +14,7 @@
 # the License.
 #
 
-# post install script for <%= project %>
+# postinstall script for <%= project %>
 
 package_name="<%= project %>"
 version="<%= @version %>"

--- a/cdap-distributions/src/rpm/scripts/common-postinst
+++ b/cdap-distributions/src/rpm/scripts/common-postinst
@@ -1,5 +1,5 @@
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-distributions/src/rpm/scripts/common-preinst
+++ b/cdap-distributions/src/rpm/scripts/common-preinst
@@ -1,5 +1,5 @@
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-distributions/src/rpm/scripts/common-preinst
+++ b/cdap-distributions/src/rpm/scripts/common-preinst
@@ -14,7 +14,7 @@
 # the License.
 #
 
-# pre install script for <%= project %>
+# preinstall script for <%= project %>
 
 package_name="<%= project %>"
 version="<%= @version %>"

--- a/cdap-distributions/src/rpm/scripts/common-prerm
+++ b/cdap-distributions/src/rpm/scripts/common-prerm
@@ -1,5 +1,5 @@
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-distributions/src/rpm/scripts/common-prerm
+++ b/cdap-distributions/src/rpm/scripts/common-prerm
@@ -14,7 +14,7 @@
 # the License.
 #
 
-# pre remove script for <%= project %>
+# prerm script for <%= project %>
 
 package_name="<%= project %>"
 version="<%= @version %>"

--- a/cdap-distributions/src/rpm/scripts/postinst
+++ b/cdap-distributions/src/rpm/scripts/postinst
@@ -27,7 +27,7 @@ chown -R cdap.cdap /var/run/cdap
 chown -R cdap.cdap /var/cdap/run
 chmod +x /opt/cdap/$package_name/bin/service
 if stat -t /opt/cdap/$package_name/conf/*-env.sh >/dev/null 2>&1 ; then
-  find /opt/cdap/$package_name/conf -name '*-env.sh' | xargs -n1 basename | sed 's/-env.sh//' | while read svcname; do
+  find -L /opt/cdap/$package_name/conf -name '*-env.sh' | xargs -n1 basename | sed 's/-env.sh//' | while read svcname; do
     if [[ -h /opt/cdap/$package_name/bin/svc-$svcname ]]; then
       unlink /opt/cdap/$package_name/bin/svc-$svcname
     fi

--- a/cdap-distributions/src/rpm/scripts/postinst
+++ b/cdap-distributions/src/rpm/scripts/postinst
@@ -14,7 +14,7 @@
 # the License.
 #
 
-# post install script for <%= project %>
+# postinstall script for <%= project %>
 
 package_name="<%= project %>"
 version="<%= @version %>"

--- a/cdap-distributions/src/rpm/scripts/postinst
+++ b/cdap-distributions/src/rpm/scripts/postinst
@@ -1,5 +1,5 @@
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-distributions/src/rpm/scripts/postrm
+++ b/cdap-distributions/src/rpm/scripts/postrm
@@ -22,7 +22,7 @@ version="<%= @version %>"
 # if remaining packages after uninstall, perform conditional restart
 if [ $1 -ge 1 ]; then 
   if stat -t /opt/cdap/$package_name/conf/*-env.sh >/dev/null 2>&1 ; then
-    find /opt/cdap/$package_name/conf -name '*-env.sh' | xargs -n1 basename | sed 's/-env.sh//' | while read svcname; do
+    find -L /opt/cdap/$package_name/conf -name '*-env.sh' | xargs -n1 basename | sed 's/-env.sh//' | while read svcname; do
       for svcname in `ls /opt/cdap/$package_name/conf/*-env.sh | xargs -n1 basename | sed 's/-env.sh//'` ; do
         service cdap-$svcname condrestart > /dev/null 2>&1
       done

--- a/cdap-distributions/src/rpm/scripts/postrm
+++ b/cdap-distributions/src/rpm/scripts/postrm
@@ -1,5 +1,5 @@
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-distributions/src/rpm/scripts/prerm
+++ b/cdap-distributions/src/rpm/scripts/prerm
@@ -22,7 +22,7 @@ version="<%= @version %>"
 # if no remaining packages installed, stop and remove the service link
 if [ $1 = 0 ]; then 
   if stat -t /opt/cdap/$package_name/conf/*-env.sh >/dev/null 2>&1 ; then
-    find /opt/cdap/$package_name/conf -name '*-env.sh' | xargs -n1 basename | sed 's/-env.sh//' | while read svcname; do
+    find -L /opt/cdap/$package_name/conf -name '*-env.sh' | xargs -n1 basename | sed 's/-env.sh//' | while read svcname; do
       service cdap-$svcname stop > /dev/null 2>&1
       if [[ -h /opt/cdap/$package_name/bin/svc-$svcname ]]; then
         unlink /opt/cdap/$package_name/bin/svc-$svcname > /dev/null 2>&1

--- a/cdap-distributions/src/rpm/scripts/prerm
+++ b/cdap-distributions/src/rpm/scripts/prerm
@@ -1,5 +1,5 @@
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of


### PR DESCRIPTION
Fixes CDAP-3646

- [x] adds ``-L`` to all find commands, so that it will accommodate certain internal tools that symlink package-owned files out to alternate locations
- [x] fixes/formats the file header comments