### PR TITLE
Move the dependency of geronimo-jms_1.1_spec as quick fix in 3.2

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-lib/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-lib/pom.xml
@@ -80,7 +80,6 @@
     <dependency>
       <groupId>org.apache.geronimo.specs</groupId>
       <artifactId>geronimo-jms_1.1_spec</artifactId>
-      <version>1.1.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.activemq</groupId>

--- a/cdap-app-templates/cdap-etl/cdap-etl-realtime/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-realtime/pom.xml
@@ -60,6 +60,11 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>
+    <!-- TODO Remove this when CDAP-3810 is fixed -->
+    <dependency>
+      <groupId>org.apache.geronimo.specs</groupId>
+      <artifactId>geronimo-jms_1.1_spec</artifactId>
+    </dependency>
   </dependencies>
 
   <build>
@@ -80,7 +85,7 @@
               <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
               <Embed-Transitive>true</Embed-Transitive>
               <Embed-Directory>lib</Embed-Directory>
-              <Export-Package>co.cask.cdap.etl.api.*</Export-Package>
+              <Export-Package>co.cask.cdap.etl.api.*;javax.jms.*</Export-Package>
             </instructions>
           </configuration>
           <executions>

--- a/cdap-app-templates/cdap-etl/pom.xml
+++ b/cdap-app-templates/cdap-etl/pom.xml
@@ -46,6 +46,7 @@
     <es.version>1.6.0</es.version>
     <es-hadoop.version>2.1.0</es-hadoop.version>
     <commons-httpclient.version>3.1</commons-httpclient.version>
+    <etl.geronimo-jms.version>1.1.1</etl.geronimo-jms.version>
   </properties>
 
   <dependencyManagement>
@@ -200,6 +201,13 @@
             <artifactId>jetty</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+
+      <!-- TODO Remove this when CDAP-3810 is fixed -->
+      <dependency>
+        <groupId>org.apache.geronimo.specs</groupId>
+        <artifactId>geronimo-jms_1.1_spec</artifactId>
+        <version>${etl.geronimo-jms.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
This will change it as a direct dependency in etl-realtime app and have Export-Package of "javax.jms.*".

Need to revert this hack and introduce a proper plugin class loading model like we used to have in 3.1.
See: https://issues.cask.co/browse/CDAP-3810 