### PR TITLE
Fix Documentation Build and Namespaces description

### DIFF
--- a/cdap-docs/developers-manual/source/building-blocks/index.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/index.rst
@@ -48,7 +48,7 @@ write data through the data abstraction layer in CDAP.
 - :doc:`Workers <workers>`
 - :doc:`Workflows <workflows>`
 
-A :doc:`Namespace <namespaces>` is a physical grouping of application and data in CDAP.
+A :doc:`Namespace <namespaces>` is a logical grouping of application and data in CDAP.
 Conceptually, namespaces can be thought of as a partitioning of a CDAP instance.
 All applications and data live in an explicit CDAP namespace.
 

--- a/cdap-docs/developers-manual/source/building-blocks/namespaces.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/namespaces.rst
@@ -10,7 +10,7 @@ Namespaces
 
 Overview
 ========
-A *Namespace* is a physical grouping of application, data and its metadata in CDAP. Conceptually,
+A *Namespace* is a logical grouping of application, data and its metadata in CDAP. Conceptually,
 namespaces can be thought of as a partitioning of a CDAP instance. Any application or data
 (referred to here as an “entity”) can exist independently in multiple namespaces at the
 same time. The data and metadata of an entity is stored independent of another instance of

--- a/cdap-docs/reference-manual/source/glossary.rst
+++ b/cdap-docs/reference-manual/source/glossary.rst
@@ -121,7 +121,7 @@ Glossary
       data serialization system that provides rich data structures and a compact, fast, binary data format.
 
    Namespace
-      A namespace is a physical grouping of application, data and its metadata in CDAP.
+      A namespace is a logical grouping of application, data and its metadata in CDAP.
       Conceptually, namespaces can be thought of as a partitioning of a CDAP instance. Any
       application or data (referred to here as an “entity”) can exist independently in
       multiple namespaces at the same time. The data and metadata of an entity is stored

--- a/cdap-docs/vars
+++ b/cdap-docs/vars
@@ -17,3 +17,6 @@ WITHOUT="without"
 WITH_JAVADOCS="$WITHOUT"
 
 MANUALS="introduction developers-manual application-templates admin-manual integrations examples-manual reference-manual"
+
+# This needs to be explicitly set as Git has trouble identifying it.
+GIT_BRANCH_PARENT="release/3.2"


### PR DESCRIPTION
- Replace "physical" with "logical" for namespaces in three files.
- Set the parent branch explicitly for the documentation build to get it to build with new "docs" prefix.

Fixes: https://issues.cask.co/browse/CDAP-3664 (namespaces)

Building at: http://builds.cask.co/browse/CDAP-DDBD572-1