### PR TITLE
(CDAP-3695) Increased timeout for run record verifications in StreamS…

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/SchedulerTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/SchedulerTestBase.java
@@ -103,12 +103,12 @@ public abstract class SchedulerTestBase {
 
     // Publish a notification on behalf of the stream with enough data to trigger the execution of the job
     metricsPublisher.increment(1024 * 1024);
-    waitForRuns(store, PROGRAM_ID, 1, 5);
-    waitUntilFinished(runtimeService, PROGRAM_ID, 5);
+    waitForRuns(store, PROGRAM_ID, 1, 15);
+    waitUntilFinished(runtimeService, PROGRAM_ID, 15);
 
     // Trigger both scheduled program
     metricsPublisher.increment(1024 * 1024);
-    waitForRuns(store, PROGRAM_ID, 3, 5);
+    waitForRuns(store, PROGRAM_ID, 3, 15);
 
     // Suspend a schedule multiple times, and make sur that it doesn't mess up anything
     streamSizeScheduler.suspendSchedule(PROGRAM_ID, PROGRAM_TYPE, SCHEDULE_NAME_2);
@@ -118,7 +118,7 @@ public abstract class SchedulerTestBase {
 
     // Since schedule 2 is suspended, only the first schedule should get triggered
     metricsPublisher.increment(1024 * 1024);
-    waitForRuns(store, PROGRAM_ID, 4, 5);
+    waitForRuns(store, PROGRAM_ID, 4, 15);
 
     // Resume schedule 2
     streamSizeScheduler.resumeSchedule(PROGRAM_ID, PROGRAM_TYPE, SCHEDULE_NAME_2);
@@ -129,13 +129,13 @@ public abstract class SchedulerTestBase {
     // Both schedules should be trigger. In particular, the schedule that has just been resumed twice should
     // only trigger once
     metricsPublisher.increment(1024 * 1024);
-    waitForRuns(store, PROGRAM_ID, 6, 5);
+    waitForRuns(store, PROGRAM_ID, 6, 15);
 
     // Update the schedule2's data trigger
     // Both schedules should now trigger execution after 1 MB of data received
     streamSizeScheduler.updateSchedule(PROGRAM_ID, PROGRAM_TYPE, UPDATE_SCHEDULE_2);
     metricsPublisher.increment(1024 * 1024);
-    waitForRuns(store, PROGRAM_ID, 8, 5);
+    waitForRuns(store, PROGRAM_ID, 8, 15);
 
     streamSizeScheduler.suspendSchedule(PROGRAM_ID, PROGRAM_TYPE, SCHEDULE_NAME_1);
     streamSizeScheduler.suspendSchedule(PROGRAM_ID, PROGRAM_TYPE, SCHEDULE_NAME_2);


### PR DESCRIPTION
…izeSchedulerTest, since it seems like sometimes expecting a completed run record to be available 5 seconds after a workflow run (or two) starts is unreasonable