### PR TITLE
Change default log back to INFO

### DIFF
--- a/cdap-distributions/src/etc/cdap/conf.dist/logback-container.xml
+++ b/cdap-distributions/src/etc/cdap/conf.dist/logback-container.xml
@@ -53,7 +53,7 @@
       </rollingPolicy>
     </appender>
 
-  <root level="ERROR">
+  <root level="INFO">
     <appender-ref ref="Rolling"/>
   </root>
 


### PR DESCRIPTION
* Change default log back container to info so that the INFO messages for customer apps are collected by default.