### PR TITLE
fix create app command so that the config sent in the request

### DIFF
--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/CreateAppCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/CreateAppCommand.java
@@ -31,16 +31,19 @@ import co.cask.cdap.proto.artifact.ArtifactSummary;
 import co.cask.common.cli.Arguments;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
+import com.google.gson.reflect.TypeToken;
 import com.google.inject.Inject;
 
 import java.io.File;
 import java.io.FileReader;
 import java.io.PrintStream;
+import java.lang.reflect.Type;
 
 /**
  * Deploys an application from an existing artifact.
  */
 public class CreateAppCommand extends AbstractAuthCommand {
+  private static final Type configType = new TypeToken<AppRequest<JsonObject>>() { }.getType();
   private static final Gson GSON = new Gson();
   private final ApplicationClient applicationClient;
   private final FilePathResolver resolver;
@@ -67,8 +70,8 @@ public class CreateAppCommand extends AbstractAuthCommand {
     if (configPath != null) {
       File configFile = resolver.resolvePathToFile(configPath);
       try (FileReader reader = new FileReader(configFile)) {
-        ConfigFile configContents = GSON.fromJson(reader, ConfigFile.class);
-        config = configContents.config;
+        AppRequest<JsonObject> appRequest = GSON.fromJson(reader, configType);
+        config = appRequest.getConfig();
       }
     }
 
@@ -90,10 +93,5 @@ public class CreateAppCommand extends AbstractAuthCommand {
       "For example, the file contents could contain: '{ \"config\": { \"stream\": \"purchases\" } }'. In this case, " +
       "the application would recieve '{ \"stream\": \"purchases\" }' as its config object.",
       Fragment.of(Article.A, ElementType.APP.getName()));
-  }
-
-  // simple class for deserializing contents of config file.
-  private static final class ConfigFile {
-    private JsonObject config;
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/CreateAppCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/CreateAppCommand.java
@@ -67,7 +67,8 @@ public class CreateAppCommand extends AbstractAuthCommand {
     if (configPath != null) {
       File configFile = resolver.resolvePathToFile(configPath);
       try (FileReader reader = new FileReader(configFile)) {
-        config = GSON.fromJson(reader, JsonObject.class);
+        ConfigFile configContents = GSON.fromJson(reader, ConfigFile.class);
+        config = configContents.config;
       }
     }
 
@@ -84,7 +85,15 @@ public class CreateAppCommand extends AbstractAuthCommand {
 
   @Override
   public String getDescription() {
-    return String.format("Creates %s from an artifact with optional configuration.", Fragment.of(
-      Article.A, ElementType.APP.getName()));
+    return String.format("Creates %s from an artifact with optional configuration. If configuration is needed, it " +
+      "must be given as a file whose contents are a JSON Object containing the application config. " +
+      "For example, the file contents could contain: '{ \"config\": { \"stream\": \"purchases\" } }'. In this case, " +
+      "the application would recieve '{ \"stream\": \"purchases\" }' as its config object.",
+      Fragment.of(Article.A, ElementType.APP.getName()));
+  }
+
+  // simple class for deserializing contents of config file.
+  private static final class ConfigFile {
+    private JsonObject config;
   }
 }


### PR DESCRIPTION
comes from a config field in the file contents. This lets us
extend the object if we have more arguments in the future, and it
also makes it so that the same file can be used to create an app
through curl and the CLI