### PR TITLE
CDAP-3239 Check if the rowfield type is simple or nullable simple

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/SleepingWorkflowApp.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/SleepingWorkflowApp.java
@@ -44,9 +44,9 @@ public class SleepingWorkflowApp extends AbstractApplication {
 
     @Override
     public void configure() {
-        setName("SleepWorkflow");
-        setDescription("FunWorkflow description");
-        addAction(new CustomAction("verify"));
+      setName("SleepWorkflow");
+      setDescription("FunWorkflow description");
+      addAction(new CustomAction("verify"));
     }
   }
 

--- a/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionRowRecordReader.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/io/ReflectionRowRecordReader.java
@@ -37,7 +37,7 @@ import javax.annotation.Nullable;
 public class ReflectionRowRecordReader extends ReflectionRowReader<StructuredRecord> {
   // these are used since we know the type or the row key in the constructor,
   // and we don't want to have a big switch statement each time we read a row.
-  private static final Map<Schema.Type, RowKeyFunction> rowKeyFuctions =
+  private static final Map<Schema.Type, RowKeyFunction> rowKeyFunctions =
     ImmutableMap.<Schema.Type, RowKeyFunction>builder()
       .put(Schema.Type.BOOLEAN, new RowKeyFunction<Boolean>() {
         @Override
@@ -94,9 +94,13 @@ public class ReflectionRowRecordReader extends ReflectionRowReader<StructuredRec
       Preconditions.checkArgument(rowField != null, "Row field not found in schema");
       Schema.Type rowType = rowField.getSchema().getType();
       Preconditions.checkArgument(rowType != Schema.Type.NULL, "Row field cannot have null type.");
-      Preconditions.checkArgument(rowType.isSimpleType(),
-        "Row field must be a simple type (boolean, bytes, int, long, float, double, or string).");
-      this.rowKeyFunction = rowKeyFuctions.get(rowType);
+      Preconditions.checkArgument(rowField.getSchema().isSimpleOrNullableSimple(),
+        "Row field must be a simple (boolean, bytes, int, long, float, double, or string) or nullable simple type.");
+      if (rowField.getSchema().isNullableSimple()) {
+        this.rowKeyFunction = rowKeyFunctions.get(rowField.getSchema().getNonNullable().getType());
+      } else {
+        this.rowKeyFunction = rowKeyFunctions.get(rowType);
+      }
     } else {
       this.rowKeyFunction = null;
     }


### PR DESCRIPTION
Also modifying couple of test cases to check explore that explore works when the row key field is of type nullable simple and when it is of simple type

JIRA : https://issues.cask.co/browse/CDAP-3239

Build : http://builds.cask.co/browse/CDAP-RBT445-3