### PR TITLE
(CDAP-3695) Make sure every notification in StreamSizeSchedulerTest i…

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/SchedulerTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/SchedulerTestBase.java
@@ -37,6 +37,8 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
@@ -45,6 +47,8 @@ import java.util.concurrent.TimeUnit;
  * Base class for scheduler tests
  */
 public abstract class SchedulerTestBase {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SchedulerTestBase.class);
 
   protected static final CConfiguration CCONF = CConfiguration.create();
 
@@ -165,11 +169,13 @@ public abstract class SchedulerTestBase {
    * Waits for the given program ran for the given number of times.
    */
   private void waitForRuns(final Store store, final Id.Program programId,
-                           int expectedRuns, long timeoutSeconds) throws Exception {
+                           final int expectedRuns, long timeoutSeconds) throws Exception {
     Tasks.waitFor(expectedRuns, new Callable<Integer>() {
       @Override
       public Integer call() throws Exception {
-        return store.getRuns(programId, ProgramRunStatus.COMPLETED, 0, Long.MAX_VALUE, 100).size();
+        int runs = store.getRuns(programId, ProgramRunStatus.COMPLETED, 0, Long.MAX_VALUE, 100).size();
+        LOG.info("Expecting {} runs of {}, got {} so far.", expectedRuns, programId, runs);
+        return runs;
       }
     }, timeoutSeconds, TimeUnit.SECONDS, 50, TimeUnit.MILLISECONDS);
   }


### PR DESCRIPTION
…s published 1 second later than the previous. One hypothesis for the flaky nature could be that multiple notifications get published at the same time, thereby leading to some notifications getting lost?

Not completely sure this fixes the flakyness completely yet, want some feedback -

The test tries to ensure that the stream size increased from the last time, so a notification must have gotten published, so a workflow must have started. Then it asserts that the workflow runs increased from the previous runs. It does this multiple times, and we've seen failures for all these assertions from time to time. The failures are because the test can't find that the runs are increased in 5 seconds after the notification is published. In this PR, I'm trying to ensure that each notification gets published one second after the last, to reduce its flakyness. However, if that's the reason for failure, could there be a problem in the notification system where it misses notifications?

Jira: [CDAP-3695](https://issues.cask.co/browse/CDAP-3695)
Build: http://builds.cask.co/browse/CDAP-RBT463-1