### PR TITLE
[CDAP-3830] Fix the metadata search on tags

### DIFF
--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/dataset/BusinessMetadataDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/dataset/BusinessMetadataDatasetTest.java
@@ -159,6 +159,45 @@ public class BusinessMetadataDatasetTest {
   }
 
   @Test
+  public void testSearchOnTags() throws Exception {
+    Assert.assertEquals(0, dataset.getTags(app1).size());
+    Assert.assertEquals(0, dataset.getTags(flow1).size());
+    Assert.assertEquals(0, dataset.getTags(dataset1).size());
+    Assert.assertEquals(0, dataset.getTags(stream1).size());
+    dataset.addTags(app1, "tag1", "tag2", "tag3");
+    dataset.addTags(flow1, "tag1");
+    dataset.addTags(dataset1, "tag3", "tag2", "tag12");
+    dataset.addTags(stream1, "tag2, tag4");
+
+    // Try to search on all tags
+    List<BusinessMetadataRecord> results =
+      dataset.findBusinessMetadataOnKeyValue("ns1", "tags:*", MetadataSearchTargetType.ALL);
+    Assert.assertEquals(4, results.size());
+
+    // Try to search for tag1*
+    results = dataset.findBusinessMetadataOnKeyValue("ns1", "tags:tag1*", MetadataSearchTargetType.ALL);
+    Assert.assertEquals(3, results.size());
+
+    // Try to search for tag1
+    results = dataset.findBusinessMetadataOnKeyValue("ns1", "tags:tag1", MetadataSearchTargetType.ALL);
+    Assert.assertEquals(2, results.size());
+
+    // Try to search for tag4
+    results = dataset.findBusinessMetadataOnKeyValue("ns1", "tags:tag4", MetadataSearchTargetType.ALL);
+    Assert.assertEquals(1, results.size());
+
+    // cleanup
+    dataset.removeTags(app1);
+    dataset.removeTags(flow1);
+    dataset.removeTags(dataset1);
+    dataset.removeTags(stream1);
+    Assert.assertEquals(0, dataset.getTags(app1).size());
+    Assert.assertEquals(0, dataset.getTags(flow1).size());
+    Assert.assertEquals(0, dataset.getTags(dataset1).size());
+    Assert.assertEquals(0, dataset.getTags(stream1).size());
+  }
+
+  @Test
   public void testSearchOnValue() throws Exception {
     // Create record
     BusinessMetadataRecord record = new BusinessMetadataRecord(flow1, "key1", "value1");


### PR DESCRIPTION
Since the tags actually will be stored as comma delimited strings, when searching
for one of the tags doing both prefix and keyword match will not work well
if an entity has more than one tags.

Assume a program has tags: tag1,tag2,tag3 then search on tags:tag2 will not yield
any result nor search on tags:tag2*.

Need to add special handling for searching tags for key:value format.