### PR TITLE
documenting workaround for CDAP-3817

### DIFF
--- a/cdap-docs/admin-manual/source/installation/installation.rst
+++ b/cdap-docs/admin-manual/source/installation/installation.rst
@@ -230,11 +230,11 @@ create a top-level ``/cdap`` directory in HDFS, owned by an HDFS user ``yarn``::
 In the CDAP packages, the default HDFS namespace is ``/cdap`` and the default HDFS user is
 ``yarn``.
 
-Also create a subdirectory as follows::
+Also, create a ``tx.snapshot`` subdirectory::
 
   $ sudo -u hdfs hadoop fs -mkdir /cdap/tx.snapshot && sudo -u hdfs hadoop fs -chown yarn /cdap/tx.snapshot
 
-Note, if your configuration contains a non-default ``data.tx.snapshot.dir``, then use that value
+**Note:** If your configuration contains a non-default ``data.tx.snapshot.dir``, use that value
 instead of ``tx.snapshot``.
 
 If you set up your cluster as above, no further changes are required.

--- a/cdap-docs/admin-manual/source/installation/installation.rst
+++ b/cdap-docs/admin-manual/source/installation/installation.rst
@@ -225,10 +225,19 @@ Preparing the Cluster
 To prepare your cluster so that CDAP can write to its default namespace,
 create a top-level ``/cdap`` directory in HDFS, owned by an HDFS user ``yarn``::
 
-  $ sudo -u hdfs hadoop fs -mkdir /cdap && hadoop fs -chown yarn /cdap
+  $ sudo -u hdfs hadoop fs -mkdir /cdap && sudo -u hdfs hadoop fs -chown yarn /cdap
 
 In the CDAP packages, the default HDFS namespace is ``/cdap`` and the default HDFS user is
-``yarn``. If you set up your cluster as above, no further changes are required.
+``yarn``.
+
+Also create a subdirectory as follows::
+
+  $ sudo -u hdfs hadoop fs -mkdir /cdap/tx.snapshot && sudo -u hdfs hadoop fs -chown yarn /cdap/tx.snapshot
+
+Note, if your configuration contains a non-default ``data.tx.snapshot.dir``, then use that value
+instead of ``tx.snapshot``.
+
+If you set up your cluster as above, no further changes are required.
 
 .. _install-preparing-the-cluster-defaults:
 

--- a/cdap-docs/reference-manual/source/release-notes.rst
+++ b/cdap-docs/reference-manual/source/release-notes.rst
@@ -36,6 +36,10 @@ Known Issues
   about a failure to enable explore on the system.queue table. A call to enable exploration
   on the table should not be made, as it is not meant to be explorable.
 
+- `CDAP-3817 <https://issues.cask.co/browse/CDAP-3817>`__ -
+  On initial startup after fresh CDAP installation, it is possible for the ``data.tx.snapshot.dir``
+  HDFS directory to be created with improper permissions.
+
 `Release 3.1.0 <http://docs.cask.co/cdap/3.1.0/index.html>`__
 =============================================================
 

--- a/cdap-docs/reference-manual/source/release-notes.rst
+++ b/cdap-docs/reference-manual/source/release-notes.rst
@@ -37,7 +37,7 @@ Known Issues
   on the table should not be made, as it is not meant to be explorable.
 
 - `CDAP-3817 <https://issues.cask.co/browse/CDAP-3817>`__ -
-  On initial startup after fresh CDAP installation, it is possible for the ``data.tx.snapshot.dir``
+  On initial startup, after a fresh CDAP installation, it is possible for the ``data.tx.snapshot.dir``
   HDFS directory to be created with improper permissions.
 
 `Release 3.1.0 <http://docs.cask.co/cdap/3.1.0/index.html>`__


### PR DESCRIPTION
This documents the workaround for CDAP-3817.  We instruct the user to create the ``tx.snapshot`` directory prior to starting cdap, to avoid the potential for it getting created with improper permissions.