### PR TITLE
CDAP-3753 Removed use of depreacted variable AUTH_SERVER_ADDRESS.

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -623,6 +623,7 @@ public final class Constants {
     /** Parent znode used for secret key distribution in ZooKeeper. */
     public static final String DIST_KEY_PARENT_ZNODE = "security.token.distributed.parent.znode";
     /** Deprecated. Use AUTH_SERVER_BIND_ADDRESS instead. **/
+    @Deprecated
     public static final String AUTH_SERVER_ADDRESS = "security.auth.server.address";
     /**
      * Address that clients should use to communicate with the Authentication Server.

--- a/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
+++ b/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
@@ -334,7 +334,7 @@ public class StandaloneMain {
     configuration.set(Constants.Metrics.SERVER_ADDRESS, "127.0.0.1");
     configuration.set(Constants.MetricsProcessor.ADDRESS, "127.0.0.1");
     configuration.set(Constants.LogSaver.ADDRESS, "127.0.0.1");
-    configuration.set(Constants.Security.AUTH_SERVER_ADDRESS, "127.0.0.1");
+    configuration.set(Constants.Security.AUTH_SERVER_BIND_ADDRESS, "127.0.0.1");
     configuration.set(Constants.Explore.SERVER_ADDRESS, "127.0.0.1");
     configuration.set(Constants.Metadata.SERVICE_BIND_ADDRESS, "127.0.0.1");
 


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-3753
This will not log warnings such as `security.auth.server.address is deprecated. Instead, use security.auth.server.bind.address` while starting up the standalone.