### PR TITLE
Move kinit code to cdap_kinit function

### DIFF
--- a/cdap-common/bin/common.sh
+++ b/cdap-common/bin/common.sh
@@ -67,6 +67,32 @@ rotate_log () {
   fi
 }
 
+# CDAP kinit using properties from cdap-site.xml
+cdap_kinit() {
+  local __principal=$(get_conf "cdap.master.kerberos.principal" "${CDAP_CONF}"/cdap-site.xml)
+  local __keytab=$(get_conf "cdap.master.kerberos.keytab" "${CDAP_CONF}"/cdap-site.xml)
+  if [ -z "${__principal}" -o -z "${__keytab}" ]; then
+    echo "ERROR: Both cdap.master.kerberos.principal and cdap.master.kerberos.keytab must be configured for Kerberos-enabled clusters!"
+    return 1
+  fi
+  if [ ! -r "${__keytab}" ]; then
+    echo "ERROR: Cannot read keytab: ${__keytab}"
+    return 1
+  fi
+  if [[ $(which kinit 2>/dev/null) ]]; then
+    # Replace _HOST in principal w/ FQDN, like Hadoop does
+    kinit -kt "${__keytab}" "${__principal/_HOST/`hostname -f`}"
+    if [[ ! $? ]]; then
+      echo "ERROR: Failed executing 'kinit -kt \"${__keytab}\" \"${__principal/_HOST/`hostname -f`}\"'"
+      return 1
+    fi
+  else
+    echo "ERROR: Cannot locate kinit! Please, ensure the appropriate Kerberos utilities are installed"
+    return 1
+  fi
+  return 0
+)
+
 # Attempts to find JAVA in few ways.
 set_java () {
   # Determine the Java command to use to start the JVM.
@@ -188,27 +214,7 @@ set_hive_classpath() {
     if [ -z "${HIVE_HOME}" -o -z "${HIVE_CONF_DIR}" -o -z "${HADOOP_CONF_DIR}" ]; then
       __secure=$(get_conf "kerberos.auth.enabled" "${CDAP_CONF}"/cdap-site.xml false)
       if [[ "${__secure}" == "true" ]]; then
-        __principal=$(get_conf "cdap.master.kerberos.principal" "${CDAP_CONF}"/cdap-site.xml)
-        __keytab=$(get_conf "cdap.master.kerberos.keytab" "${CDAP_CONF}"/cdap-site.xml)
-        if [ -z "${__principal}" -o -z "${__keytab}" ]; then
-          echo "ERROR: Both cdap.master.kerberos.principal and cdap.master.kerberos.keytab must be configured for Kerberos-enabled clusters!"
-          return 1
-        fi
-        if [ ! -r "${__keytab}" ]; then
-          echo "ERROR: Cannot read keytab: ${__keytab}"
-          return 1
-        fi
-        if [[ $(which kinit 2>/dev/null) ]]; then
-          # Replace _HOST in principal w/ FQDN, like Hadoop does
-          kinit -kt "${__keytab}" "${__principal/_HOST/`hostname -f`}"
-          if [[ ! $? ]]; then
-            echo "ERROR: Failed executing 'kinit -kt \"${__keytab}\" \"${__principal/_HOST/`hostname -f`}\"'"
-            return 1
-          fi
-        else
-          echo "ERROR: Cannot locate kinit! Please, ensure the appropriate Kerberos utilities are installed"
-          return 1
-        fi
+        cdap_kinit || return 1
       fi
 
       if [[ $(which hive 2>/dev/null) ]]; then


### PR DESCRIPTION
This allows the functionality to be reused in other scripts and functions without otherwise modifying the environment.