### PR TITLE
(CDAP-3073) Destroy BatchSinks independently of TransformExector, now…

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/ETLMapReduce.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/ETLMapReduce.java
@@ -384,8 +384,14 @@ public class ETLMapReduce extends AbstractMapReduce {
 
     @Override
     public void destroy() {
-      // Both BatchSource and BatchSink implements Transform, hence are inside the transformExecutor as well
+      // BatchSource implements Transform, hence is inside the transformExecutor as well
       Destroyables.destroyQuietly(transformExecutor);
+      // Cleanup BatchSinks separately, since they are not part of the transformExecutor
+      LOG.debug("Number of sinks to destroy: {}", sinks.size());
+      for (WrappedSink<Object, Object, Object> sink : sinks) {
+        LOG.trace("Destroying sink: {}", sink.sink);
+        Destroyables.destroyQuietly(sink.sink);
+      }
     }
   }
 


### PR DESCRIPTION
… that they're not part of the TransformExecutor

Jira: [CDAP-3073](https://issues.cask.co/browse/CDAP-3073)
Build: http://builds.cask.co/browse/CDAP-RBT478