### PR TITLE
Fix/hydrator firefox

### DIFF
--- a/cdap-ui/app/directives/dag/my-dag.less
+++ b/cdap-ui/app/directives/dag/my-dag.less
@@ -19,9 +19,6 @@
 @import "../../styles/themes/cdap/mixins.less";
 
 my-dag {
-  display: block;
-  overflow: auto;
-
   .my-js-dag {
     position: relative;
     width: inherit;
@@ -168,20 +165,26 @@ my-dag {
       width: inherit;
     }
 
-    ._jsPlumb_endpoint circle {
-      fill: white;
-      r: 2px;
-      stroke-width: 8px;
+    ._jsPlumb_endpoint {
+      svg {
+        overflow: visible;
+      }
+      circle {
+        fill: white;
+        r: 2px;
+        stroke-width: 8px;
+      }
+      &._sourceAnchor circle {
+        stroke: #48c038;
+      }
+      &._transformAnchor circle {
+        stroke: #4586f3;
+      }
+      &._sinkAnchor circle {
+        stroke: #8367df;
+      }
     }
-    ._sourceAnchor circle {
-      stroke: #48c038;
-    }
-    ._transformAnchor circle {
-      stroke: #4586f3;
-    }
-    ._sinkAnchor circle {
-      stroke: #8367df;
-    }
+
     ._jsPlumb_connector path:last-child {
       stroke-width: 0;
     }

--- a/cdap-ui/app/directives/group-side-panel/group-side-panel-ctrl.js
+++ b/cdap-ui/app/directives/group-side-panel/group-side-panel-ctrl.js
@@ -44,8 +44,4 @@ angular.module(PKG.name + '.commons')
       this.openGroup(this.groups[0]);
     }
 
-    this.toggleSidebar = function() {
-      $scope.isExpanded = !$scope.isExpanded;
-    };
-
   });

--- a/cdap-ui/app/directives/group-side-panel/group-side-panel.html
+++ b/cdap-ui/app/directives/group-side-panel/group-side-panel.html
@@ -23,14 +23,16 @@
   <div ng-if="MySidePanel.placement === 'left'">
     <div class="item"
           ng-repeat="group in MySidePanel.groups"
-          ng-click="MySidePanel.openGroup(group)">
+          ng-click="MySidePanel.openGroup(group)"
+          ng-class="{'group-bottom': MySidePanel.openedGroup !== group.name && group.name !== 'source', 'transform-bottom': MySidePanel.openedGroup !== group.name && group.name === 'transform', 'sink-bottom': MySidePanel.openedGroup !== group.name && group.name === 'sink', 'source-top': MySidePanel.openedGroup === 'source' && group.name === 'source'}">
       <div class="text-left item-heading {{group.name}}"
            tooltip="{{group.error}}"
            tooltip-placement="right"
            tooltip-append-to-body="true"
            tooltip-toggle="group.error"
            tooltip-class="tooltip-error"
-           ng-class="{'item-open': MySidePanel.openedGroup === group.name}">
+           ng-class="{'item-open': MySidePanel.openedGroup === group.name}"
+           ng-click="MySidePanel.toggleGroup(group)">
         <span class="name">{{group.name | caskCapitalizeFilter}}</span>
       </div>
 

--- a/cdap-ui/app/directives/group-side-panel/group-side-panel.html
+++ b/cdap-ui/app/directives/group-side-panel/group-side-panel.html
@@ -24,14 +24,13 @@
     <div class="item"
           ng-repeat="group in MySidePanel.groups"
           ng-click="MySidePanel.openGroup(group)"
-          ng-class="{'group-bottom': MySidePanel.openedGroup !== group.name && group.name !== 'source', 'transform-bottom': MySidePanel.openedGroup !== group.name && group.name === 'transform', 'sink-bottom': MySidePanel.openedGroup !== group.name && group.name === 'sink', 'source-top': MySidePanel.openedGroup === 'source' && group.name === 'source'}">
+          ng-class="{'item-open': MySidePanel.openedGroup === group.name}">
       <div class="text-left item-heading {{group.name}}"
            tooltip="{{group.error}}"
            tooltip-placement="right"
            tooltip-append-to-body="true"
            tooltip-toggle="group.error"
            tooltip-class="tooltip-error"
-           ng-class="{'item-open': MySidePanel.openedGroup === group.name}"
            ng-click="MySidePanel.toggleGroup(group)">
         <span class="name">{{group.name | caskCapitalizeFilter}}</span>
       </div>

--- a/cdap-ui/app/directives/group-side-panel/group-side-panel.html
+++ b/cdap-ui/app/directives/group-side-panel/group-side-panel.html
@@ -15,48 +15,38 @@
 -->
 
 <div class="side-panel text-center"
-      ng-class="{'expanded': isExpanded === true, 'left': MySidePanel.placement === 'left'}">
+      ng-class="{'left': MySidePanel.placement === 'left'}">
   <div ng-if="MySidePanel.placement === 'left'" class="hydrator-filter clearfix">
     <input class="form-control pull-left" placeholder="Filter" type="text" ng-model="MySidePanel.searchText" />
-    <div class="btn pull-right" ng-click="MySidePanel.toggleSidebar()">
-      <span class="fa" ng-class="{'fa-angle-left': isExpanded === true, 'fa-angle-right': isExpanded === false}"></span>
-      <span class="fa" ng-class="{'fa-angle-left': isExpanded === true, 'fa-angle-right': isExpanded === false}"></span>
-    </div>
   </div>
 
   <div ng-if="MySidePanel.placement === 'left'">
     <div class="item"
           ng-repeat="group in MySidePanel.groups"
-          ng-class="{'text-left': isExpanded === true}"
           ng-click="MySidePanel.openGroup(group)">
       <div class="text-left item-heading {{group.name}}"
-            tooltip="{{group.error}}"
-            tooltip-placement="right"
-            tooltip-append-to-body="true"
-            tooltip-toggle="group.error"
-            tooltip-class="tooltip-error"
-            ng-class="{'item-open': MySidePanel.openedGroup === group.name}">
-        <div tooltip="{{ group.name | caskCapitalizeFilter }}"
-             tooltip-placement="{{ MySidePanel.placement === 'left' ? 'top' : 'left' }}"
-             tooltip-enable="isExpanded === false && !group.error">
-          <span class="name">{{group.name | caskCapitalizeFilter}}</span>
-        </div>
+           tooltip="{{group.error}}"
+           tooltip-placement="right"
+           tooltip-append-to-body="true"
+           tooltip-toggle="group.error"
+           tooltip-class="tooltip-error"
+           ng-class="{'item-open': MySidePanel.openedGroup === group.name}">
+        <span class="name">{{group.name | caskCapitalizeFilter}}</span>
       </div>
 
       <div class="item-body-wrapper"
-           ng-class="{'text-left': isExpanded === true}"
            ng-if="MySidePanel.isSubMenu === true && MySidePanel.openedGroup === group.name">
         <div class="item-body">
           <div ng-repeat="plugin in MySidePanel.panel.items | filter: {name: MySidePanel.searchText} track by $index"
-                class="plugin-item"
-                popover="{{plugin.description}}"
-                popover-title="{{plugin.name}}"
-                popover-placement="right"
-                popover-append-to-body="true"
-                popover-trigger="mouseenter"
-                ng-click="MySidePanel.onItemClicked($event, plugin)">
+               class="plugin-item"
+               popover="{{plugin.description}}"
+               popover-title="{{plugin.name}}"
+               popover-placement="right"
+               popover-append-to-body="true"
+               popover-trigger="mouseenter"
+               ng-click="MySidePanel.onItemClicked($event, plugin)">
             <span ng-if="plugin.icon" class="text-center fa {{plugin.icon}}"></span>
-            <span ng-if="isExpanded === true" class="name">{{plugin.name | myEllipsis: 10}}</span>
+            <span class="name">{{plugin.name | myEllipsis: 10}}</span>
           </div>
         </div>
       </div>

--- a/cdap-ui/app/directives/group-side-panel/group-side-panel.js
+++ b/cdap-ui/app/directives/group-side-panel/group-side-panel.js
@@ -25,7 +25,6 @@ angular.module(PKG.name + '.commons')
 
         isSubMenu: '@',
         placement: '@',
-        isExpanded: '=',
 
         panel: '=',
         onPanelItemClick: '&',

--- a/cdap-ui/app/features/adapters/bottompanel.less
+++ b/cdap-ui/app/features/adapters/bottompanel.less
@@ -34,7 +34,6 @@ body.theme-cdap.state-adapters {
   div.console {
     background-color: white;
     min-height: 40vh;
-    overflow-x: hidden;
     .transition(all 0.2s ease);
     &.collapsed {
       left: 130px;
@@ -71,9 +70,7 @@ body.theme-cdap.state-adapters {
     }
   }
   div.console-type {
-    background-color: white;
     border-top: 1px solid @table-border-color;
-    width: 100%;
     h4 {
       color: #999;
       font-size: 14px;

--- a/cdap-ui/app/features/adapters/bottompanel.less
+++ b/cdap-ui/app/features/adapters/bottompanel.less
@@ -301,5 +301,7 @@ body.theme-cdap.state-adapters {
   footer {
     // Creates a bottom border for the bottom panel, needed here in order to accommodate the single scroll
     border-top: 1px solid @table-border-color;
+    position: fixed;
+    z-index: 1025;
   }
 }

--- a/cdap-ui/app/features/adapters/controllers/create/create-studio-ctrl.js
+++ b/cdap-ui/app/features/adapters/controllers/create/create-studio-ctrl.js
@@ -16,7 +16,7 @@
 
 angular.module(PKG.name + '.feature.adapters')
   .controller('AdapterCreateStudioController', function(MyAppDAGService, $scope, rConfig, $modalStack, EventPipe, $window, $timeout, MyConsoleTabService) {
-
+    this.isExpanded = true;
     var confirmOnPageExit = function (e) {
 
       if (!MyAppDAGService.isConfigTouched) { return; }
@@ -54,4 +54,8 @@ angular.module(PKG.name + '.feature.adapters')
       EventPipe.cancelEvent('plugin.reset');
       EventPipe.cancelEvent('schema.clear');
     });
+
+    this.toggleSidebar = function() {
+      this.isExpanded = !this.isExpanded;
+    };
   });

--- a/cdap-ui/app/features/adapters/etlapps.less
+++ b/cdap-ui/app/features/adapters/etlapps.less
@@ -432,7 +432,7 @@ body.theme-cdap.state-adapters-create {
   }
   my-dag {
     width: 100%;
-    height: 40vh;
+    height: 50vh;
   }
 
   .tab-pane .panel-default {

--- a/cdap-ui/app/features/adapters/etlapps.less
+++ b/cdap-ui/app/features/adapters/etlapps.less
@@ -429,10 +429,13 @@ body.theme-cdap.state-adapters-create {
   .canvas-wrapper {
     position: relative;
     margin-top: 60px;
+    display: table;
+    width: 100%;
   }
   .right-wrapper {
-    height: 100vh;
-    overflow-y: scroll;
+    display: table-cell;
+    height: 100%;
+    vertical-align: top;
   }
   my-dag {
     width: 100%;

--- a/cdap-ui/app/features/adapters/etlapps.less
+++ b/cdap-ui/app/features/adapters/etlapps.less
@@ -429,17 +429,10 @@ body.theme-cdap.state-adapters-create {
   .canvas-wrapper {
     position: relative;
     margin-top: 60px;
-    display: table;
-    width: 100%;
-  }
-  .right-wrapper {
-    display: table-cell;
-    height: 100%;
-    vertical-align: top;
   }
   my-dag {
     width: 100%;
-    height: 60vh;
+    height: 40vh;
   }
 
   .tab-pane .panel-default {

--- a/cdap-ui/app/features/adapters/leftpanel.less
+++ b/cdap-ui/app/features/adapters/leftpanel.less
@@ -19,8 +19,10 @@
 @import '../../styles/themes/cdap/mixins.less';
 
 body.theme-cdap.state-adapters-create {
-
-  .side-panel.left {
+  .left-panel-wrapper {
+    display: table-cell;
+    width: 130px;
+    vertical-align: top;
     background: #c7c7c6;
     background-image: url('@{img-path}/hydrator_bg_pattern.png'), -moz-linear-gradient(-45deg, #c7c7c6 0%, #a0a0a0 100%);
     background-image: url('@{img-path}/hydrator_bg_pattern.png'), -webkit-gradient(linear, left top, right bottom, color-stop(0%,#c7c7c6), color-stop(100%,#a0a0a0));
@@ -29,10 +31,53 @@ body.theme-cdap.state-adapters-create {
     background-image: url('@{img-path}/hydrator_bg_pattern.png'), -ms-linear-gradient(-45deg, #c7c7c6 0%,#a0a0a0 100%);
     background-image: url('@{img-path}/hydrator_bg_pattern.png'), linear-gradient(135deg, #c7c7c6 0%,#a0a0a0 100%);
     filter: progid:DXImageTransform.Microsoft.gradient(GradientType=1, startColorstr='#c7c7c6', endColorstr='#a0a0a0'), progid:DXImageTransform.Microsoft.AlphaImageLoader(src='@{img-path}/hydrator_bg_pattern.png', sizingMethod='crop');
-    float: left;
-    width: 130px;
-    height: 100vh;
     .transition(all 0.2s ease);
+    &.expanded {
+      width: 290px;
+      .item .plugin-item {
+        text-align: left;
+        width: 130px;
+        .name {
+          display: inline-block;
+        }
+      }
+    }
+    > div.btn {
+      background-color: white;
+      border: 0;
+      color: #74685a;
+      font-weight: bold;
+      height: 35px;
+      width: 25px;
+      padding-left: 10px;
+      position: relative;
+      top: 18px;
+      left: 6px;
+      z-index: 1024;
+      .border-radius(90px 0 0 90px);
+      .box-shadow(0 1px 5px 0 fade(black, 33%));
+      &:active, &.active {
+        .box-shadow(none);
+      }
+      &:after {
+        display: block;
+        content: "";
+        border-left: 4px solid transparent;
+        border-right: 4px solid transparent;
+        border-bottom: 4px solid #666;
+        position: absolute;
+        bottom: -3.5px;
+        right: 0.5px;
+        .rotate(-45deg);
+      }
+      > span {
+        font-weight: 600;
+        &:last-child {
+          position: relative;
+          right: 3px;
+        }
+      }
+    }
     .hydrator-filter {
       padding: 20px 0 20px 10px;
       input {
@@ -46,41 +91,6 @@ body.theme-cdap.state-adapters-create {
         .border-radius(25px);
         .box-shadow(inset 0 2px 5px 0 rgba(0, 0, 0, 0.33));
         .placeholder-color(white);
-      }
-      div.btn {
-        background-color: white;
-        border: 0;
-        color: #74685a;
-        font-weight: bold;
-        height: 35px;
-        width: 25px;
-        padding-left: 10px;
-        position: relative;
-        left: 6px;
-        z-index: 1024;
-        .border-radius(90px 0 0 90px);
-        .box-shadow(0 1px 5px 0 fade(black, 33%));
-        &:active, &.active {
-          .box-shadow(none);
-        }
-        &:after {
-          display: block;
-          content: "";
-          border-left: 4px solid transparent;
-          border-right: 4px solid transparent;
-          border-bottom: 4px solid #666;
-          position: absolute;
-          bottom: -3.5px;
-          right: 0.5px;
-          .rotate(-45deg);
-        }
-        > span {
-          font-weight: 600;
-          &:last-child {
-            position: relative;
-            right: 3px;
-          }
-        }
       }
     }
     .item {
@@ -151,15 +161,10 @@ body.theme-cdap.state-adapters-create {
           vertical-align: middle;
         }
         .name {
+          display: none;
           font-size: 11px;
           padding-left: 5px;
         }
-      }
-    }
-    &.expanded {
-      width: 290px;
-      .item .plugin-item {
-        width: 130px;
       }
     }
   }

--- a/cdap-ui/app/features/adapters/leftpanel.less
+++ b/cdap-ui/app/features/adapters/leftpanel.less
@@ -20,7 +20,11 @@
 
 body.theme-cdap.state-adapters-create {
   .left-panel-wrapper {
-    display: table-cell;
+    position: fixed;
+    top: 120px;
+    bottom: 53px;
+    left: 0;
+    z-index: 1024;
     width: 130px;
     vertical-align: top;
     background: #c7c7c6;
@@ -32,6 +36,10 @@ body.theme-cdap.state-adapters-create {
     background-image: url('@{img-path}/hydrator_bg_pattern.png'), linear-gradient(135deg, #c7c7c6 0%,#a0a0a0 100%);
     filter: progid:DXImageTransform.Microsoft.gradient(GradientType=1, startColorstr='#c7c7c6', endColorstr='#a0a0a0'), progid:DXImageTransform.Microsoft.AlphaImageLoader(src='@{img-path}/hydrator_bg_pattern.png', sizingMethod='crop');
     .transition(all 0.2s ease);
+    + .right-wrapper {
+      margin-left: 130px;
+      .transition(all 0.2s ease);
+    }
     &.expanded {
       width: 290px;
       .item .plugin-item {
@@ -40,6 +48,9 @@ body.theme-cdap.state-adapters-create {
         .name {
           display: inline-block;
         }
+      }
+      + .right-wrapper {
+        margin-left: 290px;
       }
     }
     > div.btn {
@@ -53,7 +64,6 @@ body.theme-cdap.state-adapters-create {
       position: relative;
       top: 18px;
       left: 6px;
-      z-index: 1024;
       .border-radius(90px 0 0 90px);
       .box-shadow(0 1px 5px 0 fade(black, 33%));
       &:active, &.active {
@@ -106,6 +116,28 @@ body.theme-cdap.state-adapters-create {
           white-space: nowrap;
         }
       }
+
+      &.group-bottom {
+        .item-heading {
+          position: absolute;
+        }
+        // Position transform or sink at bottom: 0 when either is the only group with position: absolute
+        &.transform-bottom, &.sink-bottom {
+          .item-heading {
+            bottom: 0;
+          }
+        }
+      }
+      &.source-top {
+        + .item .item-heading {
+          // Position Transform at bottom: 40px when Source is open
+          bottom: 40px;
+          + .item .item-heading {
+            // Position Sink at bottom: 0 when Transform is open
+            bottom: 0;
+          }
+        }
+      }
       .item-heading {
         color: white;
         background-color: fade(@gray-dark, 45);
@@ -113,9 +145,11 @@ body.theme-cdap.state-adapters-create {
         padding: 0 15px 0 10px;
         height: 40px;
         line-height: 40px;
+        width: 100%;
         &.item-open {
           border-bottom-color: transparent;
           color: white;
+          position: static;
         }
         span.name {
           font-size: 13px;
@@ -123,7 +157,7 @@ body.theme-cdap.state-adapters-create {
         }
       }
       .item-body-wrapper {
-        height: 149px;
+        height: 42vh;
         overflow-y: auto;
       }
       .item-body {

--- a/cdap-ui/app/features/adapters/leftpanel.less
+++ b/cdap-ui/app/features/adapters/leftpanel.less
@@ -117,27 +117,33 @@ body.theme-cdap.state-adapters-create {
         }
       }
 
-      &.group-bottom {
+      &.item-open {
         .item-heading {
+          border-bottom-color: transparent;
+          color: white;
+        }
+        + .item {
+          .transform {
+            position: absolute;
+            bottom: 40px;
+          }
+          + .item .sink {
+            position: absolute;
+            bottom: 0;
+          }
+        }
+        .transform {
+          position: static;
+        }
+        + .item .sink {
           position: absolute;
+          bottom: 0;
         }
-        // Position transform or sink at bottom: 0 when either is the only group with position: absolute
-        &.transform-bottom, &.sink-bottom {
-          .item-heading {
-            bottom: 0;
-          }
+        .sink {
+          position: static;
         }
       }
-      &.source-top {
-        + .item .item-heading {
-          // Position Transform at bottom: 40px when Source is open
-          bottom: 40px;
-          + .item .item-heading {
-            // Position Sink at bottom: 0 when Transform is open
-            bottom: 0;
-          }
-        }
-      }
+
       .item-heading {
         color: white;
         background-color: fade(@gray-dark, 45);
@@ -146,11 +152,6 @@ body.theme-cdap.state-adapters-create {
         height: 40px;
         line-height: 40px;
         width: 100%;
-        &.item-open {
-          border-bottom-color: transparent;
-          color: white;
-          position: static;
-        }
         span.name {
           font-size: 13px;
           line-height: inherit;
@@ -192,11 +193,12 @@ body.theme-cdap.state-adapters-create {
           font-size: 12px;
           height: 18px;
           width: 18px;
-          vertical-align: middle;
+          line-height: 40px;
+          vertical-align: top;
         }
         .name {
           display: none;
-          font-size: 11px;
+          font-size: 12px;
           padding-left: 5px;
         }
       }

--- a/cdap-ui/app/features/adapters/templates/create/studio.html
+++ b/cdap-ui/app/features/adapters/templates/create/studio.html
@@ -16,7 +16,14 @@
 
 <div class="canvas-wrapper">
   <div ui-view="toppanel"></div>
-  <div ui-view="leftpanel"></div>
+  <div class="left-panel-wrapper"  ng-class="{'expanded': AdapterCreateStudioController.isExpanded === true}">
+    <div class="btn pull-right" ng-click="AdapterCreateStudioController.toggleSidebar()">
+      <span class="fa" ng-class="{'fa-angle-left': AdapterCreateStudioController.isExpanded === true, 'fa-angle-right': AdapterCreateStudioController.isExpanded === false}"></span>
+      <span class="fa" ng-class="{'fa-angle-left': AdapterCreateStudioController.isExpanded === true, 'fa-angle-right': AdapterCreateStudioController.isExpanded === false}"></span>
+    </div>
+    <div ui-view="leftpanel"></div>
+  </div>
+
   <div class="right-wrapper">
     <div ui-view="canvas"></div>
     <div ui-view="bottompanel"></div>

--- a/cdap-ui/app/services/app/my-app-dag-service.js
+++ b/cdap-ui/app/services/app/my-app-dag-service.js
@@ -425,7 +425,7 @@ angular.module(PKG.name + '.services')
       }
 
       var left = initial + offsetLeft;
-      var top = 150 + offsetTop;
+      var top = 100 + offsetTop;
 
       if (inCreationMode) {
         config.style = {


### PR DESCRIPTION
*  Fixes node endpoint display issue (Firefox only)
*  Moves left panel toggle button from group-side-panel to adapters
*  Replaces floats with fixed left panel
*  Adjusts positioning of left panel groups when not opened
*  Slightly shrinks the canvas height

![groups](https://cloud.githubusercontent.com/assets/5335210/9977255/89537d64-5eb5-11e5-8e73-56bbb7cc4bae.gif)
