### PR TITLE
CDAP-3721 Reverted the modifications done to the TriggerStatus class.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/store/DatasetBasedTimeScheduleStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/store/DatasetBasedTimeScheduleStore.java
@@ -327,8 +327,8 @@ public class DatasetBasedTimeScheduleStore extends RAMJobStore {
    * Trigger and state.
    */
   private static class TriggerStatus implements Serializable {
-    private final OperableTrigger trigger;
-    private final Trigger.TriggerState state;
+    private OperableTrigger trigger;
+    private Trigger.TriggerState state;
 
     private TriggerStatus(OperableTrigger trigger, Trigger.TriggerState state) {
       this.trigger = trigger;


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-3721
`TriggerStatus` class implements `Serializable` interface. As a part of #3966 we did modifications to the this class (made the member variables `final`), this failed initialization of the scheduler with `InvalidClassException`. 

Filed https://issues.cask.co/browse/CDAP-3733 to remove this limitation.