### PR TITLE
CDAP-3326 row key should not be required for table source

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/source/TableSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/source/TableSource.java
@@ -29,7 +29,7 @@ import co.cask.cdap.template.etl.api.PipelineConfigurer;
 import co.cask.cdap.template.etl.api.batch.BatchRuntimeContext;
 import co.cask.cdap.template.etl.common.Properties;
 import co.cask.cdap.template.etl.common.RowRecordTransformer;
-import co.cask.cdap.template.etl.common.TableConfig;
+import co.cask.cdap.template.etl.common.TableSourceConfig;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
@@ -45,9 +45,9 @@ import java.util.Map;
 public class TableSource extends BatchReadableSource<byte[], Row, StructuredRecord> {
   private RowRecordTransformer rowRecordTransformer;
 
-  private final TableConfig tableConfig;
+  private final TableSourceConfig tableConfig;
 
-  public TableSource(TableConfig tableConfig) {
+  public TableSource(TableSourceConfig tableConfig) {
     this.tableConfig = tableConfig;
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/common/TableSinkConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/common/TableSinkConfig.java
@@ -27,18 +27,45 @@ import javax.annotation.Nullable;
 /**
  * {@link PluginConfig} for {@link TableSink} and {@link RealtimeTableSink}
  */
-public class TableSinkConfig extends TableConfig {
+public class TableSinkConfig extends PluginConfig {
+  @Name(Properties.Table.NAME)
+  @Description("Name of the table. If the table does not already exist, one will be created.")
+  private String name;
+
+  @Name(Properties.Table.PROPERTY_SCHEMA)
+  @Description("Optional schema of the table as a JSON Object. If the table does not already exist, one will be " +
+    "created with this schema, which will allow the table to be explored through Hive.")
+  @Nullable
+  private String schemaStr;
 
   @Name(Properties.Table.CASE_SENSITIVE_ROW_FIELD)
   @Description("Whether the schema.row.field is case sensitive, defaults to true.")
   @Nullable
   private Boolean rowFieldCaseSensitive;
 
+  @Name(Properties.Table.PROPERTY_SCHEMA_ROW_FIELD)
+  @Description("The name of the record field that should be used as the row key when writing to the table.")
+  private String rowField;
+
   public TableSinkConfig() {
     this.rowFieldCaseSensitive = true;
   }
 
+  @Nullable
   public Boolean isRowFieldCaseInsensitive() {
     return rowFieldCaseSensitive;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  @Nullable
+  public String getSchemaStr() {
+    return schemaStr;
+  }
+
+  public String getRowField() {
+    return rowField;
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/common/TableSourceConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/common/TableSourceConfig.java
@@ -28,7 +28,7 @@ import javax.annotation.Nullable;
 /**
  * {@link PluginConfig} for {@link TableSource}, {@link TableSink} and {@link RealtimeTableSink}
  */
-public class TableConfig extends PluginConfig {
+public class TableSourceConfig extends PluginConfig {
   @Name(Properties.Table.NAME)
   @Description("Name of the table. If the table does not already exist, one will be created.")
   private String name;
@@ -41,6 +41,7 @@ public class TableConfig extends PluginConfig {
 
   @Name(Properties.Table.PROPERTY_SCHEMA_ROW_FIELD)
   @Description("The name of the record field that should be used as the row key when writing to the table.")
+  @Nullable
   private String rowField;
 
   public String getName() {

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/common/TableSourceConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/common/TableSourceConfig.java
@@ -40,7 +40,8 @@ public class TableSourceConfig extends PluginConfig {
   private String schemaStr;
 
   @Name(Properties.Table.PROPERTY_SCHEMA_ROW_FIELD)
-  @Description("The name of the record field that should be used as the row key when writing to the table.")
+  @Description("Optional field name indicating that the field value should come from the row key instead of a " +
+    "row column. The field name specified must be present in the schema, and must not be nullable.")
   @Nullable
   private String rowField;
 


### PR DESCRIPTION
Fixes a bug where the row key was required for table source.
Row key is only required for table sink when we write. For a
source it is ok if we never read anything from the rowkey.