### PR TITLE
CDAP-3714 remove requirement that main class is an application

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactInspector.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactInspector.java
@@ -148,8 +148,9 @@ public class ArtifactInspector {
 
         Object appMain = artifactClassLoader.loadClass(mainClassName).newInstance();
         if (!(appMain instanceof Application)) {
-          throw new InvalidArtifactException(String.format("Application main class %s does not implement Application",
-            appMain.getClass().getName()));
+          // we don't want to error here, just don't record an application class.
+          // possible for 3rd party plugin artifacts to have the main class set
+          return builder;
         }
 
         Application app = (Application) appMain;

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactInspectorTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactInspectorTest.java
@@ -107,17 +107,6 @@ public class ArtifactInspectorTest {
     }
   }
 
-  @Test(expected = InvalidArtifactException.class)
-  public void badAppMainClassThrowsException() throws Exception {
-    File appFile = createJar(InspectionApp.AppPlugin.class,
-      new File(TMP_FOLDER.newFolder(), "InspectionApp-1.0.0.jar"), new Manifest());
-    Id.Artifact artifactId = Id.Artifact.from(Id.Namespace.DEFAULT, "InspectionApp", "1.0.0");
-    Location artifactLocation = Locations.toLocation(appFile);
-    try (CloseableClassLoader artifactClassLoader = classLoaderFactory.createClassLoader(artifactLocation)) {
-      artifactInspector.inspectArtifact(artifactId, appFile, artifactClassLoader);
-    }
-  }
-
   private static File createJar(Class<?> cls, File destFile, Manifest manifest) throws IOException {
     Location deploymentJar = AppJarHelper.createDeploymentJar(new LocalLocationFactory(TMP_FOLDER.newFolder()),
       cls, manifest);


### PR DESCRIPTION
We need to remove this requirement because there are 3rd party
jars that include this attribute in their manifest.