### PR TITLE
 removes icons + chevrons from item headings

### DIFF
--- a/cdap-ui/app/directives/group-side-panel/group-side-panel.html
+++ b/cdap-ui/app/directives/group-side-panel/group-side-panel.html
@@ -39,10 +39,7 @@
         <div tooltip="{{ group.name | caskCapitalizeFilter }}"
              tooltip-placement="{{ MySidePanel.placement === 'left' ? 'top' : 'left' }}"
              tooltip-enable="isExpanded === false && !group.error">
-          <span ng-if="isExpanded === true" class="{{group.icon}}"></span>
           <span class="name">{{group.name | caskCapitalizeFilter}}</span>
-          <span class="fa pull-right"
-                ng-class="{'fa-chevron-right': MySidePanel.openedGroup !== group.name, 'fa-chevron-down': MySidePanel.openedGroup === group.name}"></span>
         </div>
       </div>
 

--- a/cdap-ui/app/features/adapters/controllers/create/leftpanel-ctrl.js
+++ b/cdap-ui/app/features/adapters/controllers/create/leftpanel-ctrl.js
@@ -18,20 +18,16 @@ angular.module(PKG.name + '.feature.adapters')
   .controller('LeftPanelController', function($q, myAdapterApi, MyAppDAGService, MyDAGFactory, myAdapterTemplatesApi, CanvasFactory, $alert, mySettings, $state, MySidebarService, $scope, rVersion, $stateParams, GLOBALS) {
     this.pluginTypes = [
       {
-        name: 'source',
-        icon: 'icon-ETLsources'
+        name: 'source'
       },
       {
-        name: 'transform',
-        icon: 'icon-ETLtransforms'
+        name: 'transform'
       },
       {
-        name: 'sink',
-        icon: 'icon-ETLsinks'
+        name: 'sink'
       },
       {
-        name: 'templates',
-        icon: 'icon-ETLtemplates'
+        name: 'templates'
       }
     ];
 
@@ -79,8 +75,7 @@ angular.module(PKG.name + '.feature.adapters')
                 var plugins = res.map(function(plugin) {
                   return {
                     name: plugin.name,
-                    description: plugin.description,
-                    icon: 'icon-ETLtemplates'
+                    description: plugin.description
                   };
                 });
                 templatedefer.resolve(plugins);

--- a/cdap-ui/app/features/adapters/leftpanel.less
+++ b/cdap-ui/app/features/adapters/leftpanel.less
@@ -107,18 +107,9 @@ body.theme-cdap.state-adapters-create {
           border-bottom-color: transparent;
           color: white;
         }
-        span {
+        span.name {
+          font-size: 13px;
           line-height: inherit;
-          &[class^="icon-"] {
-            font-size: 18px;
-            vertical-align: top;
-            width: 14px;
-            text-align: center;
-            padding-right: 5px;
-          }
-          &.name {
-            font-size: 13px;
-          }
         }
       }
       .item-body-wrapper {


### PR DESCRIPTION
Removes the following from Hydrator left panel item headings:
*  Plugin type icons
* Chevon-left and chevron-right

![left](https://cloud.githubusercontent.com/assets/5335210/9915552/8c8d1f80-5c6c-11e5-9c7b-892f7ec32027.gif)
.2