### PR TITLE
Resize studio window based on browser height

### DIFF
--- a/cdap-ui/app/features/adapters/bottompanel.less
+++ b/cdap-ui/app/features/adapters/bottompanel.less
@@ -22,18 +22,21 @@ body.theme-cdap.state-adapters {
 
   &.state-adapters-detail {
     div.console {
-      min-height: 60vh;
-
+      @media (max-height: 500px) {
+        min-height: 60vh;
+        width: 100%;
+      }
+      @media (min-height: 501px) {
+        min-height: 40vh;
+      }
       div.console-type {
         height: inherit;
         min-height: inherit;
       }
-
     }
   }
   div.console {
     background-color: white;
-    min-height: 40vh;
     .transition(all 0.2s ease);
     &.collapsed {
       left: 130px;

--- a/cdap-ui/app/features/adapters/bottompanel.less
+++ b/cdap-ui/app/features/adapters/bottompanel.less
@@ -33,11 +33,10 @@ body.theme-cdap.state-adapters {
     background-color: white;
     width: 100%;
     .transition(all 0.2s ease);
-    @media (max-height: 500px) {
+   // Console height is 40% on larger screen
+    min-height: 40vh;
+    @media (min-height: 800px) {
       min-height: 60vh;
-    }
-    @media (min-height: 501px) {
-      min-height: 40vh;
     }
     &.collapsed {
       left: 130px;

--- a/cdap-ui/app/features/adapters/bottompanel.less
+++ b/cdap-ui/app/features/adapters/bottompanel.less
@@ -22,13 +22,7 @@ body.theme-cdap.state-adapters {
 
   &.state-adapters-detail {
     div.console {
-      @media (max-height: 500px) {
-        min-height: 60vh;
-        width: 100%;
-      }
-      @media (min-height: 501px) {
-        min-height: 40vh;
-      }
+      min-height: 60vh;
       div.console-type {
         height: inherit;
         min-height: inherit;
@@ -37,7 +31,14 @@ body.theme-cdap.state-adapters {
   }
   div.console {
     background-color: white;
+    width: 100%;
     .transition(all 0.2s ease);
+    @media (max-height: 500px) {
+      min-height: 60vh;
+    }
+    @media (min-height: 501px) {
+      min-height: 40vh;
+    }
     &.collapsed {
       left: 130px;
     }

--- a/cdap-ui/app/features/adapters/etlapps.less
+++ b/cdap-ui/app/features/adapters/etlapps.less
@@ -465,7 +465,11 @@ body.theme-cdap.state-adapters-create {
   }
   my-dag {
     width: 100%;
-    height: 50vh;
+    // Dag-Height 60% on smaller screen
+    height: 60vh;
+    @media (min-height: 800px) {
+      height: 40vh;
+    }
   }
 
   .tab-pane .panel-default {


### PR DESCRIPTION
* Resize the studio window
  * On bigger screen the top canvas is 40% and bottom is 60%
  * On smaller screen the top canvas is 60% and bottom is 40%
  * Used absolute height as 800px to determine big vs small screen