### PR TITLE
restructure plugin doc to first describe plugins and capabilities,

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRangeTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRangeTest.java
@@ -31,6 +31,15 @@ import java.util.List;
 public class ArtifactRangeTest {
 
   @Test
+  public void testWhitespace() throws InvalidArtifactRangeException {
+    ArtifactRange range = ArtifactRange.parse(Id.Namespace.DEFAULT, "name[ 1.0.0 , 2.0.0 )");
+    Assert.assertEquals(new ArtifactRange(Id.Namespace.DEFAULT, "name",
+                                          new ArtifactVersion("1.0.0"), true,
+                                          new ArtifactVersion("2.0.0"), false),
+                        range);
+  }
+
+  @Test
   public void testIsInRange() {
     ArtifactRange range = new ArtifactRange(Id.Namespace.DEFAULT, "test",
       new ArtifactVersion("1.0.0"), new ArtifactVersion("2.0.0"));

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-batch-sink-archetype/src/main/resources/archetype-resources/src/main/java/Sink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-batch-sink-archetype/src/main/resources/archetype-resources/src/main/java/Sink.java
@@ -22,6 +22,7 @@ import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.api.dataset.lib.KeyValue;
 import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.batch.BatchRuntimeContext;
 import co.cask.cdap.etl.api.batch.BatchSink;
 import co.cask.cdap.etl.api.batch.BatchSinkContext;
 import org.apache.hadoop.io.NullWritable;
@@ -38,6 +39,14 @@ public class Sink extends BatchSink<StructuredRecord, byte[], NullWritable> {
   @Override
   public void configurePipeline(PipelineConfigurer configurer) {
     // Make sure any properties that are expected are valid
+  }
+
+  @Override
+  public void initialize(BatchRuntimeContext context) throws Exception {
+    super.initialize(context);
+    // Get Config param and use to initialize
+    // String param = config.param
+    // Perform init operations, external operations etc.
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-batch-source-archetype/src/main/resources/archetype-resources/src/main/java/Source.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-batch-source-archetype/src/main/resources/archetype-resources/src/main/java/Source.java
@@ -22,6 +22,7 @@ import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.api.dataset.lib.KeyValue;
 import co.cask.cdap.api.plugin.PluginConfig;
 import co.cask.cdap.etl.api.Emitter;
+import co.cask.cdap.etl.api.batch.BatchRuntimeContext;
 import co.cask.cdap.etl.api.batch.BatchSource;
 import co.cask.cdap.etl.api.batch.BatchSourceContext;
 
@@ -53,7 +54,7 @@ public class Source extends BatchSource<byte[], byte[], StructuredRecord> {
   }
 
   @Override
-  public void initialize(BatchSourceContext context) throws Exception {
+  public void initialize(BatchRuntimeContext context) throws Exception {
     super.initialize(context);
     // Get Config param and use to initialize
     // String param = config.param

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/ArtifactConfig.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/ArtifactConfig.java
@@ -130,8 +130,8 @@ public class ArtifactConfig implements Comparable<ArtifactConfig> {
    *                                  format or unexpected value.
    */
   public static ArtifactConfig read(Id.Artifact artifactId,
-                                          File configFile,
-                                          File artifactFile) throws IOException, InvalidArtifactException {
+                                    File configFile,
+                                    File artifactFile) throws IOException, InvalidArtifactException {
     String fileName = configFile.getName();
     try (Reader reader = Files.newReader(configFile, Charsets.UTF_8)) {
       try {

--- a/cdap-docs/developers-manual/source/building-blocks/plugins.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/plugins.rst
@@ -176,13 +176,13 @@ must be placed in the appropriate directory.
 
 - **Standalone mode:** ``$CDAP_INSTALL_DIR/artifacts``
 
-- **Distributed mode:** The plugin jars should be placed in the local file system and the path
+- **Distributed mode:** The plugin JARs should be placed in the local file system and the path
   can be provided to CDAP by setting the property ``app.artifact.dir`` in
   ``cdap-site.xml``. The default path is: ``/opt/cdap/master/artifacts``
 
-For each plugin jar, there must also be a corresponding configuration file to specify which artifacts
-can use the plugins. The file name must match the name of the jar, except it must have the ``.json``
-extension instead of the ``.jar`` extension. For example, if your jar file is named
+For each plugin JAR, there must also be a corresponding configuration file to specify which artifacts
+can use the plugins. The file name must match the name of the JAR, except it must have the ``.json``
+extension instead of the ``.jar`` extension. For example, if your JAR file is named
 ``custom-transforms-1.0.0.jar``, there must be a corresponding ``custom-transforms-1.0.0.json`` file.
 If your ``custom-transforms-1.0.0.jar`` contains transforms that can be used by both the ``cdap-etl-batch``
 and ``cdap-etl-realtime`` artifacts, ``custom-transforms-1.0.0.json`` would contain:
@@ -209,8 +209,8 @@ an exclusive version. For example:
 specifies that the plugins can be used by versions 3.2.0 (inclusive) to 4.0.0 (exclusive) of the
 ``cdap-etl-batch`` and ``cdap-etl-realtime`` artifacts.
 
-If the artifact contains third party plugins, you can explicitly list them in the config file.
-For example, you may want to deploy a jdbc driver contained in a third party jar. In these cases,
+If the artifact contains third-party plugins, you can explicitly list them in the config file.
+For example, you may want to deploy a JDBC driver contained in a third-party JAR. In these cases,
 you have no control over the code to annotate the classes that should be plugins, so you need to
 list them in the configuration:
 
@@ -228,7 +228,7 @@ list them in the configuration:
       ]
     }
 
-Once your jars and matching configuration files are in place,
+Once your JARs and matching configuration files are in place,
 a RESTful API call to :ref:`load system artifacts <http-restful-api-artifact-system-load>`
 can be made to re-load the artifacts.
 
@@ -276,7 +276,7 @@ you must prefix the parent artifact name with '``system:``'.
 This is in case there is a user artifact with the same name as the system artifact.
 If you are extending a user artifact, no prefix is required.
 
-You can deploy third party jars in the same way except the plugin information needs to be explicitly listed.
+You can deploy third-party JARs in the same way except the plugin information needs to be explicitly listed.
 Using the RESTful API:
 
 .. container:: highlight

--- a/cdap-docs/developers-manual/source/building-blocks/plugins.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/plugins.rst
@@ -17,7 +17,6 @@ application class. *Plugins* can be packaged in a separate artifact from the app
 
 Plugin Usage
 ============
-
 You tell CDAP that a class is a *Plugin* by annotating the class with the type and name of the plugin.
 For example::
 
@@ -66,7 +65,6 @@ Once registered, the plugin can be instantiated and used at runtime using the pl
 
 Plugin Config
 =============
-
 A *Plugin* can also make use of the *PluginConfig* class to configure itself. Suppose we want
 to modify our no-op runnable to print a configurable message. We can do this by adding a
 *PluginConfig*, passing it into the constructor, and setting it as a field::
@@ -96,7 +94,7 @@ to modify our no-op runnable to print a configurable message. We can do this by 
 
 Your extension to *PluginConfig* must contain only primitive or boxed primitive types.
 The *PluginConfig* passed in to the *Plugin* has its fields populated using the *PluginProperties*
-specified when the *Plugin* is registered. In this example, if we want the message to be "Hello CDAP!"::
+specified when the *Plugin* was registered. In this example, if we want the message to be "Hello CDAP!"::
 
   public class ExampleWorker extends AbstractWorker {
 
@@ -117,7 +115,6 @@ can be annotated with a ``@Description`` that will be returned by the
 
 Third-Party Plugins
 ===================
-
 Sometimes there is a need to use classes in a third-party JAR as plugins. For example, you may want to be able to use
 a JDBC driver as a plugin. In these situations, you have no control over the code, which means you cannot
 annotate the relevant class with the ``@Plugin`` annotation. If this is the case, you can explicitly specify
@@ -130,25 +127,24 @@ the plugins when deploying the artifact. For example, if you are using the RESTf
 
 Plugin Deployment
 =================
-To make plugins available to another artifact (and thus available
-to any application created from one of the artifacts), the plugins must first be packaged
-in a JAR file. After that, the JAR file must be deployed as
-either a system artifact or a user artifact. A system artifact is available to users across
-any namespace. A user artifact is available only to users in the namespace to which it is deployed.
+To make plugins available to another artifact (and thus available to any application
+created from one of the artifacts), the plugins must first be packaged in a JAR file.
+After that, the JAR file must be deployed either as a system artifact or a user artifact.
+A system artifact is available to users across any namespace. A user artifact is available
+only to users in the namespace to which it is deployed.
 
 .. _plugins-deployment-packaging:
 
 Plugin Packaging
 ----------------
-
-*Plugins* are packaged as a JAR file, which contains the plugin classes and their dependencies
-inside. CDAP uses the "Export-Package" attribute in the JAR file manifest to determine
+A *Plugin* is packaged as a JAR file, which contains inside the plugin classes and their dependencies.
+CDAP uses the "Export-Package" attribute in the JAR file manifest to determine
 which classes are *visible*. A *visible* class is one that can be used by another class
 that is not from the plugin JAR itself. This means the Java package which the plugin class
 is in must be listed in "Export-Package", otherwise the plugin class will not be visible,
-and hence no one will be able to use it. This can be done in maven by editing your pom.
+and hence no one will be able to use it. This can be done in Maven by editing your pom.xml.
 For example, if your plugins are in the ``com.example.runnable`` and ``com.example.callable``
-packages, you would edit the bunlder plugin in your pom::
+packages, you would edit the bunlder plugin in your pom.xml::
 
         <plugin>
           <groupId>org.apache.felix</groupId>
@@ -191,22 +187,22 @@ and ``cdap-etl-realtime`` artifacts, ``custom-transforms-1.0.0.json`` would cont
 
   .. parsed-literal:: 
     {
-      "parents": [ "cdap-etl-batch\[|version|, |version|]", "cdap-etl-realtime[|version|, |version|]" ]
+      "parents": [ "cdap-etl-batch\[|version|,\ |version|]", "cdap-etl-realtime[|version|,\ |version|]" ]
     }
 
 This file specifies that the plugins in ``custom-transforms-1.0.0.jar`` can be used by version |version| of
 the ``cdap-etl-batch`` and ``cdap-etl-realtime`` artifacts. You can also specify a wider range of versions
-that can use the plugins, with square brackets indicating an inclusive version and parantheses indicating
+that can use the plugins, with square brackets ``[ ]`` indicating an inclusive version and parentheses ``( )`` indicating
 an exclusive version. For example:
 
-.. container:: 
+.. container:: highlight
 
   .. parsed-literal:: 
     {
       "parents": [ "cdap-etl-batch[3.2.0,4.0.0)", "cdap-etl-realtime[3.2.0,4.0.0)" ]
     }
 
-specifies that the plugins can be used by versions 3.2.0 (inclusive) to 4.0.0 (exclusive) of the
+specifies that these plugins can be used by versions 3.2.0 (inclusive) to 4.0.0 (exclusive) of the
 ``cdap-etl-batch`` and ``cdap-etl-realtime`` artifacts.
 
 If the artifact contains third-party plugins, you can explicitly list them in the config file.
@@ -214,7 +210,7 @@ For example, you may want to deploy a JDBC driver contained in a third-party JAR
 you have no control over the code to annotate the classes that should be plugins, so you need to
 list them in the configuration:
 
-.. container:: 
+.. container:: highlight
 
   .. parsed-literal:: 
     {
@@ -266,13 +262,11 @@ where ``config.json`` contains:
 
   .. parsed-literal:: 
     {
-      "parents": [ "system:cdap-etl-batch\[|version|, |version|]", "system:cdap-etl-realtime\[|version|, |version|]" ]
+      "parents": [ "system:cdap-etl-batch\[|version|,\ |version|]", "system:cdap-etl-realtime\[|version|,\ |version|]" ]
     }
 
-.. need to have a space between versions [|version, |version|] otherwise the 2nd |version| doesn't replace 
-
 Note that when deploying a user artifact that extends a system artifact,
-you must prefix the parent artifact name with '``system:``'.
+you must prefix the parent artifact name with ``'system:'``.
 This is in case there is a user artifact with the same name as the system artifact.
 If you are extending a user artifact, no prefix is required.
 
@@ -283,7 +277,7 @@ Using the RESTful API:
 
   .. parsed-literal:: 
     curl localhost:10000/v3/namespaces/default/artifacts/mysql-connector-java \\
-      -H 'Artifact-Extends: system:cdap-etl-batch\[|version|, |version|]/system:cdap-etl-realtime\[|version|, |version|]' \\
+      -H 'Artifact-Extends: system:cdap-etl-batch\[|version|,\ |version|]/system:cdap-etl-realtime\[|version|,\ |version|]' \\
       -H 'Artifact-Plugins: [ { "name": "mysql", "type": "jdbc", "className": "com.mysql.jdbc.Driver" } ]' \\
       --data-binary @/path/to/mysql-connector-java-5.1.35.jar
 
@@ -300,7 +294,7 @@ where ``config.json`` contains:
 
   .. parsed-literal:: 
     {
-      "parents": [ "system:cdap-etl-batch\[|version|, |version|]", "system:cdap-etl-realtime\[|version|, |version|]" ],
+      "parents": [ "system:cdap-etl-batch\[|version|,\ |version|]", "system:cdap-etl-realtime\[|version|,\ |version|]" ],
       "plugins": [
         {
           "name": "mysql",
@@ -314,10 +308,9 @@ where ``config.json`` contains:
 
 Deployment Verification
 -----------------------
-
 You can verify that a plugin artifact was added successfully by using the
 :ref:`RESTful Artifact API <http-restful-api-artifact-detail>` to retrieve artifact details.
-For example, to get detail about our ``custom-transforms`` artifact:
+For example, to retrieve detail about our ``custom-transforms`` artifact:
 
 .. container:: highlight
 
@@ -327,7 +320,7 @@ For example, to get detail about our ``custom-transforms`` artifact:
 If you deployed the ``custom-transforms`` artifact as a system artifact, the scope is ``system``.
 If you deployed the ``custom-transforms`` artifact as a user artifact, the scope is ``user``.
 
-You can verify that the plugins in your newly added artifact are available to its parent by using the
+You can verify that the plugins in your newly-added artifact are available to its parent by using the
 :ref:`RESTful Artifact API <http-restful-api-artifact-available-plugins>` to list plugins of a
 specific type. For example, to check if ``cdap-etl-batch`` can access the plugins in the
 ``custom-transforms`` artifact:
@@ -346,7 +339,6 @@ scope because ``cdap-etl-batch`` is a system artifact. This is true even if you 
 
 Example Use Case
 ================
-
 When writing an application class, it is often useful to create interfaces or abstract classes that define
 a logical contract in your code, but do not provide an implementation of that contract. This lets you plug in
 different implementations to fit your needs.
@@ -506,7 +498,7 @@ Since we want other artifacts to implement the ``Tokenizer`` interface, we need 
 sure the class is exposed to other artifacts. We do this by including the ``Tokenizer``'s package
 in the ``Export-Package`` manifest attribute of our JAR file. For example, if our ``Tokenizer`` full
 class name is ``com.example.api.Tokenizer``, we need to expose the ``com.example.api``
-package in our pom::
+package in our pom.xml::
 
         <plugin>
           <groupId>org.apache.felix</groupId>
@@ -587,7 +579,7 @@ been annotated with a plugin type and name::
 We package these tokenizers in a separate artifact named ``tokenizers-1.0.0.jar``. In order to make these
 plugins visibile to programs using them, we need to include their packages in the ``Export-Packages``
 manifest attribute. For example, if our classes are all in the ``com.example.tokenizer`` package,
-we need to expose the ``com.example.tokenizer`` package in our pom::
+we need to expose the ``com.example.tokenizer`` package in our pom.xml::
 
         <plugin>
           <groupId>org.apache.felix</groupId>
@@ -624,7 +616,7 @@ applications that use the tokenizer we want::
     "config": { "tokenizer": "phrase" }
   }'
 
-After a while we find that we need to support reading files where words are delimited by a character
+After a while, we find that we need to support reading files where words are delimited by a character
 other than a space. We decide to modify our ``DefaultTokenizer`` to use a ``PluginConfig`` that contains
 a property for the delimiter::
 

--- a/cdap-docs/developers-manual/source/getting-started/quick-start.rst
+++ b/cdap-docs/developers-manual/source/getting-started/quick-start.rst
@@ -92,7 +92,7 @@ or using ``curl`` to directly make an HTTP request:
 .. container:: highlight
 
   .. parsed-literal::
-    |$| curl -w'\n' localhost:10000/v3/namespaces/default/artifacts/cdap-wise \
+    |$| curl -w'\\n' localhost:10000/v3/namespaces/default/artifacts/cdap-wise \
     --data-binary @cdap-wise-|cdap-apps-version|/target/cdap-wise-|cdap-apps-version|.jar
     Artifact added successfully
 
@@ -113,7 +113,7 @@ or by using ``curl``:
 .. container:: highlight
 
   .. parsed-literal::
-    |$| curl -w'\n' -X PUT -H "Content-Type: application/json" localhost:10000/v3/namespaces/default/apps/Wise \
+    |$| curl -w'\\n' -X PUT -H "Content-Type: application/json" localhost:10000/v3/namespaces/default/apps/Wise \
     -d '{ "artifact":{ "name": "cdap-wise", "version": "0.4.0", "scope": "user" } }'
     Deploy Complete
     

--- a/cdap-docs/included-applications/source/etl/creating.rst
+++ b/cdap-docs/included-applications/source/etl/creating.rst
@@ -32,30 +32,38 @@ specifying the frequency of the Batch job run, such as every day or every hour.
 
 For example, this JSON (when in a file such as ``config.json``) provides a
 configuration for a Batch Application that runs every minute, reading data from a stream
-*myStream* and writing to a dataset (Table) called *myTable*,  without any transformations::
+*myStream* and writing to a dataset (Table) called *myTable*, without any transformations:
 
-  {
-    "template":"ETLBatch",
-    "description":"Batch ETL",
-    "config":{
-        "schedule":"* * * * *",
-        "source":{
-            "name":"Stream",
-            "properties":{  
-                "name":"myStream",
-                "duration":"1m"
-            }
+.. container:: highlight
+
+  .. parsed-literal::
+    {
+      "artifact": {
+        "name": "cdap-etl-batch",
+        "version": "|version|",
+        "scope": "system"
+      },
+      "config": {
+        "schedule": "\* \* \* \* \*",
+        "source": {
+          "name": "Stream",
+          "properties": {  
+            "name": "myStream",
+            "duration": "1m"
+          }
         },
-        "transforms":[],
-        "sink":{
-            "name":"Table",
-            "properties":{
-                "name":"myTable",
-                "schema.row.field":"ts"
+        "transforms": [ ],
+        "sinks": [
+          {
+            "name": "Table",
+            "properties": {
+              "name": "myTable",
+              "schema.row.field": "ts"
             }
-        }
-     }
-  }
+          }
+        ]
+      }
+    }
 
 The application launches a MapReduce program that runs every minute, reads data from the
 stream *myStream* and writes to a Table *myTable*. A Table Sink needs a row key field to
@@ -65,7 +73,7 @@ To create this application, called *streamETLApp*:
 
 - Using the :ref:`Lifecycle RESTful API <http-restful-api-lifecycle-create-app>`::
 
-    PUT /v3/namespaces/default/apps/streamETLApp -d @config.json 
+    curl -X PUT localhost:10000/v3/namespaces/default/apps/streamETLApp -H 'Content-Type: application/json' -d @config.json 
 
 - Using :ref:`CDAP CLI <cli>`:
 
@@ -83,39 +91,47 @@ Creating an ETL Real-Time Application
 -------------------------------------
 
 This next configuration creates a real-time application that reads from Twitter and writes to a
-stream after performing a projection transformation::
+stream after performing a projection transformation:
 
-  {
-    "template":"ETLRealtime",
-    "description":"Twitter to Stream: renames the 'message' field name to 'tweet',
-    "config":{
-        "instances":"1",
-        "source":{
-            "name":"Twitter",
-            "properties":{  
-                "AccessToken":"xxx",
-                "AccessTokenSecret":"xxx",
-                "ConsumerKey":"xxx",
-                "ConsumerSecret":"xxx"                                         
-            }
+.. container:: highlight
+
+  .. parsed-literal::
+    {
+      "artifact": {
+        "name": "cdap-etl-realtime",
+        "version": "|version|",
+        "scope": "system"
+      },
+      "config": {
+        "instances": 1,
+        "source": {
+          "name": "Twitter",
+          "properties": {  
+            "AccessToken": "xxx",
+            "AccessTokenSecret": "xxx",
+            "ConsumerKey": "xxx",
+            "ConsumerSecret": "xxx"                                         
+          }
         },
-        "transforms":[
-            {
-                "name":"Projection"
-                "properties":{
-                    "drop":"lang,time,favCount,source,geoLat,geoLong,isRetweet"
-                }
+        "transforms": [
+          {
+            "name": "Projection",
+            "properties": {
+              "drop": "lang,time,favCount,source,geoLat,geoLong,isRetweet"
             }
-       ],
-       "sink":{
-           "name":"Stream",
-           "properties":{
-               "name":"twitterStream",
-               "body.field":"tweet"
-           }
-        }
-     }
-  }
+          }
+        ],
+        "sinks": [
+          {
+            "name": "Stream",
+            "properties": {
+              "name": "twitterStream",
+              "body.field": "tweet"
+            }
+          }
+        ]
+      }
+    }
 
 
 An ETL Real-Time Application expects an instance property that will create *N* instances
@@ -135,97 +151,84 @@ that it will use as the content for the data to be written.
 Sample Application Configurations
 ---------------------------------
 
-**Database:** Sample config for using a Database Source and a Database Sink::
+**Database:** Sample config for using a Database Source and a Database Sink:
 
-  {
-    "config": {
-      "schedule": "* * * * *",
-      "source": {
-        "name": "Database",
-        "properties": {
-          "importQuery": "select id,name,age from my_table",
-          "countQuery": "select count(id) from my_table",
-          "connectionString": "jdbc:mysql://localhost:3306/test",
-          "tableName": "src_table",
-          "user": "my_user",
-          "password": "my_password",
-          "jdbcPluginName": "jdbc_plugin_name_defined_in_jdbc_plugin_json_config",
-          "jdbcPluginType": "jdbc_plugin_type_defined_in_jdbc_plugin_json_config"
-          }
-        },
-      "sink": {
-        "name": "Database",
-        "properties": {
-          "columns": "id,name,age",
-          "connectionString": "jdbc:mysql://localhost:3306/test",
-          "tableName": "dest_table",
-          "user": "my_user",
-          "password": "my_password",
-          "jdbcPluginName": "jdbc_plugin_name_defined_in_jdbc_plugin_json_config",
-          "jdbcPluginType": "jdbc_plugin_type_defined_in_jdbc_plugin_json_config"
-          }
-        },
-      "transforms": [
-        ]
+.. container:: highlight
+
+  .. parsed-literal::
+    {
+      "artifact": {
+        "name": "cdap-etl-batch",
+        "version": "|version|",
+        "scope": "system"
       },
-    "description": "ETL using a Table as source and RDBMS table as sink",
-    "template": "ETLBatch"
-  }
+      "config": {
+        "schedule": "\* \* \* \* \*",
+        "source": {
+          "name": "Database",
+          "properties": {
+            "importQuery": "select id,name,age from my_table",
+            "countQuery": "select count(id) from my_table",
+            "connectionString": "jdbc:mysql://localhost:3306/test",
+            "tableName": "src_table",
+            "user": "my_user",
+            "password": "my_password",
+            "jdbcPluginName": "jdbc_plugin_name_defined_in_jdbc_plugin_json_config",
+            "jdbcPluginType": "jdbc_plugin_type_defined_in_jdbc_plugin_json_config"
+          }
+        },
+        "sinks": [
+          {
+            "name": "Database",
+            "properties": {
+              "columns": "id,name,age",
+              "connectionString": "jdbc:mysql://localhost:3306/test",
+              "tableName": "dest_table",
+              "user": "my_user",
+              "password": "my_password",
+              "jdbcPluginName": "jdbc_plugin_name_defined_in_jdbc_plugin_json_config",
+              "jdbcPluginType": "jdbc_plugin_type_defined_in_jdbc_plugin_json_config"
+            }
+          }
+        ],
+        "transforms": [ ]
+      }
+    }
   
-**JMS:** A JMS server needs to be setup similar to using `ActiveMQ <http://activemq.apache.org>`__::
-
-  {
-    "template": "ETLRealtime",
-    "config": {
-      "instances": "1",
-      "source": {
-        "name": "JMS",
-        "properties": {
-          "jms.messages.receive": 50,
-          "jms.destination.name": "dynamicQueues/CDAP.QUEUE",
-          "jms.factory.initial": "org.apache.activemq.jndi.ActiveMQInitialContextFactory",
-          "jms.provider.url": "vm://localhost?broker.persistent=false"
-        }
-      },
-      "sink": {
-        "name": "Stream",
-        "properties": {
-          "name": "jmsStream",
-          "body.field": "message"
-        }
-      },
-      "transforms": [
-      ]
-    }
-  }
-
-
 **Kafka:** A Kafka cluster needs to be setup, and certain minimum properties specified when
-creating the source::
+creating the source:
 
-  {
-    "template": "ETLRealtime",
-    "config": {
-      "instances": "1",
-      "source": {
-        "name": "Kafka",
-        "properties": {
-          "kafka.partitions": 1,
-          "kafka.topic": "test",
-          "kafka.brokers": "localhost:9092"
-        }
+.. container:: highlight
+
+  .. parsed-literal::
+    {
+      "artifact": {
+        "name": "cdap-etl-realtime",
+        "version": "|version|",
+        "scope": "system"
       },
-      "sink": {
-        "name": "Stream",
-        "properties": {
-          "name": "myStream",
-          "body.field": "message"
-        }
-      },
-      "transforms": [
-      ]
+      "config": {
+        "instances": 1,
+        "source": {
+          "name": "Kafka",
+          "properties": {
+            "kafka.partitions": "1",
+            "kafka.topic": "test",
+            "kafka.brokers": "localhost:9092"
+          }
+        },
+        "sinks": [
+          {
+            "name": "Stream",
+            "properties": {
+              "name": "myStream",
+              "body.field": "message"
+            }
+          }
+        ],
+        "transforms": [ ]
+      }
     }
-  }
 
 
 **Prebuilt JARs:** In a case where you'd like to use prebuilt third-party JARs (such as a

--- a/cdap-docs/included-applications/source/etl/custom.rst
+++ b/cdap-docs/included-applications/source/etl/custom.rst
@@ -20,28 +20,6 @@ Creating Custom ETL Plugins
 CDAP provides for the creation of custom ETL plugins for batch/real-time sources/sinks and
 transformations to extend the existing ``cdap-etl-batch`` and ``cdap-etl-realtime`` system artifacts.
 
-To make a custom plugin available to one of the system artifacts (and thus available
-to any application created from one of the artifacts), the plugin should be packaged as a bundle jar
-and then placed in the appropriate directory. 
-
-.. _included-apps-custom-etl-plugins-installation-directory:
-
-Installation Directory
-----------------------
-
-- **Standalone mode:** ``$CDAP_INSTALL_DIR/artifacts``
-
-- **Distributed mode:** The plugin jars should be placed in the local file system and the path
-  can be provided to CDAP by setting the property ``app.template.dir`` in
-  ``cdap-site.xml``. The default path is: ``/opt/cdap/master/artifacts``
-
-A RESTful API call to :ref:`load system artifacts <http-restful-api-artifact-system-load>`
-can be made to re-load the artifacts.
-
-Alternatively, the CDAP Standalone should be restarted for this change to take effect in Standalone
-mode, and ``cdap-master`` services should be restarted in the Distributed mode.
-
-
 Plugin Types and Maven Archetypes
 =================================
 
@@ -114,7 +92,7 @@ Methods
 
 Example::
 
-  @Plugin(type = "source")
+  @Plugin(type = "batchsource")
   @Name("MyBatchSource")
   @Description("Demo Source")
   public class MyBatchSource extends BatchSource<LongWritable, String, String> {
@@ -165,7 +143,7 @@ Methods
 
 Example::
 
-  @Plugin(type = "sink")
+  @Plugin(type = "batchsink")
   @Name("MyBatchSink")
   @Description("Demo Sink")
   public class MyBatchSink extends BatchSink<String, String, NullWritable> {
@@ -214,7 +192,7 @@ Example::
   /**
    * Real-Time Source to poll data from external sources.
    */
-  @Plugin(type = "source")
+  @Plugin(type = "realtimesource")
   @Name("Source")
   @Description("Real-Time Source")
   public class Source extends RealtimeSource<StructuredRecord> {
@@ -300,7 +278,7 @@ Methods
 
 Example::
 
-  @Plugin(type = "sink")
+  @Plugin(type = "realtimesink")
   @Name("Demo")
   @Description("Demo Real-Time Sink")
   public class DemoSink extends RealtimeSink<String> {
@@ -316,7 +294,7 @@ Example::
     }
   }
 
-
+
 Creating a Transformation Plugin
 --------------------------------
 In ETL applications, a transformation operation is applied on one object at a time,
@@ -384,7 +362,7 @@ copies in each transform is emitted. The user metrics can be queried by using th
     }
   }
 
-
+
 Test Framework for Plugins
 ==========================
 
@@ -442,16 +420,12 @@ of failures.
   }
 
 .. _included-apps-custom-etl-plugins-plugin-packaging:
-
-Plugin Packaging
-================
 
-A plugin is packaged as a JAR file, which contains the plugin class and its dependencies
-inside. CDAP uses the "Export-Package" attribute in the JAR file manifest to determine
-which classes are *visible*. A *visible* class is one that can be used by another class
-that is not from the plugin JAR itself. This means the Java package which the plugin class
-is in must be listed in "Export-Package", otherwise the plugin class will not be visible,
-and hence no one will be able to use it.
+Plugin Packaging and Deployment
+===============================
+
+To package and deploy your plugin, follow the instructions describe in the
+:ref:`Plugin Packaging and Deployment Guide <plugins-deployment>`.
 
 By using one of the ``etl-plugin`` Maven archetypes, your project will be set up to generate
 the required JAR manifest. If you move the plugin class to a different Java package after
@@ -464,3 +438,4 @@ classes inside the plugin JAR that you have added to the Hadoop Job configuratio
 of those classes to the "Export-Package" as well. This is to ensure those classes are
 visible to the Hadoop MapReduce framework during the adapter execution. Otherwise, the
 execution will typically fail with a ``ClassNotFoundException``.
+

--- a/cdap-docs/included-applications/source/etl/custom.rst
+++ b/cdap-docs/included-applications/source/etl/custom.rst
@@ -424,7 +424,7 @@ of failures.
 Plugin Packaging and Deployment
 ===============================
 
-To package and deploy your plugin, follow the instructions describe in the
+To package and deploy your plugin, follow the instructions in the
 :ref:`Plugin Packaging and Deployment Guide <plugins-deployment>`.
 
 By using one of the ``etl-plugin`` Maven archetypes, your project will be set up to generate

--- a/cdap-docs/included-applications/source/etl/plugins/third-party.rst
+++ b/cdap-docs/included-applications/source/etl/plugins/third-party.rst
@@ -13,28 +13,26 @@ Using Third-Party JARs
 **Prebuilt JARs:** In a case where you'd like to use prebuilt third-party JARs (such as a
 JDBC driver) as a plugin, you will need to create a JSON file to describe the JAR.
 
-For information on the format of the JSON, please refer to the section on the
-:ref:`Plugin Packaging <included-apps-custom-etl-plugins-plugin-packaging>` in
-:ref:`Creating a Custom ETL Plugin <included-apps-custom-etl-plugins>`.
-
-Copy the JAR and the JSON file to the :ref:`Plugin directory
-<included-apps-custom-etl-plugins-installation-directory>` and then reload system artifacts by
-using the :ref:`HTTP RESTful API Load System Artifacts
-<http-restful-api-artifact-system-load>` endpoint.
+For information on the format of the JSON, please refer to the sections on
+:ref:`Third Party Plugins <plugins-third-party>` and :ref:`Plugin Deployment <plugins-deployment>`.
 
 A sample JDBC Driver Plugin configuration::
 
-  [
-    {
-      "type" : "JDBC",
-      "name" : "MySQL JDBC",
-      "description" : "Plugin for MySQL JDBC driver",
-      "className" : "com.mysql.jdbc.Driver",
-    },
-    {
-      "type" : "JDBC",
-      "name" : "PostgreSQL JDBC",
-      "description" : "Plugin for PostgreSQL JDBC driver",
-      "className" : "org.postgresql.Driver",
-    }
-  ]
+  {
+    "parents": [ "cdap-etl-batch[|version|,|version|]" ],
+    "config": [
+      {
+        "type" : "JDBC",
+        "name" : "MySQL JDBC",
+        "description" : "Plugin for MySQL JDBC driver",
+        "className" : "com.mysql.jdbc.Driver"
+      },
+      {
+        "type" : "JDBC",
+        "name" : "PostgreSQL JDBC",
+        "description" : "Plugin for PostgreSQL JDBC driver",
+        "className" : "org.postgresql.Driver"
+      }
+    ]
+  }
+

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/artifact/ArtifactRange.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/artifact/ArtifactRange.java
@@ -186,7 +186,7 @@ public class ArtifactRange {
       throw new InvalidArtifactRangeException(String.format("Invalid artifact range %s. " +
         "Could not find ',' separating lower and upper verions.", artifactRangeStr));
     }
-    String lowerStr = artifactRangeStr.substring(versionStartIndex + 1, commaIndex);
+    String lowerStr = artifactRangeStr.substring(versionStartIndex + 1, commaIndex).trim();
     ArtifactVersion lower = new ArtifactVersion(lowerStr);
     if (lower.getVersion() == null) {
       throw new InvalidArtifactRangeException(String.format(
@@ -199,7 +199,7 @@ public class ArtifactRange {
       throw new InvalidArtifactRangeException(String.format(
         "Invalid artifact range %s. Could not find enclosing ']' or ')'.", artifactRangeStr));
     }
-    String upperStr = artifactRangeStr.substring(commaIndex + 1, versionEndIndex);
+    String upperStr = artifactRangeStr.substring(commaIndex + 1, versionEndIndex).trim();
     ArtifactVersion upper = new ArtifactVersion(upperStr);
     if (upper.getVersion() == null) {
       throw new InvalidArtifactRangeException(String.format(
@@ -213,7 +213,6 @@ public class ArtifactRange {
         artifactRangeStr, lowerStr, upperStr));
     }
 
-    // for example: 'Artifact-Extends: etl-batch-1.0.0:2.0.0,etl-realtime-1.0.0:3.0.0
     return new ArtifactRange(namespace, name, lower, isLowerInclusive, upper, isUpperInclusive);
   }
 


### PR DESCRIPTION
then walk through an example. Also moving some of the deployment
docs from custom etl plugins doc to the general plugins doc and
fixing errors.