### PR TITLE
[CDAP-3675] Metadata change publishing should only be required in Dat…

### DIFF
--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/DFSStreamFileJanitorTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/DFSStreamFileJanitorTest.java
@@ -83,7 +83,7 @@ public class DFSStreamFileJanitorTest extends StreamFileJanitorTestBase {
       new TransactionMetricsModule(),
       new DiscoveryRuntimeModule().getInMemoryModules(),
       new DataFabricModules().getDistributedModules(),
-      new DataSetsModules().getDistributedModules(false),
+      new DataSetsModules().getDistributedModules(),
       Modules.override(new StreamAdminModules().getDistributedModules()).with(new AbstractModule() {
 
         @Override

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/DistributedStreamCoordinatorClientTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/DistributedStreamCoordinatorClientTest.java
@@ -74,7 +74,7 @@ public class DistributedStreamCoordinatorClientTest extends StreamCoordinatorTes
       new ZKClientModule(),
       new DiscoveryRuntimeModule().getDistributedModules(),
       new DataFabricModules().getDistributedModules(),
-      new DataSetsModules().getDistributedModules(false),
+      new DataSetsModules().getDistributedModules(),
       new TransactionMetricsModule(),
       new NotificationFeedServiceRuntimeModule().getInMemoryModules(),
       new AbstractModule() {

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/distributed/TransactionServiceClientTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/distributed/TransactionServiceClientTest.java
@@ -102,7 +102,7 @@ public class TransactionServiceClientTest extends TransactionSystemTest {
       new DiscoveryRuntimeModule().getDistributedModules(),
       new TransactionMetricsModule(),
       new DataFabricModules().getDistributedModules(),
-      new DataSetsModules().getDistributedModules(false));
+      new DataSetsModules().getDistributedModules());
 
     zkClient = injector.getInstance(ZKClientService.class);
     zkClient.startAndWait();

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/distributed/TransactionServiceTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/distributed/TransactionServiceTest.java
@@ -88,7 +88,7 @@ public class TransactionServiceTest {
         new DiscoveryRuntimeModule().getDistributedModules(),
         new TransactionMetricsModule(),
         new DataFabricModules().getDistributedModules(),
-        new DataSetsModules().getDistributedModules(false)
+        new DataSetsModules().getDistributedModules()
       );
 
       ZKClientService zkClient = injector.getInstance(ZKClientService.class);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataSetsModules.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataSetsModules.java
@@ -100,7 +100,7 @@ public class DataSetsModules extends RuntimeModule {
 
   @Override
   public Module getDistributedModules() {
-    return getDistributedModules(true);
+    return getDistributedModules(false);
   }
 
   public Module getDistributedModules(final boolean publishRequired) {

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/DatasetOpExecutorServerTwillRunnable.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/DatasetOpExecutorServerTwillRunnable.java
@@ -84,7 +84,7 @@ public class DatasetOpExecutorServerTwillRunnable extends AbstractMasterTwillRun
       new DiscoveryRuntimeModule().getDistributedModules(),
       new LocationRuntimeModule().getDistributedModules(),
       new DataFabricModules().getDistributedModules(),
-      new DataSetsModules().getDistributedModules(),
+      new DataSetsModules().getDistributedModules(true),
       new DataSetServiceModules().getDistributedModules(),
       new LoggingModules().getDistributedModules(),
       new ExploreClientModule(),


### PR DESCRIPTION
…asetOpExecutorServerTwillRunnable. Bind a NoOpPublisher by default.

Jira: [CDAP-3675](https://issues.cask.co/browse/CDAP-3675)
Build: http://builds.cask.co/browse/CDAP-RBT426