### PR TITLE
Fix/ui save reset button

### DIFF
--- a/cdap-ui/app/features/adapters/controllers/create/bottompanel-ctrl.js
+++ b/cdap-ui/app/features/adapters/controllers/create/bottompanel-ctrl.js
@@ -15,14 +15,19 @@
  */
 
 angular.module(PKG.name + '.feature.adapters')
-  .controller('BottomPanelController', function ($scope, MySidebarService, MyAppDAGService) {
+  .controller('BottomPanelController', function ($scope, MySidebarService, MyAppDAGService, MyNodeConfigService, $timeout) {
 
     MyAppDAGService.registerEditPropertiesCallback(editProperties.bind(this));
-    this.tab = {};
-    this.tab.plugin = {};
+
     function editProperties(plugin) {
-      this.tab.plugin = plugin;
       $scope.selectTab($scope.tabs[2]);
+      // Giving 100ms to load the template and then set the plugin
+      // For this service to work the controller has to register a callback
+      // with the service. The callback will not be called if plugin assignment happens
+      // before controller initialization. Hence the 100ms delay.
+      $timeout(function() {
+        MyNodeConfigService.setPlugin(plugin);
+      }, 100);
     }
 
     $scope.isExpanded = false;

--- a/cdap-ui/app/features/adapters/controllers/create/partials/nodeconfig-ctrl.js
+++ b/cdap-ui/app/features/adapters/controllers/create/partials/nodeconfig-ctrl.js
@@ -16,7 +16,7 @@
 
 
 angular.module(PKG.name + '.feature.adapters')
-  .controller('NodeConfigController', function($scope, IMPLICIT_SCHEMA, MyAppDAGService, $filter, $q, $rootScope, myAdapterApi, $state, $timeout, GLOBALS, MyNodeConfigService) {
+  .controller('NodeConfigController', function($scope, IMPLICIT_SCHEMA, MyAppDAGService, $filter, $q, $rootScope, myAdapterApi, $state, $timeout, GLOBALS, MyNodeConfigService, $bootstrapModal) {
 
     $scope.type = MyAppDAGService.metadata.template.type;
 
@@ -28,23 +28,62 @@ angular.module(PKG.name + '.feature.adapters')
     function onPluginChange(plugin) {
       var defer = $q.defer();
       if (!$scope.data.isModelTouched) {
-        $scope.plugin = plugin;
-        $scope.isValidPlugin = false;
-        // falsify the ng-if in the template for one tick so that the template gets reloaded
-        // there by reloading the controller.
-        $timeout(function() {
-          $scope.isValidPlugin = Object.keys($scope.plugin).length;
-          $scope.isSource = false;
-          $scope.isTransform = false;
-          $scope.isSink = false;
-          configurePluginInfo();
-        });
+        switchPlugin(plugin);
         defer.resolve(true);
       } else {
-        console.info('You have unsaved changes do you want to save?');
+        confirmPluginSwitch()
+          .then(
+            function yes() {
+              switchPlugin(plugin);
+            },
+            function no() {
+              console.log('User chose to stay in the same plugin');
+            }
+          );
         defer.resolve(false);
       }
       return defer.promise;
+    }
+
+    function confirmPluginSwitch() {
+      var defer = $q.defer();
+
+      var confirmInstance = $bootstrapModal.open({
+        keyboard: false,
+        templateUrl: '/assets/features/adapters/templates/partial/confirm.html',
+        windowClass: 'modal-confirm',
+        controller: ['$scope', function ($scope) {
+          $scope.continue = function () {
+            $scope.$close('close');
+          };
+
+          $scope.cancel = function () {
+            $scope.$close('keep open');
+          };
+        }]
+      });
+      confirmInstance.result.then(function (closing) {
+        if (closing === 'close') {
+          defer.resolve(true);
+        } else {
+          defer.reject(false);
+        }
+      });
+      return defer.promise;
+    }
+
+    function switchPlugin(plugin) {
+      $scope.plugin = plugin;
+      $scope.isValidPlugin = false;
+      // falsify the ng-if in the template for one tick so that the template gets reloaded
+      // there by reloading the controller.
+      $timeout(function() {
+        $scope.isValidPlugin = Object.keys($scope.plugin).length;
+        $scope.isSource = false;
+        $scope.isTransform = false;
+        $scope.isSink = false;
+        configurePluginInfo();
+      });
     }
 
     function configurePluginInfo() {

--- a/cdap-ui/app/features/adapters/controllers/create/plugin-edit-form-ctrl.js
+++ b/cdap-ui/app/features/adapters/controllers/create/plugin-edit-form-ctrl.js
@@ -219,7 +219,8 @@ angular.module(PKG.name + '.feature.adapters')
 
     this.save = function () {
       if (validateSchema()) {
-        $scope.plugin = angular.copy($scope.pluginCopy);
+        $scope.plugin.properties = angular.copy($scope.pluginCopy.properties);
+        $scope.plugin.outputSchema = angular.copy($scope.pluginCopy.outputSchema);
         $scope.data['isModelTouched'] = false;
       }
     };

--- a/cdap-ui/app/features/adapters/services/node-config-service.js
+++ b/cdap-ui/app/features/adapters/services/node-config-service.js
@@ -1,0 +1,25 @@
+angular.module(PKG.name + '.feature.adapters')
+  .service('MyNodeConfigService', function() {
+    this.pluginChangeListeners = [];
+    this.setPlugin = function(plugin) {
+      this.notifyListeners(plugin);
+    };
+
+    this.notifyListeners = function (plugin) {
+
+      this.pluginChangeListeners.forEach(function(callback) {
+        callback(plugin);
+      });
+      // $q.all(promises)
+      //   .then(function(values) {
+      //     if (values.indexOf(false) === -1) {
+      //       this.plugin = plugin;
+      //     }
+      //   }.bind(this));
+    };
+
+    this.registerPluginCallback = function(callback) {
+      this.pluginChangeListeners.push(callback);
+    };
+
+  });

--- a/cdap-ui/app/features/adapters/services/node-config-service.js
+++ b/cdap-ui/app/features/adapters/services/node-config-service.js
@@ -2,20 +2,14 @@ angular.module(PKG.name + '.feature.adapters')
   .service('MyNodeConfigService', function() {
     this.pluginChangeListeners = [];
     this.setPlugin = function(plugin) {
-      this.notifyListeners(plugin);
+      this.plugin = plugin;
+      this.notifyListeners();
     };
 
-    this.notifyListeners = function (plugin) {
-
+    this.notifyListeners = function () {
       this.pluginChangeListeners.forEach(function(callback) {
-        callback(plugin);
-      });
-      // $q.all(promises)
-      //   .then(function(values) {
-      //     if (values.indexOf(false) === -1) {
-      //       this.plugin = plugin;
-      //     }
-      //   }.bind(this));
+        callback(this.plugin);
+      }.bind(this));
     };
 
     this.registerPluginCallback = function(callback) {

--- a/cdap-ui/app/features/adapters/templates/create/popovers/plugin-edit-config-form.html
+++ b/cdap-ui/app/features/adapters/templates/create/popovers/plugin-edit-config-form.html
@@ -80,22 +80,22 @@
                 <button
                   class="btn btn-sm btn-default pull-right"
                   ng-click="PluginEditController.schemaClear()"
-                  ng-if="(!plugin.implicitSchema && !isDisabled)"
-                  ng-disabled="plugin.implicitSchema || plugin.properties.format === 'clf' || plugin.properties.format === 'syslog'">
+                  ng-if="(!pluginCopy.implicitSchema && !isDisabled)"
+                  ng-disabled="pluginCopy.implicitSchema || pluginCopy.properties.format === 'clf' || pluginCopy.properties.format === 'syslog'">
                   Clear
                 </button>
               </h4>
 
               <fieldset ng-disabled="isDisabled">
                 <my-schema-editor
-                  ng-model="plugin.outputSchema"
-                  data-disabled="plugin.implicitSchema"
-                  plugin-properties="plugin.properties"
+                  ng-model="pluginCopy.outputSchema"
+                  data-disabled="pluginCopy.implicitSchema"
+                  plugin-properties="pluginCopy.properties"
                   config="PluginEditController.schemaProperties">
                 </my-schema-editor>
               </fieldset>
 
-              <div ng-if="!plugin.outputSchema && isDisabled">
+              <div ng-if="!pluginCopy.outputSchema && isDisabled">
                 <div class="well well-lg">
                   <h4>There is no output schema</h4>
                 </div>

--- a/cdap-ui/app/features/adapters/templates/create/popovers/plugin-edit-form.html
+++ b/cdap-ui/app/features/adapters/templates/create/popovers/plugin-edit-form.html
@@ -43,10 +43,14 @@
     </div>
     <div class="btn-group pull-right">
       <div ng-if="!isDisabled" class="non-info">
-        <a class="btn btn-default" ng-click="PluginEditController.reset()">Reset</a>
+        <a class="btn btn-default"
+            ng-disabled="data.isModelTouched == false"
+            ng-click="PluginEditController.reset()">Reset</a>
       </div>
-      <div ng-if="!isDisabled" class="non-info">
-        <a class="btn btn-success" ng-click="PluginEditController.save()">Save</a>
+      <div ng-if="!isDisabled"  class="non-info">
+        <a class="btn btn-success"
+            ng-disabled="data.isModelTouched == false"
+            ng-click="PluginEditController.save()">Save</a>
       </div>
     </div>
   </div>

--- a/cdap-ui/app/features/adapters/templates/create/popovers/plugin-edit-output-schema.html
+++ b/cdap-ui/app/features/adapters/templates/create/popovers/plugin-edit-output-schema.html
@@ -25,14 +25,14 @@
   <h4>Output Schema</h4>
   <fieldset class="clearfix" ng-disabled="isDisabled">
     <my-schema-editor
-      ng-model="plugin.outputSchema"
-      data-disabled="plugin.implicitSchema"
-      plugin-properties="plugin.properties"
+      ng-model="pluginCopy.outputSchema"
+      data-disabled="pluginCopy.implicitSchema"
+      plugin-properties="pluginCopy.properties"
       config="PluginEditController.schemaProperties">
     </my-schema-editor>
   </fieldset>
 
-  <div ng-if="!plugin.outputSchema && isDisabled && plugin.properties.format !== 'clf' && plugin.properties.format !== 'syslog'">
+  <div ng-if="!pluginCopy.outputSchema && isDisabled && pluginCopy.properties.format !== 'clf' && plugin.properties.format !== 'syslog'">
     <div class="well well-lg">
       <h4>There is no output schema</h4>
     </div>

--- a/cdap-ui/app/features/adapters/templates/create/popovers/plugin-edit-properties-template.html
+++ b/cdap-ui/app/features/adapters/templates/create/popovers/plugin-edit-properties-template.html
@@ -37,10 +37,10 @@
                        class="my-widget-container"
                        data-info="{{plugin.myconfig.widget}}"
                        ng-class="{'select-wrapper': PluginEditController.groups[group].fields[field].widget === 'select'}"
-                       data-model="plugin.properties[field]"
+                       data-model="pluginCopy.properties[field]"
                        data-myconfig="PluginEditController.groups[group].fields[field]"
-                       data-properties="plugin.properties"
-                       widget-disabled="plugin.pluginTemplate && plugin.lock[field]"
+                       data-properties="pluginCopy.properties"
+                       widget-disabled="pluginCopy.pluginTemplate && pluginCopy.lock[field]"
                        widget-container>
                   </div>
                 </div>


### PR DESCRIPTION
- Adds the ability to communicate between bottom panel controller and individual tabs
- Reverses 'save' & 'reset' buttons' functionality in the bottom panel.
- Adds a confirmation before user clicks on other nodes when the current node's configuration needs to be saved.

TODO:
  - Will be adding in label 
  - Handle the case when a node is deleted to blank out the bottom panel.

![savereset](https://cloud.githubusercontent.com/assets/1452845/9882504/cfecc9da-5b89-11e5-9dea-c0d64ef82961.gif)
