### PR TITLE
Hides schema for sinks when it doesn't have a schema property

### DIFF
--- a/cdap-ui/app/features/adapters/templates/create/popovers/plugin-edit-config-form.html
+++ b/cdap-ui/app/features/adapters/templates/create/popovers/plugin-edit-config-form.html
@@ -75,7 +75,7 @@
 
         <fieldset ng-disabled="isDisabled">
           <my-schema-editor
-            ng-if="pluginCopy.properties.schema"
+            ng-if="pluginCopy.properties.schema || pluginCopy.implicitSchema"
             ng-model="pluginCopy.outputSchema"
             data-disabled="pluginCopy.implicitSchema || isDisabled"
             plugin-properties="pluginCopy.properties"

--- a/cdap-ui/app/features/adapters/templates/create/popovers/plugin-edit-config-form.html
+++ b/cdap-ui/app/features/adapters/templates/create/popovers/plugin-edit-config-form.html
@@ -62,7 +62,7 @@
           </ul>
         </div>
 
-        <h4 class="sink-schema">
+        <h4 class="sink-schema" ng-if="pluginCopy.properties.schema">
           <span>Schema</span>
           <button
             class="btn btn-sm btn-default pull-right"
@@ -75,6 +75,7 @@
 
         <fieldset ng-disabled="isDisabled">
           <my-schema-editor
+            ng-if="pluginCopy.properties.schema"
             ng-model="pluginCopy.outputSchema"
             data-disabled="pluginCopy.implicitSchema || isDisabled"
             plugin-properties="pluginCopy.properties"
@@ -82,7 +83,7 @@
           </my-schema-editor>
         </fieldset>
 
-        <div ng-if="!pluginCopy.outputSchema && isDisabled">
+        <div ng-if="pluginCopy.properties.schema && !pluginCopy.outputSchema && isDisabled">
           <div class="well well-lg">
             <h4>There is no output schema</h4>
           </div>

--- a/cdap-ui/templates/common/Database.json
+++ b/cdap-ui/templates/common/Database.json
@@ -49,7 +49,7 @@
     },
     "group3": {
       "display" : "Table Properties",
-      "position" : [ "importQuery", "countQuery", "columnNameCase" ],
+      "position" : [ "importQuery", "countQuery", "columnNameCase" , "columns"],
       "fields" : {
         "importQuery" : {
           "widget": "textbox",
@@ -66,6 +66,13 @@
           "properties" : {
             "values" : [ "UPPER", "lower", "No change" ],
             "default" : "No change"
+          }
+        },
+        "columns": {
+          "widget": "csv",
+          "label": "Columns",
+          "properties": {
+            "delimiter": ","
           }
         }
       }


### PR DESCRIPTION
- Removes output schema for sinks if it doesn't have a schema property.

FIXME: 
  Need to confirm about implicit-schema. If there is implicit-schema should we display the output schema or hide it?