### PR TITLE
Fixes UI to show console error when un-saved node config exists while publishing a pipeline

### DIFF
--- a/cdap-ui/app/directives/dag/my-dag-ctrl.js
+++ b/cdap-ui/app/directives/dag/my-dag-ctrl.js
@@ -371,7 +371,6 @@ angular.module(PKG.name + '.commons')
       resetComponent.call(this);
     }
 
-    MyNodeConfigService.registerPluginResetCallback($scope.$id, this.resetPluginSelection.bind(this));
     MyNodeConfigService.registerPluginSaveCallback($scope.$id, this.highlightRequiredFields.bind(this));
     MyAppDAGService.registerCallBack(this.addPlugin.bind(this));
     MyAppDAGService.registerResetCallBack(resetComponent.bind(this));

--- a/cdap-ui/app/features/adapters/controllers/create/partials/nodeconfig-ctrl.js
+++ b/cdap-ui/app/features/adapters/controllers/create/partials/nodeconfig-ctrl.js
@@ -21,7 +21,6 @@ angular.module(PKG.name + '.feature.adapters')
     $scope.type = MyAppDAGService.metadata.template.type;
 
     $scope.data = {};
-    $scope.data.isModelTouched = false;
 
     MyNodeConfigService.registerPluginSetCallback($scope.$id, onPluginChange);
     MyNodeConfigService.registerRemovePluginCallback($scope.$id, onPluginRemoved);
@@ -29,7 +28,7 @@ angular.module(PKG.name + '.feature.adapters')
     function onPluginRemoved(nodeId) {
       if ($scope.plugin && $scope.plugin.id === nodeId){
         $scope.isValidPlugin = false;
-        $scope.data.isModelTouched = false;
+        MyNodeConfigService.setIsPluginBeingEdited(false);
       }
     }
 
@@ -39,7 +38,7 @@ angular.module(PKG.name + '.feature.adapters')
       if (plugin && $scope.plugin && plugin.id === $scope.plugin.id) {
         return;
       }
-      if (!$scope.data.isModelTouched) {
+      if (!MyNodeConfigService.getIsPluginBeingEdited()) {
         switchPlugin(plugin);
         defer.resolve(true);
       } else {

--- a/cdap-ui/app/features/adapters/controllers/create/plugin-edit-form-ctrl.js
+++ b/cdap-ui/app/features/adapters/controllers/create/plugin-edit-form-ctrl.js
@@ -34,6 +34,7 @@ angular.module(PKG.name + '.feature.adapters')
     this.configfetched = false;
     this.properties = [];
     this.noconfig = null;
+    this.MyNodeConfigService = MyNodeConfigService;
     /////////////////////////////////////
     /*
      This is snippet is here because the widget-schema-editor edits the outputschema that we pass in
@@ -44,7 +45,7 @@ angular.module(PKG.name + '.feature.adapters')
      This should eventually be removed and moved to a service (or a factory). For lack of time my sin stays here. - Ajai
     */
     if (!$scope.isDisabled) {
-      $scope.data['isModelTouched'] = false;
+      MyNodeConfigService.setIsPluginBeingEdited(false);
     }
 
     var typeMap = 'map<string, string>';
@@ -244,7 +245,7 @@ angular.module(PKG.name + '.feature.adapters')
                     var strProp1 = JSON.stringify($scope.pluginCopy.properties);
                     var strProp2 = JSON.stringify($scope.plugin.properties);
                     if (strProp1 !== strProp2) {
-                      $scope.data['isModelTouched'] = true;
+                      MyNodeConfigService.setIsPluginBeingEdited(true);
                     }
                 }, true);
               }
@@ -331,7 +332,7 @@ angular.module(PKG.name + '.feature.adapters')
           var originalOutputSchema = $scope.plugin.outputSchema;
           var copyOutputSchema = $scope.pluginCopy.outputSchema;
           if (originalOutputSchema !== copyOutputSchema) {
-            $scope.data['isModelTouched'] = true;
+            MyNodeConfigService.setIsPluginBeingEdited(true);
           }
         });
       }
@@ -340,7 +341,7 @@ angular.module(PKG.name + '.feature.adapters')
         var copyLabel = $scope.pluginCopy.label;
         var originalLabel = $scope.plugin.label;
         if (copyLabel !== originalLabel) {
-          $scope.data['isModelTouched'] = true;
+          MyNodeConfigService.setIsPluginBeingEdited(true);
         }
       });
 
@@ -348,7 +349,7 @@ angular.module(PKG.name + '.feature.adapters')
         var copyErrorDataset = $scope.pluginCopy.errorDatasetName;
         var originalErrorDataset = $scope.plugin.errorDatasetName;
         if (copyErrorDataset !== originalErrorDataset) {
-          $scope.data['isModelTouched'] = true;
+          MyNodeConfigService.setIsPluginBeingEdited(true);
         }
       });
 
@@ -356,7 +357,7 @@ angular.module(PKG.name + '.feature.adapters')
         var copyValidationFields = JSON.stringify($scope.pluginCopy.validationFields);
         var originalValidationFields = JSON.stringify($scope.plugin.validationFields);
         if (copyValidationFields !== originalValidationFields) {
-          $scope.data['isModelTouched'] = true;
+          MyNodeConfigService.setIsPluginBeingEdited(true);
         }
       });
 
@@ -364,7 +365,7 @@ angular.module(PKG.name + '.feature.adapters')
           var strProp1 = JSON.stringify($scope.pluginCopy.properties);
           var strProp2 = JSON.stringify($scope.plugin.properties);
           if (strProp1 !== strProp2) {
-            $scope.data['isModelTouched'] = true;
+            MyNodeConfigService.setIsPluginBeingEdited(true);
           }
       }, true);
     }
@@ -374,7 +375,7 @@ angular.module(PKG.name + '.feature.adapters')
       $scope.pluginCopy.outputSchema = angular.copy($scope.plugin.outputSchema);
       $scope.pluginCopy.errorDatasetName = angular.copy($scope.plugin.errorDatasetName);
       EventPipe.emit('resetValidatorValidationFields', $scope.plugin.validationFields);
-      $scope.data['isModelTouched'] = false;
+      MyNodeConfigService.setIsPluginBeingEdited(false);
       EventPipe.emit('plugin.reset');
     };
 
@@ -389,7 +390,7 @@ angular.module(PKG.name + '.feature.adapters')
         $scope.plugin.errorDatasetName = $scope.pluginCopy.errorDatasetName;
         $scope.plugin.validationFields = angular.copy($scope.pluginCopy.validationFields);
         $scope.plugin.label = $scope.pluginCopy.label;
-        $scope.data['isModelTouched'] = false;
+        MyNodeConfigService.setIsPluginBeingEdited(false);
         MyNodeConfigService.notifyPluginSaveListeners($scope.plugin.id);
       }
     };

--- a/cdap-ui/app/features/adapters/controllers/create/toppanel-ctrl.js
+++ b/cdap-ui/app/features/adapters/controllers/create/toppanel-ctrl.js
@@ -179,9 +179,9 @@ angular.module(PKG.name + '.feature.adapters')
         }
         errors.canvas = errors.canvas || [];
         errors.canvas.push(
-          'There are un-saved changes for node: ' +
-          MyNodeConfigService.plugin.name +
-          '. Please save them before publishing the pipeline'
+          GLOBALS.en.hydrator.studio.unsavedPluginMessage1 +
+          MyNodeConfigService.plugin.label +
+          GLOBALS.en.hydrator.studio.unsavedPluginMessage2
         );
       }
 

--- a/cdap-ui/app/features/adapters/controllers/create/toppanel-ctrl.js
+++ b/cdap-ui/app/features/adapters/controllers/create/toppanel-ctrl.js
@@ -15,7 +15,7 @@
  */
 
 angular.module(PKG.name + '.feature.adapters')
-  .controller('TopPanelController', function(EventPipe, CanvasFactory, MyAppDAGService, $scope, $timeout, $bootstrapModal, ModalConfirm, $alert, $state, $stateParams, GLOBALS, AdapterErrorFactory, MyConsoleTabService) {
+  .controller('TopPanelController', function(EventPipe, CanvasFactory, MyAppDAGService, $scope, $timeout, $bootstrapModal, ModalConfirm, $alert, $state, $stateParams, GLOBALS, AdapterErrorFactory, MyConsoleTabService, MyNodeConfigService) {
 
     this.metadata = MyAppDAGService['metadata'];
     function resetMetadata() {
@@ -172,6 +172,19 @@ angular.module(PKG.name + '.feature.adapters')
 
     this.validatePipeline = function() {
       var errors = AdapterErrorFactory.isModelValid(MyAppDAGService.nodes, MyAppDAGService.connections, MyAppDAGService.metadata, MyAppDAGService.getConfig());
+
+      if (MyNodeConfigService.getIsPluginBeingEdited()) {
+        if (errors === true) {
+          errors = {};
+        }
+        errors.canvas = errors.canvas || [];
+        errors.canvas.push(
+          'There are un-saved changes for node: ' +
+          MyNodeConfigService.plugin.name +
+          '. Please save them before publishing the pipeline'
+        );
+      }
+
       if (angular.isObject(errors)) {
         MyAppDAGService.notifyError(errors);
       } else {

--- a/cdap-ui/app/features/adapters/services/node-config-service.js
+++ b/cdap-ui/app/features/adapters/services/node-config-service.js
@@ -21,6 +21,16 @@ angular.module(PKG.name + '.feature.adapters')
     this.pluginRemoveListeners = {};
     this.pluginSaveListeners = {};
 
+    this.isModelTouched = false;
+
+    this.setIsPluginBeingEdited = function(isPluginSaved) {
+      this.isModelTouched = isPluginSaved;
+    };
+
+    this.getIsPluginBeingEdited = function() {
+      return this.isModelTouched;
+    };
+
     this.resetPlugin = function(plugin) {
       this.plugin = plugin;
       this.notifyPluginResetListeners();

--- a/cdap-ui/app/features/adapters/templates/create/popovers/plugin-edit-form.html
+++ b/cdap-ui/app/features/adapters/templates/create/popovers/plugin-edit-form.html
@@ -39,12 +39,12 @@
     <div class="btn-group pull-right">
       <div ng-if="!isDisabled" class="non-info">
         <a class="btn btn-default"
-            ng-disabled="data.isModelTouched == false"
+            ng-disabled="PluginEditController.MyNodeConfigService.isModelTouched == false"
             ng-click="PluginEditController.reset()">Reset</a>
       </div>
       <div ng-if="!isDisabled"  class="non-info">
         <a class="btn btn-success"
-            ng-disabled="data.isModelTouched == false"
+            ng-disabled="PluginEditController.MyNodeConfigService.isModelTouched == false"
             ng-click="PluginEditController.save()">Save</a>
       </div>
     </div>

--- a/cdap-ui/app/services/app/my-app-dag-service.js
+++ b/cdap-ui/app/services/app/my-app-dag-service.js
@@ -636,7 +636,7 @@ angular.module(PKG.name + '.services')
       if (MyNodeConfigService.getIsPluginBeingEdited()) {
         // This should have been a popup that we show for un-saved changes while switching the node.
         // Couldn't do it here because we cannot set it to another plugin. Hence the console message.
-        // If we are able to fuse an 4 hydrogen atoms and things turn out good, we will have auto-correct
+        // If we are able to fuse 4 hydrogen atoms and things turn out good, we will have auto-correct
         // in the next realease and we should be able to remove a majority of
         // communication happening with save and reset in node configuration.
         this.notifyError({

--- a/cdap-ui/app/services/app/my-app-dag-service.js
+++ b/cdap-ui/app/services/app/my-app-dag-service.js
@@ -631,8 +631,25 @@ angular.module(PKG.name + '.services')
       return data;
     };
     this.save = function() {
-      this.isConfigTouched = false;
       var defer = $q.defer();
+
+      if (MyNodeConfigService.getIsPluginBeingEdited()) {
+        // This should have been a popup that we show for un-saved changes while switching the node.
+        // Couldn't do it here because we cannot set it to another plugin. Hence the console message.
+        // If we are able to fuse an 4 hydrogen atoms and things turn out good, we will have auto-correct
+        // in the next realease and we should be able to remove a majority of
+        // communication happening with save and reset in node configuration.
+        this.notifyError({
+          canvas: [
+            'There are un-saved changes for node: ' +
+            MyNodeConfigService.plugin.name +
+            '. Please save them before publishing the pipeline'
+          ]
+        });
+        defer.reject();
+        return defer.promise;
+      }
+      this.isConfigTouched = false;
       var config = this.getConfig();
       var errors = AdapterErrorFactory.isModelValid(this.nodes, this.connections, this.metadata, config);
 

--- a/cdap-ui/app/services/app/my-app-dag-service.js
+++ b/cdap-ui/app/services/app/my-app-dag-service.js
@@ -641,9 +641,9 @@ angular.module(PKG.name + '.services')
         // communication happening with save and reset in node configuration.
         this.notifyError({
           canvas: [
-            'There are un-saved changes for node: ' +
-            MyNodeConfigService.plugin.name +
-            '. Please save them before publishing the pipeline'
+            GLOBALS.en.hydrator.studio.unsavedPluginMessage1 +
+            MyNodeConfigService.plugin.label +
+            GLOBALS.en.hydrator.studio.unsavedPluginMessage2
           ]
         });
         defer.reject();

--- a/cdap-ui/app/services/constants.js
+++ b/cdap-ui/app/services/constants.js
@@ -50,7 +50,9 @@ angular.module(PKG.name + '.services')
           circularConnectionError: 'Please remove the circular connection in this pipeline.',
           endSinkError: 'Please end the pipeline connections in a sink.',
           parallelConnectionError: 'Please remove parallel connections in this pipeline.',
-          pluginDoesNotExist: 'Plugin does not exist: '
+          pluginDoesNotExist: 'Plugin does not exist: ',
+          unsavedPluginMessage1: 'There are un-saved changes for node: ',
+          unsavedPluginMessage2: '. Please save them before publishing the pipeline'
         },
         wizard: {
           welcomeMessage1: 'Hydrator makes it easy to prepare data so you ',


### PR DESCRIPTION
- Fixes studio to throw an error while publishing/validating a pipeline if there are un-saved node configurations.