### PR TITLE
CDAP-3900 Return empty list in case of logs are requested for the deleted program runs.

### DIFF
--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/read/FileLogReader.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/read/FileLogReader.java
@@ -174,6 +174,13 @@ public class FileLogReader implements LogReader {
     Long start = sortedFiles.floorKey(fromTimeMs);
     if (start == null) {
       start = sortedFiles.firstKey();
+
+      // It is possible that the log files for the requested range are already
+      // deleted, in case of old program runs. For such requests both the start and toTimeMs
+      // will fall outside the range sortedFiles. In that case return empty list.
+      if (start > toTimeMs) {
+        return ImmutableList.of();
+      }
     }
     return ImmutableList.copyOf(sortedFiles.subMap(start, toTimeMs).values());
   }

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/read/FileLogReaderTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/read/FileLogReaderTest.java
@@ -42,6 +42,9 @@ public class FileLogReaderTest {
                                                                                    28L, base.append("28"),
                                                                                    35L, base.append("35")));
 
+    // JIRA: CDAP-3900. Query for the logs not within the range of the sortedFiles.
+    Assert.assertEquals(Collections.<Location>emptyList(), FileLogReader.getFilesInRange(sortedFiles, 1, 9));
+
     Assert.assertEquals(Collections.<Location>emptyList(), FileLogReader.getFilesInRange(sortedFiles, 1, 10));
 
     Assert.assertEquals(ImmutableList.of(base.append("10")), FileLogReader.getFilesInRange(sortedFiles, 1, 11));


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-3900
Build: http://builds.cask.co/browse/CDAP-DUT2925-1

It is possible that the log files for the requested range are already deleted, in case of old program runs. For such requests both the start and toTimeMs will fall outside the range sortedFiles. In that case return empty list.