### PR TITLE
CDAP-2966 In case of internal server error while handling the request send more information in the response body.

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/HttpExceptionHandler.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/HttpExceptionHandler.java
@@ -53,10 +53,9 @@ public class HttpExceptionHandler extends ExceptionHandler {
       logWithTrace(request, t);
       responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);
     } else {
-      LOG.error("Unexpected error: request={} {} user={}:",
-                request.getMethod().getName(), request.getUri(),
+      LOG.error("Unexpected error: request={} {} user={}:", request.getMethod().getName(), request.getUri(),
                 SecurityRequestContext.getUserId().or("<null>"), t);
-      responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
+      responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, Throwables.getRootCause(t).getMessage());
     }
   }
 


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-2966
Build: http://builds.cask.co/browse/CDAP-DUT2853-1

In `DatasetServiceClient`, we call http handlers for the desired functionality and check the response code. If the response code is not `OK`, we throw `DatasetManagementException` with response body as a part of exception message. However `HttpExceptionHandler` while sending the `INTERNAL_SERVER_ERROR` response, sends an empty message in the response string. This causes the appropriate message to be not propagated till the UI.    
