### PR TITLE
[CDAP-3571] Adding validation to business metadata creation

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/DefaultMetadataAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/DefaultMetadataAdmin.java
@@ -16,15 +16,31 @@
 
 package co.cask.cdap.metadata;
 
+import co.cask.cdap.api.app.ApplicationSpecification;
+import co.cask.cdap.app.store.Store;
+import co.cask.cdap.common.ApplicationNotFoundException;
+import co.cask.cdap.common.DatasetNotFoundException;
+import co.cask.cdap.common.InvalidMetadataException;
 import co.cask.cdap.common.NamespaceNotFoundException;
 import co.cask.cdap.common.NotFoundException;
+import co.cask.cdap.common.ProgramNotFoundException;
+import co.cask.cdap.common.StreamNotFoundException;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.namespace.AbstractNamespaceClient;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.dataset2.DatasetManagementException;
+import co.cask.cdap.data2.metadata.dataset.BusinessMetadataDataset;
 import co.cask.cdap.data2.metadata.dataset.BusinessMetadataRecord;
 import co.cask.cdap.data2.metadata.service.BusinessMetadataStore;
+import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.metadata.MetadataRecord;
 import co.cask.cdap.proto.metadata.MetadataSearchResultRecord;
 import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
+
+import com.google.common.base.CharMatcher;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
@@ -38,26 +54,43 @@ import javax.annotation.Nullable;
  * Implementation of {@link MetadataAdmin} that interacts directly with {@link BusinessMetadataStore}
  */
 public class DefaultMetadataAdmin implements MetadataAdmin {
+  private static final CharMatcher keywordMatcher = CharMatcher.inRange('A', 'Z')
+    .or(CharMatcher.inRange('a', 'z'))
+    .or(CharMatcher.inRange('0', '9'))
+    .or(CharMatcher.is('_')
+          .or(CharMatcher.is('-')));
+
   private final AbstractNamespaceClient namespaceClient;
   private final BusinessMetadataStore businessMds;
+  private final CConfiguration cConf;
+  private final Store store;
+  private final DatasetFramework datasetFramework;
+  private final StreamAdmin streamAdmin;
 
   @Inject
-  DefaultMetadataAdmin(AbstractNamespaceClient namespaceClient, BusinessMetadataStore businessMds) {
+  DefaultMetadataAdmin(AbstractNamespaceClient namespaceClient, BusinessMetadataStore businessMds,
+                       CConfiguration cConf, Store store, DatasetFramework datasetFramework,
+                       StreamAdmin streamAdmin) {
     this.namespaceClient = namespaceClient;
     this.businessMds = businessMds;
+    this.cConf = cConf;
+    this.store = store;
+    this.datasetFramework = datasetFramework;
+    this.streamAdmin = streamAdmin;
   }
 
   @Override
-  public void addProperties(Id.NamespacedId entityId, Map<String, String> properties) throws NotFoundException {
+  public void addProperties(Id.NamespacedId entityId, Map<String, String> properties)
+    throws NotFoundException, InvalidMetadataException {
     ensureEntityExists(entityId);
-    // TODO: CDAP-3571 Validation
-    // TODO: Check if app exists
+    validateProperties(entityId, properties);
     businessMds.setProperties(entityId, properties);
   }
 
   @Override
-  public void addTags(Id.NamespacedId entityId, String... tags) throws NotFoundException {
+  public void addTags(Id.NamespacedId entityId, String... tags) throws NotFoundException, InvalidMetadataException {
     ensureEntityExists(entityId);
+    validateTags(entityId, tags);
     businessMds.addTags(entityId, tags);
   }
 
@@ -154,15 +187,125 @@ public class DefaultMetadataAdmin implements MetadataAdmin {
 
   /**
    * Ensures that the specified {@link Id.NamespacedId} exists. Currently only verifies that the namespace exists.
-   * TODO: Verify that the actual entity (app/program/stream/dataset) also exists.
    */
-  private void ensureEntityExists(Id.NamespacedId entityId) throws NamespaceNotFoundException {
+  private void ensureEntityExists(Id.NamespacedId entityId) throws NotFoundException   {
     try {
       namespaceClient.get(entityId.getNamespace());
     } catch (NamespaceNotFoundException e) {
       throw e;
     } catch (Exception e) {
       throw Throwables.propagate(e);
+    }
+
+    // Check existence of entity
+    String targetType = getTargetType(entityId);
+    if (Id.Program.class.getSimpleName().equals(targetType)) {
+      Id.Program program = (Id.Program) entityId;
+      Id.Application application = program.getApplication();
+      ApplicationSpecification appSpec = store.getApplication(application);
+      if (appSpec == null) {
+        throw new ApplicationNotFoundException(application);
+      }
+      ensureProgramExists(appSpec, program);
+    } else if (Id.Application.class.getSimpleName().equals(targetType)) {
+      Id.Application application = (Id.Application) entityId;
+      if (store.getApplication(application) == null) {
+        throw new ApplicationNotFoundException(application);
+      }
+    } else if (Id.DatasetInstance.class.getSimpleName().equals(targetType)) {
+      Id.DatasetInstance datasetInstance = (Id.DatasetInstance) entityId;
+      try {
+        if (!datasetFramework.hasInstance(datasetInstance)) {
+          throw new DatasetNotFoundException(datasetInstance);
+        }
+      } catch (DatasetManagementException ex) {
+        throw new IllegalStateException(ex);
+      }
+    } else if (Id.Stream.class.getSimpleName().equals(targetType)) {
+      Id.Stream stream = (Id.Stream) entityId;
+      try {
+        if (!streamAdmin.exists(stream)) {
+          throw new StreamNotFoundException(stream);
+        }
+      } catch (StreamNotFoundException streamEx) {
+        throw streamEx;
+      } catch (Exception ex)  {
+        throw new IllegalStateException(ex);
+      }
+    } else {
+      throw new IllegalArgumentException("Invalid target type " + targetType + " for metadata storage.");
+    }
+  }
+
+  private void ensureProgramExists(ApplicationSpecification appSpec, Id.Program program) throws NotFoundException {
+    ProgramType programType = program.getType();
+
+    Set<String> programNames = null;
+    if (programType == ProgramType.FLOW && appSpec.getFlows() != null) {
+      programNames = appSpec.getFlows().keySet();
+    } else if (programType == ProgramType.MAPREDUCE && appSpec.getMapReduce() != null) {
+      programNames = appSpec.getMapReduce().keySet();
+    } else if (programType == ProgramType.WORKFLOW && appSpec.getWorkflows() != null) {
+      programNames = appSpec.getWorkflows().keySet();
+    } else if (programType == ProgramType.SERVICE && appSpec.getServices() != null) {
+      programNames = appSpec.getServices().keySet();
+    } else if (programType == ProgramType.SPARK && appSpec.getSpark() != null) {
+      programNames = appSpec.getSpark().keySet();
+    } else if (programType == ProgramType.WORKER && appSpec.getWorkers() != null) {
+      programNames = appSpec.getWorkers().keySet();
+    }
+
+    if (programNames != null) {
+      if (programNames.contains(program.getId())) {
+        // is valid.
+        return;
+      }
+    }
+    throw new ProgramNotFoundException(program);
+  }
+
+  // Helper methods to validate the metadata entries.
+
+  private void validateProperties(Id.NamespacedId entityId,
+                                  Map<String, String> properties) throws InvalidMetadataException {
+    for (Map.Entry<String, String> entry : properties.entrySet()) {
+      // validate key
+      validateAllowedFormat(entityId, entry.getKey());
+      validateTagReservedKey(entityId, entry.getKey());
+      validateLength(entityId, entry.getKey());
+
+      // validate value
+      validateAllowedFormat(entityId, entry.getValue());
+      validateLength(entityId, entry.getValue());
+    }
+  }
+
+  public void validateTags(Id.NamespacedId entityId, String ... tags) throws InvalidMetadataException {
+    for (String tag : tags) {
+      validateAllowedFormat(entityId, tag);
+      validateLength(entityId, tag);
+    }
+  }
+
+  // Validate the key should not be be reserved {@link BusinessMetadataDataset.TAGS_KEY}
+  private void validateTagReservedKey(Id.NamespacedId entityId, String key) throws InvalidMetadataException {
+    if (BusinessMetadataDataset.TAGS_KEY.equals(key.toLowerCase())) {
+      throw new InvalidMetadataException(entityId,
+                                  "Could not set metadata with reserved key " + BusinessMetadataDataset.TAGS_KEY);
+    }
+  }
+
+  private void validateAllowedFormat(Id.NamespacedId entityId, String keyword) throws InvalidMetadataException {
+    if (!keywordMatcher.matchesAllOf(keyword)) {
+      throw new InvalidMetadataException(entityId, "Illegal format for the value : " + keyword);
+    }
+  }
+
+  private void validateLength(Id.NamespacedId entityId, String keyword) throws InvalidMetadataException {
+    // check for max char per value
+    if (keyword.length() > cConf.getInt(Constants.Metadata.MAX_CHARS_ALLOWED)) {
+      throw new InvalidMetadataException(entityId, "Metadata " + keyword + " should not exceed maximum of " +
+        cConf.get(Constants.Metadata.MAX_CHARS_ALLOWED) + " characters.");
     }
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataAdmin.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.metadata;
 
+import co.cask.cdap.common.InvalidMetadataException;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.metadata.MetadataRecord;
@@ -37,16 +38,19 @@ public interface MetadataAdmin {
    * Existing keys are updated with new values, newer keys are appended to the metadata.
    *
    * @throws NotFoundException if the specified entity was not found
+   * @throws InvalidMetadataException if some of the properties violate metadata validation rules
    */
-  void addProperties(Id.NamespacedId entityId, Map<String, String> properties) throws NotFoundException;
+  void addProperties(Id.NamespacedId entityId, Map<String, String> properties)
+    throws NotFoundException, InvalidMetadataException;
 
   /**
    * Adds the specified tags to specified {@link Id.Application}, {@link Id.Program}, {@link Id.DatasetInstance} or
    * {@link Id.Stream}.
    *
    * @throws NotFoundException if the specified entity was not found
+   * @throws InvalidMetadataException if some of the properties violate metadata validation rules
    */
-  void addTags(Id.NamespacedId entityId, String... tags) throws NotFoundException;
+  void addTags(Id.NamespacedId entityId, String... tags) throws NotFoundException, InvalidMetadataException;
 
   /**
    * Returns a set of {@link MetadataRecord} representing all metadata (including properties and tags) for the specified

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataHttpHandler.java
@@ -546,8 +546,14 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
   public void searchMetadata(HttpRequest request, HttpResponder responder,
                              @PathParam("namespace-id") String namespaceId,
                              @QueryParam("query") String searchQuery,
-                             @QueryParam("target") MetadataSearchTargetType target) throws Exception {
-    Set<MetadataSearchResultRecord> results = metadataAdmin.searchMetadata(searchQuery, target);
+                             @QueryParam("target") String target) throws Exception {
+    MetadataSearchTargetType metadataSearchTargetType;
+    if (target != null) {
+      metadataSearchTargetType = MetadataSearchTargetType.valueOf(target.toUpperCase());
+    } else {
+      metadataSearchTargetType = null;
+    }
+    Set<MetadataSearchResultRecord> results = metadataAdmin.searchMetadata(searchQuery, metadataSearchTargetType);
 
     responder.sendJson(HttpResponseStatus.OK, results);
   }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataTestBase.java
@@ -169,6 +169,34 @@ public abstract class MetadataTestBase extends AppFabricTestBase {
     return GSON.fromJson(response.getResponseBodyAsString(), MAP_STRING_STRING_TYPE);
   }
 
+  protected void getPropertiesFromInvalidEntity(Id.Application app) throws IOException {
+    String path = getVersionedAPIPath(String.format("apps/%s/metadata/properties", app.getId()), app.getNamespaceId());
+    HttpResponse response = makeGetRequest(path);
+    Assert.assertEquals(404, response.getResponseCode());
+  }
+
+  protected void getPropertiesFromInvalidEntity(Id.Program program) throws IOException {
+    String path = getVersionedAPIPath(String.format("apps/%s/%s/%s/metadata/properties", program.getApplicationId(),
+                                                    program.getType().getCategoryName(), program.getId()),
+                                      program.getNamespaceId());
+    HttpResponse response = makeGetRequest(path);
+    Assert.assertEquals(404, response.getResponseCode());
+  }
+
+  protected void getPropertiesFromInvalidEntity(Id.DatasetInstance dataset) throws IOException {
+    String path = getVersionedAPIPath(String.format("datasets/%s/metadata/properties",
+                                                    dataset.getId()), dataset.getNamespaceId());
+    HttpResponse response = makeGetRequest(path);
+    Assert.assertEquals(404, response.getResponseCode());
+  }
+
+  protected void getPropertiesFromInvalidEntity(Id.Stream stream) throws IOException {
+    String path = getVersionedAPIPath(String.format("streams/%s/metadata/properties",
+                                                    stream.getId()), stream.getNamespaceId());
+    HttpResponse response = makeGetRequest(path);
+    Assert.assertEquals(404, response.getResponseCode());
+  }
+
   protected void removeMetadata(Id.Application app) throws IOException {
     String path = getVersionedAPIPath(String.format("apps/%s/metadata", app.getId()), app.getNamespaceId());
     HttpResponse response = makeDeleteRequest(path);

--- a/cdap-common/src/main/java/co/cask/cdap/common/InvalidMetadataException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/InvalidMetadataException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.common;
+
+import co.cask.cdap.proto.Id;
+
+/**
+ * Base exception for Metadata validation.
+ */
+public class InvalidMetadataException extends BadRequestException {
+
+  private final Id.NamespacedId targetId;
+
+  public InvalidMetadataException(Id.NamespacedId targetId, String message) {
+    super("Unable to set metadata for " + targetId + " with error: " + message);
+    this.targetId = targetId;
+  }
+
+  public Id.NamespacedId getTargetId() {
+    return targetId;
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -889,5 +889,6 @@ public final class Constants {
     public static final String UPDATES_KAFKA_TOPIC = "metadata.updates.kafka.topic";
     public static final String UPDATES_PUBLISH_ENABLED = "metadata.updates.publish.enabled";
     public static final String UPDATES_KAFKA_BROKER_LIST = "metadata.updates.kafka.broker.list";
+    public static final String MAX_CHARS_ALLOWED = "metadata.max.allowed.chars";
   }
 }

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -1573,4 +1573,11 @@
     </description>
   </property>
 
+  <property>
+    <name>metadata.max.allowed.chars</name>
+    <value>50</value>
+    <description>Maximum number of characters for metadata keys, values, and tags</description>
+  </property>
+
+
 </configuration>

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/BusinessMetadataDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/BusinessMetadataDataset.java
@@ -46,8 +46,8 @@ import javax.annotation.Nullable;
  * Dataset that manages Business Metadata using an {@link IndexedTable}.
  */
 public class BusinessMetadataDataset extends AbstractDataset {
-  private static final String TAGS_KEY = "tags";
-  private static final String TAGS_SEPARATOR = ",";
+  public static final String TAGS_KEY = "tags";
+  public static final String TAGS_SEPARATOR = ",";
 
   // column keys
   static final String KEYVALUE_COLUMN = "kv";

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/DatasetOpExecutorServerTwillRunnable.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/DatasetOpExecutorServerTwillRunnable.java
@@ -33,6 +33,7 @@ import co.cask.cdap.common.twill.AbstractMasterTwillRunnable;
 import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.DataSetServiceModules;
 import co.cask.cdap.data.runtime.DataSetsModules;
+import co.cask.cdap.data.stream.StreamAdminModules;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetOpExecutorService;
 import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.internal.app.store.DefaultStore;
@@ -41,6 +42,7 @@ import co.cask.cdap.logging.guice.LoggingModules;
 import co.cask.cdap.metadata.MetadataService;
 import co.cask.cdap.metadata.MetadataServiceModule;
 import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
+import co.cask.cdap.notifications.feeds.client.NotificationFeedClientModule;
 import co.cask.cdap.proto.Id;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.Service;
@@ -104,6 +106,8 @@ public class DatasetOpExecutorServerTwillRunnable extends AbstractMasterTwillRun
       new ExploreClientModule(),
       new NamespaceClientRuntimeModule().getDistributedModules(),
       new MetadataServiceModule(),
+      new StreamAdminModules().getDistributedModules(),
+      new NotificationFeedClientModule(),
       new AbstractModule() {
         @Override
         protected void configure() {


### PR DESCRIPTION
Wire the CDAP-3571 to addProperties and addTags for checking.

Add validation for non existence entities. Update unit tests.