### PR TITLE
Improve network handling for CDAP VM

### DIFF
--- a/cdap-distributions/src/packer/scripts/network-cleanup.sh
+++ b/cdap-distributions/src/packer/scripts/network-cleanup.sh
@@ -14,7 +14,19 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-# Remove UDEV persistent network rules
+# Disable automatic udev rules for network interfaces in Ubuntu,
+# source: http://6.ptmc.org/164/
 rm -f /etc/udev/rules.d/70-persistent-net.rules
+mkdir -p /etc/udev/rules.d/70-persistent-net.rules
+rm -f /lib/udev/rules.d/75-persistent-net-generator.rules
+rm -rf /dev/.udev/ /var/lib/dhcp/*
+
+# Remove HWADDR/UUID from ifcfg-* files (RHEL-compatable)
+for ndev in /etc/sysconfig/network-scripts/ifcfg-*; do
+  [[ "${ndev##*/}" != "ifcfg-lo" ]] && sed -i '/^HWADDR/d;/^UUID/d' ${ndev}
+done
+
+# Adding a 2 sec delay to the interface up, to make the dhclient happy
+echo "pre-up sleep 2" >> /etc/network/interfaces
 
 exit 0


### PR DESCRIPTION
This prevents the persistent network generator rules from running, removes any previously created rules, removes any DHCP and UDEV cached data, and adds a two second delay after interface is up before starting DHCP (copied from chef/bento's networking scripts).