### PR TITLE
Add support for both prefix scan search via * and keyword specific search

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataHttpHandlerTest.java
@@ -97,18 +97,25 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     Assert.assertEquals(expected, searchProperties);
 
     // test prefix search for service
-    searchProperties = searchMetadata(Id.Namespace.DEFAULT.getId(), "sKey:s", "ALL");
+    searchProperties = searchMetadata(Id.Namespace.DEFAULT.getId(), "sKey:s*", "ALL");
     expected = ImmutableSet.of(
       new MetadataSearchResultRecord(pingService, MetadataSearchTargetType.PROGRAM)
     );
     Assert.assertEquals(expected, searchProperties);
 
     // search without any target param
-    searchProperties = searchMetadata(Id.Namespace.DEFAULT.getId(), "sKey:s", null);
+    searchProperties = searchMetadata(Id.Namespace.DEFAULT.getId(), "sKey:s*", null);
     Assert.assertEquals(expected, searchProperties);
 
+    // Should get empty
+    searchProperties = searchMetadata(Id.Namespace.DEFAULT.getId(), "sKey:s", null);
+    Assert.assertTrue(searchProperties.size() == 0);
+
+    searchProperties = searchMetadata(Id.Namespace.DEFAULT.getId(), "s", null);
+    Assert.assertTrue(searchProperties.size() == 0);
+
     // search non-existent property should return empty set
-    searchProperties = searchMetadata(Id.Namespace.DEFAULT.getId(), "NullKey:s", null);
+    searchProperties = searchMetadata(Id.Namespace.DEFAULT.getId(), "NullKey:s*", null);
     Assert.assertEquals(ImmutableSet.of(), searchProperties);
 
     // test removal
@@ -168,13 +175,13 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     Assert.assertTrue(tags.containsAll(streamTags));
     Assert.assertTrue(streamTags.containsAll(tags));
     // test search for stream
-    Set<MetadataSearchResultRecord> searchTags = searchMetadata(Id.Namespace.DEFAULT.getId(), "stT", "STREAM");
+    Set<MetadataSearchResultRecord> searchTags = searchMetadata(Id.Namespace.DEFAULT.getId(), "stT*", "STREAM");
     Set<MetadataSearchResultRecord> expected = ImmutableSet.of(
       new MetadataSearchResultRecord(mystream, MetadataSearchTargetType.STREAM)
     );
     Assert.assertEquals(expected, searchTags);
     // test prefix search, should match stream and service programs
-    searchTags = searchMetadata(Id.Namespace.DEFAULT.getId(), "s", "ALL");
+    searchTags = searchMetadata(Id.Namespace.DEFAULT.getId(), "s*", "ALL");
     expected = ImmutableSet.of(
       new MetadataSearchResultRecord(mystream, MetadataSearchTargetType.STREAM),
       new MetadataSearchResultRecord(pingService, MetadataSearchTargetType.PROGRAM)
@@ -182,7 +189,7 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     Assert.assertEquals(expected, searchTags);
 
     // search without any target param
-    searchTags = searchMetadata(Id.Namespace.DEFAULT.getId(), "s", null);
+    searchTags = searchMetadata(Id.Namespace.DEFAULT.getId(), "s*", null);
     Assert.assertEquals(expected, searchTags);
 
     // search non-existent tags should return empty set

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/BusinessMetadataDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/BusinessMetadataDataset.java
@@ -360,10 +360,16 @@ public class BusinessMetadataDataset extends AbstractDataset {
                                                       MetadataSearchTargetType type) {
     List<BusinessMetadataRecord> results = new LinkedList<>();
 
-    byte[] startKey = Bytes.toBytes(searchValue.toLowerCase());
-    byte[] stopKey = Bytes.stopKeyForPrefix(startKey);
-
-    Scanner scanner = indexedTable.scanByIndex(Bytes.toBytes(column), startKey, stopKey);
+    Scanner scanner;
+    String lowerCaseSearchValue = searchValue.toLowerCase();
+    if (lowerCaseSearchValue.endsWith("*")) {
+      byte[] startKey = Bytes.toBytes(lowerCaseSearchValue.substring(0, lowerCaseSearchValue.lastIndexOf("*")));
+      byte[] stopKey = Bytes.stopKeyForPrefix(startKey);
+      scanner = indexedTable.scanByIndex(Bytes.toBytes(column), startKey, stopKey);
+    } else {
+      byte[] value = Bytes.toBytes(lowerCaseSearchValue);
+      scanner = indexedTable.readByIndex(Bytes.toBytes(column), value);
+    }
     try {
       Row next;
       while ((next = scanner.next()) != null) {

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/dataset/BusinessMetadataDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/dataset/BusinessMetadataDatasetTest.java
@@ -189,6 +189,19 @@ public class BusinessMetadataDatasetTest {
     for (BusinessMetadataRecord result2 : results2) {
       Assert.assertEquals("value1", result2.getValue());
     }
+
+    // Save it
+    dataset.setProperty(stream1, "key21", "value21");
+
+    // Search for it based on value asterix
+    List<BusinessMetadataRecord> results3 = dataset.findBusinessMetadataOnValue("value2*",
+                                                                                MetadataSearchTargetType.ALL);
+
+    // Assert check
+    Assert.assertEquals(2, results3.size());
+    for (BusinessMetadataRecord result3 : results3) {
+      Assert.assertTrue(result3.getValue().startsWith("value2"));
+    }
   }
 
   @Test


### PR DESCRIPTION
Currently the metadata search using prefix scan search by default.

So search for value will return for value, value1, value2, and value21.

With the change search for value will return value, search for value2* will return value2 and value21.

Merge changes from #4004 for testing.