### PR TITLE
Metadata and Lineage clients

### DIFF
--- a/cdap-app-fabric/pom.xml
+++ b/cdap-app-fabric/pom.xml
@@ -92,6 +92,13 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-client</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/DefaultMetadataAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/DefaultMetadataAdmin.java
@@ -129,8 +129,7 @@ public class DefaultMetadataAdmin implements MetadataAdmin {
 
   @Override
   public Set<MetadataSearchResultRecord> searchMetadata(String namespaceId, String searchQuery,
-                                                        @Nullable final MetadataSearchTargetType type)
-    throws NotFoundException {
+                                                        @Nullable final MetadataSearchTargetType type) {
     Iterable<BusinessMetadataRecord> results;
     if (type == null) {
       results = businessMds.searchMetadata(namespaceId, searchQuery);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataHttpHandler.java
@@ -27,6 +27,7 @@ import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
 import co.cask.http.AbstractHttpHandler;
 import co.cask.http.HttpResponder;
 import com.google.common.base.Charsets;
+import com.google.common.base.Preconditions;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
@@ -521,30 +522,30 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
   }
 
   private Map<String, String> readMetadata(HttpRequest request) throws BadRequestException, IOException {
-    ChannelBuffer content = request.getContent();
-    if (!content.readable()) {
-      throw new BadRequestException("Unable to read business metadata from request.");
-    }
-    try (Reader reader = new InputStreamReader(new ChannelBufferInputStream(content), Charsets.UTF_8)) {
-      Map<String, String> metadata = GSON.fromJson(reader, MAP_STRING_STRING_TYPE);
-      if (metadata == null) {
-        throw new BadRequestException("Null metadata was read from request.");
+    try {
+      ChannelBuffer content = request.getContent();
+      Preconditions.checkArgument(content.readable());
+      try (Reader reader = new InputStreamReader(new ChannelBufferInputStream(content), Charsets.UTF_8)) {
+        Map<String, String> metadata = GSON.fromJson(reader, MAP_STRING_STRING_TYPE);
+        Preconditions.checkNotNull(metadata);
+        return metadata;
       }
-      return metadata;
+    } catch (Throwable t) {
+      throw new BadRequestException("Unable to read business metadata from the request.", t);
     }
   }
 
   private String[] readArray(HttpRequest request) throws BadRequestException, IOException {
-    ChannelBuffer content = request.getContent();
-    if (!content.readable()) {
-      throw new BadRequestException("Unable to read a list of keys from the request.");
-    }
-    try (Reader reader = new InputStreamReader(new ChannelBufferInputStream(content), Charsets.UTF_8)) {
-      List<String> toReturn = GSON.fromJson(reader, LIST_STRING_TYPE);
-      if (toReturn == null) {
-        throw new BadRequestException("Null value was read from request.");
+    try {
+      ChannelBuffer content = request.getContent();
+      Preconditions.checkArgument(content.readable());
+      try (Reader reader = new InputStreamReader(new ChannelBufferInputStream(content), Charsets.UTF_8)) {
+        List<String> toReturn = GSON.fromJson(reader, LIST_STRING_TYPE);
+        Preconditions.checkNotNull(toReturn);
+        return toReturn.toArray(new String[toReturn.size()]);
       }
-      return toReturn.toArray(new String[toReturn.size()]);
+    } catch (Throwable t) {
+      throw new BadRequestException("Unable to read a list of keys from the request.", t);
     }
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataHttpHandler.java
@@ -37,7 +37,6 @@ import org.jboss.netty.buffer.ChannelBufferInputStream;
 import org.jboss.netty.handler.codec.http.HttpRequest;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 
-import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.lang.reflect.Type;
@@ -521,7 +520,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                          String.format("Tag %s for stream %s deleted successfully.", tag, stream));
   }
 
-  private Map<String, String> readMetadata(HttpRequest request) throws BadRequestException, IOException {
+  private Map<String, String> readMetadata(HttpRequest request) throws BadRequestException {
     try {
       ChannelBuffer content = request.getContent();
       Preconditions.checkArgument(content.readable());
@@ -535,7 +534,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
     }
   }
 
-  private String[] readArray(HttpRequest request) throws BadRequestException, IOException {
+  private String[] readArray(HttpRequest request) throws BadRequestException {
     try {
       ChannelBuffer content = request.getContent();
       Preconditions.checkArgument(content.readable());

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataHttpHandler.java
@@ -526,7 +526,11 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
       throw new BadRequestException("Unable to read business metadata from request.");
     }
     try (Reader reader = new InputStreamReader(new ChannelBufferInputStream(content), Charsets.UTF_8)) {
-      return GSON.fromJson(reader, MAP_STRING_STRING_TYPE);
+      Map<String, String> metadata = GSON.fromJson(reader, MAP_STRING_STRING_TYPE);
+      if (metadata == null) {
+        throw new BadRequestException("Null metadata was read from request.");
+      }
+      return metadata;
     }
   }
 
@@ -537,6 +541,9 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
     }
     try (Reader reader = new InputStreamReader(new ChannelBufferInputStream(content), Charsets.UTF_8)) {
       List<String> toReturn = GSON.fromJson(reader, LIST_STRING_TYPE);
+      if (toReturn == null) {
+        throw new BadRequestException("Null value was read from request.");
+      }
       return toReturn.toArray(new String[toReturn.size()]);
     }
   }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/LineageTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/LineageTest.java
@@ -17,6 +17,8 @@
 package co.cask.cdap.metadata;
 
 import co.cask.cdap.AllProgramsApp;
+import co.cask.cdap.common.BadRequestException;
+import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.utils.Tasks;
@@ -35,6 +37,7 @@ import co.cask.cdap.proto.metadata.lineage.LineageRecord;
 import co.cask.cdap.test.SlowTests;
 import co.cask.common.http.HttpResponse;
 import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
@@ -62,9 +65,6 @@ import javax.annotation.Nullable;
 public class LineageTest extends MetadataTestBase {
   private static final Logger LOG = LoggerFactory.getLogger(LineageTest.class);
 
-  private static final Gson GSON = new GsonBuilder()
-    .registerTypeAdapter(Id.NamespacedId.class, new NamespacedIdCodec())
-    .create();
   private static final String STOPPED = "STOPPED";
 
   @Test
@@ -82,34 +82,34 @@ public class LineageTest extends MetadataTestBase {
 
       // Add metadata to applicaton
       ImmutableMap<String, String> appProperties = ImmutableMap.of("app-key1", "app-value1");
-      Assert.assertEquals(200, addProperties(app, appProperties).getResponseCode());
+      addProperties(app, appProperties);
       Assert.assertEquals(appProperties, getProperties(app));
       ImmutableSet<String> appTags = ImmutableSet.of("app-tag1");
-      Assert.assertEquals(200, addTags(app, appTags).getResponseCode());
+      addTags(app, appTags);
       Assert.assertEquals(appTags, getTags(app));
 
       // Add metadata to flow
       ImmutableMap<String, String> flowProperties = ImmutableMap.of("flow-key1", "flow-value1");
-      Assert.assertEquals(200, addProperties(flow, flowProperties).getResponseCode());
+      addProperties(flow, flowProperties);
       Assert.assertEquals(flowProperties, getProperties(flow));
       ImmutableSet<String> flowTags = ImmutableSet.of("flow-tag1", "flow-tag2");
-      Assert.assertEquals(200, addTags(flow, flowTags).getResponseCode());
+      addTags(flow, flowTags);
       Assert.assertEquals(flowTags, getTags(flow));
 
       // Add metadata to dataset
       ImmutableMap<String, String> dataProperties = ImmutableMap.of("data-key1", "data-value1");
-      Assert.assertEquals(200, addProperties(dataset, dataProperties).getResponseCode());
+      addProperties(dataset, dataProperties);
       Assert.assertEquals(dataProperties, getProperties(dataset));
       ImmutableSet<String> dataTags = ImmutableSet.of("data-tag1", "data-tag2");
-      Assert.assertEquals(200, addTags(dataset, dataTags).getResponseCode());
+      addTags(dataset, dataTags);
       Assert.assertEquals(dataTags, getTags(dataset));
 
       // Add metadata to stream
       ImmutableMap<String, String> streamProperties = ImmutableMap.of("stream-key1", "stream-value1");
-      Assert.assertEquals(200, addProperties(stream, streamProperties).getResponseCode());
+      addProperties(stream, streamProperties);
       Assert.assertEquals(streamProperties, getProperties(stream));
       ImmutableSet<String> streamTags = ImmutableSet.of("stream-tag1", "stream-tag2");
-      Assert.assertEquals(200, addTags(stream, streamTags).getResponseCode());
+      addTags(stream, streamTags);
       Assert.assertEquals(streamTags, getTags(stream));
 
       long startTime = TimeMathParser.nowInSeconds();
@@ -120,9 +120,7 @@ public class LineageTest extends MetadataTestBase {
       long stopTime = TimeMathParser.nowInSeconds();
 
       // Fetch dataset lineage
-      HttpResponse httpResponse = fetchLineage(dataset, startTime, stopTime, 10);
-      Assert.assertEquals(200, httpResponse.getResponseCode());
-      LineageRecord lineage = GSON.fromJson(httpResponse.getResponseBodyAsString(), LineageRecord.class);
+      LineageRecord lineage = fetchLineage(dataset, startTime, stopTime, 10);
 
       LineageRecord expected =
         LineageSerializer.toLineageRecord(
@@ -139,22 +137,16 @@ public class LineageTest extends MetadataTestBase {
       Assert.assertEquals(expected, lineage);
 
       // Fetch dataset lineage with time strings
-      httpResponse = fetchLineage(dataset, "now-1h", "now+1h", 10);
-      Assert.assertEquals(200, httpResponse.getResponseCode());
-      lineage = GSON.fromJson(httpResponse.getResponseBodyAsString(), LineageRecord.class);
+      lineage = fetchLineage(dataset, "now-1h", "now+1h", 10);
       Assert.assertEquals(expected.getRelations(), lineage.getRelations());
 
       // Fetch stream lineage
-      httpResponse = fetchLineage(stream, startTime, stopTime, 10);
-      Assert.assertEquals(200, httpResponse.getResponseCode());
-      lineage = GSON.fromJson(httpResponse.getResponseBodyAsString(), LineageRecord.class);
+      lineage = fetchLineage(stream, startTime, stopTime, 10);
       // same as dataset's lineage
       Assert.assertEquals(expected, lineage);
 
       // Fetch stream lineage with time strings
-      httpResponse = fetchLineage(stream, "now-1h", "now+1h", 10);
-      Assert.assertEquals(200, httpResponse.getResponseCode());
-      lineage = GSON.fromJson(httpResponse.getResponseBodyAsString(), LineageRecord.class);
+      lineage = fetchLineage(stream, "now-1h", "now+1h", 10);
       // same as dataset's lineage
       Assert.assertEquals(expected.getRelations(), lineage.getRelations());
 
@@ -171,9 +163,7 @@ public class LineageTest extends MetadataTestBase {
       long laterStartTime = stopTime + 1000;
       long laterEndTime = stopTime + 5000;
       // Fetch stream lineage
-      httpResponse = fetchLineage(stream, laterStartTime, laterEndTime, 10);
-      Assert.assertEquals(200, httpResponse.getResponseCode());
-      lineage = GSON.fromJson(httpResponse.getResponseBodyAsString(), LineageRecord.class);
+      lineage = fetchLineage(stream, laterStartTime, laterEndTime, 10);
 
       Assert.assertEquals(
         LineageSerializer.toLineageRecord(laterStartTime, laterEndTime, new Lineage(ImmutableSet.<Relation>of())),
@@ -183,23 +173,18 @@ public class LineageTest extends MetadataTestBase {
       long earlierStartTime = startTime - 5000;
       long earlierEndTime = startTime - 1000;
       // Fetch stream lineage
-      httpResponse = fetchLineage(stream, earlierStartTime, earlierEndTime, 10);
-      Assert.assertEquals(200, httpResponse.getResponseCode());
-      lineage = GSON.fromJson(httpResponse.getResponseBodyAsString(), LineageRecord.class);
+      lineage = fetchLineage(stream, earlierStartTime, earlierEndTime, 10);
 
       Assert.assertEquals(
         LineageSerializer.toLineageRecord(earlierStartTime, earlierEndTime, new Lineage(ImmutableSet.<Relation>of())),
         lineage);
 
       // Test bad time ranges
-      httpResponse = fetchLineage(dataset, "sometime", "sometime", 10);
-      Assert.assertEquals(400, httpResponse.getResponseCode());
-      httpResponse = fetchLineage(dataset, "now+1h", "now-1h", 10);
-      Assert.assertEquals(400, httpResponse.getResponseCode());
+      fetchLineage(dataset, "sometime", "sometime", 10, BadRequestException.class);
+      fetchLineage(dataset, "now+1h", "now-1h", 10, BadRequestException.class);
 
       // Test non-existent run
-      httpResponse = fetchRunMetadataResponse(new Id.Run(flow, RunIds.generate(1000).getId()));
-      Assert.assertEquals(404, httpResponse.getResponseCode());
+      assertRunMetadataNotFound(new Id.Run(flow, RunIds.generate(1000).getId()));
     } finally {
       try {
         deleteNamespace(namespace);
@@ -263,9 +248,7 @@ public class LineageTest extends MetadataTestBase {
       long oneHour = TimeUnit.HOURS.toSeconds(1);
 
       // Fetch dataset lineage
-      HttpResponse httpResponse = fetchLineage(dataset, now - oneHour, now + oneHour, 10);
-      Assert.assertEquals(200, httpResponse.getResponseCode());
-      LineageRecord lineage = GSON.fromJson(httpResponse.getResponseBodyAsString(), LineageRecord.class);
+      LineageRecord lineage = fetchLineage(dataset, now - oneHour, now + oneHour, 10);
 
       // dataset is accessed by all programs
       LineageRecord expected =
@@ -293,9 +276,7 @@ public class LineageTest extends MetadataTestBase {
       Assert.assertEquals(expected, lineage);
 
       // Fetch stream lineage
-      httpResponse = fetchLineage(stream, now - oneHour, now + oneHour, 10);
-      Assert.assertEquals(200, httpResponse.getResponseCode());
-      lineage = GSON.fromJson(httpResponse.getResponseBodyAsString(), LineageRecord.class);
+      lineage = fetchLineage(stream, now - oneHour, now + oneHour, 10);
 
       // stream too is accessed by all programs
       Assert.assertEquals(expected, lineage);
@@ -341,24 +322,25 @@ public class LineageTest extends MetadataTestBase {
     Id.DatasetInstance dataset = Id.DatasetInstance.from(namespace, AllProgramsApp.DATASET_NAME);
     Id.Stream stream = Id.Stream.from(namespace, AllProgramsApp.STREAM_NAME);
 
-    HttpResponse httpResponse = fetchLineage(dataset, 0, 10000, 10);
-    Assert.assertEquals(404, httpResponse.getResponseCode());
+    fetchLineage(dataset, 0, 10000, 10, NotFoundException.class);
 
-    httpResponse = fetchLineage(stream, 0, 10000, 10);
-    Assert.assertEquals(404, httpResponse.getResponseCode());
+    try {
+      fetchLineage(stream, 0, 10000, 10);
+      Assert.fail("Expected not to be able to fetch lineage for nonexistent stream: " + stream);
+    } catch (NotFoundException expected) {
+    }
 
-    httpResponse = fetchRunMetadataResponse(new Id.Run(flow, RunIds.generate(1000).getId()));
-    Assert.assertEquals(404, httpResponse.getResponseCode());
+    assertRunMetadataNotFound(new Id.Run(flow, RunIds.generate(1000).getId()));
   }
 
   @Test
   public void testLineageForNonExistingEntity() throws Exception {
     Id.DatasetInstance datasetInstance = Id.DatasetInstance.from("default", "dummy");
-    Assert.assertEquals(404, fetchLineage(datasetInstance, 100, 200, 10).getResponseCode());
-    Assert.assertEquals(400, fetchLineage(datasetInstance, -100, 200, 10).getResponseCode());
-    Assert.assertEquals(400, fetchLineage(datasetInstance, 100, -200, 10).getResponseCode());
-    Assert.assertEquals(400, fetchLineage(datasetInstance, 200, 100, 10).getResponseCode());
-    Assert.assertEquals(400, fetchLineage(datasetInstance, 100, 200, -10).getResponseCode());
+    fetchLineage(datasetInstance, 100, 200, 10, NotFoundException.class);
+    fetchLineage(datasetInstance, -100, 200, 10, BadRequestException.class);
+    fetchLineage(datasetInstance, 100, -200, 10, BadRequestException.class);
+    fetchLineage(datasetInstance, 200, 100, 10, BadRequestException.class);
+    fetchLineage(datasetInstance, 100, 200, -10, BadRequestException.class);
   }
 
   private RunId runAndWait(Id.Program program) throws Exception {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataHttpHandlerTest.java
@@ -19,12 +19,16 @@ package co.cask.cdap.metadata;
 import co.cask.cdap.AppWithDataset;
 import co.cask.cdap.WordCountApp;
 import co.cask.cdap.WordCountMinusFlowApp;
+import co.cask.cdap.common.BadRequestException;
+import co.cask.cdap.common.NotFoundException;
+import co.cask.cdap.common.UnauthorizedException;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.metadata.MetadataRecord;
 import co.cask.cdap.proto.metadata.MetadataScope;
 import co.cask.cdap.proto.metadata.MetadataSearchResultRecord;
+import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
 import co.cask.common.http.HttpResponse;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -63,21 +67,23 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
   }
 
   @Test
-  public void testProperties() throws IOException {
+  public void testProperties() throws Exception {
     // should fail because we haven't provided any metadata in the request
-    Assert.assertEquals(400, addProperties(application).getResponseCode());
+    addProperties(application, null, BadRequestException.class);
     Map<String, String> appProperties = ImmutableMap.of("aKey", "aValue", "aK", "aV");
-    Assert.assertEquals(200, addProperties(application, appProperties).getResponseCode());
+    addProperties(application, appProperties);
     // should fail because we haven't provided any metadata in the request
-    Assert.assertEquals(400, addProperties(pingService).getResponseCode());
+    addProperties(pingService, null, BadRequestException.class);
     Map<String, String> serviceProperties = ImmutableMap.of("sKey", "sValue", "sK", "sV");
-    Assert.assertEquals(200, addProperties(pingService, serviceProperties).getResponseCode());
-    Assert.assertEquals(400, addProperties(myds).getResponseCode());
+    addProperties(pingService, serviceProperties);
+    // should fail because we haven't provided any metadata in the request
+    addProperties(myds, null, BadRequestException.class);
     Map<String, String> datasetProperties = ImmutableMap.of("dKey", "dValue", "dK", "dV");
-    Assert.assertEquals(200, addProperties(myds, datasetProperties).getResponseCode());
-    Assert.assertEquals(400, addProperties(mystream).getResponseCode());
+    addProperties(myds, datasetProperties);
+    // should fail because we haven't provided any metadata in the request
+    addProperties(mystream, null, BadRequestException.class);
     Map<String, String> streamProperties = ImmutableMap.of("stKey", "stValue", "stK", "stV");
-    Assert.assertEquals(200, addProperties(mystream, streamProperties).getResponseCode());
+    addProperties(mystream, streamProperties);
     // retrieve properties and verify
     Map<String, String> properties = getProperties(application);
     Assert.assertEquals(appProperties, properties);
@@ -89,37 +95,37 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     Assert.assertEquals(streamProperties, properties);
 
     // test search for stream
-    Set<MetadataSearchResultRecord> searchProperties = searchMetadata(Id.Namespace.DEFAULT.getId(),
-                                                                      "stKey:stValue", "STREAM");
+    Set<MetadataSearchResultRecord> searchProperties = searchMetadata(Id.Namespace.DEFAULT,
+                                                                      "stKey:stValue", MetadataSearchTargetType.STREAM);
     Set<MetadataSearchResultRecord> expected = ImmutableSet.of(
       new MetadataSearchResultRecord(mystream)
     );
     Assert.assertEquals(expected, searchProperties);
 
     // test prefix search for service
-    searchProperties = searchMetadata(Id.Namespace.DEFAULT.getId(), "sKey:s*", "ALL");
+    searchProperties = searchMetadata(Id.Namespace.DEFAULT, "sKey:s*", MetadataSearchTargetType.ALL);
     expected = ImmutableSet.of(
       new MetadataSearchResultRecord(pingService)
     );
     Assert.assertEquals(expected, searchProperties);
 
     // search without any target param
-    searchProperties = searchMetadata(Id.Namespace.DEFAULT.getId(), "sKey:s*", null);
+    searchProperties = searchMetadata(Id.Namespace.DEFAULT, "sKey:s*", null);
     Assert.assertEquals(expected, searchProperties);
 
     // Should get empty
-    searchProperties = searchMetadata(Id.Namespace.DEFAULT.getId(), "sKey:s", null);
+    searchProperties = searchMetadata(Id.Namespace.DEFAULT, "sKey:s", null);
     Assert.assertTrue(searchProperties.size() == 0);
 
-    searchProperties = searchMetadata(Id.Namespace.DEFAULT.getId(), "s", null);
+    searchProperties = searchMetadata(Id.Namespace.DEFAULT, "s", null);
     Assert.assertTrue(searchProperties.size() == 0);
 
     // search non-existent property should return empty set
-    searchProperties = searchMetadata(Id.Namespace.DEFAULT.getId(), "NullKey:s*", null);
+    searchProperties = searchMetadata(Id.Namespace.DEFAULT, "NullKey:s*", null);
     Assert.assertEquals(ImmutableSet.<MetadataSearchResultRecord>of(), searchProperties);
 
     // search invalid ns should return empty set
-    searchProperties = searchMetadata("invalidnamespace", "sKey:s*", null);
+    searchProperties = searchMetadata(Id.Namespace.from("invalidnamespace"), "sKey:s*", null);
     Assert.assertEquals(ImmutableSet.of(), searchProperties);
 
     // test removal
@@ -143,28 +149,28 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     Assert.assertTrue(getProperties(mystream).isEmpty());
 
     // non-existing namespace
-    Assert.assertEquals(404, addProperties(nonExistingApp, appProperties).getResponseCode());
-    Assert.assertEquals(404, addProperties(nonExistingService, serviceProperties).getResponseCode());
-    Assert.assertEquals(404, addProperties(nonExistingDataset, datasetProperties).getResponseCode());
-    Assert.assertEquals(404, addProperties(nonExistingStream, streamProperties).getResponseCode());
+    addProperties(nonExistingApp, appProperties, NotFoundException.class);
+    addProperties(nonExistingService, serviceProperties, NotFoundException.class);
+    addProperties(nonExistingDataset, datasetProperties, NotFoundException.class);
+    addProperties(nonExistingStream, streamProperties, NotFoundException.class);
   }
 
   @Test
-  public void testTags() throws IOException {
+  public void testTags() throws Exception {
     // should fail because we haven't provided any metadata in the request
-    Assert.assertEquals(400, addTags(application).getResponseCode());
+    addTags(application, null, BadRequestException.class);
     Set<String> appTags = ImmutableSet.of("aTag", "aT");
-    Assert.assertEquals(200, addTags(application, appTags).getResponseCode());
+    addTags(application, appTags);
     // should fail because we haven't provided any metadata in the request
-    Assert.assertEquals(400, addTags(pingService).getResponseCode());
+    addTags(pingService, null, BadRequestException.class);
     Set<String> serviceTags = ImmutableSet.of("sTag", "sT");
-    Assert.assertEquals(200, addTags(pingService, serviceTags).getResponseCode());
-    Assert.assertEquals(400, addTags(myds).getResponseCode());
+    addTags(pingService, serviceTags);
+    addTags(myds, null, BadRequestException.class);
     Set<String> datasetTags = ImmutableSet.of("dTag", "dT");
-    Assert.assertEquals(200, addTags(myds, datasetTags).getResponseCode());
-    Assert.assertEquals(400, addTags(mystream).getResponseCode());
+    addTags(myds, datasetTags);
+    addTags(mystream, null, BadRequestException.class);
     Set<String> streamTags = ImmutableSet.of("stTag", "stT");
-    Assert.assertEquals(200, addTags(mystream, streamTags).getResponseCode());
+    addTags(mystream, streamTags);
     // retrieve tags and verify
     Set<String> tags = getTags(application);
     Assert.assertTrue(tags.containsAll(appTags));
@@ -179,13 +185,14 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     Assert.assertTrue(tags.containsAll(streamTags));
     Assert.assertTrue(streamTags.containsAll(tags));
     // test search for stream
-    Set<MetadataSearchResultRecord> searchTags = searchMetadata(Id.Namespace.DEFAULT.getId(), "stT*", "STREAM");
+    Set<MetadataSearchResultRecord> searchTags =
+      searchMetadata(Id.Namespace.DEFAULT, "stT*", MetadataSearchTargetType.STREAM);
     Set<MetadataSearchResultRecord> expected = ImmutableSet.of(
       new MetadataSearchResultRecord(mystream)
     );
     Assert.assertEquals(expected, searchTags);
     // test prefix search, should match stream and service programs
-    searchTags = searchMetadata(Id.Namespace.DEFAULT.getId(), "s*", "ALL");
+    searchTags = searchMetadata(Id.Namespace.DEFAULT, "s*", MetadataSearchTargetType.ALL);
     expected = ImmutableSet.of(
       new MetadataSearchResultRecord(mystream),
       new MetadataSearchResultRecord(pingService)
@@ -193,11 +200,11 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     Assert.assertEquals(expected, searchTags);
 
     // search without any target param
-    searchTags = searchMetadata(Id.Namespace.DEFAULT.getId(), "s*", null);
+    searchTags = searchMetadata(Id.Namespace.DEFAULT, "s*", null);
     Assert.assertEquals(expected, searchTags);
 
     // search non-existent tags should return empty set
-    searchTags = searchMetadata(Id.Namespace.DEFAULT.getId(), "NullKey", null);
+    searchTags = searchMetadata(Id.Namespace.DEFAULT, "NullKey", null);
     Assert.assertEquals(ImmutableSet.<MetadataSearchResultRecord>of(), searchTags);
 
     // test removal
@@ -222,14 +229,14 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     Assert.assertTrue(getTags(myds).isEmpty());
     Assert.assertTrue(getTags(mystream).isEmpty());
     // non-existing namespace
-    Assert.assertEquals(404, addTags(nonExistingApp, appTags).getResponseCode());
-    Assert.assertEquals(404, addTags(nonExistingService, serviceTags).getResponseCode());
-    Assert.assertEquals(404, addTags(nonExistingDataset, datasetTags).getResponseCode());
-    Assert.assertEquals(404, addTags(nonExistingStream, streamTags).getResponseCode());
+    addTags(nonExistingApp, appTags, NotFoundException.class);
+    addTags(nonExistingService, serviceTags, NotFoundException.class);
+    addTags(nonExistingDataset, datasetTags, NotFoundException.class);
+    addTags(nonExistingStream, streamTags, NotFoundException.class);
   }
 
   @Test
-  public void testMetadata() throws IOException {
+  public void testMetadata() throws Exception {
     assertCleanState();
     // Remove when nothing exists
     removeAllMetadata();
@@ -243,14 +250,14 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     Set<String> serviceTags = ImmutableSet.of("sTag");
     Set<String> datasetTags = ImmutableSet.of("dTag");
     Set<String> streamTags = ImmutableSet.of("stTag");
-    Assert.assertEquals(200, addProperties(application, appProperties).getResponseCode());
-    Assert.assertEquals(200, addProperties(pingService, serviceProperties).getResponseCode());
-    Assert.assertEquals(200, addProperties(myds, datasetProperties).getResponseCode());
-    Assert.assertEquals(200, addProperties(mystream, streamProperties).getResponseCode());
-    Assert.assertEquals(200, addTags(application, appTags).getResponseCode());
-    Assert.assertEquals(200, addTags(pingService, serviceTags).getResponseCode());
-    Assert.assertEquals(200, addTags(myds, datasetTags).getResponseCode());
-    Assert.assertEquals(200, addTags(mystream, streamTags).getResponseCode());
+    addProperties(application, appProperties);
+    addProperties(pingService, serviceProperties);
+    addProperties(myds, datasetProperties);
+    addProperties(mystream, streamProperties);
+    addTags(application, appTags);
+    addTags(pingService, serviceTags);
+    addTags(myds, datasetTags);
+    addTags(mystream, streamTags);
     // verify app
     Set<MetadataRecord> metadataRecords = getMetadata(application);
     Assert.assertEquals(1, metadataRecords.size());
@@ -322,10 +329,10 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     Id.Application nonExistingApp = Id.Application.from(Id.Namespace.DEFAULT, "NonExistingStream");
 
     Map<String, String> properties = ImmutableMap.of("aKey", "aValue", "aK", "aV");
-    Assert.assertEquals(404, addProperties(nonExistingApp, properties).getResponseCode());
-    Assert.assertEquals(404, addProperties(nonExistingProgram, properties).getResponseCode());
-    Assert.assertEquals(404, addProperties(nonExistingDataset, properties).getResponseCode());
-    Assert.assertEquals(404, addProperties(nonExistingStream, properties).getResponseCode());
+    addProperties(nonExistingApp, properties, NotFoundException.class);
+    addProperties(nonExistingProgram, properties, NotFoundException.class);
+    addProperties(nonExistingDataset, properties, NotFoundException.class);
+    addProperties(nonExistingStream, properties, NotFoundException.class);
   }
 
   @Test
@@ -336,27 +343,27 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
       builder.append("a");
     }
     Map<String, String> properties = ImmutableMap.of("aKey", builder.toString());
-    Assert.assertEquals(400, addProperties(application, properties).getResponseCode());
+    addProperties(application, properties, BadRequestException.class);
     properties = ImmutableMap.of(builder.toString(), "aValue");
-    Assert.assertEquals(400, addProperties(application, properties).getResponseCode());
+    addProperties(application, properties, BadRequestException.class);
 
     // Try to add tag as property
     properties = ImmutableMap.of("tags", "aValue");
-    Assert.assertEquals(400, addProperties(application, properties).getResponseCode());
+    addProperties(application, properties, BadRequestException.class);
 
     // Invalid chars
     properties = ImmutableMap.of("aKey$", "aValue");
-    Assert.assertEquals(400, addProperties(application, properties).getResponseCode());
+    addProperties(application, properties, BadRequestException.class);
 
     properties = ImmutableMap.of("aKey", "aValue$");
-    Assert.assertEquals(400, addProperties(application, properties).getResponseCode());
+    addProperties(application, properties, BadRequestException.class);
   }
 
   @Test
   public void testInvalidTags() throws IOException {
     // Invalid chars
     Set<String> tags = ImmutableSet.of("aTag$");
-    Assert.assertEquals(400, addTags(application, tags).getResponseCode());
+    addTags(application, tags, BadRequestException.class);
 
     // Test length
     StringBuilder builder = new StringBuilder(100);
@@ -364,7 +371,7 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
       builder.append("a");
     }
     tags = ImmutableSet.of(builder.toString());
-    Assert.assertEquals(400, addTags(application, tags).getResponseCode());
+    addTags(application, tags, BadRequestException.class);
   }
 
   @Test
@@ -391,14 +398,14 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     deleteApp(wordCountApp, 200);
   }
 
-  private void removeAllMetadata() throws IOException {
+  private void removeAllMetadata() throws Exception {
     removeMetadata(application);
     removeMetadata(pingService);
     removeMetadata(myds);
     removeMetadata(mystream);
   }
 
-  private void assertCleanState() throws IOException {
+  private void assertCleanState() throws Exception {
     // Assert clean state
     Set<MetadataRecord> appMetadatas = getMetadata(application);
     // only user metadata right now.
@@ -424,37 +431,5 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     MetadataRecord streamMetadata = streamMetadatas.iterator().next();
     Assert.assertTrue(streamMetadata.getProperties().isEmpty());
     Assert.assertTrue(streamMetadata.getTags().isEmpty());
-  }
-
-  private HttpResponse addProperties(Id.Application app) throws IOException {
-    return addProperties(app, null);
-  }
-
-  private HttpResponse addProperties(Id.Program program) throws IOException {
-    return addProperties(program, null);
-  }
-
-  private HttpResponse addProperties(Id.DatasetInstance dataset) throws IOException {
-    return addProperties(dataset, null);
-  }
-
-  private HttpResponse addProperties(Id.Stream stream) throws IOException {
-    return addProperties(stream, null);
-  }
-
-  private HttpResponse addTags(Id.Application app) throws IOException {
-    return addTags(app, null);
-  }
-
-  private HttpResponse addTags(Id.Program program) throws IOException {
-    return addTags(program, null);
-  }
-
-  private HttpResponse addTags(Id.DatasetInstance dataset) throws IOException {
-    return addTags(dataset, null);
-  }
-
-  private HttpResponse addTags(Id.Stream stream) throws IOException {
-    return addTags(stream, null);
   }
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataHttpHandlerTest.java
@@ -21,7 +21,6 @@ import co.cask.cdap.WordCountApp;
 import co.cask.cdap.WordCountMinusFlowApp;
 import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.common.NotFoundException;
-import co.cask.cdap.common.UnauthorizedException;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramType;
@@ -29,7 +28,6 @@ import co.cask.cdap.proto.metadata.MetadataRecord;
 import co.cask.cdap.proto.metadata.MetadataScope;
 import co.cask.cdap.proto.metadata.MetadataSearchResultRecord;
 import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
-import co.cask.common.http.HttpResponse;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.junit.After;
@@ -131,12 +129,12 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     // test removal
     removeProperties(application);
     Assert.assertTrue(getProperties(application).isEmpty());
-    removeProperties(pingService, "sKey");
-    removeProperties(pingService, "sK");
+    removeProperty(pingService, "sKey");
+    removeProperty(pingService, "sK");
     Assert.assertTrue(getProperties(pingService).isEmpty());
-    removeProperties(myds, "dKey");
+    removeProperty(myds, "dKey");
     Assert.assertEquals(ImmutableMap.of("dK", "dV"), getProperties(myds));
-    removeProperties(mystream, "stK");
+    removeProperty(mystream, "stK");
     Assert.assertEquals(ImmutableMap.of("stKey", "stValue"), getProperties(mystream));
     // cleanup
     removeProperties(application);
@@ -208,16 +206,16 @@ public class MetadataHttpHandlerTest extends MetadataTestBase {
     Assert.assertEquals(ImmutableSet.<MetadataSearchResultRecord>of(), searchTags);
 
     // test removal
-    removeTags(application, "aTag");
+    removeTag(application, "aTag");
     Assert.assertEquals(ImmutableSet.of("aT"), getTags(application));
     removeTags(pingService);
     Assert.assertTrue(getTags(pingService).isEmpty());
     removeTags(pingService);
     Assert.assertTrue(getTags(pingService).isEmpty());
-    removeTags(myds, "dT");
+    removeTag(myds, "dT");
     Assert.assertEquals(ImmutableSet.of("dTag"), getTags(myds));
-    removeTags(mystream, "stT");
-    removeTags(mystream, "stTag");
+    removeTag(mystream, "stT");
+    removeTag(mystream, "stTag");
     Assert.assertTrue(getTags(mystream).isEmpty());
     // cleanup
     removeTags(application);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataTestBase.java
@@ -210,35 +210,35 @@ public abstract class MetadataTestBase extends AppFabricTestBase {
   }
 
   protected void removeProperties(Id.Application app) throws Exception {
-    removeProperties(app, null);
+    metadataClient.removeProperties(app);
   }
 
-  private void removeProperties(Id.Application app, @Nullable String propertyToRemove) throws Exception {
-    metadataClient.removeProperties(app, propertyToRemove);
+  private void removeProperty(Id.Application app, String propertyToRemove) throws Exception {
+    metadataClient.removeProperty(app, propertyToRemove);
   }
 
   protected void removeProperties(Id.Program program) throws Exception {
-    removeProperties(program, null);
+    metadataClient.removeProperties(program);
   }
 
-  protected void removeProperties(Id.Program program, @Nullable String propertyToRemove) throws Exception {
-    metadataClient.removeProperties(program, propertyToRemove);
+  protected void removeProperty(Id.Program program, String propertyToRemove) throws Exception {
+    metadataClient.removeProperty(program, propertyToRemove);
   }
 
   protected void removeProperties(Id.DatasetInstance dataset) throws Exception {
-    removeProperties(dataset, null);
+    metadataClient.removeProperties(dataset);
   }
 
-  protected void removeProperties(Id.DatasetInstance dataset, @Nullable String propertyToRemove) throws Exception {
-    metadataClient.removeProperties(dataset, propertyToRemove);
+  protected void removeProperty(Id.DatasetInstance dataset, String propertyToRemove) throws Exception {
+    metadataClient.removeProperty(dataset, propertyToRemove);
   }
 
   protected void removeProperties(Id.Stream stream) throws Exception {
-    removeProperties(stream, null);
+    metadataClient.removeProperties(stream);
   }
 
-  protected void removeProperties(Id.Stream stream, @Nullable String propertyToRemove) throws Exception {
-    metadataClient.removeProperties(stream, propertyToRemove);
+  protected void removeProperty(Id.Stream stream, String propertyToRemove) throws Exception {
+    metadataClient.removeProperty(stream, propertyToRemove);
   }
 
   protected void addTags(Id.Application app, @Nullable Set<String> tags) throws Exception {
@@ -325,35 +325,35 @@ public abstract class MetadataTestBase extends AppFabricTestBase {
   }
 
   protected void removeTags(Id.Application app) throws Exception {
-    removeTags(app, null);
+    metadataClient.removeTags(app);
   }
 
-  protected void removeTags(Id.Application app, @Nullable String tagToRemove) throws Exception {
-    metadataClient.removeTags(app, tagToRemove);
+  protected void removeTag(Id.Application app, String tagToRemove) throws Exception {
+    metadataClient.removeTag(app, tagToRemove);
   }
 
   protected void removeTags(Id.Program program) throws Exception {
-    removeTags(program, null);
+    metadataClient.removeTags(program);
   }
 
-  private void removeTags(Id.Program program, @Nullable String tagToRemove) throws Exception {
-    metadataClient.removeTags(program, tagToRemove);
+  private void removeTag(Id.Program program, String tagToRemove) throws Exception {
+    metadataClient.removeTag(program, tagToRemove);
   }
 
   protected void removeTags(Id.DatasetInstance dataset) throws Exception {
-    removeTags(dataset, null);
+    metadataClient.removeTags(dataset);
   }
 
-  protected void removeTags(Id.DatasetInstance dataset, @Nullable String tagToRemove) throws Exception {
-    metadataClient.removeTags(dataset, tagToRemove);
+  protected void removeTag(Id.DatasetInstance dataset, String tagToRemove) throws Exception {
+    metadataClient.removeTag(dataset, tagToRemove);
   }
 
   protected void removeTags(Id.Stream stream) throws Exception {
-    removeTags(stream, null);
+    metadataClient.removeTags(stream);
   }
 
-  protected void removeTags(Id.Stream stream, @Nullable String tagToRemove) throws Exception {
-    metadataClient.removeTags(stream, tagToRemove);
+  protected void removeTag(Id.Stream stream, String tagToRemove) throws Exception {
+    metadataClient.removeTag(stream, tagToRemove);
   }
 
   // expect an exception during fetching of lineage

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataTestBase.java
@@ -16,20 +16,21 @@
 
 package co.cask.cdap.metadata;
 
+import co.cask.cdap.client.LineageClient;
+import co.cask.cdap.client.MetadataClient;
+import co.cask.cdap.client.config.ClientConfig;
+import co.cask.cdap.client.config.ConnectionConfig;
+import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.discovery.EndpointStrategy;
 import co.cask.cdap.common.discovery.RandomEndpointStrategy;
 import co.cask.cdap.internal.app.services.http.AppFabricTestBase;
 import co.cask.cdap.proto.Id;
-import co.cask.cdap.proto.codec.NamespacedIdCodec;
 import co.cask.cdap.proto.metadata.MetadataRecord;
 import co.cask.cdap.proto.metadata.MetadataSearchResultRecord;
-import co.cask.common.http.HttpRequest;
-import co.cask.common.http.HttpRequests;
-import co.cask.common.http.HttpResponse;
-import com.google.common.reflect.TypeToken;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
+import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
+import co.cask.cdap.proto.metadata.lineage.LineageRecord;
+import com.google.common.collect.Iterators;
 import org.apache.twill.discovery.Discoverable;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.apache.twill.discovery.ServiceDiscovered;
@@ -37,12 +38,10 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 
 import java.io.IOException;
-import java.lang.reflect.Type;
 import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.URLEncoder;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
@@ -50,14 +49,8 @@ import javax.annotation.Nullable;
  * Base class for metadata tests.
  */
 public abstract class MetadataTestBase extends AppFabricTestBase {
-  private static final Gson GSON = new GsonBuilder()
-    .registerTypeAdapter(Id.NamespacedId.class, new NamespacedIdCodec())
-    .create();
-  private static final Type SET_STRING_TYPE = new TypeToken<Set<String>>() { }.getType();
-  private static final Type SET_METADATA_SEARCH_RESULT_TYPE =
-    new TypeToken<Set<MetadataSearchResultRecord>>() { }.getType();
-  private static final Type SET_METADATA_RECORD_TYPE = new TypeToken<Set<MetadataRecord>>() { }.getType();
-  private static String metadataServiceUrl;
+  private static MetadataClient metadataClient;
+  private static LineageClient lineageClient;
 
   @BeforeClass
   public static void setup() throws MalformedURLException {
@@ -66,441 +59,358 @@ public abstract class MetadataTestBase extends AppFabricTestBase {
     EndpointStrategy endpointStrategy = new RandomEndpointStrategy(metadataHttpDiscovered);
     Discoverable discoverable = endpointStrategy.pick(1, TimeUnit.SECONDS);
     Assert.assertNotNull(discoverable);
+    String host = "127.0.0.1";
     int port = discoverable.getSocketAddress().getPort();
-    metadataServiceUrl = String.format("http://127.0.0.1:%d", port);
+    ConnectionConfig connectionConfig = ConnectionConfig.builder().setHostname(host).setPort(port).build();
+    ClientConfig config = ClientConfig.builder().setConnectionConfig(connectionConfig).build();
+    metadataClient = new MetadataClient(config);
+    lineageClient = new LineageClient(config);
   }
 
-  protected HttpResponse addProperties(Id.Application app, @Nullable Map<String, String> properties)
-    throws IOException {
-    String path = getVersionedAPIPath(String.format("apps/%s/metadata/properties", app.getId()), app.getNamespaceId());
-    if (properties == null) {
-      return makePostRequest(path);
+  protected void addProperties(Id.Application app, @Nullable Map<String, String> properties) throws Exception {
+    metadataClient.addProperties(app, properties);
+  }
+
+  protected void addProperties(final Id.Application app, @Nullable final Map<String, String> properties,
+                               Class<? extends Exception> expectedExceptionClass) throws IOException {
+    expectException(new Callable<Void>() {
+      @Override
+      public Void call() throws Exception {
+        addProperties(app, properties);
+        return null;
+      }
+    }, expectedExceptionClass);
+  }
+
+  protected void addProperties(Id.Program program, @Nullable Map<String, String> properties) throws Exception {
+    metadataClient.addProperties(program, properties);
+  }
+
+  protected void addProperties(final Id.Program program, @Nullable final Map<String, String> properties,
+                               Class<? extends Exception> expectedExceptionClass) throws IOException {
+    expectException(new Callable<Void>() {
+      @Override
+      public Void call() throws Exception {
+        addProperties(program, properties);
+        return null;
+      }
+    }, expectedExceptionClass);
+  }
+
+  protected void addProperties(Id.DatasetInstance dataset, @Nullable Map<String, String> properties) throws Exception {
+    metadataClient.addProperties(dataset, properties);
+  }
+
+  protected void addProperties(final Id.DatasetInstance dataset, @Nullable final Map<String, String> properties,
+                               Class<? extends Exception> expectedExceptionClass) throws IOException {
+    expectException(new Callable<Void>() {
+      @Override
+      public Void call() throws Exception {
+        addProperties(dataset, properties);
+        return null;
+      }
+    }, expectedExceptionClass);
+  }
+
+  protected void addProperties(Id.Stream stream, @Nullable Map<String, String> properties)
+    throws Exception {
+    metadataClient.addProperties(stream, properties);
+  }
+
+  protected void addProperties(final Id.Stream stream, @Nullable final Map<String, String> properties,
+                               Class<? extends Exception> expectedExceptionClass) throws IOException {
+    expectException(new Callable<Void>() {
+      @Override
+      public Void call() throws Exception {
+        addProperties(stream, properties);
+        return null;
+      }
+    }, expectedExceptionClass);
+  }
+
+  protected Set<MetadataRecord> getMetadata(Id.Application app) throws Exception {
+    return metadataClient.getMetadata(app);
+  }
+
+  protected Set<MetadataRecord> getMetadata(Id.Program program) throws Exception {
+    return metadataClient.getMetadata(program);
+  }
+
+  protected Set<MetadataRecord> getMetadata(Id.DatasetInstance dataset) throws Exception {
+    return metadataClient.getMetadata(dataset);
+  }
+
+  protected Set<MetadataRecord> getMetadata(Id.Stream stream) throws Exception {
+    return metadataClient.getMetadata(stream);
+  }
+
+  // Currently, getMetadata(entity) returns a single-element set, so we can get the properties from there
+  protected Map<String, String> getProperties(Id.Application app) throws Exception {
+    return Iterators.getOnlyElement(getMetadata(app).iterator()).getProperties();
+  }
+
+  protected Map<String, String> getProperties(Id.Program program) throws Exception {
+    return Iterators.getOnlyElement(getMetadata(program).iterator()).getProperties();
+  }
+
+  protected Map<String, String> getProperties(Id.DatasetInstance dataset) throws Exception {
+    return Iterators.getOnlyElement(getMetadata(dataset).iterator()).getProperties();
+  }
+
+  protected Map<String, String> getProperties(Id.Stream stream) throws Exception {
+    return Iterators.getOnlyElement(getMetadata(stream).iterator()).getProperties();
+  }
+
+  protected void getPropertiesFromInvalidEntity(Id.Application app) throws Exception {
+    try {
+      getProperties(app);
+      Assert.fail("Expected not to be able to get properties from invalid entity: " + app);
+    } catch (NotFoundException expected) {
     }
-    return makePostRequest(path, GSON.toJson(properties));
   }
 
-  protected HttpResponse addProperties(Id.Program program, @Nullable Map<String, String> properties)
-    throws IOException {
-    String path = getVersionedAPIPath(String.format("apps/%s/%s/%s/metadata/properties", program.getApplicationId(),
-                                                    program.getType().getCategoryName(), program.getId()),
-                                      program.getNamespaceId());
-    if (properties == null) {
-      return makePostRequest(path);
+  protected void getPropertiesFromInvalidEntity(Id.Program program) throws Exception {
+    try {
+      getProperties(program);
+      Assert.fail("Expected not to be able to get properties from invalid entity: " + program);
+    } catch (NotFoundException expected) {
     }
-    return makePostRequest(path, GSON.toJson(properties));
   }
 
-  protected HttpResponse addProperties(Id.DatasetInstance dataset,
-                                       @Nullable Map<String, String> properties) throws IOException {
-    String path = getVersionedAPIPath(String.format("datasets/%s/metadata/properties",
-                                                    dataset.getId()), dataset.getNamespaceId());
-    if (properties == null) {
-      return makePostRequest(path);
+  protected void getPropertiesFromInvalidEntity(Id.DatasetInstance dataset) throws Exception {
+    try {
+      getProperties(dataset);
+      Assert.fail("Expected not to be able to get properties from invalid entity: " + dataset);
+    } catch (NotFoundException expected) {
     }
-    return makePostRequest(path, GSON.toJson(properties));
   }
 
-  protected HttpResponse addProperties(Id.Stream stream, @Nullable Map<String, String> properties) throws IOException {
-    String path = getVersionedAPIPath(String.format("streams/%s/metadata/properties",
-                                                    stream.getId()), stream.getNamespaceId());
-    if (properties == null) {
-      return makePostRequest(path);
+  protected void getPropertiesFromInvalidEntity(Id.Stream stream) throws Exception {
+    try {
+      getProperties(stream);
+      Assert.fail("Expected not to be able to get properties from invalid entity: " + stream);
+    } catch (NotFoundException expected) {
     }
-    return makePostRequest(path, GSON.toJson(properties));
   }
 
-  protected Set<MetadataRecord> getMetadata(Id.Application app) throws IOException {
-    String path = getVersionedAPIPath(String.format("apps/%s/metadata", app.getId()), app.getNamespaceId());
-    HttpResponse response = makeGetRequest(path);
-    Assert.assertEquals(200, response.getResponseCode());
-    return GSON.fromJson(response.getResponseBodyAsString(), SET_METADATA_RECORD_TYPE);
+  protected void removeMetadata(Id.Application app) throws Exception {
+    metadataClient.removeMetadata(app);
   }
 
-  protected Set<MetadataRecord> getMetadata(Id.Program program) throws IOException {
-    String path = getVersionedAPIPath(String.format("apps/%s/%s/%s/metadata", program.getApplicationId(),
-                                                    program.getType().getCategoryName(), program.getId()),
-                                      program.getNamespaceId());
-    HttpResponse response = makeGetRequest(path);
-    Assert.assertEquals(200, response.getResponseCode());
-    return GSON.fromJson(response.getResponseBodyAsString(), SET_METADATA_RECORD_TYPE);
+  protected void removeMetadata(Id.Program program) throws Exception {
+    metadataClient.removeMetadata(program);
   }
 
-  protected Set<MetadataRecord> getMetadata(Id.DatasetInstance dataset) throws IOException {
-    String path = getVersionedAPIPath(String.format("datasets/%s/metadata",
-                                                    dataset.getId()), dataset.getNamespaceId());
-    HttpResponse response = makeGetRequest(path);
-    Assert.assertEquals(200, response.getResponseCode());
-    return GSON.fromJson(response.getResponseBodyAsString(), SET_METADATA_RECORD_TYPE);
+  protected void removeMetadata(Id.DatasetInstance dataset) throws Exception {
+    metadataClient.removeMetadata(dataset);
   }
 
-  protected Set<MetadataRecord> getMetadata(Id.Stream stream) throws IOException {
-    String path = getVersionedAPIPath(String.format("streams/%s/metadata",
-                                                    stream.getId()), stream.getNamespaceId());
-    HttpResponse response = makeGetRequest(path);
-    Assert.assertEquals(200, response.getResponseCode());
-    return GSON.fromJson(response.getResponseBodyAsString(), SET_METADATA_RECORD_TYPE);
+  protected void removeMetadata(Id.Stream stream) throws Exception {
+    metadataClient.removeMetadata(stream);
   }
 
-  protected Map<String, String> getProperties(Id.Application app) throws IOException {
-    String path = getVersionedAPIPath(String.format("apps/%s/metadata/properties", app.getId()), app.getNamespaceId());
-    HttpResponse response = makeGetRequest(path);
-    Assert.assertEquals(200, response.getResponseCode());
-    return GSON.fromJson(response.getResponseBodyAsString(), MAP_STRING_STRING_TYPE);
-  }
-
-  protected Map<String, String> getProperties(Id.Program program) throws IOException {
-    String path = getVersionedAPIPath(String.format("apps/%s/%s/%s/metadata/properties", program.getApplicationId(),
-                                                    program.getType().getCategoryName(), program.getId()),
-                                      program.getNamespaceId());
-    HttpResponse response = makeGetRequest(path);
-    Assert.assertEquals(200, response.getResponseCode());
-    return GSON.fromJson(response.getResponseBodyAsString(), MAP_STRING_STRING_TYPE);
-  }
-
-  protected Map<String, String> getProperties(Id.DatasetInstance dataset) throws IOException {
-    String path = getVersionedAPIPath(String.format("datasets/%s/metadata/properties",
-                                                    dataset.getId()), dataset.getNamespaceId());
-    HttpResponse response = makeGetRequest(path);
-    Assert.assertEquals(200, response.getResponseCode());
-    return GSON.fromJson(response.getResponseBodyAsString(), MAP_STRING_STRING_TYPE);
-  }
-
-  protected Map<String, String> getProperties(Id.Stream stream) throws IOException {
-    String path = getVersionedAPIPath(String.format("streams/%s/metadata/properties",
-                                                    stream.getId()), stream.getNamespaceId());
-    HttpResponse response = makeGetRequest(path);
-    Assert.assertEquals(200, response.getResponseCode());
-    return GSON.fromJson(response.getResponseBodyAsString(), MAP_STRING_STRING_TYPE);
-  }
-
-  protected void getPropertiesFromInvalidEntity(Id.Application app) throws IOException {
-    String path = getVersionedAPIPath(String.format("apps/%s/metadata/properties", app.getId()), app.getNamespaceId());
-    HttpResponse response = makeGetRequest(path);
-    Assert.assertEquals(404, response.getResponseCode());
-  }
-
-  protected void getPropertiesFromInvalidEntity(Id.Program program) throws IOException {
-    String path = getVersionedAPIPath(String.format("apps/%s/%s/%s/metadata/properties", program.getApplicationId(),
-                                                    program.getType().getCategoryName(), program.getId()),
-                                      program.getNamespaceId());
-    HttpResponse response = makeGetRequest(path);
-    Assert.assertEquals(404, response.getResponseCode());
-  }
-
-  protected void getPropertiesFromInvalidEntity(Id.DatasetInstance dataset) throws IOException {
-    String path = getVersionedAPIPath(String.format("datasets/%s/metadata/properties",
-                                                    dataset.getId()), dataset.getNamespaceId());
-    HttpResponse response = makeGetRequest(path);
-    Assert.assertEquals(404, response.getResponseCode());
-  }
-
-  protected void getPropertiesFromInvalidEntity(Id.Stream stream) throws IOException {
-    String path = getVersionedAPIPath(String.format("streams/%s/metadata/properties",
-                                                    stream.getId()), stream.getNamespaceId());
-    HttpResponse response = makeGetRequest(path);
-    Assert.assertEquals(404, response.getResponseCode());
-  }
-
-  protected void removeMetadata(Id.Application app) throws IOException {
-    String path = getVersionedAPIPath(String.format("apps/%s/metadata", app.getId()), app.getNamespaceId());
-    HttpResponse response = makeDeleteRequest(path);
-    Assert.assertEquals(200, response.getResponseCode());
-  }
-
-  protected void removeMetadata(Id.Program program) throws IOException {
-    String path = getVersionedAPIPath(String.format("apps/%s/%s/%s/metadata", program.getApplicationId(),
-                                                    program.getType().getCategoryName(), program.getId()),
-                                      program.getNamespaceId());
-    HttpResponse response = makeDeleteRequest(path);
-    Assert.assertEquals(200, response.getResponseCode());
-  }
-
-  protected void removeMetadata(Id.DatasetInstance dataset) throws IOException {
-    String path = getVersionedAPIPath(String.format("datasets/%s/metadata",
-                                                    dataset.getId()), dataset.getNamespaceId());
-    HttpResponse response = makeDeleteRequest(path);
-    Assert.assertEquals(200, response.getResponseCode());
-  }
-
-  protected void removeMetadata(Id.Stream stream) throws IOException {
-    String path = getVersionedAPIPath(String.format("streams/%s/metadata",
-                                                    stream.getId()), stream.getNamespaceId());
-    HttpResponse response = makeDeleteRequest(path);
-    Assert.assertEquals(200, response.getResponseCode());
-  }
-
-  protected void removeProperties(Id.Application app) throws IOException {
+  protected void removeProperties(Id.Application app) throws Exception {
     removeProperties(app, null);
   }
 
-  private void removeProperties(Id.Application app, @Nullable String propertyToRemove) throws IOException {
-    String path = getVersionedAPIPath(String.format("apps/%s/metadata/properties", app.getId()), app.getNamespaceId());
-    if (propertyToRemove != null) {
-      path = String.format("%s/%s", path, propertyToRemove);
-    }
-    HttpResponse response = makeDeleteRequest(path);
-    Assert.assertEquals(200, response.getResponseCode());
+  private void removeProperties(Id.Application app, @Nullable String propertyToRemove) throws Exception {
+    metadataClient.removeProperties(app, propertyToRemove);
   }
 
-  protected void removeProperties(Id.Program program) throws IOException {
+  protected void removeProperties(Id.Program program) throws Exception {
     removeProperties(program, null);
   }
 
-  protected void removeProperties(Id.Program program, @Nullable String propertyToRemove) throws IOException {
-    String path = getVersionedAPIPath(String.format("apps/%s/%s/%s/metadata/properties", program.getApplicationId(),
-                                                    program.getType().getCategoryName(), program.getId()),
-                                      program.getNamespaceId());
-    if (propertyToRemove != null) {
-      path = String.format("%s/%s", path, propertyToRemove);
-    }
-    HttpResponse response = makeDeleteRequest(path);
-    Assert.assertEquals(200, response.getResponseCode());
+  protected void removeProperties(Id.Program program, @Nullable String propertyToRemove) throws Exception {
+    metadataClient.removeProperties(program, propertyToRemove);
   }
 
-  protected void removeProperties(Id.DatasetInstance dataset) throws IOException {
+  protected void removeProperties(Id.DatasetInstance dataset) throws Exception {
     removeProperties(dataset, null);
   }
 
-  protected void removeProperties(Id.DatasetInstance dataset, @Nullable String propertyToRemove) throws IOException {
-    String path = getVersionedAPIPath(String.format("datasets/%s/metadata/properties",
-                                                    dataset.getId()), dataset.getNamespaceId());
-    if (propertyToRemove != null) {
-      path = String.format("%s/%s", path, propertyToRemove);
-    }
-    HttpResponse response = makeDeleteRequest(path);
-    Assert.assertEquals(200, response.getResponseCode());
+  protected void removeProperties(Id.DatasetInstance dataset, @Nullable String propertyToRemove) throws Exception {
+    metadataClient.removeProperties(dataset, propertyToRemove);
   }
 
-  protected void removeProperties(Id.Stream stream) throws IOException {
+  protected void removeProperties(Id.Stream stream) throws Exception {
     removeProperties(stream, null);
   }
 
-  protected void removeProperties(Id.Stream stream, @Nullable String propertyToRemove) throws IOException {
-    String path = getVersionedAPIPath(String.format("streams/%s/metadata/properties",
-                                                    stream.getId()), stream.getNamespaceId());
-    if (propertyToRemove != null) {
-      path = String.format("%s/%s", path, propertyToRemove);
-    }
-    HttpResponse response = makeDeleteRequest(path);
-    Assert.assertEquals(200, response.getResponseCode());
+  protected void removeProperties(Id.Stream stream, @Nullable String propertyToRemove) throws Exception {
+    metadataClient.removeProperties(stream, propertyToRemove);
   }
 
-  protected HttpResponse addTags(Id.Application app, @Nullable Set<String> tags) throws IOException {
-    String path = getVersionedAPIPath(String.format("apps/%s/metadata/tags", app.getId()), app.getNamespaceId());
-    if (tags == null) {
-      return makePostRequest(path);
-    }
-    return makePostRequest(path, GSON.toJson(tags));
+  protected void addTags(Id.Application app, @Nullable Set<String> tags) throws Exception {
+    metadataClient.addTags(app, tags);
   }
 
-  protected HttpResponse addTags(Id.Program program, @Nullable Set<String> tags) throws IOException {
-    String path = getVersionedAPIPath(String.format("apps/%s/%s/%s/metadata/tags", program.getApplicationId(),
-                                                    program.getType().getCategoryName(), program.getId()),
-                                      program.getNamespaceId());
-    if (tags == null) {
-      return makePostRequest(path);
-    }
-    return makePostRequest(path, GSON.toJson(tags));
+  protected void addTags(final Id.Application app, @Nullable final Set<String> tags,
+                         Class<? extends Exception> expectedExceptionClass) throws IOException {
+    expectException(new Callable<Void>() {
+      @Override
+      public Void call() throws Exception {
+        addTags(app, tags);
+        return null;
+      }
+    }, expectedExceptionClass);
   }
 
-  protected HttpResponse addTags(Id.DatasetInstance dataset, @Nullable Set<String> tags) throws IOException {
-    String path = getVersionedAPIPath(String.format("datasets/%s/metadata/tags",
-                                                    dataset.getId()), dataset.getNamespaceId());
-    if (tags == null) {
-      return makePostRequest(path);
-    }
-    return makePostRequest(path, GSON.toJson(tags));
+  protected void addTags(Id.Program program, @Nullable Set<String> tags)
+    throws Exception {
+    metadataClient.addTags(program, tags);
   }
 
-  protected HttpResponse addTags(Id.Stream stream, @Nullable Set<String> tags) throws IOException {
-    String path = getVersionedAPIPath(String.format("streams/%s/metadata/tags",
-                                                    stream.getId()), stream.getNamespaceId());
-    if (tags == null) {
-      return makePostRequest(path);
-    }
-    return makePostRequest(path, GSON.toJson(tags));
+  protected void addTags(final Id.Program program, @Nullable final Set<String> tags,
+                         Class<? extends Exception> expectedExceptionClass) throws IOException {
+    expectException(new Callable<Void>() {
+      @Override
+      public Void call() throws Exception {
+        addTags(program, tags);
+        return null;
+      }
+    }, expectedExceptionClass);
   }
 
-  protected Set<MetadataSearchResultRecord> searchMetadata(String namespaceId,
-                                                           String query, String target) throws IOException {
-    String path;
-    if (target == null) {
-      path = getVersionedAPIPath(String.format("metadata/search?query=%s", query), namespaceId);
-    } else {
-      path = getVersionedAPIPath(String.format("metadata/search?query=%s&target=%s", query, target), namespaceId);
-    }
-    HttpResponse response = makeGetRequest(path);
-    Assert.assertEquals(200, response.getResponseCode());
-    return GSON.fromJson(response.getResponseBodyAsString(), SET_METADATA_SEARCH_RESULT_TYPE);
+  protected void addTags(Id.DatasetInstance dataset, @Nullable Set<String> tags) throws Exception {
+    metadataClient.addTags(dataset, tags);
   }
 
-  protected Set<String> getTags(Id.Application app) throws IOException {
-    String path = getVersionedAPIPath(String.format("apps/%s/metadata/tags", app.getId()), app.getNamespaceId());
-    HttpResponse response = makeGetRequest(path);
-    Assert.assertEquals(200, response.getResponseCode());
-    return GSON.fromJson(response.getResponseBodyAsString(), SET_STRING_TYPE);
+  protected void addTags(final Id.DatasetInstance dataset, @Nullable final Set<String> tags,
+                         Class<? extends Exception> expectedExceptionClass) throws IOException {
+    expectException(new Callable<Void>() {
+      @Override
+      public Void call() throws Exception {
+        addTags(dataset, tags);
+        return null;
+      }
+    }, expectedExceptionClass);
   }
 
-  protected Set<String> getTags(Id.Program program) throws IOException {
-    String path = getVersionedAPIPath(String.format("apps/%s/%s/%s/metadata/tags", program.getApplicationId(),
-                                                    program.getType().getCategoryName(), program.getId()),
-                                      program.getNamespaceId());
-    HttpResponse response = makeGetRequest(path);
-    Assert.assertEquals(200, response.getResponseCode());
-    return GSON.fromJson(response.getResponseBodyAsString(), SET_STRING_TYPE);
+  protected void addTags(Id.Stream stream, @Nullable Set<String> tags) throws Exception {
+    metadataClient.addTags(stream, tags);
   }
 
-  protected Set<String> getTags(Id.DatasetInstance dataset) throws IOException {
-    String path = getVersionedAPIPath(String.format("datasets/%s/metadata/tags",
-                                                    dataset.getId()), dataset.getNamespaceId());
-    HttpResponse response = makeGetRequest(path);
-    Assert.assertEquals(200, response.getResponseCode());
-    return GSON.fromJson(response.getResponseBodyAsString(), SET_STRING_TYPE);
+  protected void addTags(final Id.Stream stream, @Nullable final Set<String> tags,
+                         Class<? extends Exception> expectedExceptionClass) throws IOException {
+    expectException(new Callable<Void>() {
+      @Override
+      public Void call() throws Exception {
+        addTags(stream, tags);
+        return null;
+      }
+    }, expectedExceptionClass);
   }
 
-  protected Set<String> getTags(Id.Stream stream) throws IOException {
-    String path = getVersionedAPIPath(String.format("streams/%s/metadata/tags",
-                                                    stream.getId()), stream.getNamespaceId());
-    HttpResponse response = makeGetRequest(path);
-    Assert.assertEquals(200, response.getResponseCode());
-    return GSON.fromJson(response.getResponseBodyAsString(), SET_STRING_TYPE);
+  protected Set<MetadataSearchResultRecord> searchMetadata(Id.Namespace namespaceId, String query,
+                                                           MetadataSearchTargetType target) throws Exception {
+    return metadataClient.searchMetadata(namespaceId, query, target);
   }
 
-  protected void removeTags(Id.Application app) throws IOException {
+  // Currently, getMetadata(entity) returns a single-element set, so we can get the tags from there
+  protected Set<String> getTags(Id.Application app) throws Exception {
+    return Iterators.getOnlyElement(getMetadata(app).iterator()).getTags();
+  }
+
+  protected Set<String> getTags(Id.Program program) throws Exception {
+    return Iterators.getOnlyElement(getMetadata(program).iterator()).getTags();
+  }
+
+  protected Set<String> getTags(Id.DatasetInstance dataset) throws Exception {
+    return Iterators.getOnlyElement(getMetadata(dataset).iterator()).getTags();
+  }
+
+  protected Set<String> getTags(Id.Stream stream) throws Exception {
+    return Iterators.getOnlyElement(getMetadata(stream).iterator()).getTags();
+  }
+
+  protected void removeTags(Id.Application app) throws Exception {
     removeTags(app, null);
   }
 
-  protected void removeTags(Id.Application app, @Nullable String tagToRemove) throws IOException {
-    String path = getVersionedAPIPath(String.format("apps/%s/metadata/tags", app.getId()), app.getNamespaceId());
-    if (tagToRemove != null) {
-      path = String.format("%s/%s", path, tagToRemove);
-    }
-    HttpResponse response = makeDeleteRequest(path);
-    Assert.assertEquals(200, response.getResponseCode());
+  protected void removeTags(Id.Application app, @Nullable String tagToRemove) throws Exception {
+    metadataClient.removeTags(app, tagToRemove);
   }
 
-  protected void removeTags(Id.Program program) throws IOException {
+  protected void removeTags(Id.Program program) throws Exception {
     removeTags(program, null);
   }
 
-  private void removeTags(Id.Program program, @Nullable String tagToRemove) throws IOException {
-    String path = getVersionedAPIPath(String.format("apps/%s/%s/%s/metadata/tags", program.getApplicationId(),
-                                                    program.getType().getCategoryName(), program.getId()),
-                                      program.getNamespaceId());
-    if (tagToRemove != null) {
-      path = String.format("%s/%s", path, tagToRemove);
-    }
-    HttpResponse response = makeDeleteRequest(path);
-    Assert.assertEquals(200, response.getResponseCode());
+  private void removeTags(Id.Program program, @Nullable String tagToRemove) throws Exception {
+    metadataClient.removeTags(program, tagToRemove);
   }
 
-  protected void removeTags(Id.DatasetInstance dataset) throws IOException {
+  protected void removeTags(Id.DatasetInstance dataset) throws Exception {
     removeTags(dataset, null);
   }
 
-  protected void removeTags(Id.DatasetInstance dataset, @Nullable String tagToRemove) throws IOException {
-    String path = getVersionedAPIPath(String.format("datasets/%s/metadata/tags",
-                                                    dataset.getId()), dataset.getNamespaceId());
-    if (tagToRemove != null) {
-      path = String.format("%s/%s", path, tagToRemove);
-    }
-    HttpResponse response = makeDeleteRequest(path);
-    Assert.assertEquals(200, response.getResponseCode());
+  protected void removeTags(Id.DatasetInstance dataset, @Nullable String tagToRemove) throws Exception {
+    metadataClient.removeTags(dataset, tagToRemove);
   }
 
-  protected void removeTags(Id.Stream stream) throws IOException {
+  protected void removeTags(Id.Stream stream) throws Exception {
     removeTags(stream, null);
   }
 
-  protected void removeTags(Id.Stream stream, @Nullable String tagToRemove) throws IOException {
-    String path = getVersionedAPIPath(String.format("streams/%s/metadata/tags",
-                                                    stream.getId()), stream.getNamespaceId());
-    if (tagToRemove != null) {
-      path = String.format("%s/%s", path, tagToRemove);
+  protected void removeTags(Id.Stream stream, @Nullable String tagToRemove) throws Exception {
+    metadataClient.removeTags(stream, tagToRemove);
+  }
+
+  // expect an exception during fetching of lineage
+  protected void fetchLineage(Id.DatasetInstance datasetInstance, long start, long end, int levels,
+                              Class<? extends Exception> expectedExceptionClass) throws Exception {
+    fetchLineage(datasetInstance, Long.toString(start), Long.toString(end), levels, expectedExceptionClass);
+  }
+
+  // expect an exception during fetching of lineage
+  protected void fetchLineage(final Id.DatasetInstance datasetInstance, final String start, final String end,
+                              final int levels, Class<? extends Exception> expectedExceptionClass) throws Exception {
+    expectException(new Callable<Void>() {
+      @Override
+      public Void call() throws Exception {
+        fetchLineage(datasetInstance, start, end, levels);
+        return null;
+      }
+    }, expectedExceptionClass);
+  }
+
+  protected LineageRecord fetchLineage(Id.DatasetInstance datasetInstance, long start, long end,
+                                       int levels) throws Exception {
+    return lineageClient.getLineage(datasetInstance, start, end, levels);
+  }
+
+  protected LineageRecord fetchLineage(Id.DatasetInstance datasetInstance, String start, String end,
+                                       int levels) throws Exception {
+    return lineageClient.getLineage(datasetInstance, start, end, levels);
+  }
+
+  protected LineageRecord fetchLineage(Id.Stream stream, long start, long end, int levels) throws Exception {
+    return lineageClient.getLineage(stream, start, end, levels);
+  }
+
+  protected LineageRecord fetchLineage(Id.Stream stream, String start, String end, int levels) throws Exception {
+    return lineageClient.getLineage(stream, start, end, levels);
+  }
+
+  protected Set<MetadataRecord> fetchRunMetadata(Id.Run run) throws Exception {
+    return metadataClient.getMetadata(run);
+  }
+
+  protected void assertRunMetadataNotFound(Id.Run run) throws Exception {
+    try {
+      fetchRunMetadata(run);
+      Assert.fail("Excepted not to fetch Metadata for a nonexistent Run.");
+    } catch (NotFoundException expected) {
+      // expected
     }
-    HttpResponse response = makeDeleteRequest(path);
-    Assert.assertEquals(200, response.getResponseCode());
   }
 
-  protected HttpResponse fetchLineage(Id.DatasetInstance datasetInstance, long start, long end, int levels)
-    throws IOException {
-    String path = getVersionedAPIPath(
-      String.format("datasets/%s/lineage?start=%d&end=%d&levels=%d", datasetInstance.getId(), start, end, levels),
-      datasetInstance.getNamespaceId());
-    return makeGetRequest(path);
-  }
-
-  protected HttpResponse fetchLineage(Id.DatasetInstance datasetInstance, String start, String end, int levels)
-    throws IOException {
-    String path = getVersionedAPIPath(
-      String.format("datasets/%s/lineage?start=%s&end=%s&levels=%d",
-                    datasetInstance.getId(),
-                    URLEncoder.encode(start, "UTF-8"),
-                    URLEncoder.encode(end, "UTF-8"), levels),
-      datasetInstance.getNamespaceId());
-    return makeGetRequest(path);
-  }
-
-  protected HttpResponse fetchLineage(Id.Stream stream, long start, long end, int levels)
-    throws IOException {
-    String path = getVersionedAPIPath(
-      String.format("streams/%s/lineage?start=%d&end=%d&levels=%d", stream.getId(), start, end, levels),
-      stream.getNamespaceId());
-    return makeGetRequest(path);
-  }
-
-  protected HttpResponse fetchLineage(Id.Stream stream, String start, String end, int levels)
-    throws IOException {
-    String path = getVersionedAPIPath(
-      String.format("streams/%s/lineage?start=%s&end=%s&levels=%d",
-                    stream.getId(),
-                    URLEncoder.encode(start, "UTF-8"),
-                    URLEncoder.encode(end, "UTF-8"), levels),
-      stream.getNamespaceId());
-    return makeGetRequest(path);
-  }
-
-  protected Set<MetadataRecord> fetchRunMetadata(Id.Run run) throws IOException {
-    HttpResponse response = fetchRunMetadataResponse(run);
-    Assert.assertEquals(200, response.getResponseCode());
-    String responseBody = response.getResponseBodyAsString();
-    return GSON.fromJson(responseBody, SET_METADATA_RECORD_TYPE);
-  }
-
-  protected HttpResponse fetchRunMetadataResponse(Id.Run run) throws IOException {
-    Id.Program program = run.getProgram();
-    String path = getVersionedAPIPath(String.format("apps/%s/%s/%s/runs/%s/metadata",
-                                                    program.getApplicationId(), program.getType().getCategoryName(),
-                                                    program.getId(), run.getId()),
-                                      program.getNamespaceId());
-    return makeGetRequest(path);
-  }
-
-  // The following methods are needed because AppFabricTestBase's doGet, doPost, doPut, doDelete are hardwired to
-  // AppFabric Service
-  private HttpResponse makePostRequest(String resource) throws IOException {
-    return makePostRequest(resource, null);
-  }
-
-  private HttpResponse makePostRequest(String resource, @Nullable String body) throws IOException {
-    HttpRequest.Builder postBuilder = HttpRequest.post(getMetadataUrl(resource));
-    if (body != null) {
-      postBuilder.withBody(body);
+  private <T> void expectException(Callable<T> callable, Class<? extends Exception> expectedExceptionClass) {
+    try {
+      callable.call();
+      Assert.fail("Expected to have exception of class: " + expectedExceptionClass);
+    } catch (Exception e) {
+      Assert.assertTrue(e.getClass() == expectedExceptionClass);
     }
-    return HttpRequests.execute(postBuilder.build());
-  }
-
-  private HttpResponse makeGetRequest(String resource) throws IOException {
-    HttpRequest request = HttpRequest.get(getMetadataUrl(resource)).build();
-    return HttpRequests.execute(request);
-  }
-
-  private HttpResponse makeDeleteRequest(String resource) throws IOException {
-    HttpRequest request = HttpRequest.delete(getMetadataUrl(resource)).build();
-    return HttpRequests.execute(request);
-  }
-
-  private URL getMetadataUrl(String resource) throws MalformedURLException {
-    return new URL(String.format("%s%s", metadataServiceUrl, resource));
   }
 }

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/ClientTestsSuite.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/ClientTestsSuite.java
@@ -29,19 +29,20 @@ import org.junit.runners.Suite;
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
   ApplicationClientTestRun.class,
+  ArtifactClientTestRun.class,
   DatasetClientTestRun.class,
+  MetaClientTestRun.class,
   MetricsClientTestRun.class,
   MonitorClientTestRun.class,
-  ProgramClientTestRun.class,
-  QueryClientTestRun.class,
-  StreamClientTestRun.class,
-  ServiceClientTestRun.class,
-  MetaClientTestRun.class,
   NamespaceClientTestRun.class,
   PreferencesClientTestRun.class,
+  ProgramClientTestRun.class,
+  QueryClientTestRun.class,
   ScheduleClientTestRun.class,
+  ServiceClientTestRun.class,
+  StreamClientTestRun.class,
   WorkflowClientTestRun.class,
-  ArtifactClientTestRun.class })
+})
 public class ClientTestsSuite extends ClientTestBase {
 
 }

--- a/cdap-client/src/main/java/co/cask/cdap/client/ApplicationClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ApplicationClient.java
@@ -79,8 +79,7 @@ public class ApplicationClient {
   }
 
   public ApplicationClient(ClientConfig config) {
-    this.config = config;
-    this.restClient = new RESTClient(config);
+    this(config, new RESTClient(config));
   }
 
   /**

--- a/cdap-client/src/main/java/co/cask/cdap/client/DatasetClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/DatasetClient.java
@@ -68,8 +68,7 @@ public class DatasetClient {
   }
 
   public DatasetClient(ClientConfig config) {
-    this.config = config;
-    this.restClient = new RESTClient(config);
+    this(config, new RESTClient(config));
   }
 
   /**

--- a/cdap-client/src/main/java/co/cask/cdap/client/DatasetModuleClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/DatasetModuleClient.java
@@ -64,8 +64,7 @@ public class DatasetModuleClient {
   }
 
   public DatasetModuleClient(ClientConfig config) {
-    this.config = config;
-    this.restClient = new RESTClient(config);
+    this(config, new RESTClient(config));
   }
 
   /**

--- a/cdap-client/src/main/java/co/cask/cdap/client/DatasetTypeClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/DatasetTypeClient.java
@@ -56,8 +56,7 @@ public class DatasetTypeClient {
   }
 
   public DatasetTypeClient(ClientConfig config) {
-    this.config = config;
-    this.restClient = new RESTClient(config);
+    this(config, new RESTClient(config));
   }
 
   /**

--- a/cdap-client/src/main/java/co/cask/cdap/client/LineageClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/LineageClient.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.client;
+
+import co.cask.cdap.client.config.ClientConfig;
+import co.cask.cdap.client.util.RESTClient;
+import co.cask.cdap.common.BadRequestException;
+import co.cask.cdap.common.NotFoundException;
+import co.cask.cdap.common.UnauthorizedException;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.codec.NamespacedIdCodec;
+import co.cask.cdap.proto.metadata.lineage.LineageRecord;
+import co.cask.common.http.HttpRequest;
+import co.cask.common.http.HttpResponse;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+
+/**
+ * Provides ways to interact with CDAP Lineage.
+ */
+public class LineageClient {
+
+  private static final Gson GSON = new GsonBuilder()
+    .registerTypeAdapter(Id.NamespacedId.class, new NamespacedIdCodec()).create();
+
+  private final RESTClient restClient;
+  private final ClientConfig config;
+
+  @Inject
+  public LineageClient(ClientConfig config, RESTClient restClient) {
+    this.config = config;
+    this.restClient = restClient;
+  }
+
+  public LineageClient(ClientConfig config) {
+    this.config = config;
+    this.restClient = new RESTClient(config);
+  }
+
+  /**
+   * Retrieves Lineage for a given dataset.
+   *
+   * @param datasetInstance the dataset for which to retrieve lineage
+   * @param startTime start time for the query, in seconds
+   * @param endTime end time for the query, in seconds
+   * @param levels number of levels to compute lineage for, or {@code null} to use the LineageHandler's default value
+   * @return {@link LineageRecord} for the specified dataset.
+   */
+  public LineageRecord getLineage(Id.DatasetInstance datasetInstance, long startTime, long endTime,
+                                  @Nullable Integer levels)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    return getLineage(datasetInstance, Long.toString(startTime), Long.toString(endTime), levels);
+  }
+
+  /**
+   * Retrieves Lineage for a given dataset.
+   *
+   * @param datasetInstance the dataset for which to retrieve lineage
+   * @param startTime start time for the query, in seconds, or in 'now - xs' format
+   * @param endTime end time for the query, in seconds, or in 'now - xs' format
+   * @param levels number of levels to compute lineage for, or {@code null} to use the LineageHandler's default value
+   * @return {@link LineageRecord} for the specified dataset.
+   */
+  public LineageRecord getLineage(Id.DatasetInstance datasetInstance, String startTime, String endTime,
+                                  @Nullable Integer levels)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    String path = String.format("datasets/%s/lineage?start=%s&end=%s", datasetInstance.getId(),
+                                URLEncoder.encode(startTime, "UTF-8"), URLEncoder.encode(endTime, "UTF-8"));
+    if (levels != null) {
+      path = String.format("%s&levels=%d", path, levels);
+    }
+    return getLineage(datasetInstance, path);
+  }
+
+  /**
+   * Retrieves Lineage for a given stream.
+   *
+   * @param streamId the stream for which to retrieve lineage
+   * @param startTime start time for the query, in seconds
+   * @param endTime end time for the query, in seconds
+   * @param levels number of levels to compute lineage for, or {@code null} to use the LineageHandler's default value
+   * @return {@link LineageRecord} for the specified stream.
+   */
+  public LineageRecord getLineage(Id.Stream streamId, long startTime, long endTime, @Nullable Integer levels)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    return getLineage(streamId, Long.toString(startTime), Long.toString(endTime), levels);
+  }
+
+  /**
+   * Retrieves Lineage for a given stream.
+   *
+   * @param streamId the stream for which to retrieve lineage
+   * @param startTime start time for the query, in seconds, or in 'now - xs' format
+   * @param endTime end time for the query, in seconds, or in 'now - xs' format
+   * @param levels number of levels to compute lineage for, or {@code null} to use the LineageHandler's default value
+   * @return {@link LineageRecord} for the specified stream.
+   */
+  public LineageRecord getLineage(Id.Stream streamId, String startTime, String endTime, @Nullable Integer levels)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    String path = String.format("streams/%s/lineage?start=%s&end=%s", streamId.getId(),
+                                URLEncoder.encode(startTime, "UTF-8"), URLEncoder.encode(endTime, "UTF-8"));
+    if (levels != null) {
+      path = String.format("%s&levels=%d", path, levels);
+    }
+    return getLineage(streamId, path);
+  }
+
+  private LineageRecord getLineage(Id.NamespacedId namespacedId, String path)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    URL lineageURL = config.resolveNamespacedURLV3(namespacedId.getNamespace(), path);
+    HttpResponse response = restClient.execute(HttpRequest.get(lineageURL).build(),
+                                               config.getAccessToken(),
+                                               HttpURLConnection.HTTP_BAD_REQUEST, HttpURLConnection.HTTP_NOT_FOUND);
+    if (response.getResponseCode() == HttpURLConnection.HTTP_BAD_REQUEST) {
+      throw new BadRequestException(response.getResponseBodyAsString());
+    }
+    if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
+      throw new NotFoundException(namespacedId);
+    }
+    return GSON.fromJson(response.getResponseBodyAsString(), LineageRecord.class);
+  }
+}

--- a/cdap-client/src/main/java/co/cask/cdap/client/LineageClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/LineageClient.java
@@ -54,8 +54,7 @@ public class LineageClient {
   }
 
   public LineageClient(ClientConfig config) {
-    this.config = config;
-    this.restClient = new RESTClient(config);
+    this(config, new RESTClient());
   }
 
   /**

--- a/cdap-client/src/main/java/co/cask/cdap/client/MetaClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/MetaClient.java
@@ -49,8 +49,7 @@ public class MetaClient {
   }
 
   public MetaClient(ClientConfig config) {
-    this.config = config;
-    this.restClient = new RESTClient(config);
+    this(config, new RESTClient(config));
   }
 
   public void ping() throws IOException, UnauthorizedException {

--- a/cdap-client/src/main/java/co/cask/cdap/client/MetadataClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/MetadataClient.java
@@ -242,108 +242,195 @@ public class MetadataClient {
   }
 
   /**
-   * Removes properties from an application.
+   * Removes a property from an application.
+   *
+   * @param appId app to remove property from
+   * @param propertyToRemove property to be removed
+   */
+  public void removeProperty(Id.Application appId, String propertyToRemove)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    removeProperty(appId, constructPath(appId), propertyToRemove);
+  }
+
+  /**
+   * Removes a property from a dataset.
+   *
+   * @param datasetInstance dataset to remove property from
+   * @param propertyToRemove property to be removed
+   */
+  public void removeProperty(Id.DatasetInstance datasetInstance, String propertyToRemove)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    removeProperty(datasetInstance, constructPath(datasetInstance), propertyToRemove);
+  }
+
+  /**
+   * Removes a property from a stream.
+   *
+   * @param streamId stream to remove property from
+   * @param propertyToRemove property to be removed
+   */
+  public void removeProperty(Id.Stream streamId, String propertyToRemove)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    removeProperty(streamId, constructPath(streamId), propertyToRemove);
+  }
+
+  /**
+   * Removes a property from a program.
+   *
+   * @param programId program to remove property from
+   * @param propertyToRemove property to be removed
+   */
+  public void removeProperty(Id.Program programId, String propertyToRemove)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    removeProperty(programId, constructPath(programId), propertyToRemove);
+  }
+
+  private void removeProperty(Id.NamespacedId namespacedId, String entityPath, String propertyToRemove)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    String path = String.format("%s/metadata/properties/%s", entityPath, propertyToRemove);
+    makeRequest(namespacedId, path, HttpMethod.DELETE);
+  }
+
+
+  /**
+   * Removes all properties from an application.
    *
    * @param appId app to remove properties from
-   * @param propertyToRemove property to be removed, or {@code null} to remove all properties for the entity
    */
-  public void removeProperties(Id.Application appId, @Nullable String propertyToRemove)
+  public void removeProperties(Id.Application appId)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    removeProperties(appId, constructPath(appId), propertyToRemove);
+    removeProperties(appId, constructPath(appId));
   }
 
   /**
-   * Removes properties from a dataset.
+   * Removes all properties from a dataset.
    *
    * @param datasetInstance dataset to remove properties from
-   * @param propertyToRemove property to be removed, or {@code null} to remove all properties for the entity
    */
-  public void removeProperties(Id.DatasetInstance datasetInstance, @Nullable String propertyToRemove)
+  public void removeProperties(Id.DatasetInstance datasetInstance)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    removeProperties(datasetInstance, constructPath(datasetInstance), propertyToRemove);
+    removeProperties(datasetInstance, constructPath(datasetInstance));
   }
 
   /**
-   * Removes properties from a stream.
+   * Removes all properties from a stream.
    *
    * @param streamId stream to remove properties from
-   * @param propertyToRemove property to be removed, or {@code null} to remove all properties for the entity
    */
-  public void removeProperties(Id.Stream streamId, @Nullable String propertyToRemove)
+  public void removeProperties(Id.Stream streamId)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    removeProperties(streamId, constructPath(streamId), propertyToRemove);
+    removeProperties(streamId, constructPath(streamId));
   }
 
   /**
-   * Removes properties from a program.
+   * Removes all properties from a program.
    *
    * @param programId program to remove properties from
-   * @param propertyToRemove property to be removed, or {@code null} to remove all properties for the entity
    */
-  public void removeProperties(Id.Program programId, @Nullable String propertyToRemove)
+  public void removeProperties(Id.Program programId)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    removeProperties(programId, constructPath(programId), propertyToRemove);
+    removeProperties(programId, constructPath(programId));
   }
 
-  private void removeProperties(Id.NamespacedId namespacedId, String entityPath, @Nullable String propertyToRemove)
+  private void removeProperties(Id.NamespacedId namespacedId, String entityPath)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
     String path = String.format("%s/metadata/properties", entityPath);
-    if (propertyToRemove != null) {
-      path = path + "/" + propertyToRemove;
-    }
     makeRequest(namespacedId, path, HttpMethod.DELETE);
   }
 
   /**
-   * Removes tags from an application.
+   * Removes a tag from an application.
+   *
+   * @param appId app to remove tag from
+   * @param tagToRemove tag to be removed
+   */
+  public void removeTag(Id.Application appId, String tagToRemove)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    removeTag(appId, constructPath(appId), tagToRemove);
+  }
+
+  /**
+   * Removes a tag from a dataset.
+   *
+   * @param datasetInstance dataset to remove tag from
+   * @param tagToRemove tag to be removed
+   */
+  public void removeTag(Id.DatasetInstance datasetInstance, String tagToRemove)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    removeTag(datasetInstance, constructPath(datasetInstance), tagToRemove);
+  }
+
+  /**
+   * Removes a tag from a stream.
+   *
+   * @param streamId stream to remove tag from
+   * @param tagToRemove tag to be removed
+   */
+  public void removeTag(Id.Stream streamId, String tagToRemove)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    removeTag(streamId, constructPath(streamId), tagToRemove);
+  }
+
+  /**
+   * Removes a tag from a program.
+   *
+   * @param programId program to remove tag from
+   * @param tagToRemove tag to be removed
+   */
+  public void removeTag(Id.Program programId, String tagToRemove)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    removeTag(programId, constructPath(programId), tagToRemove);
+  }
+
+  private void removeTag(Id.NamespacedId namespacedId, String entityPath, String tagToRemove)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    String path = String.format("%s/metadata/tags/%s", entityPath, tagToRemove);
+    makeRequest(namespacedId, path, HttpMethod.DELETE);
+  }
+
+  /**
+   * Removes all tags from an application.
    *
    * @param appId app to remove tags from
-   * @param tagToRemove tag to be removed, or {@code null} to remove all tags for the entity
    */
-  public void removeTags(Id.Application appId, @Nullable String tagToRemove)
+  public void removeTags(Id.Application appId)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    removeTags(appId, constructPath(appId), tagToRemove);
+    removeTags(appId, constructPath(appId));
   }
 
   /**
-   * Removes tags from a dataset.
+   * Removes all tags from a dataset.
    *
    * @param datasetInstance dataset to remove tags from
-   * @param tagToRemove tag to be removed, or {@code null} to remove all tags for the entity
    */
-  public void removeTags(Id.DatasetInstance datasetInstance, @Nullable String tagToRemove)
+  public void removeTags(Id.DatasetInstance datasetInstance)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    removeTags(datasetInstance, constructPath(datasetInstance), tagToRemove);
+    removeTags(datasetInstance, constructPath(datasetInstance));
   }
 
   /**
-   * Removes tags from a stream.
+   * Removes all tags from a stream.
    *
    * @param streamId stream to remove tags from
-   * @param tagToRemove tag to be removed, or {@code null} to remove all tags for the entity
    */
-  public void removeTags(Id.Stream streamId, @Nullable String tagToRemove)
+  public void removeTags(Id.Stream streamId)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    removeTags(streamId, constructPath(streamId), tagToRemove);
+    removeTags(streamId, constructPath(streamId));
   }
 
   /**
-   * Removes tags from a program.
+   * Removes all tags from a program.
    *
    * @param programId program to remove tags from
-   * @param tagToRemove tag to be removed, or {@code null} to remove all tags for the entity
    */
-  public void removeTags(Id.Program programId, @Nullable String tagToRemove)
+  public void removeTags(Id.Program programId)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    removeTags(programId, constructPath(programId), tagToRemove);
+    removeTags(programId, constructPath(programId));
   }
 
-  private void removeTags(Id.NamespacedId namespacedId, String entityPath, @Nullable String tagToRemove)
+  private void removeTags(Id.NamespacedId namespacedId, String entityPath)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
     String path = String.format("%s/metadata/tags", entityPath);
-    if (tagToRemove != null) {
-      path = path + "/" + tagToRemove;
-    }
     makeRequest(namespacedId, path, HttpMethod.DELETE);
   }
 

--- a/cdap-client/src/main/java/co/cask/cdap/client/MetadataClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/MetadataClient.java
@@ -1,0 +1,473 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.client;
+
+import co.cask.cdap.client.config.ClientConfig;
+import co.cask.cdap.client.util.RESTClient;
+import co.cask.cdap.common.BadRequestException;
+import co.cask.cdap.common.NotFoundException;
+import co.cask.cdap.common.UnauthorizedException;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.codec.NamespacedIdCodec;
+import co.cask.cdap.proto.metadata.MetadataRecord;
+import co.cask.cdap.proto.metadata.MetadataSearchResultRecord;
+import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
+import co.cask.common.http.HttpRequest;
+import co.cask.common.http.HttpResponse;
+import com.google.common.reflect.TypeToken;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+
+/**
+ * Provides ways to interact with CDAP Metadata.
+ */
+public class MetadataClient {
+
+  private static final Gson GSON = new GsonBuilder()
+    .registerTypeAdapter(Id.NamespacedId.class, new NamespacedIdCodec()).create();
+  private static final Type SET_METADATA_RECORD_TYPE = new TypeToken<Set<MetadataRecord>>() { }.getType();
+  private static final Type SET_METADATA_SEARCH_RESULT_TYPE =
+    new TypeToken<Set<MetadataSearchResultRecord>>() { }.getType();
+
+  private final RESTClient restClient;
+  private final ClientConfig config;
+
+  @Inject
+  public MetadataClient(ClientConfig config, RESTClient restClient) {
+    this.config = config;
+    this.restClient = restClient;
+  }
+
+  public MetadataClient(ClientConfig config) {
+    this.config = config;
+    this.restClient = new RESTClient(config);
+  }
+
+  /**
+   * Returns search results for metadata.
+   *
+   * @param namespace the namespace to search in
+   * @param query the query string with which to search
+   * @param target the target type. If null, all possible types will be searched
+   * @return A set of {@link MetadataSearchResultRecord} for the given query.
+   */
+  public Set<MetadataSearchResultRecord> searchMetadata(Id.Namespace namespace, String query,
+                                                        @Nullable MetadataSearchTargetType target)
+    throws IOException, UnauthorizedException {
+
+    String path = String.format("metadata/search?query=%s", query);
+    if (target != null) {
+      path = path + "&target=" + target.getInternalName();
+    }
+    URL searchURL = config.resolveNamespacedURLV3(namespace, path);
+    HttpResponse response = restClient.execute(HttpRequest.get(searchURL).build(),
+                                               config.getAccessToken());
+    return GSON.fromJson(response.getResponseBodyAsString(), SET_METADATA_SEARCH_RESULT_TYPE);
+  }
+
+
+  /**
+   * @param appId the app for which to retrieve metadata
+   * @return The metadata for the application.
+   */
+  public Set<MetadataRecord> getMetadata(Id.Application appId)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    String path = String.format("apps/%s/metadata", appId.getId());
+    return getMetadata(appId, path);
+  }
+
+  /**
+   * @param datasetInstance the dataset for which to retrieve metadata
+   * @return The metadata for the dataset.
+   */
+  public Set<MetadataRecord> getMetadata(Id.DatasetInstance datasetInstance)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    String path = String.format("datasets/%s/metadata", datasetInstance.getId());
+    return getMetadata(datasetInstance, path);
+  }
+
+  /**
+   * @param streamId the stream for which to retrieve metadata
+   * @return The metadata for the stream.
+   */
+  public Set<MetadataRecord> getMetadata(Id.Stream streamId)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    String path = String.format("streams/%s/metadata", streamId.getId());
+    return getMetadata(streamId, path);
+  }
+
+  /**
+   * @param programId the program for which to retrieve metadata
+   * @return The metadata for the program.
+   */
+  public Set<MetadataRecord> getMetadata(Id.Program programId)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    String path = String.format("apps/%s/%s/%s/metadata",
+                                programId.getApplicationId(), programId.getType().getCategoryName(), programId.getId());
+    return getMetadata(programId, path);
+  }
+
+  /**
+   * @param runId the run for which to retrieve metadata
+   * @return The metadata for the run.
+   */
+  public Set<MetadataRecord> getMetadata(Id.Run runId)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    Id.Program programId = runId.getProgram();
+    String path = String.format("apps/%s/%s/%s/runs/%s/metadata",
+                                programId.getApplicationId(), programId.getType().getCategoryName(), programId.getId(),
+                                runId.getId());
+    return getMetadata(runId, path);
+  }
+
+  private Set<MetadataRecord> getMetadata(Id.NamespacedId namespacedId, String path)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    URL url = config.resolveNamespacedURLV3(namespacedId.getNamespace(), path);
+    HttpResponse response = restClient.execute(HttpRequest.get(url).build(), config.getAccessToken(),
+                                               HttpURLConnection.HTTP_BAD_REQUEST, HttpURLConnection.HTTP_NOT_FOUND);
+    if (response.getResponseCode() == HttpURLConnection.HTTP_BAD_REQUEST) {
+      throw new BadRequestException(response.getResponseBodyAsString());
+    }
+    if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
+      throw new NotFoundException(namespacedId);
+    }
+    return GSON.fromJson(response.getResponseBodyAsString(), SET_METADATA_RECORD_TYPE);
+  }
+
+  /**
+   * Adds tags to an application.
+   *
+   * @param appId app to add tags to
+   * @param tags tags to be added
+   */
+  public void addTags(Id.Application appId, Set<String> tags)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    String path = String.format("apps/%s/metadata/tags", appId.getId());
+    addTags(appId, path, tags);
+  }
+
+  /**
+   * Adds tags to a dataset.
+   *
+   * @param datasetInstance dataset to add tags to
+   * @param tags tags to be added
+   */
+  public void addTags(Id.DatasetInstance datasetInstance, Set<String> tags)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    String path = String.format("datasets/%s/metadata/tags", datasetInstance.getId());
+    addTags(datasetInstance, path, tags);
+  }
+
+  /**
+   * Adds tags to a stream.
+   *
+   * @param streamId stream to add tags to
+   * @param tags tags to be added
+   */
+  public void addTags(Id.Stream streamId, Set<String> tags)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    String path = String.format("streams/%s/metadata/tags", streamId.getId());
+    addTags(streamId, path, tags);
+  }
+
+  /**
+   * Adds tags to a program.
+   *
+   * @param programId program to add tags to
+   * @param tags tags to be added
+   */
+  public void addTags(Id.Program programId, Set<String> tags)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    String path = String.format("apps/%s/%s/%s/metadata/tags",
+                                programId.getApplicationId(), programId.getType().getCategoryName(), programId.getId());
+    addTags(programId, path, tags);
+  }
+
+  private void addTags(Id.NamespacedId namespacedId, String path, Set<String> tags)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    URL url = config.resolveNamespacedURLV3(namespacedId.getNamespace(), path);
+    HttpResponse response =
+      restClient.execute(HttpRequest.post(url).withBody(GSON.toJson(tags)).build(), config.getAccessToken(),
+                         HttpURLConnection.HTTP_BAD_REQUEST, HttpURLConnection.HTTP_NOT_FOUND);
+    if (response.getResponseCode() == HttpURLConnection.HTTP_BAD_REQUEST) {
+      throw new BadRequestException(response.getResponseBodyAsString());
+    }
+    if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
+      throw new NotFoundException(namespacedId);
+    }
+  }
+
+  /**
+   * Adds properties to an application.
+   *
+   * @param appId app to add tags to
+   * @param properties tags to be added
+   */
+  public void addProperties(Id.Application appId, Map<String, String> properties)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    String path = String.format("apps/%s/metadata/properties", appId.getId());
+    addProperties(appId, path, properties);
+  }
+
+  /**
+   * Adds properties to a dataset.
+   *
+   * @param datasetInstance dataset to add tags to
+   * @param properties tags to be added
+   */
+  public void addProperties(Id.DatasetInstance datasetInstance, Map<String, String> properties)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    String path = String.format("datasets/%s/metadata/properties", datasetInstance.getId());
+    addProperties(datasetInstance, path, properties);
+  }
+
+  /**
+   * Adds properties to a stream.
+   *
+   * @param streamId stream to add tags to
+   * @param properties tags to be added
+   */
+  public void addProperties(Id.Stream streamId, Map<String, String> properties)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    String path = String.format("streams/%s/metadata/properties", streamId.getId());
+    addProperties(streamId, path, properties);
+  }
+
+  /**
+   * Adds properties to a program.
+   *
+   * @param programId program to add tags to
+   * @param properties tags to be added
+   */
+  public void addProperties(Id.Program programId, Map<String, String> properties)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    String path = String.format("apps/%s/%s/%s/metadata/properties",
+                                programId.getApplicationId(), programId.getType().getCategoryName(), programId.getId());
+    addProperties(programId, path, properties);
+  }
+
+  private void addProperties(Id.NamespacedId namespacedId, String path, Map<String, String> properties)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    URL url = config.resolveNamespacedURLV3(namespacedId.getNamespace(), path);
+    HttpResponse response =
+      restClient.execute(HttpRequest.post(url).withBody(GSON.toJson(properties)).build(), config.getAccessToken(),
+                         HttpURLConnection.HTTP_BAD_REQUEST, HttpURLConnection.HTTP_NOT_FOUND);
+    if (response.getResponseCode() == HttpURLConnection.HTTP_BAD_REQUEST) {
+      throw new BadRequestException(response.getResponseBodyAsString());
+    }
+    if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
+      throw new NotFoundException(namespacedId);
+    }
+  }
+
+  /**
+   * Removes properties from an application.
+   *
+   * @param appId app to remove properties from
+   * @param propertyToRemove property to be removed, or {@code null} to remove all properties for the entity
+   */
+  public void removeProperties(Id.Application appId, @Nullable String propertyToRemove)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    String path = String.format("apps/%s/metadata/properties", appId.getId());
+    removeProperties(appId, path, propertyToRemove);
+  }
+
+  /**
+   * Removes properties from a dataset.
+   *
+   * @param datasetInstance dataset to remove properties from
+   * @param propertyToRemove property to be removed, or {@code null} to remove all properties for the entity
+   */
+  public void removeProperties(Id.DatasetInstance datasetInstance, @Nullable String propertyToRemove)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    String path = String.format("datasets/%s/metadata/properties", datasetInstance.getId());
+    removeProperties(datasetInstance, path, propertyToRemove);
+  }
+
+  /**
+   * Removes properties from a stream.
+   *
+   * @param streamId stream to remove properties from
+   * @param propertyToRemove property to be removed, or {@code null} to remove all properties for the entity
+   */
+  public void removeProperties(Id.Stream streamId, @Nullable String propertyToRemove)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    String path = String.format("streams/%s/metadata/properties", streamId.getId());
+    removeProperties(streamId, path, propertyToRemove);
+  }
+
+  /**
+   * Removes properties from a program.
+   *
+   * @param programId program to remove properties from
+   * @param propertyToRemove property to be removed, or {@code null} to remove all properties for the entity
+   */
+  public void removeProperties(Id.Program programId, @Nullable String propertyToRemove)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    String path = String.format("apps/%s/%s/%s/metadata/properties",
+                                programId.getApplicationId(), programId.getType().getCategoryName(), programId.getId());
+    removeProperties(programId, path, propertyToRemove);
+  }
+
+  private void removeProperties(Id.NamespacedId namespacedId, String path, @Nullable String propertyToRemove)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    if (propertyToRemove != null) {
+      path = path + "/" + propertyToRemove;
+    }
+    URL tagURL = config.resolveNamespacedURLV3(namespacedId.getNamespace(), path);
+    HttpResponse response = restClient.execute(HttpRequest.delete(tagURL).build(), config.getAccessToken(),
+                                               HttpURLConnection.HTTP_BAD_REQUEST, HttpURLConnection.HTTP_NOT_FOUND);
+    if (response.getResponseCode() == HttpURLConnection.HTTP_BAD_REQUEST) {
+      throw new BadRequestException(response.getResponseBodyAsString());
+    }
+    if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
+      throw new NotFoundException(namespacedId);
+    }
+  }
+
+  /**
+   * Removes tags from an application.
+   *
+   * @param appId app to remove tags from
+   * @param tagToRemove tag to be removed, or {@code null} to remove all tags for the entity
+   */
+  public void removeTags(Id.Application appId, @Nullable String tagToRemove)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    String path = String.format("apps/%s/metadata/tags", appId.getId());
+    removeTags(appId, path, tagToRemove);
+  }
+
+  /**
+   * Removes tags from a dataset.
+   *
+   * @param datasetInstance dataset to remove tags from
+   * @param tagToRemove tag to be removed, or {@code null} to remove all tags for the entity
+   */
+  public void removeTags(Id.DatasetInstance datasetInstance, @Nullable String tagToRemove)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    String path = String.format("datasets/%s/metadata/tags", datasetInstance.getId());
+    removeTags(datasetInstance, path, tagToRemove);
+  }
+
+  /**
+   * Removes tags from a stream.
+   *
+   * @param streamId stream to remove tags from
+   * @param tagToRemove tag to be removed, or {@code null} to remove all tags for the entity
+   */
+  public void removeTags(Id.Stream streamId, @Nullable String tagToRemove)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    String path = String.format("streams/%s/metadata/tags", streamId.getId());
+    removeTags(streamId, path, tagToRemove);
+  }
+
+  /**
+   * Removes tags from a program.
+   *
+   * @param programId program to remove tags from
+   * @param tagToRemove tag to be removed, or {@code null} to remove all tags for the entity
+   */
+  public void removeTags(Id.Program programId, @Nullable String tagToRemove)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    String path = String.format("apps/%s/%s/%s/metadata/tags",
+                                programId.getApplicationId(), programId.getType().getCategoryName(), programId.getId());
+    removeTags(programId, path, tagToRemove);
+  }
+
+  private void removeTags(Id.NamespacedId namespacedId, String path, @Nullable String tagToRemove)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    if (tagToRemove != null) {
+      path = path + "/" + tagToRemove;
+    }
+    URL tagURL = config.resolveNamespacedURLV3(namespacedId.getNamespace(), path);
+    HttpResponse response = restClient.execute(HttpRequest.delete(tagURL).build(), config.getAccessToken(),
+                                               HttpURLConnection.HTTP_BAD_REQUEST, HttpURLConnection.HTTP_NOT_FOUND);
+    if (response.getResponseCode() == HttpURLConnection.HTTP_BAD_REQUEST) {
+      throw new BadRequestException(response.getResponseBodyAsString());
+    }
+    if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
+      throw new NotFoundException(namespacedId);
+    }
+  }
+
+ /**
+  * Removes metadata from an application.
+  *
+  * @param appId app to remove metadata from
+  */
+  public void removeMetadata(Id.Application appId)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    String path = String.format("apps/%s/metadata", appId.getId());
+    removeMetadata(appId, path);
+  }
+
+  /**
+   * Removes metadata from a dataset.
+   *
+   * @param datasetInstance dataset to remove metadata from
+   */
+  public void removeMetadata(Id.DatasetInstance datasetInstance)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    String path = String.format("datasets/%s/metadata", datasetInstance.getId());
+    removeMetadata(datasetInstance, path);
+  }
+
+  /**
+   * Removes metadata from a stream.
+   *
+   * @param streamId stream to remove metadata from
+   */
+  public void removeMetadata(Id.Stream streamId)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    String path = String.format("streams/%s/metadata", streamId.getId());
+    removeMetadata(streamId, path);
+  }
+
+  /**
+   * Removes metadata from a program.
+   *
+   * @param programId program to remove metadata from
+   */
+  public void removeMetadata(Id.Program programId)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    String path = String.format("apps/%s/%s/%s/metadata",
+                                programId.getApplicationId(), programId.getType().getCategoryName(), programId.getId());
+    removeMetadata(programId, path);
+  }
+
+  private void removeMetadata(Id.NamespacedId namespacedId, String path)
+    throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    URL tagURL = config.resolveNamespacedURLV3(namespacedId.getNamespace(), path);
+    HttpResponse response = restClient.execute(HttpRequest.delete(tagURL).build(), config.getAccessToken(),
+                                               HttpURLConnection.HTTP_BAD_REQUEST, HttpURLConnection.HTTP_NOT_FOUND);
+    if (response.getResponseCode() == HttpURLConnection.HTTP_BAD_REQUEST) {
+      throw new BadRequestException(response.getResponseBodyAsString());
+    }
+    if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
+      throw new NotFoundException(namespacedId);
+    }
+  }
+}

--- a/cdap-client/src/main/java/co/cask/cdap/client/MetadataClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/MetadataClient.java
@@ -95,8 +95,7 @@ public class MetadataClient {
    */
   public Set<MetadataRecord> getMetadata(Id.Application appId)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    String path = String.format("apps/%s/metadata", appId.getId());
-    return getMetadata(appId, path);
+    return getMetadata(appId, constructPath(appId));
   }
 
   /**
@@ -105,8 +104,7 @@ public class MetadataClient {
    */
   public Set<MetadataRecord> getMetadata(Id.DatasetInstance datasetInstance)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    String path = String.format("datasets/%s/metadata", datasetInstance.getId());
-    return getMetadata(datasetInstance, path);
+    return getMetadata(datasetInstance, constructPath(datasetInstance));
   }
 
   /**
@@ -115,8 +113,7 @@ public class MetadataClient {
    */
   public Set<MetadataRecord> getMetadata(Id.Stream streamId)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    String path = String.format("streams/%s/metadata", streamId.getId());
-    return getMetadata(streamId, path);
+    return getMetadata(streamId, constructPath(streamId));
   }
 
   /**
@@ -125,9 +122,7 @@ public class MetadataClient {
    */
   public Set<MetadataRecord> getMetadata(Id.Program programId)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    String path = String.format("apps/%s/%s/%s/metadata",
-                                programId.getApplicationId(), programId.getType().getCategoryName(), programId.getId());
-    return getMetadata(programId, path);
+    return getMetadata(programId, constructPath(programId));
   }
 
   /**
@@ -136,15 +131,12 @@ public class MetadataClient {
    */
   public Set<MetadataRecord> getMetadata(Id.Run runId)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    Id.Program programId = runId.getProgram();
-    String path = String.format("apps/%s/%s/%s/runs/%s/metadata",
-                                programId.getApplicationId(), programId.getType().getCategoryName(), programId.getId(),
-                                runId.getId());
-    return getMetadata(runId, path);
+    return getMetadata(runId, constructPath(runId));
   }
 
-  private Set<MetadataRecord> getMetadata(Id.NamespacedId namespacedId, String path)
+  private Set<MetadataRecord> getMetadata(Id.NamespacedId namespacedId, String entityPath)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    String path = String.format("%s/metadata", entityPath);
     HttpResponse response = makeRequest(namespacedId, path, HttpMethod.GET);
     return GSON.fromJson(response.getResponseBodyAsString(), SET_METADATA_RECORD_TYPE);
   }
@@ -157,8 +149,7 @@ public class MetadataClient {
    */
   public void addTags(Id.Application appId, Set<String> tags)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    String path = String.format("apps/%s/metadata/tags", appId.getId());
-    addTags(appId, path, tags);
+    addTags(appId, constructPath(appId), tags);
   }
 
   /**
@@ -169,8 +160,7 @@ public class MetadataClient {
    */
   public void addTags(Id.DatasetInstance datasetInstance, Set<String> tags)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    String path = String.format("datasets/%s/metadata/tags", datasetInstance.getId());
-    addTags(datasetInstance, path, tags);
+    addTags(datasetInstance, constructPath(datasetInstance), tags);
   }
 
   /**
@@ -181,8 +171,7 @@ public class MetadataClient {
    */
   public void addTags(Id.Stream streamId, Set<String> tags)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    String path = String.format("streams/%s/metadata/tags", streamId.getId());
-    addTags(streamId, path, tags);
+    addTags(streamId, constructPath(streamId), tags);
   }
 
   /**
@@ -193,13 +182,12 @@ public class MetadataClient {
    */
   public void addTags(Id.Program programId, Set<String> tags)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    String path = String.format("apps/%s/%s/%s/metadata/tags",
-                                programId.getApplicationId(), programId.getType().getCategoryName(), programId.getId());
-    addTags(programId, path, tags);
+    addTags(programId, constructPath(programId), tags);
   }
 
-  private void addTags(Id.NamespacedId namespacedId, String path, Set<String> tags)
+  private void addTags(Id.NamespacedId namespacedId, String entityPath, Set<String> tags)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    String path = String.format("%s/metadata/tags", entityPath);
     makeRequest(namespacedId, path, HttpMethod.POST, GSON.toJson(tags));
   }
 
@@ -211,8 +199,7 @@ public class MetadataClient {
    */
   public void addProperties(Id.Application appId, Map<String, String> properties)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    String path = String.format("apps/%s/metadata/properties", appId.getId());
-    addProperties(appId, path, properties);
+    addProperties(appId, constructPath(appId), properties);
   }
 
   /**
@@ -223,8 +210,7 @@ public class MetadataClient {
    */
   public void addProperties(Id.DatasetInstance datasetInstance, Map<String, String> properties)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    String path = String.format("datasets/%s/metadata/properties", datasetInstance.getId());
-    addProperties(datasetInstance, path, properties);
+    addProperties(datasetInstance, constructPath(datasetInstance), properties);
   }
 
   /**
@@ -235,8 +221,7 @@ public class MetadataClient {
    */
   public void addProperties(Id.Stream streamId, Map<String, String> properties)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    String path = String.format("streams/%s/metadata/properties", streamId.getId());
-    addProperties(streamId, path, properties);
+    addProperties(streamId, constructPath(streamId), properties);
   }
 
   /**
@@ -247,13 +232,12 @@ public class MetadataClient {
    */
   public void addProperties(Id.Program programId, Map<String, String> properties)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    String path = String.format("apps/%s/%s/%s/metadata/properties",
-                                programId.getApplicationId(), programId.getType().getCategoryName(), programId.getId());
-    addProperties(programId, path, properties);
+    addProperties(programId, constructPath(programId), properties);
   }
 
-  private void addProperties(Id.NamespacedId namespacedId, String path, Map<String, String> properties)
+  private void addProperties(Id.NamespacedId namespacedId, String entityPath, Map<String, String> properties)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    String path = String.format("%s/metadata/properties", entityPath);
     makeRequest(namespacedId, path, HttpMethod.POST, GSON.toJson(properties));
   }
 
@@ -265,8 +249,7 @@ public class MetadataClient {
    */
   public void removeProperties(Id.Application appId, @Nullable String propertyToRemove)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    String path = String.format("apps/%s/metadata/properties", appId.getId());
-    removeProperties(appId, path, propertyToRemove);
+    removeProperties(appId, constructPath(appId), propertyToRemove);
   }
 
   /**
@@ -277,8 +260,7 @@ public class MetadataClient {
    */
   public void removeProperties(Id.DatasetInstance datasetInstance, @Nullable String propertyToRemove)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    String path = String.format("datasets/%s/metadata/properties", datasetInstance.getId());
-    removeProperties(datasetInstance, path, propertyToRemove);
+    removeProperties(datasetInstance, constructPath(datasetInstance), propertyToRemove);
   }
 
   /**
@@ -289,8 +271,7 @@ public class MetadataClient {
    */
   public void removeProperties(Id.Stream streamId, @Nullable String propertyToRemove)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    String path = String.format("streams/%s/metadata/properties", streamId.getId());
-    removeProperties(streamId, path, propertyToRemove);
+    removeProperties(streamId, constructPath(streamId), propertyToRemove);
   }
 
   /**
@@ -301,13 +282,12 @@ public class MetadataClient {
    */
   public void removeProperties(Id.Program programId, @Nullable String propertyToRemove)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    String path = String.format("apps/%s/%s/%s/metadata/properties",
-                                programId.getApplicationId(), programId.getType().getCategoryName(), programId.getId());
-    removeProperties(programId, path, propertyToRemove);
+    removeProperties(programId, constructPath(programId), propertyToRemove);
   }
 
-  private void removeProperties(Id.NamespacedId namespacedId, String path, @Nullable String propertyToRemove)
+  private void removeProperties(Id.NamespacedId namespacedId, String entityPath, @Nullable String propertyToRemove)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    String path = String.format("%s/metadata/properties", entityPath);
     if (propertyToRemove != null) {
       path = path + "/" + propertyToRemove;
     }
@@ -322,8 +302,7 @@ public class MetadataClient {
    */
   public void removeTags(Id.Application appId, @Nullable String tagToRemove)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    String path = String.format("apps/%s/metadata/tags", appId.getId());
-    removeTags(appId, path, tagToRemove);
+    removeTags(appId, constructPath(appId), tagToRemove);
   }
 
   /**
@@ -334,8 +313,7 @@ public class MetadataClient {
    */
   public void removeTags(Id.DatasetInstance datasetInstance, @Nullable String tagToRemove)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    String path = String.format("datasets/%s/metadata/tags", datasetInstance.getId());
-    removeTags(datasetInstance, path, tagToRemove);
+    removeTags(datasetInstance, constructPath(datasetInstance), tagToRemove);
   }
 
   /**
@@ -346,8 +324,7 @@ public class MetadataClient {
    */
   public void removeTags(Id.Stream streamId, @Nullable String tagToRemove)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    String path = String.format("streams/%s/metadata/tags", streamId.getId());
-    removeTags(streamId, path, tagToRemove);
+    removeTags(streamId, constructPath(streamId), tagToRemove);
   }
 
   /**
@@ -358,13 +335,12 @@ public class MetadataClient {
    */
   public void removeTags(Id.Program programId, @Nullable String tagToRemove)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    String path = String.format("apps/%s/%s/%s/metadata/tags",
-                                programId.getApplicationId(), programId.getType().getCategoryName(), programId.getId());
-    removeTags(programId, path, tagToRemove);
+    removeTags(programId, constructPath(programId), tagToRemove);
   }
 
-  private void removeTags(Id.NamespacedId namespacedId, String path, @Nullable String tagToRemove)
+  private void removeTags(Id.NamespacedId namespacedId, String entityPath, @Nullable String tagToRemove)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
+    String path = String.format("%s/metadata/tags", entityPath);
     if (tagToRemove != null) {
       path = path + "/" + tagToRemove;
     }
@@ -378,8 +354,7 @@ public class MetadataClient {
   */
   public void removeMetadata(Id.Application appId)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    String path = String.format("apps/%s/metadata", appId.getId());
-    makeRequest(appId, path, HttpMethod.DELETE);
+    removeMetadata(appId, constructPath(appId));
   }
 
   /**
@@ -389,8 +364,7 @@ public class MetadataClient {
    */
   public void removeMetadata(Id.DatasetInstance datasetInstance)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    String path = String.format("datasets/%s/metadata", datasetInstance.getId());
-    makeRequest(datasetInstance, path, HttpMethod.DELETE);
+    removeMetadata(datasetInstance, constructPath(datasetInstance));
   }
 
   /**
@@ -400,8 +374,7 @@ public class MetadataClient {
    */
   public void removeMetadata(Id.Stream streamId)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    String path = String.format("streams/%s/metadata", streamId.getId());
-    makeRequest(streamId, path, HttpMethod.DELETE);
+    removeMetadata(streamId, constructPath(streamId));
   }
 
   /**
@@ -411,9 +384,13 @@ public class MetadataClient {
    */
   public void removeMetadata(Id.Program programId)
     throws IOException, UnauthorizedException, NotFoundException, BadRequestException {
-    String path = String.format("apps/%s/%s/%s/metadata",
-                                programId.getApplicationId(), programId.getType().getCategoryName(), programId.getId());
-    makeRequest(programId, path, HttpMethod.DELETE);
+    removeMetadata(programId, constructPath(programId));
+  }
+
+  private void removeMetadata(Id.NamespacedId namespacedId, String entityPath)
+    throws UnauthorizedException, BadRequestException, NotFoundException, IOException {
+    String path = String.format("%s/metadata", entityPath);
+    makeRequest(namespacedId, path, HttpMethod.DELETE);
   }
 
   private HttpResponse makeRequest(Id.NamespacedId namespacedId, String path, HttpMethod httpMethod)
@@ -439,5 +416,31 @@ public class MetadataClient {
       throw new NotFoundException(namespacedId);
     }
     return response;
+  }
+
+  // construct a component of the path, specific to each entity type
+
+  private String constructPath(Id.Application appId) {
+    return String.format("apps/%s", appId.getId());
+  }
+
+  private String constructPath(Id.Program programId) {
+    return String.format("apps/%s/%s/%s",
+                         programId.getApplicationId(), programId.getType().getCategoryName(), programId.getId());
+  }
+
+  private String constructPath(Id.Run runId) {
+    Id.Program programId = runId.getProgram();
+    return String.format("apps/%s/%s/%s/runs/%s",
+                         programId.getApplicationId(), programId.getType().getCategoryName(), programId.getId(),
+                         runId.getId());
+  }
+
+  private String constructPath(Id.DatasetInstance datasetInstance) {
+    return String.format("datasets/%s", datasetInstance.getId());
+  }
+
+  private String constructPath(Id.Stream streamId) {
+    return String.format("streams/%s", streamId.getId());
   }
 }

--- a/cdap-client/src/main/java/co/cask/cdap/client/MonitorClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/MonitorClient.java
@@ -59,8 +59,7 @@ public class MonitorClient {
   }
 
   public MonitorClient(ClientConfig config) {
-    this.config = config;
-    this.restClient = new RESTClient(config);
+    this(config, new RESTClient(config));
   }
 
   /**

--- a/cdap-client/src/main/java/co/cask/cdap/client/NamespaceClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/NamespaceClient.java
@@ -47,8 +47,7 @@ public class NamespaceClient extends AbstractNamespaceClient {
   }
 
   public NamespaceClient(ClientConfig config) {
-    this.config = config;
-    this.restClient = new RESTClient(config);
+    this(config, new RESTClient(config));
   }
 
   @Override

--- a/cdap-client/src/main/java/co/cask/cdap/client/PreferencesClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/PreferencesClient.java
@@ -54,8 +54,7 @@ public class PreferencesClient {
   }
 
   public PreferencesClient(ClientConfig config) {
-    this.config = config;
-    this.restClient = new RESTClient(config);
+    this(config, new RESTClient(config));
   }
 
   /**

--- a/cdap-client/src/main/java/co/cask/cdap/client/QueryClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/QueryClient.java
@@ -33,12 +33,10 @@ import javax.inject.Inject;
 @Beta
 public class QueryClient {
 
-  private final ClientConfig config;
   private final ExploreClient exploreClient;
 
   @Inject
   public QueryClient(final ClientConfig config) {
-    this.config = config;
 
     Supplier<String> hostname = new Supplier<String>() {
       @Override

--- a/cdap-client/src/main/java/co/cask/cdap/client/ScheduleClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ScheduleClient.java
@@ -58,8 +58,7 @@ public class ScheduleClient {
   }
 
   public ScheduleClient(ClientConfig config) {
-    this.config = config;
-    this.restClient = new RESTClient(config);
+    this(config, new RESTClient(config));
   }
 
   public List<ScheduleSpecification> list(Id.Workflow workflow)

--- a/cdap-client/src/main/java/co/cask/cdap/client/ServiceClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ServiceClient.java
@@ -53,8 +53,7 @@ public class ServiceClient {
   }
 
   public ServiceClient(ClientConfig config) {
-    this.config = config;
-    this.restClient = new RESTClient(config);
+    this(config, new RESTClient(config));
   }
 
   /**

--- a/cdap-client/src/main/java/co/cask/cdap/client/StreamClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/StreamClient.java
@@ -81,8 +81,7 @@ public class StreamClient {
   }
 
   public StreamClient(ClientConfig config) {
-    this.config = config;
-    this.restClient = new RESTClient(config);
+    this(config, new RESTClient(config));
   }
 
   /**

--- a/cdap-client/src/main/java/co/cask/cdap/client/StreamViewClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/StreamViewClient.java
@@ -59,8 +59,7 @@ public class StreamViewClient {
   }
 
   public StreamViewClient(ClientConfig config) {
-    this.config = config;
-    this.restClient = new RESTClient(config);
+    this(config, new RESTClient(config));
   }
 
   /**


### PR DESCRIPTION
Implement `MetadataClient` and `LineageClient`.
Update metadata/lineage test cases to utilize these.
Update `MetadataHttpHandler` to respond with 400 (instead of 500), if null metadata is given in request.

The methods exposed in `MetadataClient` are:
`searchMetadata`
For each of the following program entity types: `Application`, `DatasetInstance`, `Stream`, `Program`:
`getMetadata`
`addTags`
`addProperties`
`removeProperties`
`removeTags`
`removeMetadata`

https://issues.cask.co/browse/CDAP-3889
http://builds.cask.co/browse/CDAP-DUT2918-4