### PR TITLE
CDAP-3691 fix snapshot filesets to work with multiple sinks

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/sink/SnapshotFileBatchSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/sink/SnapshotFileBatchSink.java
@@ -26,6 +26,7 @@ import org.apache.twill.filesystem.Location;
 
 import java.io.IOException;
 import java.text.SimpleDateFormat;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -49,7 +50,7 @@ public abstract class SnapshotFileBatchSink<KEY_OUT, VAL_OUT> extends FileBatchS
 
   @Override
   public void prepareRun(BatchSinkContext context) {
-    sinkArgs = new HashMap<>();
+    sinkArgs = getAdditionalFileSetArguments();
     SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd-hh-mm");
     FileSetArguments.setOutputPath(sinkArgs, format.format(context.getLogicalStartTime()));
     context.addOutput(config.name, sinkArgs);
@@ -72,6 +73,14 @@ public abstract class SnapshotFileBatchSink<KEY_OUT, VAL_OUT> extends FileBatchS
       //necessary because onRunFinish doesn't throw exceptions
       throw new RuntimeException(e);
     }
+  }
+
+  /**
+   * This base class will set the output path argument. Any additional arguments should be returned by this method.
+   */
+  protected Map<String, String> getAdditionalFileSetArguments() {
+    //no-op
+    return Collections.emptyMap();
   }
 
   /**

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/sink/TimePartitionedFileSetDatasetAvroSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/sink/TimePartitionedFileSetDatasetAvroSink.java
@@ -63,6 +63,8 @@ public class TimePartitionedFileSetDatasetAvroSink extends
     super.configurePipeline(pipelineConfigurer);
     String tpfsName = tpfsSinkConfig.name;
     String basePath = tpfsSinkConfig.basePath == null ? tpfsName : tpfsSinkConfig.basePath;
+    // parse it to make sure its valid
+    new Schema.Parser().parse(config.schema);
     pipelineConfigurer.createDataset(tpfsName, TimePartitionedFileSet.class.getName(), FileSetProperties.builder()
       .setBasePath(basePath)
       .setInputFormat(AvroKeyInputFormat.class)
@@ -71,15 +73,14 @@ public class TimePartitionedFileSetDatasetAvroSink extends
       .setSerDe("org.apache.hadoop.hive.serde2.avro.AvroSerDe")
       .setExploreInputFormat("org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat")
       .setExploreOutputFormat("org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat")
-      .setTableProperty("avro.schema.literal", (config.schema))
+      .setTableProperty("avro.schema.literal", config.schema)
       .build());
   }
 
   @Override
   protected Map<String, String> getAdditionalTPFSArguments() {
     Map<String, String> args = new HashMap<>();
-    Schema avroSchema = new Schema.Parser().parse(config.schema);
-    args.put(FileSetProperties.OUTPUT_PROPERTIES_PREFIX + "avro.schema.output.key", avroSchema.toString());
+    args.put(FileSetProperties.OUTPUT_PROPERTIES_PREFIX + "avro.schema.output.key", config.schema);
     return args;
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/sink/TimePartitionedFileSetDatasetParquetSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/template/etl/batch/sink/TimePartitionedFileSetDatasetParquetSink.java
@@ -53,7 +53,6 @@ public class TimePartitionedFileSetDatasetParquetSink extends
     "Object.";
   private StructuredToAvroTransformer recordTransformer;
   private final TPFSParquetSinkConfig config;
-  private String hiveSchema;
 
   public TimePartitionedFileSetDatasetParquetSink(TPFSParquetSinkConfig config) {
     super(config);
@@ -65,6 +64,9 @@ public class TimePartitionedFileSetDatasetParquetSink extends
     super.configurePipeline(pipelineConfigurer);
     String tpfsName = tpfsSinkConfig.name;
     String basePath = tpfsSinkConfig.basePath == null ? tpfsName : tpfsSinkConfig.basePath;
+    // parse to make sure it's valid
+    new org.apache.avro.Schema.Parser().parse(config.schema.toLowerCase());
+    String hiveSchema;
     try {
       hiveSchema = SchemaConverter.toHiveSchema(Schema.parseJson(config.schema.toLowerCase()));
     } catch (UnsupportedTypeException | IOException e) {
@@ -83,8 +85,7 @@ public class TimePartitionedFileSetDatasetParquetSink extends
   @Override
   protected Map<String, String> getAdditionalTPFSArguments() {
     Map<String, String> args = new HashMap<>();
-    org.apache.avro.Schema avroSchema = new org.apache.avro.Schema.Parser().parse(config.schema.toLowerCase());
-    args.put(FileSetProperties.OUTPUT_PROPERTIES_PREFIX + "parquet.avro.schema", avroSchema.toString());
+    args.put(FileSetProperties.OUTPUT_PROPERTIES_PREFIX + "parquet.avro.schema", config.schema.toLowerCase());
     return args;
   }
 


### PR DESCRIPTION
Adding avro and parquet schema settings as arguments passed to
the filesets so that they can be used for the correct output when
multiple sinks are configured.