### PR TITLE
Instead of returning stack trace just return the rootcause message.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/DelayedHttpServiceResponder.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/DelayedHttpServiceResponder.java
@@ -155,9 +155,10 @@ public final class DelayedHttpServiceResponder implements HttpServiceResponder {
    * method is called to allow setting the failure response without an additional warning.
    */
   public void setTransactionFailureResponse(Throwable t) {
-    Throwable rootCause = Throwables.getRootCause(t);
+    LOG.error("Exception occurred while handling request:", t);
+    @SuppressWarnings("ThrowableResultOfMethodCallIgnored")
     ByteBuffer buffer = Charsets.UTF_8.encode("Exception occurred while handling request: "
-                                                + Throwables.getStackTraceAsString(rootCause));
+                                                + Throwables.getRootCause(t).getMessage());
 
     bufferedResponse = new BufferedResponse(HttpResponseStatus.INTERNAL_SERVER_ERROR.getCode(),
                                             ChannelBuffers.wrappedBuffer(buffer),

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
@@ -734,7 +734,7 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     request = HttpRequest.get(url).build();
     response = HttpRequests.execute(request);
     Assert.assertEquals(500, response.getResponseCode());
-    Assert.assertTrue(response.getResponseBodyAsString().contains("IllegalStateException"));
+    Assert.assertTrue(response.getResponseBodyAsString().contains("Exception"));
 
     // Call the verify ClassLoader endpoint
     url = new URL(serviceURL, "verifyClassLoader");


### PR DESCRIPTION
In case of exception while accessing the service handler, instead of returning entire stack trace, just return the root cause message.