### PR TITLE
Added some conservative checks for testGetServiceURL(), so we retry u…

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/ServiceDiscoverer.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/ServiceDiscoverer.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.api;
 
 import java.net.URL;
+import javax.annotation.Nullable;
 
 /**
  * An interface for Discovery Service.
@@ -30,6 +31,7 @@ public interface ServiceDiscoverer {
    * @param serviceId     Service name
    * @return URL for the discovered service or null if the service is not found
    */
+  @Nullable
   URL getServiceURL(String applicationId, String serviceId);
 
   /**
@@ -38,5 +40,6 @@ public interface ServiceDiscoverer {
    * @param serviceId Service Name
    * @return URL for the discovered service or null if the service is not found
    */
+  @Nullable
   URL getServiceURL(String serviceId);
 }


### PR DESCRIPTION
…ntil the service responds. Also added some logging in the test to get more insight into its flakyness. Cleaned up some deprecation/warnings in TestFrameworkTestRun. Also Added missing @Nullable annotations to ServiceDiscoverer methods.

Build: http://builds.cask.co/browse/CDAP-RBT437