### PR TITLE
Multiple Output Datasets & Dynamic Partitioning of PartitionedFileSet

### DIFF
--- a/cdap-docs/developers-manual/source/building-blocks/datasets/datasets-mapreduce.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/datasets/datasets-mapreduce.rst
@@ -51,7 +51,7 @@ To read a range of keys and give a hint that you want 16 splits, write::
   ...
   public void beforeSubmit(MapReduceContext context) throws Exception {
     ...
-    context.setInput("myTable", kvTable.getSplits(16, startKey, stopKey);
+    context.setInput("myTable", kvTable.getSplits(16, startKey, stopKey));
   }
 
 

--- a/cdap-docs/developers-manual/source/building-blocks/datasets/datasets-mapreduce.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/datasets/datasets-mapreduce.rst
@@ -72,7 +72,7 @@ parameters of the Reducer.
 
 .. rubric:: Multiple Output Destinations of a MapReduce Program
 
-To write to multiple output datasets from a MapReduce program, add the datasets as output::
+To write to multiple output datasets from a MapReduce program, begin by adding the datasets as outputs::
 
   public void beforeSubmit(MapReduceContext context) throws Exception {
     ...
@@ -80,9 +80,9 @@ To write to multiple output datasets from a MapReduce program, add the datasets 
     context.addOutput("catalog");
   }
 
-Then, have the ``mapper`` or ``reducer`` implement ``ProgramLifeCycle<MapReduceTaskContext>``, in order
-to get access to the MapReduceTaskContext in the initialize method and write using the write method
-of the ``MapReduceTaskContext``::
+Then, have the ``mapper`` and/or ``reducer`` implement ``ProgramLifeCycle<MapReduceTaskContext>``. 
+This is to obtain access to the ``MapReduceTaskContext`` in their initialization methods and 
+to be able to write using the write method of the ``MapReduceTaskContext``::
 
   public static class CustomMapper extends Mapper<LongWritable, Text, NullWritable, Text>
     implements ProgramLifecycle<MapReduceTaskContext<NullWritable, Text>> {
@@ -106,9 +106,9 @@ of the ``MapReduceTaskContext``::
 
   }
 
-Note that the multiple output write method - ``MapReduceTaskContext#write(String, KEY key, VALUE value)`` - can
+Note that the multiple output write method |---| ``MapReduceTaskContext.write(String, KEY key, VALUE value)`` |---| can
 only be used if there are multiple outputs. Similarly, the single output write
-method - ``MapReduceTaskContext#write(KEY key, VALUE value)`` - can only be used if there
+method |---| ``MapReduceTaskContext.write(KEY key, VALUE value)`` |---| can only be used if there
 is a single output to the MapReduce program.
 
 .. rubric:: Directly Reading and Writing Datasets

--- a/cdap-docs/developers-manual/source/building-blocks/datasets/datasets-mapreduce.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/datasets/datasets-mapreduce.rst
@@ -51,7 +51,7 @@ To read a range of keys and give a hint that you want 16 splits, write::
   ...
   public void beforeSubmit(MapReduceContext context) throws Exception {
     ...
-    context.setInput(kvTable, kvTable.getSplits(16, startKey, stopKey);
+    context.setInput("myTable", kvTable.getSplits(16, startKey, stopKey);
   }
 
 
@@ -69,6 +69,47 @@ The ``write()`` method is used to redirect all writes performed by a Reducer to 
 Again, the ``KEY`` and ``VALUE`` type parameters must match the output key and value type
 parameters of the Reducer.
 
+
+.. rubric:: Multiple Output Destinations of a MapReduce Program
+
+To write to multiple output datasets from a MapReduce program, add the datasets as output::
+
+  public void beforeSubmit(MapReduceContext context) throws Exception {
+    ...
+    context.addOutput("productCounts");
+    context.addOutput("catalog");
+  }
+
+Then, have the ``mapper`` or ``reducer`` implement ``ProgramLifeCycle<MapReduceTaskContext>``, in order
+to get access to the MapReduceTaskContext in the initialize method and write using the write method
+of the ``MapReduceTaskContext``::
+
+  public static class CustomMapper extends Mapper<LongWritable, Text, NullWritable, Text>
+    implements ProgramLifecycle<MapReduceTaskContext<NullWritable, Text>> {
+
+    private MapReduceTaskContext<NullWritable, Text> mapReduceTaskContext;
+
+    @Override
+    public void initialize(MapReduceTaskContext<NullWritable, Text> context) throws Exception {
+      this.mapReduceTaskContext = context;
+    }
+
+    protected void map(LongWritable key, Text value, Context context) throws IOException, InterruptedException {
+      // compute some condition
+      ...
+      if (someCondition) {
+        mapReduceTaskContext.write("productCounts", key, value);
+      } else {
+        mapReduceTaskContext.write("catalog", key, value);
+      }
+    }
+
+  }
+
+Note that the multiple output write method - ``MapReduceTaskContext#write(String, KEY key, VALUE value)`` - can
+only be used if there are multiple outputs. Similarly, the single output write
+method - ``MapReduceTaskContext#write(KEY key, VALUE value)`` - can only be used if there
+is a single output to the MapReduce program.
 
 .. rubric:: Directly Reading and Writing Datasets
 

--- a/cdap-docs/developers-manual/source/building-blocks/datasets/fileset.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/datasets/fileset.rst
@@ -350,10 +350,11 @@ Then set the class of the custom partitioner as runtime arguments of the output 
   PartitionedFileSetArguments.setDynamicPartitioner(cleanRecordsArgs, TimeAndZipPartitioner.class);
   context.addOutput(DataCleansing.CLEAN_RECORDS, cleanRecordsArgs);
 
-Now, for each record processed by the MapReduce job, the record will be written to a path corresponding
+With this, each record processed by the MapReduce job will be written to a path corresponding
 to the ``Partition`` that it was mapped to by the ``DynamicPartitioner``, and the set of new ``Partition``s
 will be registered with the output ``PartitionedFileSet`` at the end of the job.
-
+Note that any partitions written to must not previously exist. Otherwise, the MapReduce job will fail
+and none of the partitions will be added to the ``PartitionedFileSet``.
 
 Incrementally Processing PartitionedFileSets
 ============================================

--- a/cdap-docs/developers-manual/source/building-blocks/datasets/fileset.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/datasets/fileset.rst
@@ -353,8 +353,8 @@ Then set the class of the custom partitioner as runtime arguments of the output 
 With this, each record processed by the MapReduce job will be written to a path corresponding
 to the ``Partition`` that it was mapped to by the ``DynamicPartitioner``, and the set of new ``Partition``\ s
 will be registered with the output ``PartitionedFileSet`` at the end of the job.
-Note that any partitions written to must not previously exist. Otherwise, the MapReduce job will fail
-and none of the partitions will be added to the ``PartitionedFileSet``.
+Note that any partitions written to must not previously exist. Otherwise, the MapReduce job will fail at the
+end of the job and none of the partitions will be added to the ``PartitionedFileSet``.
 
 Incrementally Processing PartitionedFileSets
 ============================================

--- a/cdap-docs/developers-manual/source/building-blocks/datasets/fileset.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/datasets/fileset.rst
@@ -318,6 +318,43 @@ For example, give these arguments when starting the MapReduce through a RESTful 
     "dataset.totals.output.partition.key.league" : "nfl"
   }
 
+Dynamic Partitioning of MapReduce Output
+========================================
+
+A MapReduce job can also write to multiple partitions of a PartitionedFileSet, using the
+``DynamicPartitioner`` class. To do so, define a class that implements ``DynamicPartitioner``.
+The core method to override is the ``getPartitionKey`` method which maps a record's key and value
+to a ``PartitionKey``, which defines which ``Partition`` the record should be written to::
+
+  public static final class TimeAndZipPartitioner extends DynamicPartitioner<NullWritable, Text> {
+
+    private Long time;
+    private JsonParser jsonParser;
+
+    @Override
+    public void initialize(MapReduceTaskContext<NullWritable, Text> mapReduceTaskContext) {
+      this.time = mapReduceTaskContext.getLogicalStartTime();
+      this.jsonParser = new JsonParser();
+    }
+
+    @Override
+    public PartitionKey getPartitionKey(NullWritable key, Text value) {
+      int zip = jsonParser.parse(value.toString()).getAsJsonObject().get("zip").getAsInt();
+      return PartitionKey.builder().addLongField("time", time).addIntField("zip", zip).build();
+    }
+  }
+
+Then, set the class of the custom partitioner as runtime arguments of the output PartitionedFileSet::
+
+  Map<String, String> cleanRecordsArgs = new HashMap<>();
+  PartitionedFileSetArguments.setDynamicPartitioner(cleanRecordsArgs, TimeAndZipPartitioner.class);
+  context.addOutput(DataCleansing.CLEAN_RECORDS, cleanRecordsArgs);
+
+Then, for each record processed by the MapReduce job, the record will be written to a path corresponding
+to the ``Partition`` that it was mapped to by the ``DynamicPartitioner``, and the set of new ``Partition``s
+will be registered with the output ``PartitionedFileSet`` at the end of the job.
+
+
 Incrementally Processing PartitionedFileSets
 ============================================
 

--- a/cdap-docs/developers-manual/source/building-blocks/datasets/fileset.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/datasets/fileset.rst
@@ -351,7 +351,7 @@ Then set the class of the custom partitioner as runtime arguments of the output 
   context.addOutput(DataCleansing.CLEAN_RECORDS, cleanRecordsArgs);
 
 With this, each record processed by the MapReduce job will be written to a path corresponding
-to the ``Partition`` that it was mapped to by the ``DynamicPartitioner``, and the set of new ``Partition``s
+to the ``Partition`` that it was mapped to by the ``DynamicPartitioner``, and the set of new ``Partition``\ s
 will be registered with the output ``PartitionedFileSet`` at the end of the job.
 Note that any partitions written to must not previously exist. Otherwise, the MapReduce job will fail
 and none of the partitions will be added to the ``PartitionedFileSet``.

--- a/cdap-docs/developers-manual/source/building-blocks/datasets/fileset.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/datasets/fileset.rst
@@ -321,9 +321,9 @@ For example, give these arguments when starting the MapReduce through a RESTful 
 Dynamic Partitioning of MapReduce Output
 ========================================
 
-A MapReduce job can also write to multiple partitions of a PartitionedFileSet, using the
+A MapReduce job can write to multiple partitions of a PartitionedFileSet using the
 ``DynamicPartitioner`` class. To do so, define a class that implements ``DynamicPartitioner``.
-The core method to override is the ``getPartitionKey`` method which maps a record's key and value
+The core method to override is the ``getPartitionKey`` method; it maps a record's key and value
 to a ``PartitionKey``, which defines which ``Partition`` the record should be written to::
 
   public static final class TimeAndZipPartitioner extends DynamicPartitioner<NullWritable, Text> {
@@ -344,13 +344,13 @@ to a ``PartitionKey``, which defines which ``Partition`` the record should be wr
     }
   }
 
-Then, set the class of the custom partitioner as runtime arguments of the output PartitionedFileSet::
+Then set the class of the custom partitioner as runtime arguments of the output PartitionedFileSet::
 
   Map<String, String> cleanRecordsArgs = new HashMap<>();
   PartitionedFileSetArguments.setDynamicPartitioner(cleanRecordsArgs, TimeAndZipPartitioner.class);
   context.addOutput(DataCleansing.CLEAN_RECORDS, cleanRecordsArgs);
 
-Then, for each record processed by the MapReduce job, the record will be written to a path corresponding
+Now, for each record processed by the MapReduce job, the record will be written to a path corresponding
 to the ``Partition`` that it was mapped to by the ``DynamicPartitioner``, and the set of new ``Partition``s
 will be registered with the output ``PartitionedFileSet`` at the end of the job.
 

--- a/cdap-docs/developers-manual/source/building-blocks/mapreduce-programs.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/mapreduce-programs.rst
@@ -134,7 +134,7 @@ MapReduce and Datasets
 Both a CDAP ``mapper`` and ``reducer`` can directly read
 or write to a dataset, similar to the way a flowlet or service can.
 
-To access a dataset directly in mapper or reducer,
+To access a dataset directly in a mapper or reducer,
 inject the dataset into the mapper or reducer that uses it::
 
      public static class CatalogJoinMapper extends Mapper<byte[], Purchase, ...> {

--- a/cdap-docs/developers-manual/source/building-blocks/mapreduce-programs.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/mapreduce-programs.rst
@@ -134,20 +134,8 @@ MapReduce and Datasets
 Both a CDAP ``mapper`` and ``reducer`` can directly read
 or write to a dataset, similar to the way a flowlet or service can.
 
-To access a dataset directly in mapper or reducer, you need (1) a
-declaration and (2) an injection:
-
-#. Declare the dataset in the MapReduce’s configure() method.
-   For example, to have access to a dataset named *catalog*::
-
-     public class MyMapReduceJob implements MapReduce {
-       @Override
-       public void configure(MapReduceConfigurer configurer) {
-         ...
-         useDatasets(Arrays.asList("catalog"))
-         ...
-
-#. Inject the dataset into the mapper or reducer that uses it::
+To access a dataset directly in mapper or reducer,
+inject the dataset into the mapper or reducer that uses it::
 
      public static class CatalogJoinMapper extends Mapper<byte[], Purchase, ...> {
        @UseDataSet("catalog")

--- a/cdap-docs/included-applications/build.sh
+++ b/cdap-docs/included-applications/build.sh
@@ -37,7 +37,7 @@ function download_includes() {
   test_an_include 95ae9c116aa257efd5e3bb6cacaa4033 ../../cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/batch/sink/TimePartitionedFileSetDatasetParquetSink.java
 
   # Batchsources
-  test_an_include 67ee7fbac8e3971bd37e99186890097d ../../cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/batch/source/DBSource.java
+  test_an_include 794758bc0afbc404fa33143177afbb81 ../../cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/batch/source/DBSource.java
   test_an_include fd0399dc86a461466d119dc1e1cbe2f4 ../../cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/batch/source/ElasticsearchSource.java
   test_an_include f85320e0da353c790434a770aba6d040 ../../cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/batch/source/FileBatchSource.java
   test_an_include a3e5de66820f096813a6d58fdba86b52 ../../cdap-app-templates/cdap-etl/cdap-etl-lib/src/main/java/co/cask/cdap/etl/batch/source/KVTableSource.java


### PR DESCRIPTION
Documentation for:
1) Multiple Output Datasets of a MapReduce program.
2) Dynamic Partitioning of PartitionedFileSet, as output of a MapReduce program.

https://issues.cask.co/browse/CDAP-3687