### PR TITLE
Fix for output schema for sinks

### DIFF
--- a/cdap-ui/app/directives/dag/my-dag-ctrl.js
+++ b/cdap-ui/app/directives/dag/my-dag-ctrl.js
@@ -80,6 +80,7 @@ angular.module(PKG.name + '.commons')
             p.error.message = 'Missing required fields';
             p.warning = true;
           }
+          p.properties = plugin.properties;
         }
       });
     };

--- a/cdap-ui/app/features/adapters/templates/create/popovers/plugin-edit-config-form.html
+++ b/cdap-ui/app/features/adapters/templates/create/popovers/plugin-edit-config-form.html
@@ -62,8 +62,9 @@
           </ul>
         </div>
 
-        <h4 class="sink-schema" ng-if="pluginCopy.properties.schema">
+        <h4 class="sink-schema" ng-if="pluginCopy.properties.schema || pluginCopy.implicitSchema || pluginCopy._backendProperties['schema'].required">
           <span>Schema</span>
+          <span class="fa fa-asterisk ng-scope" ng-if="pluginCopy._backendProperties['schema'].required"></span>
           <button
             class="btn btn-sm btn-default pull-right"
             ng-click="PluginEditController.schemaClear()"
@@ -75,7 +76,7 @@
 
         <fieldset ng-disabled="isDisabled">
           <my-schema-editor
-            ng-if="pluginCopy.properties.schema || pluginCopy.implicitSchema"
+            ng-if="pluginCopy.properties.schema || pluginCopy.implicitSchema || pluginCopy._backendProperties['schema'].required"
             ng-model="pluginCopy.outputSchema"
             data-disabled="pluginCopy.implicitSchema || isDisabled"
             plugin-properties="pluginCopy.properties"


### PR DESCRIPTION
- Removes output schema for sinks that doesn't have a 'schema' property.
- Adds red asterisk to output schema for sinks that has a required schema property.
- Adds output schema for sink if the node configuration has an implicit schema attached to it.