### PR TITLE
[CDAP-3722] Add filtering search metadata on active namespace.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/DefaultMetadataAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/DefaultMetadataAdmin.java
@@ -144,14 +144,14 @@ public class DefaultMetadataAdmin implements MetadataAdmin {
   }
 
   @Override
-  public Set<MetadataSearchResultRecord> searchMetadata(String searchQuery,
+  public Set<MetadataSearchResultRecord> searchMetadata(String namespaceId, String searchQuery,
                                                         @Nullable final MetadataSearchTargetType type)
     throws NotFoundException {
     Iterable<BusinessMetadataRecord> results;
     if (type == null) {
-      results = businessMds.searchMetadata(searchQuery);
+      results = businessMds.searchMetadata(namespaceId, searchQuery);
     } else {
-      results = businessMds.searchMetadataOnType(searchQuery, type);
+      results = businessMds.searchMetadataOnType(namespaceId, searchQuery, type);
     }
 
     Set<MetadataSearchResultRecord> searchResultRecords = new LinkedHashSet<>();

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataAdmin.java
@@ -116,6 +116,7 @@ public interface MetadataAdmin {
   /**
    * Execute search for metadata for particular type of CDAP object.
    *
+   * @param namespaceId The namespace id to be filter the search by.
    * @param searchQuery The query need to be executed for the search.
    * @param type The particular type of CDAP object that the metadata need to be searched. If null all possible types
    *             will be searched.
@@ -123,6 +124,6 @@ public interface MetadataAdmin {
    * @return a {@link Set} records for metadata search.
    * @throws NotFoundException if there is not record found for particular query text.
    */
-  Set<MetadataSearchResultRecord> searchMetadata(String searchQuery, @Nullable MetadataSearchTargetType type)
-    throws NotFoundException;
+  Set<MetadataSearchResultRecord> searchMetadata(String namespaceId, String searchQuery,
+                                                 @Nullable MetadataSearchTargetType type) throws NotFoundException;
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataHttpHandler.java
@@ -555,7 +555,8 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
     } else {
       metadataSearchTargetType = null;
     }
-    Set<MetadataSearchResultRecord> results = metadataAdmin.searchMetadata(searchQuery, metadataSearchTargetType);
+    Set<MetadataSearchResultRecord> results = metadataAdmin.searchMetadata(namespaceId, searchQuery,
+                                                                           metadataSearchTargetType);
 
     responder.sendJson(HttpResponseStatus.OK, results, SET_METADATA_SEARCH_RESULT_TYPE, GSON);
   }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataHttpHandlerTest.java
@@ -118,6 +118,10 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     searchProperties = searchMetadata(Id.Namespace.DEFAULT.getId(), "NullKey:s*", null);
     Assert.assertEquals(ImmutableSet.<MetadataSearchResultRecord>of(), searchProperties);
 
+    // search invalid ns should return empty set
+    searchProperties = searchMetadata("invalidnamespace", "sKey:s*", null);
+    Assert.assertEquals(ImmutableSet.of(), searchProperties);
+
     // test removal
     removeProperties(application);
     Assert.assertTrue(getProperties(application).isEmpty());

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/BusinessMetadataDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/BusinessMetadataDataset.java
@@ -344,23 +344,27 @@ public class BusinessMetadataDataset extends AbstractDataset {
   /**
    * Find the instance of {@link BusinessMetadataRecord} based on key.
    *
+   * @param namespaceId The namespace id to filter
    * @param value The metadata value to be found
    * @param type The target type of objects to search from
    * @return The {@link Iterable} of {@link BusinessMetadataRecord} that fit the value
    */
-  public List<BusinessMetadataRecord> findBusinessMetadataOnValue(String value, MetadataSearchTargetType type) {
-    return executeSearchOnColumns(BusinessMetadataDataset.CASE_INSENSITIVE_VALUE_COLUMN, value, type);
+  public List<BusinessMetadataRecord> findBusinessMetadataOnValue(String namespaceId, String value,
+                                                                  MetadataSearchTargetType type) {
+    return executeSearchOnColumns(namespaceId, BusinessMetadataDataset.CASE_INSENSITIVE_VALUE_COLUMN, value, type);
   }
 
   /**
    * Find the instance of {@link BusinessMetadataRecord} for key:value pair
    *
+   * @param namespaceId The namespace id to filter
    * @param keyValue The metadata value to be found.
    * @param type The target type of objects to search from.
    * @return The {@link Iterable} of {@link BusinessMetadataRecord} that fit the key value pair.
    */
-  public List<BusinessMetadataRecord> findBusinessMetadataOnKeyValue(String keyValue, MetadataSearchTargetType type) {
-    return executeSearchOnColumns(BusinessMetadataDataset.KEYVALUE_COLUMN, keyValue, type);
+  public List<BusinessMetadataRecord> findBusinessMetadataOnKeyValue(String namespaceId, String keyValue,
+                                                                     MetadataSearchTargetType type) {
+    return executeSearchOnColumns(namespaceId, BusinessMetadataDataset.KEYVALUE_COLUMN, keyValue, type);
   }
 
   /**
@@ -387,18 +391,18 @@ public class BusinessMetadataDataset extends AbstractDataset {
   }
 
   // Helper method to execute IndexedTable search on target index column.
-  List<BusinessMetadataRecord> executeSearchOnColumns(String column, String searchValue,
+  List<BusinessMetadataRecord> executeSearchOnColumns(String namespaceId, String column, String searchValue,
                                                       MetadataSearchTargetType type) {
     List<BusinessMetadataRecord> results = new LinkedList<>();
 
     Scanner scanner;
-    String lowerCaseSearchValue = searchValue.toLowerCase();
-    if (lowerCaseSearchValue.endsWith("*")) {
-      byte[] startKey = Bytes.toBytes(lowerCaseSearchValue.substring(0, lowerCaseSearchValue.lastIndexOf("*")));
+    String namespacedSearchValue = namespaceId + KEYVALUE_SEPARATOR + searchValue.toLowerCase();
+    if (namespacedSearchValue.endsWith("*")) {
+      byte[] startKey = Bytes.toBytes(namespacedSearchValue.substring(0, namespacedSearchValue.lastIndexOf("*")));
       byte[] stopKey = Bytes.stopKeyForPrefix(startKey);
       scanner = indexedTable.scanByIndex(Bytes.toBytes(column), startKey, stopKey);
     } else {
-      byte[] value = Bytes.toBytes(lowerCaseSearchValue);
+      byte[] value = Bytes.toBytes(namespacedSearchValue);
       scanner = indexedTable.readByIndex(Bytes.toBytes(column), value);
     }
     try {
@@ -435,10 +439,16 @@ public class BusinessMetadataDataset extends AbstractDataset {
     MDSKey mdsKey = MdsValueKey.getMDSKey(targetId, metadataType, key);
     Put put = new Put(mdsKey.getKey());
 
-     // Now add the index columns. To support case insensitive we will store it as lower case for index columns.
-    put.add(Bytes.toBytes(KEYVALUE_COLUMN),
-            Bytes.toBytes(record.getKey().toLowerCase() + KEYVALUE_SEPARATOR + record.getValue().toLowerCase()));
-    put.add(Bytes.toBytes(CASE_INSENSITIVE_VALUE_COLUMN), Bytes.toBytes(record.getValue().toLowerCase()));
+    // Now add the index columns. To support case insensitive we will store it as lower case for index columns.
+    String lowerCaseKey = record.getKey().toLowerCase();
+    String lowerCaseValue = record.getValue().toLowerCase();
+
+    String nameSpacedKVIndexValue =
+      MdsValueKey.getNamespaceId(mdsKey) + KEYVALUE_SEPARATOR + lowerCaseKey + KEYVALUE_SEPARATOR + lowerCaseValue;
+    put.add(Bytes.toBytes(KEYVALUE_COLUMN), Bytes.toBytes(nameSpacedKVIndexValue));
+
+    String nameSpacedVIndexValue = MdsValueKey.getNamespaceId(mdsKey) + KEYVALUE_SEPARATOR + lowerCaseValue;
+    put.add(Bytes.toBytes(CASE_INSENSITIVE_VALUE_COLUMN), Bytes.toBytes(nameSpacedVIndexValue));
 
     // Add to value column
     put.add(Bytes.toBytes(VALUE_COLUMN), Bytes.toBytes(record.getValue()));

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MdsValueKey.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MdsValueKey.java
@@ -87,9 +87,19 @@ public class MdsValueKey {
   public static Id.NamespacedId getNamespaceIdFromKey(String type, MDSKey key) {
     MDSKey.Splitter keySplitter = key.split();
 
-    // The rowkey is [rowPrefix][targetType][targetId][metadata-type][key], so skip the first string.
+    // The rowkey is [rowPrefix][targetType][targetId][metadata-type][key], so skip the first two.
     keySplitter.skipBytes();
     keySplitter.skipString();
     return KeyHelper.getNamespaceIdFromKey(keySplitter, type);
+  }
+
+  public static String getNamespaceId(MDSKey key) {
+    MDSKey.Splitter keySplitter = key.split();
+
+    // The rowkey is [rowPrefix][targetType][targetId][metadata-type][key], so skip the first two.
+    keySplitter.skipBytes();
+    keySplitter.skipString();
+    // We are getting the first part of [targetId] which always be the namespace id.
+    return keySplitter.getString();
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/service/BusinessMetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/service/BusinessMetadataStore.java
@@ -90,10 +90,11 @@ public interface BusinessMetadataStore {
   /**
    * Search to the underlying Business Metadata Dataset.
    */
-  Iterable<BusinessMetadataRecord> searchMetadata(String searchQuery);
+  Iterable<BusinessMetadataRecord> searchMetadata(String namespaceId, String searchQuery);
 
   /**
    * Search to the underlying Business Metadata Dataset for a target type.
    */
-  Iterable<BusinessMetadataRecord> searchMetadataOnType(String searchQuery, MetadataSearchTargetType type);
+  Iterable<BusinessMetadataRecord> searchMetadataOnType(String namespaceId, String searchQuery,
+                                                        MetadataSearchTargetType type);
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/service/DefaultBusinessMetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/service/DefaultBusinessMetadataStore.java
@@ -383,15 +383,16 @@ public class DefaultBusinessMetadataStore implements BusinessMetadataStore {
    * Search to the underlying Business Metadata Dataset.
    */
   @Override
-  public Iterable<BusinessMetadataRecord> searchMetadata(final String searchQuery) {
-    return searchMetadataOnType(searchQuery, MetadataSearchTargetType.ALL);
+  public Iterable<BusinessMetadataRecord> searchMetadata(final String namespaceId, final String searchQuery) {
+    return searchMetadataOnType(namespaceId, searchQuery, MetadataSearchTargetType.ALL);
   }
 
   /**
    * Search to the underlying Business Metadata Dataset for a target type.
    */
   @Override
-  public Iterable<BusinessMetadataRecord> searchMetadataOnType(final String searchQuery,
+  public Iterable<BusinessMetadataRecord> searchMetadataOnType(final String namespaceId,
+                                                               final String searchQuery,
                                                                final MetadataSearchTargetType type) {
     return execute(new TransactionExecutor.Function<BusinessMetadataDataset, Iterable<BusinessMetadataRecord>>() {
       @Override
@@ -400,10 +401,10 @@ public class DefaultBusinessMetadataStore implements BusinessMetadataStore {
         // Check for existence of separator char to make sure we did search in the right indexed column.
         if (searchQuery.contains(BusinessMetadataDataset.KEYVALUE_SEPARATOR)) {
           // key=value search
-          return input.findBusinessMetadataOnKeyValue(searchQuery, type);
+          return input.findBusinessMetadataOnKeyValue(namespaceId, searchQuery, type);
         }
         // value search
-        return input.findBusinessMetadataOnValue(searchQuery, type);
+        return input.findBusinessMetadataOnValue(namespaceId, searchQuery, type);
       }
     });
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/service/NoOpBusinessMetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/service/NoOpBusinessMetadataStore.java
@@ -84,12 +84,13 @@ public class NoOpBusinessMetadataStore implements BusinessMetadataStore {
   }
 
   @Override
-  public Iterable<BusinessMetadataRecord> searchMetadata(String searchQuery) {
+  public Iterable<BusinessMetadataRecord> searchMetadata(String namespaceId, String searchQuery) {
     return null;
   }
 
   @Override
-  public Iterable<BusinessMetadataRecord> searchMetadataOnType(String searchQuery, MetadataSearchTargetType type) {
+  public Iterable<BusinessMetadataRecord> searchMetadataOnType(String namespaceId, String searchQuery,
+                                                               MetadataSearchTargetType type) {
     return null;
   }
 }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/dataset/BusinessMetadataDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/dataset/BusinessMetadataDatasetTest.java
@@ -169,15 +169,21 @@ public class BusinessMetadataDatasetTest {
 
     // Search for it based on value
     List<BusinessMetadataRecord> results =
-      dataset.findBusinessMetadataOnValue("value1", MetadataSearchTargetType.PROGRAM);
+      dataset.findBusinessMetadataOnValue("ns1", "value1", MetadataSearchTargetType.PROGRAM);
 
     // Assert check
     Assert.assertEquals(1, results.size());
 
-    // Case insensitive
-    results = dataset.findBusinessMetadataOnValue("ValUe1", MetadataSearchTargetType.PROGRAM);
-
     BusinessMetadataRecord result = results.get(0);
+    Assert.assertEquals(record, result);
+
+    // Case insensitive
+    results = dataset.findBusinessMetadataOnValue("ns1", "ValUe1", MetadataSearchTargetType.PROGRAM);
+
+    // Assert check
+    Assert.assertEquals(1, results.size());
+
+    result = results.get(0);
     Assert.assertEquals(record, result);
 
     // Save it
@@ -185,7 +191,7 @@ public class BusinessMetadataDatasetTest {
 
     // Search for it based on value
     List<BusinessMetadataRecord> results2 =
-      dataset.findBusinessMetadataOnValue("value1", MetadataSearchTargetType.PROGRAM);
+      dataset.findBusinessMetadataOnValue("ns1", "value1", MetadataSearchTargetType.PROGRAM);
 
     // Assert check
     Assert.assertEquals(2, results2.size());
@@ -198,7 +204,7 @@ public class BusinessMetadataDatasetTest {
     dataset.setProperty(stream1, "key21", "value21");
 
     // Search for it based on value asterix
-    List<BusinessMetadataRecord> results3 = dataset.findBusinessMetadataOnValue("value2*",
+    List<BusinessMetadataRecord> results3 = dataset.findBusinessMetadataOnValue("ns1", "value2*",
                                                                                 MetadataSearchTargetType.ALL);
 
     // Assert check
@@ -206,6 +212,13 @@ public class BusinessMetadataDatasetTest {
     for (BusinessMetadataRecord result3 : results3) {
       Assert.assertTrue(result3.getValue().startsWith("value2"));
     }
+
+    // Search for it based on value asterix
+    List<BusinessMetadataRecord> results4 = dataset.findBusinessMetadataOnValue("ns12", "value2*",
+                                                                                MetadataSearchTargetType.ALL);
+
+    // Assert check
+    Assert.assertEquals(0, results4.size());
   }
 
   @Test
@@ -220,7 +233,7 @@ public class BusinessMetadataDatasetTest {
 
     // Search for it based on value
     List<BusinessMetadataRecord> results =
-      dataset.findBusinessMetadataOnKeyValue("key1" + BusinessMetadataDataset.KEYVALUE_SEPARATOR + "value1",
+      dataset.findBusinessMetadataOnKeyValue("ns1", "key1" + BusinessMetadataDataset.KEYVALUE_SEPARATOR + "value1",
                                              MetadataSearchTargetType.PROGRAM);
 
     // Assert check
@@ -228,6 +241,13 @@ public class BusinessMetadataDatasetTest {
 
     BusinessMetadataRecord result = results.get(0);
     Assert.assertEquals(record, result);
+
+    // Test wrong ns
+    List<BusinessMetadataRecord> results2  =
+      dataset.findBusinessMetadataOnKeyValue("ns12", "key1" + BusinessMetadataDataset.KEYVALUE_SEPARATOR + "value1",
+                                             MetadataSearchTargetType.PROGRAM);
+    // Assert check
+    Assert.assertEquals(0, results2.size());
   }
 
   @Test


### PR DESCRIPTION
Right now, when search done on value or key:value the returned entities are not filtered by active namespace.

We now add namespace as prefix on the value and key:value index columns in the IndexedTable for BusinessMetadataDataset.

Updated tests accordingly.