### PR TITLE
Fix Documentation for 3.2.0

### DIFF
--- a/cdap-docs/included-applications/source/conf.py
+++ b/cdap-docs/included-applications/source/conf.py
@@ -19,3 +19,13 @@ html_context = {"html_short_title_toc":html_short_title_toc}
 
 # Remove this guide from the mapping as it will fail as it has been deleted by clean
 intersphinx_mapping.pop("includedapps", None)
+
+# Add a custom config value that can be used for conditional content
+def setup(app):
+    app.add_config_value('release_version', '', 'env')
+
+# Set the condition
+if version == ('3.2.0'):
+    release_version = 'equal_to_3.2.0'
+else:
+    release_version = 'greater_than_3.2.0'

--- a/cdap-docs/included-applications/source/etl/plugins/batchsinks/database.rst
+++ b/cdap-docs/included-applications/source/etl/plugins/batchsinks/database.rst
@@ -25,11 +25,13 @@ of the FileSet to a database table where it can be served to your users.
 
 **columns:** Comma-separated list of columns in the specified table to export to.
 
-**columnCase:** Sets the case of the column names returned by the column check query.
-Possible options are ``upper`` or ``lower``. By default or for any other input, the column names are not modified and
-the names returned from the database are used as-is. Note that setting this property provides predictability
-of column name cases across different databases but might result in column name conflicts if multiple column
-names are the same when the case is ignored. (Optional)
+.. ifconfig:: release_version in ('greater_than_3.2.0')
+
+  **columnCase:** Sets the case of the column names returned by the column check query.
+  Possible options are ``upper`` or ``lower``. By default or for any other input, the column names are not modified and
+  the names returned from the database are used as-is. Note that setting this property provides predictability
+  of column name cases across different databases but might result in column name conflicts if multiple column
+  names are the same when the case is ignored. (Optional)
 
 .. connection information from DBConfig.java
 


### PR DESCRIPTION
Add a conditional text block to the database sink reference page as these changes do not take affect until 3.2.1.

The PR that was merged yesterday fixed the documentation build, but it inadvertently added a change that doesn't take affect until 3.2.1. To allow the documentation to be built as "3.2.0", yet contain the changes required for 3.2.1, this adds a conditional test for including the affected paragraph. Once the version changes to greater than 3.2.0, the paragraph will be included.

If other documentation manuals need fixes such as this, this code could be moved to the common conf.py and accessed from all.

Building at: http://builds.cask.co/browse/CDAP-DDB23-1