### PR TITLE
Adds node configuration of each node in detailed view(non-editable)

### DIFF
--- a/cdap-ui/app/directives/dag/my-dag-ctrl.js
+++ b/cdap-ui/app/directives/dag/my-dag-ctrl.js
@@ -156,8 +156,8 @@ angular.module(PKG.name + '.commons')
     };
 
     function drawNode(id, type) {
-      var sourceSettings = angular.copy(MyDAGFactory.getSettings().source),
-          sinkSettings = angular.copy(MyDAGFactory.getSettings().sink);
+      var sourceSettings = angular.copy(MyDAGFactory.getSettings(this.isDisabled).source),
+          sinkSettings = angular.copy(MyDAGFactory.getSettings(this.isDisabled).sink);
       var artifactType = GLOBALS.pluginTypes[MyAppDAGService.metadata.template.type];
       switch(type) {
         case artifactType.source:
@@ -313,7 +313,7 @@ angular.module(PKG.name + '.commons')
         this.instance.repaintEverything();
       }.bind(this));
 
-      this.instance.importDefaults(MyDAGFactory.getSettings().default);
+      this.instance.importDefaults(MyDAGFactory.getSettings(this.isDisabled).default);
 
       // Need to move this to the controller that is using this directive.
       this.instance.bind('connection', function (con) {
@@ -337,7 +337,7 @@ angular.module(PKG.name + '.commons')
 
         this.instance.reset();
         this.instance = jsPlumb.getInstance();
-        this.instance.importDefaults(MyDAGFactory.getSettings().default);
+        this.instance.importDefaults(MyDAGFactory.getSettings(this.isDisabled).default);
         this.instance.bind('connection', function (con) {
           if (!this.isDisabled) {
             createPopover(con.connection);

--- a/cdap-ui/app/directives/dag/my-dag-factory.js
+++ b/cdap-ui/app/directives/dag/my-dag-factory.js
@@ -26,6 +26,24 @@ angular.module(PKG.name + '.commons')
       radius: 5,
       lineWidth: 2
     };
+    function createSchemaOnEdge() {
+      return angular.element('<div><div class="label-container text-center"><i class="icon-SchemaEdge"></i></div></div>');
+    }
+    var connectorOverlays = {
+      connectorOverlays: [
+        [ 'Arrow', { location: 1, length: 12, width: 12, height: 10, foldback: 1 } ],
+        [ 'Custom', {
+          create: createSchemaOnEdge,
+          location: 0.5,
+          id: 'label'
+        }]
+      ]
+    };
+    var disabledConnectorOverlays = {
+      connectorOverlays: [
+        [ 'Arrow', { location: 1, length: 12, width: 12, height: 10, foldback: 1 } ]
+      ]
+    };
 
     var commonSettings = {
       endpoint:'Dot',
@@ -36,16 +54,6 @@ angular.module(PKG.name + '.commons')
         radius: 5,
         lineWidth: 3
       },
-      connectorOverlays: [
-        [ 'Arrow', { location: 1, length: 12, width: 12, height: 10, foldback: 1 } ],
-        [ 'Custom', {
-          create: function() {
-            return angular.element('<div><div class="label-container text-center"><i class="icon-SchemaEdge"></i></div></div>');
-          },
-          location: 0.5,
-          id: 'label'
-        }]
-      ],
       anchors: [ 'Static']
     };
     var sourceSettings = angular.extend({
@@ -59,13 +67,24 @@ angular.module(PKG.name + '.commons')
       connectorStyle: connectorStyle
     }, commonSettings);
 
-    function getSettings() {
-      return {
-        default: defaultSettings,
-        common: commonSettings,
-        source: sourceSettings,
-        sink: sinkSettings
-      };
+    function getSettings(isDisabled) {
+      var settings = {};
+      if (isDisabled) {
+        settings = {
+          default: defaultSettings,
+          commonSettings: angular.extend(commonSettings, disabledConnectorOverlays),
+          source: angular.extend(sourceSettings, disabledConnectorOverlays),
+          sink: angular.extend(sinkSettings, disabledConnectorOverlays)
+        };
+      } else {
+        settings = {
+          default: defaultSettings,
+          commonSettings: angular.extend(commonSettings, connectorOverlays),
+          source: angular.extend(sourceSettings, connectorOverlays),
+          sink: angular.extend(sinkSettings, connectorOverlays)
+        };
+      }
+      return settings;
     }
 
     function getIcon(plugin) {

--- a/cdap-ui/app/directives/dag/my-dag.html
+++ b/cdap-ui/app/directives/dag/my-dag.html
@@ -24,7 +24,7 @@
     <div ng-repeat="plugin in MyDAGController.plugins" class="box {{plugin.type}}" ng-style="plugin.style"
            data-type="{{plugin.type}}"
            id="{{plugin.id}}"
-           ng-click="MyDAGController.isDisabled || MyDAGController.onPluginClick(plugin)"
+           ng-click="MyDAGController.onPluginClick(plugin)"
            ng-class="{'selected': plugin.selected}">
       <div class="node">
         <div class="error-node-notification"

--- a/cdap-ui/app/directives/navbar-hydrator/navbar.html
+++ b/cdap-ui/app/directives/navbar-hydrator/navbar.html
@@ -24,7 +24,7 @@
 <nav>
   <ul class="nav navbar-nav">
     <li>
-      <a ui-sref="adapters.list" ui-sref-active="active">
+      <a ui-sref="adapters.list" ng-class="{'active': $state.is('adaters.list') || $state.is('adapters.detail')}">
         <span> My Pipelines </span>
       </a>
     </li>

--- a/cdap-ui/app/features/adapters/controllers/create/plugin-edit-form-ctrl.js
+++ b/cdap-ui/app/features/adapters/controllers/create/plugin-edit-form-ctrl.js
@@ -43,7 +43,10 @@ angular.module(PKG.name + '.feature.adapters')
      So we are temporarily doing the coversion here before passing it to the widget-schema-editor so that it doesn't trigger that initial change.
      This should eventually be removed and moved to a service (or a factory). For lack of time my sin stays here. - Ajai
     */
-    $scope.data['isModelTouched'] = false;
+    if (!$scope.isDisabled) {
+      $scope.data['isModelTouched'] = false;
+    }
+
     var typeMap = 'map<string, string>';
     var mapObj = {
       type: 'map',
@@ -156,6 +159,7 @@ angular.module(PKG.name + '.feature.adapters')
         return null;
       }
     }
+    /////////////////////////////////////
 
     this.noproperty = Object.keys(
       $scope.plugin._backendProperties || {}
@@ -227,76 +231,23 @@ angular.module(PKG.name + '.feature.adapters')
             this.config = res;
             this.noconfig = false;
 
-            if ($scope.plugin._backendProperties.schema) {
-              $scope.$watch('pluginCopy.outputSchema', function () {
-                if (!$scope.pluginCopy.outputSchema) {
-                  if ($scope.pluginCopy.properties && $scope.plugin.properties.schema) {
-                    $scope.pluginCopy.properties.schema = null;
-                  }
-                  return;
-                }
-
-                if (!$scope.pluginCopy.properties) {
-                  $scope.pluginCopy.properties = {};
-                }
-                if ($scope.pluginCopy.properties.schema !== $scope.pluginCopy.outputSchema) {
-                  $scope.pluginCopy.properties.schema = $scope.pluginCopy.outputSchema;
-                }
-              });
-            } else {
-              $scope.$watch('pluginCopy.outputSchema', function () {
-                var originalOutputSchema = $scope.plugin.outputSchema;
-                var copyOutputSchema = $scope.pluginCopy.outputSchema;
-                if (originalOutputSchema !== copyOutputSchema) {
-                  $scope.data['isModelTouched'] = true;
-                }
-              });
+            if (!$scope.isDisabled) {
+              setWatchersForPropertiesAndSchema();
             }
-
-            $scope.$watch('pluginCopy.label', function() {
-              var copyLabel = $scope.pluginCopy.label;
-              var originalLabel = $scope.plugin.label;
-              if (copyLabel !== originalLabel) {
-                $scope.data['isModelTouched'] = true;
-              }
-            });
-
-            $scope.$watch('pluginCopy.errorDatasetName', function() {
-              var copyErrorDataset = $scope.pluginCopy.errorDatasetName;
-              var originalErrorDataset = $scope.plugin.errorDatasetName;
-              if (copyErrorDataset !== originalErrorDataset) {
-                $scope.data['isModelTouched'] = true;
-              }
-            });
-
-            $scope.$watch('pluginCopy.validationFields', function() {
-              var copyValidationFields = JSON.stringify($scope.pluginCopy.validationFields);
-              var originalValidationFields = JSON.stringify($scope.plugin.validationFields);
-              if (copyValidationFields !== originalValidationFields) {
-                $scope.data['isModelTouched'] = true;
-              }
-            });
-
-            $scope.$watch('pluginCopy.properties', function() {
-                var strProp1 = JSON.stringify($scope.pluginCopy.properties);
-                var strProp2 = JSON.stringify($scope.plugin.properties);
-                if (strProp1 !== strProp2) {
-                  $scope.data['isModelTouched'] = true;
-                }
-            }, true);
-
           }.bind(this),
           function error() {
             // TODO: Hacky. Need to fix this for am-fade-top animation for modals.
             $timeout(function() {
               $scope.pluginCopy = angular.copy($scope.plugin);
-              $scope.$watch('pluginCopy.properties', function() {
-                  var strProp1 = JSON.stringify($scope.pluginCopy.properties);
-                  var strProp2 = JSON.stringify($scope.plugin.properties);
-                  if (strProp1 !== strProp2) {
-                    $scope.data['isModelTouched'] = true;
-                  }
-              }, true);
+              if (!$scope.isDisabled) {
+                $scope.$watch('pluginCopy.properties', function() {
+                    var strProp1 = JSON.stringify($scope.pluginCopy.properties);
+                    var strProp2 = JSON.stringify($scope.plugin.properties);
+                    if (strProp1 !== strProp2) {
+                      $scope.data['isModelTouched'] = true;
+                    }
+                }, true);
+              }
               // Didn't receive a configuration from the backend. Fallback to all textboxes.
               this.noconfig = true;
               this.configfetched = true;
@@ -356,6 +307,66 @@ angular.module(PKG.name + '.feature.adapters')
         info: 'Info',
         description: myHelpers.objectQuery($scope, 'plugin', '_backendProperties', property, 'description') || 'No Description Available'
       };
+    }
+
+    function setWatchersForPropertiesAndSchema() {
+      if ($scope.plugin._backendProperties.schema) {
+        $scope.$watch('pluginCopy.outputSchema', function () {
+          if (!$scope.pluginCopy.outputSchema) {
+            if ($scope.pluginCopy.properties && $scope.plugin.properties.schema) {
+              $scope.pluginCopy.properties.schema = null;
+            }
+            return;
+          }
+
+          if (!$scope.pluginCopy.properties) {
+            $scope.pluginCopy.properties = {};
+          }
+          if ($scope.pluginCopy.properties.schema !== $scope.pluginCopy.outputSchema) {
+            $scope.pluginCopy.properties.schema = $scope.pluginCopy.outputSchema;
+          }
+        });
+      } else {
+        $scope.$watch('pluginCopy.outputSchema', function () {
+          var originalOutputSchema = $scope.plugin.outputSchema;
+          var copyOutputSchema = $scope.pluginCopy.outputSchema;
+          if (originalOutputSchema !== copyOutputSchema) {
+            $scope.data['isModelTouched'] = true;
+          }
+        });
+      }
+
+      $scope.$watch('pluginCopy.label', function() {
+        var copyLabel = $scope.pluginCopy.label;
+        var originalLabel = $scope.plugin.label;
+        if (copyLabel !== originalLabel) {
+          $scope.data['isModelTouched'] = true;
+        }
+      });
+
+      $scope.$watch('pluginCopy.errorDatasetName', function() {
+        var copyErrorDataset = $scope.pluginCopy.errorDatasetName;
+        var originalErrorDataset = $scope.plugin.errorDatasetName;
+        if (copyErrorDataset !== originalErrorDataset) {
+          $scope.data['isModelTouched'] = true;
+        }
+      });
+
+      $scope.$watch('pluginCopy.validationFields', function() {
+        var copyValidationFields = JSON.stringify($scope.pluginCopy.validationFields);
+        var originalValidationFields = JSON.stringify($scope.plugin.validationFields);
+        if (copyValidationFields !== originalValidationFields) {
+          $scope.data['isModelTouched'] = true;
+        }
+      });
+
+      $scope.$watch('pluginCopy.properties', function() {
+          var strProp1 = JSON.stringify($scope.pluginCopy.properties);
+          var strProp2 = JSON.stringify($scope.plugin.properties);
+          if (strProp1 !== strProp2) {
+            $scope.data['isModelTouched'] = true;
+          }
+      }, true);
     }
 
     this.reset = function () {

--- a/cdap-ui/app/features/adapters/controllers/detail-ctrl.js
+++ b/cdap-ui/app/features/adapters/controllers/detail-ctrl.js
@@ -15,12 +15,13 @@
  */
 
 angular.module(PKG.name + '.feature.adapters')
-  .controller('AdpaterDetailController', function($scope, rAdapterDetail, GLOBALS, MyAppDAGService, CanvasFactory, $state, myWorkFlowApi, myWorkersApi, myAppsApi, AdapterDetail, $timeout ) {
+  .controller('AdpaterDetailController', function($scope, rAdapterDetail, GLOBALS, MyAppDAGService, CanvasFactory, $state, myWorkFlowApi, myWorkersApi, myAppsApi, AdapterDetail, $timeout, MyNodeConfigService) {
     $scope.GLOBALS = GLOBALS;
     $scope.template = rAdapterDetail.template;
     $scope.description = rAdapterDetail.description;
     $scope.app = rAdapterDetail;
     $scope.runOnceLoading = false;
+    MyAppDAGService.registerEditPropertiesCallback(viewProperties.bind(this));
 
     AdapterDetail.initialize(rAdapterDetail, $state);
 
@@ -48,6 +49,10 @@ angular.module(PKG.name + '.feature.adapters')
       {
         title: 'Datasets',
         template: '/assets/features/adapters/templates/tabs/datasets.html'
+      },
+      {
+        title: 'Node Configuration',
+        template: '/assets/features/adapters/templates/tabs/node-configuration.html'
       }
     ];
 
@@ -56,7 +61,16 @@ angular.module(PKG.name + '.feature.adapters')
       $scope.activeTab = tab;
     };
 
-
+    function viewProperties(plugin) {
+      $scope.selectTab($scope.tabs[6]);
+      // Giving 100ms to load the template and then set the plugin
+      // For this service to work the controller has to register a callback
+      // with the service. The callback will not be called if plugin assignment happens
+      // before controller initialization. Hence the 100ms delay.
+      $timeout(function() {
+        MyNodeConfigService.setPlugin(plugin);
+      }, 100);
+    }
     var params = {
       namespace: $state.params.namespace,
       appId: rAdapterDetail.name,

--- a/cdap-ui/app/features/adapters/templates/create/popovers/plugin-edit-config-form.html
+++ b/cdap-ui/app/features/adapters/templates/create/popovers/plugin-edit-config-form.html
@@ -76,7 +76,7 @@
         <fieldset ng-disabled="isDisabled">
           <my-schema-editor
             ng-model="pluginCopy.outputSchema"
-            data-disabled="pluginCopy.implicitSchema"
+            data-disabled="pluginCopy.implicitSchema || isDisabled"
             plugin-properties="pluginCopy.properties"
             config="PluginEditController.schemaProperties">
           </my-schema-editor>

--- a/cdap-ui/app/features/adapters/templates/create/popovers/plugin-edit-output-schema.html
+++ b/cdap-ui/app/features/adapters/templates/create/popovers/plugin-edit-output-schema.html
@@ -26,7 +26,7 @@
   <fieldset class="clearfix" ng-disabled="isDisabled">
     <my-schema-editor
       ng-model="pluginCopy.outputSchema"
-      data-disabled="pluginCopy.implicitSchema"
+      data-disabled="pluginCopy.implicitSchema || isDisabled"
       plugin-properties="pluginCopy.properties"
       config="PluginEditController.schemaProperties">
     </my-schema-editor>

--- a/cdap-ui/app/features/adapters/templates/detail.html
+++ b/cdap-ui/app/features/adapters/templates/detail.html
@@ -129,7 +129,11 @@
       </li>
     </ul>
   </div>
+  
   <div class="console-type">
-    <div ng-include="activeTab.template" ng-if="tabs.length > 0"></div>
+    <div ng-repeat="tab in tabs"
+         ng-include="tab.template"
+         ng-show="activeTab.title === tab.title">
+      </div>
   </div>
 </div>

--- a/cdap-ui/app/features/adapters/templates/tabs/node-configuration.html
+++ b/cdap-ui/app/features/adapters/templates/tabs/node-configuration.html
@@ -1,0 +1,3 @@
+<div ng-init="isDisabled=true">
+  <div ng-include="'/assets/features/adapters/templates/partial/node-config.html'"></div>
+</div>

--- a/cdap-ui/app/features/home/routes.js
+++ b/cdap-ui/app/features/home/routes.js
@@ -15,7 +15,7 @@
  */
 
 angular.module(PKG.name+'.feature.home')
-  .config(function ($stateProvider, $urlRouterProvider, $urlMatcherFactoryProvider) {
+  .config(function ($stateProvider, $urlRouterProvider, $urlMatcherFactoryProvider, MYAUTH_ROLE) {
 
     /**
      * Ignores trailing slash
@@ -61,6 +61,10 @@ angular.module(PKG.name+'.feature.home')
         url: '/ns/:namespace',
         abstract: true,
         template: '<ui-view/>',
+        data: {
+          authorizedRoles: MYAUTH_ROLE.all,
+          highlightTab: 'development'
+        },
         resolve: {
           rNsList: function (myNamespace) {
             return myNamespace.getList();


### PR DESCRIPTION
- Adds Node Configuration to detailed view
- Removes Schema on Edge in detailed view (as the schema information is not consistently available in UI)
- Fixes hydrator and cdap header to highlight appropriate options.

![nodeconfig-detailed](https://cloud.githubusercontent.com/assets/1452845/10008897/9b5cf852-6089-11e5-9858-5f326208974a.gif)

