### PR TITLE
[ CDAP-3634] Add support for case insensitive search for metadata

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/BusinessMetadataDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/BusinessMetadataDataset.java
@@ -52,6 +52,7 @@ public class BusinessMetadataDataset extends AbstractDataset {
   // column keys
   static final String KEYVALUE_COLUMN = "kv";
   static final String VALUE_COLUMN = "v";
+  static final String CASE_INSENSITIVE_VALUE_COLUMN = "civ";
 
   /**
    * Identifies the type of metadata - property or tag
@@ -340,7 +341,7 @@ public class BusinessMetadataDataset extends AbstractDataset {
    * @return The {@link Iterable} of {@link BusinessMetadataRecord} that fit the value
    */
   public List<BusinessMetadataRecord> findBusinessMetadataOnValue(String value, MetadataSearchTargetType type) {
-    return executeSearchOnColumns(BusinessMetadataDataset.VALUE_COLUMN, value, type);
+    return executeSearchOnColumns(BusinessMetadataDataset.CASE_INSENSITIVE_VALUE_COLUMN, value, type);
   }
 
   /**
@@ -359,7 +360,7 @@ public class BusinessMetadataDataset extends AbstractDataset {
                                                       MetadataSearchTargetType type) {
     List<BusinessMetadataRecord> results = new LinkedList<>();
 
-    byte[] startKey = Bytes.toBytes(searchValue);
+    byte[] startKey = Bytes.toBytes(searchValue.toLowerCase());
     byte[] stopKey = Bytes.stopKeyForPrefix(startKey);
 
     Scanner scanner = indexedTable.scanByIndex(Bytes.toBytes(column), startKey, stopKey);
@@ -457,8 +458,12 @@ public class BusinessMetadataDataset extends AbstractDataset {
   private void write(MDSKey id, BusinessMetadataRecord record) {
     Put put = new Put(id.getKey());
 
-     // Now add the index columns.
-    put.add(Bytes.toBytes(KEYVALUE_COLUMN), Bytes.toBytes(record.getKey() + KEYVALUE_SEPARATOR + record.getValue()));
+     // Now add the index columns. To support case insensitive we will store it as lower case for index columns.
+    put.add(Bytes.toBytes(KEYVALUE_COLUMN),
+            Bytes.toBytes(record.getKey().toLowerCase() + KEYVALUE_SEPARATOR + record.getValue().toLowerCase()));
+    put.add(Bytes.toBytes(CASE_INSENSITIVE_VALUE_COLUMN), Bytes.toBytes(record.getValue().toLowerCase()));
+
+    // Add to value column
     put.add(Bytes.toBytes(VALUE_COLUMN), Bytes.toBytes(record.getValue()));
 
     indexedTable.put(put);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/BusinessMetadataDefinition.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/BusinessMetadataDefinition.java
@@ -35,7 +35,7 @@ public class BusinessMetadataDefinition extends AbstractDatasetDefinition<Busine
 
   public static final String METADATA_INDEX_TABLE_NAME = "metadata_index";
   public static final String INDEXED_COLS = BusinessMetadataDataset.KEYVALUE_COLUMN + "," +
-    BusinessMetadataDataset.VALUE_COLUMN;
+    BusinessMetadataDataset.CASE_INSENSITIVE_VALUE_COLUMN;
 
   private final DatasetDefinition<? extends IndexedTable, ?> indexedTableDef;
 

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/dataset/BusinessMetadataDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/dataset/BusinessMetadataDatasetTest.java
@@ -164,11 +164,14 @@ public class BusinessMetadataDatasetTest {
     dataset.setProperty(flow1, "key2", "value2");
 
     // Search for it based on value
-    List<BusinessMetadataRecord> results = dataset.findBusinessMetadataOnValue("value1",
-                                                                               MetadataSearchTargetType.PROGRAM);
+    List<BusinessMetadataRecord> results =
+      dataset.findBusinessMetadataOnValue("value1", MetadataSearchTargetType.PROGRAM);
 
     // Assert check
     Assert.assertEquals(1, results.size());
+
+    // Case insensitive
+    results = dataset.findBusinessMetadataOnValue("ValUe1", MetadataSearchTargetType.PROGRAM);
 
     BusinessMetadataRecord result = results.get(0);
     Assert.assertEquals(record, result);
@@ -177,8 +180,8 @@ public class BusinessMetadataDatasetTest {
     dataset.setProperty(flow1, "key3", "value1");
 
     // Search for it based on value
-    List<BusinessMetadataRecord> results2 = dataset.findBusinessMetadataOnValue("value1",
-                                                                                MetadataSearchTargetType.PROGRAM);
+    List<BusinessMetadataRecord> results2 =
+      dataset.findBusinessMetadataOnValue("value1", MetadataSearchTargetType.PROGRAM);
 
     // Assert check
     Assert.assertEquals(2, results2.size());


### PR DESCRIPTION
Support metadata search with case insensitive. So search for value "value" and "VaLue" should yields same result.

To do this, we are introducing new column on the metadata index table column to store lower case value and key:value combo.