### PR TITLE
(CDAP-3716) Refactor code that causes deadlock

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/AbstractProgramRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/AbstractProgramRuntimeService.java
@@ -277,7 +277,7 @@ public abstract class AbstractProgramRuntimeService extends AbstractIdleService 
   }
 
   protected void updateRuntimeInfo(ProgramType type, RunId runId, RuntimeInfo runtimeInfo) {
-    Lock lock = runtimeInfosLock.writeLock();
+    Lock lock = runtimeInfosLock.readLock();
     lock.lock();
     try {
       if (!runtimeInfos.contains(type, runId)) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedProgramRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedProgramRuntimeService.java
@@ -63,10 +63,6 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.google.inject.Inject;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.PathFilter;
-import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.twill.api.ResourceReport;
 import org.apache.twill.api.RunId;
@@ -127,7 +123,7 @@ public final class DistributedProgramRuntimeService extends AbstractProgramRunti
     this.queueAdmin = queueAdmin;
     this.streamAdmin = streamAdmin;
     this.txExecutorFactory = txExecutorFactory;
-    this.resourceReporter = new ClusterResourceReporter(metricsCollectionService, hConf, cConf);
+    this.resourceReporter = new ClusterResourceReporter(metricsCollectionService, hConf);
   }
 
   @Override
@@ -385,28 +381,11 @@ public final class DistributedProgramRuntimeService extends AbstractProgramRunti
    */
   private class ClusterResourceReporter extends AbstractResourceReporter {
     private static final String RM_CLUSTER_METRICS_PATH = "/ws/v1/cluster/metrics";
-    private final Path hbasePath;
-    private final Path namedspacedPath;
-    private final PathFilter namespacedFilter;
     private final List<URL> rmUrls;
-    private final String namespace;
-    private FileSystem hdfs;
 
-    public ClusterResourceReporter(MetricsCollectionService metricsCollectionService, Configuration hConf,
-                                   CConfiguration cConf) {
-      super(metricsCollectionService.getContext(
-        ImmutableMap.<String, String>of()));
-      try {
-        this.hdfs = FileSystem.get(hConf);
-      } catch (IOException e) {
-        LOG.error("unable to get hdfs, cluster storage metrics will be unavailable");
-        this.hdfs = null;
-      }
+    public ClusterResourceReporter(MetricsCollectionService metricsCollectionService, Configuration hConf) {
+      super(metricsCollectionService.getContext(ImmutableMap.<String, String>of()));
 
-      this.namespace = cConf.get(Constants.CFG_HDFS_NAMESPACE);
-      this.namedspacedPath = new Path(namespace);
-      this.hbasePath = new Path(hConf.get(HConstants.HBASE_DIR));
-      this.namespacedFilter = new NamespacedPathFilter();
       List<URL> rmUrls = Collections.emptyList();
       try {
         rmUrls = getResourceManagerURLs(hConf);
@@ -544,13 +523,6 @@ public final class DistributedProgramRuntimeService extends AbstractProgramRunti
         if (conn != null) {
           conn.disconnect();
         }
-      }
-    }
-
-    private class NamespacedPathFilter implements PathFilter {
-      @Override
-      public boolean accept(Path path) {
-        return path.getName().startsWith(namespace);
       }
     }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/InMemoryProgramRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/InMemoryProgramRuntimeService.java
@@ -70,7 +70,7 @@ public final class InMemoryProgramRuntimeService extends AbstractProgramRuntimeS
   }
 
   @Override
-  public synchronized RuntimeInfo run(Program program, ProgramOptions options) {
+  public RuntimeInfo run(Program program, ProgramOptions options) {
     try {
       File tmpDir = new File(cConf.get(Constants.CFG_LOCAL_DATA_DIR), cConf.get(Constants.AppFabric.TEMP_DIR));
       final File destinationUnpackedJarDir = new File(tmpDir, String.format("%s.%s",

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/app/runtime/AbstractProgramRuntimeServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/app/runtime/AbstractProgramRuntimeServiceTest.java
@@ -24,11 +24,14 @@ import co.cask.cdap.common.utils.Tasks;
 import co.cask.cdap.internal.app.runtime.ProgramControllerServiceAdapter;
 import co.cask.cdap.internal.app.runtime.ProgramRunnerFactory;
 import co.cask.cdap.internal.app.runtime.SimpleProgramOptions;
+import co.cask.cdap.internal.app.runtime.artifact.ArtifactRepository;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramLiveInfo;
 import co.cask.cdap.proto.ProgramType;
 import com.google.common.util.concurrent.AbstractExecutionThreadService;
+import com.google.common.util.concurrent.AbstractIdleService;
 import com.google.common.util.concurrent.Service;
+import org.apache.twill.api.RunId;
 import org.apache.twill.filesystem.Location;
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -40,6 +43,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import javax.annotation.Nullable;
 
 /**
  * Unit-test for AbstractProgramRuntimeService base functionalities.
@@ -54,21 +58,7 @@ public class AbstractProgramRuntimeServiceTest {
     // This test is for testing condition in (CDAP-3579)
     // The race condition is if a program finished very fast such that inside the AbstractProgramRuntimeService is
     // still in the run method, it holds the object lock, making the callback from the listener block forever.
-    ProgramRunnerFactory runnerFactory = new ProgramRunnerFactory() {
-      @Override
-      public ProgramRunner create(Type programType) {
-        return new ProgramRunner() {
-          @Override
-          public ProgramController run(Program program, ProgramOptions options) {
-            Service service = new FastService();
-            ProgramController controller = new ProgramControllerServiceAdapter(service,
-                                                                               program.getId(), RunIds.generate());
-            service.start();
-            return controller;
-          }
-        };
-      }
-    };
+    ProgramRunnerFactory runnerFactory = createProgramRunnerFactory();
 
     ProgramRuntimeService runtimeService = new AbstractProgramRuntimeService(CConfiguration.create(),
                                                                              runnerFactory, null) {
@@ -94,6 +84,46 @@ public class AbstractProgramRuntimeServiceTest {
     } finally {
       runtimeService.stopAndWait();
     }
+  }
+
+  @Test (timeout = 5000L)
+  public void testUpdateDeadLock() {
+    // This test is for testing (CDAP-3716)
+    // Create a service to simulate an existing running app.
+    Service service = new TestService();
+    Id.Program programId = Id.Program.from(Id.Namespace.DEFAULT, "dummyApp", ProgramType.WORKER, "dummy");
+    RunId runId = RunIds.generate();
+    ProgramRuntimeService.RuntimeInfo extraInfo = createRuntimeInfo(service, programId, runId);
+    service.startAndWait();
+
+    ProgramRunnerFactory runnerFactory = createProgramRunnerFactory();
+    TestProgramRuntimeService runtimeService = new TestProgramRuntimeService(CConfiguration.create(),
+                                                                             runnerFactory, null, extraInfo);
+    runtimeService.startAndWait();
+
+    // The lookup will get deadlock for CDAP-3716
+    Assert.assertNotNull(runtimeService.lookup(programId, runId));
+    service.stopAndWait();
+
+    runtimeService.stopAndWait();
+  }
+
+  private ProgramRunnerFactory createProgramRunnerFactory() {
+    return new ProgramRunnerFactory() {
+      @Override
+      public ProgramRunner create(Type programType) {
+        return new ProgramRunner() {
+          @Override
+          public ProgramController run(Program program, ProgramOptions options) {
+            Service service = new FastService();
+            ProgramController controller = new ProgramControllerServiceAdapter(service, program.getId(),
+                                                                               RunIds.generate());
+            service.start();
+            return controller;
+          }
+        };
+      }
+    };
   }
 
   private Program createDummyProgram() throws IOException {
@@ -155,6 +185,33 @@ public class AbstractProgramRuntimeServiceTest {
     };
   }
 
+  private ProgramRuntimeService.RuntimeInfo createRuntimeInfo(Service service,
+                                                              final Id.Program programId, RunId runId) {
+    final ProgramControllerServiceAdapter controller = new ProgramControllerServiceAdapter(service, programId, runId);
+    return new ProgramRuntimeService.RuntimeInfo() {
+      @Override
+      public ProgramController getController() {
+        return controller;
+      }
+
+      @Override
+      public ProgramType getType() {
+        return programId.getType();
+      }
+
+      @Override
+      public Id.Program getProgramId() {
+        return programId;
+      }
+
+      @Nullable
+      @Override
+      public RunId getTwillRunId() {
+        return null;
+      }
+    };
+  }
+
   /**
    * A guava service that has wil be completed immediate right after it is started.
    */
@@ -163,6 +220,53 @@ public class AbstractProgramRuntimeServiceTest {
     @Override
     protected void run() throws Exception {
       // No-op
+    }
+  }
+
+  /**
+   * A guava service that will not terminate until stop is called.
+   */
+  private static final class TestService extends AbstractIdleService {
+
+    @Override
+    protected void startUp() throws Exception {
+      // no-op
+    }
+
+    @Override
+    protected void shutDown() throws Exception {
+      // no-op
+    }
+  }
+
+  /**
+   * A runtime service that will insert an extra RuntimeInfo for the lookup call to simulate the situation
+   * where an app is already running when the service starts.
+   */
+  private static final class TestProgramRuntimeService extends AbstractProgramRuntimeService {
+
+    private final RuntimeInfo extraInfo;
+
+    protected TestProgramRuntimeService(CConfiguration cConf, ProgramRunnerFactory programRunnerFactory,
+                                        @Nullable ArtifactRepository artifactRepository, RuntimeInfo extraInfo) {
+      super(cConf, programRunnerFactory, artifactRepository);
+      this.extraInfo = extraInfo;
+    }
+
+    @Override
+    public ProgramLiveInfo getLiveInfo(Id.Program programId) {
+      return new ProgramLiveInfo(programId, "runtime") { };
+    }
+
+    @Override
+    public RuntimeInfo lookup(Id.Program programId, RunId runId) {
+      RuntimeInfo info = super.lookup(programId, runId);
+      if (info != null) {
+        return info;
+      }
+
+      updateRuntimeInfo(programId.getType(), runId, extraInfo);
+      return extraInfo;
     }
   }
 }


### PR DESCRIPTION
- Remove unnecessary synchronize method
- Always update the in memory runtimeInfos from the controller callback thread
- Remove bunch of unused code