### PR TITLE
add margin right to pagination in history tab (hydrator detail view)

### DIFF
--- a/cdap-ui/app/features/adapters/etlapps.less
+++ b/cdap-ui/app/features/adapters/etlapps.less
@@ -192,6 +192,12 @@ body.theme-cdap.state-adapters-detail {
     top: 40px;
     right: 10px;
   }
+
+  my-program-history {
+    ul.pagination {
+      margin-right: 15px;
+    }
+  }
 }
 
 body.theme-cdap.state-adapters-create {


### PR DESCRIPTION
![screen shot 2015-09-21 at 12 07 58 pm](https://cloud.githubusercontent.com/assets/4398643/10002034/c6745efc-6059-11e5-9636-da535a9ee7df.png)
