### PR TITLE
CDAP-3700 Reduce LogSaver connections to HBase

### DIFF
--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/AbstractKafkaLogProcessor.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/AbstractKafkaLogProcessor.java
@@ -36,8 +36,9 @@ public abstract class AbstractKafkaLogProcessor implements KafkaLogProcessor {
   public void init(Set<Integer> partitions, CheckpointManager checkpointManager) {
     partitonCheckpoints.clear();
     try {
-     for (Integer partition : partitions) {
-        partitonCheckpoints.put(partition, checkpointManager.getCheckpoint(partition));
+      Map<Integer, Checkpoint> partitionMap = checkpointManager.getCheckpoint(partitions);
+      for (Map.Entry<Integer, Checkpoint> partition : partitionMap.entrySet()) {
+        partitonCheckpoints.put(partition.getKey(), partition.getValue());
       }
     } catch (Exception e) {
       throw Throwables.propagate(e);

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/CheckPointWriter.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/CheckPointWriter.java
@@ -52,9 +52,7 @@ public class CheckPointWriter implements Flushable, Runnable {
 
   private void checkpoint() {
     try {
-      for (Map.Entry<Integer, Checkpoint> entry : partitionCheckpoints.entrySet()) {
-        checkpointManager.saveCheckpoint(entry.getKey(), entry.getValue());
-      }
+      checkpointManager.saveCheckpoint(partitionCheckpoints);
     } catch (Exception e) {
       throw Throwables.propagate(e);
     }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/CheckpointManager.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/CheckpointManager.java
@@ -19,14 +19,18 @@ package co.cask.cdap.logging.save;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.dataset.table.Row;
 import co.cask.cdap.api.dataset.table.Table;
-import co.cask.cdap.data2.dataset2.tx.DatasetContext;
-import co.cask.cdap.data2.dataset2.tx.Transactional;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.data2.transaction.Transactions;
+import co.cask.tephra.TransactionAware;
 import co.cask.tephra.TransactionExecutor;
 import co.cask.tephra.TransactionExecutorFactory;
-import com.google.common.base.Supplier;
-import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Manages reading/writing of checkpoint information for a topic and partition.
@@ -37,46 +41,97 @@ public final class CheckpointManager {
   private static final byte [] OFFSET_COLNAME = Bytes.toBytes("nextOffset");
   private static final byte [] MAX_TIME_COLNAME = Bytes.toBytes("maxEventTime");
 
-  private final Transactional<DatasetContext<Table>, Table> mds;
   private final byte [] rowKeyPrefix;
+  private final LogSaverTableUtil tableUtil;
+  private final TransactionExecutorFactory transactionExecutorFactory;
+  private Map<Integer, Checkpoint> lastCheckpoint;
 
   public CheckpointManager(final LogSaverTableUtil tableUtil,
                            TransactionExecutorFactory txExecutorFactory, String topic, int prefix) {
     this.rowKeyPrefix = Bytes.add(Bytes.toBytes(prefix), Bytes.toBytes(topic));
-    this.mds = Transactional.of(txExecutorFactory, new Supplier<DatasetContext<Table>>() {
-      @Override
-      public DatasetContext<Table> get() {
-        try {
-          return DatasetContext.of(tableUtil.getMetaTable());
-        } catch (Exception e) {
-          // there's nothing much we can do here
-          throw Throwables.propagate(e);
-        }
-      }
-    });
+    this.tableUtil = tableUtil;
+    this.transactionExecutorFactory = txExecutorFactory;
+    this.lastCheckpoint = new HashMap<>();
   }
 
+  private <T> T execute(TransactionExecutor.Function<Table, T> func) {
+    try {
+      Table table = tableUtil.getMetaTable();
+      if (table instanceof TransactionAware) {
+        TransactionExecutor txExecutor = Transactions.createTransactionExecutor(transactionExecutorFactory,
+                                                                                (TransactionAware) table);
+        return txExecutor.execute(func, table);
+      } else {
+        throw new RuntimeException(String.format("Table %s is not TransactionAware, " +
+                                                   "Exception while trying to cast it to TransactionAware. " +
+                                                   "Please check why the table is not TransactionAware", table));
+      }
+    } catch (Exception e) {
+      throw new RuntimeException(String.format("Error accessing %s table", tableUtil.getMetaTableName()), e);
+    }
+  }
 
-  public void saveCheckpoint(final int partition, final Checkpoint checkpoint) throws Exception {
-    LOG.trace("Saving checkpoint {} for partition {}", checkpoint, partition);
-    mds.execute(new TransactionExecutor.Function<DatasetContext<Table>, Void>() {
+  private void execute(TransactionExecutor.Procedure<Table> procedure) {
+    try {
+      Table table = tableUtil.getMetaTable();
+      if (table instanceof TransactionAware) {
+        TransactionExecutor txExecutor = Transactions.createTransactionExecutor(transactionExecutorFactory,
+                                                                                (TransactionAware) table);
+        txExecutor.execute(procedure, table);
+      } else {
+        throw new RuntimeException(String.format("Table %s is not TransactionAware, " +
+                                                   "Exception while trying to cast it to TransactionAware. " +
+                                                   "Please check why the table is not TransactionAware", table));
+      }
+    } catch (Exception e) {
+      throw new RuntimeException(String.format("Error accessing %s table", tableUtil.getMetaTableName()), e);
+    }
+  }
+
+  public void saveCheckpoint(final Map<Integer, Checkpoint> checkpoints) throws Exception {
+    // if the checkpoints have not changed, we skip writing to table and return.
+    if (lastCheckpoint.equals(checkpoints)) {
+      return;
+    }
+
+    execute(new TransactionExecutor.Procedure<Table>() {
       @Override
-      public Void apply(DatasetContext<Table> ctx) throws Exception {
-        Table table = ctx.get();
-        byte[] key = Bytes.add(rowKeyPrefix, Bytes.toBytes(partition));
-        table.put(key, OFFSET_COLNAME, Bytes.toBytes(checkpoint.getNextOffset()));
-        table.put(key, MAX_TIME_COLNAME, Bytes.toBytes(checkpoint.getMaxEventTime()));
-        return null;
+      public void apply(Table table) throws Exception {
+        for (Map.Entry<Integer, Checkpoint> entry : checkpoints.entrySet()) {
+          byte[] key = Bytes.add(rowKeyPrefix, Bytes.toBytes(entry.getKey()));
+          Checkpoint checkpoint = entry.getValue();
+          table.put(key, OFFSET_COLNAME, Bytes.toBytes(checkpoint.getNextOffset()));
+          table.put(key, MAX_TIME_COLNAME, Bytes.toBytes(checkpoint.getMaxEventTime()));
+        }
+        // update last checkpoint
+        lastCheckpoint = ImmutableMap.copyOf(checkpoints);
+      }
+    });
+    LOG.trace("Saving checkpoints for partitions {}", checkpoints);
+  }
+
+  public Map<Integer, Checkpoint> getCheckpoint(final Set<Integer> partitions) throws Exception {
+    return execute(new TransactionExecutor.Function<Table, Map<Integer, Checkpoint>>() {
+      @Override
+      public Map<Integer, Checkpoint> apply(Table table) throws Exception {
+        Map<Integer, Checkpoint> checkpoints = new HashMap<Integer, Checkpoint>();
+        for (final int partition : partitions) {
+          Row result =
+            table.get(Bytes.add(rowKeyPrefix, Bytes.toBytes(partition)));
+          checkpoints.put(partition,
+                             new Checkpoint(result.getLong(OFFSET_COLNAME, -1),
+                                            result.getLong(MAX_TIME_COLNAME, -1)));
+        }
+        return checkpoints;
       }
     });
   }
 
   public Checkpoint getCheckpoint(final int partition) throws Exception {
-    Checkpoint checkpoint = mds.execute(new TransactionExecutor.Function<DatasetContext<Table>, Checkpoint>() {
+    Checkpoint checkpoint = execute(new TransactionExecutor.Function<Table, Checkpoint>() {
       @Override
-      public Checkpoint apply(DatasetContext<Table> ctx) throws Exception {
-        Row result =
-          ctx.get().get(Bytes.add(rowKeyPrefix, Bytes.toBytes(partition)));
+      public Checkpoint apply(Table table) throws Exception {
+        Row result = table.get(Bytes.add(rowKeyPrefix, Bytes.toBytes(partition)));
         return new Checkpoint(result.getLong(OFFSET_COLNAME, -1), result.getLong(MAX_TIME_COLNAME, -1));
       }
     });

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/CheckpointingLogFileWriter.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/CheckpointingLogFileWriter.java
@@ -102,10 +102,7 @@ public class CheckpointingLogFileWriter implements LogFileWriter<KafkaLogEvent> 
     avroFileWriter.flush();
 
     // Save the max checkpoint seen for each partition
-    for (Map.Entry<Integer, Checkpoint> entry : partitionCheckpointMap.entrySet()) {
-      LOG.trace("Saving checkpoint {} for partition {}", entry.getValue(), entry.getKey());
-      checkpointManager.saveCheckpoint(entry.getKey(), entry.getValue());
-    }
+    checkpointManager.saveCheckpoint(partitionCheckpointMap);
     lastCheckpointTime = currentTs;
   }
 }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/LogMetricsPlugin.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/LogMetricsPlugin.java
@@ -72,8 +72,9 @@ public class LogMetricsPlugin extends AbstractKafkaLogProcessor {
 
     partitionCheckpoints.clear();
     try {
-      for (Integer partition : partitions) {
-        partitionCheckpoints.put(partition, checkpointManager.getCheckpoint(partition));
+      Map<Integer, Checkpoint> partitionMap = checkpointManager.getCheckpoint(partitions);
+      for (Map.Entry<Integer, Checkpoint> partition : partitionMap.entrySet()) {
+        partitionCheckpoints.put(partition.getKey(), partition.getValue());
       }
     } catch (Exception e) {
       LOG.error("Caught exception while reading checkpoint", e);
@@ -81,7 +82,7 @@ public class LogMetricsPlugin extends AbstractKafkaLogProcessor {
     }
 
     checkPointWriter = new CheckPointWriter(checkpointManager, partitionCheckpoints);
-    scheduledExecutor.scheduleWithFixedDelay(checkPointWriter, 100, 10000, TimeUnit.MILLISECONDS);
+    scheduledExecutor.scheduleWithFixedDelay(checkPointWriter, 100, 500, TimeUnit.MILLISECONDS);
   }
 
   @Override

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/TestDistributedLogReader.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/TestDistributedLogReader.java
@@ -48,6 +48,7 @@ import co.cask.cdap.logging.save.KafkaLogWriterPlugin;
 import co.cask.cdap.test.SlowTests;
 import co.cask.tephra.TransactionManager;
 import co.cask.tephra.runtime.TransactionModules;
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -315,7 +316,7 @@ public class TestDistributedLogReader extends KafkaTestBase {
     CheckpointManager checkpointManager =
       checkpointManagerFactory.create(KafkaTopic.getTopic(), KafkaLogWriterPlugin.CHECKPOINT_ROW_KEY_PREFIX);
     long checkpointTime = logCallback.getEvents().get(numExpectedEvents - 1).getLoggingEvent().getTimeStamp();
-    checkpointManager.saveCheckpoint(stringPartitioner.partition(loggingContext.getLogPartition(), -1),
-                                     new Checkpoint(numExpectedEvents, checkpointTime));
+    checkpointManager.saveCheckpoint(ImmutableMap.of(stringPartitioner.partition(loggingContext.getLogPartition(), -1),
+                                                     new Checkpoint(numExpectedEvents, checkpointTime)));
   }
 }

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/save/LogSaverPluginTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/save/LogSaverPluginTest.java
@@ -49,6 +49,7 @@ import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
 import co.cask.cdap.test.SlowTests;
 import co.cask.tephra.TransactionManager;
 import co.cask.tephra.runtime.TransactionModules;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -232,7 +233,7 @@ public class LogSaverPluginTest extends KafkaTestBase {
       if (processor instanceof  KafkaLogWriterPlugin) {
         KafkaLogWriterPlugin plugin = (KafkaLogWriterPlugin) processor;
         CheckpointManager manager = plugin.getCheckPointManager();
-        manager.saveCheckpoint(0, new Checkpoint(10, -1));
+        manager.saveCheckpoint(ImmutableMap.of(0, new Checkpoint(10, -1)));
         Set<Integer> partitions = Sets.newHashSet(0, 1);
         plugin.init(partitions);
       }


### PR DESCRIPTION
we now Use TransactionExecutor instead of Transactional to avoid having many connections open to  HBase while writing in an transaction.

we have also added few improvements to reduce the number of transactions by sending the partition and the checkpoint in a map and having them written in one transaction, rather than creating a new transaction for each partition and checkpoint.

we also skip writing to table if the checkpoints have not changed by comparing with a local map of the past checkpoint.

JIRA: https://issues.cask.co/browse/CDAP-3700