### PR TITLE
Fix/ui push messages to console tab

### DIFF
--- a/cdap-ui/app/directives/dag/my-dag-ctrl.js
+++ b/cdap-ui/app/directives/dag/my-dag-ctrl.js
@@ -352,6 +352,9 @@ angular.module(PKG.name + '.commons')
         this.plugins = [];
         angular.forEach(MyAppDAGService.nodes, function(node) {
           this.plugins.push(node);
+          if (node._backendProperties) {
+            this.highlightRequiredFields(this.plugins[this.plugins.length -1]);
+          }
         }.bind(this));
         $timeout(this.drawGraph.bind(this));
     }

--- a/cdap-ui/app/directives/dag/my-dag-ctrl.js
+++ b/cdap-ui/app/directives/dag/my-dag-ctrl.js
@@ -78,6 +78,7 @@ angular.module(PKG.name + '.commons')
       angular.forEach(this.plugins, function (plugin) {
         if (errObj[plugin.id]) {
           plugin.error = errObj[plugin.id];
+          plugin.requiredFieldCount = plugin.error.requiredFieldCount;
         } else if (plugin.error) {
           delete plugin.error;
         }

--- a/cdap-ui/app/directives/dag/my-dag-ctrl.js
+++ b/cdap-ui/app/directives/dag/my-dag-ctrl.js
@@ -32,7 +32,8 @@ angular.module(PKG.name + '.commons')
         if (plug.id === plugin.id) {
           plug.selected = true;
         }
-      });
+        this.highlightRequiredFields(plug);
+      }.bind(this));
     };
 
     this.addPlugin = function addPlugin(config, type) {
@@ -94,9 +95,6 @@ angular.module(PKG.name + '.commons')
       });
 
       plugin.selected = true;
-      if (plugin.error) {
-        delete plugin.error;
-      }
       MyAppDAGService.editPluginProperties($scope, plugin.id, plugin.type);
     };
 

--- a/cdap-ui/app/directives/dag/my-dag-ctrl.js
+++ b/cdap-ui/app/directives/dag/my-dag-ctrl.js
@@ -289,6 +289,8 @@ angular.module(PKG.name + '.commons')
     }
 
     $scope.$on('$destroy', function() {
+      MyNodeConfigService.unRegisterPluginResetCallback($scope.$id);
+      MyNodeConfigService.unRegisterPluginSaveCallback($scope.$id);
       closeAllPopovers();
       angular.forEach(popoverScopes, function (s) {
         s.$destroy();
@@ -356,8 +358,8 @@ angular.module(PKG.name + '.commons')
       resetComponent.call(this);
     }
 
-    MyNodeConfigService.registerPluginResetCallback(this.resetPluginSelection.bind(this));
-    MyNodeConfigService.registerPluginSaveCallback(this.highlightRequiredFields.bind(this));
+    MyNodeConfigService.registerPluginResetCallback($scope.$id, this.resetPluginSelection.bind(this));
+    MyNodeConfigService.registerPluginSaveCallback($scope.$id, this.highlightRequiredFields.bind(this));
     MyAppDAGService.registerCallBack(this.addPlugin.bind(this));
     MyAppDAGService.registerResetCallBack(resetComponent.bind(this));
   });

--- a/cdap-ui/app/directives/dag/my-dag-ctrl.js
+++ b/cdap-ui/app/directives/dag/my-dag-ctrl.js
@@ -59,16 +59,20 @@ angular.module(PKG.name + '.commons')
 
       AdapterErrorFactory.isValidPlugin(plugin);
 
-      if (!plugin.valid) {
-        this.plugins.forEach(function(p) {
-          if (p.id === plugin.id) {
+      this.plugins.forEach(function(p) {
+        if (p.id === plugin.id) {
+          if (plugin.valid) {
+            p.requiredFieldCount = 0;
+            p.error = false;
+            p.warning = false;
+          } else {
             p.requiredFieldCount = plugin.requiredFieldCount;
             p.error = {};
             p.error.message = 'Missing required fields';
             p.warning = true;
           }
-        });
-      }
+        }
+      });
     };
 
     this.removePlugin = function(index, nodeId) {

--- a/cdap-ui/app/directives/dag/my-dag.html
+++ b/cdap-ui/app/directives/dag/my-dag.html
@@ -29,11 +29,11 @@
       <div class="node">
         <div class="error-node-notification"
              ng-if="plugin.error"
-             tooltip="{{plugin.error}}"
+             tooltip="{{plugin.error.message}}"
              tooltip-append-to-body="true"
              tooltip-class="tooltip-error">
           <span class="badge badge-danger">
-            <i class="fa fa-exclamation"></i>
+            <span>{{plugin.requiredFieldCount}}</span>
           </span>
         </div>
         <div class="fa fa-close"

--- a/cdap-ui/app/directives/dag/my-dag.html
+++ b/cdap-ui/app/directives/dag/my-dag.html
@@ -32,7 +32,7 @@
              tooltip="{{plugin.error.message}}"
              tooltip-append-to-body="true"
              tooltip-class="tooltip-error">
-          <span class="badge badge-danger">
+          <span class="badge" ng-class="{'badge-danger': plugin.warning !== true, 'badge-warning': plugin.warning === true}">
             <span>{{plugin.requiredFieldCount}}</span>
           </span>
         </div>

--- a/cdap-ui/app/directives/validators/validator-ctrl.js
+++ b/cdap-ui/app/directives/validators/validator-ctrl.js
@@ -34,7 +34,7 @@
  * }
  **/
 angular.module(PKG.name + '.commons')
-  .controller('MyValidatorsCtrl', function($scope, myAdapterValidatorsApi) {
+  .controller('MyValidatorsCtrl', function($scope, myAdapterValidatorsApi, EventPipe) {
     var vm = this;
 
     vm.validators = [];
@@ -197,8 +197,19 @@ angular.module(PKG.name + '.commons')
         validationScript: fn
       };
 
-      $scope.model.properties = validatorProperties;
-      $scope.model.validationFields = vm.validationFields;
+      if ($scope.model.properties !== validatorProperties) {
+        $scope.model.properties = validatorProperties;
+      }
+      if ($scope.model.validationFields !== vm.validationFields) {
+        $scope.model.validationFields = vm.validationFields;
+      }
+
     }
 
+    // Since validation fields is a reference and we overwrite the array
+    // reference all the time $watch will not be triggered hence the event communication.
+    EventPipe.on('resetValidatorValidationFields', function(validationFields) {
+      vm.validationFields = validationFields || {};
+      $scope.model.validationFields = vm.validationFields;
+    });
   });

--- a/cdap-ui/app/features/adapters/bottompanel.less
+++ b/cdap-ui/app/features/adapters/bottompanel.less
@@ -247,5 +247,24 @@ body.theme-cdap.state-adapters {
         }
       }
     }
+    .console-wrapper {
+      padding: 10px 0;
+      div.btn {
+        margin: 0 0 5px 20px;
+      }
+    }
+    pre {
+      background-color: transparent;
+      border: 0;
+      display: inline;
+      padding: 0;
+      word-break: normal;
+      white-space: pre-wrap;
+      &:after {
+        display: block;
+        content: '';
+        margin-bottom: 10px;
+      }
+    }
   }
 }

--- a/cdap-ui/app/features/adapters/controllers/create/bottompanel-ctrl.js
+++ b/cdap-ui/app/features/adapters/controllers/create/bottompanel-ctrl.js
@@ -68,7 +68,7 @@ angular.module(PKG.name + '.feature.adapters')
       },
       {
         title: 'Reference',
-        template: '/assets/features/adapters/templates/partial/reference.html'
+        template: '/assets/features/adapters/templates/partial/reference-tab.html'
       }
     ];
 

--- a/cdap-ui/app/features/adapters/controllers/create/bottompanel-ctrl.js
+++ b/cdap-ui/app/features/adapters/controllers/create/bottompanel-ctrl.js
@@ -15,9 +15,14 @@
  */
 
 angular.module(PKG.name + '.feature.adapters')
-  .controller('BottomPanelController', function ($scope, MySidebarService, MyAppDAGService, MyNodeConfigService, $timeout) {
+  .controller('BottomPanelController', function ($scope, MySidebarService, MyAppDAGService, MyNodeConfigService, $timeout, MyConsoleTabService) {
 
     MyAppDAGService.registerEditPropertiesCallback(editProperties.bind(this));
+    MyConsoleTabService.registerOnMessageUpdates(showConsoleTab.bind(this));
+
+    function showConsoleTab() {
+      $scope.selectTab($scope.tabs[0]);
+    }
 
     function editProperties(plugin) {
       $scope.selectTab($scope.tabs[2]);

--- a/cdap-ui/app/features/adapters/controllers/create/bottompanel-ctrl.js
+++ b/cdap-ui/app/features/adapters/controllers/create/bottompanel-ctrl.js
@@ -19,8 +19,17 @@ angular.module(PKG.name + '.feature.adapters')
 
     MyAppDAGService.registerEditPropertiesCallback(editProperties.bind(this));
     MyConsoleTabService.registerOnMessageUpdates(showConsoleTab.bind(this));
+    MyAppDAGService.errorCallback(showConsoleTab.bind(this));
 
-    function showConsoleTab() {
+    function showConsoleTab(errors) {
+      if (errors.canvas && errors.canvas.length) {
+        errors.canvas.forEach(function(err) {
+          MyConsoleTabService.addMessage({
+            type: 'error',
+            content: err
+          });
+        });
+      }
       $scope.selectTab($scope.tabs[0]);
     }
 

--- a/cdap-ui/app/features/adapters/controllers/create/bottompanel-ctrl.js
+++ b/cdap-ui/app/features/adapters/controllers/create/bottompanel-ctrl.js
@@ -20,6 +20,9 @@ angular.module(PKG.name + '.feature.adapters')
     MyAppDAGService.registerEditPropertiesCallback(editProperties.bind(this));
     MyConsoleTabService.registerOnMessageUpdates(showConsoleTab.bind(this));
     MyAppDAGService.errorCallback(showConsoleTab.bind(this));
+    // FIXME: We should be able to remove this now.
+    // Expand and collapse of the sidebar resizes the main container natively.
+    MySidebarService.registerIsExpandedCallback(isExpanded.bind(this));
 
     function showConsoleTab(errors) {
       if (errors.canvas && errors.canvas.length) {
@@ -34,7 +37,7 @@ angular.module(PKG.name + '.feature.adapters')
     }
 
     function editProperties(plugin) {
-      $scope.selectTab($scope.tabs[2]);
+      $scope.selectTab($scope.tabs[2], false);
       // Giving 100ms to load the template and then set the plugin
       // For this service to work the controller has to register a callback
       // with the service. The callback will not be called if plugin assignment happens
@@ -49,8 +52,6 @@ angular.module(PKG.name + '.feature.adapters')
     function isExpanded(value) {
       $scope.isExpanded = !value;
     }
-
-    MySidebarService.registerIsExpandedCallback(isExpanded.bind(this));
 
     $scope.tabs = [
       {

--- a/cdap-ui/app/features/adapters/controllers/create/create-studio-ctrl.js
+++ b/cdap-ui/app/features/adapters/controllers/create/create-studio-ctrl.js
@@ -15,7 +15,7 @@
  */
 
 angular.module(PKG.name + '.feature.adapters')
-  .controller('AdapterCreateStudioController', function(MyAppDAGService, $scope, rConfig, $modalStack, EventPipe, $window, $timeout) {
+  .controller('AdapterCreateStudioController', function(MyAppDAGService, $scope, rConfig, $modalStack, EventPipe, $window, $timeout, MyConsoleTabService) {
 
     var confirmOnPageExit = function (e) {
 
@@ -49,6 +49,7 @@ angular.module(PKG.name + '.feature.adapters')
 
     $scope.$on('$destroy', function() {
       $modalStack.dismissAll();
+      MyConsoleTabService.resetMessages();
       $window.onbeforeunload = null;
       EventPipe.cancelEvent('plugin.reset');
       EventPipe.cancelEvent('schema.clear');

--- a/cdap-ui/app/features/adapters/controllers/create/leftpanel-ctrl.js
+++ b/cdap-ui/app/features/adapters/controllers/create/leftpanel-ctrl.js
@@ -87,7 +87,9 @@ angular.module(PKG.name + '.feature.adapters')
             if (!angular.isObject(res)) {
               return;
             }
-
+            if (!res || !res[$state.params.namespace]) {
+              return;
+            }
             var templates = res[$state.params.namespace][MyAppDAGService.metadata.template.type];
             if (!templates) {
               return;

--- a/cdap-ui/app/features/adapters/controllers/create/partials/console-tab-ctrl.js
+++ b/cdap-ui/app/features/adapters/controllers/create/partials/console-tab-ctrl.js
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 angular.module(PKG.name + '.feature.adapters')
   .controller('ConsoleTabController', function(MyConsoleTabService) {
     this.messages = MyConsoleTabService.messages;

--- a/cdap-ui/app/features/adapters/controllers/create/partials/console-tab-ctrl.js
+++ b/cdap-ui/app/features/adapters/controllers/create/partials/console-tab-ctrl.js
@@ -1,0 +1,8 @@
+angular.module(PKG.name + '.feature.adapters')
+  .controller('ConsoleTabController', function(MyConsoleTabService) {
+    this.messages = MyConsoleTabService.messages;
+    this.clearMessages = function() {
+      MyConsoleTabService.resetMessages();
+      this.messages = MyConsoleTabService.messages;
+    };
+  });

--- a/cdap-ui/app/features/adapters/controllers/create/partials/nodeconfig-ctrl.js
+++ b/cdap-ui/app/features/adapters/controllers/create/partials/nodeconfig-ctrl.js
@@ -35,6 +35,7 @@ angular.module(PKG.name + '.feature.adapters')
 
     function onPluginChange(plugin) {
       var defer = $q.defer();
+      $scope.type = MyAppDAGService.metadata.template.type;
       if (plugin && $scope.plugin && plugin.id === $scope.plugin.id) {
         return;
       }

--- a/cdap-ui/app/features/adapters/controllers/create/partials/nodeconfig-ctrl.js
+++ b/cdap-ui/app/features/adapters/controllers/create/partials/nodeconfig-ctrl.js
@@ -23,8 +23,8 @@ angular.module(PKG.name + '.feature.adapters')
     $scope.data = {};
     $scope.data.isModelTouched = false;
 
-    MyNodeConfigService.registerPluginSetCallback(onPluginChange);
-    MyNodeConfigService.registerRemovePluginCallback(onPluginRemoved);
+    MyNodeConfigService.registerPluginSetCallback($scope.$id, onPluginChange);
+    MyNodeConfigService.registerRemovePluginCallback($scope.$id, onPluginRemoved);
 
     function onPluginRemoved(nodeId) {
       if ($scope.plugin.id === nodeId){
@@ -35,7 +35,7 @@ angular.module(PKG.name + '.feature.adapters')
 
     function onPluginChange(plugin) {
       var defer = $q.defer();
-      if ($scope.plugin && plugin.id === $scope.plugin.id) {
+      if (plugin && $scope.plugin && plugin.id === $scope.plugin.id) {
         return;
       }
       if (!$scope.data.isModelTouched) {
@@ -60,7 +60,7 @@ angular.module(PKG.name + '.feature.adapters')
     function confirmPluginSwitch() {
       var defer = $q.defer();
 
-      var confirmInstance = $bootstrapModal.open({
+      $bootstrapModal.open({
         keyboard: false,
         templateUrl: '/assets/features/adapters/templates/partial/confirm.html',
         windowClass: 'modal-confirm',
@@ -73,8 +73,7 @@ angular.module(PKG.name + '.feature.adapters')
             $scope.$close('keep open');
           };
         }]
-      });
-      confirmInstance.result.then(function (closing) {
+      }).result.then(function (closing) {
         if (closing === 'close') {
           defer.resolve(true);
         } else {
@@ -89,13 +88,15 @@ angular.module(PKG.name + '.feature.adapters')
       $scope.isValidPlugin = false;
       // falsify the ng-if in the template for one tick so that the template gets reloaded
       // there by reloading the controller.
-      $timeout(function() {
-        $scope.isValidPlugin = Object.keys($scope.plugin).length;
-        $scope.isSource = false;
-        $scope.isTransform = false;
-        $scope.isSink = false;
-        configurePluginInfo();
-      });
+      $timeout(setPluginInfo);
+    }
+
+    function setPluginInfo() {
+      $scope.isValidPlugin = Object.keys($scope.plugin).length;
+      $scope.isSource = false;
+      $scope.isTransform = false;
+      $scope.isSink = false;
+      configurePluginInfo();
     }
 
     function configurePluginInfo() {
@@ -243,5 +244,11 @@ angular.module(PKG.name + '.feature.adapters')
           return defer.promise;
         });
     }
+
+    $scope.$on('$destroy', function() {
+      MyNodeConfigService.unRegisterPluginSetCallback($scope.$id);
+      MyNodeConfigService.unRegisterRemovePluginCallback($scope.$id);
+      console.info('destroyed');
+    });
 
   });

--- a/cdap-ui/app/features/adapters/controllers/create/partials/nodeconfig-ctrl.js
+++ b/cdap-ui/app/features/adapters/controllers/create/partials/nodeconfig-ctrl.js
@@ -27,7 +27,7 @@ angular.module(PKG.name + '.feature.adapters')
     MyNodeConfigService.registerRemovePluginCallback($scope.$id, onPluginRemoved);
 
     function onPluginRemoved(nodeId) {
-      if ($scope.plugin.id === nodeId){
+      if ($scope.plugin && $scope.plugin.id === nodeId){
         $scope.isValidPlugin = false;
         $scope.data.isModelTouched = false;
       }
@@ -177,22 +177,6 @@ angular.module(PKG.name + '.feature.adapters')
             $scope.plugin.outputSchema = angular.copy(JSON.stringify(input)) || null;
           }
 
-          if ($scope.plugin._backendProperties.schema) {
-            $scope.$watch('plugin.outputSchema', function () {
-              if (!$scope.plugin.outputSchema) {
-                if ($scope.plugin.properties && $scope.plugin.properties.schema) {
-                  $scope.plugin.properties.schema = null;
-                }
-                return;
-              }
-
-              if (!$scope.plugin.properties) {
-                $scope.plugin.properties = {};
-              }
-              $scope.plugin.properties.schema = $scope.plugin.outputSchema;
-            });
-          }
-
           if ($scope.plugin.type === artifactTypeExtension.source) {
             $scope.isSource = true;
           }
@@ -248,7 +232,6 @@ angular.module(PKG.name + '.feature.adapters')
     $scope.$on('$destroy', function() {
       MyNodeConfigService.unRegisterPluginSetCallback($scope.$id);
       MyNodeConfigService.unRegisterRemovePluginCallback($scope.$id);
-      console.info('destroyed');
     });
 
   });

--- a/cdap-ui/app/features/adapters/controllers/create/partials/referece-tab-ctrl.js
+++ b/cdap-ui/app/features/adapters/controllers/create/partials/referece-tab-ctrl.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+ 
+angular.module(PKG.name + '.feature.adapters')
+  .controller('ReferenceTabController', function(MyNodeConfigService, MyAppDAGService, GLOBALS, $rootScope, $sce) {
+    if (MyAppDAGService.metadata.template.type === GLOBALS.etlBatch) {
+      this.infoPluginType = 'batch';
+    } else if (MyAppDAGService.metadata.template.type === GLOBALS.etlRealtime) {
+      this.infoPluginType = 'real-time';
+    }
+    var plugin = MyNodeConfigService.plugin;
+    if (!plugin) {
+      return;
+    }
+
+
+    this.constructUrl = function() {
+      this.infoPluginCategory = plugin.type;
+      this.infoPluginName = plugin.name.toLowerCase();
+      var hideNav = '.html?hidenav';
+      var baseUrl = [
+        'http://docs.cask.co/cdap/' + $rootScope.cdapVersion + '/en/included-applications/etl/plugins/'
+      ];
+
+      if (this.infoPluginCategory === 'transform') {
+        this.infoPluginCategory = 'transform';
+      }
+
+      baseUrl.push(this.infoPluginCategory + 's', '/' , this.infoPluginName, hideNav);
+      this.infoUrl = baseUrl.join('');
+    };
+
+    this.trustSrc = function(src) {
+      return $sce.trustAsResourceUrl(src);
+    };
+
+    this.constructUrl();
+  });

--- a/cdap-ui/app/features/adapters/controllers/create/plugin-edit-form-ctrl.js
+++ b/cdap-ui/app/features/adapters/controllers/create/plugin-edit-form-ctrl.js
@@ -186,6 +186,13 @@ angular.module(PKG.name + '.feature.adapters')
             // TODO: Hacky. Need to fix this for am-fade-top animation for modals.
             $timeout(function() {
               $scope.pluginCopy = angular.copy($scope.plugin);
+              $scope.$watch('pluginCopy.properties', function() {
+                  var strProp1 = JSON.stringify($scope.pluginCopy.properties);
+                  var strProp2 = JSON.stringify($scope.plugin.properties);
+                  if (strProp1 !== strProp2) {
+                    $scope.data['isModelTouched'] = true;
+                  }
+              }, true);
               // Didn't receive a configuration from the backend. Fallback to all textboxes.
               this.noconfig = true;
               this.configfetched = true;

--- a/cdap-ui/app/features/adapters/controllers/create/plugin-edit-form-ctrl.js
+++ b/cdap-ui/app/features/adapters/controllers/create/plugin-edit-form-ctrl.js
@@ -15,7 +15,7 @@
  */
 
 angular.module(PKG.name + '.feature.adapters')
-  .controller('PluginEditController', function($scope, PluginConfigFactory, myHelpers, EventPipe, $timeout, MyAppDAGService, $sce, $rootScope, GLOBALS, MyNodeConfigService) {
+  .controller('PluginEditController', function($scope, PluginConfigFactory, myHelpers, EventPipe, $timeout, MyAppDAGService, GLOBALS, MyNodeConfigService) {
     $scope.pluginCopy = {};
 
     var propertiesFromBackend = Object.keys($scope.plugin._backendProperties);
@@ -34,46 +34,6 @@ angular.module(PKG.name + '.feature.adapters')
     this.configfetched = false;
     this.properties = [];
     this.noconfig = null;
-    if (MyAppDAGService.metadata.template.type === GLOBALS.etlBatch) {
-      this.infoPluginType = 'batch';
-    } else if (MyAppDAGService.metadata.template.type === GLOBALS.etlRealtime) {
-      this.infoPluginType = 'real-time';
-    }
-
-    this.infoPluginCategory = $scope.plugin.type + 's';
-
-    this.infoPluginName = $scope.plugin.name.toLowerCase();
-    var docsUrl = 'http://docs.cask.co/cdap/';
-    var etlPath = '/en/included-applications/etl/plugins/';
-    var hideNav = '.html?hidenav';
-    if (this.infoPluginCategory === 'transforms') {
-      this.infoPluginCategory = 'transformations';
-      this.infoUrl = [
-        docsUrl,
-        $rootScope.cdapVersion,
-        etlPath,
-        this.infoPluginCategory,
-        '/',
-        this.infoPluginName,
-        hideNav
-      ].join('');
-    } else {
-      this.infoUrl = [
-        docsUrl,
-        $rootScope.cdapVersion ,
-        etlPath,
-        this.infoPluginCategory,
-        '/',
-        this.infoPluginType,
-        '/',
-        this.infoPluginName,
-        hideNav
-      ].join('');
-    }
-
-    this.trustSrc = function(src) {
-      return $sce.trustAsResourceUrl(src);
-    };
 
     this.noproperty = Object.keys(
       $scope.plugin._backendProperties || {}

--- a/cdap-ui/app/features/adapters/controllers/create/plugin-edit-form-ctrl.js
+++ b/cdap-ui/app/features/adapters/controllers/create/plugin-edit-form-ctrl.js
@@ -17,7 +17,6 @@
 angular.module(PKG.name + '.feature.adapters')
   .controller('PluginEditController', function($scope, PluginConfigFactory, myHelpers, EventPipe, $timeout, MyAppDAGService, $sce, $rootScope, GLOBALS, MyNodeConfigService) {
     $scope.pluginCopy = {};
-    var saveWatch;
 
     var propertiesFromBackend = Object.keys($scope.plugin._backendProperties);
     // Make a local copy that is a mix of properties from backend + config from nodejs
@@ -132,21 +131,54 @@ angular.module(PKG.name + '.feature.adapters')
             this.config = res;
             this.noconfig = false;
 
-            saveWatch = $scope.$watch('pluginCopy', function() {
-              var strProp1 = JSON.stringify($scope.pluginCopy.properties);
-              var strProp2 = JSON.stringify($scope.plugin.properties);
-              var copyOutputSchema = JSON.stringify($scope.pluginCopy.outputSchema);
-              var originalOutputSchema = JSON.stringify($scope.plugin.outputSchema);
+            if ($scope.plugin._backendProperties.schema) {
+              $scope.$watch('pluginCopy.outputSchema', function () {
+                if (!$scope.pluginCopy.outputSchema) {
+                  if ($scope.pluginCopy.properties && $scope.plugin.properties.schema) {
+                    $scope.pluginCopy.properties.schema = null;
+                  }
+                  return;
+                }
+
+                if (!$scope.pluginCopy.properties) {
+                  $scope.pluginCopy.properties = {};
+                }
+                if ($scope.pluginCopy.properties.schema !== $scope.pluginCopy.outputSchema) {
+                  $scope.pluginCopy.properties.schema = $scope.pluginCopy.outputSchema;
+                }
+              });
+            }
+
+            $scope.$watch('pluginCopy.label', function() {
               var copyLabel = $scope.pluginCopy.label;
-              var originLabel = $scope.plugin.label;
-              if ( (strProp1 !== strProp2) ||
-                   (copyOutputSchema !== originalOutputSchema) ||
-                   (copyLabel !== originLabel)
-                 ) {
+              var originalLabel = $scope.plugin.label;
+              if (copyLabel !== originalLabel) {
                 $scope.data['isModelTouched'] = true;
-              } else {
-                $scope.data['isModelTouched'] = false;
               }
+            });
+
+            $scope.$watch('pluginCopy.errorDatasetName', function() {
+              var copyErrorDataset = $scope.pluginCopy.errorDatasetName;
+              var originalErrorDataset = $scope.plugin.errorDatasetName;
+              if (copyErrorDataset !== originalErrorDataset) {
+                $scope.data['isModelTouched'] = true;
+              }
+            });
+
+            $scope.$watch('pluginCopy.validationFields', function() {
+              var copyValidationFields = JSON.stringify($scope.pluginCopy.validationFields);
+              var originalValidationFields = JSON.stringify($scope.plugin.validationFields);
+              if (copyValidationFields !== originalValidationFields) {
+                $scope.data['isModelTouched'] = true;
+              }
+            });
+
+            $scope.$watch('pluginCopy.properties', function() {
+                var strProp1 = JSON.stringify($scope.pluginCopy.properties);
+                var strProp2 = JSON.stringify($scope.plugin.properties);
+                if (strProp1 !== strProp2) {
+                  $scope.data['isModelTouched'] = true;
+                }
             }, true);
 
           }.bind(this),
@@ -216,7 +248,12 @@ angular.module(PKG.name + '.feature.adapters')
     }
 
     this.reset = function () {
-      $scope.pluginCopy = angular.copy($scope.plugin);
+      $scope.pluginCopy.properties = angular.copy($scope.plugin.properties);
+      $scope.pluginCopy.outputSchema = angular.copy($scope.plugin.outputSchema);
+      $scope.pluginCopy.inputSchema = angular.copy($scope.plugin.inputSchema);
+      $scope.pluginCopy.errorDatasetName = angular.copy($scope.plugin.errorDatasetName);
+      // $scope.pluginCopy.validationFields = angular.copy($scope.plugin.validationFields);
+      EventPipe.emit('resetValidatorValidationFields', $scope.plugin.validationFields);
       $scope.data['isModelTouched'] = false;
       EventPipe.emit('plugin.reset');
     };
@@ -226,9 +263,11 @@ angular.module(PKG.name + '.feature.adapters')
     };
 
     this.save = function () {
-      if (validateSchema()) {
+      if (validateSchema() || $scope.plugin.name === 'Validator') {
         $scope.plugin.properties = angular.copy($scope.pluginCopy.properties);
         $scope.plugin.outputSchema = angular.copy($scope.pluginCopy.outputSchema);
+        $scope.plugin.errorDatasetName = angular.copy($scope.pluginCopy.errorDatasetName);
+        $scope.plugin.validationFields = angular.copy($scope.pluginCopy.validationFields);
         $scope.plugin.label = $scope.pluginCopy.label;
         $scope.data['isModelTouched'] = false;
         MyNodeConfigService.notifyPluginSaveListeners($scope.plugin.id);

--- a/cdap-ui/app/features/adapters/controllers/create/plugin-edit-form-ctrl.js
+++ b/cdap-ui/app/features/adapters/controllers/create/plugin-edit-form-ctrl.js
@@ -219,7 +219,6 @@ angular.module(PKG.name + '.feature.adapters')
       $scope.pluginCopy.outputSchema = angular.copy($scope.plugin.outputSchema);
       $scope.pluginCopy.inputSchema = angular.copy($scope.plugin.inputSchema);
       $scope.pluginCopy.errorDatasetName = angular.copy($scope.plugin.errorDatasetName);
-      // $scope.pluginCopy.validationFields = angular.copy($scope.plugin.validationFields);
       EventPipe.emit('resetValidatorValidationFields', $scope.plugin.validationFields);
       $scope.data['isModelTouched'] = false;
       EventPipe.emit('plugin.reset');

--- a/cdap-ui/app/features/adapters/controllers/create/plugin-edit-form-ctrl.js
+++ b/cdap-ui/app/features/adapters/controllers/create/plugin-edit-form-ctrl.js
@@ -15,7 +15,7 @@
  */
 
 angular.module(PKG.name + '.feature.adapters')
-  .controller('PluginEditController', function($scope, PluginConfigFactory, myHelpers, EventPipe, $timeout, MyAppDAGService, $sce, $rootScope, GLOBALS) {
+  .controller('PluginEditController', function($scope, PluginConfigFactory, myHelpers, EventPipe, $timeout, MyAppDAGService, $sce, $rootScope, GLOBALS, MyNodeConfigService) {
     $scope.pluginCopy = {};
     var saveWatch;
 
@@ -231,6 +231,7 @@ angular.module(PKG.name + '.feature.adapters')
         $scope.plugin.outputSchema = angular.copy($scope.pluginCopy.outputSchema);
         $scope.plugin.label = $scope.pluginCopy.label;
         $scope.data['isModelTouched'] = false;
+        MyNodeConfigService.notifyPluginSaveListeners($scope.plugin.id);
       }
     };
 

--- a/cdap-ui/app/features/adapters/controllers/create/toppanel-ctrl.js
+++ b/cdap-ui/app/features/adapters/controllers/create/toppanel-ctrl.js
@@ -45,6 +45,7 @@ angular.module(PKG.name + '.feature.adapters')
     };
 
     this.openMetadata = function () {
+      this.metadata = MyAppDAGService['metadata'];
       if (this.metadataExpanded) { return; }
       EventPipe.emit('popovers.close');
       var name = this.metadata.name;
@@ -55,8 +56,8 @@ angular.module(PKG.name + '.feature.adapters')
     };
 
     this.resetMetadata = function() {
-      this.pipelineName = this.metadata.name;
-      this.pipelineDescription = this.metadata.description;
+      this.metadata.name = this.pipelineName;
+      this.metadata.description = this.pipelineDescription;
       this.metadataExpanded = false;
     };
 

--- a/cdap-ui/app/features/adapters/controllers/create/toppanel-ctrl.js
+++ b/cdap-ui/app/features/adapters/controllers/create/toppanel-ctrl.js
@@ -15,8 +15,7 @@
  */
 
 angular.module(PKG.name + '.feature.adapters')
-
-  .controller('TopPanelController', function(EventPipe, CanvasFactory, MyAppDAGService, $scope, $timeout, $bootstrapModal, ModalConfirm, $alert, $state, $stateParams, GLOBALS, AdapterErrorFactory) {
+  .controller('TopPanelController', function(EventPipe, CanvasFactory, MyAppDAGService, $scope, $timeout, $bootstrapModal, ModalConfirm, $alert, $state, $stateParams, GLOBALS, AdapterErrorFactory, MyConsoleTabService) {
 
     this.metadata = MyAppDAGService['metadata'];
     function resetMetadata() {
@@ -143,7 +142,7 @@ angular.module(PKG.name + '.feature.adapters')
             .saveAsDraft()
             .then(
               function success() {
-                $alert({
+                MyConsoleTabService.addMessage({
                   type: 'success',
                   content: MyAppDAGService.metadata.name + ' successfully saved as draft.'
                 });
@@ -175,6 +174,11 @@ angular.module(PKG.name + '.feature.adapters')
       var errors = AdapterErrorFactory.isModelValid(MyAppDAGService.nodes, MyAppDAGService.connections, MyAppDAGService.metadata, MyAppDAGService.getConfig());
       if (angular.isObject(errors)) {
         MyAppDAGService.notifyError(errors);
+      } else {
+        MyConsoleTabService.addMessage({
+          type: 'success',
+          content: MyAppDAGService.metadata.name + ' is valid .'
+        });
       }
     };
   });

--- a/cdap-ui/app/features/adapters/controllers/create/toppanel-ctrl.js
+++ b/cdap-ui/app/features/adapters/controllers/create/toppanel-ctrl.js
@@ -15,7 +15,8 @@
  */
 
 angular.module(PKG.name + '.feature.adapters')
-  .controller('TopPanelController', function(EventPipe, CanvasFactory, MyAppDAGService, $scope, $timeout, $alert, $bootstrapModal, $state, $stateParams, GLOBALS) {
+
+  .controller('TopPanelController', function(EventPipe, CanvasFactory, MyAppDAGService, $scope, $timeout, $bootstrapModal, ModalConfirm, $alert, $state, $stateParams, GLOBALS, AdapterErrorFactory) {
 
     this.metadata = MyAppDAGService['metadata'];
     function resetMetadata() {
@@ -152,6 +153,10 @@ angular.module(PKG.name + '.feature.adapters')
                 console.info('Failed saving as draft');
               }
             );
+          break;
+        case 'Validate':
+          this.validatePipeline();
+          break;
       }
     };
 
@@ -166,4 +171,10 @@ angular.module(PKG.name + '.feature.adapters')
         );
     };
 
+    this.validatePipeline = function() {
+      var errors = AdapterErrorFactory.isModelValid(MyAppDAGService.nodes, MyAppDAGService.connections, MyAppDAGService.metadata, MyAppDAGService.getConfig());
+      if (angular.isObject(errors)) {
+        MyAppDAGService.notifyError(errors);
+      }
+    };
   });

--- a/cdap-ui/app/features/adapters/services/adapter-error-factory.js
+++ b/cdap-ui/app/features/adapters/services/adapter-error-factory.js
@@ -20,6 +20,7 @@ angular.module(PKG.name + '.feature.adapters')
     function isModelValid (nodes, connections, metadata, config) {
       var validationRules = [
         hasExactlyOneSource,
+        hasAtleastOneSink,
         hasNameAndTemplateType,
         checkForRequiredField,
         checkForUnconnectedNodes
@@ -45,6 +46,20 @@ angular.module(PKG.name + '.feature.adapters')
       }
     }
 
+    function hasAtleastOneSink(nodes, connections, metadata, config, errors) {
+      var sink = [];
+      var artifactType = GLOBALS.pluginTypes[metadata.template.type];
+
+      angular.forEach(nodes, function (value, key) {
+        if (value.type === artifactType.sink) {
+          sink.push(key);
+        }
+      });
+      if (sink.length === 0) {
+        addCanvasError('Application should have atleast 1 sink', errors);
+      }
+    }
+
     function hasExactlyOneSource(nodes, connections, metadata, config, errors) {
       var source = [];
       var artifactType = GLOBALS.pluginTypes[metadata.template.type];
@@ -55,19 +70,9 @@ angular.module(PKG.name + '.feature.adapters')
         }
       });
 
-      if (source.length !== 1) {
-        if (source.length < 1) {
-          errors.source = 'Application is missing a source';
-        } else if (source.length > 1) {
-          angular.forEach(source, function (node) {
-            errors[node] = 'Application should only have 1 source';
-          });
-
-          addCanvasError('Application should only have 1 source', errors);
-
-        }
+      if (source.length === 0) {
+        addCanvasError('Application can have at most 1 source', errors);
       }
-
     }
 
     function hasNameAndTemplateType(nodes, connections, metadata, config, errors) {
@@ -75,6 +80,7 @@ angular.module(PKG.name + '.feature.adapters')
       if (typeof name !== 'string' || !name.length) {
         errors.name = 'Application needs to have a name';
         metadata.error = 'Enter application name';
+        addCanvasError('Application needs to have a name', errors);
         return;
       }
 
@@ -83,6 +89,7 @@ angular.module(PKG.name + '.feature.adapters')
       if (!pattern.test(name)) {
         errors.name = 'Application name can only have alphabets, numbers, and \'_\'';
         metadata.error = 'Application name can only have alphabets, numbers, and \'_\'';
+        addCanvasError('Application name can only have alphabets, numbers, and \'_\'', errors);
       }
 
       // Should probably add template type check here. Waiting for design.

--- a/cdap-ui/app/features/adapters/services/adapter-error-factory.js
+++ b/cdap-ui/app/features/adapters/services/adapter-error-factory.js
@@ -98,18 +98,24 @@ angular.module(PKG.name + '.feature.adapters')
     function checkForRequiredField(nodes, connections, metadata, config, errors) {
 
       if(config.source.name && !isValidPlugin(config.source)) {
-        errors[config.source.id] = 'Source is missing required fields';
+        errors[config.source.id] = {};
+        errors[config.source.id].message = 'Source is missing required fields';
+        errors[config.source.id].requiredFieldCount = config.source.requiredFieldCount;
       }
 
       config.sinks.forEach(function(sink) {
         if (sink.name && !isValidPlugin(sink)) {
-          errors[sink.id] = 'Sink is missing required fields';
+          errors[sink.id] = {};
+          errors[sink.id].message = 'Sink is missing required fields';
+          errors[sink.id].requiredFieldCount = sink.requiredFieldCount;
         }
       });
 
       config.transforms.forEach(function(transform) {
         if (transform.name && !isValidPlugin(transform)) {
-          errors[transform.id] = 'Transform is missing required fields';
+          errors[transform.id] ={};
+          errors[transform.id].message = 'Transform is missing required fields';
+          errors[transform.id].requiredFieldCount = transform.requiredFieldCount;
         }
       });
 
@@ -119,14 +125,16 @@ angular.module(PKG.name + '.feature.adapters')
       var keys = Object.keys(plugin.properties);
       if (!keys.length) {
         plugin.valid = false;
+        plugin.requiredFieldCount = Object.keys(plugin._backendProperties).length;
         return plugin.valid;
       }
       plugin.valid = true;
+      plugin.requiredFieldCount = 0;
       for (i=0; i< keys.length; i++) {
         var property = plugin.properties[keys[i]];
         if (plugin._backendProperties[keys[i]] && plugin._backendProperties[keys[i]].required && (!property || property === '')) {
           plugin.valid = false;
-          break;
+          plugin.requiredFieldCount += 1;
         }
       }
       return plugin.valid;

--- a/cdap-ui/app/features/adapters/services/adapter-error-factory.js
+++ b/cdap-ui/app/features/adapters/services/adapter-error-factory.js
@@ -129,7 +129,6 @@ angular.module(PKG.name + '.feature.adapters')
         keys = Object.keys(plugin._backendProperties);
         for (i =0; i<keys.length; i++) {
           if (plugin._backendProperties[keys[i]] && plugin._backendProperties[keys[i]].required) {
-            console.info(plugin.name, keys[i], plugin._backendProperties[keys[i]]);
             plugin.requiredFieldCount += 1;
             plugin.valid = false;
           }

--- a/cdap-ui/app/features/adapters/services/adapter-error-factory.js
+++ b/cdap-ui/app/features/adapters/services/adapter-error-factory.js
@@ -123,13 +123,19 @@ angular.module(PKG.name + '.feature.adapters')
     function isValidPlugin(plugin) {
       var i;
       var keys = Object.keys(plugin.properties);
-      if (!keys.length) {
-        plugin.valid = false;
-        plugin.requiredFieldCount = Object.keys(plugin._backendProperties).length;
-        return plugin.valid;
-      }
       plugin.valid = true;
       plugin.requiredFieldCount = 0;
+      if (!keys.length) {
+        keys = Object.keys(plugin._backendProperties);
+        for (i =0; i<keys.length; i++) {
+          if (plugin._backendProperties[keys[i]] && plugin._backendProperties[keys[i]].required) {
+            console.info(plugin.name, keys[i], plugin._backendProperties[keys[i]]);
+            plugin.requiredFieldCount += 1;
+            plugin.valid = false;
+          }
+        }
+        return plugin.valid;
+      }
       for (i=0; i< keys.length; i++) {
         var property = plugin.properties[keys[i]];
         if (plugin._backendProperties[keys[i]] && plugin._backendProperties[keys[i]].required && (!property || property === '')) {
@@ -258,6 +264,7 @@ angular.module(PKG.name + '.feature.adapters')
 
     return {
       isModelValid: isModelValid,
+      isValidPlugin: isValidPlugin,
       hasNameAndTemplateType: hasNameAndTemplateType
     };
 

--- a/cdap-ui/app/features/adapters/services/console-tab-service.js
+++ b/cdap-ui/app/features/adapters/services/console-tab-service.js
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 angular.module(PKG.name + '.feature.adapters')
   .service('MyConsoleTabService', function() {
     this.messages = [];

--- a/cdap-ui/app/features/adapters/services/console-tab-service.js
+++ b/cdap-ui/app/features/adapters/services/console-tab-service.js
@@ -1,0 +1,24 @@
+angular.module(PKG.name + '.feature.adapters')
+  .service('MyConsoleTabService', function() {
+    this.messages = [];
+    this.resetMessages = function() {
+      this.messages = [];
+    };
+
+    this.onMessageUpdateListeners = [];
+    this.addMessage = function(message) {
+      this.messages.push(message);
+      this.notifyMessageUpdateListeners(message);
+    };
+
+    this.registerOnMessageUpdates = function(callback) {
+      this.onMessageUpdateListeners.push(callback);
+    };
+
+    this.notifyMessageUpdateListeners = function(message) {
+      this.onMessageUpdateListeners.forEach(function(callback) {
+        callback(message);
+      });
+    };
+
+  });

--- a/cdap-ui/app/features/adapters/services/node-config-service.js
+++ b/cdap-ui/app/features/adapters/services/node-config-service.js
@@ -16,10 +16,10 @@
 
 angular.module(PKG.name + '.feature.adapters')
   .service('MyNodeConfigService', function() {
-    this.pluginChangeListeners = [];
-    this.pluginResetListeners = [];
-    this.pluginRemoveListeners = [];
-    this.pluginSaveListeners = [];
+    this.pluginChangeListeners = {};
+    this.pluginResetListeners = {};
+    this.pluginRemoveListeners = {};
+    this.pluginSaveListeners = {};
 
     this.resetPlugin = function(plugin) {
       this.plugin = plugin;
@@ -27,13 +27,17 @@ angular.module(PKG.name + '.feature.adapters')
     };
 
     this.notifyPluginResetListeners = function() {
-      this.pluginResetListeners.forEach(function(callback) {
+      angular.forEach(this.pluginResetListeners, function(callback) {
         callback(this.plugin);
       }.bind(this));
     };
 
-    this.registerPluginResetCallback = function(callback) {
-      this.pluginResetListeners.push(callback);
+    this.registerPluginResetCallback = function(id, callback) {
+      this.pluginResetListeners[id] = callback;
+    };
+
+    this.unRegisterPluginResetCallback = function(id) {
+      delete this.pluginResetListeners[id];
     };
 
     this.setPlugin = function(plugin) {
@@ -42,13 +46,17 @@ angular.module(PKG.name + '.feature.adapters')
     };
 
     this.notifyPluginSetListeners = function () {
-      this.pluginChangeListeners.forEach(function(callback) {
+      angular.forEach(this.pluginChangeListeners, function(callback) {
         callback(this.plugin);
       }.bind(this));
     };
 
-    this.registerPluginSetCallback = function(callback) {
-      this.pluginChangeListeners.push(callback);
+    this.registerPluginSetCallback = function(id, callback) {
+      this.pluginChangeListeners[id] = callback;
+    };
+
+    this.unRegisterPluginSetCallback = function(id) {
+      delete this.pluginChangeListeners[id];
     };
 
     this.removePlugin = function(nodeId) {
@@ -56,24 +64,32 @@ angular.module(PKG.name + '.feature.adapters')
       this.notifyPluginRemoveListeners(nodeId);
     };
 
-    this.registerRemovePluginCallback = function(callback) {
-      this.pluginRemoveListeners.push(callback);
+    this.registerRemovePluginCallback = function(id, callback) {
+      this.pluginRemoveListeners[id] = callback;
     };
 
     this.notifyPluginRemoveListeners = function(nodeId) {
-      this.pluginRemoveListeners.forEach(function(callback) {
+      angular.forEach(this.pluginRemoveListeners, function(callback) {
         callback(nodeId);
       });
+    };
+
+    this.unRegisterRemovePluginCallback = function(id) {
+      delete this.pluginRemoveListeners[id];
     };
 
     this.notifyPluginSaveListeners = function(nodeId) {
-      this.pluginSaveListeners.forEach(function(callback) {
+      angular.forEach(this.pluginSaveListeners, function(callback) {
         callback(nodeId);
       });
     };
 
-    this.registerPluginSaveCallback = function(callback) {
-      this.pluginSaveListeners.push(callback);
+    this.registerPluginSaveCallback = function(id, callback) {
+      this.pluginSaveListeners[id] = callback;
+    };
+
+    this.unRegisterPluginSaveCallback = function(id) {
+      delete this.pluginSaveListeners[id];
     };
 
   });

--- a/cdap-ui/app/features/adapters/services/node-config-service.js
+++ b/cdap-ui/app/features/adapters/services/node-config-service.js
@@ -19,6 +19,7 @@ angular.module(PKG.name + '.feature.adapters')
     this.pluginChangeListeners = [];
     this.pluginResetListeners = [];
     this.pluginRemoveListeners = [];
+    this.pluginSaveListeners = [];
 
     this.resetPlugin = function(plugin) {
       this.plugin = plugin;
@@ -63,6 +64,16 @@ angular.module(PKG.name + '.feature.adapters')
       this.pluginRemoveListeners.forEach(function(callback) {
         callback(nodeId);
       });
+    };
+
+    this.notifyPluginSaveListeners = function(nodeId) {
+      this.pluginSaveListeners.forEach(function(callback) {
+        callback(nodeId);
+      });
+    };
+
+    this.registerPluginSaveCallback = function(callback) {
+      this.pluginSaveListeners.push(callback);
     };
 
   });

--- a/cdap-ui/app/features/adapters/templates/create/bottompanel.html
+++ b/cdap-ui/app/features/adapters/templates/create/bottompanel.html
@@ -18,7 +18,7 @@
   <div class="console-tabs clearfix">
     <ul class="nav nav-tabs pull-left" role="tablist">
       <li ng-repeat="tab in tabs"
-          ng-click="selectTab(tab)"
+          ng-click="selectTab(tab, true)"
           ng-class="{'active': tab.title == activeTab.title}"
           role="presentation"
           data-toggle="tab">
@@ -27,6 +27,9 @@
     </ul>
   </div>
   <div class="console-type" ng-class="{'is-collapsed': isCollapsed}">
-    <div ng-include="activeTab.template" ng-if="tabs.length > 0"></div>
+    <div ng-repeat="tab in tabs"
+          ng-include="tab.template"
+          ng-show="activeTab.title === tab.title">
+      </div>
   </div>
 </div>

--- a/cdap-ui/app/features/adapters/templates/create/popovers/plugin-edit-form.html
+++ b/cdap-ui/app/features/adapters/templates/create/popovers/plugin-edit-form.html
@@ -81,9 +81,5 @@
 
     </div>
 
-    <div ng-show="showinfo" class="embed-responsive embed-responsive-4by3">
-      <iframe class="ember-responsive-item" src="{{PluginEditController.trustSrc(PluginEditController.infoUrl)}}"></iframe>
-    </div>
-
   </div>
 </div>

--- a/cdap-ui/app/features/adapters/templates/create/popovers/plugin-edit-noconfig-form.html
+++ b/cdap-ui/app/features/adapters/templates/create/popovers/plugin-edit-noconfig-form.html
@@ -14,15 +14,15 @@
   the License.
 -->
 
-<div class="row" ng-if="plugin.name !== 'Validator'">
+<div class="row" ng-if="pluginCopy.name !== 'Validator'">
   <div class="col-xs-12">
     <div class="modal-content-scroll" ng-class="{'padding-offset-right': isSource, 'padding-offset-left': isTransform}">
       <fieldset ng-disabled="isDisabled">
         <div ng-if="PluginEditController.noconfig">
           <div class="well well-lg widget-group-container">
-            <div ng-repeat="(name, value) in plugin.properties track by $index">
+            <div ng-repeat="(name, value) in pluginCopy.properties track by $index">
               <div class="form-group">
-                <label ng-init="title='info';description=plugin._backendProperties[name].description"
+                <label ng-init="title='info';description=pluginCopy._backendProperties[name].description"
                         class="control-label">
                   <span>{{name}}</span>
                   <span class="fa fa-info-circle"
@@ -30,12 +30,12 @@
                         tooltip-placement="right"
                         tooltip-append-to-body="true">
                   </span>
-                  <span class="fa fa-asterisk" ng-if="plugin.properties[name].required"></span>
+                  <span class="fa fa-asterisk" ng-if="pluginCopy._backendProperties[name].required"></span>
                 </label>
                 <input type="text"
                         class="form-control"
-                        ng-model="plugin.properties[name]"
-                        ng-disabled="plugin.pluginTemplate && plugin.lock[name]" />
+                        ng-model="pluginCopy.properties[name]"
+                        ng-disabled="pluginCopy.pluginTemplate && pluginCopy.lock[name]" />
 
               </div>
             </div>
@@ -46,7 +46,7 @@
   </div>
 </div>
 
-<div ng-if="isTransform && plugin.name === 'Validator'">
+<div ng-if="isTransform && pluginCopy.name === 'Validator'">
   <div class="col-lg-12">
     <div class="modal-scroll-content">
       <div ng-include="'/assets/features/adapters/templates/create/popovers/plugin-edit-validator-transform.html'"></div>

--- a/cdap-ui/app/features/adapters/templates/create/popovers/plugin-edit-validator-transform.html
+++ b/cdap-ui/app/features/adapters/templates/create/popovers/plugin-edit-validator-transform.html
@@ -17,4 +17,4 @@
 <my-validators
   input-schema="inputSchema"
   is-disabled="isDisabled"
-  ng-model="plugin"></my-validators>
+  ng-model="pluginCopy"></my-validators>

--- a/cdap-ui/app/features/adapters/templates/create/toppanel.html
+++ b/cdap-ui/app/features/adapters/templates/create/toppanel.html
@@ -27,7 +27,7 @@
 
         <div class="input-group pull-left">
           <input type="text"
-                 ng-model="TopPanelController.pipelineName"
+                 ng-model="TopPanelController.metadata['name']"
                  my-maxlength="64"
                  placeholder="[Pipeline Name]"
                  tooltip="{{ TopPanelController.metadata.name }}"
@@ -45,7 +45,7 @@
 
       <textarea type="text"
                 class="pull-left"
-                ng-model="TopPanelController.pipelineDescription"
+                ng-model="TopPanelController.metadata['description']"
                 my-maxlength="144"
                 placeholder="Enter a description for your pipeline."
                 tooltip="{{ TopPanelController.metadata.description }}"
@@ -56,7 +56,7 @@
 
     <div class="btn-group pull-right">
       <a class="btn btn-default" ng-click="TopPanelController.resetMetadata()">Cancel</a>
-      <a class="btn btn-success" ng-click="TopPanelController.saveMetadata()">Save</a>
+      <a class="btn btn-success" ng-click="TopPanelController.metadataExpanded = false;">Save</a>
     </div>
   </div>
   <div class="btn-group pull-right clearfix">

--- a/cdap-ui/app/features/adapters/templates/partial/console.html
+++ b/cdap-ui/app/features/adapters/templates/partial/console.html
@@ -14,6 +14,23 @@
   the License.
 -->
 
-<div class="text-center">
-  <p>Console tab</p>
+<div ng-controller="ConsoleTabController as ConsoleTabController">
+  <div class="bottompanel-header clearfix">
+    <div class="pull-right">
+      <div class="btn btn-default"
+           ng-disabled="ConsoleTabController.messages.length === 0"
+           ng-click="ConsoleTabController.clearMessages()">
+        Clear
+      </div>
+    </div>
+  </div>
+
+  <div ng-repeat="message in ConsoleTabController.messages track by $index">
+    <div ng-class="{'text-danger': message.type === 'error', 'text-info': message.type === 'info', 'text-success': message.type === 'success'}"
+         ng-bind-html="message.content"></div>
+  </div>
+
+  <div ng-if="ConsoleTabController.messages.length === 0">
+    <h3>No messages as of now.</h3>
+  </div>
 </div>

--- a/cdap-ui/app/features/adapters/templates/partial/console.html
+++ b/cdap-ui/app/features/adapters/templates/partial/console.html
@@ -15,21 +15,25 @@
 -->
 
 <div ng-controller="ConsoleTabController as ConsoleTabController">
-  <div class="bottompanel-header clearfix">
-    <div class="pull-right">
-      <div class="btn btn-default"
-           ng-disabled="ConsoleTabController.messages.length === 0"
-           ng-click="ConsoleTabController.clearMessages()">
-        Clear
+
+  <div class="bottompanel-body">
+    <div class="console-wrapper">
+      <div class="pull-right">
+        <div class="btn btn-default"
+             ng-disabled="ConsoleTabController.messages.length === 0"
+             ng-click="ConsoleTabController.clearMessages()">
+          Clear
+        </div>
+      </div>
+      <div ng-repeat="message in ConsoleTabController.messages track by $index">
+        <pre ng-class="{'text-danger': message.type === 'error', 'text-info': message.type === 'info', 'text-success': message.type === 'success'}">{{message.content}}</pre>
+      </div>
+
+      <div ng-if="ConsoleTabController.messages.length === 0">
+        <pre>No messages as of now.</pre>
       </div>
     </div>
+
   </div>
 
-  <div ng-repeat="message in ConsoleTabController.messages track by $index">
-    <div ng-class="{'text-danger': message.type === 'error', 'text-info': message.type === 'info', 'text-success': message.type === 'success'}">{{message.content}}</div>
-  </div>
-
-  <div ng-if="ConsoleTabController.messages.length === 0">
-    <h3>No messages as of now.</h3>
-  </div>
 </div>

--- a/cdap-ui/app/features/adapters/templates/partial/console.html
+++ b/cdap-ui/app/features/adapters/templates/partial/console.html
@@ -26,8 +26,7 @@
   </div>
 
   <div ng-repeat="message in ConsoleTabController.messages track by $index">
-    <div ng-class="{'text-danger': message.type === 'error', 'text-info': message.type === 'info', 'text-success': message.type === 'success'}"
-         ng-bind-html="message.content"></div>
+    <div ng-class="{'text-danger': message.type === 'error', 'text-info': message.type === 'info', 'text-success': message.type === 'success'}">{{message.content}}</div>
   </div>
 
   <div ng-if="ConsoleTabController.messages.length === 0">

--- a/cdap-ui/app/features/adapters/templates/partial/reference-tab.html
+++ b/cdap-ui/app/features/adapters/templates/partial/reference-tab.html
@@ -1,0 +1,21 @@
+<!--
+  Copyright © 2015 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+-->
+
+<div class="embed-responsive embed-responsive-4by3"
+      ng-if="$parent.activeTab.title === $parent.tab.title" 
+      ng-controller="ReferenceTabController as ReferenceTabController">
+  <iframe class="ember-responsive-item" src="{{ReferenceTabController.trustSrc(ReferenceTabController.infoUrl)}}"></iframe>
+</div>

--- a/cdap-ui/app/services/app/my-app-dag-service.js
+++ b/cdap-ui/app/services/app/my-app-dag-service.js
@@ -352,7 +352,7 @@ angular.module(PKG.name + '.services')
         defer.resolve(this.nodes[config.id]);
         MyNodeConfigService.notifyPluginSaveListeners(config.id);
       }
-      
+
       if (inCreationMode) {
         /*
           The reason to use a promise here is to fetch the backend properties for each plugin

--- a/cdap-ui/app/services/app/my-app-dag-service.js
+++ b/cdap-ui/app/services/app/my-app-dag-service.js
@@ -47,7 +47,7 @@
 
 */
 angular.module(PKG.name + '.services')
-  .service('MyAppDAGService', function(myAdapterApi, $q, $bootstrapModal, $state, $filter, mySettings, AdapterErrorFactory, IMPLICIT_SCHEMA, myHelpers, PluginConfigFactory, ModalConfirm, EventPipe, CanvasFactory, $rootScope, GLOBALS) {
+  .service('MyAppDAGService', function(myAdapterApi, $q, $bootstrapModal, $state, $filter, mySettings, AdapterErrorFactory, IMPLICIT_SCHEMA, myHelpers, PluginConfigFactory, ModalConfirm, EventPipe, CanvasFactory, $rootScope, GLOBALS, MyNodeConfigService) {
 
     var countSink = 0,
         countSource = 0,
@@ -342,6 +342,7 @@ angular.module(PKG.name + '.services')
               this.nodes[config.id].properties[key] = this.nodes[config.id].properties[key] || '';
             }.bind(this));
             defer.resolve(this.nodes[config.id]);
+            MyNodeConfigService.notifyPluginSaveListeners(config.id);
           }.bind(this));
 
       } else if(Object.keys(conf._backendProperties).length !== Object.keys(conf.properties).length) {
@@ -349,7 +350,9 @@ angular.module(PKG.name + '.services')
           config.properties[key] = config.properties[key] || '';
         });
         defer.resolve(this.nodes[config.id]);
+        MyNodeConfigService.notifyPluginSaveListeners(config.id);
       }
+      
       if (inCreationMode) {
         /*
           The reason to use a promise here is to fetch the backend properties for each plugin

--- a/cdap-ui/app/services/app/my-app-dag-service.js
+++ b/cdap-ui/app/services/app/my-app-dag-service.js
@@ -47,7 +47,7 @@
 
 */
 angular.module(PKG.name + '.services')
-  .service('MyAppDAGService', function(myAdapterApi, $q, $bootstrapModal, $state, $filter, mySettings, AdapterErrorFactory, IMPLICIT_SCHEMA, myHelpers, PluginConfigFactory, ModalConfirm, EventPipe, CanvasFactory, $rootScope, GLOBALS, MyConsoleTabService) {
+  .service('MyAppDAGService', function(myAdapterApi, $q, $bootstrapModal, $state, $filter, mySettings, AdapterErrorFactory, IMPLICIT_SCHEMA, myHelpers, PluginConfigFactory, ModalConfirm, EventPipe, CanvasFactory, $rootScope, GLOBALS) {
 
     var countSink = 0,
         countSource = 0,
@@ -287,9 +287,9 @@ angular.module(PKG.name + '.services')
     };
 
     this.addNodes = function(conf, type, inCreationMode) {
+      var defer = $q.defer();
       this.isConfigTouched = true;
-      // FIXME: Utterly irrelavant place to set style. This needs to be moved ASAP.
-      var artifactType = GLOBALS.pluginTypes[this.metadata.template.type];
+
       var config = {
         id: conf.id,
         name: conf.name,
@@ -306,6 +306,92 @@ angular.module(PKG.name + '.services')
         _backendProperties: conf._backendProperties,
         type: conf.type
       };
+
+      angular.extend(config, styleNode.call(this, type, inCreationMode));
+
+      this.nodes[config.id] = config;
+
+      PluginConfigFactory.fetch(
+        null,
+        this.metadata.template.type,
+        config.name
+      ).then(function (res) {
+        if (res.implicit) {
+          var schema = res.implicit.schema;
+          var keys = Object.keys(schema);
+
+          var formattedSchema = [];
+          angular.forEach(keys, function (key) {
+            formattedSchema.push({
+              name: key,
+              type: schema[key]
+            });
+          });
+
+          var obj = { fields: formattedSchema };
+          this.nodes[config.id].outputSchema = JSON.stringify(obj);
+        }
+      }.bind(this));
+
+      if (!conf._backendProperties) {
+        fetchBackendProperties
+          .call(this, this.nodes[config.id])
+          .then(function() {
+            this.nodes[config.id].properties = this.nodes[config.id].properties || {};
+            angular.forEach(this.nodes[config.id]._backendProperties, function(value, key) {
+              this.nodes[config.id].properties[key] = this.nodes[config.id].properties[key] || '';
+            }.bind(this));
+            defer.resolve(this.nodes[config.id]);
+          }.bind(this));
+
+      } else if(Object.keys(conf._backendProperties).length !== Object.keys(conf.properties).length) {
+        angular.forEach(conf._backendProperties, function(value, key) {
+          config.properties[key] = config.properties[key] || '';
+        });
+        defer.resolve(this.nodes[config.id]);
+      }
+      if (inCreationMode) {
+        /*
+          The reason to use a promise here is to fetch the backend properties for each plugin
+          before notifying listeners about the change. This helps in showing the #of required
+          fields as a warning in the nodes in DAG as soon as they are added to Canvas.
+        */
+        defer
+          .promise
+          .then(function() {
+            this.notifyListeners(config, type);
+          }.bind(this));
+      }
+      return defer.promise;
+    };
+
+    this.removeNode = function (nodeId) {
+      this.isConfigTouched = true;
+      var type = this.nodes[nodeId].type;
+      var artifactTypeExtension = GLOBALS.pluginTypes[this.metadata.template.type];
+      switch (type) {
+        case artifactTypeExtension.source:
+          countSource--;
+          break;
+        case 'transform':
+          countTransform--;
+          break;
+        case artifactTypeExtension.sink:
+          countSink--;
+          break;
+      }
+
+      delete this.nodes[nodeId];
+    };
+
+    this.setIsDisabled = function(isDisabled) {
+      this.isDisabled = isDisabled;
+    };
+
+    function styleNode(type, inCreationMode) {
+      var config = {};
+      // FIXME: Utterly irrelavant place to set style. This needs to be moved ASAP.
+      var artifactType = GLOBALS.pluginTypes[this.metadata.template.type];
       var offsetLeft = 0;
       var offsetTop = 0;
       var initial = 0;
@@ -344,73 +430,8 @@ angular.module(PKG.name + '.services')
           top: top + 'px'
         };
       }
-
-      this.nodes[config.id] = config;
-
-      PluginConfigFactory.fetch(
-        null,
-        this.metadata.template.type,
-        config.name
-      ).then(function (res) {
-        if (res.implicit) {
-          var schema = res.implicit.schema;
-          var keys = Object.keys(schema);
-
-          var formattedSchema = [];
-          angular.forEach(keys, function (key) {
-            formattedSchema.push({
-              name: key,
-              type: schema[key]
-            });
-          });
-
-          var obj = { fields: formattedSchema };
-          this.nodes[config.id].outputSchema = JSON.stringify(obj);
-        }
-      }.bind(this));
-
-      if (!conf._backendProperties) {
-        fetchBackendProperties
-          .call(this, this.nodes[config.id])
-          .then(function() {
-            this.nodes[config.id].properties = this.nodes[config.id].properties || {};
-            angular.forEach(this.nodes[config.id]._backendProperties, function(value, key) {
-              this.nodes[config.id].properties[key] = this.nodes[config.id].properties[key] || '';
-            }.bind(this));
-          }.bind(this));
-
-      } else if(Object.keys(conf._backendProperties).length !== Object.keys(conf.properties).length) {
-        angular.forEach(conf._backendProperties, function(value, key) {
-          config.properties[key] = config.properties[key] || '';
-        });
-      }
-      if (inCreationMode) {
-        this.notifyListeners(config, type);
-      }
-    };
-
-    this.removeNode = function (nodeId) {
-      this.isConfigTouched = true;
-      var type = this.nodes[nodeId].type;
-      var artifactTypeExtension = GLOBALS.pluginTypes[this.metadata.template.type];
-      switch (type) {
-        case artifactTypeExtension.source:
-          countSource--;
-          break;
-        case 'transform':
-          countTransform--;
-          break;
-        case artifactTypeExtension.sink:
-          countSink--;
-          break;
-      }
-
-      delete this.nodes[nodeId];
-    };
-
-    this.setIsDisabled = function(isDisabled) {
-      this.isDisabled = isDisabled;
-    };
+      return config;
+    }
 
     function fetchBackendProperties(plugin, scope) {
       var defer = $q.defer();
@@ -517,7 +538,12 @@ angular.module(PKG.name + '.services')
     function pruneNonBackEndProperties(config) {
       function propertiesIterator(properties, backendProperties) {
         angular.forEach(properties, function(value, key) {
-          if ((!backendProperties[key] && key !== 'errorDatasetName') || properties[key] === '' || properties[key] === null) {
+          // If its a required field don't remove it.
+          if (backendProperties[key] && backendProperties[key].required) {
+            return;
+          }
+          if ((!backendProperties[key] && key !== 'errorDatasetName') || properties[key] === '' || properties[key] === null
+          ) {
             delete properties[key];
           }
           // FIXME: Remove this once https://issues.cask.co/browse/CDAP-3614 is fixed.
@@ -624,13 +650,6 @@ angular.module(PKG.name + '.services')
                }.bind(this));
             }.bind(this),
             function error(err) {
-              this.isConfigTouched = true;
-              angular.forEach(err, function(value) {
-                MyConsoleTabService.addMessage({
-                  type: 'error',
-                  content: value
-                });
-              });
               defer.reject({
                 messages: err
               });
@@ -638,15 +657,6 @@ angular.module(PKG.name + '.services')
             }
           );
       } else {
-        if (errors.canvas) {
-          this.isConfigTouched = true;
-          errors.canvas.forEach(function(canvasError) {
-            MyConsoleTabService.addMessage({
-              type: 'error',
-              content: canvasError
-            });
-          });
-        }
         this.notifyError(errors);
         defer.reject(errors);
       }

--- a/cdap-ui/app/services/app/my-app-dag-service.js
+++ b/cdap-ui/app/services/app/my-app-dag-service.js
@@ -653,8 +653,11 @@ angular.module(PKG.name + '.services')
               defer.reject({
                 messages: err
               });
+              this.notifyError({
+                canvas: [err.data]
+              });
               EventPipe.emit('hideLoadingIcon.immediate');
-            }
+            }.bind(this)
           );
       } else {
         this.notifyError(errors);

--- a/cdap-ui/app/services/app/my-app-dag-service.js
+++ b/cdap-ui/app/services/app/my-app-dag-service.js
@@ -47,7 +47,7 @@
 
 */
 angular.module(PKG.name + '.services')
-  .service('MyAppDAGService', function(myAdapterApi, $q, $bootstrapModal, $state, $filter, mySettings, AdapterErrorFactory, IMPLICIT_SCHEMA, myHelpers, PluginConfigFactory, ModalConfirm, EventPipe, CanvasFactory, $rootScope, GLOBALS) {
+  .service('MyAppDAGService', function(myAdapterApi, $q, $bootstrapModal, $state, $filter, mySettings, AdapterErrorFactory, IMPLICIT_SCHEMA, myHelpers, PluginConfigFactory, ModalConfirm, EventPipe, CanvasFactory, $rootScope, GLOBALS, MyConsoleTabService) {
 
     var countSink = 0,
         countSource = 0,
@@ -624,6 +624,13 @@ angular.module(PKG.name + '.services')
                }.bind(this));
             }.bind(this),
             function error(err) {
+              this.isConfigTouched = true;
+              angular.forEach(err, function(value) {
+                MyConsoleTabService.addMessage({
+                  type: 'error',
+                  content: value
+                });
+              });
               defer.reject({
                 messages: err
               });
@@ -631,6 +638,15 @@ angular.module(PKG.name + '.services')
             }
           );
       } else {
+        if (errors.canvas) {
+          this.isConfigTouched = true;
+          errors.canvas.forEach(function(canvasError) {
+            MyConsoleTabService.addMessage({
+              type: 'error',
+              content: canvasError
+            });
+          });
+        }
         this.notifyError(errors);
         defer.reject(errors);
       }

--- a/cdap-ui/templates/common/Validator.json
+++ b/cdap-ui/templates/common/Validator.json
@@ -1,0 +1,6 @@
+{
+  "id": "Validator",
+  "groups" : {
+    "position": [  ]
+  }
+}


### PR DESCRIPTION
- Adds error badges during plugin add
- Adds console tab functionality (show warnings, info and error messages).
- Dynamically show (all the time) how many required fields left to be filled for any node.
- On validate/publish make the warning badges as errors.
- Fix validator to be edited in the new node config tab
- Fix plugins that has schema as its property.
- Fix editing plugins that doesn't have any configuration in node proxy.
- Fix the ability for the user to switch between different tabs when editing a plugin.
- Fix the need for user to save a node that has just been opened.
- Add reference tab contents.
- Add the validate button functionality.