### PR TITLE
CDAP-3406 Update Kerberos docs

### DIFF
--- a/cdap-docs/admin-manual/source/installation/installation.rst
+++ b/cdap-docs/admin-manual/source/installation/installation.rst
@@ -607,7 +607,7 @@ When all the packages and dependencies have been installed, and the configuratio
 parameters set, you can start the services on each of the CDAP boxes by running the
 command::
 
-  $ for i in /etc/init.d/cdap* ; do sudo service $i restart ; done
+  $ for i in `ls /etc/init.d/ | grep cdap` ; do sudo service $i restart ; done
 
 When all the services have completed starting, the CDAP UI should then be
 accessible through a browser at port ``9999``. 

--- a/cdap-docs/admin-manual/source/installation/installation.rst
+++ b/cdap-docs/admin-manual/source/installation/installation.rst
@@ -455,7 +455,7 @@ Secure Hadoop
 .............
 When running CDAP on top of a secure Hadoop cluster (using Kerberos
 authentication), the CDAP processes will need to obtain Kerberos credentials in order to
-authenticate with Hadoop, HBase, ZooKeeper, and optionally Hive.  In this case, the setting for
+authenticate with Hadoop, HBase, ZooKeeper, and (optionally) Hive.  In this case, the setting for
 ``hdfs.user`` in ``cdap-site.xml`` will be ignored and the CDAP processes will be identified by the
 default authenticated Kerberos principal.
 
@@ -510,8 +510,8 @@ In order to configure **CDAP Explore Service for secure Hadoop:**
 
 .. highlight:: xml
 
-- To allow CDAP to act as a Hive client, it must be given proxyuser permissions and allowed from all hosts. For example,
-  to the configuration file ``core-site.xml``, set these properties, where ``cdap`` is a system group which the ``cdap``
+- To allow CDAP to act as a Hive client, it must be given ``proxyuser`` permissions and allowed from all hosts. For example,
+  to the configuration file ``core-site.xml``, set these properties, where ``cdap`` is a system group to which the ``cdap``
   user is a member::
 
     <property>
@@ -523,10 +523,11 @@ In order to configure **CDAP Explore Service for secure Hadoop:**
       <value>*</value>
     </property>
 
-- To execute Hive queries on a secure cluster, the cluster must be running the MapReduce JobHistoryServer. Consult your
+- To execute Hive queries on a secure cluster, the cluster must be running the MapReduce ``JobHistoryServer``. Consult your
   distribution documentation on the proper configuration of this service.
-- To execute Hive queries on a secure cluster using CDAP Explore Service, the Hive MetaStore service must be configured for
-  Kerberos authentication. Consult your distribution documentation on the proper configuration of this service.
+- To execute Hive queries on a secure cluster using the CDAP Explore Service, the Hive MetaStore service 
+  must be configured for Kerberos authentication. Consult your distribution documentation on the proper 
+  configuration of the Hive MetaStore service.
 
 With all these properties set, the CDAP Explore Service will run on secure Hadoop clusters.
 

--- a/cdap-docs/admin-manual/source/installation/installation.rst
+++ b/cdap-docs/admin-manual/source/installation/installation.rst
@@ -511,7 +511,7 @@ In order to configure **CDAP Explore Service for secure Hadoop:**
 .. highlight:: xml
 
 - To allow CDAP to act as a Hive client, it must be given ``proxyuser`` permissions and allowed from all hosts. 
-  For example, to the configuration file ``core-site.xml``, set these properties, where ``cdap`` is a system 
+  For example: set the following properties in the configuration file ``core-site.xml``, where ``cdap`` is a system 
   group to which the ``cdap`` user is a member::
 
     <property>

--- a/cdap-docs/admin-manual/source/installation/installation.rst
+++ b/cdap-docs/admin-manual/source/installation/installation.rst
@@ -510,9 +510,9 @@ In order to configure **CDAP Explore Service for secure Hadoop:**
 
 .. highlight:: xml
 
-- To allow CDAP to act as a Hive client, it must be given ``proxyuser`` permissions and allowed from all hosts. For example,
-  to the configuration file ``core-site.xml``, set these properties, where ``cdap`` is a system group to which the ``cdap``
-  user is a member::
+- To allow CDAP to act as a Hive client, it must be given ``proxyuser`` permissions and allowed from all hosts. 
+  For example, to the configuration file ``core-site.xml``, set these properties, where ``cdap`` is a system 
+  group to which the ``cdap`` user is a member::
 
     <property>
       <name>hadoop.proxyuser.hive.groups</name>

--- a/cdap-docs/admin-manual/source/installation/installation.rst
+++ b/cdap-docs/admin-manual/source/installation/installation.rst
@@ -523,8 +523,8 @@ In order to configure **CDAP Explore Service for secure Hadoop:**
       <value>*</value>
     </property>
 
-- To execute Hive queries on a secure cluster, the cluster must be running the MapReduce ``JobHistoryServer``. Consult your
-  distribution documentation on the proper configuration of this service.
+- To execute Hive queries on a secure cluster, the cluster must be running the MapReduce ``JobHistoryServer`` 
+  service. Consult your distribution documentation on the proper configuration of this service.
 - To execute Hive queries on a secure cluster using the CDAP Explore Service, the Hive MetaStore service 
   must be configured for Kerberos authentication. Consult your distribution documentation on the proper 
   configuration of the Hive MetaStore service.


### PR DESCRIPTION
This updates the Kerberos section of our installation documents. It removes some sections which are best left up to the individual distributions to document and only documents the changes required for CDAP, specifically.