### PR TITLE
CDAP-3610: TransactionManagerDebuggerMain prints checkpoints

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/TransactionManagerDebuggerMain.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/TransactionManagerDebuggerMain.java
@@ -356,6 +356,7 @@ public class TransactionManagerDebuggerMain {
         System.out.println("\tExpiring at: " + formatter.format(new Date(txInfo.getExpiration())));
       }
       System.out.println("\tVisibility upper bound: " + txIdToString(txInfo.getVisibilityUpperBound()));
+      System.out.println("\tCheckpoints: " + txInfo.getCheckpointWritePointers());
     }
 
     if (snapshot.getInvalid().contains(txId)) {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/TransactionManagerDebuggerMain.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/TransactionManagerDebuggerMain.java
@@ -587,7 +587,9 @@ public class TransactionManagerDebuggerMain {
         System.out.println("Oldest long transaction:" +
                            "\n\tWritePtr " + txIdToString(oldestLong.getKey()) +
                            "\n\tVisibility upper bound: " +
-                           txIdToString(oldestLong.getValue().getVisibilityUpperBound()));
+                           txIdToString(oldestLong.getValue().getVisibilityUpperBound()) +
+                           "\n\tCheckpoints: " +
+                           oldestLong.getValue().getCheckpointWritePointers());
       }
       if (inProgress.size() - longTxCount > 0) {
         // Print some information about short transactions
@@ -599,7 +601,9 @@ public class TransactionManagerDebuggerMain {
                            "\n\tWritePtr " + txIdToString(oldestShort.getKey()) +
                            "\n\tExpiring at: " + formatter.format(new Date(oldestShort.getValue().getExpiration())) +
                            "\n\tVisibility upper bound: " +
-                           txIdToString(oldestShort.getValue().getVisibilityUpperBound()));
+                           txIdToString(oldestShort.getValue().getVisibilityUpperBound()) +
+                           "\n\tCheckpoints: " +
+                           oldestShort.getValue().getCheckpointWritePointers());
       }
     }
   }


### PR DESCRIPTION
- Prints checkpoints array for SnapshotCodecV4
- Prints Empty array for version below 4.

Tested with TransactionSnapshot dumped for version 3 and 4 from unit tests.
Output: https://issues.cask.co/browse/CDAP-3610?focusedCommentId=18591&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-18591

