### PR TITLE
CDAP-3662: Metadata notifications should always only be published to external Kafka

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataHttpHandler.java
@@ -26,13 +26,11 @@ import co.cask.cdap.proto.metadata.MetadataSearchResultRecord;
 import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
 import co.cask.http.AbstractHttpHandler;
 import co.cask.http.HttpResponder;
-
 import com.google.common.base.Charsets;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
 import com.google.inject.Inject;
-
 import org.jboss.netty.buffer.ChannelBuffer;
 import org.jboss.netty.buffer.ChannelBufferInputStream;
 import org.jboss.netty.handler.codec.http.HttpRequest;

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -883,5 +883,6 @@ public final class Constants {
     public static final String HANDLERS_NAME = "metadata.handlers";
     public static final String UPDATES_KAFKA_TOPIC = "metadata.updates.kafka.topic";
     public static final String UPDATES_PUBLISH_ENABLED = "metadata.updates.publish.enabled";
+    public static final String UPDATES_KAFKA_BROKER_LIST = "metadata.updates.kafka.broker.list";
   }
 }

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -1553,14 +1553,20 @@
   </property>
 
   <property>
+    <name>metadata.updates.kafka.broker.list</name>
+    <value>127.0.0.1:${kafka.bind.port}</value>
+    <description>Kafka broker list to which metadata update notifications are published</description>
+  </property>
+
+  <property>
     <name>metadata.updates.kafka.topic</name>
-    <value>metadata-updates</value>
+    <value>cdap-metadata-updates</value>
     <description>Kafka topic to which metadata update notifications are published</description>
   </property>
 
   <property>
     <name>metadata.updates.publish.enabled</name>
-    <value>true</value>
+    <value>false</value>
     <description>
       Determines if metadata updates will be published to Apache Kafka. External systems can subscribe to the
       Kafka topic determined by ${metadata.updates.kafka.topic} to receive notifications of metadata updates.

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/publisher/KafkaMetadataChangePublisher.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/publisher/KafkaMetadataChangePublisher.java
@@ -22,20 +22,24 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.codec.NamespacedIdCodec;
 import co.cask.cdap.proto.metadata.MetadataChangeRecord;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.inject.Inject;
+import kafka.javaapi.producer.Producer;
+import kafka.producer.KeyedMessage;
+import kafka.producer.ProducerConfig;
+import org.apache.twill.internal.kafka.client.ByteBufferEncoder;
+import org.apache.twill.internal.kafka.client.IntegerEncoder;
+import org.apache.twill.internal.kafka.client.IntegerPartitioner;
 import org.apache.twill.kafka.client.Compression;
-import org.apache.twill.kafka.client.KafkaClient;
 import org.apache.twill.kafka.client.KafkaPublisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.ByteBuffer;
-import java.util.concurrent.ExecutionException;
+import java.util.Properties;
 
 /**
  * A {@link MetadataChangePublisher} that publishes metadata changes to an Apache Kafka topic determined by the
@@ -47,38 +51,43 @@ public class KafkaMetadataChangePublisher implements MetadataChangePublisher {
   private static final Gson GSON = new GsonBuilder()
     .registerTypeAdapter(Id.NamespacedId.class, new NamespacedIdCodec())
     .create();
-  private static final String PUBLISHER_CACHE_KEY = "kafkaPublisher";
   private final KafkaPublisher.Ack ack;
-  // This cache will always only contain a single entry, since we will always use the same key.
-  // However, using it will take care of synchronization issues while creating a publisher.
-  private final LoadingCache<String, KafkaPublisher> publishers;
+  private final Supplier<Producer<Integer, ByteBuffer>> producer;
   private final String topic;
+  private final String brokerList;
 
   @Inject
-  KafkaMetadataChangePublisher(CConfiguration cConf, final KafkaClient kafkaClient) {
+  KafkaMetadataChangePublisher(CConfiguration cConf) {
     this.ack = KafkaPublisher.Ack.FIRE_AND_FORGET;
     this.topic = cConf.get(Constants.Metadata.UPDATES_KAFKA_TOPIC);
-    this.publishers = CacheBuilder.newBuilder().build(new CacheLoader<String, KafkaPublisher>() {
+    this.brokerList = cConf.get(Constants.Metadata.UPDATES_KAFKA_BROKER_LIST);
+    this.producer = Suppliers.memoize(new Supplier<Producer<Integer, ByteBuffer>>() {
       @Override
-      @SuppressWarnings("NullableProblems")
-      public KafkaPublisher load(String key) throws Exception {
-        return kafkaClient.getPublisher(ack, Compression.SNAPPY);
+      public Producer<Integer, ByteBuffer> get() {
+        Properties props = new Properties();
+        props.put("metadata.broker.list", brokerList);
+        props.put("serializer.class", ByteBufferEncoder.class.getName());
+        props.put("key.serializer.class", IntegerEncoder.class.getName());
+        props.put("partitioner.class", IntegerPartitioner.class.getName());
+        props.put("request.required.acks", Integer.toString(ack.getAck()));
+        props.put("compression.codec", Compression.SNAPPY.getCodec());
+        ProducerConfig config = new ProducerConfig(props);
+        return new Producer<>(config);
       }
     });
   }
 
   @Override
   public void publish(MetadataChangeRecord changeRecord) {
-    KafkaPublisher publisher;
-    try {
-      publisher = publishers.get(PUBLISHER_CACHE_KEY);
-    } catch (ExecutionException e) {
-      LOG.warn("Unable to get kafka publisher, will not be able to publish metadata.");
-      return;
-    }
     byte[] changesToPublish = Bytes.toBytes(GSON.toJson(changeRecord));
-    KafkaPublisher.Preparer preparer = publisher.prepare(topic);
-    preparer.add(ByteBuffer.wrap(changesToPublish), changeRecord.getPrevious().getTargetId().hashCode());
-    preparer.send();
+    Object partitionKey = changeRecord.getPrevious().getTargetId();
+    @SuppressWarnings("ConstantConditions")
+    ByteBuffer message = ByteBuffer.wrap(changesToPublish);
+
+    try {
+      producer.get().send(new KeyedMessage<>(topic, Math.abs(partitionKey.hashCode()), message));
+    } catch (Exception e) {
+      LOG.error("Failed to send message to topic {} with broker list {}", topic, brokerList, e);
+    }
   }
 }


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-3662
http://builds.cask.co/browse/CDAP-RBT424

- [x] Get KafkaMetadataChangePublisherTest to pass locally
- [x] Test in cluster with external Kafka