### PR TITLE
CDAP-3603 make invalid transform configs fail app creation

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/transform/LogParserTransform.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/transform/LogParserTransform.java
@@ -24,6 +24,7 @@ import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.plugin.PluginConfig;
 import co.cask.cdap.template.etl.api.Emitter;
+import co.cask.cdap.template.etl.api.PipelineConfigurer;
 import co.cask.cdap.template.etl.api.Transform;
 import co.cask.cdap.template.etl.api.TransformContext;
 import net.sf.uadetector.ReadableUserAgent;
@@ -95,7 +96,8 @@ public class LogParserTransform extends Transform<StructuredRecord, StructuredRe
   }
 
   @Override
-  public void initialize(TransformContext context) throws Exception {
+  public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
+    super.configurePipeline(pipelineConfigurer);
     if (!S3_LOG.equals(config.logFormat) && !CLF_LOG.equals(config.logFormat) &&
         !CLOUDFRONT_LOG.equals(config.logFormat)) {
       LOG.error("Log format not currently supported.");

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/template/etl/transform/ValidatorTransformTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/template/etl/transform/ValidatorTransformTest.java
@@ -56,7 +56,7 @@ public class ValidatorTransformTest {
     config.validators = "apache";
 
     ValidatorTransform transform = new ValidatorTransform(config);
-    transform.setUpInitialScript(ImmutableList.<Validator>of(new CoreValidator()));
+    transform.setUpInitialScript(new MockTransformContext(), ImmutableList.<Validator>of(new CoreValidator()));
     MockEmitter<StructuredRecord> emitter = new MockEmitter<>();
 
     StructuredRecord validRecord = StructuredRecord.builder(SCHEMA)

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/template/etl/transform/ValidatorTransformTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/test/java/co/cask/cdap/template/etl/transform/ValidatorTransformTest.java
@@ -56,7 +56,7 @@ public class ValidatorTransformTest {
     config.validators = "apache";
 
     ValidatorTransform transform = new ValidatorTransform(config);
-    transform.setUpInitialScript(new MockTransformContext(), ImmutableList.<Validator>of(new CoreValidator()));
+    transform.setUpInitialScript(ImmutableList.<Validator>of(new CoreValidator()));
     MockEmitter<StructuredRecord> emitter = new MockEmitter<>();
 
     StructuredRecord validRecord = StructuredRecord.builder(SCHEMA)


### PR DESCRIPTION
Moved logic in transforms that validate config settings from
initialize into configurePipeline so that invalid configs fail
early at application creation instead of at runtime.