### PR TITLE
Fix misleading error message when trying to load JMS connector plugin.

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/realtime/source/JmsSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/realtime/source/JmsSource.java
@@ -198,7 +198,10 @@ public class JmsSource extends RealtimeSource<StructuredRecord> {
     String pluginId = getPluginId();
     Class<Object> driver  = pipelineConfigurer.usePluginClass(config.jmsPluginType, config.jmsPluginName, pluginId,
                                                               PluginProperties.builder().build());
-    Preconditions.checkArgument(driver != null, "JMS Initial Connection Factory Context class must be found.");
+    Preconditions.checkArgument(driver != null,
+                                "Unable to find JMS Initial Connection Factory Context class. Please make sure that " +
+                                  "the plugin '%s' of type '%s' containing the class has been installed correctly.",
+                                config.jmsPluginName, config.jmsPluginType);
   }
 
   private String getPluginId() {


### PR DESCRIPTION
Similar to JDBC plugin error message, the JSM realtime source plugin also have mileading error message when the plugin class could not be found.