### PR TITLE
Disables user to add more than 12 widgets on a given dashboard

### DIFF
--- a/cdap-ui/Gulpfile.js
+++ b/cdap-ui/Gulpfile.js
@@ -145,7 +145,8 @@ gulp.task('js:lib', function() {
       './bower_components/angular-ui-ace/ui-ace.js',
       './bower_components/jsPlumb/dist/js/dom.jsPlumb-1.7.5-min.js',
       './bower_components/angular-gridster/dist/angular-gridster.min.js',
-      './bower_components/angular-cron-jobs/dist/angular-cron-jobs.min.js'
+      './bower_components/angular-cron-jobs/dist/angular-cron-jobs.min.js',
+      './bower_components/angularjs-dropdown-multiselect/dist/angularjs-dropdown-multiselect.min.js'
 
     ].concat([
       './bower_components/cask-angular-*/*/module.js'

--- a/cdap-ui/app/directives/metric-picker/metric-picker.html
+++ b/cdap-ui/app/directives/metric-picker/metric-picker.html
@@ -1,32 +1,25 @@
 <!--
   Copyright © 2015 Cask Data, Inc.
- 
+
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of
   the License at
- 
+
   http://www.apache.org/licenses/LICENSE-2.0
- 
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
   License for the specific language governing permissions and limitations under
   the License.
---> 
+-->
 
 <div class="form-group">
   <div class="col-xs-12 col-sm-12">
     <div class="input-group">
-      <div class="input-group-btn">
-        <button type="button" class="btn btn-default form-control mp-dropdown-toggle"
-          ng-model="metric.type"
-          bs-options="t for t in available.types"
-          data-container="body"
-          bs-select>
-            <strong ng-bind="metric.type"></strong>
-            <span class="caret"></span>
-        </button>
-      </div>
+      <span class="input-group-addon">
+        <span ng-bind="metric.type"></span>
+      </span>
       <input type="text" class="form-control mp-input-group-input"
         placeholder="Context"
         ng-model="metric.context"
@@ -41,29 +34,42 @@
 </div>
 
 <div class="metrics-container">
-<div ng-repeat="name in metric.names" class="h6">
-  <div class="input-group">
-    <span class="input-group-addon">
-      <i class="fa fa-line-chart"></i>
-    </span>
-    <input type="text" class="form-control"
-      placeholder="Metric Name"
-      ng-model="name.name"
-      bs-options="m for m in available.names"
-      data-watch-options="1"
-      data-min-length="0"
-      data-limit="100"
-      data-container="body"
-      bs-typeahead />
-    <div class="input-group-addon" ng-click="deleteMetric($index)">
-      <span>
-        <i class="fa fa-fw fa-trash"></i>
+  <div class="control-label clearfix">
+    <label class="pull-left">
+      <span>Metric(s)</span>
+      <span class="fa fa-asterisk"></span>
+    </label>
+    <small class="pull-right">Max 12 per dashboard</small>
+  </div>
+
+  <div ng-repeat="name in metric.names" class="h6">
+    <div class="input-group">
+      <span class="input-group-addon">
+        <i class="fa fa-line-chart"></i>
       </span>
+      <input type="text" class="form-control"
+        placeholder="Metric Name"
+        ng-model="name.name"
+        bs-options="m.id as m.label for m in available.names"
+        data-watch-options="1"
+        data-min-length="0"
+        data-limit="100"
+        data-container="body"
+        bs-typeahead />
+      <div class="input-group-addon" ng-click="deleteMetric($index)">
+        <span>
+          <i class="fa fa-fw fa-trash"></i>
+        </span>
+      </div>
     </div>
   </div>
 </div>
-</div>
 
-<button class="btn btn-primary" ng-click="addMetricName()" type="button" >
+<button class="btn btn-primary"
+        ng-click="addMetricName()"
+        type="button"
+        tooltip-class="tooltip-info"
+        tooltip-placement="right"
+        tooltip="Add metrics to the same widget">
   <span class="fa fa-fw fa-plus"></span>
 </button>

--- a/cdap-ui/app/directives/metric-picker/metric-picker.html
+++ b/cdap-ui/app/directives/metric-picker/metric-picker.html
@@ -41,41 +41,14 @@
     </label>
     <small class="pull-right">Max 12 per dashboard</small>
   </div>
-
-  <!-- <div ng-repeat="name in metric.names" class="h6">
-    <div class="input-group">
-      <span class="input-group-addon">
-        <i class="fa fa-line-chart"></i>
-      </span>
-      <input type="text" class="form-control"
-        placeholder="Metric Name"
-        ng-model="name.name"
-        bs-options="m.id as m.label for m in available.names"
-        data-watch-options="1"
-        data-min-length="0"
-        data-limit="100"
-        data-container="body"
-        bs-typeahead />
-      <div class="input-group-addon" ng-click="deleteMetric($index)">
-        <span>
-          <i class="fa fa-fw fa-trash"></i>
-        </span>
+  <div class="clearfix">
+    <div class="pull-left">
+      <div ng-dropdown-multiselect=""
+           options="available.names"
+           translation-texts="{dynamicButtonTextSuffix: 'Selected'}"
+           selected-model="metric.names"
+           extra-settings="metricsSettings">
       </div>
     </div>
-  </div> -->
-  <div ng-dropdown-multiselect=""
-       options="available.names"
-       selected-model="metric.names"
-       extra-settings="metricsSettings">
   </div>
-
 </div>
-<!--
-<button class="btn btn-primary"
-        ng-click="addMetricName()"
-        type="button"
-        tooltip-class="tooltip-info"
-        tooltip-placement="right"
-        tooltip="Add metrics to the same widget">
-  <span class="fa fa-fw fa-plus"></span> -->
-</button>

--- a/cdap-ui/app/directives/metric-picker/metric-picker.html
+++ b/cdap-ui/app/directives/metric-picker/metric-picker.html
@@ -42,7 +42,7 @@
     <small class="pull-right">Max 12 per dashboard</small>
   </div>
 
-  <div ng-repeat="name in metric.names" class="h6">
+  <!-- <div ng-repeat="name in metric.names" class="h6">
     <div class="input-group">
       <span class="input-group-addon">
         <i class="fa fa-line-chart"></i>
@@ -62,14 +62,20 @@
         </span>
       </div>
     </div>
+  </div> -->
+  <div ng-dropdown-multiselect=""
+       options="available.names"
+       selected-model="metric.names"
+       extra-settings="metricsSettings">
   </div>
-</div>
 
+</div>
+<!--
 <button class="btn btn-primary"
         ng-click="addMetricName()"
         type="button"
         tooltip-class="tooltip-info"
         tooltip-placement="right"
         tooltip="Add metrics to the same widget">
-  <span class="fa fa-fw fa-plus"></span>
+  <span class="fa fa-fw fa-plus"></span> -->
 </button>

--- a/cdap-ui/app/directives/metric-picker/metric-picker.js
+++ b/cdap-ui/app/directives/metric-picker/metric-picker.js
@@ -15,11 +15,9 @@
  */
 
 angular.module(PKG.name + '.commons')
-  .directive('myMetricPicker', function (MyDataSource, $stateParams, $log, MyMetricsQueryHelper, myHelpers) {
+  .directive('myMetricPicker', function (MyDataSource, $stateParams, $log, MyMetricsQueryHelper) {
 
     var dSrc = new MyDataSource();
-    var addAllOptionId = 'allMetricsAsWidgets';
-    var addAllOptionLabel = 'Add all metrics as individual widgets';
 
     function MetricPickerCtrl ($scope) {
 
@@ -28,7 +26,7 @@ angular.module(PKG.name + '.commons')
       $scope.metricsSettings = {
         externalProp: ''
       };
-      
+
       $scope.available = {
         contexts: [],
         types: ['system', ns],
@@ -38,22 +36,18 @@ angular.module(PKG.name + '.commons')
       $scope.metric = {
         context: '',
         type: ns,
-        names: [{name: ''}],
+        names: [],
         resetNames: function() {
-          this.names = [{name: ''}];
+          this.names = [];
         },
         getNames: function() {
           return this.names.map(function(value) {
-            return value.name;
+            return value.id;
           });
         },
         getName: function() {
           return this.getNames().join(', ');
         }
-      };
-
-      $scope.addMetricName = function() {
-        $scope.metric.names.push({name: ''});
       };
 
       $scope.deleteMetric = function(idx) {
@@ -103,16 +97,6 @@ angular.module(PKG.name + '.commons')
             }
             return true;
           };
-
-          ngModel.$validators.metricsLimitValidation = function() {
-            var availableMetricSlots = scope.metricsLimit - scope.metricsSlotsFilled;
-            var hasMetricsLimitReached = myHelpers.objectQuery(scope, 'metric', 'names', 0, 'name', 'id') === addAllOptionId &&  availableMetricSlots < scope.available.names.length;
-            if (hasMetricsLimitReached) {
-              return false;
-            }
-            return true;
-          };
-
         }
 
         function getBaseContext () {
@@ -176,10 +160,6 @@ angular.module(PKG.name + '.commons')
             },
             function (res) {
               var metricsArray = [];
-              metricsArray.push({
-                id: addAllOptionId,
-                label: addAllOptionLabel
-              });
               // 'Add All' option to add all metrics in current context.
               res.forEach(function(metric) {
                 metricsArray.push({
@@ -214,33 +194,16 @@ angular.module(PKG.name + '.commons')
           }
 
           if(newVal.names) {
-            var isAddAll = false;
-            for (var i = 0; i < newVal.names.length; i++) {
-              if (newVal.names[i].name === addAllOptionId) {
-                isAddAll = true;
-              }
-            }
             var context = getBaseContext();
             if (newVal.context) {
               context += '.' + newVal.context;
             }
-            var allMetrics = scope.available.names.slice(1).map(function(e) {return e.id;}); // Remove 'Add All' option
-            if (isAddAll) {
-              ngModel.$setViewValue({
-                addAll: true,
-                allMetrics: allMetrics,
-                context: context,
-                names: newVal.getNames(),
-                name: newVal.getName()
-              });
-              return;
-            } else {
-              ngModel.$setViewValue({
-                context: context,
-                names: newVal.getNames(),
-                name: newVal.getName()
-              });
-            }
+
+            ngModel.$setViewValue({
+              context: context,
+              names: newVal.getNames(),
+              name: newVal.getName()
+            });
           } else {
             if(ngModel.$dirty) {
               ngModel.$setViewValue(null);
@@ -250,7 +213,6 @@ angular.module(PKG.name + '.commons')
 
         };
         scope.$watch('metric', metricChanged, true);
-
         fetchAhead();
       }
     };

--- a/cdap-ui/app/directives/metric-picker/metric-picker.js
+++ b/cdap-ui/app/directives/metric-picker/metric-picker.js
@@ -25,6 +25,10 @@ angular.module(PKG.name + '.commons')
 
       var ns = [$stateParams.namespace,'namespace'].join(' ');
 
+      $scope.metricsSettings = {
+        externalProp: ''
+      };
+      
       $scope.available = {
         contexts: [],
         types: ['system', ns],

--- a/cdap-ui/app/directives/metric-picker/metric-picker.js
+++ b/cdap-ui/app/directives/metric-picker/metric-picker.js
@@ -24,7 +24,8 @@ angular.module(PKG.name + '.commons')
       var ns = [$stateParams.namespace,'namespace'].join(' ');
 
       $scope.metricsSettings = {
-        externalProp: ''
+        externalProp: '',
+        closeOnBlur: false
       };
 
       $scope.available = {

--- a/cdap-ui/app/directives/metric-picker/metric-picker.less
+++ b/cdap-ui/app/directives/metric-picker/metric-picker.less
@@ -18,11 +18,15 @@
 
 my-metric-picker {
   > .metrics-container {
-    overflow-y: auto;
-    max-height: 180px;
+    .dropdown-menu {
+      .divider {
+        margin: 0;
+      }
+    }
   }
   .glyphicon {
     .fa;
   }
   .glyphicon-ok:before { content: @fa-var-check; }
+  .glyphicon-remove:before {content: @fa-var-times; }
 }

--- a/cdap-ui/app/directives/metric-picker/metric-picker.less
+++ b/cdap-ui/app/directives/metric-picker/metric-picker.less
@@ -18,5 +18,5 @@ my-metric-picker {
   > .metrics-container {
     overflow-y: auto;
     max-height: 180px;
-  }
+  }  
 }

--- a/cdap-ui/app/directives/metric-picker/metric-picker.less
+++ b/cdap-ui/app/directives/metric-picker/metric-picker.less
@@ -14,9 +14,15 @@
  * the License.
  */
 
+@import "../../../bower_components/font-awesome/less/font-awesome.less";
+
 my-metric-picker {
   > .metrics-container {
     overflow-y: auto;
     max-height: 180px;
-  }  
+  }
+  .glyphicon {
+    .fa;
+  }
+  .glyphicon-ok:before { content: @fa-var-check; }
 }

--- a/cdap-ui/app/features/dashboard/controllers/addwdgt-ctrl.js
+++ b/cdap-ui/app/features/dashboard/controllers/addwdgt-ctrl.js
@@ -46,30 +46,33 @@ function ($scope, $modalInstance, caskFocusManager, Widget) {
     }
   });
 
-  $scope.doAddWidget = _.once(function () {
-
-    if ($scope.model.metric.addAll) {
-      var widgets = [];
-      // If the user chooses 'Add All' option, add all the metrics in the current context.
-      angular.forEach($scope.model.metric.allMetrics, function(value) {
-        widgets.push(
-          new Widget({
-            type: $scope.model.type,
-            title: $scope.model.metric.title,
-            metric: {
-              context: $scope.model.metric.context,
-              names: [value],
-              name: value
-            }
-          })
-        );
-      });
-      $scope.currentBoard.addWidget(widgets);
-    } else {
-      $scope.currentBoard.addWidget($scope.model);
-    }
+  $scope.addMetricsToIndividualWidgets = _.debounce(function() {
+    var widgets = [];
+    angular.forEach($scope.model.metric.names, function(value) {
+      widgets.push(
+        new Widget({
+          type: $scope.model.type,
+          title: $scope.model.title,
+          metric: {
+            context: $scope.model.metric.context,
+            names: [value],
+            name: value
+          }
+        })
+      );
+    });
+    $scope.currentBoard.addWidget(widgets);
     $scope.$close();
-  });
+  }, 1000);
+
+  $scope.addMetricsToWidget = _.debounce(function () {
+    var metrics = $scope.model.metric;
+    if (!metrics) {
+      return;
+    }
+    $scope.currentBoard.addWidget($scope.model);
+    $scope.$close();
+  }, 1000);
 
   $scope.closeModal = function() {
     $modalInstance.close();

--- a/cdap-ui/app/features/dashboard/routes.js
+++ b/cdap-ui/app/features/dashboard/routes.js
@@ -75,6 +75,9 @@ angular.module(PKG.name+'.feature.dashboard')
         onEnter: function ($state, $bootstrapModal, $rootScope, rDashboardsModel, tab) {
           var scope = $rootScope.$new();
           scope.currentBoard = rDashboardsModel.current();
+          scope.metricsLimit = rDashboardsModel.current().WIDGET_LIMIT;
+          scope.pendingMetricsSlots = rDashboardsModel.current().columns.length;
+
           $bootstrapModal.open({
             templateUrl: '/assets/features/dashboard/templates/partials/addwdgt.html',
             size: 'md',

--- a/cdap-ui/app/features/dashboard/routes.js
+++ b/cdap-ui/app/features/dashboard/routes.js
@@ -72,16 +72,18 @@ angular.module(PKG.name+'.feature.dashboard')
 
       .state('dashboard.user.addwdgt', {
         url: '/widget/add',
-        onEnter: function ($state, $bootstrapModal, $rootScope, rDashboardsModel, tab) {
+        onEnter: function ($stateParams, $state, $bootstrapModal, $rootScope, rDashboardsModel, tab) {
           var scope = $rootScope.$new();
-          scope.currentBoard = rDashboardsModel.current();
-          scope.metricsLimit = rDashboardsModel.current().WIDGET_LIMIT;
-          scope.pendingMetricsSlots = rDashboardsModel.current().columns.length;
+          var currentBoard = rDashboardsModel.data[$stateParams.tab];
+          scope.currentBoard = currentBoard;
+          scope.metricsLimit = currentBoard.WIDGET_LIMIT;
+          scope.metricsSlotsFilled = currentBoard.columns.length;
 
           $bootstrapModal.open({
             templateUrl: '/assets/features/dashboard/templates/partials/addwdgt.html',
-            size: 'md',
+            size: 'lg',
             backdrop: true,
+            windowClass: 'cdap-modal',
             keyboard: true,
             scope: scope,
             controller: 'DashboardAddWdgtCtrl'

--- a/cdap-ui/app/features/dashboard/style.less
+++ b/cdap-ui/app/features/dashboard/style.less
@@ -164,22 +164,6 @@ body.state-dashboard {
       }
     }
   }
-
-  [as-sortable],
-  .as-sortable-item,
-  .as-sortable-placeholder { min-height: 100px; }
-
-  .as-sortable-placeholder {
-    border: 1px dashed @gray-light;
-    background-color: @gray-lighter;
-
-    // mimic a bootstrap panel
-    margin-bottom: @line-height-computed;
-    border-radius: @panel-border-radius;
-  }
-
-  .as-sortable-drag { opacity: .6; }
-
   .panel-heading {
     user-select: none;
 
@@ -200,6 +184,12 @@ body.state-dashboard {
       bacground: transparent;
   }
 
+  .modal {
+    .modal-body {
+      // This is needed for multi-select in ops add widget modal.
+      overflow: visible;
+    }
+  }
 }
 
 // @red: red;

--- a/cdap-ui/app/features/dashboard/templates/dashboard.html
+++ b/cdap-ui/app/features/dashboard/templates/dashboard.html
@@ -1,18 +1,18 @@
 <!--
   Copyright © 2015 Cask Data, Inc.
- 
+
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of
   the License at
- 
+
   http://www.apache.org/licenses/LICENSE-2.0
- 
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
   License for the specific language governing permissions and limitations under
   the License.
---> 
+-->
 
 <my-breadcrumbs></my-breadcrumbs>
 <aside role="toolbar" ng-init="dashboardNumber = dashboards.length + 1">

--- a/cdap-ui/app/features/dashboard/templates/partials/addwdgt.html
+++ b/cdap-ui/app/features/dashboard/templates/partials/addwdgt.html
@@ -19,7 +19,7 @@
       ng-submit="doAddWidget()"
         novalidate>
   <div class="modal-header clearfix">
-      <h4 class="modal-title pull-left">Add a Widget</h4>
+      <h4 class="modal-title pull-left">Add Widget(s)</h4>
       <a class="btn pull-right" ng-click="closeModal()">
         <span class="fa fa-remove"></span>
         <span class="sr-only"> Close </span>
@@ -44,13 +44,15 @@
 
           <div class="form-group">
             <label class="col-xs-3 control-label">
-              <span>Metric</span>
+              <span>Context</span>
               <span class="fa fa-asterisk"></span>
             </label>
             <div class="col-xs-8">
 
               <my-metric-picker
                 ng-model="model.metric"
+                data-metrics-limit="metricsLimit"
+                data-metrics-slots-filled="pendingMetricsSlots"
                 required
               ></my-metric-picker>
 

--- a/cdap-ui/app/features/dashboard/templates/partials/addwdgt.html
+++ b/cdap-ui/app/features/dashboard/templates/partials/addwdgt.html
@@ -83,7 +83,7 @@
     </button>
     <button ng-click="addMetricsToIndividualWidgets()"
       class="btn btn-default"
-      ng-disabled="addWdgtForm.$invalid || (!model.metric && ((metricsLimit - metricsSlotsFilled) < model.metric.names.length))">
+      ng-disabled="addWdgtForm.$invalid || ((metricsLimit - metricsSlotsFilled) < model.metric.names.length)">
       Add widgets
     </button>
   </div>

--- a/cdap-ui/app/features/dashboard/templates/partials/addwdgt.html
+++ b/cdap-ui/app/features/dashboard/templates/partials/addwdgt.html
@@ -14,12 +14,14 @@
   the License.
 -->
 
+
+
 <form name="addWdgtForm"
       class="form-horizontal"
       ng-submit="doAddWidget()"
         novalidate>
   <div class="modal-header clearfix">
-      <h4 class="modal-title pull-left">Add Widget(s)</h4>
+      <h3 class="pull-left">Add Widget(s)</h3>
       <a class="btn pull-right" ng-click="closeModal()">
         <span class="fa fa-remove"></span>
         <span class="sr-only"> Close </span>
@@ -52,7 +54,7 @@
               <my-metric-picker
                 ng-model="model.metric"
                 data-metrics-limit="metricsLimit"
-                data-metrics-slots-filled="pendingMetricsSlots"
+                data-metrics-slots-filled="metricsSlotsFilled"
                 required
               ></my-metric-picker>
 
@@ -72,12 +74,16 @@
             </div>
           </div>
 
-        </div>
   </div>
   <div class="modal-footer">
-      <button type="submit"
-        ng-disabled="addWdgtForm.$invalid"
-        class="btn btn-primary"
-      >Add</button>
+    <button ng-click="addMetricsToWidget()"
+      class="btn btn-default">
+      Add to a widget
+    </button>
+    <button ng-click="addMetricsToIndividualWidgets()"
+      class="btn btn-default"
+      ng-disabled="!model.metric || ((metricsLimit - metricsSlotsFilled) < model.metric.names.length)">
+      Add widgets
+    </button>
   </div>
 </form>

--- a/cdap-ui/app/features/dashboard/templates/partials/addwdgt.html
+++ b/cdap-ui/app/features/dashboard/templates/partials/addwdgt.html
@@ -77,12 +77,13 @@
   </div>
   <div class="modal-footer">
     <button ng-click="addMetricsToWidget()"
+      ng-disabled="addWdgtForm.$invalid"
       class="btn btn-default">
       Add to a widget
     </button>
     <button ng-click="addMetricsToIndividualWidgets()"
       class="btn btn-default"
-      ng-disabled="!model.metric || ((metricsLimit - metricsSlotsFilled) < model.metric.names.length)">
+      ng-disabled="addWdgtForm.$invalid || (!model.metric && ((metricsLimit - metricsSlotsFilled) < model.metric.names.length))">
       Add widgets
     </button>
   </div>

--- a/cdap-ui/app/features/dashboard/widgets.less
+++ b/cdap-ui/app/features/dashboard/widgets.less
@@ -84,4 +84,20 @@ body.state-dashboard {
     .border-radius(4px);
     .select-wrapper(@background-color: @cdap-darkness, @color: white);
   }
+
+  my-metric-picker {
+    .tooltip.tooltip-info {
+      z-index: 1020; // lower z-index than modal
+
+      .tooltip-inner {
+        background-color: #ffffff;
+        color: #333333;
+        border: none;
+      }
+
+      .tooltip-arrow {
+        border-right-color: #ffffff;
+      }
+    }
+  }
 }

--- a/cdap-ui/app/main.js
+++ b/cdap-ui/app/main.js
@@ -79,7 +79,8 @@ angular
       'angularMoment',
       'ui.ace',
       'gridster',
-      'angular-cron-jobs'
+      'angular-cron-jobs',
+      'angularjs-dropdown-multiselect'
 
     ]).name,
 

--- a/cdap-ui/bower.json
+++ b/cdap-ui/bower.json
@@ -36,7 +36,8 @@
     "angular-ui-ace": "bower",
     "jsPlumb": "1.7.5",
     "angular-gridster": "0.13.5",
-    "angular-cron-jobs": "1.4.1"
+    "angular-cron-jobs": "1.4.1",
+    "angularjs-dropdown-multiselect": "~1.5.2"
   },
   "resolutions": {
     "angular": "1.4.3",

--- a/cdap-ui/bower.json
+++ b/cdap-ui/bower.json
@@ -37,10 +37,11 @@
     "jsPlumb": "1.7.5",
     "angular-gridster": "0.13.5",
     "angular-cron-jobs": "1.4.1",
-    "angularjs-dropdown-multiselect": "~1.5.2"
+    "angularjs-dropdown-multiselect": "1.5.2"
   },
   "resolutions": {
     "angular": "1.4.3",
-    "d3": "3.5.5"
+    "d3": "3.5.5",
+    "lodash": "3.10.1"
   }
 }


### PR DESCRIPTION
- Disables adding more than 12 widgets per dashboard.
- Modifies the label in add widget modal 
- Modifies the 'Add All' option and adds a tooltip to the plus button in the modal

Existing modal: 
<img width="1069" alt="screen shot 2015-09-30 at 7 30 30 pm" src="https://cloud.githubusercontent.com/assets/1452845/10211623/f68ec9a4-67a9-11e5-8e37-d0544d302a3f.png">

Modified Modal: 
<img width="1009" alt="screen shot 2015-09-30 at 7 30 03 pm" src="https://cloud.githubusercontent.com/assets/1452845/10211628/ffbef63e-67a9-11e5-83e6-e649bdf1d2f5.png">

GIF of how it works: 
![dashboard](https://cloud.githubusercontent.com/assets/1452845/10211634/0b9b231a-67aa-11e5-9956-de18228ce1d5.gif)
