### PR TITLE
(CDAP-3713) Removed all catch blocks in HTTP Handlers where we respon…

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/NotificationFeedHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/NotificationFeedHttpHandler.java
@@ -90,7 +90,7 @@ public class NotificationFeedHttpHandler extends AbstractHttpHandler {
       }
     } catch (NotificationFeedException e) {
       LOG.error("Could not create notification feed.", e);
-      responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
+      responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, e.getMessage());
     } catch (JsonSyntaxException e) {
       responder.sendString(HttpResponseStatus.BAD_REQUEST, "Invalid json object provided in request body.");
     } catch (IOException e) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
@@ -45,7 +45,6 @@ import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
 import co.cask.cdap.internal.app.runtime.flow.FlowUtils;
 import co.cask.cdap.internal.app.runtime.schedule.Scheduler;
 import co.cask.cdap.internal.app.runtime.schedule.SchedulerException;
-import co.cask.cdap.internal.app.services.AdapterService;
 import co.cask.cdap.internal.app.services.ProgramLifecycleService;
 import co.cask.cdap.internal.app.services.PropertiesResolver;
 import co.cask.cdap.internal.app.store.RunRecordMeta;
@@ -89,6 +88,7 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import javax.ws.rs.DELETE;
@@ -117,7 +117,6 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   private final PreferencesStore preferencesStore;
   private final NamespacedLocationFactory namespacedLocationFactory;
   private final PropertiesResolver propertiesResolver;
-  private final AdapterService adapterService;
   private final MetricStore metricStore;
   private final MRJobInfoFetcher mrJobInfoFetcher;
 
@@ -191,7 +190,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
                                      Scheduler scheduler, PreferencesStore preferencesStore,
                                      NamespacedLocationFactory namespacedLocationFactory,
                                      MRJobInfoFetcher mrJobInfoFetcher,
-                                     PropertiesResolver propertiesResolver, AdapterService adapterService,
+                                     PropertiesResolver propertiesResolver,
                                      MetricStore metricStore) {
     this.namespacedLocationFactory = namespacedLocationFactory;
     this.store = store;
@@ -204,7 +203,6 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
     this.preferencesStore = preferencesStore;
     this.mrJobInfoFetcher = mrJobInfoFetcher;
     this.propertiesResolver = propertiesResolver;
-    this.adapterService = adapterService;
   }
 
   /**
@@ -328,7 +326,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
                             @PathParam("type") String type,
                             @PathParam("id") String id,
                             @PathParam("action") String action)
-    throws NotFoundException, BadRequestException, IOException, NotImplementedException {
+    throws NotFoundException, BadRequestException, IOException, NotImplementedException, SchedulerException {
 
     if (type.equals("schedules")) {
       suspendResumeSchedule(responder, namespaceId, appId, id, action);
@@ -355,7 +353,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   }
 
   private void suspendResumeSchedule(HttpResponder responder, String namespaceId, String appId, String scheduleName,
-                                     String action) {
+                                     String action) throws SchedulerException {
     try {
 
       if (!action.equals("suspend") && !action.equals("resume")) {
@@ -407,10 +405,6 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
       responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);
     } catch (NotFoundException e) {
       responder.sendString(HttpResponseStatus.NOT_FOUND, e.getMessage());
-    } catch (Throwable e) {
-      LOG.error("Got exception when performing action '{}' on schedule '{}' for app '{}'",
-                action, scheduleName, appId, e);
-      responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
     }
   }
 
@@ -466,9 +460,6 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
       responder.sendStatus(HttpResponseStatus.NOT_FOUND);
     } catch (SecurityException e) {
       responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);
-    } catch (Throwable e) {
-      LOG.error("Got exception:", e);
-      responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
     }
   }
 
@@ -490,18 +481,13 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
 
     Id.Program id = Id.Program.from(namespaceId, appId, type, programId);
 
-    try {
-      if (!store.programExists(id)) {
-        responder.sendString(HttpResponseStatus.NOT_FOUND, "Program not found");
-        return;
-      }
-      Map<String, String> runtimeArgs = preferencesStore.getProperties(id.getNamespaceId(), appId,
-                                                                       programType, programId);
-      responder.sendJson(HttpResponseStatus.OK, runtimeArgs);
-    } catch (Throwable e) {
-      LOG.error("Error getting runtime args {}", e.getMessage(), e);
-      responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
+    if (!store.programExists(id)) {
+      responder.sendString(HttpResponseStatus.NOT_FOUND, "Program not found");
+      return;
     }
+    Map<String, String> runtimeArgs = preferencesStore.getProperties(id.getNamespaceId(), appId,
+                                                                     programType, programId);
+    responder.sendJson(HttpResponseStatus.OK, runtimeArgs);
   }
 
   /**
@@ -522,18 +508,13 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
 
     Id.Program id = Id.Program.from(namespaceId, appId, type, programId);
 
-    try {
-      if (!store.programExists(id)) {
-        responder.sendString(HttpResponseStatus.NOT_FOUND, "Program not found");
-        return;
-      }
-      Map<String, String> args = decodeArguments(request);
-      preferencesStore.setProperties(namespaceId, appId, programType, programId, args);
-      responder.sendStatus(HttpResponseStatus.OK);
-    } catch (Throwable e) {
-      LOG.error("Error getting runtime args {}", e.getMessage(), e);
-      responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
+    if (!store.programExists(id)) {
+      responder.sendString(HttpResponseStatus.NOT_FOUND, "Program not found");
+      return;
     }
+    Map<String, String> args = decodeArguments(request);
+    preferencesStore.setProperties(namespaceId, appId, programType, programId, args);
+    responder.sendStatus(HttpResponseStatus.OK);
   }
 
   @GET
@@ -560,9 +541,6 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
       }
     } catch (SecurityException e) {
       responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);
-    } catch (Throwable e) {
-      LOG.error("Got exception:", e);
-      responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
     }
   }
 
@@ -665,7 +643,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   @POST
   @Path("/instances")
   public void getInstances(HttpRequest request, HttpResponder responder,
-                           @PathParam("namespace-id") String namespaceId) {
+                           @PathParam("namespace-id") String namespaceId) throws IOException {
     try {
       List<BatchEndpointInstances> args = instancesFromBatchArgs(decodeArrayArguments(request, responder));
       // if args is null then the response has already been sent
@@ -696,9 +674,6 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
       responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);
     } catch (JsonSyntaxException e) {
       responder.sendStatus(HttpResponseStatus.BAD_REQUEST);
-    } catch (Throwable e) {
-      LOG.error("Got exception:", e);
-      responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
     }
   }
 
@@ -712,7 +687,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   @GET
   @Path("/flows")
   public void getAllFlows(HttpRequest request, HttpResponder responder,
-                          @PathParam("namespace-id") String namespaceId) {
+                          @PathParam("namespace-id") String namespaceId) throws Exception {
     programList(responder, namespaceId, ProgramType.FLOW, store);
   }
 
@@ -722,7 +697,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   @GET
   @Path("/mapreduce")
   public void getAllMapReduce(HttpRequest request, HttpResponder responder,
-                              @PathParam("namespace-id") String namespaceId) {
+                              @PathParam("namespace-id") String namespaceId) throws Exception {
     programList(responder, namespaceId, ProgramType.MAPREDUCE, store);
   }
 
@@ -732,7 +707,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   @GET
   @Path("/spark")
   public void getAllSpark(HttpRequest request, HttpResponder responder,
-                          @PathParam("namespace-id") String namespaceId) {
+                          @PathParam("namespace-id") String namespaceId) throws Exception {
     programList(responder, namespaceId, ProgramType.SPARK, store);
   }
 
@@ -742,7 +717,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   @GET
   @Path("/workflows")
   public void getAllWorkflows(HttpRequest request, HttpResponder responder,
-                              @PathParam("namespace-id") String namespaceId) {
+                              @PathParam("namespace-id") String namespaceId) throws Exception {
     programList(responder, namespaceId, ProgramType.WORKFLOW, store);
   }
 
@@ -752,14 +727,14 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   @GET
   @Path("/services")
   public void getAllServices(HttpRequest request, HttpResponder responder,
-                             @PathParam("namespace-id") String namespaceId) {
+                             @PathParam("namespace-id") String namespaceId) throws Exception {
     programList(responder, namespaceId, ProgramType.SERVICE, store);
   }
 
   @GET
   @Path("/workers")
   public void getAllWorkers(HttpRequest request, HttpResponder responder,
-                            @PathParam("namespace-id") String namespaceId) {
+                            @PathParam("namespace-id") String namespaceId) throws Exception {
     programList(responder, namespaceId, ProgramType.WORKER, store);
   }
 
@@ -781,8 +756,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
       if (respondIfElementNotFound(e, responder)) {
         return;
       }
-      LOG.error("Got exception: ", e);
-      responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
+      throw e;
     }
   }
 
@@ -794,7 +768,8 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   public void setWorkerInstances(HttpRequest request, HttpResponder responder,
                                  @PathParam("namespace-id") String namespaceId,
                                  @PathParam("app-id") String appId,
-                                 @PathParam("worker-id") String workerId) {
+                                 @PathParam("worker-id") String workerId)
+    throws ExecutionException, InterruptedException {
     int instances;
     try {
       try {
@@ -834,8 +809,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
       if (respondIfElementNotFound(e, responder)) {
         return;
       }
-      LOG.error("Got exception:", e);
-      responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
+      throw e;
     }
   }
 
@@ -858,8 +832,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
       if (respondIfElementNotFound(e, responder)) {
         return;
       }
-      LOG.error("Got exception:", e);
-      responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
+      throw e;
     }
   }
 
@@ -871,7 +844,8 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   public synchronized void setFlowletInstances(HttpRequest request, HttpResponder responder,
                                                @PathParam("namespace-id") String namespaceId,
                                                @PathParam("app-id") String appId, @PathParam("flow-id") String flowId,
-                                               @PathParam("flowlet-id") String flowletId) {
+                                               @PathParam("flowlet-id") String flowletId)
+    throws ExecutionException, InterruptedException {
     int instances;
     try {
       try {
@@ -914,8 +888,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
       if (respondIfElementNotFound(e, responder)) {
         return;
       }
-      LOG.error("Got exception:", e);
-      responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
+      throw e;
     }
   }
 
@@ -944,7 +917,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   public void deleteFlowQueues(HttpRequest request, HttpResponder responder,
                                @PathParam("namespace-id") String namespaceId,
                                @PathParam("app-id") String appId,
-                               @PathParam("flow-id") String flowId) {
+                               @PathParam("flow-id") String flowId) throws Exception {
     Id.Program programId = Id.Program.from(namespaceId, appId, ProgramType.FLOW, flowId);
     try {
       ProgramStatus status = getProgramStatus(programId);
@@ -959,9 +932,6 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
       }
     } catch (SecurityException e) {
       responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);
-    } catch (Throwable e) {
-      LOG.error("Got exception:", e);
-      responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
     }
   }
 
@@ -992,9 +962,6 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
                          new ServiceInstances(instances, getInstanceCount(programId, serviceId)));
     } catch (SecurityException e) {
       responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);
-    } catch (Throwable e) {
-      LOG.error("Got exception:", e);
-      responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
     }
   }
 
@@ -1006,7 +973,8 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   public void setServiceInstances(HttpRequest request, HttpResponder responder,
                                   @PathParam("namespace-id") String namespaceId,
                                   @PathParam("app-id") String appId,
-                                  @PathParam("service-id") String serviceId) {
+                                  @PathParam("service-id") String serviceId)
+    throws ExecutionException, InterruptedException {
     try {
       Id.Program programId = Id.Program.from(namespaceId, appId, ProgramType.SERVICE, serviceId);
       if (!store.programExists(programId)) {
@@ -1046,8 +1014,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
       if (respondIfElementNotFound(throwable, responder)) {
         return;
       }
-      LOG.error("Got exception : ", throwable);
-      responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
+      throw throwable;
     }
   }
 
@@ -1395,9 +1362,6 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
       }
     } catch (SecurityException e) {
       responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);
-    } catch (Throwable e) {
-      LOG.error("Got exception:", e);
-      responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
     }
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/WorkflowHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/WorkflowHttpHandler.java
@@ -36,7 +36,7 @@ import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.config.PreferencesStore;
 import co.cask.cdap.data2.transaction.queue.QueueAdmin;
 import co.cask.cdap.internal.app.runtime.schedule.Scheduler;
-import co.cask.cdap.internal.app.services.AdapterService;
+import co.cask.cdap.internal.app.runtime.schedule.SchedulerException;
 import co.cask.cdap.internal.app.services.ProgramLifecycleService;
 import co.cask.cdap.internal.app.services.PropertiesResolver;
 import co.cask.cdap.proto.Id;
@@ -59,9 +59,8 @@ import com.google.inject.Singleton;
 import org.jboss.netty.handler.codec.http.HttpHeaders;
 import org.jboss.netty.handler.codec.http.HttpRequest;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
@@ -79,7 +78,6 @@ import javax.ws.rs.QueryParam;
 @Singleton
 @Path(Constants.Gateway.API_VERSION_3 + "/namespaces/{namespace-id}")
 public class WorkflowHttpHandler extends ProgramLifecycleHttpHandler {
-  private static final Logger LOG = LoggerFactory.getLogger(ProgramLifecycleHttpHandler.class);
   private static final Gson GSON = new GsonBuilder()
     .registerTypeAdapter(ScheduleSpecification.class, new ScheduleSpecificationCodec())
     .registerTypeAdapter(WorkflowTokenDetail.class, new WorkflowTokenDetailCodec())
@@ -94,9 +92,9 @@ public class WorkflowHttpHandler extends ProgramLifecycleHttpHandler {
                              QueueAdmin queueAdmin, Scheduler scheduler, PreferencesStore preferencesStore,
                              NamespacedLocationFactory namespacedLocationFactory, MRJobInfoFetcher mrJobInfoFetcher,
                              ProgramLifecycleService lifecycleService, PropertiesResolver resolver,
-                             AdapterService adapterService, MetricStore metricStore) {
+                             MetricStore metricStore) {
     super(store, configuration, runtimeService, lifecycleService, queueAdmin, scheduler,
-          preferencesStore, namespacedLocationFactory, mrJobInfoFetcher, resolver, adapterService, metricStore);
+          preferencesStore, namespacedLocationFactory, mrJobInfoFetcher, resolver, metricStore);
     this.workflowClient = workflowClient;
   }
 
@@ -150,7 +148,7 @@ public class WorkflowHttpHandler extends ProgramLifecycleHttpHandler {
   public void getWorkflowStatusOld(HttpRequest request, HttpResponder responder,
                                   @PathParam("namespace-id") String namespaceId,
                                   @PathParam("app-id") String appId, @PathParam("workflow-name") String workflowName,
-                                  @PathParam("run-id") String runId) {
+                                  @PathParam("run-id") String runId) throws IOException {
     getWorkflowStatus(request, responder, namespaceId, appId, workflowName, runId);
   }
 
@@ -159,7 +157,7 @@ public class WorkflowHttpHandler extends ProgramLifecycleHttpHandler {
   public void getWorkflowStatus(HttpRequest request, final HttpResponder responder,
                                 @PathParam("namespace-id") String namespaceId,
                                 @PathParam("app-id") String appId, @PathParam("workflow-name") String workflowName,
-                                @PathParam("run-id") String runId) {
+                                @PathParam("run-id") String runId) throws IOException {
     try {
       workflowClient.getWorkflowStatus(namespaceId, appId, workflowName, runId,
                                        new WorkflowClient.Callback() {
@@ -185,9 +183,6 @@ public class WorkflowHttpHandler extends ProgramLifecycleHttpHandler {
                                        });
     } catch (SecurityException e) {
       responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);
-    } catch (Throwable e) {
-      LOG.error("Caught exception", e);
-      responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
     }
   }
 
@@ -198,7 +193,8 @@ public class WorkflowHttpHandler extends ProgramLifecycleHttpHandler {
   @Path("/apps/{app-id}/workflows/{workflow-id}/previousruntime")
   public void getPreviousScheduledRunTime(HttpRequest request, HttpResponder responder,
                                   @PathParam("namespace-id") String namespaceId,
-                                  @PathParam("app-id") String appId, @PathParam("workflow-id") String workflowId) {
+                                  @PathParam("app-id") String appId,
+                                  @PathParam("workflow-id") String workflowId) throws SchedulerException {
     getScheduledRuntime(responder, namespaceId, appId, workflowId, true);
   }
 
@@ -209,12 +205,13 @@ public class WorkflowHttpHandler extends ProgramLifecycleHttpHandler {
   @Path("/apps/{app-id}/workflows/{workflow-id}/nextruntime")
   public void getNextScheduledRunTime(HttpRequest request, HttpResponder responder,
                                   @PathParam("namespace-id") String namespaceId,
-                                  @PathParam("app-id") String appId, @PathParam("workflow-id") String workflowId) {
+                                  @PathParam("app-id") String appId,
+                                  @PathParam("workflow-id") String workflowId) throws SchedulerException {
     getScheduledRuntime(responder, namespaceId, appId, workflowId, false);
   }
 
   private void getScheduledRuntime(HttpResponder responder, String namespaceId, String appId, String workflowId,
-                                   boolean previousRuntimeRequested) {
+                                   boolean previousRuntimeRequested) throws SchedulerException {
     try {
       Id.Program id = Id.Program.from(namespaceId, appId, ProgramType.WORKFLOW, workflowId);
       List<ScheduledRuntime> runtimes;
@@ -226,9 +223,6 @@ public class WorkflowHttpHandler extends ProgramLifecycleHttpHandler {
       responder.sendJson(HttpResponseStatus.OK, runtimes);
     } catch (SecurityException e) {
       responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);
-    } catch (Throwable e) {
-      LOG.error("Got exception:", e);
-      responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
     }
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/util/AbstractAppFabricHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/util/AbstractAppFabricHttpHandler.java
@@ -167,7 +167,8 @@ public abstract class AbstractAppFabricHttpHandler extends AbstractHttpHandler {
     }
   }
 
-  protected final void programList(HttpResponder responder, String namespaceId, ProgramType type, Store store) {
+  protected final void programList(HttpResponder responder, String namespaceId, ProgramType type,
+                                   Store store) throws Exception {
     try {
       Id.Namespace namespace = Id.Namespace.from(namespaceId);
       List<ProgramRecord> programRecords = listPrograms(namespace, type, store);
@@ -179,9 +180,6 @@ public abstract class AbstractAppFabricHttpHandler extends AbstractHttpHandler {
       }
     } catch (SecurityException e) {
       responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);
-    } catch (Throwable e) {
-      LOG.error("Got exception: ", e);
-      responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
     }
   }
 
@@ -272,9 +270,6 @@ public abstract class AbstractAppFabricHttpHandler extends AbstractHttpHandler {
       responder.sendJson(HttpResponseStatus.OK, runtimeService.getLiveInfo(programId));
     } catch (SecurityException e) {
       responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);
-    } catch (Throwable e) {
-      LOG.error("Got exception:", e);
-      responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
     }
   }
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricClient.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricClient.java
@@ -66,6 +66,7 @@ import java.io.File;
 import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 import javax.annotation.Nullable;
 import javax.ws.rs.core.MediaType;
 
@@ -170,7 +171,8 @@ public class AppFabricClient {
     return json.get("status");
   }
 
-  public void setWorkerInstances(String namespaceId, String appId, String workerId, int instances) {
+  public void setWorkerInstances(String namespaceId, String appId, String workerId, int instances)
+    throws ExecutionException, InterruptedException {
     MockResponder responder = new MockResponder();
     String uri = String.format("%s/apps/%s/worker/%s/instances", getNamespacePath(namespaceId), appId, workerId);
     HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.PUT, uri);
@@ -190,7 +192,8 @@ public class AppFabricClient {
     return responder.decodeResponseContent(Instances.class);
   }
 
-  public void setServiceInstances(String namespaceId, String applicationId, String serviceName, int instances) {
+  public void setServiceInstances(String namespaceId, String applicationId, String serviceName,
+                                  int instances) throws ExecutionException, InterruptedException {
     MockResponder responder = new MockResponder();
     String uri = String.format("%s/apps/%s/services/%s/instances",
                                getNamespacePath(namespaceId), applicationId, serviceName);
@@ -212,8 +215,8 @@ public class AppFabricClient {
     return responder.decodeResponseContent(ServiceInstances.class);
   }
 
-  public void setFlowletInstances(String namespaceId, String applicationId,
-                                  String flowId, String flowletName, int instances) {
+  public void setFlowletInstances(String namespaceId, String applicationId, String flowId,
+                                  String flowletName, int instances) throws ExecutionException, InterruptedException {
     MockResponder responder = new MockResponder();
     String uri = String.format("%s/apps/%s/flows/%s/flowlets/%s/instances/%s",
                                getNamespacePath(namespaceId), applicationId, flowId, flowletName, instances);

--- a/cdap-common/src/main/java/co/cask/cdap/gateway/handlers/ConfigHandler.java
+++ b/cdap-common/src/main/java/co/cask/cdap/gateway/handlers/ConfigHandler.java
@@ -53,17 +53,12 @@ public class ConfigHandler extends AbstractHttpHandler {
   @Path("/config/cdap")
   @GET
   public void configCDAP(@SuppressWarnings("UnusedParameters") HttpRequest request, HttpResponder responder,
-                         @DefaultValue("json") @QueryParam("format") String format) {
+                         @DefaultValue("json") @QueryParam("format") String format) throws IOException {
     if ("json".equals(format)) {
       responder.sendJson(HttpResponseStatus.OK, configService.getCConf());
     } else if ("xml".equals(format)) {
-      try {
-        String xmlString = configService.getCConfXMLString();
-        responder.sendContent(HttpResponseStatus.OK, newChannelBuffer(xmlString), "application/xml", null);
-      } catch (IOException e) {
-        LOG.info("Failed to write cConf to XML", e);
-        responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
-      }
+      String xmlString = configService.getCConfXMLString();
+      responder.sendContent(HttpResponseStatus.OK, newChannelBuffer(xmlString), "application/xml", null);
     } else {
 
       responder.sendString(HttpResponseStatus.BAD_REQUEST, "Invalid format: " + format + ". Valid formats: json, xml");
@@ -73,17 +68,12 @@ public class ConfigHandler extends AbstractHttpHandler {
   @Path("/config/hadoop")
   @GET
   public void configHadoop(@SuppressWarnings("UnusedParameters") HttpRequest request, HttpResponder responder,
-                          @DefaultValue("json") @QueryParam("format") String format) {
+                          @DefaultValue("json") @QueryParam("format") String format) throws IOException {
     if ("json".equals(format)) {
       responder.sendJson(HttpResponseStatus.OK, configService.getHConf());
     } else if ("xml".equals(format)) {
-      try {
-        String xmlString = configService.getHConfXMLString();
-        responder.sendContent(HttpResponseStatus.OK, newChannelBuffer(xmlString), "application/xml", null);
-      } catch (IOException e) {
-        LOG.info("Failed to write hConf to XML", e);
-        responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
-      }
+      String xmlString = configService.getHConfXMLString();
+      responder.sendContent(HttpResponseStatus.OK, newChannelBuffer(xmlString), "application/xml", null);
     } else {
       responder.sendString(HttpResponseStatus.BAD_REQUEST, "Invalid format: " + format + ". Valid formats: json, xml");
     }

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/executor/AbstractExploreMetadataHttpHandler.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/executor/AbstractExploreMetadataHttpHandler.java
@@ -44,7 +44,8 @@ public class AbstractExploreMetadataHttpHandler extends AbstractHttpHandler {
   private static final Gson GSON = new Gson();
 
   protected void handleResponseEndpointExecution(HttpRequest request, HttpResponder responder,
-                                                 final EndpointCoreExecution<QueryHandle> execution) {
+                                                 final EndpointCoreExecution<QueryHandle> execution)
+    throws ExploreException, IOException {
     genericEndpointExecution(request, responder, new EndpointCoreExecution<Void>() {
       @Override
       public Void execute(HttpRequest request, HttpResponder responder)
@@ -59,7 +60,7 @@ public class AbstractExploreMetadataHttpHandler extends AbstractHttpHandler {
   }
 
   protected void genericEndpointExecution(HttpRequest request, HttpResponder responder,
-                                          EndpointCoreExecution<Void> execution) {
+                                          EndpointCoreExecution<Void> execution) throws ExploreException, IOException {
     try {
       execution.execute(request, responder);
     } catch (IllegalArgumentException e) {
@@ -69,9 +70,6 @@ public class AbstractExploreMetadataHttpHandler extends AbstractHttpHandler {
       LOG.debug("Got exception:", e);
       responder.sendString(HttpResponseStatus.BAD_REQUEST,
                            String.format("[SQLState %s] %s", e.getSQLState(), e.getMessage()));
-    } catch (Throwable e) {
-      LOG.error("Got exception:", e);
-      responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
     }
   }
 

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/executor/ExploreMetadataHttpHandler.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/executor/ExploreMetadataHttpHandler.java
@@ -54,7 +54,7 @@ public class ExploreMetadataHttpHandler extends AbstractExploreMetadataHttpHandl
 
   @POST
   @Path("jdbc/catalogs")
-  public void getJDBCCatalogs(HttpRequest request, HttpResponder responder) {
+  public void getJDBCCatalogs(HttpRequest request, HttpResponder responder) throws ExploreException, IOException {
     handleResponseEndpointExecution(request, responder, new EndpointCoreExecution<QueryHandle>() {
       @Override
       public QueryHandle execute(HttpRequest request, HttpResponder responder)
@@ -67,7 +67,8 @@ public class ExploreMetadataHttpHandler extends AbstractExploreMetadataHttpHandl
 
   @GET
   @Path("jdbc/info/{type}")
-  public void getJDBCInfo(HttpRequest request, HttpResponder responder, @PathParam("type") final String type) {
+  public void getJDBCInfo(HttpRequest request, HttpResponder responder,
+                          @PathParam("type") final String type) throws ExploreException, IOException {
     genericEndpointExecution(request, responder, new EndpointCoreExecution<Void>() {
       @Override
       public Void execute(HttpRequest request, HttpResponder responder)
@@ -83,7 +84,7 @@ public class ExploreMetadataHttpHandler extends AbstractExploreMetadataHttpHandl
 
   @POST
   @Path("jdbc/tableTypes")
-  public void getJDBCTableTypes(HttpRequest request, HttpResponder responder) {
+  public void getJDBCTableTypes(HttpRequest request, HttpResponder responder) throws ExploreException, IOException {
     handleResponseEndpointExecution(request, responder, new EndpointCoreExecution<QueryHandle>() {
       @Override
       public QueryHandle execute(HttpRequest request, HttpResponder responder)
@@ -96,7 +97,7 @@ public class ExploreMetadataHttpHandler extends AbstractExploreMetadataHttpHandl
 
   @POST
   @Path("jdbc/types")
-  public void getJDBCTypes(HttpRequest request, HttpResponder responder) {
+  public void getJDBCTypes(HttpRequest request, HttpResponder responder) throws ExploreException, IOException {
     handleResponseEndpointExecution(request, responder, new EndpointCoreExecution<QueryHandle>() {
       @Override
       public QueryHandle execute(HttpRequest request, HttpResponder responder)
@@ -115,7 +116,7 @@ public class ExploreMetadataHttpHandler extends AbstractExploreMetadataHttpHandl
   @PUT
   @Path("namespaces/{namespace-id}")
   public void create(HttpRequest request, HttpResponder responder,
-                     @PathParam("namespace-id") final String namespaceId) {
+                     @PathParam("namespace-id") final String namespaceId) throws ExploreException, IOException {
     handleResponseEndpointExecution(request, responder, new EndpointCoreExecution<QueryHandle>() {
       @Override
       public QueryHandle execute(HttpRequest request, HttpResponder responder)
@@ -128,7 +129,7 @@ public class ExploreMetadataHttpHandler extends AbstractExploreMetadataHttpHandl
   @DELETE
   @Path("namespaces/{namespace-id}")
   public void delete(HttpRequest request, HttpResponder responder,
-                     @PathParam("namespace-id") final String namespaceId) {
+                     @PathParam("namespace-id") final String namespaceId) throws ExploreException, IOException {
     handleResponseEndpointExecution(request, responder, new EndpointCoreExecution<QueryHandle>() {
       @Override
       public QueryHandle execute(HttpRequest request, HttpResponder responder)

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/executor/NamespacedExploreMetadataHttpHandler.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/executor/NamespacedExploreMetadataHttpHandler.java
@@ -84,7 +84,7 @@ public class NamespacedExploreMetadataHttpHandler extends AbstractExploreMetadat
   @POST
   @Path("jdbc/tables")
   public void getJDBCTables(HttpRequest request, HttpResponder responder,
-                            @PathParam("namespace-id") final String namespaceId) {
+                            @PathParam("namespace-id") final String namespaceId) throws ExploreException, IOException {
     handleResponseEndpointExecution(request, responder, new EndpointCoreExecution<QueryHandle>() {
       @Override
       public QueryHandle execute(HttpRequest request, HttpResponder responder)
@@ -100,7 +100,7 @@ public class NamespacedExploreMetadataHttpHandler extends AbstractExploreMetadat
   @POST
   @Path("jdbc/columns")
   public void getJDBCColumns(HttpRequest request, HttpResponder responder,
-                             @PathParam("namespace-id") final String namespaceId) {
+                             @PathParam("namespace-id") final String namespaceId) throws ExploreException, IOException {
     handleResponseEndpointExecution(request, responder, new EndpointCoreExecution<QueryHandle>() {
       @Override
       public QueryHandle execute(HttpRequest request, HttpResponder responder)
@@ -116,7 +116,7 @@ public class NamespacedExploreMetadataHttpHandler extends AbstractExploreMetadat
   @POST
   @Path("jdbc/schemas")
   public void getJDBCSchemas(HttpRequest request, HttpResponder responder,
-                             @PathParam("namespace-id") final String namespaceId) {
+                             @PathParam("namespace-id") final String namespaceId) throws ExploreException, IOException {
     handleResponseEndpointExecution(request, responder, new EndpointCoreExecution<QueryHandle>() {
       @Override
       public QueryHandle execute(HttpRequest request, HttpResponder responder)
@@ -131,7 +131,8 @@ public class NamespacedExploreMetadataHttpHandler extends AbstractExploreMetadat
   @POST
   @Path("jdbc/functions")
   public void getJDBCFunctions(HttpRequest request, HttpResponder responder,
-                               @PathParam("namespace-id") final String namespaceId) {
+                               @PathParam("namespace-id") final String namespaceId)
+    throws ExploreException, IOException {
     handleResponseEndpointExecution(request, responder, new EndpointCoreExecution<QueryHandle>() {
       @Override
       public QueryHandle execute(HttpRequest request, HttpResponder responder)

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/LogHandler.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/LogHandler.java
@@ -122,9 +122,6 @@ public class LogHandler extends AbstractHttpHandler {
       responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);
     } catch (IllegalArgumentException e) {
       responder.sendString(HttpResponseStatus.BAD_REQUEST, e.getMessage());
-    }  catch (Throwable e) {
-      LOG.error("Caught exception", e);
-      responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
     }
   }
 
@@ -176,9 +173,6 @@ public class LogHandler extends AbstractHttpHandler {
       responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);
     } catch (IllegalArgumentException e) {
       responder.sendString(HttpResponseStatus.BAD_REQUEST, e.getMessage());
-    } catch (Throwable e) {
-      LOG.error("Caught exception", e);
-      responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
     }
   }
 
@@ -256,9 +250,6 @@ public class LogHandler extends AbstractHttpHandler {
       responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);
     } catch (IllegalArgumentException e) {
       responder.sendString(HttpResponseStatus.BAD_REQUEST, e.getMessage());
-    } catch (Throwable e) {
-      LOG.error("Caught exception", e);
-      responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
     }
   }
 
@@ -284,9 +275,6 @@ public class LogHandler extends AbstractHttpHandler {
       logCallback.close();
     } catch (IllegalArgumentException e) {
       responder.sendString(HttpResponseStatus.BAD_REQUEST, e.getMessage());
-    } catch (Throwable e) {
-      LOG.error("Caught exception", e);
-      responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
     }
   }
 
@@ -310,9 +298,6 @@ public class LogHandler extends AbstractHttpHandler {
       logCallback.close();
     } catch (IllegalArgumentException e) {
       responder.sendString(HttpResponseStatus.BAD_REQUEST, e.getMessage());
-    } catch (Throwable e) {
-      LOG.error("Caught exception", e);
-      responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
     }
   }
 
@@ -336,9 +321,6 @@ public class LogHandler extends AbstractHttpHandler {
       logCallback.close();
     } catch (IllegalArgumentException e) {
       responder.sendString(HttpResponseStatus.BAD_REQUEST, e.getMessage());
-    } catch (Throwable e) {
-      LOG.error("Caught exception", e);
-      responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
     }
   }
 

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/MetricsHandler.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/MetricsHandler.java
@@ -51,7 +51,6 @@ import org.jboss.netty.handler.codec.http.QueryStringDecoder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -137,7 +136,7 @@ public class MetricsHandler extends AbstractHttpHandler {
   @Path("/search")
   public void search(HttpRequest request, HttpResponder responder,
                      @QueryParam("target") String target,
-                     @QueryParam("tag") List<String> tags) throws IOException {
+                     @QueryParam("tag") List<String> tags) throws Exception {
     if (target == null) {
       responder.sendJson(HttpResponseStatus.BAD_REQUEST, "Required target param is missing");
       return;
@@ -156,15 +155,12 @@ public class MetricsHandler extends AbstractHttpHandler {
     }
   }
 
-  private void searchMetricAndRespond(HttpResponder responder, List<String> tagValues) {
+  private void searchMetricAndRespond(HttpResponder responder, List<String> tagValues) throws Exception {
     try {
       responder.sendJson(HttpResponseStatus.OK, getMetrics(humanToTagNames(parseTagValues(tagValues))));
     } catch (IllegalArgumentException e) {
       LOG.warn("Invalid request", e);
       responder.sendString(HttpResponseStatus.BAD_REQUEST, e.getMessage());
-    } catch (Exception e) {
-      LOG.warn("Exception while retrieving available metrics", e);
-      responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
     }
   }
 


### PR DESCRIPTION
…d with an empty message, and let HttpExceptionHandler respond with a more descriptive message instead. This would help immensely while debugging test failures.

Jira: [CDAP-3713](https://issues.cask.co/browse/CDAP-3713)
Build: http://builds.cask.co/browse/CDAP-RBT453-1