### PR TITLE
CDAP-3605 Entity deletion should remove its metadata.

### DIFF
--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/DFSStreamFileJanitorTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/DFSStreamFileJanitorTest.java
@@ -29,6 +29,8 @@ import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data.runtime.TransactionMetricsModule;
 import co.cask.cdap.data.stream.service.InMemoryStreamMetaStore;
 import co.cask.cdap.data.stream.service.StreamMetaStore;
+import co.cask.cdap.data2.metadata.service.BusinessMetadataStore;
+import co.cask.cdap.data2.metadata.service.NoOpBusinessMetadataStore;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.data2.transaction.stream.StreamConfig;
 import co.cask.cdap.notifications.feeds.NotificationFeedManager;
@@ -63,6 +65,7 @@ public class DFSStreamFileJanitorTest extends StreamFileJanitorTestBase {
 
   @BeforeClass
   public static void init() throws IOException {
+
     Configuration hConf = new Configuration();
     hConf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, tmpFolder.newFolder().getAbsolutePath());
     dfsCluster = new MiniDFSCluster.Builder(hConf).numDataNodes(1).build();
@@ -83,7 +86,12 @@ public class DFSStreamFileJanitorTest extends StreamFileJanitorTestBase {
       new TransactionMetricsModule(),
       new DiscoveryRuntimeModule().getInMemoryModules(),
       new DataFabricModules().getDistributedModules(),
-      new DataSetsModules().getDistributedModules(),
+      Modules.override(new DataSetsModules().getDistributedModules()).with(new AbstractModule() {
+        @Override
+        protected void configure() {
+          bind(BusinessMetadataStore.class).to(NoOpBusinessMetadataStore.class);
+        }
+      }),
       Modules.override(new StreamAdminModules().getDistributedModules()).with(new AbstractModule() {
 
         @Override

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/DistributedStreamCoordinatorClientTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/DistributedStreamCoordinatorClientTest.java
@@ -26,6 +26,8 @@ import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data.runtime.TransactionMetricsModule;
 import co.cask.cdap.data.stream.service.InMemoryStreamMetaStore;
 import co.cask.cdap.data.stream.service.StreamMetaStore;
+import co.cask.cdap.data2.metadata.service.BusinessMetadataStore;
+import co.cask.cdap.data2.metadata.service.NoOpBusinessMetadataStore;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.notifications.feeds.guice.NotificationFeedServiceRuntimeModule;
 import com.google.inject.AbstractModule;
@@ -74,7 +76,12 @@ public class DistributedStreamCoordinatorClientTest extends StreamCoordinatorTes
       new ZKClientModule(),
       new DiscoveryRuntimeModule().getDistributedModules(),
       new DataFabricModules().getDistributedModules(),
-      new DataSetsModules().getDistributedModules(),
+      Modules.override(new DataSetsModules().getDistributedModules()).with(new AbstractModule() {
+        @Override
+        protected void configure() {
+          bind(BusinessMetadataStore.class).to(NoOpBusinessMetadataStore.class);
+        }
+      }),
       new TransactionMetricsModule(),
       new NotificationFeedServiceRuntimeModule().getInMemoryModules(),
       new AbstractModule() {

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/distributed/TransactionServiceClientTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/distributed/TransactionServiceClientTest.java
@@ -25,6 +25,8 @@ import co.cask.cdap.common.utils.Networks;
 import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data.runtime.TransactionMetricsModule;
+import co.cask.cdap.data2.metadata.service.BusinessMetadataStore;
+import co.cask.cdap.data2.metadata.service.NoOpBusinessMetadataStore;
 import co.cask.tephra.Transaction;
 import co.cask.tephra.TransactionSystemClient;
 import co.cask.tephra.TransactionSystemTest;
@@ -33,8 +35,10 @@ import co.cask.tephra.distributed.TransactionService;
 import co.cask.tephra.persist.TransactionSnapshot;
 import co.cask.tephra.persist.TransactionStateStorage;
 import co.cask.tephra.snapshot.SnapshotCodecProvider;
+import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import com.google.inject.util.Modules;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseTestingUtility;
 import org.apache.twill.internal.zookeeper.InMemoryZKServer;
@@ -102,7 +106,12 @@ public class TransactionServiceClientTest extends TransactionSystemTest {
       new DiscoveryRuntimeModule().getDistributedModules(),
       new TransactionMetricsModule(),
       new DataFabricModules().getDistributedModules(),
-      new DataSetsModules().getDistributedModules());
+      Modules.override(new DataSetsModules().getDistributedModules()).with(new AbstractModule() {
+        @Override
+        protected void configure() {
+          bind(BusinessMetadataStore.class).to(NoOpBusinessMetadataStore.class);
+        }
+      }));
 
     zkClient = injector.getInstance(ZKClientService.class);
     zkClient.startAndWait();

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/distributed/TransactionServiceTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/distributed/TransactionServiceTest.java
@@ -30,6 +30,8 @@ import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;
 import co.cask.cdap.data.runtime.TransactionMetricsModule;
 import co.cask.cdap.data2.dataset2.lib.table.inmemory.InMemoryTable;
 import co.cask.cdap.data2.dataset2.lib.table.inmemory.InMemoryTableService;
+import co.cask.cdap.data2.metadata.service.BusinessMetadataStore;
+import co.cask.cdap.data2.metadata.service.NoOpBusinessMetadataStore;
 import co.cask.tephra.DefaultTransactionExecutor;
 import co.cask.tephra.TransactionAware;
 import co.cask.tephra.TransactionExecutor;
@@ -38,8 +40,10 @@ import co.cask.tephra.TransactionSystemClient;
 import co.cask.tephra.TxConstants;
 import co.cask.tephra.distributed.TransactionService;
 import com.google.common.collect.ImmutableList;
+import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import com.google.inject.util.Modules;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseTestingUtility;
 import org.apache.twill.internal.zookeeper.InMemoryZKServer;
@@ -88,7 +92,12 @@ public class TransactionServiceTest {
         new DiscoveryRuntimeModule().getDistributedModules(),
         new TransactionMetricsModule(),
         new DataFabricModules().getDistributedModules(),
-        new DataSetsModules().getDistributedModules()
+        Modules.override(new DataSetsModules().getDistributedModules()).with(new AbstractModule() {
+          @Override
+          protected void configure() {
+            bind(BusinessMetadataStore.class).to(NoOpBusinessMetadataStore.class);
+          }
+        })
       );
 
       ZKClientService zkClient = injector.getInstance(ZKClientService.class);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataSetsModules.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataSetsModules.java
@@ -26,6 +26,9 @@ import co.cask.cdap.data2.dataset2.InMemoryDatasetFramework;
 import co.cask.cdap.data2.metadata.publisher.KafkaMetadataChangePublisher;
 import co.cask.cdap.data2.metadata.publisher.MetadataChangePublisher;
 import co.cask.cdap.data2.metadata.publisher.NoOpMetadataChangePublisher;
+import co.cask.cdap.data2.metadata.service.BusinessMetadataStore;
+import co.cask.cdap.data2.metadata.service.DefaultBusinessMetadataStore;
+import co.cask.cdap.data2.metadata.service.NoOpBusinessMetadataStore;
 import co.cask.cdap.data2.metadata.writer.BasicLineageWriter;
 import co.cask.cdap.data2.metadata.writer.LineageWriter;
 import co.cask.cdap.data2.metadata.writer.LineageWriterDatasetFramework;
@@ -55,6 +58,9 @@ public class DataSetsModules extends RuntimeModule {
                   .implement(DatasetDefinitionRegistry.class, DefaultDatasetDefinitionRegistry.class)
                   .build(DatasetDefinitionRegistryFactory.class));
 
+        bind(BusinessMetadataStore.class).to(NoOpBusinessMetadataStore.class);
+        expose(BusinessMetadataStore.class);
+
         bind(DatasetFramework.class)
           .annotatedWith(Names.named(BASIC_DATASET_FRAMEWORK))
           .to(InMemoryDatasetFramework.class).in(Scopes.SINGLETON);
@@ -83,6 +89,9 @@ public class DataSetsModules extends RuntimeModule {
                   .implement(DatasetDefinitionRegistry.class, DefaultDatasetDefinitionRegistry.class)
                   .build(DatasetDefinitionRegistryFactory.class));
 
+        bind(BusinessMetadataStore.class).to(DefaultBusinessMetadataStore.class);
+        expose(BusinessMetadataStore.class);
+
         bind(DatasetFramework.class)
           .annotatedWith(Names.named(BASIC_DATASET_FRAMEWORK))
           .to(RemoteDatasetFramework.class);
@@ -110,6 +119,9 @@ public class DataSetsModules extends RuntimeModule {
         install(new FactoryModuleBuilder()
                   .implement(DatasetDefinitionRegistry.class, DefaultDatasetDefinitionRegistry.class)
                   .build(DatasetDefinitionRegistryFactory.class));
+
+        bind(BusinessMetadataStore.class).to(DefaultBusinessMetadataStore.class);
+        expose(BusinessMetadataStore.class);
 
         bind(DatasetFramework.class)
           .annotatedWith(Names.named(BASIC_DATASET_FRAMEWORK))

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/service/BusinessMetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/service/BusinessMetadataStore.java
@@ -16,432 +16,84 @@
 
 package co.cask.cdap.data2.metadata.service;
 
-import co.cask.cdap.api.dataset.DatasetProperties;
-import co.cask.cdap.common.ServiceUnavailableException;
-import co.cask.cdap.common.conf.CConfiguration;
-import co.cask.cdap.common.conf.Constants;
-import co.cask.cdap.data.runtime.DataSetsModules;
-import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
-import co.cask.cdap.data2.dataset2.DatasetFramework;
-import co.cask.cdap.data2.dataset2.DatasetManagementException;
-import co.cask.cdap.data2.dataset2.tx.Transactional;
 import co.cask.cdap.data2.metadata.dataset.BusinessMetadataDataset;
 import co.cask.cdap.data2.metadata.dataset.BusinessMetadataRecord;
-import co.cask.cdap.data2.metadata.publisher.MetadataChangePublisher;
 import co.cask.cdap.proto.Id;
-import co.cask.cdap.proto.metadata.MetadataChangeRecord;
 import co.cask.cdap.proto.metadata.MetadataRecord;
 import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
-import co.cask.tephra.TransactionExecutor;
-import co.cask.tephra.TransactionExecutorFactory;
-import com.google.common.base.Supplier;
-import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterators;
-import com.google.common.collect.Sets;
-import com.google.inject.Inject;
-import com.google.inject.name.Named;
 
-import java.io.IOException;
-import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicReference;
 
 /**
- * Implements operations on {@link BusinessMetadataDataset} transactionally.
+ * Define operations on {@link BusinessMetadataDataset} transactionally.
  */
-public class BusinessMetadataStore {
-
-  private static final Id.DatasetInstance BUSINESS_METADATA_INSTANCE_ID =
-    Id.DatasetInstance.from(Id.Namespace.SYSTEM, "business.metadata");
-  private static final Map<String, String> EMPTY_PROPERTIES = ImmutableMap.of();
-  private static final Set<String> EMPTY_TAGS = ImmutableSet.of();
-
-  private final Transactional<BusinessMdsIterable, BusinessMetadataDataset> txnl;
-  private final CConfiguration cConf;
-  private final MetadataChangePublisher changePublisher;
-
-  @Inject
-  BusinessMetadataStore(TransactionExecutorFactory txExecutorFactory,
-                        @Named(DataSetsModules.BASIC_DATASET_FRAMEWORK) final DatasetFramework dsFramework,
-                        CConfiguration cConf, MetadataChangePublisher changePublisher) {
-    this.txnl = Transactional.of(txExecutorFactory, new Supplier<BusinessMdsIterable>() {
-      @Override
-      public BusinessMdsIterable get() {
-        try {
-          BusinessMetadataDataset dataset =
-            DatasetsUtil.getOrCreateDataset(dsFramework, BUSINESS_METADATA_INSTANCE_ID,
-                                            BusinessMetadataDataset.class.getName(),
-                                            DatasetProperties.EMPTY, null, null);
-            return new BusinessMdsIterable(dataset);
-        } catch (DatasetManagementException | IOException | ServiceUnavailableException e) {
-          throw Throwables.propagate(e);
-        }
-      }
-    });
-    this.cConf = cConf;
-    this.changePublisher = changePublisher;
-  }
+public interface BusinessMetadataStore {
 
   /**
    * Adds/updates metadata for the specified {@link Id.NamespacedId}.
    */
-  public void setProperties(final Id.NamespacedId entityId, final Map<String, String> properties) {
-    if (!cConf.getBoolean(Constants.Metadata.UPDATES_PUBLISH_ENABLED)) {
-      setPropertiesNoPublish(entityId, properties);
-      return;
-    }
-    final ImmutableMap.Builder<String, String> propAdditions = ImmutableMap.builder();
-    final ImmutableMap.Builder<String, String> propDeletions = ImmutableMap.builder();
-    final AtomicReference<MetadataRecord> previousRef = new AtomicReference<>();
-    txnl.executeUnchecked(new TransactionExecutor.Function<BusinessMdsIterable, Void>() {
-      @Override
-      public Void apply(BusinessMdsIterable input) throws Exception {
-        Map<String, String> existingProperties = input.businessMds.getProperties(entityId);
-        Set<String> existingTags = input.businessMds.getTags(entityId);
-        previousRef.set(new MetadataRecord(entityId, existingProperties, existingTags));
-        for (Map.Entry<String, String> entry : properties.entrySet()) {
-          String existingValue = existingProperties.get(entry.getKey());
-          if (existingValue != null && existingValue.equals(entry.getValue())) {
-            // Value already exists and is the same as the value being passed. No update necessary.
-            continue;
-          }
-          // At this point, its either an update of an existing property (1 addition + 1 deletion) or a new property.
-          // If it is an update, then mark a single deletion.
-          if (existingValue != null) {
-            propDeletions.put(entry.getKey(), existingValue);
-          }
-          // In both update or new cases, mark a single addition.
-          propAdditions.put(entry.getKey(), entry.getValue());
-          input.businessMds.setProperty(entityId, entry.getKey(), entry.getValue());
-        }
-        return null;
-      }
-    });
-    publish(previousRef.get(), new MetadataRecord(entityId, propAdditions.build(), EMPTY_TAGS),
-            new MetadataRecord(entityId, propDeletions.build(), EMPTY_TAGS));
-  }
-
-  private void setPropertiesNoPublish(final Id.NamespacedId entityId, final Map<String, String> properties) {
-    txnl.executeUnchecked(new TransactionExecutor.Function<BusinessMdsIterable, Void>() {
-      @Override
-      public Void apply(BusinessMdsIterable input) throws Exception {
-        for (Map.Entry<String, String> entry : properties.entrySet()) {
-          input.businessMds.setProperty(entityId, entry.getKey(), entry.getValue());
-        }
-        return null;
-      }
-    });
-  }
+  void setProperties(final Id.NamespacedId entityId, final Map<String, String> properties);
 
   /**
    * Adds tags for the specified {@link Id.NamespacedId}.
    */
-  public void addTags(final Id.NamespacedId entityId, final String ... tagsToAdd) {
-    if (!cConf.getBoolean(Constants.Metadata.UPDATES_PUBLISH_ENABLED)) {
-      addTagsNoPublish(entityId, tagsToAdd);
-      return;
-    }
-    final AtomicReference<MetadataRecord> previousRef = new AtomicReference<>();
-    txnl.executeUnchecked(new TransactionExecutor.Function<BusinessMdsIterable, Void>() {
-      @Override
-      public Void apply(BusinessMdsIterable input) throws Exception {
-        Map<String, String> existingProperties = input.businessMds.getProperties(entityId);
-        Set<String> existingTags = input.businessMds.getTags(entityId);
-        previousRef.set(new MetadataRecord(entityId, existingProperties, existingTags));
-        input.businessMds.addTags(entityId, tagsToAdd);
-        return null;
-      }
-    });
-    publish(previousRef.get(), new MetadataRecord(entityId, EMPTY_PROPERTIES, Sets.newHashSet(tagsToAdd)),
-            new MetadataRecord(entityId));
-  }
-
-  private void addTagsNoPublish(final Id.NamespacedId entityId, final String... tagsToAdd) {
-    txnl.executeUnchecked(new TransactionExecutor.Function<BusinessMdsIterable, Void>() {
-      @Override
-      public Void apply(BusinessMdsIterable input) throws Exception {
-        input.businessMds.addTags(entityId, tagsToAdd);
-        return null;
-      }
-    });
-  }
+  void addTags(final Id.NamespacedId entityId, final String ... tagsToAdd);
 
   /**
    * @return a {@link MetadataRecord} representing all the metadata (including properties and tags) for the specified
    * {@link Id.NamespacedId}.
    */
-  public MetadataRecord getMetadata(final Id.NamespacedId entityId) {
-    return txnl.executeUnchecked(new TransactionExecutor.Function<BusinessMdsIterable, MetadataRecord>() {
-      @Override
-      public MetadataRecord apply(BusinessMdsIterable input) throws Exception {
-        Map<String, String> properties = input.businessMds.getProperties(entityId);
-        Set<String> tags = input.businessMds.getTags(entityId);
-        return new MetadataRecord(entityId, properties, tags);
-      }
-    });
-  }
+  MetadataRecord getMetadata(final Id.NamespacedId entityId);
 
   /**
    * @return a set of {@link MetadataRecord}s representing all the metadata (including properties and tags)
    * for the specified set of {@link Id.NamespacedId}s.
    */
-  public Set<MetadataRecord> getMetadata(final Set<Id.NamespacedId> entityIds) {
-    return txnl.executeUnchecked(new TransactionExecutor.Function<BusinessMdsIterable, Set<MetadataRecord>>() {
-      @Override
-      public Set<MetadataRecord> apply(BusinessMdsIterable input) throws Exception {
-        Set<MetadataRecord> metadataRecords = new HashSet<>(entityIds.size());
-        for (Id.NamespacedId entityId : entityIds) {
-          Map<String, String> properties = input.businessMds.getProperties(entityId);
-          Set<String> tags = input.businessMds.getTags(entityId);
-          metadataRecords.add(new MetadataRecord(entityId, properties, tags));
-        }
-        return metadataRecords;
-      }
-    });
-  }
+  Set<MetadataRecord> getMetadata(final Set<Id.NamespacedId> entityIds);
 
   /**
    * @return the metadata for the specified {@link Id.NamespacedId}
    */
-  public Map<String, String> getProperties(final Id.NamespacedId entityId) {
-    return txnl.executeUnchecked(new TransactionExecutor.Function<BusinessMdsIterable, Map<String, String>>() {
-      @Override
-      public Map<String, String> apply(BusinessMdsIterable input) throws Exception {
-        return input.businessMds.getProperties(entityId);
-      }
-    });
-  }
+  Map<String, String> getProperties(final Id.NamespacedId entityId);
 
   /**
    * @return the tags for the specified {@link Id.NamespacedId}
    */
-  public Set<String> getTags(final Id.NamespacedId entityId) {
-    return txnl.executeUnchecked(new TransactionExecutor.Function<BusinessMdsIterable, Set<String>>() {
-      @Override
-      public Set<String> apply(BusinessMdsIterable input) throws Exception {
-        return input.businessMds.getTags(entityId);
-      }
-    });
-  }
+  Set<String> getTags(final Id.NamespacedId entityId);
 
   /**
    * Removes all metadata (including properties and tags) for the specified {@link Id.NamespacedId}.
    */
-  public void removeMetadata(final Id.NamespacedId entityId) {
-    if (!cConf.getBoolean(Constants.Metadata.UPDATES_PUBLISH_ENABLED)) {
-      removeMetadataNoPublish(entityId);
-      return;
-    }
-    final AtomicReference<MetadataRecord> previousRef = new AtomicReference<>();
-    txnl.executeUnchecked(new TransactionExecutor.Function<BusinessMdsIterable, Void>() {
-      @Override
-      public Void apply(BusinessMdsIterable input) throws Exception {
-        previousRef.set(new MetadataRecord(entityId, input.businessMds.getProperties(entityId),
-                                           input.businessMds.getTags(entityId)));
-        input.businessMds.removeProperties(entityId);
-        input.businessMds.removeTags(entityId);
-        return null;
-      }
-    });
-    MetadataRecord previous = previousRef.get();
-    publish(previous, new MetadataRecord(entityId), new MetadataRecord(previous));
-  }
-
-  public void removeMetadataNoPublish(final Id.NamespacedId entityId) {
-    txnl.executeUnchecked(new TransactionExecutor.Function<BusinessMdsIterable, Void>() {
-      @Override
-      public Void apply(BusinessMdsIterable input) throws Exception {
-        input.businessMds.removeProperties(entityId);
-        input.businessMds.removeTags(entityId);
-        return null;
-      }
-    });
-  }
+  void removeMetadata(final Id.NamespacedId entityId);
 
   /**
    * Removes all properties for the specified {@link Id.NamespacedId}.
    */
-  public void removeProperties(final Id.NamespacedId entityId) {
-    if (!cConf.getBoolean(Constants.Metadata.UPDATES_PUBLISH_ENABLED)) {
-      removePropertiesNoPublish(entityId);
-      return;
-    }
-    final AtomicReference<MetadataRecord> previousRef = new AtomicReference<>();
-    txnl.executeUnchecked(new TransactionExecutor.Function<BusinessMdsIterable, Void>() {
-      @Override
-      public Void apply(BusinessMdsIterable input) throws Exception {
-        previousRef.set(new MetadataRecord(entityId, input.businessMds.getProperties(entityId),
-                                           input.businessMds.getTags(entityId)));
-        input.businessMds.removeProperties(entityId);
-        return null;
-      }
-    });
-    publish(previousRef.get(), new MetadataRecord(entityId),
-            new MetadataRecord(entityId, previousRef.get().getProperties(), EMPTY_TAGS));
-  }
-
-  private void removePropertiesNoPublish(final Id.NamespacedId entityId) {
-    txnl.executeUnchecked(new TransactionExecutor.Function<BusinessMdsIterable, Void>() {
-      @Override
-      public Void apply(BusinessMdsIterable input) throws Exception {
-        input.businessMds.removeProperties(entityId);
-        return null;
-      }
-    });
-  }
+  void removeProperties(final Id.NamespacedId entityId);
 
   /**
    * Removes the specified properties of the {@link Id.NamespacedId}.
    */
-  public void removeProperties(final Id.NamespacedId entityId, final String... keys) {
-    if (!cConf.getBoolean(Constants.Metadata.UPDATES_PUBLISH_ENABLED)) {
-      removePropertiesNoPublish(entityId, keys);
-      return;
-    }
-    final AtomicReference<MetadataRecord> previousRef = new AtomicReference<>();
-    final ImmutableMap.Builder<String, String> deletesBuilder = ImmutableMap.builder();
-    txnl.executeUnchecked(new TransactionExecutor.Function<BusinessMdsIterable, Void>() {
-      @Override
-      public Void apply(BusinessMdsIterable input) throws Exception {
-        previousRef.set(new MetadataRecord(entityId, input.businessMds.getProperties(entityId),
-                                           input.businessMds.getTags(entityId)));
-        for (String key : keys) {
-          BusinessMetadataRecord record = input.businessMds.getProperty(entityId, key);
-          if (record == null) {
-            continue;
-          }
-          deletesBuilder.put(record.getKey(), record.getValue());
-        }
-        input.businessMds.removeProperties(entityId, keys);
-        return null;
-      }
-    });
-    publish(previousRef.get(), new MetadataRecord(entityId),
-            new MetadataRecord(entityId, deletesBuilder.build(), EMPTY_TAGS));
-  }
-
-  private void removePropertiesNoPublish(final Id.NamespacedId entityId, final String... keys) {
-    txnl.executeUnchecked(new TransactionExecutor.Function<BusinessMdsIterable, Void>() {
-      @Override
-      public Void apply(BusinessMdsIterable input) throws Exception {
-        input.businessMds.removeProperties(entityId, keys);
-        return null;
-      }
-    });
-  }
+  void removeProperties(final Id.NamespacedId entityId, final String... keys);
 
   /**
-   * Removes all the tags from the {@link Id.NamespacedId}
+   * Removes tags of the {@link Id.NamespacedId}.
    */
-  public void removeTags(final Id.NamespacedId entityId) {
-    if (!cConf.getBoolean(Constants.Metadata.UPDATES_PUBLISH_ENABLED)) {
-      removeTagsNoPublish(entityId);
-      return;
-    }
-    final AtomicReference<MetadataRecord> previousRef = new AtomicReference<>();
-    txnl.executeUnchecked(new TransactionExecutor.Function<BusinessMdsIterable, Void>() {
-      @Override
-      public Void apply(BusinessMdsIterable input) throws Exception {
-        previousRef.set(new MetadataRecord(entityId, input.businessMds.getProperties(entityId),
-                                           input.businessMds.getTags(entityId)));
-        input.businessMds.removeTags(entityId);
-        return null;
-      }
-    });
-    MetadataRecord previous = previousRef.get();
-    publish(previous, new MetadataRecord(entityId), new MetadataRecord(entityId, EMPTY_PROPERTIES, previous.getTags()));
-  }
-
-  public void removeTagsNoPublish(final Id.NamespacedId entityId) {
-    txnl.executeUnchecked(new TransactionExecutor.Function<BusinessMdsIterable, Void>() {
-      @Override
-      public Void apply(BusinessMdsIterable input) throws Exception {
-        input.businessMds.removeTags(entityId);
-        return null;
-      }
-    });
-  }
+  void removeTags(final Id.NamespacedId entityId);
 
   /**
    * Removes the specified tags from the {@link Id.NamespacedId}
    */
-  public void removeTags(final Id.NamespacedId entityId, final String ... tagsToRemove) {
-    if (!cConf.getBoolean(Constants.Metadata.UPDATES_PUBLISH_ENABLED)) {
-      removeTagsNoPublish(entityId, tagsToRemove);
-      return;
-    }
-    final AtomicReference<MetadataRecord> previousRef = new AtomicReference<>();
-    txnl.executeUnchecked(new TransactionExecutor.Function<BusinessMdsIterable, Void>() {
-      @Override
-      public Void apply(BusinessMdsIterable input) throws Exception {
-        previousRef.set(new MetadataRecord(entityId, input.businessMds.getProperties(entityId),
-                                           input.businessMds.getTags(entityId)));
-        input.businessMds.removeTags(entityId, tagsToRemove);
-        return null;
-      }
-    });
-    publish(previousRef.get(), new MetadataRecord(entityId),
-            new MetadataRecord(entityId, EMPTY_PROPERTIES, Sets.newHashSet(tagsToRemove)));
-  }
-
-  private void removeTagsNoPublish(final Id.NamespacedId entityId, final String ... tagsToRemove) {
-    txnl.executeUnchecked(new TransactionExecutor.Function<BusinessMdsIterable, Void>() {
-      @Override
-      public Void apply(BusinessMdsIterable input) throws Exception {
-        input.businessMds.removeTags(entityId, tagsToRemove);
-        return null;
-      }
-    });
-  }
+  void removeTags(final Id.NamespacedId entityId, final String ... tagsToRemove);
 
   /**
    * Search to the underlying Business Metadata Dataset.
    */
-  public Iterable<BusinessMetadataRecord> searchMetadata(final String searchQuery) {
-    return searchMetadataOnType(searchQuery, MetadataSearchTargetType.ALL);
-  }
+  Iterable<BusinessMetadataRecord> searchMetadata(String searchQuery);
 
   /**
    * Search to the underlying Business Metadata Dataset for a target type.
    */
-  public Iterable<BusinessMetadataRecord> searchMetadataOnType(final String searchQuery,
-                                                               final MetadataSearchTargetType type) {
-    return txnl.executeUnchecked(new TransactionExecutor.Function<BusinessMdsIterable,
-      Iterable<BusinessMetadataRecord>>() {
-      @Override
-      public Iterable<BusinessMetadataRecord> apply(BusinessMdsIterable input) throws Exception {
-        // Currently we support two types of search formats: value and key:value.
-        // Check for existence of separator char to make sure we did search in the right indexed column.
-        if (searchQuery.contains(BusinessMetadataDataset.KEYVALUE_SEPARATOR)) {
-          // key=value search
-          return input.businessMds.findBusinessMetadataOnKeyValue(searchQuery, type);
-        }
-        // value search
-        return input.businessMds.findBusinessMetadataOnValue(searchQuery, type);
-      }
-    });
-  }
-
-  private void publish(MetadataRecord previous, MetadataRecord additions, MetadataRecord deletions) {
-    MetadataChangeRecord.MetadataDiffRecord diff = new MetadataChangeRecord.MetadataDiffRecord(additions, deletions);
-    MetadataChangeRecord changeRecord = new MetadataChangeRecord(previous, diff, System.currentTimeMillis());
-    changePublisher.publish(changeRecord);
-  }
-
-  private static final class BusinessMdsIterable implements Iterable<BusinessMetadataDataset> {
-    private final BusinessMetadataDataset businessMds;
-
-    private BusinessMdsIterable(BusinessMetadataDataset mdsTable) {
-      this.businessMds = mdsTable;
-    }
-
-    @Override
-    public Iterator<BusinessMetadataDataset> iterator() {
-      return Iterators.singletonIterator(businessMds);
-    }
-  }
+  Iterable<BusinessMetadataRecord> searchMetadataOnType(String searchQuery, MetadataSearchTargetType type);
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/service/DefaultBusinessMetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/service/DefaultBusinessMetadataStore.java
@@ -1,0 +1,460 @@
+/*
+ * Copyright 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.data2.metadata.service;
+
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.common.ServiceUnavailableException;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.data.runtime.DataSetsModules;
+import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.dataset2.DatasetManagementException;
+import co.cask.cdap.data2.dataset2.tx.Transactional;
+import co.cask.cdap.data2.metadata.dataset.BusinessMetadataDataset;
+import co.cask.cdap.data2.metadata.dataset.BusinessMetadataRecord;
+import co.cask.cdap.data2.metadata.publisher.MetadataChangePublisher;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.metadata.MetadataChangeRecord;
+import co.cask.cdap.proto.metadata.MetadataRecord;
+import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
+import co.cask.tephra.TransactionExecutor;
+import co.cask.tephra.TransactionExecutorFactory;
+import com.google.common.base.Supplier;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Sets;
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Implementation of {@link BusinessMetadataStore} used in distributed mode.
+ */
+public class DefaultBusinessMetadataStore implements BusinessMetadataStore {
+
+  private static final Id.DatasetInstance BUSINESS_METADATA_INSTANCE_ID =
+    Id.DatasetInstance.from(Id.Namespace.SYSTEM, "business.metadata");
+  private static final Map<String, String> EMPTY_PROPERTIES = ImmutableMap.of();
+  private static final Set<String> EMPTY_TAGS = ImmutableSet.of();
+
+  private final Transactional<BusinessMdsIterable, BusinessMetadataDataset> txnl;
+  private final CConfiguration cConf;
+  private final MetadataChangePublisher changePublisher;
+
+  @Inject
+  DefaultBusinessMetadataStore(TransactionExecutorFactory txExecutorFactory,
+                               @Named(DataSetsModules.BASIC_DATASET_FRAMEWORK) final DatasetFramework dsFramework,
+                               CConfiguration cConf, MetadataChangePublisher changePublisher) {
+    this.txnl = Transactional.of(txExecutorFactory, new Supplier<BusinessMdsIterable>() {
+      @Override
+      public BusinessMdsIterable get() {
+        try {
+          BusinessMetadataDataset dataset =
+            DatasetsUtil.getOrCreateDataset(dsFramework, BUSINESS_METADATA_INSTANCE_ID,
+                                            BusinessMetadataDataset.class.getName(),
+                                            DatasetProperties.EMPTY, null, null);
+          return new BusinessMdsIterable(dataset);
+        } catch (DatasetManagementException | IOException | ServiceUnavailableException e) {
+          throw Throwables.propagate(e);
+        }
+      }
+    });
+    this.cConf = cConf;
+    this.changePublisher = changePublisher;
+  }
+
+  /**
+   * Adds/updates metadata for the specified {@link Id.NamespacedId}.
+   */
+  @Override
+  public void setProperties(final Id.NamespacedId entityId, final Map<String, String> properties) {
+    if (!cConf.getBoolean(Constants.Metadata.UPDATES_PUBLISH_ENABLED)) {
+      setPropertiesNoPublish(entityId, properties);
+      return;
+    }
+    final ImmutableMap.Builder<String, String> propAdditions = ImmutableMap.builder();
+    final ImmutableMap.Builder<String, String> propDeletions = ImmutableMap.builder();
+    final AtomicReference<MetadataRecord> previousRef = new AtomicReference<>();
+    txnl.executeUnchecked(new TransactionExecutor.Function<BusinessMdsIterable, Void>() {
+      @Override
+      public Void apply(BusinessMdsIterable input) throws Exception {
+        Map<String, String> existingProperties = input.businessMds.getProperties(entityId);
+        Set<String> existingTags = input.businessMds.getTags(entityId);
+        previousRef.set(new MetadataRecord(entityId, existingProperties, existingTags));
+        for (Map.Entry<String, String> entry : properties.entrySet()) {
+          String existingValue = existingProperties.get(entry.getKey());
+          if (existingValue != null && existingValue.equals(entry.getValue())) {
+            // Value already exists and is the same as the value being passed. No update necessary.
+            continue;
+          }
+          // At this point, its either an update of an existing property (1 addition + 1 deletion) or a new property.
+          // If it is an update, then mark a single deletion.
+          if (existingValue != null) {
+            propDeletions.put(entry.getKey(), existingValue);
+          }
+          // In both update or new cases, mark a single addition.
+          propAdditions.put(entry.getKey(), entry.getValue());
+          input.businessMds.setProperty(entityId, entry.getKey(), entry.getValue());
+        }
+        return null;
+      }
+    });
+    publish(previousRef.get(), new MetadataRecord(entityId, propAdditions.build(), EMPTY_TAGS),
+            new MetadataRecord(entityId, propDeletions.build(), EMPTY_TAGS));
+  }
+
+  private void setPropertiesNoPublish(final Id.NamespacedId entityId, final Map<String, String> properties) {
+    txnl.executeUnchecked(new TransactionExecutor.Function<BusinessMdsIterable, Void>() {
+      @Override
+      public Void apply(BusinessMdsIterable input) throws Exception {
+        for (Map.Entry<String, String> entry : properties.entrySet()) {
+          input.businessMds.setProperty(entityId, entry.getKey(), entry.getValue());
+        }
+        return null;
+      }
+    });
+  }
+
+  /**
+   * Adds tags for the specified {@link Id.NamespacedId}.
+   */
+  @Override
+  public void addTags(final Id.NamespacedId entityId, final String ... tagsToAdd) {
+    if (!cConf.getBoolean(Constants.Metadata.UPDATES_PUBLISH_ENABLED)) {
+      addTagsNoPublish(entityId, tagsToAdd);
+      return;
+    }
+    final AtomicReference<MetadataRecord> previousRef = new AtomicReference<>();
+    txnl.executeUnchecked(new TransactionExecutor.Function<BusinessMdsIterable, Void>() {
+      @Override
+      public Void apply(BusinessMdsIterable input) throws Exception {
+        Map<String, String> existingProperties = input.businessMds.getProperties(entityId);
+        Set<String> existingTags = input.businessMds.getTags(entityId);
+        previousRef.set(new MetadataRecord(entityId, existingProperties, existingTags));
+        input.businessMds.addTags(entityId, tagsToAdd);
+        return null;
+      }
+    });
+    publish(previousRef.get(), new MetadataRecord(entityId, EMPTY_PROPERTIES, Sets.newHashSet(tagsToAdd)),
+            new MetadataRecord(entityId));
+  }
+
+  private void addTagsNoPublish(final Id.NamespacedId entityId, final String... tagsToAdd) {
+    txnl.executeUnchecked(new TransactionExecutor.Function<BusinessMdsIterable, Void>() {
+      @Override
+      public Void apply(BusinessMdsIterable input) throws Exception {
+        input.businessMds.addTags(entityId, tagsToAdd);
+        return null;
+      }
+    });
+  }
+
+  /**
+   * @return a {@link MetadataRecord} representing all the metadata (including properties and tags) for the specified
+   * {@link Id.NamespacedId}.
+   */
+  @Override
+  public MetadataRecord getMetadata(final Id.NamespacedId entityId) {
+    return txnl.executeUnchecked(new TransactionExecutor.Function<BusinessMdsIterable, MetadataRecord>() {
+      @Override
+      public MetadataRecord apply(BusinessMdsIterable input) throws Exception {
+        Map<String, String> properties = input.businessMds.getProperties(entityId);
+        Set<String> tags = input.businessMds.getTags(entityId);
+        return new MetadataRecord(entityId, properties, tags);
+      }
+    });
+  }
+
+  /**
+   * @return a set of {@link MetadataRecord}s representing all the metadata (including properties and tags)
+   * for the specified set of {@link Id.NamespacedId}s.
+   */
+  @Override
+  public Set<MetadataRecord> getMetadata(final Set<Id.NamespacedId> entityIds) {
+    return txnl.executeUnchecked(new TransactionExecutor.Function<BusinessMdsIterable, Set<MetadataRecord>>() {
+      @Override
+      public Set<MetadataRecord> apply(BusinessMdsIterable input) throws Exception {
+        Set<MetadataRecord> metadataRecords = new HashSet<>(entityIds.size());
+        for (Id.NamespacedId entityId : entityIds) {
+          Map<String, String> properties = input.businessMds.getProperties(entityId);
+          Set<String> tags = input.businessMds.getTags(entityId);
+          metadataRecords.add(new MetadataRecord(entityId, properties, tags));
+        }
+        return metadataRecords;
+      }
+    });
+  }
+
+  /**
+   * @return the metadata for the specified {@link Id.NamespacedId}
+   */
+  @Override
+  public Map<String, String> getProperties(final Id.NamespacedId entityId) {
+    return txnl.executeUnchecked(new TransactionExecutor.Function<BusinessMdsIterable, Map<String, String>>() {
+      @Override
+      public Map<String, String> apply(BusinessMdsIterable input) throws Exception {
+        return input.businessMds.getProperties(entityId);
+      }
+    });
+  }
+
+  /**
+   * @return the tags for the specified {@link Id.NamespacedId}
+   */
+  @Override
+  public Set<String> getTags(final Id.NamespacedId entityId) {
+    return txnl.executeUnchecked(new TransactionExecutor.Function<BusinessMdsIterable, Set<String>>() {
+      @Override
+      public Set<String> apply(BusinessMdsIterable input) throws Exception {
+        return input.businessMds.getTags(entityId);
+      }
+    });
+  }
+
+  /**
+   * Removes all metadata (including properties and tags) for the specified {@link Id.NamespacedId}.
+   */
+  @Override
+  public void removeMetadata(final Id.NamespacedId entityId) {
+    if (!cConf.getBoolean(Constants.Metadata.UPDATES_PUBLISH_ENABLED)) {
+      removeMetadataNoPublish(entityId);
+      return;
+    }
+    final AtomicReference<MetadataRecord> previousRef = new AtomicReference<>();
+    txnl.executeUnchecked(new TransactionExecutor.Function<BusinessMdsIterable, Void>() {
+      @Override
+      public Void apply(BusinessMdsIterable input) throws Exception {
+        previousRef.set(new MetadataRecord(entityId, input.businessMds.getProperties(entityId),
+                                           input.businessMds.getTags(entityId)));
+        input.businessMds.removeProperties(entityId);
+        input.businessMds.removeTags(entityId);
+        return null;
+      }
+    });
+    MetadataRecord previous = previousRef.get();
+    publish(previous, new MetadataRecord(entityId), new MetadataRecord(previous));
+  }
+
+  private void removeMetadataNoPublish(final Id.NamespacedId entityId) {
+    txnl.executeUnchecked(new TransactionExecutor.Function<BusinessMdsIterable, Void>() {
+      @Override
+      public Void apply(BusinessMdsIterable input) throws Exception {
+        input.businessMds.removeProperties(entityId);
+        input.businessMds.removeTags(entityId);
+        return null;
+      }
+    });
+  }
+
+  /**
+   * Removes all properties for the specified {@link Id.NamespacedId}.
+   */
+  @Override
+  public void removeProperties(final Id.NamespacedId entityId) {
+    if (!cConf.getBoolean(Constants.Metadata.UPDATES_PUBLISH_ENABLED)) {
+      removePropertiesNoPublish(entityId);
+      return;
+    }
+    final AtomicReference<MetadataRecord> previousRef = new AtomicReference<>();
+    txnl.executeUnchecked(new TransactionExecutor.Function<BusinessMdsIterable, Void>() {
+      @Override
+      public Void apply(BusinessMdsIterable input) throws Exception {
+        previousRef.set(new MetadataRecord(entityId, input.businessMds.getProperties(entityId),
+                                           input.businessMds.getTags(entityId)));
+        input.businessMds.removeProperties(entityId);
+        return null;
+      }
+    });
+    publish(previousRef.get(), new MetadataRecord(entityId),
+            new MetadataRecord(entityId, previousRef.get().getProperties(), EMPTY_TAGS));
+  }
+
+  private void removePropertiesNoPublish(final Id.NamespacedId entityId) {
+    txnl.executeUnchecked(new TransactionExecutor.Function<BusinessMdsIterable, Void>() {
+      @Override
+      public Void apply(BusinessMdsIterable input) throws Exception {
+        input.businessMds.removeProperties(entityId);
+        return null;
+      }
+    });
+  }
+
+  /**
+   * Removes the specified properties of the {@link Id.NamespacedId}.
+   */
+  @Override
+  public void removeProperties(final Id.NamespacedId entityId, final String... keys) {
+    if (!cConf.getBoolean(Constants.Metadata.UPDATES_PUBLISH_ENABLED)) {
+      removePropertiesNoPublish(entityId, keys);
+      return;
+    }
+    final AtomicReference<MetadataRecord> previousRef = new AtomicReference<>();
+    final ImmutableMap.Builder<String, String> deletesBuilder = ImmutableMap.builder();
+    txnl.executeUnchecked(new TransactionExecutor.Function<BusinessMdsIterable, Void>() {
+      @Override
+      public Void apply(BusinessMdsIterable input) throws Exception {
+        previousRef.set(new MetadataRecord(entityId, input.businessMds.getProperties(entityId),
+                                           input.businessMds.getTags(entityId)));
+        for (String key : keys) {
+          BusinessMetadataRecord record = input.businessMds.getProperty(entityId, key);
+          if (record == null) {
+            continue;
+          }
+          deletesBuilder.put(record.getKey(), record.getValue());
+        }
+        input.businessMds.removeProperties(entityId, keys);
+        return null;
+      }
+    });
+    publish(previousRef.get(), new MetadataRecord(entityId),
+            new MetadataRecord(entityId, deletesBuilder.build(), EMPTY_TAGS));
+  }
+
+  private void removePropertiesNoPublish(final Id.NamespacedId entityId, final String... keys) {
+    txnl.executeUnchecked(new TransactionExecutor.Function<BusinessMdsIterable, Void>() {
+      @Override
+      public Void apply(BusinessMdsIterable input) throws Exception {
+        input.businessMds.removeProperties(entityId, keys);
+        return null;
+      }
+    });
+  }
+
+  /**
+   * Removes all the tags from the {@link Id.NamespacedId}
+   */
+  @Override
+  public void removeTags(final Id.NamespacedId entityId) {
+    if (!cConf.getBoolean(Constants.Metadata.UPDATES_PUBLISH_ENABLED)) {
+      removeTagsNoPublish(entityId);
+      return;
+    }
+    final AtomicReference<MetadataRecord> previousRef = new AtomicReference<>();
+    txnl.executeUnchecked(new TransactionExecutor.Function<BusinessMdsIterable, Void>() {
+      @Override
+      public Void apply(BusinessMdsIterable input) throws Exception {
+        previousRef.set(new MetadataRecord(entityId, input.businessMds.getProperties(entityId),
+                                           input.businessMds.getTags(entityId)));
+        input.businessMds.removeTags(entityId);
+        return null;
+      }
+    });
+    MetadataRecord previous = previousRef.get();
+    publish(previous, new MetadataRecord(entityId), new MetadataRecord(entityId, EMPTY_PROPERTIES, previous.getTags()));
+  }
+
+  private void removeTagsNoPublish(final Id.NamespacedId entityId) {
+    txnl.executeUnchecked(new TransactionExecutor.Function<BusinessMdsIterable, Void>() {
+      @Override
+      public Void apply(BusinessMdsIterable input) throws Exception {
+        input.businessMds.removeTags(entityId);
+        return null;
+      }
+    });
+  }
+
+  /**
+   * Removes the specified tags from the {@link Id.NamespacedId}
+   */
+  @Override
+  public void removeTags(final Id.NamespacedId entityId, final String ... tagsToRemove) {
+    if (!cConf.getBoolean(Constants.Metadata.UPDATES_PUBLISH_ENABLED)) {
+      removeTagsNoPublish(entityId, tagsToRemove);
+      return;
+    }
+    final AtomicReference<MetadataRecord> previousRef = new AtomicReference<>();
+    txnl.executeUnchecked(new TransactionExecutor.Function<BusinessMdsIterable, Void>() {
+      @Override
+      public Void apply(BusinessMdsIterable input) throws Exception {
+        previousRef.set(new MetadataRecord(entityId, input.businessMds.getProperties(entityId),
+                                           input.businessMds.getTags(entityId)));
+        input.businessMds.removeTags(entityId, tagsToRemove);
+        return null;
+      }
+    });
+    publish(previousRef.get(), new MetadataRecord(entityId),
+            new MetadataRecord(entityId, EMPTY_PROPERTIES, Sets.newHashSet(tagsToRemove)));
+  }
+
+  private void removeTagsNoPublish(final Id.NamespacedId entityId, final String ... tagsToRemove) {
+    txnl.executeUnchecked(new TransactionExecutor.Function<BusinessMdsIterable, Void>() {
+      @Override
+      public Void apply(BusinessMdsIterable input) throws Exception {
+        input.businessMds.removeTags(entityId, tagsToRemove);
+        return null;
+      }
+    });
+  }
+
+  /**
+   * Search to the underlying Business Metadata Dataset.
+   */
+  @Override
+  public Iterable<BusinessMetadataRecord> searchMetadata(final String searchQuery) {
+    return searchMetadataOnType(searchQuery, MetadataSearchTargetType.ALL);
+  }
+
+  /**
+   * Search to the underlying Business Metadata Dataset for a target type.
+   */
+  @Override
+  public Iterable<BusinessMetadataRecord> searchMetadataOnType(final String searchQuery,
+                                                               final MetadataSearchTargetType type) {
+    return txnl.executeUnchecked(new TransactionExecutor.Function<BusinessMdsIterable,
+      Iterable<BusinessMetadataRecord>>() {
+      @Override
+      public Iterable<BusinessMetadataRecord> apply(BusinessMdsIterable input) throws Exception {
+        // Currently we support two types of search formats: value and key:value.
+        // Check for existence of separator char to make sure we did search in the right indexed column.
+        if (searchQuery.contains(BusinessMetadataDataset.KEYVALUE_SEPARATOR)) {
+          // key=value search
+          return input.businessMds.findBusinessMetadataOnKeyValue(searchQuery, type);
+        }
+        // value search
+        return input.businessMds.findBusinessMetadataOnValue(searchQuery, type);
+      }
+    });
+  }
+
+  private void publish(MetadataRecord previous, MetadataRecord additions, MetadataRecord deletions) {
+    MetadataChangeRecord.MetadataDiffRecord diff = new MetadataChangeRecord.MetadataDiffRecord(additions, deletions);
+    MetadataChangeRecord changeRecord = new MetadataChangeRecord(previous, diff, System.currentTimeMillis());
+    changePublisher.publish(changeRecord);
+  }
+
+  private static final class BusinessMdsIterable implements Iterable<BusinessMetadataDataset> {
+    private final BusinessMetadataDataset businessMds;
+
+    private BusinessMdsIterable(BusinessMetadataDataset mdsTable) {
+      this.businessMds = mdsTable;
+    }
+
+    @Override
+    public Iterator<BusinessMetadataDataset> iterator() {
+      return Iterators.singletonIterator(businessMds);
+    }
+  }
+
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/service/NoOpBusinessMetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/service/NoOpBusinessMetadataStore.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.data2.metadata.service;
+
+import co.cask.cdap.data2.metadata.dataset.BusinessMetadataRecord;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.metadata.MetadataRecord;
+import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Implementation of {@link BusinessMetadataStore} used in memory mode.
+ */
+public class NoOpBusinessMetadataStore implements BusinessMetadataStore {
+
+  @Override
+  public void setProperties(Id.NamespacedId entityId, Map<String, String> properties) {
+    // NO-OP
+  }
+
+  @Override
+  public void addTags(Id.NamespacedId entityId, String... tagsToAdd) {
+    // NO-OP
+  }
+
+  @Override
+  public MetadataRecord getMetadata(Id.NamespacedId entityId) {
+    return null;
+  }
+
+  @Override
+  public Set<MetadataRecord> getMetadata(Set<Id.NamespacedId> entityIds) {
+    return null;
+  }
+
+  @Override
+  public Map<String, String> getProperties(Id.NamespacedId entityId) {
+    return null;
+  }
+
+  @Override
+  public Set<String> getTags(Id.NamespacedId entityId) {
+    return null;
+  }
+
+  @Override
+  public void removeMetadata(Id.NamespacedId entityId) {
+    // NO-OP
+  }
+
+  @Override
+  public void removeProperties(Id.NamespacedId entityId) {
+    // NO-OP
+  }
+
+  @Override
+  public void removeProperties(Id.NamespacedId entityId, String... keys) {
+    // NO-OP
+  }
+
+  @Override
+  public void removeTags(Id.NamespacedId entityId) {
+    // NO-OP
+  }
+
+  @Override
+  public void removeTags(Id.NamespacedId entityId, String... tagsToRemove) {
+    // NO-OP
+  }
+
+  @Override
+  public Iterable<BusinessMetadataRecord> searchMetadata(String searchQuery) {
+    return null;
+  }
+
+  @Override
+  public Iterable<BusinessMetadataRecord> searchMetadataOnType(String searchQuery, MetadataSearchTargetType type) {
+    return null;
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/LineageWriterDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/LineageWriterDatasetFramework.java
@@ -27,6 +27,7 @@ import co.cask.cdap.data2.datafabric.dataset.type.DatasetClassLoaderProvider;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.DatasetManagementException;
 import co.cask.cdap.data2.metadata.lineage.AccessType;
+import co.cask.cdap.data2.metadata.service.BusinessMetadataStore;
 import co.cask.cdap.proto.DatasetSpecificationSummary;
 import co.cask.cdap.proto.Id;
 import com.google.common.annotations.VisibleForTesting;
@@ -45,12 +46,14 @@ public class LineageWriterDatasetFramework implements DatasetFramework, ProgramC
   private final DatasetFramework delegate;
   private final LineageWriter lineageWriter;
   private final ProgramContext programContext = new ProgramContext();
+  private final BusinessMetadataStore businessMds;
 
   @Inject
-  LineageWriterDatasetFramework(
-    @Named(DataSetsModules.BASIC_DATASET_FRAMEWORK) DatasetFramework datasetFramework, LineageWriter lineageWriter) {
+  LineageWriterDatasetFramework(@Named(DataSetsModules.BASIC_DATASET_FRAMEWORK) DatasetFramework datasetFramework,
+                                LineageWriter lineageWriter, BusinessMetadataStore businessMds) {
     this.delegate = datasetFramework;
     this.lineageWriter = lineageWriter;
+    this.businessMds = businessMds;
   }
 
   @Override
@@ -125,12 +128,21 @@ public class LineageWriterDatasetFramework implements DatasetFramework, ProgramC
   @Override
   public void deleteInstance(Id.DatasetInstance datasetInstanceId)
     throws DatasetManagementException, IOException, ServiceUnavailableException {
+    // Remove metadata for the dataset (TODO: https://issues.cask.co/browse/CDAP-3670)
+    businessMds.removeMetadata(datasetInstanceId);
     delegate.deleteInstance(datasetInstanceId);
   }
 
   @Override
   public void deleteAllInstances(Id.Namespace namespaceId)
     throws DatasetManagementException, IOException, ServiceUnavailableException {
+    Collection<DatasetSpecificationSummary> datasets = this.getInstances(namespaceId);
+    for (DatasetSpecificationSummary dataset : datasets) {
+      String dsName = dataset.getName();
+      Id.DatasetInstance datasetInstanceId = Id.DatasetInstance.from(namespaceId, dsName);
+      // Remove metadata for the dataset (TODO: https://issues.cask.co/browse/CDAP-3670)
+      businessMds.removeMetadata(datasetInstanceId);
+    }
     delegate.deleteAllInstances(namespaceId);
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/FileStreamAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/FileStreamAdmin.java
@@ -28,6 +28,7 @@ import co.cask.cdap.data.stream.StreamFileOffset;
 import co.cask.cdap.data.stream.StreamUtils;
 import co.cask.cdap.data.stream.service.StreamMetaStore;
 import co.cask.cdap.data2.metadata.lineage.AccessType;
+import co.cask.cdap.data2.metadata.service.BusinessMetadataStore;
 import co.cask.cdap.data2.metadata.writer.LineageWriter;
 import co.cask.cdap.data2.registry.UsageRegistry;
 import co.cask.cdap.explore.client.ExploreFacade;
@@ -84,6 +85,7 @@ public class FileStreamAdmin implements StreamAdmin {
   private final StreamMetaStore streamMetaStore;
   private final ExploreTableNaming tableNaming;
   private ExploreFacade exploreFacade;
+  private final BusinessMetadataStore businessMds;
 
   @Inject
   public FileStreamAdmin(NamespacedLocationFactory namespacedLocationFactory,
@@ -94,7 +96,8 @@ public class FileStreamAdmin implements StreamAdmin {
                          UsageRegistry usageRegistry,
                          LineageWriter lineageWriter,
                          StreamMetaStore streamMetaStore,
-                         ExploreTableNaming tableNaming) {
+                         ExploreTableNaming tableNaming,
+                         BusinessMetadataStore businessMds) {
     this.namespacedLocationFactory = namespacedLocationFactory;
     this.cConf = cConf;
     this.notificationFeedManager = notificationFeedManager;
@@ -105,6 +108,7 @@ public class FileStreamAdmin implements StreamAdmin {
     this.lineageWriter = lineageWriter;
     this.streamMetaStore = streamMetaStore;
     this.tableNaming = tableNaming;
+    this.businessMds = businessMds;
   }
 
   @SuppressWarnings("unused")
@@ -406,6 +410,9 @@ public class FileStreamAdmin implements StreamAdmin {
           if (!configLocation.delete()) {
             LOG.debug("Could not delete stream config location " + streamLocation.toURI().getPath());
           }
+
+          // Remove metadata for the stream
+          businessMds.removeMetadata(streamId);
 
           // Move the stream directory to the deleted directory
           // The target directory has a timestamp appended to the stream name

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
@@ -44,6 +44,8 @@ import co.cask.cdap.data2.dataset2.DatasetManagementException;
 import co.cask.cdap.data2.dataset2.DefaultDatasetDefinitionRegistry;
 import co.cask.cdap.data2.dataset2.InMemoryDatasetFramework;
 import co.cask.cdap.data2.dataset2.lib.hbase.AbstractHBaseDataSetAdmin;
+import co.cask.cdap.data2.metadata.service.BusinessMetadataStore;
+import co.cask.cdap.data2.metadata.service.NoOpBusinessMetadataStore;
 import co.cask.cdap.data2.metadata.writer.LineageWriter;
 import co.cask.cdap.data2.metadata.writer.NoOpLineageWriter;
 import co.cask.cdap.data2.registry.UsageRegistry;
@@ -206,6 +208,8 @@ public class UpgradeTool {
           bind(DatasetFramework.class).to(InMemoryDatasetFramework.class).in(Scopes.SINGLETON);
           // Upgrade tool does not need to record lineage for now.
           bind(LineageWriter.class).to(NoOpLineageWriter.class);
+          // No need to do anything with Metadata store for now.
+          bind(BusinessMetadataStore.class).to(NoOpBusinessMetadataStore.class);
         }
 
         @Provides


### PR DESCRIPTION
Intercept the entity deletion of App, Program, Dataset, and Stream so it also remove the corresponding business metadata (property and tags).

Move BusinessMetadataStore to interface and add new implementations for in memory and distributed mode.

For UpgradeTool I bind the BusinessMetadataStore to in-memory since it seems like it will have dataset service ready at the time of the upgrade.

Use Modules.override to change the binding for the DatasetsModule to make BusinessMetadataStore bind to in-memory for some tests that do not need business metadata store testing and does not have DatasetService and TransactionManager running.