### PR TITLE
Fixes to continue polling when frequence or duration is changed

### DIFF
--- a/cdap-ui/app/features/dashboard/controllers/userdashboard-ctrl.js
+++ b/cdap-ui/app/features/dashboard/controllers/userdashboard-ctrl.js
@@ -122,6 +122,17 @@ function ($scope, $state, $dropdown, rDashboardsModel, MY_CONFIG, $alert, Dashbo
     DashboardHelper.startPollDashboard($scope.currentBoard);
   };
 
+  $scope.$watch('timeOptions.durationMs', function() {
+    if ($scope.liveDashboard) {
+      $scope.updateWithFrequency();
+    }
+  });
+  $scope.updateRefreshInterval =  function() {
+    if ($scope.liveDashboard) {
+      $scope.updateWithFrequency();
+    }
+  };
+
   $scope.stopPolling = function() {
     $scope.liveDashboard = false;
     applyOnWidgets(rDashboardsModel, function (widget) {

--- a/cdap-ui/app/features/dashboard/templates/userdashboard.html
+++ b/cdap-ui/app/features/dashboard/templates/userdashboard.html
@@ -1,18 +1,18 @@
 <!--
   Copyright © 2015 Cask Data, Inc.
- 
+
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of
   the License at
- 
+
   http://www.apache.org/licenses/LICENSE-2.0
- 
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
   License for the specific language governing permissions and limitations under
   the License.
---> 
+-->
 
 <div class="well well-lg" ng-if="unknownBoard">
   <h3 class="text-center"> This dashboard is either deleted or not found.</h3>
@@ -66,6 +66,7 @@
 
           <button type="button" class="btn btn-default form-control mp-dropdown-toggle"
           ng-model="timeOptions.refreshInterval"
+          ng-change="updateRefreshInterval()"
           bs-options="t.name for t in refreshIntervals"
           bs-select>
             <strong ng-bind="timeOptions.refreshInterval.name"></strong>


### PR DESCRIPTION
In Ops dashboard, on change in frequency or duration the polling should automatically change without forcing the user to stop and restart the polling again.