### PR TITLE
Misc lineage fixes

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/LineageHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/LineageHandler.java
@@ -97,7 +97,7 @@ public class LineageHandler extends AbstractHttpHandler {
   }
 
   @GET
-  @Path("/namespaces/{namespace-id}/apps/{app-id}/{program-type}/{program-id}/runs/{run-id}/metadata/accesses")
+  @Path("/namespaces/{namespace-id}/apps/{app-id}/{program-type}/{program-id}/runs/{run-id}/metadata")
   public void getAccessesForRun(HttpRequest request, HttpResponder responder,
                                 @PathParam("namespace-id") String namespaceId,
                                 @PathParam("app-id") String appId,
@@ -107,7 +107,7 @@ public class LineageHandler extends AbstractHttpHandler {
     Id.Run run = new Id.Run(
       Id.Program.from(namespaceId, appId, ProgramType.valueOfCategoryName(programType), programId),
       runId);
-    responder.sendJson(HttpResponseStatus.OK, lineageStore.getAccesses(run), SET_METADATA_RECORD_TYPE, GSON);
+    responder.sendJson(HttpResponseStatus.OK, lineageStore.getRunMetadata(run), SET_METADATA_RECORD_TYPE, GSON);
   }
 
   private void checkArguments(long start, long end, int levels) throws BadRequestException {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/LineageTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/LineageTest.java
@@ -143,7 +143,7 @@ public class LineageTest extends MetadataTestBase {
                                 new MetadataRecord(programForFlow, flowProperties, flowTags),
                                 new MetadataRecord(dataset, dataProperties, dataTags),
                                 new MetadataRecord(stream, streamProperties, streamTags)),
-                          fetchAccesses(new Id.Run(flow, flowRunId.getId())));
+                          fetchRunMetadata(new Id.Run(flow, flowRunId.getId())));
     } finally {
       try {
         deleteNamespace(namespace);
@@ -249,7 +249,7 @@ public class LineageTest extends MetadataTestBase {
                                 new MetadataRecord(programForFlow, emptyMap(), emptySet()),
                                 new MetadataRecord(dataset, datasetProperties, emptySet()),
                                 new MetadataRecord(stream, emptyMap(), emptySet())),
-                          fetchAccesses(new Id.Run(flow, flowRunId.getId())));
+                          fetchRunMetadata(new Id.Run(flow, flowRunId.getId())));
 
       // Id.Worker needs conversion to Id.Program JIRA - CDAP-3658
       Id.Program programForWorker = Id.Program.from(worker.getApplication(), worker.getType(), worker.getId());
@@ -257,7 +257,7 @@ public class LineageTest extends MetadataTestBase {
                                 new MetadataRecord(programForWorker, emptyMap(), workerTags),
                                 new MetadataRecord(dataset, datasetProperties, emptySet()),
                                 new MetadataRecord(stream, emptyMap(), emptySet())),
-                          fetchAccesses(new Id.Run(worker, workerRunId.getId())));
+                          fetchRunMetadata(new Id.Run(worker, workerRunId.getId())));
 
       // Id.Spark needs conversion to Id.Program JIRA - CDAP-3658
       Id.Program programForSpark = Id.Program.from(spark.getApplication(), spark.getType(), spark.getId());
@@ -265,7 +265,7 @@ public class LineageTest extends MetadataTestBase {
                                 new MetadataRecord(programForSpark, emptyMap(), sparkTags),
                                 new MetadataRecord(dataset, datasetProperties, emptySet()),
                                 new MetadataRecord(stream, emptyMap(), emptySet())),
-                          fetchAccesses(new Id.Run(spark, sparkRunId.getId())));
+                          fetchRunMetadata(new Id.Run(spark, sparkRunId.getId())));
     } finally {
       try {
         deleteNamespace(namespace);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataTestBase.java
@@ -393,9 +393,9 @@ public abstract class MetadataTestBase extends AppFabricTestBase {
     return makeGetRequest(path);
   }
 
-  protected Set<MetadataRecord> fetchAccesses(Id.Run run) throws IOException {
+  protected Set<MetadataRecord> fetchRunMetadata(Id.Run run) throws IOException {
     Id.Program program = run.getProgram();
-    String path = getVersionedAPIPath(String.format("apps/%s/%s/%s/runs/%s/metadata/accesses",
+    String path = getVersionedAPIPath(String.format("apps/%s/%s/%s/runs/%s/metadata",
                                                     program.getApplicationId(), program.getType().getCategoryName(),
                                                     program.getId(), run.getId()),
                                       program.getNamespaceId());

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/lineage/LineageDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/lineage/LineageDataset.java
@@ -157,7 +157,7 @@ public class LineageDataset extends AbstractDataset {
    * @return a set of {@link MetadataRecord}s (associated with both program and data it accesses)
    * for a given program run.
    */
-  public Set<MetadataRecord> getAccesses(Id.Run run) {
+  public Set<MetadataRecord> getRunMetadata(Id.Run run) {
     ImmutableSet.Builder<MetadataRecord> recordBuilder = ImmutableSet.builder();
     byte[] startKey = getRunScanStartKey(run);
     Scanner scanner = accessRegistryTable.scan(startKey, Bytes.stopKeyForPrefix(startKey));

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/lineage/LineageStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/lineage/LineageStore.java
@@ -127,11 +127,11 @@ public class LineageStore {
    * @return a set of {@link MetadataRecord}s (associated with both program and data it accesses)
    * for a given program run.
    */
-  public Set<MetadataRecord> getAccesses(final Id.Run run) {
+  public Set<MetadataRecord> getRunMetadata(final Id.Run run) {
     return execute(new TransactionExecutor.Function<LineageDataset, Set<MetadataRecord>>() {
       @Override
       public Set<MetadataRecord> apply(LineageDataset input) throws Exception {
-        return input.getAccesses(run);
+        return input.getRunMetadata(run);
       }
     });
   }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/lineage/LineageDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/lineage/LineageDatasetTest.java
@@ -71,8 +71,8 @@ public class LineageDatasetTest {
     Assert.assertEquals(expected, relations.iterator().next());
 
     // Assert metadata
-    System.out.println(lineageDataset.getAccesses(run));
-    Assert.assertEquals(metadataRecords, lineageDataset.getAccesses(run));
+    System.out.println(lineageDataset.getRunMetadata(run));
+    Assert.assertEquals(metadataRecords, lineageDataset.getRunMetadata(run));
   }
 
   @Test
@@ -179,16 +179,16 @@ public class LineageDatasetTest {
     );
 
     // Verify metadata
-    Assert.assertEquals(metaProgram1Data1Run1, lineageDataset.getAccesses(run11));
-    Assert.assertEquals(2, lineageDataset.getAccesses(run11).size());
+    Assert.assertEquals(metaProgram1Data1Run1, lineageDataset.getRunMetadata(run11));
+    Assert.assertEquals(2, lineageDataset.getRunMetadata(run11).size());
     Assert.assertEquals(toSet(metaProgram2Data2Run2, metaProgram2Stream1Run2),
-                        lineageDataset.getAccesses(run22));
-    Assert.assertEquals(3, lineageDataset.getAccesses(run22).size());
+                        lineageDataset.getRunMetadata(run22));
+    Assert.assertEquals(3, lineageDataset.getRunMetadata(run22).size());
     Assert.assertEquals(toSet(metaProgram2Stream2Run3, metaProgram2Data2Run3),
-                        lineageDataset.getAccesses(run23));
-    Assert.assertEquals(3, lineageDataset.getAccesses(run23).size());
-    Assert.assertEquals(metaProgram3Data2Run4, lineageDataset.getAccesses(run34));
-    Assert.assertEquals(2, lineageDataset.getAccesses(run34).size());
+                        lineageDataset.getRunMetadata(run23));
+    Assert.assertEquals(3, lineageDataset.getRunMetadata(run23).size());
+    Assert.assertEquals(metaProgram3Data2Run4, lineageDataset.getRunMetadata(run34));
+    Assert.assertEquals(2, lineageDataset.getRunMetadata(run34).size());
   }
 
   private static LineageDataset getLineageDataset(String instanceId) throws Exception {

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/lineage/LineageDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/lineage/LineageDatasetTest.java
@@ -71,7 +71,6 @@ public class LineageDatasetTest {
     Assert.assertEquals(expected, relations.iterator().next());
 
     // Assert metadata
-    System.out.println(lineageDataset.getRunMetadata(run));
     Assert.assertEquals(metadataRecords, lineageDataset.getRunMetadata(run));
   }
 

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/lineage/LineageServiceTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/lineage/LineageServiceTest.java
@@ -120,7 +120,7 @@ public class LineageServiceTest {
       oneLevelLineage.getRelations());
 
     // Assert metadata
-    Assert.assertEquals(toSet(run1data1, run1data2), lineageStore.getAccesses(run1));
+    Assert.assertEquals(toSet(run1data1, run1data2), lineageStore.getRunMetadata(run1));
   }
 
   @Test

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/writer/BasicLineageWriterTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/writer/BasicLineageWriterTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.metadata.writer;
+
+import co.cask.cdap.api.dataset.module.DatasetDefinitionRegistry;
+import co.cask.cdap.common.app.RunIds;
+import co.cask.cdap.data.runtime.DataSetsModules;
+import co.cask.cdap.data2.dataset2.DatasetDefinitionRegistryFactory;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.dataset2.DatasetFrameworkTestUtil;
+import co.cask.cdap.data2.dataset2.DefaultDatasetDefinitionRegistry;
+import co.cask.cdap.data2.dataset2.InMemoryDatasetFramework;
+import co.cask.cdap.data2.metadata.lineage.AccessType;
+import co.cask.cdap.data2.metadata.lineage.LineageStore;
+import co.cask.cdap.data2.metadata.publisher.MetadataChangePublisher;
+import co.cask.cdap.data2.metadata.publisher.NoOpMetadataChangePublisher;
+import co.cask.cdap.data2.metadata.service.BusinessMetadataStore;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.metadata.MetadataRecord;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.AbstractModule;
+import com.google.inject.Injector;
+import com.google.inject.assistedinject.FactoryModuleBuilder;
+import com.google.inject.name.Names;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+/**
+ * Tests BasicLineageWriter
+ */
+public class BasicLineageWriterTest {
+  @ClassRule
+  public static DatasetFrameworkTestUtil dsFrameworkUtil = new DatasetFrameworkTestUtil();
+
+  @Test
+  public void testWrites() throws Exception {
+    Injector injector = getInjector();
+    BusinessMetadataStore businessMetadataStore = injector.getInstance(BusinessMetadataStore.class);
+    LineageStore lineageStore = injector.getInstance(LineageStore.class);
+    LineageWriter lineageWriter = new BasicLineageWriter(businessMetadataStore, lineageStore);
+
+    // Define entities
+    Id.Program program = Id.Program.from("default", "app", ProgramType.FLOW, "flow");
+    Id.Stream stream = Id.Stream.from("default", "stream");
+    Id.Run run1 = new Id.Run(program, RunIds.generate(10000).getId());
+    Id.Run run2 = new Id.Run(program, RunIds.generate(20000).getId());
+
+    // Tag stream
+    businessMetadataStore.addTags(stream, "stag1", "stag2");
+    // Write access for run1
+    lineageWriter.addAccess(run1, stream, AccessType.READ);
+    // Assert tags on stream
+    Assert.assertEquals(
+      ImmutableSet.of(
+        new MetadataRecord(stream, ImmutableMap.<String, String>of(), ImmutableSet.of("stag1", "stag2")),
+        new MetadataRecord(program.getApplication(), ImmutableMap.<String, String>of(), ImmutableSet.<String>of()),
+        new MetadataRecord(program, ImmutableMap.<String, String>of(), ImmutableSet.<String>of())),
+      lineageStore.getRunMetadata(run1));
+
+    // Add another tag to stream
+    businessMetadataStore.addTags(stream, "stag3");
+    // Write access for run1 again
+    lineageWriter.addAccess(run1, stream, AccessType.READ);
+    // The write should be no-op, and metadata for run1 should not be updated
+    Assert.assertEquals(
+      ImmutableSet.of(
+        new MetadataRecord(stream, ImmutableMap.<String, String>of(), ImmutableSet.of("stag1", "stag2")),
+        new MetadataRecord(program.getApplication(), ImmutableMap.<String, String>of(), ImmutableSet.<String>of()),
+        new MetadataRecord(program, ImmutableMap.<String, String>of(), ImmutableSet.<String>of())),
+      lineageStore.getRunMetadata(run1));
+
+    // However, you can write access for another run
+    lineageWriter.addAccess(run2, stream, AccessType.READ);
+    // Assert new tags get picked up
+    Assert.assertEquals(
+      ImmutableSet.of(
+        new MetadataRecord(stream, ImmutableMap.<String, String>of(), ImmutableSet.of("stag1", "stag2", "stag3")),
+        new MetadataRecord(program.getApplication(), ImmutableMap.<String, String>of(), ImmutableSet.<String>of()),
+        new MetadataRecord(program, ImmutableMap.<String, String>of(), ImmutableSet.<String>of())),
+      lineageStore.getRunMetadata(run2));
+  }
+
+  private static Injector getInjector() {
+    return dsFrameworkUtil.getInjector().createChildInjector(
+      new AbstractModule() {
+        @Override
+        protected void configure() {
+          install(new FactoryModuleBuilder()
+                    .implement(DatasetDefinitionRegistry.class, DefaultDatasetDefinitionRegistry.class)
+                    .build(DatasetDefinitionRegistryFactory.class));
+          bind(DatasetFramework.class)
+            .annotatedWith(Names.named(DataSetsModules.BASIC_DATASET_FRAMEWORK))
+            .to(InMemoryDatasetFramework.class);
+          bind(MetadataChangePublisher.class).to(NoOpMetadataChangePublisher.class);
+        }
+      }
+    );
+  }
+}

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterPathLookup.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterPathLookup.java
@@ -88,7 +88,7 @@ public final class RouterPathLookup extends AbstractHttpHandler {
       matches(uriParts, "v3", "namespaces", null, "streams", null, "metadata", "tags") ||
       matches(uriParts, "v3", "namespaces", null, "metadata", "search") ||
       matches(uriParts, "v3", "namespaces", null, "datasets", null, "lineage") ||
-      matches(uriParts, "v3", "namespaces", null, "apps", null, null, null, "runs", null, "metadata", "accesses")) {
+      matches(uriParts, "v3", "namespaces", null, "apps", null, null, null, "runs", null, "metadata")) {
       return Constants.Service.METADATA_SERVICE;
     } else if ((matches(uriParts, "v3", "namespaces", null, "streams", null, "adapters")
       || matches(uriParts, "v3", "namespaces", null, "streams", null, "programs")

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/RouterPathTest.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/RouterPathTest.java
@@ -356,7 +356,7 @@ public class RouterPathTest {
     // lineage
     assertMetadataRouting("/v3/namespaces/default/////datasets/ds1/lineage");
     // get metadata for accesses
-    assertMetadataRouting("/v3/namespaces/default//apps/WordCount/flows/WordCountFlow/runs/runid/metadata/accesses");
+    assertMetadataRouting("/v3/namespaces/default//apps/WordCount/flows/WordCountFlow/runs/runid/metadata");
   }
 
   private void assertMetadataRouting(String path) {


### PR DESCRIPTION
 * Renaming lineage REST enpoint /metadata/accesses to /metadata
 * Adding test to verify duplicate access record filtering

It would be easier to review them as separate commits.