### PR TITLE
fixes padding issue on select dropdown

### DIFF
--- a/cdap-ui/app/features/adapters/bottompanel.less
+++ b/cdap-ui/app/features/adapters/bottompanel.less
@@ -129,6 +129,9 @@ body.theme-cdap.state-adapters {
         height: 30px;
         padding: 0 5px;
         vertical-align: middle;
+        select.form-control {
+          padding-right: 20px;
+        }
         &.name {
           width: 35%;
         }


### PR DESCRIPTION
*  Adds right padding to select dropdown to prevent overflowing text

![text](https://cloud.githubusercontent.com/assets/5335210/9978312/7f3471fe-5edc-11e5-821b-9e6b63980dff.gif)
