### PR TITLE
Fixes converting numbers while saving pipeline + Kafka.json configuration fixes

### DIFF
--- a/cdap-ui/app/services/app/my-app-dag-service.js
+++ b/cdap-ui/app/services/app/my-app-dag-service.js
@@ -542,17 +542,19 @@ angular.module(PKG.name + '.services')
       function propertiesIterator(properties, backendProperties) {
         angular.forEach(properties, function(value, key) {
           // If its a required field don't remove it.
-          if (backendProperties[key] && backendProperties[key].required) {
-            return;
-          }
-          if ((!backendProperties[key] && key !== 'errorDatasetName') || properties[key] === '' || properties[key] === null
-          ) {
+          var isRequiredField = backendProperties[key] && backendProperties[key].required;
+          var isErrorDatasetName = !backendProperties[key] && key !== 'errorDatasetName';
+          var isPropertyEmptyOrNull = properties[key] === '' || properties[key] === null;
+          var isPropertyNotAString = properties[key] && typeof properties[key] !== 'string';
+
+          if (!isRequiredField && (isErrorDatasetName || isPropertyEmptyOrNull)) {
             delete properties[key];
           }
           // FIXME: Remove this once https://issues.cask.co/browse/CDAP-3614 is fixed.
-          if (properties[key] && typeof properties[key] !== 'string') {
+          if (isPropertyNotAString) {
             properties[key] = properties[key].toString();
           }
+
         });
         return properties;
       }

--- a/cdap-ui/templates/cdap-etl-realtime/Kafka.json
+++ b/cdap-ui/templates/cdap-etl-realtime/Kafka.json
@@ -51,7 +51,7 @@
              "description": "Specifies the start offset for processing from the queue",
              "properties": {
                "width": "extra-small",
-               "default": 0
+               "default": 1
              },
              "min": 1
           }
@@ -66,15 +66,15 @@
              "widget" : "select",
              "label"  : "Format",
              "properties" : {
-               "values" : [ "", "avro", "clf", "csv", "grok", "syslog", "text", "tsv" ],
-               "default" : ""
+               "values" : [ "avro", "clf", "csv", "grok", "syslog", "text", "tsv" ],
+               "default" : "text"
              }
           }
        }
     }
   },
   "schema" : {
-     "widget": "stream-properties",
+     "widget": "schema",
      "schema-types" : [ "boolean", "int", "long", "float", "double", "bytes", "string", "map<string, string>" ],
      "schema-default-type" : "string",
      "property-watch": "format"


### PR DESCRIPTION
- Converts all numbers or any other types to be string for plugin properties before publishing it to backend.
- Fixes Kafka.json file (offset, partition and schema) to have proper default values.