### PR TITLE
update to reflect app.artifact.dir instead of app.template.dir

### DIFF
--- a/cdap-docs/integrations/source/partners/cloudera/configuring.rst
+++ b/cdap-docs/integrations/source/partners/cloudera/configuring.rst
@@ -274,8 +274,8 @@ of Cloudera's ``${PARCELS_ROOT}`` directory, for example::
   /opt/cloudera/parcels/CDAP/master/artifacts
 
 Ensure that the ``App Artifact Dir`` configuration option points to this path on disk. Since this
-directory can change when CDAP parcels are upgraded, advanced users are encouraged to place
-these artiracts in a static directory outside the parcel root, and configure accordingly.
+directory can change when CDAP parcels are upgraded, users are encouraged to place
+these artifacts in a static directory outside the parcel root, and configure accordingly.
 
 .. _cloudera-direct-parcel-access:
 

--- a/cdap-docs/integrations/source/partners/cloudera/configuring.rst
+++ b/cdap-docs/integrations/source/partners/cloudera/configuring.rst
@@ -266,16 +266,16 @@ query, try setting ``hive.exec.stagingdir`` in your Hive configuration to
 This can be done in Cloudera Manager using the *Hive Client
 Advanced Configuration Snippet (Safety Valve) for hive-site.xml* configuration field.
 
-.. rubric:: Missing Application Templates
+.. rubric:: Missing System Artifacts
 
-The bundled application templates are included in the CDAP parcel, located in a subdirectory
+The bundled system artifacts are included in the CDAP parcel, located in a subdirectory
 of Cloudera's ``${PARCELS_ROOT}`` directory, for example::
 
-  /opt/cloudera/parcels/CDAP/master/templates
+  /opt/cloudera/parcels/CDAP/master/artifacts
 
-Ensure that the ``App Template Dir`` configuration option points to this path on disk. Since this
+Ensure that the ``App Artifact Dir`` configuration option points to this path on disk. Since this
 directory can change when CDAP parcels are upgraded, advanced users are encouraged to place
-these templates in a static directory outside the parcel root, and configure accordingly.
+these artiracts in a static directory outside the parcel root, and configure accordingly.
 
 .. _cloudera-direct-parcel-access:
 


### PR DESCRIPTION
update to Cloudera docs to reflect that ``app.template.dir`` is now ``app.artifact.dir``