### PR TITLE
CDAP-3727 fix bug with order of system artifact loading

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepositoryTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepositoryTest.java
@@ -141,10 +141,10 @@ public class ArtifactRepositoryTest {
       createManifest(ManifestFields.EXPORT_PACKAGE, PluginTestRunnable.class.getPackage().getName()));
 
     // write plugins jar
-    Id.Artifact pluginArtifactId = Id.Artifact.from(Id.Namespace.SYSTEM, "myPlugin", "1.0.0");
+    Id.Artifact pluginArtifactId = Id.Artifact.from(Id.Namespace.SYSTEM, "APlugin", "1.0.0");
 
     Manifest manifest = createManifest(ManifestFields.EXPORT_PACKAGE, TestPlugin.class.getPackage().getName());
-    createPluginJar(TestPlugin.class, new File(systemArtifactsDir, "myPlugin-1.0.0.jar"), manifest);
+    createPluginJar(TestPlugin.class, new File(systemArtifactsDir, "APlugin-1.0.0.jar"), manifest);
 
     // write plugins config file
     Map<String, PluginPropertyField> emptyMap = Collections.emptyMap();
@@ -152,7 +152,7 @@ public class ArtifactRepositoryTest {
       new PluginClass("typeA", "manual1", "desc", "co.cask.classname", null, emptyMap),
       new PluginClass("typeB", "manual2", "desc", "co.cask.otherclassname", null, emptyMap)
     );
-    File pluginConfigFile = new File(systemArtifactsDir, "myPlugin-1.0.0.json");
+    File pluginConfigFile = new File(systemArtifactsDir, "APlugin-1.0.0.json");
     ArtifactConfig pluginConfig = ArtifactConfig.builder(pluginArtifactId, pluginConfigFile)
       .addParents(new ArtifactRange(
         Id.Namespace.SYSTEM, "PluginTest", new ArtifactVersion("0.9.0"), new ArtifactVersion("2.0.0")))

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -187,7 +187,8 @@
 
   <property>
     <name>app.artifact.dir</name>
-    <value>/opt/cdap/master/artifacts</value>
+    <!--value>/opt/cdap/master/artifacts</value-->
+    <value>artifacts</value>
     <description>
       Directory where all system artifacts and their corresponding config files are stored
     </description>

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -187,8 +187,7 @@
 
   <property>
     <name>app.artifact.dir</name>
-    <!--value>/opt/cdap/master/artifacts</value-->
-    <value>artifacts</value>
+    <value>/opt/cdap/master/artifacts</value>
     <description>
       Directory where all system artifacts and their corresponding config files are stored
     </description>


### PR DESCRIPTION
The previous implementation tried to enforce ordering by sorting
on the artifacts, with parents ordered larger than children. The
problem was the comparison make sense when 2 artifacts were being
compared, but it wasn't a natural ordering. That is, there could
be a scenario where A < B, B < C, but A > C.

Instead, since we enforce only 1 level of dependencies, just
adding all parents first, then adding the children.