### PR TITLE
CDAP-3442 fix deploy failures when a config is given to plain app

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/InMemoryConfigurator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/InMemoryConfigurator.java
@@ -173,7 +173,7 @@ public final class InMemoryConfigurator implements Configurator {
         appConfig = ((Class<? extends Config>) configType).newInstance();
       } else {
         try {
-          appConfig = GSON.fromJson(configString, Artifacts.getConfigType(app.getClass()));
+          appConfig = GSON.fromJson(configString, configType);
         } catch (JsonSyntaxException e) {
           throw new IllegalArgumentException("Invalid JSON configuration was provided. Please check the syntax.", e);
         }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/InMemoryConfigurator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/InMemoryConfigurator.java
@@ -175,7 +175,11 @@ public final class InMemoryConfigurator implements Configurator {
         appConfig = (Config) configToken.getRawType().newInstance();
       } else {
         try {
-          appConfig = GSON.fromJson(configString, configToken.getType());
+          if (Config.class == configToken.getRawType()) {
+            appConfig = new Config();
+          } else {
+            appConfig = GSON.fromJson(configString, configToken.getType());
+          }
         } catch (JsonSyntaxException e) {
           throw new IllegalArgumentException("Invalid JSON configuration was provided. Please check the syntax.", e);
         }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactInspector.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactInspector.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.internal.app.runtime.artifact;
 
+import co.cask.cdap.api.Config;
 import co.cask.cdap.api.annotation.Description;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
@@ -153,21 +154,26 @@ public class ArtifactInspector {
 
         Application app = (Application) appMain;
 
-        TypeToken typeToken = TypeToken.of(app.getClass());
-        TypeToken<?> resultToken = typeToken.resolveType(Application.class.getTypeParameters()[0]);
-        Schema configSchema = null;
+        java.lang.reflect.Type configType;
         // if the user parameterized their application, like 'xyz extends Application<T>',
         // we can deserialize the config into that object. Otherwise it'll just be a Config
-        if (resultToken.getType() instanceof Class) {
-          configSchema = schemaGenerator.generate(resultToken.getType());
+        try {
+          configType = Artifacts.getConfigType(app.getClass());
+        } catch (Exception e) {
+          throw new InvalidArtifactException(String.format(
+            "Could not resolve config type for Application class %s in artifact %s. " +
+              "The type must extend Config and cannot be parameterized.", mainClassName, artifactId));
         }
+
+        Schema configSchema = configType == Config.class ? null : schemaGenerator.generate(configType);
         builder.addApp(new ApplicationClass(mainClassName, "", configSchema));
       } catch (ClassNotFoundException e) {
         throw new InvalidArtifactException(String.format(
           "Could not find Application main class %s in artifact %s.", mainClassName, artifactId));
       } catch (UnsupportedTypeException e) {
         throw new InvalidArtifactException(String.format(
-          "Config for Application %s in artifact %s has an unsupported schema.", mainClassName, artifactId));
+          "Config for Application %s in artifact %s has an unsupported schema. " +
+            "The type must extend Config and cannot be parameterized.", mainClassName, artifactId));
       } catch (InstantiationException | IllegalAccessException e) {
         throw new InvalidArtifactException(String.format(
           "Could not instantiate Application class %s in artifact %s.", mainClassName, artifactId), e);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/Artifacts.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/Artifacts.java
@@ -49,7 +49,8 @@ public final class Artifacts {
     }
 
     // It has to be Config
-    Preconditions.checkArgument(Config.class == configType.getRawType(), "Application config type not supported. " +
+    Preconditions.checkArgument(Config.class == configType.getRawType(),
+      "Application config type " + configType + " not supported. " +
       "Type must extend Config and cannot be parameterized.");
     return Config.class;
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/Artifacts.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/Artifacts.java
@@ -16,8 +16,15 @@
 
 package co.cask.cdap.internal.app.runtime.artifact;
 
+import co.cask.cdap.api.Config;
+import co.cask.cdap.api.app.Application;
 import co.cask.cdap.api.artifact.ArtifactId;
+import co.cask.cdap.internal.lang.Reflections;
 import co.cask.cdap.proto.Id;
+import com.google.common.base.Preconditions;
+import com.google.common.reflect.TypeToken;
+
+import java.lang.reflect.Type;
 
 /**
  * Util class that contains helper methods related to handling of {@link Id.Artifact}s.
@@ -26,6 +33,25 @@ public final class Artifacts {
 
   public static String getFileName(ArtifactId artifactId) {
     return String.format("%s-%s-%s.jar", artifactId.getScope(), artifactId.getName(), artifactId.getVersion());
+  }
+
+  /**
+   * Resolve the application's config type.
+   *
+   * @param appClass the application class to resolve the config type for
+   * @return the resolved config type
+   * @throws IllegalArgumentException if the config type is not a valid type
+   */
+  public static Type getConfigType(Class<? extends Application> appClass) {
+    TypeToken<?> configType = TypeToken.of(appClass).resolveType(Application.class.getTypeParameters()[0]);
+    if (Reflections.isResolved(configType.getType())) {
+      return configType.getType();
+    }
+
+    // It has to be Config
+    Preconditions.checkArgument(Config.class == configType.getRawType(), "Application config type not supported. " +
+      "Type must extend Config and cannot be parameterized.");
+    return Config.class;
   }
 
   private Artifacts() {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactInspectorTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactInspectorTest.java
@@ -27,6 +27,7 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.io.Locations;
 import co.cask.cdap.common.utils.DirUtils;
 import co.cask.cdap.internal.app.runtime.artifact.app.InspectionApp;
+import co.cask.cdap.internal.app.runtime.artifact.app.InvalidConfigApp;
 import co.cask.cdap.internal.io.ReflectionSchemaGenerator;
 import co.cask.cdap.internal.test.AppJarHelper;
 import co.cask.cdap.proto.Id;
@@ -62,6 +63,19 @@ public class ArtifactInspectorTest {
 
     classLoaderFactory = new ArtifactClassLoaderFactory(TMP_FOLDER.newFolder());
     artifactInspector = new ArtifactInspector(cConf, classLoaderFactory, TMP_FOLDER.newFolder());
+  }
+
+  @Test(expected = InvalidArtifactException.class)
+  public void testInvalidConfigApp() throws Exception {
+    Manifest manifest = new Manifest();
+    File appFile =
+      createJar(InvalidConfigApp.class, new File(TMP_FOLDER.newFolder(), "InvalidConfigApp-1.0.0.jar"), manifest);
+
+    Id.Artifact artifactId = Id.Artifact.from(Id.Namespace.DEFAULT, "InvalidConfigApp", "1.0.0");
+    Location artifactLocation = Locations.toLocation(appFile);
+    try (CloseableClassLoader artifactClassLoader = classLoaderFactory.createClassLoader(artifactLocation)) {
+      artifactInspector.inspectArtifact(artifactId, appFile, artifactClassLoader);
+    }
   }
 
   @Test

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/app/InvalidConfigApp.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/app/InvalidConfigApp.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.artifact.app;
+
+import co.cask.cdap.api.Config;
+import co.cask.cdap.api.app.AbstractApplication;
+
+/**
+ * App used to test invalid configs.
+ */
+public class InvalidConfigApp extends AbstractApplication<InvalidConfigApp.InvalidConfig> {
+
+  public static class InvalidConfig<T> extends Config {
+    private T x;
+  }
+
+  @Override
+  public void configure() {
+    // nothing since its not a real app
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/AppLifecycleHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/AppLifecycleHttpHandlerTest.java
@@ -18,6 +18,7 @@ package co.cask.cdap.internal.app.services.http.handlers;
 
 import co.cask.cdap.AppWithDataset;
 import co.cask.cdap.AppWithDatasetDuplicate;
+import co.cask.cdap.AppWithNoServices;
 import co.cask.cdap.BloatedWordCountApp;
 import co.cask.cdap.ConfigTestApp;
 import co.cask.cdap.WordCountApp;
@@ -66,6 +67,13 @@ public class AppLifecycleHttpHandlerTest extends AppFabricTestBase {
     HttpResponse response = deploy(WordCountApp.class, Constants.Gateway.API_VERSION_3_TOKEN, TEST_NAMESPACE1);
     Assert.assertEquals(200, response.getStatusLine().getStatusCode());
     response = doDelete(getVersionedAPIPath("apps/", Constants.Gateway.API_VERSION_3_TOKEN, TEST_NAMESPACE1));
+    Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+  }
+
+  @Test
+  public void testDeployWithExtraConfig() throws Exception {
+    ExtraConfig extraConfig = new ExtraConfig();
+    HttpResponse response = deploy(AppWithNoServices.class, "ExtraConfigApp", extraConfig);
     Assert.assertEquals(200, response.getStatusLine().getStatusCode());
   }
 
@@ -277,5 +285,9 @@ public class AppLifecycleHttpHandlerTest extends AppFabricTestBase {
 
     List<ArtifactSummary> summaries = readResponse(response, new TypeToken<List<ArtifactSummary>>() { }.getType());
     Assert.assertFalse(summaries.isEmpty());
+  }
+
+  private static class ExtraConfig extends Config {
+    private final int x = 5;
   }
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/AppLifecycleHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/AppLifecycleHttpHandlerTest.java
@@ -288,6 +288,7 @@ public class AppLifecycleHttpHandlerTest extends AppFabricTestBase {
   }
 
   private static class ExtraConfig extends Config {
+    @SuppressWarnings("unused")
     private final int x = 5;
   }
 }


### PR DESCRIPTION
Fixes a bug where application deployment would fail if a config
was given to an Application class that extends AbstractApplication
without any special config object.