### PR TITLE
Docs/3.2 cleanup

### DIFF
--- a/cdap-docs/_common/_source/index.rst
+++ b/cdap-docs/_common/_source/index.rst
@@ -74,10 +74,12 @@ on the installation, monitoring and diagnosing fully distributed CDAP in a Hadoo
 - |included-applications|_
 
   - **Big Data without Big Development:** How to use CDAP "out-of-the-box" to solve problems and use cases 
-  - **Introduction to Application Templates:** Applications that are reusable through configuration and
+  - **Introduction to Included Applications:** Applications that are reusable through configuration and
     extensible through plugins 
-  - **ETL:** Making performing ETL possible without writing code 
+  - **Cask Hydrator and ETL Pipelines:** Makes performing ETL possible without writing code 
   - **Creating Custom ETL Plugins:** For developers of custom ETL plugins 
+  - **Data Quality:** An extensible *Included Application* to assess the quality of data
+    using its out-of-the-box functionality and libraries
   
   
 .. |admin-manual| replace:: **Administration Manual:**

--- a/cdap-docs/_common/common_conf.py
+++ b/cdap-docs/_common/common_conf.py
@@ -173,6 +173,9 @@ rst_epilog = """
 .. role:: gp
 .. |$| replace:: :gp:`$`
 
+.. role:: gp
+.. |cdap >| replace:: :gp:`cdap >`
+
 .. |http:| replace:: http:
 .. |https:| replace:: https:
 

--- a/cdap-docs/introduction/source/index.rst
+++ b/cdap-docs/introduction/source/index.rst
@@ -75,7 +75,7 @@ Installation
 
           Starting Standalone CDAP ................
           Standalone CDAP started successfully.
-          Connect to the Console at http://localhost:9999
+          Connect to the CDAP UI at http://localhost:9999
 
 
 .. container:: table-block
@@ -102,7 +102,7 @@ Installation
        - ``$ ./bin/cdap-cli.sh``
          ::
 
-          Successfully connected CDAP instance at http://localhost:10000
+          Successfully connected to CDAP instance at http://localhost:10000/default
           cdap (http://localhost:10000/default)> 
 
 Data Ingestion
@@ -134,7 +134,7 @@ Data Ingestion
          - Configure **Kafka** or **Flume** to write to time partitions
          
      * - Using CDAP
-       - ``> create stream logEventStream``
+       - ``cdap > create stream logEventStream``
           
      * -  
        - ::
@@ -162,7 +162,7 @@ Data Ingestion
          - Create external table in **Hive** called ``stream_logeventstream``
          
      * - Using CDAP
-       - ``> load stream logEventStream examples/resources/accesslog.txt``
+       - ``cdap > load stream logEventStream examples/resources/accesslog.txt``
           
      * -  
        - ::
@@ -200,7 +200,7 @@ Data Exploration
          - ``DESCRIBE stream_logeventstream``
          
      * - Using CDAP
-       - ``> execute 'describe stream_logEventStream'``
+       - ``cdap > execute 'describe stream_logEventStream'``
           
      * -  
        - ::
@@ -233,7 +233,7 @@ Data Exploration
          - ``SELECT * FROM stream_logeventstream LIMIT 2``
 
      * - Using CDAP
-       - ``> execute 'select * from stream_logEventStream limit 2'``
+       - ``cdap > execute 'select * from stream_logEventStream limit 2'``
           
      * -  
        - ::
@@ -282,7 +282,7 @@ Data Exploration: Attaching A Schema
          - Recreate the Hive table with new schema
          
      * - Using CDAP
-       - ``> set stream format logEventStream clf``
+       - ``cdap > set stream format logEventStream clf``
           
      * -  
        - ::
@@ -309,7 +309,7 @@ Data Exploration: Attaching A Schema
          - ``DESCRIBE stream_logeventsetream``
          
      * - Using CDAP
-       - ``> execute 'describe stream_logEventStream'``
+       - ``cdap > execute 'describe stream_logEventStream'``
           
      * -  
        - ::
@@ -350,7 +350,7 @@ Data Exploration: Attaching A Schema
          - ``SELECT * FROM stream_logeventsetream LIMIT 2``
          
      * - Using CDAP
-       - ``> execute 'select * from stream_logEventStream limit 2'``
+       - ``cdap > execute 'select * from stream_logEventStream limit 2'``
           
      * -  
        - ::
@@ -394,7 +394,7 @@ Data Exploration: Attaching A Schema
        - Write code to compute the various stats: number of unique elements, histograms, etc.
          
      * - Using CDAP
-       - ``> get stream-stats logEventStream limit 1000``
+       - ``cdap > get stream-stats logEventStream limit 1000``
           
      * -  
        - ::
@@ -515,7 +515,7 @@ Advanced Data Exploration
        - - Create a file in Hadoop file system called ``ip2geo``
          
      * - Using CDAP
-       - ``> create stream ip2geo``
+       - ``cdap > create stream ip2geo``
           
      * -  
        - ::
@@ -543,7 +543,7 @@ Advanced Data Exploration
          - Create external table in Hive called ``stream_ip2geo``
 
      * - Using CDAP
-       - ``> load stream ip2geo examples/resources/ip2geo-maps.csv``
+       - ``cdap > load stream ip2geo examples/resources/ip2geo-maps.csv``
           
      * -  
        - ::
@@ -569,7 +569,7 @@ Advanced Data Exploration
        - Write data to Kafka or append directly to HDFS
          
      * - Using CDAP
-       - ``> send stream ip2geo '69.181.160.120, Los Angeles, CA'``
+       - ``cdap > send stream ip2geo '69.181.160.120, Los Angeles, CA'``
           
      * -  
        - ::
@@ -596,7 +596,7 @@ Advanced Data Exploration
          - ``SELECT * FROM stream_ip2geo``
          
      * - Using CDAP
-       - ``> execute 'select * from stream_ip2geo'``
+       - ``cdap > execute 'select * from stream_ip2geo'``
           
      * -  
        - ::
@@ -649,7 +649,7 @@ Advanced Data Exploration
          - Recreate the Hive table with new schema
          
      * - Using CDAP
-       - ``> set stream format ip2geo csv "ip string, city string, state string"``
+       - ``cdap > set stream format ip2geo csv "ip string, city string, state string"``
           
      * -  
        - ::
@@ -675,7 +675,7 @@ Advanced Data Exploration
          - ``SELECT * FROM stream_ip2geo``
          
      * - Using CDAP
-       - ``> execute 'select * from stream_ip2geo'``
+       - ``cdap > execute 'select * from stream_ip2geo'``
           
      * -  
        - ::
@@ -729,69 +729,65 @@ Advanced Data Exploration
          - ``SELECT remote_host, city, state, request from stream_logEventStream join stream_ip2geo on (stream_logEventStream.remote_host = stream_ip2geo.ip) limit 10``
          
      * - Using CDAP
-       - ``> execute 'select remote_host, city, state, request from stream_logEventStream join stream_ip2geo on (stream_logEventStream.remote_host = stream_ip2geo.ip) limit 10'``
+       - ``cdap > execute 'select remote_host, city, state, request from stream_logEventStream join stream_ip2geo on (stream_logEventStream.remote_host = stream_ip2geo.ip) limit 10'``
           
      * -  
        - ::
 
-          +===============================================================================================================+
-          | remote_host: STRING          | city: STRING                 | state: STRING | request: STRING                 |
-          +===============================================================================================================+
-          | 69.181.160.120               |  Los Angeles                 |  CA           | GET /ajax/planStatusHistoryNeig |
-          |                              |                              |               | hbouringSummaries.action?planKe |
-          |                              |                              |               | y=COOP-DBT&buildNumber=284&_=14 |
-          |                              |                              |               | 23341312519 HTTP/1.1            |
-          |---------------------------------------------------------------------------------------------------------------|
-          | 69.181.160.120               |  Los Angeles                 |  CA           | GET /rest/api/latest/server?_=1 |
-          |                              |                              |               | 423341312520 HTTP/1.1           |
-          |---------------------------------------------------------------------------------------------------------------|
-          | 69.181.160.120               |  Los Angeles                 |  CA           | GET /ajax/planStatusHistoryNeig |
-          |                              |                              |               | hbouringSummaries.action?planKe |
-          |                              |                              |               | y=COOP-DBT&buildNumber=284&_=14 |
-          |                              |                              |               | 23341312521 HTTP/1.1            |
-          |---------------------------------------------------------------------------------------------------------------|
-          | 69.181.160.120               |  Los Angeles                 |  CA           | GET /ajax/planStatusHistoryNeig |
-          |                              |                              |               | hbouringSummaries.action?planKe |
-          |                              |                              |               | y=COOP-DBT&buildNumber=284&_=14 |
-          |                              |                              |               | 23341312522 HTTP/1.1            |
-          |---------------------------------------------------------------------------------------------------------------|
-          | 69.181.160.120               |  Los Angeles                 |  CA           | GET /rest/api/latest/server?_=1 |
-          |                              |                              |               | 423341312523 HTTP/1.1           |
-          |---------------------------------------------------------------------------------------------------------------|
-          | 69.181.160.120               |  Los Angeles                 |  CA           | GET /ajax/planStatusHistoryNeig |
-          |                              |                              |               | hbouringSummaries.action?planKe |
-          |                              |                              |               | y=COOP-DBT&buildNumber=284&_=14 |
-          |                              |                              |               | 23341312524 HTTP/1.1            |
-          |---------------------------------------------------------------------------------------------------------------|
-          | 69.181.160.120               |  Los Angeles                 |  CA           | GET /ajax/planStatusHistoryNeig |
-          |                              |                              |               | hbouringSummaries.action?planKe |
-          |                              |                              |               | y=COOP-DBT&buildNumber=284&_=14 |
-          |                              |                              |               | 23341312525 HTTP/1.1            |
-          |---------------------------------------------------------------------------------------------------------------|
-          | 69.181.160.120               |  Los Angeles                 |  CA           | GET /rest/api/latest/server?_=1 |
-          |                              |                              |               | 423341312526 HTTP/1.1           |
-          |---------------------------------------------------------------------------------------------------------------|
-          | 69.181.160.120               |  Los Angeles                 |  CA           | GET /ajax/planStatusHistoryNeig |
-          |                              |                              |               | hbouringSummaries.action?planKe |
-          |                              |                              |               | y=COOP-DBT&buildNumber=284&_=14 |
-          |                              |                              |               | 23341312527 HTTP/1.1            |
-          |---------------------------------------------------------------------------------------------------------------|
-          | 69.181.160.120               |  Los Angeles                 |  CA           | GET /ajax/planStatusHistoryNeig |
-          |                              |                              |               | hbouringSummaries.action?planKe |
-          |                              |                              |               | y=COOP-DBT&buildNumber=284&_=14 |
-          |                              |                              |               | 23341312528 HTTP/1.1            |
-          +===============================================================================================================+
+          +======================================================================================================================+
+          | remote_host: STRING | city: STRING | state: STRING | request: STRING                                                 |
+          +======================================================================================================================+
+          | 108.206.32.124      |  Santa Clara |  CA           | GET /browse/CDAP-DUT725-8 HTTP/1.1                              |
+          |----------------------------------------------------------------------------------------------------------------------|
+          | 108.206.32.124      |  Santa Clara |  CA           | GET /s/d41d8cd98f00b204e9800998ecf8427e-CDN/en_US/4411/1/1.0/_/ |
+          |                     |              |               | download/batch/bamboo.web.resources:base-model/bamboo.web.resou |
+          |                     |              |               | rces:base-model.js HTTP/1.1                                     |
+          |----------------------------------------------------------------------------------------------------------------------|
+          | 108.206.32.124      |  Santa Clara |  CA           | GET /s/d41d8cd98f00b204e9800998ecf8427e-CDN/en_US/4411/1/1.0/_/ |
+          |                     |              |               | download/batch/bamboo.web.resources:model-deployment-version/ba |
+          |                     |              |               | mboo.web.resources:model-deployment-version.js HTTP/1.1         |
+          |----------------------------------------------------------------------------------------------------------------------|
+          | 108.206.32.124      |  Santa Clara |  CA           | GET /s/d41d8cd98f00b204e9800998ecf8427e-CDN/en_US/4411/1/1.0/_/ |
+          |                     |              |               | download/batch/bamboo.web.resources:model-deployment-result/bam |
+          |                     |              |               | boo.web.resources:model-deployment-result.js HTTP/1.1           |
+          |----------------------------------------------------------------------------------------------------------------------|
+          | 108.206.32.124      |  Santa Clara |  CA           | GET /s/d41d8cd98f00b204e9800998ecf8427e-T/en_US/4411/1/3.5.7/_/ |
+          |                     |              |               | download/batch/com.atlassian.support.stp:stp-license-status-res |
+          |                     |              |               | ources/com.atlassian.support.stp:stp-license-status-resources.c |
+          |                     |              |               | ss HTTP/1.1                                                     |
+          |----------------------------------------------------------------------------------------------------------------------|
+          | 108.206.32.124      |  Santa Clara |  CA           | GET /s/d41d8cd98f00b204e9800998ecf8427e-CDN/en_US/4411/1/1.0/_/ |
+          |                     |              |               | download/batch/bamboo.web.resources:model-deployment-operations |
+          |                     |              |               | /bamboo.web.resources:model-deployment-operations.js HTTP/1.1   |
+          |----------------------------------------------------------------------------------------------------------------------|
+          | 108.206.32.124      |  Santa Clara |  CA           | GET /s/d41d8cd98f00b204e9800998ecf8427e-CDN/en_US/4411/1/1.0/_/ |
+          |                     |              |               | download/batch/bamboo.web.resources:model-deployment-environmen |
+          |                     |              |               | t/bamboo.web.resources:model-deployment-environment.js HTTP/1.1 |
+          |----------------------------------------------------------------------------------------------------------------------|
+          | 108.206.32.124      |  Santa Clara |  CA           | GET /s/d41d8cd98f00b204e9800998ecf8427e-CDN/en_US/4411/1/1.0/_/ |
+          |                     |              |               | download/batch/bamboo.web.resources:model-deployment-project/ba |
+          |                     |              |               | mboo.web.resources:model-deployment-project.js HTTP/1.1         |
+          |----------------------------------------------------------------------------------------------------------------------|
+          | 108.206.32.124      |  Santa Clara |  CA           | GET /s/71095c56c641f2c4a4f189b9dfcd7a38-CDN/en_US/4411/1/5.6.2/ |
+          |                     |              |               | _/download/batch/bamboo.deployments:deployment-project-list/bam |
+          |                     |              |               | boo.deployments:deployment-project-list.js?locale=en-US HTTP/1. |
+          |                     |              |               | 1                                                               |
+          |----------------------------------------------------------------------------------------------------------------------|
+          | 108.206.32.124      |  Santa Clara |  CA           | GET /s/d41d8cd98f00b204e9800998ecf8427e-CDN/en_US/4411/1/5dddb6 |
+          |                     |              |               | ea4dc4fd5569d992cf603f31e5/_/download/contextbatch2/css/atl.gen |
+          |                     |              |               | eral,bamboo.result/batch.css HTTP/1.1                           |
+          +======================================================================================================================+
           Fetched 10 rows
-        
 
 Transforming Your Data
 ======================
-- CDAP Application Templates are applications that are reusable through configuration
-- Build your own Application Templates, using simple APIs
-- CDAP includes built-in ETL (Extract, Transform, Load) Application Templates
-- ETL Application Templates provide pre-defined transformations to be applied on streams or other datasets
-- In this example, we will use the ETLBatch Application Template to convert data in a stream to
-  Avro formatted files in a ``TimePartitionedFileSet`` that can be queried using either Hive or Impala
+- CDAP Included Applications are applications that are reusable through the configuration of artifacts
+- Built-in ETL (Extract, Transform, Load) and Data Quality applications
+- ETL includes over 30 Plugins to build applications merely through configuration of parameters
+- Build your own custom plugins, using simple APIs
+- ETL Transformations provide pre-defined transformations to be applied on streams or other datasets
+- In this example, we will use the ETL batch system artifact to convert data in a stream to
+  Avro-formatted files in a ``TimePartitionedFileSet`` that can be queried using either Hive or Impala
 
 .. container:: table-block
 
@@ -799,7 +795,7 @@ Transforming Your Data
      :widths: 80 20
      :stub-columns: 1
      
-     * - Create a stream-conversion adapter using the ETLBatch Application Template
+     * - Create a stream-conversion application using the ETL batch system artifact
        - 
        
   .. list-table::
@@ -815,11 +811,10 @@ Transforming Your Data
          - Keep track of last processed times
          
      * - Using CDAP
-       - Write a configuration file, saving it to ``example/resources/adapter-config.json``::
+       - Write a configuration file, saving it to ``examples/resources/application-config.json``::
 
           {
               "description": "Periodically reads stream data and writes it to a TimePartitionedFileSet",
-              "template": "ETLBatch",
               "config": {
                   "schedule": "*/5 * * * *",
                   "source": {
@@ -838,39 +833,41 @@ Transforming Your Data
                           }
                       }
                   ],
-                  "sink": {
-                      "name": "TPFSAvro",
-                      "properties": {
-                          "name": "logEventStream.converted",
-                          "schema": "{
-                              \"type\":\"record\",
-                              \"name\":\"logEvent\",
-                              \"fields\":[
-                                  {\"name\":\"ts\",\"type\":\"long\"},
-                                  {\"name\":\"remotehost\",\"type\":[\"string\",\"null\"]},
-                                  {\"name\":\"remotelogname\",\"type\":[\"string\",\"null\"]},
-                                  {\"name\":\"authuser\",\"type\":[\"string\",\"null\"]},
-                                  {\"name\":\"date\",\"type\":[\"string\",\"null\"]},
-                                  {\"name\":\"request\",\"type\":[\"string\",\"null\"]},
-                                  {\"name\":\"status\",\"type\":[\"int\",\"null\"]},
-                                  {\"name\":\"contentlength\",\"type\":[\"int\",\"null\"]},
-                                  {\"name\":\"referrer\",\"type\":[\"string\",\"null\"]},
-                                  {\"name\":\"useragent\",\"type\":[\"string\",\"null\"]}
-                              ]
-                          }",
-                          "basePath": "logEventStream.converted"
-                      }
-                  }
+                  "sinks": [
+                    {
+                        "name": "TPFSAvro",
+                        "properties": {
+                            "name": "logEventStream_converted",
+                            "schema": "{
+                                \"type\":\"record\",
+                                \"name\":\"logEvent\",
+                                \"fields\":[
+                                    {\"name\":\"ts\",\"type\":\"long\"},
+                                    {\"name\":\"remotehost\",\"type\":[\"string\",\"null\"]},
+                                    {\"name\":\"remotelogname\",\"type\":[\"string\",\"null\"]},
+                                    {\"name\":\"authuser\",\"type\":[\"string\",\"null\"]},
+                                    {\"name\":\"date\",\"type\":[\"string\",\"null\"]},
+                                    {\"name\":\"request\",\"type\":[\"string\",\"null\"]},
+                                    {\"name\":\"status\",\"type\":[\"int\",\"null\"]},
+                                    {\"name\":\"contentlength\",\"type\":[\"int\",\"null\"]},
+                                    {\"name\":\"referrer\",\"type\":[\"string\",\"null\"]},
+                                    {\"name\":\"useragent\",\"type\":[\"string\",\"null\"]}
+                                ]
+                            }",
+                            "basePath": "logEventStream_converted"
+                        }
+                    }
+                  ]
               }
           }
 
      * - 
-       - Create an adapter using that configuration through the CLI::
+       - Create an application using that configuration through the CLI::
 
-           > create adapter logEventStreamConverter example/resources/adapter-config.json 
-           Successfully created adapter 'logEventStreamConverter'
-           > start adapter logEventStreamConverter
-           Successfully started adapter 'logEventStreamConverter'
+           cdap > create app logEventStreamConverter cdap-etl-batch 3.2.0 system examples/resources/application-config.json 
+           Successfully created application
+           cdap > resume schedule logEventStreamConverter.etlWorkflow
+           Successfully resumed schedule 'etlWorkflow' in app 'logEventStreamConverter'
 
 .. container:: table-block
 
@@ -878,7 +875,7 @@ Transforming Your Data
      :widths: 80 20
      :stub-columns: 1
      
-     * - List the adapters available in the CDAP instance
+     * - List the applications available in the CDAP instance
        - 
        
   .. list-table::
@@ -890,10 +887,22 @@ Transforming Your Data
        - - Not available
          
      * - Using CDAP
-       - ``> list adapters``
+       - ``cdap > list apps``
 
      * -  
        - ::
+
+          +=======================================================================================+
+          | id                      | descript | artifactName   | artifactVersion | artifactScope |
+          |                         | ion      |                |                 |               |
+          +=======================================================================================+
+          | logEventStreamConverter | Batch Ex | cdap-etl-batch | 3.2.0           | SYSTEM        |
+          |                         | tract-Tr |                |                 |               |
+          |                         | ansform- |                |                 |               |
+          |                         | Load (ET |                |                 |               |
+          |                         | L) Templ |                |                 |               |
+          |                         | ate      |                |                 |               |
+          +=======================================================================================+
 
           +======================================================================================================================+
           | name                | description         | template | config              | properties                              |
@@ -987,7 +996,7 @@ Transforming Your Data
          - Create external table in Hive called ``stream_ip2geo``
          
      * - Using CDAP
-       - ``> load stream logEventStream examples/resources/accesslog.txt``
+       - ``cdap > load stream logEventStream examples/resources/accesslog.txt``
           
      * -  
        - ::
@@ -1017,7 +1026,7 @@ Transforming Your Data
        - Dataset that is time partitioned
           
      * -  
-       - ``> list dataset instances``
+       - ``cdap > list dataset instances``
          ::
 
           +=================================================================================+
@@ -1045,7 +1054,7 @@ Transforming Your Data
          - ``'describe user_logEventStream_converted'`` 
          
      * - Using CDAP
-       - ``> execute 'describe dataset_logEventStream_converted'``
+       - ``cdap > execute 'describe dataset_logEventStream_converted'``
           
      * -  
        - ::
@@ -1099,7 +1108,7 @@ Transforming Your Data
          - ``SELECT ts, request, status FROM dataset_logEventStream_converted LIMIT 2``
          
      * - Using CDAP
-       - ``> execute 'SELECT ts, request, status FROM dataset_logEventStream_converted LIMIT 2'``
+       - ``cdap > execute 'SELECT ts, request, status FROM dataset_logEventStream_converted LIMIT 2'``
 
      * -  
        - ::
@@ -1162,7 +1171,7 @@ Building Real World Applications
 
          From within the CDAP CLI:
 
-         | ``> deploy app examples/cdap-wise-``\ |literal-cdap-apps-version|\ ``/target/cdap-wise-``\ |literal-cdap-apps-version|\ ``.jar``
+         | ``cdap > deploy app examples/cdap-wise-``\ |literal-cdap-apps-version|\ ``/target/cdap-wise-``\ |literal-cdap-apps-version|\ ``.jar``
           
      * -  
        - ::
@@ -1189,7 +1198,7 @@ Building Real World Applications
          - Check **YARN** Console
          
      * - Using CDAP
-       - ``> describe app Wise``
+       - ``cdap > describe app Wise``
           
      * -  
        - ::
@@ -1224,7 +1233,7 @@ Building Real World Applications
          - ``yarn jar /path/to/myprogram.jar``
          
      * - Using CDAP
-       - ``> start flow Wise.WiseFlow``
+       - ``cdap > start flow Wise.WiseFlow``
           
      * -  
        - ::
@@ -1252,7 +1261,7 @@ Building Real World Applications
          - ``yarn application -status <APP ID>``
          
      * - Using CDAP
-       - ``> get flow status Wise.WiseFlow``
+       - ``cdap > get flow status Wise.WiseFlow``
           
      * -  
        - ::
@@ -1279,7 +1288,7 @@ Building Real World Applications
          - Create external table in Hive called ``cdap_stream_logeventstream``
          
      * - Using CDAP
-       - ``> load stream logEventStream examples/resources/accesslog.txt``
+       - ``cdap > load stream logEventStream examples/resources/accesslog.txt``
           
      * -  
        - ::
@@ -1311,7 +1320,7 @@ Building Real World Applications
          - Click on container logs
          
      * - Using CDAP
-       - ``> get flow logs Wise.WiseFlow``
+       - ``cdap > get flow logs Wise.WiseFlow``
     
      * -  
        - ::
@@ -1356,7 +1365,7 @@ Building Real World Applications
          - ``oozie job -start <arguments>``
          
      * - Using CDAP
-       - ``> start workflow Wise.Wiseworkflow``
+       - ``cdap > start workflow Wise.Wiseworkflow``
           
      * -  
        - ::
@@ -1383,7 +1392,7 @@ Building Real World Applications
          - ``oozie job -info <jobid>``
          
      * - Using CDAP
-       - ``> get workflow status Wise.Wiseworkflow``
+       - ``cdap > get workflow status Wise.Wiseworkflow``
           
      * -  
        - ::
@@ -1411,7 +1420,7 @@ Building Real World Applications
          - ``yarn jar /path/to/myprogram.jar``
          
      * - Using CDAP
-       - ``> start service Wise.WiseService``
+       - ``cdap > start service Wise.WiseService``
           
      * -  
        - ::
@@ -1439,7 +1448,7 @@ Building Real World Applications
          - ``yarn application -status <APP ID>``
          
      * - Using CDAP
-       - ``> get service status Wise.WiseService``
+       - ``cdap > get service status Wise.WiseService``
           
      * -  
        - ::
@@ -1472,7 +1481,7 @@ Building Real World Applications
          - Click on container logs
          
      * - Using CDAP
-       - ``> get endpoints service Wise.WiseService``
+       - ``cdap > get endpoints service Wise.WiseService``
           
      * -  
        - ::
@@ -1505,7 +1514,7 @@ Building Real World Applications
          - Run ``curl http://hostname:port/ip/69.181.160.120/count``
          
      * - Using CDAP
-       - ``> call service Wise.WiseService GET /ip/69.181.160.120/count``
+       - ``cdap > call service Wise.WiseService GET /ip/69.181.160.120/count``
           
      * -  
        - ::
@@ -1540,7 +1549,7 @@ Building Real World Applications
          
      * - Using CDAP
        - - The listing will depend on if you have run all of the previous examples
-         - ``> list dataset instances``
+         - ``cdap > list dataset instances``
           
      * -  
        - ::
@@ -1574,7 +1583,7 @@ Building Real World Applications
          - ``"SELECT * FROM dataset_bouncecountstore LIMIT 5"``
          
      * - Using CDAP
-       - ``> execute 'SELECT * FROM dataset_bouncecountstore LIMIT 5'``
+       - ``cdap > execute 'SELECT * FROM dataset_bouncecountstore LIMIT 5'``
           
      * -  
        - ::
@@ -1628,7 +1637,7 @@ Building Real World Applications
          - ``yarn application -kill <application ID>``
          
      * - Using CDAP
-       - ``> stop service Wise.WiseService``
+       - ``cdap > stop service Wise.WiseService``
           
      * -  
        - ::
@@ -1656,7 +1665,7 @@ Building Real World Applications
          - ``yarn application -kill <application ID>``
          
      * - Using CDAP
-       - ``> stop flow Wise.WiseFlow``
+       - ``cdap > stop flow Wise.WiseFlow``
           
      * -  
        - ::
@@ -1682,7 +1691,7 @@ Building Real World Applications
          - Remove the service jars and flow jars
          
      * - Using CDAP
-       - ``> delete app Wise``
+       - ``cdap > delete app Wise``
           
      * -  
        - ::

--- a/cdap-docs/introduction/source/index.rst
+++ b/cdap-docs/introduction/source/index.rst
@@ -811,7 +811,7 @@ Transforming Your Data
          - Keep track of last processed times
          
      * - Using CDAP
-       - Write a configuration file, saving it to ``examples/resources/application-config.json``::
+       - Write a configuration file, saving it to ``examples/resources/app-config.json``::
 
           {
               "description": "Periodically reads stream data and writes it to a TimePartitionedFileSet",
@@ -864,7 +864,7 @@ Transforming Your Data
      * - 
        - Create an application using that configuration through the CLI::
 
-           cdap > create app logEventStreamConverter cdap-etl-batch 3.2.0 system examples/resources/application-config.json 
+           cdap > create app logEventStreamConverter cdap-etl-batch 3.2.0 system examples/resources/app-config.json 
            Successfully created application
            cdap > resume schedule logEventStreamConverter.etlWorkflow
            Successfully resumed schedule 'etlWorkflow' in app 'logEventStreamConverter'
@@ -903,6 +903,19 @@ Transforming Your Data
           |                         | L) Templ |                |                 |               |
           |                         | ate      |                |                 |               |
           +=======================================================================================+
+
+     * - 
+       - ``cdap > describe app logEventStreamConverter``
+
+     * -  
+       - ::
+       
+          +====================================================================+
+          | type      | id           | description                             |
+          +====================================================================+
+          | MapReduce | ETLMapReduce | MapReduce driver for Batch ETL Adapters |
+          | Workflow  | ETLWorkflow  | Workflow for Batch ETL MapReduce Driver |
+          +====================================================================+
 
           +======================================================================================================================+
           | name                | description         | template | config              | properties                              |

--- a/cdap-docs/introduction/source/index.rst
+++ b/cdap-docs/introduction/source/index.rst
@@ -10,6 +10,7 @@
 Introduction to CDAP
 ====================
 
+
 Simple Access to Powerful Technology
 ====================================
 
@@ -37,6 +38,7 @@ We'll look at these areas:
   - `Transforming Your Data`_
   - `Building Real World Applications`_
 
+
 .. highlight:: console
 
 Installation
@@ -44,7 +46,6 @@ Installation
 - Download and install CDAP to run in standalone mode on a laptop
 - Startup CDAP
 - Startup CDAP Command Line Interface
-
 
 .. container:: table-block
 
@@ -67,16 +68,17 @@ Installation
        - - Install CDAP by downloading zipfile, unzipping and starting **CDAP Server**
       
      * -  
-       - | ``$ unzip cdap-sdk-``\ |literal-release|\ ``.zip``
-         | ``$ cd cdap-sdk-``\ |literal-release|
-         | ``$ ./bin/cdap.sh start``
-         
-         ::
+       - .. container:: highlight
 
-          Starting Standalone CDAP ................
-          Standalone CDAP started successfully.
-          Connect to the CDAP UI at http://localhost:9999
-
+          .. parsed-literal::    
+      
+            |$| unzip cdap-sdk-\ |release|\ .zip
+            |$| cd cdap-sdk-\ |release|
+            |$| ./bin/cdap.sh start
+          
+            Starting Standalone CDAP ................
+            Standalone CDAP started successfully.
+            Connect to the CDAP UI at http://localhost:9999
 
 .. container:: table-block
 
@@ -98,12 +100,16 @@ Installation
      * - Using CDAP
        - - Start **CDAP CLI** (Command Line Interface)
 
-     * - 
-       - ``$ ./bin/cdap-cli.sh``
-         ::
+     * -  
+       - .. container:: highlight
 
-          Successfully connected to CDAP instance at http://localhost:10000/default
-          cdap (http://localhost:10000/default)> 
+          .. parsed-literal::    
+      
+            |$| ./bin/cdap-cli.sh
+            
+            Successfully connected to CDAP instance at \http://localhost:10000/default
+            |cdap >| 
+
 
 Data Ingestion
 ==============
@@ -113,7 +119,6 @@ Data Ingestion
 - CDAP supports easy exploration and processing in both real time and batch
 - Ingest using RESTful, Flume, language-specific APIs, or Tools
 - The abstraction of streams lets you disconnect how you ingest from how you process
-
 
 .. container:: table-block
 
@@ -134,13 +139,13 @@ Data Ingestion
          - Configure **Kafka** or **Flume** to write to time partitions
          
      * - Using CDAP
-       - ``cdap > create stream logEventStream``
-          
-     * -  
-       - ::
+       - .. container:: highlight
        
-          Successfully created stream with ID 'logEventStream'
+          .. parsed-literal::
+       
+           |cdap >| create stream logEventStream
 
+           Successfully created stream with ID 'logEventStream'
 
 .. container:: table-block
 
@@ -162,12 +167,13 @@ Data Ingestion
          - Create external table in **Hive** called ``stream_logeventstream``
          
      * - Using CDAP
-       - ``cdap > load stream logEventStream examples/resources/accesslog.txt``
-          
-     * -  
-       - ::
+       - .. container:: highlight
        
-          Successfully sent stream event to stream 'logEventStream'
+          .. parsed-literal::
+       
+           |cdap >| load stream logEventStream examples/resources/accesslog.txt
+
+           Successfully sent stream event to stream 'logEventStream'
 
 
 Data Exploration
@@ -179,7 +185,6 @@ Data Exploration
 - Support different data formats; extensible to support custom formats
 - Supported data formats include Avro, Text, CSV, TSV, CLF, and Custom
 - Query using SQL
-
 
 .. container:: table-block
 
@@ -200,19 +205,20 @@ Data Exploration
          - ``DESCRIBE stream_logeventstream``
          
      * - Using CDAP
-       - ``cdap > execute 'describe stream_logEventStream'``
-          
-     * -  
-       - ::
+       - .. container:: highlight
+       
+          .. parsed-literal::
+       
+            |cdap >| execute 'describe stream_logEventStream'
 
-          +=========================================================================================================+
-          | col_name: STRING                 | data_type: STRING                | comment: STRING                   |
-          +=========================================================================================================+
-          | ts                               | bigint                           | from deserializer                 |
-          | headers                          | map<string,string>               | from deserializer                 |
-          | body                             | string                           | from deserializer                 |
-          +=========================================================================================================+
-          Fetched 3 rows
+            +=========================================================================================================+
+            | col_name: STRING                 | data_type: STRING                | comment: STRING                   |
+            +=========================================================================================================+
+            | ts                               | bigint                           | from deserializer                 |
+            | headers                          | map<string,string>               | from deserializer                 |
+            | body                             | string                           | from deserializer                 |
+            +=========================================================================================================+
+            Fetched 3 rows
 
 .. container:: table-block
 
@@ -233,31 +239,36 @@ Data Exploration
          - ``SELECT * FROM stream_logeventstream LIMIT 2``
 
      * - Using CDAP
-       - ``cdap > execute 'select * from stream_logEventStream limit 2'``
-          
-     * -  
-       - ::
+       - .. container:: highlight
+       
+          .. parsed-literal::
 
-          +==============================================================================================================+
-          | stream_logeventstream.ts: | stream_logeventstream.hea | stream_logeventstream.body: STRING                   |
-          | BIGINT                    | ders: map<string,string>  |                                                      |
-          +==============================================================================================================+
-          | 1428969220987             | {"content.type":"text/pla | 69.181.160.120 - - [08/Feb/2015:04:36:40 +0000] "GET |
-          |                           | in"}                      |  /ajax/planStatusHistoryNeighbouringSummaries.action |
-          |                           |                           | ?planKey=COOP-DBT&buildNumber=284&_=1423341312519 HT |
-          |                           |                           | TP/1.1" 200 508 "http://builds.cask.co/browse/COOP-D |
-          |                           |                           | BT-284/log" "Mozilla/5.0 (Macintosh; Intel Mac OS X  |
-          |                           |                           | 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chro |
-          |                           |                           | me/38.0.2125.122 Safari/537.36"                      |
-          |--------------------------------------------------------------------------------------------------------------|
-          | 1428969220987             | {"content.type":"text/pla | 69.181.160.120 - - [08/Feb/2015:04:36:47 +0000] "GET |
-          |                           | in"}                      |  /rest/api/latest/server?_=1423341312520 HTTP/1.1" 2 |
-          |                           |                           | 00 45 "http://builds.cask.co/browse/COOP-DBT-284/log |
-          |                           |                           | " "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) A |
-          |                           |                           | ppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.21 |
-          |                           |                           | 25.122 Safari/537.36"                                |
-          +==============================================================================================================+
-          Fetched 2 rows
+            |cdap >| execute 'select * from stream_logEventStream limit 2'
+
+         .. container:: highlight
+       
+          ::
+          
+            +==============================================================================================================+
+            | stream_logeventstream.ts: | stream_logeventstream.hea | stream_logeventstream.body: STRING                   |
+            | BIGINT                    | ders: map<string,string>  |                                                      |
+            +==============================================================================================================+
+            | 1428969220987             | {"content.type":"text/pla | 69.181.160.120 - - [08/Feb/2015:04:36:40 +0000] "GET |
+            |                           | in"}                      |  /ajax/planStatusHistoryNeighbouringSummaries.action |
+            |                           |                           | ?planKey=COOP-DBT&buildNumber=284&_=1423341312519 HT |
+            |                           |                           | TP/1.1" 200 508 "http://builds.cask.co/browse/COOP-D |
+            |                           |                           | BT-284/log" "Mozilla/5.0 (Macintosh; Intel Mac OS X  |
+            |                           |                           | 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chro |
+            |                           |                           | me/38.0.2125.122 Safari/537.36"                      |
+            |--------------------------------------------------------------------------------------------------------------|
+            | 1428969220987             | {"content.type":"text/pla | 69.181.160.120 - - [08/Feb/2015:04:36:47 +0000] "GET |
+            |                           | in"}                      |  /rest/api/latest/server?_=1423341312520 HTTP/1.1" 2 |
+            |                           |                           | 00 45 "http://builds.cask.co/browse/COOP-DBT-284/log |
+            |                           |                           | " "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) A |
+            |                           |                           | ppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.21 |
+            |                           |                           | 25.122 Safari/537.36"                                |
+            +==============================================================================================================+
+            Fetched 2 rows
 
 
 Data Exploration: Attaching A Schema
@@ -282,13 +293,13 @@ Data Exploration: Attaching A Schema
          - Recreate the Hive table with new schema
          
      * - Using CDAP
-       - ``cdap > set stream format logEventStream clf``
-          
-     * -  
-       - ::
+       - .. container:: highlight
+       
+          .. parsed-literal::
 
-          Successfully set format of stream 'logEventStream'
-
+            |cdap >| set stream format logEventStream clf
+  
+            Successfully set format of stream 'logEventStream'
 
 .. container:: table-block
 
@@ -309,27 +320,28 @@ Data Exploration: Attaching A Schema
          - ``DESCRIBE stream_logeventsetream``
          
      * - Using CDAP
-       - ``cdap > execute 'describe stream_logEventStream'``
-          
-     * -  
-       - ::
+       - .. container:: highlight
+       
+          .. parsed-literal::
 
-          +=============================================================================+
-          | col_name: STRING          | data_type: STRING       | comment: STRING       |
-          +=============================================================================+
-          | ts                        | bigint                  | from deserializer     |
-          | headers                   | map<string,string>      | from deserializer     |
-          | remote_host               | string                  | from deserializer     |
-          | remote_login              | string                  | from deserializer     |
-          | auth_user                 | string                  | from deserializer     |
-          | date                      | string                  | from deserializer     |
-          | request                   | string                  | from deserializer     |
-          | status                    | int                     | from deserializer     |
-          | content_length            | int                     | from deserializer     |
-          | referrer                  | string                  | from deserializer     |
-          | user_agent                | string                  | from deserializer     |
-          +=============================================================================+
-          Fetched 11 rows
+            |cdap >| execute 'describe stream_logEventStream'
+
+            +=============================================================================+
+            | col_name: STRING          | data_type: STRING       | comment: STRING       |
+            +=============================================================================+
+            | ts                        | bigint                  | from deserializer     |
+            | headers                   | map<string,string>      | from deserializer     |
+            | remote_host               | string                  | from deserializer     |
+            | remote_login              | string                  | from deserializer     |
+            | auth_user                 | string                  | from deserializer     |
+            | date                      | string                  | from deserializer     |
+            | request                   | string                  | from deserializer     |
+            | status                    | int                     | from deserializer     |
+            | content_length            | int                     | from deserializer     |
+            | referrer                  | string                  | from deserializer     |
+            | user_agent                | string                  | from deserializer     |
+            +=============================================================================+
+            Fetched 11 rows
 
 .. container:: table-block
 
@@ -350,31 +362,50 @@ Data Exploration: Attaching A Schema
          - ``SELECT * FROM stream_logeventsetream LIMIT 2``
          
      * - Using CDAP
-       - ``cdap > execute 'select * from stream_logEventStream limit 2'``
-          
-     * -  
-       - ::
+       - .. container:: highlight
+       
+          .. parsed-literal::
 
-          +===================================================================================================================+
-          | stream_ | stream_ | stream_ | stream_ | stream_ | stream_ | stream_ | stream_ | stream_ | stream_ | stream_logeve |
-          | logeven | logeven | logeven | logeven | logeven | logeven | logeven | logeven | logeven | logeven | ntstream.user |
-          | tstream | tstream | tstream | tstream | tstream | tstream | tstream | tstream | tstream | tstream | _agent: STRIN |
-          | .ts: BI | .header | .remote | .remote | .auth_u | .date:  | .reques | .status | .conten | .referr | G             |
-          | GINT    | s: map< | _host:  | _login: | ser: ST | STRING  | t: STRI | : INT   | t_lengt | er: STR |               |
-          |         | string, | STRING  |  STRING | RING    |         | NG      |         | h: INT  | ING     |               |
-          |         | string> |         |         |         |         |         |         |         |         |               |
-          +===================================================================================================================+
-          | 1428100 | {}      | 255.255 |         |         | 23/Sep/ | GET /cd | 401     | 2969    |         | Mozilla/4.0 ( |
-          | 343436  |         | .255.18 |         |         | 2014:11 | ap.html |         |         |         | compatible; M |
-          |         |         | 5       |         |         | :45:38  |  HTTP/1 |         |         |         | SIE 7.0; Wind |
-          |         |         |         |         |         | -0400   | .0      |         |         |         | ows NT 5.1)   |
-          |-------------------------------------------------------------------------------------------------------------------|
-          | 1428100 | {}      | 255.255 |         |         | 23/Sep/ | GET /cd | 401     | 2969    |         | Mozilla/4.0 ( |
-          | 483106  |         | .255.18 |         |         | 2014:11 | ap.html |         |         |         | compatible; M |
-          |         |         | 5       |         |         | :45:38  |  HTTP/1 |         |         |         | SIE 7.0; Wind |
-          |         |         |         |         |         | -0400   | .0      |         |         |         | ows NT 5.1)   |
-          +===================================================================================================================+
-          Fetched 2 rows
+            |cdap >| execute 'select * from stream_logEventStream limit 2'
+
+         .. container:: highlight
+       
+          ::
+          
+            +==================================================================================================================================+
+            | stream_l | stream_l | stream_l | stream_l | stream_l | stream_l | stream_l | stream_l | stream_l | stream_l | stream_logeventstr |
+            | ogevents | ogevents | ogevents | ogevents | ogevents | ogevents | ogevents | ogevents | ogevents | ogevents | eam.user_agent: ST |
+            | tream.ts | tream.he | tream.re | tream.re | tream.au | tream.da | tream.re | tream.st | tream.co | tream.re | RING               |
+            | : BIGINT | aders: m | mote_hos | mote_log | th_user: | te: STRI | quest: S | atus: IN | ntent_le | ferrer:  |                    |
+            |          | ap<strin | t: STRIN | in: STRI |  STRING  | NG       | TRING    | T        | ngth: IN | STRING   |                    |
+            |          | g,string | G        | NG       |          |          |          |          | T        |          |                    |
+            |          | >        |          |          |          |          |          |          |          |          |                    |
+            +==================================================================================================================================+
+            | 14437238 | {"conten | 69.181.1 |          |          | 08/Feb/2 | GET /aja | 200      | 508      | http://b | Mozilla/5.0 (Macin |
+            | 45737    | t.type": | 60.120   |          |          | 015:04:3 | x/planSt |          |          | uilds.ca | tosh; Intel Mac OS |
+            |          | "text/pl |          |          |          | 6:40 +00 | atusHist |          |          | sk.co/br |  X 10_10_1) AppleW |
+            |          | ain"}    |          |          |          | 00       | oryNeigh |          |          | owse/COO | ebKit/537.36 (KHTM |
+            |          |          |          |          |          |          | bouringS |          |          | P-DBT-28 | L, like Gecko) Chr |
+            |          |          |          |          |          |          | ummaries |          |          | 4/log    | ome/38.0.2125.122  |
+            |          |          |          |          |          |          | .action? |          |          |          | Safari/537.36      |
+            |          |          |          |          |          |          | planKey= |          |          |          |                    |
+            |          |          |          |          |          |          | COOP-DBT |          |          |          |                    |
+            |          |          |          |          |          |          | &buildNu |          |          |          |                    |
+            |          |          |          |          |          |          | mber=284 |          |          |          |                    |
+            |          |          |          |          |          |          | &_=14233 |          |          |          |                    |
+            |          |          |          |          |          |          | 41312519 |          |          |          |                    |
+            |          |          |          |          |          |          |  HTTP/1. |          |          |          |                    |
+            |          |          |          |          |          |          | 1        |          |          |          |                    |
+            |----------------------------------------------------------------------------------------------------------------------------------|
+            | 14437238 | {"conten | 69.181.1 |          |          | 08/Feb/2 | GET /res | 200      | 45       | http://b | Mozilla/5.0 (Macin |
+            | 45737    | t.type": | 60.120   |          |          | 015:04:3 | t/api/la |          |          | uilds.ca | tosh; Intel Mac OS |
+            |          | "text/pl |          |          |          | 6:47 +00 | test/ser |          |          | sk.co/br |  X 10_10_1) AppleW |
+            |          | ain"}    |          |          |          | 00       | ver?_=14 |          |          | owse/COO | ebKit/537.36 (KHTM |
+            |          |          |          |          |          |          | 23341312 |          |          | P-DBT-28 | L, like Gecko) Chr |
+            |          |          |          |          |          |          | 520 HTTP |          |          | 4/log    | ome/38.0.2125.122  |
+            |          |          |          |          |          |          | /1.1     |          |          |          | Safari/537.36      |
+            +==================================================================================================================================+
+            Fetched 2 rows
           
 .. container:: table-block
 
@@ -394,100 +425,105 @@ Data Exploration: Attaching A Schema
        - Write code to compute the various stats: number of unique elements, histograms, etc.
          
      * - Using CDAP
-       - ``cdap > get stream-stats logEventStream limit 1000``
+       - .. container:: highlight
+       
+          .. parsed-literal::
+
+            |cdap >| get stream-stats logEventStream limit 1000
+
+         .. container:: highlight
+       
+          ::
           
-     * -  
-       - ::
+            column: stream_logeventstream.remote_host, type: STRING
+            Unique elements: 6
 
-          column: stream_logeventstream.remote_host, type: STRING
-          Unique elements: 6
+            column: stream_logeventstream.remote_login, type: STRING
+            Unique elements: 0
 
-          column: stream_logeventstream.remote_login, type: STRING
-          Unique elements: 0
+            column: stream_logeventstream.auth_user, type: STRING
+            Unique elements: 0
 
-          column: stream_logeventstream.auth_user, type: STRING
-          Unique elements: 0
+            column: stream_logeventstream.date, type: STRING
+            Unique elements: 750
 
-          column: stream_logeventstream.date, type: STRING
-          Unique elements: 750
+            column: stream_logeventstream.request, type: STRING
+            Unique elements: 972
 
-          column: stream_logeventstream.request, type: STRING
-          Unique elements: 972
+            column: stream_logeventstream.status, type: INT
+            Unique elements: 4
+            Histogram:
+              [200, 299]: 977  |+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+              [300, 399]: 17   |
+              [400, 499]: 6    |
 
-          column: stream_logeventstream.status, type: INT
-          Unique elements: 4
-          Histogram:
-            [200, 299]: 977  |+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-            [300, 399]: 17   |
-            [400, 499]: 6    |
+            column: stream_logeventstream.content_length, type: INT
+            Unique elements: 142
+            Histogram:
+              [0, 99]: 205           |+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+              [100, 199]: 1          |
+              [200, 299]: 9          |+
+              [300, 399]: 9          |+
+              [400, 499]: 3          |
+              [500, 599]: 300        |+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+              [600, 699]: 4          |
+              [800, 899]: 2          |
+              [900, 999]: 1          |
+              [1300, 1399]: 10       |++
+              [1400, 1499]: 206      |++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+              [1500, 1599]: 2        |
+              [1600, 1699]: 2        |
+              [2500, 2599]: 1        |
+              [2700, 2799]: 1        |
+              [2800, 2899]: 1        |
+              [4200, 4299]: 1        |
+              [5700, 5799]: 5        |
+              [7100, 7199]: 1        |
+              [7300, 7399]: 4        |
+              [7800, 7899]: 1        |
+              [8200, 8299]: 5        |
+              [8700, 8799]: 3        |
+              [8800, 8899]: 12       |++
+              [8900, 8999]: 22       |+++++
+              [9000, 9099]: 16       |+++
+              [9100, 9199]: 9        |+
+              [9200, 9299]: 4        |
+              [9300, 9399]: 3        |
+              [9400, 9499]: 5        |
+              [9600, 9699]: 1        |
+              [9700, 9799]: 2        |
+              [9800, 9899]: 39       |++++++++++
+              [9900, 9999]: 4        |
+              [10000, 10099]: 1      |
+              [10100, 10199]: 8      |+
+              [10200, 10299]: 1      |
+              [10300, 10399]: 3      |
+              [10400, 10499]: 1      |
+              [10500, 10599]: 1      |
+              [10600, 10699]: 9      |+
+              [10700, 10799]: 32     |++++++++
+              [10800, 10899]: 5      |
+              [10900, 10999]: 3      |
+              [11000, 11099]: 4      |
+              [11100, 11199]: 1      |
+              [11200, 11299]: 4      |
+              [11300, 11399]: 2      |
+              [11500, 11599]: 1      |
+              [11800, 11899]: 3      |
+              [17900, 17999]: 2      |
+              [36500, 36599]: 1      |
+              [105800, 105899]: 1    |
+              [397900, 397999]: 2    |
+              [1343400, 1343499]: 1  |
+              [1351600, 1351699]: 1  |
 
-          column: stream_logeventstream.content_length, type: INT
-          Unique elements: 142
-          Histogram:
-            [0, 99]: 205           |+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-            [100, 199]: 1          |
-            [200, 299]: 9          |+
-            [300, 399]: 9          |+
-            [400, 499]: 3          |
-            [500, 599]: 300        |+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-            [600, 699]: 4          |
-            [800, 899]: 2          |
-            [900, 999]: 1          |
-            [1300, 1399]: 10       |++
-            [1400, 1499]: 206      |++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-            [1500, 1599]: 2        |
-            [1600, 1699]: 2        |
-            [2500, 2599]: 1        |
-            [2700, 2799]: 1        |
-            [2800, 2899]: 1        |
-            [4200, 4299]: 1        |
-            [5700, 5799]: 5        |
-            [7100, 7199]: 1        |
-            [7300, 7399]: 4        |
-            [7800, 7899]: 1        |
-            [8200, 8299]: 5        |
-            [8700, 8799]: 3        |
-            [8800, 8899]: 12       |++
-            [8900, 8999]: 22       |+++++
-            [9000, 9099]: 16       |+++
-            [9100, 9199]: 9        |+
-            [9200, 9299]: 4        |
-            [9300, 9399]: 3        |
-            [9400, 9499]: 5        |
-            [9600, 9699]: 1        |
-            [9700, 9799]: 2        |
-            [9800, 9899]: 39       |++++++++++
-            [9900, 9999]: 4        |
-            [10000, 10099]: 1      |
-            [10100, 10199]: 8      |+
-            [10200, 10299]: 1      |
-            [10300, 10399]: 3      |
-            [10400, 10499]: 1      |
-            [10500, 10599]: 1      |
-            [10600, 10699]: 9      |+
-            [10700, 10799]: 32     |++++++++
-            [10800, 10899]: 5      |
-            [10900, 10999]: 3      |
-            [11000, 11099]: 4      |
-            [11100, 11199]: 1      |
-            [11200, 11299]: 4      |
-            [11300, 11399]: 2      |
-            [11500, 11599]: 1      |
-            [11800, 11899]: 3      |
-            [17900, 17999]: 2      |
-            [36500, 36599]: 1      |
-            [105800, 105899]: 1    |
-            [397900, 397999]: 2    |
-            [1343400, 1343499]: 1  |
-            [1351600, 1351699]: 1  |
+            column: stream_logeventstream.referrer, type: STRING
+            Unique elements: 8
 
-          column: stream_logeventstream.referrer, type: STRING
-          Unique elements: 8
+            column: stream_logeventstream.user_agent, type: STRING
+            Unique elements: 4
 
-          column: stream_logeventstream.user_agent, type: STRING
-          Unique elements: 4
-
-          Analyzing 1000 stream events in the time range [0, 9223372036854775807]...
+            Analyzing 1000 stream events in the time range [0, 9223372036854775807]...
 
 
 Advanced Data Exploration
@@ -495,7 +531,6 @@ Advanced Data Exploration
 - CDAP has the ability to join multiple streams using SQL
 - Data in a stream can be ingested in real time or batch
 - CDAP supports joining with other streams using Hive SQL
-
 
 .. container:: table-block
 
@@ -515,13 +550,13 @@ Advanced Data Exploration
        - - Create a file in Hadoop file system called ``ip2geo``
          
      * - Using CDAP
-       - ``cdap > create stream ip2geo``
-          
-     * -  
-       - ::
+       - .. container:: highlight
+       
+          .. parsed-literal::
 
-          Successfully created stream with ID 'ip2geo'
+            |cdap >| create stream ip2geo
 
+            Successfully created stream with ID 'ip2geo'
 
 .. container:: table-block
 
@@ -543,13 +578,13 @@ Advanced Data Exploration
          - Create external table in Hive called ``stream_ip2geo``
 
      * - Using CDAP
-       - ``cdap > load stream ip2geo examples/resources/ip2geo-maps.csv``
-          
-     * -  
-       - ::
+       - .. container:: highlight
+       
+          .. parsed-literal::
 
-          Successfully sent stream event to stream 'ip2geo'
+            |cdap >| load stream ip2geo examples/resources/ip2geo-maps.csv
 
+            Successfully sent stream event to stream 'ip2geo'
 
 .. container:: table-block
 
@@ -569,13 +604,13 @@ Advanced Data Exploration
        - Write data to Kafka or append directly to HDFS
          
      * - Using CDAP
-       - ``cdap > send stream ip2geo '69.181.160.120, Los Angeles, CA'``
+       - .. container:: highlight
+       
+          .. parsed-literal::
+
+            |cdap >| send stream ip2geo '69.181.160.120, Los Angeles, CA'
           
-     * -  
-       - ::
-
-          Successfully sent stream event to stream 'ip2geo'
-
+            Successfully sent stream event to stream 'ip2geo'
 
 .. container:: table-block
 
@@ -596,39 +631,39 @@ Advanced Data Exploration
          - ``SELECT * FROM stream_ip2geo``
          
      * - Using CDAP
-       - ``cdap > execute 'select * from stream_ip2geo'``
-          
-     * -  
-       - ::
+       - .. container:: highlight
+       
+          .. parsed-literal::
 
-          +===========================================================================================================+
-          | stream_ip2geo.ts: BIGINT | stream_ip2geo.headers: map<string,string> | stream_ip2geo.body: STRING         |
-          +===========================================================================================================+
-          | 1428892912060            | {"content.type":"text/csv"}               | 108.206.32.124, Santa Clara, CA    |
-          | 1428892912060            | {"content.type":"text/csv"}               | 109.63.206.34, San Jose, CA        |
-          | 1428892912060            | {"content.type":"text/csv"}               | 113.72.144.115, New York, New York |
-          | 1428892912060            | {"content.type":"text/csv"}               | 123.125.71.19, Palo Alto, CA       |
-          | 1428892912060            | {"content.type":"text/csv"}               | 123.125.71.27, Redwood, CA         |
-          | 1428892912060            | {"content.type":"text/csv"}               | 123.125.71.28, Los Altos, CA       |
-          | 1428892912060            | {"content.type":"text/csv"}               | 123.125.71.58, Mountain View, CA   |
-          | 1428892912060            | {"content.type":"text/csv"}               | 142.54.173.19, Houston, TX         |
-          | 1428892912060            | {"content.type":"text/csv"}               | 144.76.137.226, Dallas, TX         |
-          | 1428892912060            | {"content.type":"text/csv"}               | 144.76.201.175, Bedminister, NJ    |
-          | 1428892912060            | {"content.type":"text/csv"}               | 162.210.196.97, Milipitas, CA      |
-          | 1428892912060            | {"content.type":"text/csv"}               | 188.138.17.205, Santa Barbara, CA  |
-          | 1428892912060            | {"content.type":"text/csv"}               | 195.110.40.7, Orlando, FL          |
-          | 1428892912060            | {"content.type":"text/csv"}               | 201.91.5.170, Tampa, FL            |
-          | 1428892912060            | {"content.type":"text/csv"}               | 220.181.108.158, Miami, FL         |
-          | 1428892912060            | {"content.type":"text/csv"}               | 220.181.108.161, Chicago, IL       |
-          | 1428892912060            | {"content.type":"text/csv"}               | 220.181.108.184, Philadelphia, PA  |
-          | 1428892912060            | {"content.type":"text/csv"}               | 222.205.101.211, Indianpolis, IN   |
-          | 1428892912060            | {"content.type":"text/csv"}               | 24.4.216.155, Denver, CO           |
-          | 1428892912060            | {"content.type":"text/csv"}               | 66.249.75.153, San Diego, CA       |
-          | 1428892912060            | {"content.type":"text/csv"}               | 77.75.77.11, Austin, TX            |
-          | 1428892981049            | {}                                        | 69.181.160.120, Los Angeles, CA    |
-          +===========================================================================================================+
-          Fetched 22 rows
+            |cdap >| execute 'select * from stream_ip2geo'
 
+            +===========================================================================================================+
+            | stream_ip2geo.ts: BIGINT | stream_ip2geo.headers: map<string,string> | stream_ip2geo.body: STRING         |
+            +===========================================================================================================+
+            | 1428892912060            | {"content.type":"text/csv"}               | 108.206.32.124, Santa Clara, CA    |
+            | 1428892912060            | {"content.type":"text/csv"}               | 109.63.206.34, San Jose, CA        |
+            | 1428892912060            | {"content.type":"text/csv"}               | 113.72.144.115, New York, New York |
+            | 1428892912060            | {"content.type":"text/csv"}               | 123.125.71.19, Palo Alto, CA       |
+            | 1428892912060            | {"content.type":"text/csv"}               | 123.125.71.27, Redwood, CA         |
+            | 1428892912060            | {"content.type":"text/csv"}               | 123.125.71.28, Los Altos, CA       |
+            | 1428892912060            | {"content.type":"text/csv"}               | 123.125.71.58, Mountain View, CA   |
+            | 1428892912060            | {"content.type":"text/csv"}               | 142.54.173.19, Houston, TX         |
+            | 1428892912060            | {"content.type":"text/csv"}               | 144.76.137.226, Dallas, TX         |
+            | 1428892912060            | {"content.type":"text/csv"}               | 144.76.201.175, Bedminister, NJ    |
+            | 1428892912060            | {"content.type":"text/csv"}               | 162.210.196.97, Milipitas, CA      |
+            | 1428892912060            | {"content.type":"text/csv"}               | 188.138.17.205, Santa Barbara, CA  |
+            | 1428892912060            | {"content.type":"text/csv"}               | 195.110.40.7, Orlando, FL          |
+            | 1428892912060            | {"content.type":"text/csv"}               | 201.91.5.170, Tampa, FL            |
+            | 1428892912060            | {"content.type":"text/csv"}               | 220.181.108.158, Miami, FL         |
+            | 1428892912060            | {"content.type":"text/csv"}               | 220.181.108.161, Chicago, IL       |
+            | 1428892912060            | {"content.type":"text/csv"}               | 220.181.108.184, Philadelphia, PA  |
+            | 1428892912060            | {"content.type":"text/csv"}               | 222.205.101.211, Indianpolis, IN   |
+            | 1428892912060            | {"content.type":"text/csv"}               | 24.4.216.155, Denver, CO           |
+            | 1428892912060            | {"content.type":"text/csv"}               | 66.249.75.153, San Diego, CA       |
+            | 1428892912060            | {"content.type":"text/csv"}               | 77.75.77.11, Austin, TX            |
+            | 1428892981049            | {}                                        | 69.181.160.120, Los Angeles, CA    |
+            +===========================================================================================================+
+            Fetched 22 rows
 
 .. container:: table-block
 
@@ -649,12 +684,13 @@ Advanced Data Exploration
          - Recreate the Hive table with new schema
          
      * - Using CDAP
-       - ``cdap > set stream format ip2geo csv "ip string, city string, state string"``
-          
-     * -  
-       - ::
+       - .. container:: highlight
+       
+          .. parsed-literal::
 
-          Successfully set format of stream 'ip2geo'
+            |cdap >| set stream format ip2geo csv "ip string, city string, state string"
+          
+            Successfully set format of stream 'ip2geo'
 
 .. container:: table-block
 
@@ -675,40 +711,40 @@ Advanced Data Exploration
          - ``SELECT * FROM stream_ip2geo``
          
      * - Using CDAP
-       - ``cdap > execute 'select * from stream_ip2geo'``
-          
-     * -  
-       - ::
+       - .. container:: highlight
+       
+          .. parsed-literal::
 
-          +================================================================================================================+
-          | stream_ip2geo.ts:| stream_ip2geo.headers:      | stream_ip2geo.ip:| stream_ip2geo.city: | stream_ip2geo.state: |
-          | BIGINT           | map<string,string>          | STRING           | STRING              | STRING               |
-          +================================================================================================================+
-          | 1428892912060    | {"content.type":"text/csv"} | 108.206.32.124   |  Santa Clara        |  CA                  |
-          | 1428892912060    | {"content.type":"text/csv"} | 109.63.206.34    |  San Jose           |  CA                  |
-          | 1428892912060    | {"content.type":"text/csv"} | 113.72.144.115   |  New York           |  New York            |
-          | 1428892912060    | {"content.type":"text/csv"} | 123.125.71.19    |  Palo Alto          |  CA                  |
-          | 1428892912060    | {"content.type":"text/csv"} | 123.125.71.27    |  Redwood            |  CA                  |
-          | 1428892912060    | {"content.type":"text/csv"} | 123.125.71.28    |  Los Altos          |  CA                  |
-          | 1428892912060    | {"content.type":"text/csv"} | 123.125.71.58    |  Mountain View      |  CA                  |
-          | 1428892912060    | {"content.type":"text/csv"} | 142.54.173.19    |  Houston            |  TX                  |
-          | 1428892912060    | {"content.type":"text/csv"} | 144.76.137.226   |  Dallas             |  TX                  |
-          | 1428892912060    | {"content.type":"text/csv"} | 144.76.201.175   |  Bedminister        |  NJ                  |
-          | 1428892912060    | {"content.type":"text/csv"} | 162.210.196.97   |  Milipitas          |  CA                  |
-          | 1428892912060    | {"content.type":"text/csv"} | 188.138.17.205   |  Santa Barbara      |  CA                  |
-          | 1428892912060    | {"content.type":"text/csv"} | 195.110.40.7     |  Orlando            |  FL                  |
-          | 1428892912060    | {"content.type":"text/csv"} | 201.91.5.170     |  Tampa              |  FL                  |
-          | 1428892912060    | {"content.type":"text/csv"} | 220.181.108.158  |  Miami              |  FL                  |
-          | 1428892912060    | {"content.type":"text/csv"} | 220.181.108.161  |  Chicago            |  IL                  |
-          | 1428892912060    | {"content.type":"text/csv"} | 220.181.108.184  |  Philadelphia       |  PA                  |
-          | 1428892912060    | {"content.type":"text/csv"} | 222.205.101.211  |  Indianpolis        |  IN                  |
-          | 1428892912060    | {"content.type":"text/csv"} | 24.4.216.155     |  Denver             |  CO                  |
-          | 1428892912060    | {"content.type":"text/csv"} | 66.249.75.153    |  San Diego          |  CA                  |
-          | 1428892912060    | {"content.type":"text/csv"} | 77.75.77.11      |  Austin             |  TX                  |
-          | 1428892981049    | {}                          | 69.181.160.120   |  Los Angeles        |  CA                  |
-          +================================================================================================================+
-          Fetched 22 rows
-
+            |cdap >| execute 'select * from stream_ip2geo'
+                    
+            +================================================================================================================+
+            | stream_ip2geo.ts:| stream_ip2geo.headers:      | stream_ip2geo.ip:| stream_ip2geo.city: | stream_ip2geo.state: |
+            | BIGINT           | map<string,string>          | STRING           | STRING              | STRING               |
+            +================================================================================================================+
+            | 1428892912060    | {"content.type":"text/csv"} | 108.206.32.124   |  Santa Clara        |  CA                  |
+            | 1428892912060    | {"content.type":"text/csv"} | 109.63.206.34    |  San Jose           |  CA                  |
+            | 1428892912060    | {"content.type":"text/csv"} | 113.72.144.115   |  New York           |  New York            |
+            | 1428892912060    | {"content.type":"text/csv"} | 123.125.71.19    |  Palo Alto          |  CA                  |
+            | 1428892912060    | {"content.type":"text/csv"} | 123.125.71.27    |  Redwood            |  CA                  |
+            | 1428892912060    | {"content.type":"text/csv"} | 123.125.71.28    |  Los Altos          |  CA                  |
+            | 1428892912060    | {"content.type":"text/csv"} | 123.125.71.58    |  Mountain View      |  CA                  |
+            | 1428892912060    | {"content.type":"text/csv"} | 142.54.173.19    |  Houston            |  TX                  |
+            | 1428892912060    | {"content.type":"text/csv"} | 144.76.137.226   |  Dallas             |  TX                  |
+            | 1428892912060    | {"content.type":"text/csv"} | 144.76.201.175   |  Bedminister        |  NJ                  |
+            | 1428892912060    | {"content.type":"text/csv"} | 162.210.196.97   |  Milipitas          |  CA                  |
+            | 1428892912060    | {"content.type":"text/csv"} | 188.138.17.205   |  Santa Barbara      |  CA                  |
+            | 1428892912060    | {"content.type":"text/csv"} | 195.110.40.7     |  Orlando            |  FL                  |
+            | 1428892912060    | {"content.type":"text/csv"} | 201.91.5.170     |  Tampa              |  FL                  |
+            | 1428892912060    | {"content.type":"text/csv"} | 220.181.108.158  |  Miami              |  FL                  |
+            | 1428892912060    | {"content.type":"text/csv"} | 220.181.108.161  |  Chicago            |  IL                  |
+            | 1428892912060    | {"content.type":"text/csv"} | 220.181.108.184  |  Philadelphia       |  PA                  |
+            | 1428892912060    | {"content.type":"text/csv"} | 222.205.101.211  |  Indianpolis        |  IN                  |
+            | 1428892912060    | {"content.type":"text/csv"} | 24.4.216.155     |  Denver             |  CO                  |
+            | 1428892912060    | {"content.type":"text/csv"} | 66.249.75.153    |  San Diego          |  CA                  |
+            | 1428892912060    | {"content.type":"text/csv"} | 77.75.77.11      |  Austin             |  TX                  |
+            | 1428892981049    | {}                          | 69.181.160.120   |  Los Angeles        |  CA                  |
+            +================================================================================================================+
+            Fetched 22 rows
 
 .. container:: table-block
 
@@ -729,59 +765,67 @@ Advanced Data Exploration
          - ``SELECT remote_host, city, state, request from stream_logEventStream join stream_ip2geo on (stream_logEventStream.remote_host = stream_ip2geo.ip) limit 10``
          
      * - Using CDAP
-       - ``cdap > execute 'select remote_host, city, state, request from stream_logEventStream join stream_ip2geo on (stream_logEventStream.remote_host = stream_ip2geo.ip) limit 10'``
-          
-     * -  
-       - ::
+       - .. container:: highlight
+       
+          .. parsed-literal::
 
-          +======================================================================================================================+
-          | remote_host: STRING | city: STRING | state: STRING | request: STRING                                                 |
-          +======================================================================================================================+
-          | 108.206.32.124      |  Santa Clara |  CA           | GET /browse/CDAP-DUT725-8 HTTP/1.1                              |
-          |----------------------------------------------------------------------------------------------------------------------|
-          | 108.206.32.124      |  Santa Clara |  CA           | GET /s/d41d8cd98f00b204e9800998ecf8427e-CDN/en_US/4411/1/1.0/_/ |
-          |                     |              |               | download/batch/bamboo.web.resources:base-model/bamboo.web.resou |
-          |                     |              |               | rces:base-model.js HTTP/1.1                                     |
-          |----------------------------------------------------------------------------------------------------------------------|
-          | 108.206.32.124      |  Santa Clara |  CA           | GET /s/d41d8cd98f00b204e9800998ecf8427e-CDN/en_US/4411/1/1.0/_/ |
-          |                     |              |               | download/batch/bamboo.web.resources:model-deployment-version/ba |
-          |                     |              |               | mboo.web.resources:model-deployment-version.js HTTP/1.1         |
-          |----------------------------------------------------------------------------------------------------------------------|
-          | 108.206.32.124      |  Santa Clara |  CA           | GET /s/d41d8cd98f00b204e9800998ecf8427e-CDN/en_US/4411/1/1.0/_/ |
-          |                     |              |               | download/batch/bamboo.web.resources:model-deployment-result/bam |
-          |                     |              |               | boo.web.resources:model-deployment-result.js HTTP/1.1           |
-          |----------------------------------------------------------------------------------------------------------------------|
-          | 108.206.32.124      |  Santa Clara |  CA           | GET /s/d41d8cd98f00b204e9800998ecf8427e-T/en_US/4411/1/3.5.7/_/ |
-          |                     |              |               | download/batch/com.atlassian.support.stp:stp-license-status-res |
-          |                     |              |               | ources/com.atlassian.support.stp:stp-license-status-resources.c |
-          |                     |              |               | ss HTTP/1.1                                                     |
-          |----------------------------------------------------------------------------------------------------------------------|
-          | 108.206.32.124      |  Santa Clara |  CA           | GET /s/d41d8cd98f00b204e9800998ecf8427e-CDN/en_US/4411/1/1.0/_/ |
-          |                     |              |               | download/batch/bamboo.web.resources:model-deployment-operations |
-          |                     |              |               | /bamboo.web.resources:model-deployment-operations.js HTTP/1.1   |
-          |----------------------------------------------------------------------------------------------------------------------|
-          | 108.206.32.124      |  Santa Clara |  CA           | GET /s/d41d8cd98f00b204e9800998ecf8427e-CDN/en_US/4411/1/1.0/_/ |
-          |                     |              |               | download/batch/bamboo.web.resources:model-deployment-environmen |
-          |                     |              |               | t/bamboo.web.resources:model-deployment-environment.js HTTP/1.1 |
-          |----------------------------------------------------------------------------------------------------------------------|
-          | 108.206.32.124      |  Santa Clara |  CA           | GET /s/d41d8cd98f00b204e9800998ecf8427e-CDN/en_US/4411/1/1.0/_/ |
-          |                     |              |               | download/batch/bamboo.web.resources:model-deployment-project/ba |
-          |                     |              |               | mboo.web.resources:model-deployment-project.js HTTP/1.1         |
-          |----------------------------------------------------------------------------------------------------------------------|
-          | 108.206.32.124      |  Santa Clara |  CA           | GET /s/71095c56c641f2c4a4f189b9dfcd7a38-CDN/en_US/4411/1/5.6.2/ |
-          |                     |              |               | _/download/batch/bamboo.deployments:deployment-project-list/bam |
-          |                     |              |               | boo.deployments:deployment-project-list.js?locale=en-US HTTP/1. |
-          |                     |              |               | 1                                                               |
-          |----------------------------------------------------------------------------------------------------------------------|
-          | 108.206.32.124      |  Santa Clara |  CA           | GET /s/d41d8cd98f00b204e9800998ecf8427e-CDN/en_US/4411/1/5dddb6 |
-          |                     |              |               | ea4dc4fd5569d992cf603f31e5/_/download/contextbatch2/css/atl.gen |
-          |                     |              |               | eral,bamboo.result/batch.css HTTP/1.1                           |
-          +======================================================================================================================+
-          Fetched 10 rows
+            |cdap >| execute 'select remote_host, city, state, request from stream_logEventStream join stream_ip2geo on (stream_logEventStream.remote_host = stream_ip2geo.ip) limit 10'
+
+         .. container:: highlight
+       
+          ::
+
+            +======================================================================================================================+
+            | remote_host: STRING | city: STRING | state: STRING | request: STRING                                                 |
+            +======================================================================================================================+
+            | 108.206.32.124      |  Santa Clara |  CA           | GET /browse/CDAP-DUT725-8 HTTP/1.1                              |
+            |----------------------------------------------------------------------------------------------------------------------|
+            | 108.206.32.124      |  Santa Clara |  CA           | GET /s/d41d8cd98f00b204e9800998ecf8427e-CDN/en_US/4411/1/1.0/_/ |
+            |                     |              |               | download/batch/bamboo.web.resources:base-model/bamboo.web.resou |
+            |                     |              |               | rces:base-model.js HTTP/1.1                                     |
+            |----------------------------------------------------------------------------------------------------------------------|
+            | 108.206.32.124      |  Santa Clara |  CA           | GET /s/d41d8cd98f00b204e9800998ecf8427e-CDN/en_US/4411/1/1.0/_/ |
+            |                     |              |               | download/batch/bamboo.web.resources:model-deployment-version/ba |
+            |                     |              |               | mboo.web.resources:model-deployment-version.js HTTP/1.1         |
+            |----------------------------------------------------------------------------------------------------------------------|
+            | 108.206.32.124      |  Santa Clara |  CA           | GET /s/d41d8cd98f00b204e9800998ecf8427e-CDN/en_US/4411/1/1.0/_/ |
+            |                     |              |               | download/batch/bamboo.web.resources:model-deployment-result/bam |
+            |                     |              |               | boo.web.resources:model-deployment-result.js HTTP/1.1           |
+            |----------------------------------------------------------------------------------------------------------------------|
+            | 108.206.32.124      |  Santa Clara |  CA           | GET /s/d41d8cd98f00b204e9800998ecf8427e-T/en_US/4411/1/3.5.7/_/ |
+            |                     |              |               | download/batch/com.atlassian.support.stp:stp-license-status-res |
+            |                     |              |               | ources/com.atlassian.support.stp:stp-license-status-resources.c |
+            |                     |              |               | ss HTTP/1.1                                                     |
+            |----------------------------------------------------------------------------------------------------------------------|
+            | 108.206.32.124      |  Santa Clara |  CA           | GET /s/d41d8cd98f00b204e9800998ecf8427e-CDN/en_US/4411/1/1.0/_/ |
+            |                     |              |               | download/batch/bamboo.web.resources:model-deployment-operations |
+            |                     |              |               | /bamboo.web.resources:model-deployment-operations.js HTTP/1.1   |
+            |----------------------------------------------------------------------------------------------------------------------|
+            | 108.206.32.124      |  Santa Clara |  CA           | GET /s/d41d8cd98f00b204e9800998ecf8427e-CDN/en_US/4411/1/1.0/_/ |
+            |                     |              |               | download/batch/bamboo.web.resources:model-deployment-environmen |
+            |                     |              |               | t/bamboo.web.resources:model-deployment-environment.js HTTP/1.1 |
+            |----------------------------------------------------------------------------------------------------------------------|
+            | 108.206.32.124      |  Santa Clara |  CA           | GET /s/d41d8cd98f00b204e9800998ecf8427e-CDN/en_US/4411/1/1.0/_/ |
+            |                     |              |               | download/batch/bamboo.web.resources:model-deployment-project/ba |
+            |                     |              |               | mboo.web.resources:model-deployment-project.js HTTP/1.1         |
+            |----------------------------------------------------------------------------------------------------------------------|
+            | 108.206.32.124      |  Santa Clara |  CA           | GET /s/71095c56c641f2c4a4f189b9dfcd7a38-CDN/en_US/4411/1/5.6.2/ |
+            |                     |              |               | _/download/batch/bamboo.deployments:deployment-project-list/bam |
+            |                     |              |               | boo.deployments:deployment-project-list.js?locale=en-US HTTP/1. |
+            |                     |              |               | 1                                                               |
+            |----------------------------------------------------------------------------------------------------------------------|
+            | 108.206.32.124      |  Santa Clara |  CA           | GET /s/d41d8cd98f00b204e9800998ecf8427e-CDN/en_US/4411/1/5dddb6 |
+            |                     |              |               | ea4dc4fd5569d992cf603f31e5/_/download/contextbatch2/css/atl.gen |
+            |                     |              |               | eral,bamboo.result/batch.css HTTP/1.1                           |
+            +======================================================================================================================+
+            Fetched 10 rows
+
 
 Transforming Your Data
 ======================
-- CDAP Included Applications are applications that are reusable through the configuration of artifacts
+- CDAP :ref:`Included Applications <included-apps-index>` are applications that are
+  reusable through the configuration of artifacts and can be used to create an application
+  without writing any code at all
 - Built-in ETL (Extract, Transform, Load) and Data Quality applications
 - ETL includes over 30 Plugins to build applications merely through configuration of parameters
 - Build your own custom plugins, using simple APIs
@@ -811,63 +855,72 @@ Transforming Your Data
          - Keep track of last processed times
          
      * - Using CDAP
-       - Write a configuration file, saving it to ``examples/resources/app-config.json``::
-
-          {
-              "description": "Periodically reads stream data and writes it to a TimePartitionedFileSet",
-              "config": {
-                  "schedule": "*/5 * * * *",
-                  "source": {
-                      "name": "Stream",
-                      "properties": {
-                          "name": "logEventStream",
-                          "duration": "5m",
-                          "format": "clf"
-                      }
-                  },
-                  "transforms": [
-                      {
-                          "name": "Projection",
-                          "properties": {
-                              "drop": "headers"
-                          }
-                      }
-                  ],
-                  "sinks": [
-                    {
-                        "name": "TPFSAvro",
-                        "properties": {
-                            "name": "logEventStream_converted",
-                            "schema": "{
-                                \"type\":\"record\",
-                                \"name\":\"logEvent\",
-                                \"fields\":[
-                                    {\"name\":\"ts\",\"type\":\"long\"},
-                                    {\"name\":\"remotehost\",\"type\":[\"string\",\"null\"]},
-                                    {\"name\":\"remotelogname\",\"type\":[\"string\",\"null\"]},
-                                    {\"name\":\"authuser\",\"type\":[\"string\",\"null\"]},
-                                    {\"name\":\"date\",\"type\":[\"string\",\"null\"]},
-                                    {\"name\":\"request\",\"type\":[\"string\",\"null\"]},
-                                    {\"name\":\"status\",\"type\":[\"int\",\"null\"]},
-                                    {\"name\":\"contentlength\",\"type\":[\"int\",\"null\"]},
-                                    {\"name\":\"referrer\",\"type\":[\"string\",\"null\"]},
-                                    {\"name\":\"useragent\",\"type\":[\"string\",\"null\"]}
-                                ]
-                            }",
-                            "basePath": "logEventStream_converted"
-                        }
-                    }
-                  ]
-              }
-          }
+       - - Write a configuration file, saving it to ``examples/resources/app-config.json``:
 
      * - 
-       - Create an application using that configuration through the CLI::
+       - ::
 
-           cdap > create app logEventStreamConverter cdap-etl-batch 3.2.0 system examples/resources/app-config.json 
-           Successfully created application
-           cdap > resume schedule logEventStreamConverter.etlWorkflow
-           Successfully resumed schedule 'etlWorkflow' in app 'logEventStreamConverter'
+            {
+                "description": "Periodically reads stream data and writes it to a TimePartitionedFileSet",
+                "config": {
+                    "schedule": "*/5 * * * *",
+                    "source": {
+                        "name": "Stream",
+                        "properties": {
+                            "name": "logEventStream",
+                            "duration": "5m",
+                            "format": "clf"
+                        }
+                    },
+                    "transforms": [
+                        {
+                            "name": "Projection",
+                            "properties": {
+                                "drop": "headers"
+                            }
+                        }
+                    ],
+                    "sinks": [
+                      {
+                          "name": "TPFSAvro",
+                          "properties": {
+                              "name": "logEventStream_converted",
+                              "schema": "{
+                                  \"type\":\"record\",
+                                  \"name\":\"logEvent\",
+                                  \"fields\":[
+                                      {\"name\":\"ts\",\"type\":\"long\"},
+                                      {\"name\":\"remotehost\",\"type\":[\"string\",\"null\"]},
+                                      {\"name\":\"remotelogname\",\"type\":[\"string\",\"null\"]},
+                                      {\"name\":\"authuser\",\"type\":[\"string\",\"null\"]},
+                                      {\"name\":\"date\",\"type\":[\"string\",\"null\"]},
+                                      {\"name\":\"request\",\"type\":[\"string\",\"null\"]},
+                                      {\"name\":\"status\",\"type\":[\"int\",\"null\"]},
+                                      {\"name\":\"contentlength\",\"type\":[\"int\",\"null\"]},
+                                      {\"name\":\"referrer\",\"type\":[\"string\",\"null\"]},
+                                      {\"name\":\"useragent\",\"type\":[\"string\",\"null\"]}
+                                  ]
+                              }",
+                              "basePath": "logEventStream_converted"
+                          }
+                      }
+                    ]
+                }
+            }
+
+     * - 
+       - - Create an application using that configuration through the CLI:
+
+     * - 
+       - .. container:: highlight
+     
+          .. parsed-literal::
+
+            |cdap >| create app logEventStreamConverter cdap-etl-batch |version| system examples/resources/app-config.json
+            Successfully created application
+          
+            |cdap >| resume schedule logEventStreamConverter.etlWorkflow
+            Successfully resumed schedule 'etlWorkflow' in app 'logEventStreamConverter'
 
 .. container:: table-block
 
@@ -887,107 +940,70 @@ Transforming Your Data
        - - Not available
          
      * - Using CDAP
-       - ``cdap > list apps``
-
-     * -  
-       - ::
-
-          +=======================================================================================+
-          | id                      | descript | artifactName   | artifactVersion | artifactScope |
-          |                         | ion      |                |                 |               |
-          +=======================================================================================+
-          | logEventStreamConverter | Batch Ex | cdap-etl-batch | 3.2.0           | SYSTEM        |
-          |                         | tract-Tr |                |                 |               |
-          |                         | ansform- |                |                 |               |
-          |                         | Load (ET |                |                 |               |
-          |                         | L) Templ |                |                 |               |
-          |                         | ate      |                |                 |               |
-          +=======================================================================================+
-
-     * - 
-       - ``cdap > describe app logEventStreamConverter``
-
-     * -  
-       - ::
+       - .. container:: highlight
        
-          +====================================================================+
-          | type      | id           | description                             |
-          +====================================================================+
-          | MapReduce | ETLMapReduce | MapReduce driver for Batch ETL Adapters |
-          | Workflow  | ETLWorkflow  | Workflow for Batch ETL MapReduce Driver |
-          +====================================================================+
+          .. parsed-literal::
 
-          +======================================================================================================================+
-          | name                | description         | template | config              | properties                              |
-          +======================================================================================================================+
-          | logEventStreamConve | Periodically reads  | ETLBatch | {"schedule":"*/5 *  | schedule={"schedule":{"name":"logEventS |
-          | rter                | stream data and wri |          | * * *","source":{"n | treamConverter.etl.batch.adapter.logEve |
-          |                     | tes it to a TimePar |          | ame":"Stream","prop | ntStreamConverter.schedule","descriptio |
-          |                     | titionedFileSet     |          | erties":{"name":"lo | n":"Schedule for logEventStreamConverte |
-          |                     |                     |          | gEventStream","dura | r Adapter"},"program":{"programName":"E |
-          |                     |                     |          | tion":"5m","format" | TLworkflow","programType":"WORKFLOW"}," |
-          |                     |                     |          | :"clf"}},"transform | properties":{"transformIds":"[\"Project |
-          |                     |                     |          | s":[{"name":"Projec | ion:0\"]","name":"logEventStreamConvert |
-          |                     |                     |          | tion","properties": | er","sinkId":"sink:TPFSAvro","config":" |
-          |                     |                     |          | {"drop":"headers"}} | {\"schedule\":\"*/5 * * * *\",\"source\ |
-          |                     |                     |          | ],"sink":{"name":"T | ":{\"name\":\"Stream\",\"properties\":{ |
-          |                     |                     |          | PFSAvro","propertie | \"duration\":\"5m\",\"name\":\"logEvent |
-          |                     |                     |          | s":{"name":"logEven | Stream\",\"format\":\"clf\"}},\"sink\": |
-          |                     |                     |          | tStream.converted", | {\"name\":\"TPFSAvro\",\"properties\":{ |
-          |                     |                     |          | "schema":"{\n       | \"basePath\":\"logEventStream.converted |
-          |                     |                     |          |               \"typ | \",\"schema\":\"{\\n                    |
-          |                     |                     |          | e\":\"record\",\n   |  \\\"type\\\":\\\"record\\\",\\n        |
-          |                     |                     |          |                   \ |              \\\"name\\\":\\\"logEvent\ |
-          |                     |                     |          | "name\":\"logEvent\ | \\",\\n                    \\\"fields\\ |
-          |                     |                     |          | ",\n                | \":[\\n                        {\\\"nam |
-          |                     |                     |          |      \"fields\":[\n | e\\\":\\\"ts\\\",\\\"type\\\":\\\"long\ |
-          |                     |                     |          |                     | \\"},\\n                        {\\\"na |
-          |                     |                     |          |      {\"name\":\"ts | me\\\":\\\"remotehost\\\",\\\"type\\\": |
-          |                     |                     |          | \",\"type\":\"long\ | [\\\"string\\\",\\\"null\\\"]},\\n      |
-          |                     |                     |          | "},\n               |                    {\\\"name\\\":\\\"re |
-          |                     |                     |          |           {\"name\" | motelogname\\\",\\\"type\\\":[\\\"strin |
-          |                     |                     |          | :\"remotehost\",\"t | g\\\",\\\"null\\\"]},\\n                |
-          |                     |                     |          | ype\":[\"string\",\ |          {\\\"name\\\":\\\"authuser\\\" |
-          |                     |                     |          | "null\"]},\n        | ,\\\"type\\\":[\\\"string\\\",\\\"null\ |
-          |                     |                     |          |                  {\ | \\"]},\\n                        {\\\"n |
-          |                     |                     |          | "name\":\"remotelog | ame\\\":\\\"date\\\",\\\"type\\\":[\\\" |
-          |                     |                     |          | name\",\"type\":[\" | string\\\",\\\"null\\\"]},\\n           |
-          |                     |                     |          | string\",\"null\"]} |               {\\\"name\\\":\\\"request |
-          |                     |                     |          | ,\n                 | \\\",\\\"type\\\":[\\\"string\\\",\\\"n |
-          |                     |                     |          |         {\"name\":\ | ull\\\"]},\\n                        {\ |
-          |                     |                     |          | "authuser\",\"type\ | \\"name\\\":\\\"status\\\",\\\"type\\\" |
-          |                     |                     |          | ":[\"string\",\"nul | :[\\\"int\\\",\\\"null\\\"]},\\n        |
-          |                     |                     |          | l\"]},\n            |                  {\\\"name\\\":\\\"cont |
-          |                     |                     |          |              {\"nam | entlength\\\",\\\"type\\\":[\\\"int\\\" |
-          |                     |                     |          | e\":\"date\",\"type | ,\\\"null\\\"]},\\n                     |
-          |                     |                     |          | \":[\"string\",\"nu |     {\\\"name\\\":\\\"referrer\\\",\\\" |
-          |                     |                     |          | ll\"]},\n           | type\\\":[\\\"string\\\",\\\"null\\\"]} |
-          |                     |                     |          |               {\"na | ,\\n                        {\\\"name\\ |
-          |                     |                     |          | me\":\"request\",\" | \":\\\"useragent\\\",\\\"type\\\":[\\\" |
-          |                     |                     |          | type\":[\"string\", | string\\\",\\\"null\\\"]}\\n            |
-          |                     |                     |          | \"null\"]},\n       |          ]\\n                }\",\"name |
-          |                     |                     |          |                   { | \":\"logEventStream.converted\"}},\"tra |
-          |                     |                     |          | \"name\":\"status\" | nsforms\":[{\"name\":\"Projection\",\"p |
-          |                     |                     |          | ,\"type\":[\"int\", | roperties\":{\"drop\":\"headers\"}}]}", |
-          |                     |                     |          | \"null\"]},\n       | "sourceId":"source:Stream"}}            |
-          |                     |                     |          |                   { | instances=1                             |
-          |                     |                     |          | \"name\":\"contentl |                                         |
-          |                     |                     |          | ength\",\"type\":[\ |                                         |
-          |                     |                     |          | "int\",\"null\"]},\ |                                         |
-          |                     |                     |          | n                   |                                         |
-          |                     |                     |          |       {\"name\":\"r |                                         |
-          |                     |                     |          | eferrer\",\"type\": |                                         |
-          |                     |                     |          | [\"string\",\"null\ |                                         |
-          |                     |                     |          | "]},\n              |                                         |
-          |                     |                     |          |            {\"name\ |                                         |
-          |                     |                     |          | ":\"useragent\",\"t |                                         |
-          |                     |                     |          | ype\":[\"string\",\ |                                         |
-          |                     |                     |          | "null\"]}\n         |                                         |
-          |                     |                     |          |             ]\n     |                                         |
-          |                     |                     |          |             }","bas |                                         |
-          |                     |                     |          | ePath":"logEventStr |                                         |
-          |                     |                     |          | eam.converted"}}}   |                                         |
-          +======================================================================================================================+
+            |cdap >| list apps
+
+            +=======================================================================================+
+            | id                      | descript | artifactName   | artifactVersion | artifactScope |
+            |                         | ion      |                |                 |               |
+            +=======================================================================================+
+            | logEventStreamConverter | Batch Ex | cdap-etl-batch | 3.2.0           | SYSTEM        |
+            |                         | tract-Tr |                |                 |               |
+            |                         | ansform- |                |                 |               |
+            |                         | Load (ET |                |                 |               |
+            |                         | L) Templ |                |                 |               |
+            |                         | ate      |                |                 |               |
+            +=======================================================================================+
+
+            |cdap >| describe app logEventStreamConverter
+
+            +========================================================================+
+            | type      | id           | description                                 |
+            +========================================================================+
+            | MapReduce | ETLMapReduce | MapReduce Driver for ETL Batch Applications |
+            | Workflow  | ETLWorkflow  | Workflow for ETL Batch MapReduce Driver     |
+            +========================================================================+
+
+            |cdap >| describe stream logEventStream
+
+            +==================================================================================+
+            | ttl              | format | schema                   | notification.threshold.mb |
+            +==================================================================================+
+            | 9223372036854775 | clf    | {"type":"record","name": | 1024                      |
+            |                  |        | "streamEvent","fields":[ |                           |
+            |                  |        | {"name":"remote_host","t |                           |
+            |                  |        | ype":["string","null"]}, |                           |
+            |                  |        | {"name":"remote_login"," |                           |
+            |                  |        | type":["string","null"]} |                           |
+            |                  |        | ,{"name":"auth_user","ty |                           |
+            |                  |        | pe":["string","null"]},{ |                           |
+            |                  |        | "name":"date","type":["s |                           |
+            |                  |        | tring","null"]},{"name": |                           |
+            |                  |        | "request","type":["strin |                           |
+            |                  |        | g","null"]},{"name":"sta |                           |
+            |                  |        | tus","type":["int","null |                           |
+            |                  |        | "]},{"name":"content_len |                           |
+            |                  |        | gth","type":["int","null |                           |
+            |                  |        | "]},{"name":"referrer"," |                           |
+            |                  |        | type":["string","null"]} |                           |
+            |                  |        | ,{"name":"user_agent","t |                           |
+            |                  |        | ype":["string","null"]}] |                           |
+            |                  |        | }                        |                           |
+            +==================================================================================+
+
+            |cdap >| get workflow schedules logEventStreamConverter.ETLWorkflow
+
+            +=================================================================================================================+
+            | application | program     | program type | name        | type        | description | properties  | runtime args |
+            +=================================================================================================================+
+            | logEventStr | ETLWorkflow | WORKFLOW     | etlWorkflow | co.cask.cda | batch etl s | cron entry: | {}           |
+            | eamConverte |             |              |             | p.internal. | chedule     |  \*/5 * * *  |              |
+            | r           |             |              |             | schedule.Ti |             | *           |              |
+            |             |             |              |             | meSchedule  |             |             |              |
+            +=================================================================================================================+  
 
 .. container:: table-block
 
@@ -1009,13 +1025,13 @@ Transforming Your Data
          - Create external table in Hive called ``stream_ip2geo``
          
      * - Using CDAP
-       - ``cdap > load stream logEventStream examples/resources/accesslog.txt``
+       - .. container:: highlight
+       
+          .. parsed-literal::
+
+            |cdap >| load stream logEventStream examples/resources/accesslog.txt
           
-     * -  
-       - ::
-
-          Successfully sent stream event to stream 'logEventStream'
-
+            Successfully sent stream event to stream 'logEventStream'
 
 .. container:: table-block
 
@@ -1037,16 +1053,18 @@ Transforming Your Data
          
      * - Using CDAP
        - Dataset that is time partitioned
-          
-     * -  
-       - ``cdap > list dataset instances``
-         ::
 
-          +=================================================================================+
-          | name                      | type                                                |
-          +=================================================================================+
-          | logEventStream.converted  | co.cask.cdap.api.dataset.lib.TimePartitionedFileSet |
-          +=================================================================================+
+         .. container:: highlight
+       
+          .. parsed-literal::
+
+            |cdap >| list dataset instances
+
+            +=================================================================================+
+            | name                      | type                                                |
+            +=================================================================================+
+            | logEventStream_converted  | co.cask.cdap.api.dataset.lib.TimePartitionedFileSet |
+            +=================================================================================+
 
 .. container:: table-block
 
@@ -1067,40 +1085,41 @@ Transforming Your Data
          - ``'describe user_logEventStream_converted'`` 
          
      * - Using CDAP
-       - ``cdap > execute 'describe dataset_logEventStream_converted'``
-          
-     * -  
-       - ::
+       - .. container:: highlight
+       
+          .. parsed-literal::
 
-          +=======================================================================+
-          | col_name: STRING        | data_type: STRING    | comment: STRING      |
-          +=======================================================================+
-          | ts                      | bigint               | from deserializer    |
-          | remotehost              | string               | from deserializer    |
-          | remotelogname           | string               | from deserializer    |
-          | authuser                | string               | from deserializer    |
-          | date                    | string               | from deserializer    |
-          | request                 | string               | from deserializer    |
-          | status                  | int                  | from deserializer    |
-          | contentlength           | int                  | from deserializer    |
-          | referrer                | string               | from deserializer    |
-          | useragent               | string               | from deserializer    |
-          | year                    | int                  |                      |
-          | month                   | int                  |                      |
-          | day                     | int                  |                      |
-          | hour                    | int                  |                      |
-          | minute                  | int                  |                      |
-          |                         |                      |                      |
-          | # Partition Information |                      |                      |
-          | # col_name              | data_type            | comment              |
-          |                         |                      |                      |
-          | year                    | int                  |                      |
-          | month                   | int                  |                      |
-          | day                     | int                  |                      |
-          | hour                    | int                  |                      |
-          | minute                  | int                  |                      |
-          +=======================================================================+
-          Fetched 24 rows
+            |cdap >| execute 'describe dataset_logEventStream_converted'
+          
+            +=======================================================================+
+            | col_name: STRING        | data_type: STRING    | comment: STRING      |
+            +=======================================================================+
+            | ts                      | bigint               | from deserializer    |
+            | remotehost              | string               | from deserializer    |
+            | remotelogname           | string               | from deserializer    |
+            | authuser                | string               | from deserializer    |
+            | date                    | string               | from deserializer    |
+            | request                 | string               | from deserializer    |
+            | status                  | int                  | from deserializer    |
+            | contentlength           | int                  | from deserializer    |
+            | referrer                | string               | from deserializer    |
+            | useragent               | string               | from deserializer    |
+            | year                    | int                  |                      |
+            | month                   | int                  |                      |
+            | day                     | int                  |                      |
+            | hour                    | int                  |                      |
+            | minute                  | int                  |                      |
+            |                         |                      |                      |
+            | # Partition Information |                      |                      |
+            | # col_name              | data_type            | comment              |
+            |                         |                      |                      |
+            | year                    | int                  |                      |
+            | month                   | int                  |                      |
+            | day                     | int                  |                      |
+            | hour                    | int                  |                      |
+            | minute                  | int                  |                      |
+            +=======================================================================+
+            Fetched 24 rows
 
 .. container:: table-block
 
@@ -1121,23 +1140,54 @@ Transforming Your Data
          - ``SELECT ts, request, status FROM dataset_logEventStream_converted LIMIT 2``
          
      * - Using CDAP
-       - ``cdap > execute 'SELECT ts, request, status FROM dataset_logEventStream_converted LIMIT 2'``
+       - - Instead of waiting for the schedule to run, you can directly start the workflow and check its status:
 
-     * -  
-       - ::
+     * - 
+       - .. container:: highlight
+       
+          .. parsed-literal::
 
-          +=====================================================================+
-          | ts: BIGINT    | request: STRING                       | status: INT |
-          +=====================================================================+
-          | 1430769459594 | GET /ajax/planStatusHistoryNeighbouri | 200         |
-          |               | ngSummaries.action?planKey=COOP-DBT&b |             |
-          |               | uildNumber=284&_=1423341312519 HTTP/1 |             |
-          |               | .1                                    |             |
-          |---------------------------------------------------------------------|
-          | 1430769459594 | GET /rest/api/latest/server?_=1423341 | 200         |
-          |               | 312520 HTTP/1.1                       |             |
-          +=====================================================================+
-          Fetched 2 rows
+            |cdap >| start workflow logEventStreamConverter.ETLWorkflow
+            
+            Successfully started workflow 'ETLWorkflow' of application 'logEventStreamConverter' with stored runtime arguments '{}'            
+            
+            |cdap >| get workflow status logEventStreamConverter.ETLWorkflow
+            
+            RUNNING
+
+            ...
+            
+            |cdap >| get workflow status logEventStreamConverter.ETLWorkflow
+            
+            STOPPED
+
+     * - 
+       - - Once the workflow has stopped, retrieve the first two events from the converted data: 
+
+     * - 
+       - .. container:: highlight
+       
+          .. parsed-literal::
+
+            |cdap >| execute 'SELECT ts, request, status FROM dataset_logEventStream_converted LIMIT 2'
+          
+         .. container:: highlight
+         
+          ::
+          
+            +=====================================================================+
+            | ts: BIGINT    | request: STRING                       | status: INT |
+            +=====================================================================+
+            | 1430769459594 | GET /ajax/planStatusHistoryNeighbouri | 200         |
+            |               | ngSummaries.action?planKey=COOP-DBT&b |             |
+            |               | uildNumber=284&_=1423341312519 HTTP/1 |             |
+            |               | .1                                    |             |
+            |---------------------------------------------------------------------|
+            | 1430769459594 | GET /rest/api/latest/server?_=1423341 | 200         |
+            |               | 312520 HTTP/1.1                       |             |
+            +=====================================================================+
+            Fetched 2 rows
+
 
 Building Real World Applications
 ================================
@@ -1178,19 +1228,23 @@ Building Real World Applications
      * - Using CDAP
        - Download the Wise app and unzip into the ``examples`` directory of your CDAP SDK:
        
-         | ``$ cd $CDAP_SDK_HOME/examples``
-         | ``$ curl -O http://repository.cask.co/downloads/co/cask/cdap/apps/``\ |literal-cdap-apps-version|\ ``/cdap-wise-``\ |literal-cdap-apps-version|\ ``.zip`` 
-         | ``$ unzip cdap-wise-``\ |literal-cdap-apps-version|\ ``.zip`` 
+         .. container:: highlight
+
+          .. parsed-literal::    
+      
+            |$| cd $CDAP_SDK_HOME/examples
+            |$| curl -O \http://repository.cask.co/downloads/co/cask/cdap/apps/\ |cdap-apps-version|\ /cdap-wise-\ |cdap-apps-version|\ .zip
+            |$| unzip cdap-wise-\ |cdap-apps-version|\ .zip
 
          From within the CDAP CLI:
 
-         | ``cdap > deploy app examples/cdap-wise-``\ |literal-cdap-apps-version|\ ``/target/cdap-wise-``\ |literal-cdap-apps-version|\ ``.jar``
+         .. container:: highlight
+
+          .. parsed-literal::    
+
+            |cdap >| deploy app examples/cdap-wise-\ |cdap-apps-version|/target/cdap-wise-\ |cdap-apps-version|.jar
           
-     * -  
-       - ::
-
-          Successfully deployed application
-
+            Successfully deployed application
 
 .. container:: table-block
 
@@ -1211,19 +1265,20 @@ Building Real World Applications
          - Check **YARN** Console
          
      * - Using CDAP
-       - ``cdap > describe app Wise``
-          
-     * -  
-       - ::
+       - .. container:: highlight
+       
+          .. parsed-literal::
 
-          +=====================================================================+
-          | type      | id                    | description                     |
-          +=====================================================================+
-          | Flow      | WiseFlow              | Wise flow                       |
-          | MapReduce | BounceCountsMapReduce | Bounce Counts MapReduce Program |
-          | Service   | WiseService           |                                 |
-          | workflow  | Wiseworkflow          | Wise workflow                   |
-          +=====================================================================+
+            |cdap >| describe app Wise
+
+            +=====================================================================+
+            | type      | id                    | description                     |
+            +=====================================================================+
+            | Flow      | WiseFlow              | Wise flow                       |
+            | MapReduce | BounceCountsMapReduce | Bounce Counts MapReduce Program |
+            | Service   | WiseService           |                                 |
+            | workflow  | WiseWorkflow          | Wise workflow                   |
+            +=====================================================================+
 
 .. container:: table-block
 
@@ -1246,12 +1301,13 @@ Building Real World Applications
          - ``yarn jar /path/to/myprogram.jar``
          
      * - Using CDAP
-       - ``cdap > start flow Wise.WiseFlow``
-          
-     * -  
-       - ::
+       - .. container:: highlight
+       
+          .. parsed-literal::
 
-          Successfully started flow 'WiseFlow' of application 'Wise' with stored runtime arguments '{}
+            |cdap >| start flow Wise.WiseFlow
+          
+            Successfully started flow 'WiseFlow' of application 'Wise' with stored runtime arguments '{}
 
 .. container:: table-block
 
@@ -1274,12 +1330,13 @@ Building Real World Applications
          - ``yarn application -status <APP ID>``
          
      * - Using CDAP
-       - ``cdap > get flow status Wise.WiseFlow``
-          
-     * -  
-       - ::
+       - .. container:: highlight
+       
+          .. parsed-literal::
 
-          RUNNING
+            |cdap >| get flow status Wise.WiseFlow
+          
+            RUNNING
 
 .. container:: table-block
 
@@ -1301,25 +1358,24 @@ Building Real World Applications
          - Create external table in Hive called ``cdap_stream_logeventstream``
          
      * - Using CDAP
-       - ``cdap > load stream logEventStream examples/resources/accesslog.txt``
-          
-     * -  
-       - ::
+       - .. container:: highlight
+       
+          .. parsed-literal::
 
-          Successfully sent stream event to stream 'logEventStream'  
+            |cdap >| load stream logEventStream examples/resources/accesslog.txt
 
-.. highlight:: none
-      
+            Successfully sent stream event to stream 'logEventStream'  
+
 .. container:: table-block
 
   .. list-table::
      :widths: 80 20
      :stub-columns: 1
      
-     * - Retrieve 
+     * - Retrieve logs
        - 
        
- .. list-table::
+  .. list-table::
      :widths: 15 85
      :class: triple-table
      :stub-columns: 1
@@ -1333,27 +1389,28 @@ Building Real World Applications
          - Click on container logs
          
      * - Using CDAP
-       - ``cdap > get flow logs Wise.WiseFlow``
-    
-     * -  
-       - ::
+       - .. container:: highlight
+       
+          .. parsed-literal::
 
-          2015-04-15 09:22:53,775 - INFO  [FlowletRuntimeService
-          STARTING:c.c.c.i.a.r.f.FlowletRuntimeService$1@110] - Initializing flowlet:
-          flowlet=pageViewCount, instance=0, groupsize=1, namespaceId=default, applicationId=Wise,
-          program=WiseFlow, runid=aae85671-e38b-11e4-bd5e-3ee74a48f4aa
-          2015-04-15 09:22:53,779 - INFO  [FlowletRuntimeService
-          STARTING:c.c.c.i.a.r.f.FlowletRuntimeService$1@117] - Flowlet initialized:
-          flowlet=pageViewCount, instance=0, groupsize=1, namespaceId=default, applicationId=Wise,
-          program=WiseFlow, runid=aae85671-e38b-11e4-bd5e-3ee74a48f4aa
-          ...
-          2015-04-15 10:07:54,708 - INFO  [FlowletRuntimeService
-          STARTING:c.c.c.i.a.r.f.FlowletRuntimeService$1@117] - Flowlet initialized: flowlet=parser,
-          instance=0, groupsize=1, namespaceId=default, applicationId=Wise, program=WiseFlow,
-          runid=f4e0e52a-e391-11e4-a467-3ee74a48f4aa
-          2015-04-15 10:07:54,709 - DEBUG [FlowletRuntimeService
-          STARTING:c.c.c.i.a.r.AbstractProgramController@230] - Program started: WiseFlow:parser
-          f4e0e52a-e391-11e4-a467-3ee74a48f4aa
+            |cdap >| get flow logs Wise.WiseFlow
+
+            2015-04-15 09:22:53,775 - INFO  [FlowletRuntimeService
+            STARTING:c.c.c.i.a.r.f.FlowletRuntimeService$1@110] - Initializing flowlet:
+            flowlet=pageViewCount, instance=0, groupsize=1, namespaceId=default, applicationId=Wise,
+            program=WiseFlow, runid=aae85671-e38b-11e4-bd5e-3ee74a48f4aa
+            2015-04-15 09:22:53,779 - INFO  [FlowletRuntimeService
+            STARTING:c.c.c.i.a.r.f.FlowletRuntimeService$1@117] - Flowlet initialized:
+            flowlet=pageViewCount, instance=0, groupsize=1, namespaceId=default, applicationId=Wise,
+            program=WiseFlow, runid=aae85671-e38b-11e4-bd5e-3ee74a48f4aa
+            ...
+            2015-04-15 10:07:54,708 - INFO  [FlowletRuntimeService
+            STARTING:c.c.c.i.a.r.f.FlowletRuntimeService$1@117] - Flowlet initialized: flowlet=parser,
+            instance=0, groupsize=1, namespaceId=default, applicationId=Wise, program=WiseFlow,
+            runid=f4e0e52a-e391-11e4-a467-3ee74a48f4aa
+            2015-04-15 10:07:54,709 - DEBUG [FlowletRuntimeService
+            STARTING:c.c.c.i.a.r.AbstractProgramController@230] - Program started: WiseFlow:parser
+            f4e0e52a-e391-11e4-a467-3ee74a48f4aa
 
 .. highlight:: console
 
@@ -1378,13 +1435,13 @@ Building Real World Applications
          - ``oozie job -start <arguments>``
          
      * - Using CDAP
-       - ``cdap > start workflow Wise.Wiseworkflow``
+       - .. container:: highlight
+       
+          .. parsed-literal::
+
+            |cdap >| start workflow Wise.WiseWorkflow
           
-     * -  
-       - ::
-
-          Successfully started workflow 'Wiseworkflow' of application 'Wise' with stored runtime arguments '{}'
-
+            Successfully started workflow 'WiseWorkflow' of application 'Wise' with stored runtime arguments '{}'
 
 .. container:: table-block
 
@@ -1405,12 +1462,13 @@ Building Real World Applications
          - ``oozie job -info <jobid>``
          
      * - Using CDAP
-       - ``cdap > get workflow status Wise.Wiseworkflow``
-          
-     * -  
-       - ::
+       - .. container:: highlight
+       
+          .. parsed-literal::
 
-          RUNNING
+            |cdap >| get workflow status Wise.Wiseworkflow
+          
+            RUNNING
 
 .. container:: table-block
 
@@ -1433,12 +1491,13 @@ Building Real World Applications
          - ``yarn jar /path/to/myprogram.jar``
          
      * - Using CDAP
-       - ``cdap > start service Wise.WiseService``
-          
-     * -  
-       - ::
+       - .. container:: highlight
+       
+          .. parsed-literal::
 
-          Successfully started service 'WiseService' of application 'Wise' with stored runtime arguments '{}'
+            |cdap >| start service Wise.WiseService
+          
+            Successfully started service 'WiseService' of application 'Wise' with stored runtime arguments '{}'
 
 .. container:: table-block
 
@@ -1461,13 +1520,13 @@ Building Real World Applications
          - ``yarn application -status <APP ID>``
          
      * - Using CDAP
-       - ``cdap > get service status Wise.WiseService``
+       - .. container:: highlight
+       
+          .. parsed-literal::
+
+            |cdap >| get service status Wise.WiseService
           
-     * -  
-       - ::
-
-          RUNNING
-
+            RUNNING
 
 .. rubric:: Serve the processed data in real time
 
@@ -1494,18 +1553,18 @@ Building Real World Applications
          - Click on container logs
          
      * - Using CDAP
-       - ``cdap > get endpoints service Wise.WiseService``
+       - .. container:: highlight
+       
+          .. parsed-literal::
+
+            |cdap >| get endpoints service Wise.WiseService
           
-     * -  
-       - ::
-
-          +=========================+
-          | method | path           |
-          +=========================+
-          | GET    | /ip/{ip}/count |
-          | POST   | /ip/{ip}/count |
-          +=========================+
-
+            +=========================+
+            | method | path           |
+            +=========================+
+            | GET    | /ip/{ip}/count |
+            | POST   | /ip/{ip}/count |
+            +=========================+
 
 .. container:: table-block
 
@@ -1527,20 +1586,27 @@ Building Real World Applications
          - Run ``curl http://hostname:port/ip/69.181.160.120/count``
          
      * - Using CDAP
-       - ``cdap > call service Wise.WiseService GET /ip/69.181.160.120/count``
-          
-     * -  
-       - ::
+       - .. container:: highlight
+       
+          .. parsed-literal::
 
-          +================================================+
-          | status | headers            | body size | body |
-          +================================================+
-          | 200    | Content-Length : 4 | 4         | 6699 |
-          |        | Connection : keep- |           |      |
-          |        | alive              |           |      |
-          |        | Content-Type : app |           |      |
-          |        | lication/json      |           |      |
-          +================================================+
+            |cdap >| call service Wise.WiseService GET /ip/69.181.160.120/count
+          
+            < 200 OK
+            < Content-Length: 5
+            < Connection: keep-alive
+            < Content-Type: application/json
+            20097
+
+..             +=================================================+
+..             | status | headers            | body size | body  |
+..             +=================================================+
+..             | 200    | Content-Length : 5 | 5         | 20097 |
+..             |        | Connection : keep- |           |       |
+..             |        | alive              |           |       |
+..             |        | Content-Type : app |           |       |
+..             |        | lication/json      |           |       |
+..             +=================================================+
 
 .. container:: table-block
 
@@ -1561,19 +1627,22 @@ Building Real World Applications
          - ``hbase shell> list "cdap.user.*"``
          
      * - Using CDAP
-       - - The listing will depend on if you have run all of the previous examples
-         - ``cdap > list dataset instances``
-          
-     * -  
-       - ::
+       - - The listing returned will depend on whether you have run all of the previous examples
 
-          +================================================================================+
-          | name                     | type                                                |
-          +================================================================================+
-          | pageViewStore            | co.cask.cdap.apps.wise.PageViewStore                |
-          | bounceCountStore         | co.cask.cdap.apps.wise.BounceCountStore             |
-          | logEventStream.converted | co.cask.cdap.api.dataset.lib.TimePartitionedFileSet |
-          +================================================================================+
+     * -  
+       - .. container:: highlight
+
+          .. parsed-literal::    
+      
+            |cdap >| list dataset instances
+
+            +================================================================================+
+            | name                     | type                                                |
+            +================================================================================+
+            | pageViewStore            | co.cask.cdap.apps.wise.PageViewStore                |
+            | bounceCountStore         | co.cask.cdap.apps.wise.BounceCountStore             |
+            | logEventStream.converted | co.cask.cdap.api.dataset.lib.TimePartitionedFileSet |
+            +================================================================================+
 
 .. rubric:: View bounce count results 
 
@@ -1596,38 +1665,41 @@ Building Real World Applications
          - ``"SELECT * FROM dataset_bouncecountstore LIMIT 5"``
          
      * - Using CDAP
-       - ``cdap > execute 'SELECT * FROM dataset_bouncecountstore LIMIT 5'``
+       - .. container:: highlight
+       
+          .. parsed-literal::
+
+            |cdap >| execute 'SELECT * FROM dataset_bouncecountstore LIMIT 5'
           
-     * -  
-       - ::
+         .. container:: highlight
+         
+          ::
 
-          +===============================================================================================+
-          | dataset_bouncecountstore.uri: STRING   | dataset_bouncecountstore  | dataset_bouncecountstore |
-          |                                        | .totalvisits: BIGINT      | .bounces: BIGINT         |
-          +===============================================================================================+
-          | /CDAP-DUT-50/index.php                 | 2                         | 2                        |
-          |-----------------------------------------------------------------------------------------------|
-          | /ajax/planStatusHistoryNeighbouringSum | 2                         | 2                        |
-          | maries.action?planKey=CDAP-DUT&buildNu |                           |                          |
-          | mber=50&_=1423398146659                |                           |                          |
-          |-----------------------------------------------------------------------------------------------|
-          | /ajax/planStatusHistoryNeighbouringSum | 2                         | 0                        |
-          | maries.action?planKey=COOP-DBT&buildNu |                           |                          |
-          | mber=284&_=1423341312519               |                           |                          |
-          |-----------------------------------------------------------------------------------------------|
-          | /ajax/planStatusHistoryNeighbouringSum | 2                         | 0                        |
-          | maries.action?planKey=COOP-DBT&buildNu |                           |                          |
-          | mber=284&_=1423341312521               |                           |                          |
-          |-----------------------------------------------------------------------------------------------|
-          | /ajax/planStatusHistoryNeighbouringSum | 2                         | 0                        |
-          | maries.action?planKey=COOP-DBT&buildNu |                           |                          |
-          | mber=284&_=1423341312522               |                           |                          |
-          +===============================================================================================+
-          Fetched 5 rows
-
+            +===============================================================================================+
+            | dataset_bouncecountstore.uri: STRING   | dataset_bouncecountstore  | dataset_bouncecountstore |
+            |                                        | .totalvisits: BIGINT      | .bounces: BIGINT         |
+            +===============================================================================================+
+            | /CDAP-DUT-50/index.php                 | 2                         | 2                        |
+            |-----------------------------------------------------------------------------------------------|
+            | /ajax/planStatusHistoryNeighbouringSum | 2                         | 2                        |
+            | maries.action?planKey=CDAP-DUT&buildNu |                           |                          |
+            | mber=50&_=1423398146659                |                           |                          |
+            |-----------------------------------------------------------------------------------------------|
+            | /ajax/planStatusHistoryNeighbouringSum | 2                         | 0                        |
+            | maries.action?planKey=COOP-DBT&buildNu |                           |                          |
+            | mber=284&_=1423341312519               |                           |                          |
+            |-----------------------------------------------------------------------------------------------|
+            | /ajax/planStatusHistoryNeighbouringSum | 2                         | 0                        |
+            | maries.action?planKey=COOP-DBT&buildNu |                           |                          |
+            | mber=284&_=1423341312521               |                           |                          |
+            |-----------------------------------------------------------------------------------------------|
+            | /ajax/planStatusHistoryNeighbouringSum | 2                         | 0                        |
+            | maries.action?planKey=COOP-DBT&buildNu |                           |                          |
+            | mber=284&_=1423341312522               |                           |                          |
+            +===============================================================================================+
+            Fetched 5 rows
 
 .. rubric:: Stop Application and Delete From Server
-
 
 .. container:: table-block
 
@@ -1650,12 +1722,13 @@ Building Real World Applications
          - ``yarn application -kill <application ID>``
          
      * - Using CDAP
-       - ``cdap > stop service Wise.WiseService``
-          
-     * -  
-       - ::
+       - .. container:: highlight
        
-          Successfully stopped service 'WiseService' of application 'Wise'
+          .. parsed-literal::
+
+            |cdap >| stop service Wise.WiseService
+          
+            Successfully stopped service 'WiseService' of application 'Wise'
 
 .. container:: table-block
 
@@ -1678,12 +1751,13 @@ Building Real World Applications
          - ``yarn application -kill <application ID>``
          
      * - Using CDAP
-       - ``cdap > stop flow Wise.WiseFlow``
-          
-     * -  
-       - ::
+       - .. container:: highlight
        
-          Successfully stopped flow 'WiseFlow' of application 'Wise'
+          .. parsed-literal::
+
+            |cdap >| stop flow Wise.WiseFlow
+          
+            Successfully stopped flow 'WiseFlow' of application 'Wise'
 
 .. container:: table-block
 
@@ -1704,12 +1778,13 @@ Building Real World Applications
          - Remove the service jars and flow jars
          
      * - Using CDAP
-       - ``cdap > delete app Wise``
-          
-     * -  
-       - ::
+       - .. container:: highlight
        
-          Successfully deleted application 'Wise'
+          .. parsed-literal::
+
+            |cdap >| delete app Wise
+          
+            Successfully deleted application 'Wise'
 
 
 Summary

--- a/cdap-docs/introduction/source/index.rst
+++ b/cdap-docs/introduction/source/index.rst
@@ -65,7 +65,7 @@ Installation
        - - Install and startup **Hadoop** and related technologies, as required
          
      * - Using CDAP
-       - - Install CDAP by downloading zipfile, unzipping and starting **CDAP Server**
+       - - Install **CDAP** by downloading zipfile, unzipping and starting **CDAP Server**
       
      * -  
        - .. container:: highlight
@@ -162,8 +162,8 @@ Data Ingestion
      :stub-columns: 1
 
      * - Without CDAP
-       - - Write a custom consumer for Kafka that reads from source
-         - Write the data to HDFS
+       - - Write a custom consumer for **Kafka** that reads from source
+         - Write the data to **HDFS**
          - Create external table in **Hive** called ``stream_logeventstream``
          
      * - Using CDAP
@@ -201,7 +201,7 @@ Data Exploration
      :stub-columns: 1
 
      * - Without CDAP
-       - - Run Hive command using Hive CLI       
+       - - Run Hive command using **Hive CLI**
          - ``DESCRIBE stream_logeventstream``
          
      * - Using CDAP
@@ -235,7 +235,7 @@ Data Exploration
      :stub-columns: 1
 
      * - Without CDAP
-       - - Run Hive command using Hive CLI
+       - - Run Hive command using **Hive CLI**
          - ``SELECT * FROM stream_logeventstream LIMIT 2``
 
      * - Using CDAP
@@ -271,7 +271,7 @@ Data Exploration
             Fetched 2 rows
 
 
-Data Exploration: Attaching A Schema
+Data Exploration: Attaching a Schema
 ====================================
 
 .. container:: table-block
@@ -289,8 +289,8 @@ Data Exploration: Attaching A Schema
      :stub-columns: 1
 
      * - Without CDAP
-       - - Drop the external Hive table
-         - Recreate the Hive table with new schema
+       - - Drop the external **Hive** table
+         - Recreate the **Hive** table with new schema
          
      * - Using CDAP
        - .. container:: highlight
@@ -307,7 +307,7 @@ Data Exploration: Attaching A Schema
      :widths: 80 20
      :stub-columns: 1
      
-     * - Describe new format of the ingested Data
+     * - Describe new format of the ingested data
        - 
        
   .. list-table::
@@ -316,7 +316,7 @@ Data Exploration: Attaching A Schema
      :stub-columns: 1
 
      * - Without CDAP
-       - - Run Hive command using Hive CLI
+       - - Run Hive command using **Hive CLI**
          - ``DESCRIBE stream_logeventsetream``
          
      * - Using CDAP
@@ -358,7 +358,7 @@ Data Exploration: Attaching A Schema
      :stub-columns: 1
 
      * - Without CDAP
-       - - Run Hive command using Hive CLI
+       - - Run Hive command using **Hive CLI**
          - ``SELECT * FROM stream_logeventsetream LIMIT 2``
          
      * - Using CDAP
@@ -547,7 +547,7 @@ Advanced Data Exploration
      :stub-columns: 1
 
      * - Without CDAP
-       - - Create a file in Hadoop file system called ``ip2geo``
+       - - Create a file in **Hadoop** file system called ``ip2geo``
          
      * - Using CDAP
        - .. container:: highlight
@@ -573,9 +573,9 @@ Advanced Data Exploration
      :stub-columns: 1
 
      * - Without CDAP
-       - - Write a custom consumer that reads from source (example: Kafka)
-         - Write the data to HDFS
-         - Create external table in Hive called ``stream_ip2geo``
+       - - Write a custom consumer that reads from source (example: **Kafka**)
+         - Write the data to **HDFS**
+         - Create external table in **Hive** called ``stream_ip2geo``
 
      * - Using CDAP
        - .. container:: highlight
@@ -601,7 +601,7 @@ Advanced Data Exploration
      :stub-columns: 1
 
      * - Without CDAP
-       - Write data to Kafka or append directly to HDFS
+       - Write data to **Kafka** or append directly to **HDFS**
          
      * - Using CDAP
        - .. container:: highlight
@@ -627,7 +627,7 @@ Advanced Data Exploration
      :stub-columns: 1
 
      * - Without CDAP
-       - - Run Hive command using Hive CLI
+       - - Run **Hive** command using **Hive CLI**
          - ``SELECT * FROM stream_ip2geo``
          
      * - Using CDAP
@@ -680,8 +680,8 @@ Advanced Data Exploration
      :stub-columns: 1
 
      * - Without CDAP
-       - - Drop the external Hive table
-         - Recreate the Hive table with new schema
+       - - Drop the external **Hive** table
+         - Recreate the **Hive** table with new schema
          
      * - Using CDAP
        - .. container:: highlight
@@ -707,7 +707,7 @@ Advanced Data Exploration
      :stub-columns: 1
 
      * - Without CDAP
-       - - Run Hive command using Hive CLI
+       - - Run **Hive** command using **Hive CLI**
          - ``SELECT * FROM stream_ip2geo``
          
      * - Using CDAP
@@ -761,7 +761,7 @@ Advanced Data Exploration
      :stub-columns: 1
 
      * - Without CDAP
-       - - Run Hive command using Hive CLI
+       - - Run **Hive** command using **Hive CLI**
          - ``SELECT remote_host, city, state, request from stream_logEventStream join stream_ip2geo on (stream_logEventStream.remote_host = stream_ip2geo.ip) limit 10``
          
      * - Using CDAP
@@ -848,9 +848,9 @@ Transforming Your Data
      :stub-columns: 1
 
      * - Without CDAP
-       - - Write a custom consumer that reads from source (example: Kafka)
-         - Write the data to HDFS
-         - Create an external table in Hive called ``stream_ip2geo``
+       - - Write a custom consumer that reads from source (example: **Kafka**)
+         - Write the data to **HDFS**
+         - Create an external table in **Hive** called ``stream_ip2geo``
          - Orchestrate running the custom consumer periodically using **Oozie**
          - Keep track of last processed times
          
@@ -1020,9 +1020,9 @@ Transforming Your Data
      :stub-columns: 1
 
      * - Without CDAP
-       - - Write a custom consumer that reads from source (example: Kafka)
-         - Write the data to HDFS
-         - Create external table in Hive called ``stream_ip2geo``
+       - - Write a custom consumer that reads from source (example: **Kafka**)
+         - Write the data to **HDFS**
+         - Create external table in **Hive** called ``stream_ip2geo``
          
      * - Using CDAP
        - .. container:: highlight
@@ -1081,7 +1081,7 @@ Transforming Your Data
      :stub-columns: 1
 
      * - Without CDAP
-       - - Run Hive query using Hive CLI
+       - - Run **Hive** query using **Hive CLI**
          - ``'describe user_logEventStream_converted'`` 
          
      * - Using CDAP
@@ -1136,7 +1136,7 @@ Transforming Your Data
      :stub-columns: 1
 
      * - Without CDAP
-       - - Run Hive query using Hive CLI
+       - - Run **Hive** query using **Hive CLI**
          - ``SELECT ts, request, status FROM dataset_logEventStream_converted LIMIT 2``
          
      * - Using CDAP
@@ -1222,7 +1222,7 @@ Building Real World Applications
        - - Write and execute **MapReduce** using **Hadoop**
          - Separate environment for processing in real-time setup stack
          - Add ability to periodically copy datasets into **SQL** using **Sqoop**
-         - Orchestrate the Mapreduce job using Oozie
+         - Orchestrate the **MapReduce** job using **Oozie**
          - Write an application to serve the data
          
      * - Using CDAP
@@ -1261,7 +1261,7 @@ Building Real World Applications
      :stub-columns: 1
 
      * - Without CDAP
-       - - Check Oozie
+       - - Check **Oozie**
          - Check **YARN** Console
          
      * - Using CDAP
@@ -1297,7 +1297,7 @@ Building Real World Applications
      * - Without CDAP
        - - Set classpath in environment variable 
          - ``CLASSPATH=/my/classpath``
-         - Run the command to start the yarn application
+         - Run the command to start the **YARN** application
          - ``yarn jar /path/to/myprogram.jar``
          
      * - Using CDAP
@@ -1307,7 +1307,7 @@ Building Real World Applications
 
             |cdap >| start flow Wise.WiseFlow
           
-            Successfully started flow 'WiseFlow' of application 'Wise' with stored runtime arguments '{}
+            Successfully started flow 'WiseFlow' of application 'Wise' with stored runtime arguments '{}'
 
 .. container:: table-block
 
@@ -1353,9 +1353,9 @@ Building Real World Applications
      :stub-columns: 1
 
      * - Without CDAP
-       - - Write a custom consumer for Kafka that reads from source
-         - Write the data to HDFS
-         - Create external table in Hive called ``cdap_stream_logeventstream``
+       - - Write a custom consumer for **Kafka** that reads from source
+         - Write the data to **HDFS**
+         - Create external table in **Hive** called ``cdap_stream_logeventstream``
          
      * - Using CDAP
        - .. container:: highlight
@@ -1431,7 +1431,7 @@ Building Real World Applications
      :stub-columns: 1
 
      * - Without CDAP
-       - - Start the job using Oozie
+       - - Start the job using **Oozie**
          - ``oozie job -start <arguments>``
          
      * - Using CDAP
@@ -1458,7 +1458,7 @@ Building Real World Applications
      :stub-columns: 1
 
      * - Without CDAP
-       - - Get the workflow status from Oozie
+       - - Get the workflow status from **Oozie**
          - ``oozie job -info <jobid>``
          
      * - Using CDAP
@@ -1545,11 +1545,11 @@ Building Real World Applications
      :stub-columns: 1
 
      * - Without CDAP
-       - - Navigate to the resouce manager UI
-         - Find the Wise.WiseService on UI
+       - - Navigate to the **Resource Manager UI**
+         - Find the *Wise.WiseService* on UI
          - Click to the see application logs
          - Find all the node managers for the application containers
-         - Navigate to all the containers in sepearate tabs 
+         - Navigate to all the containers in separate tabs 
          - Click on container logs
          
      * - Using CDAP
@@ -1582,8 +1582,8 @@ Building Real World Applications
 
      * - Without CDAP
        - - Discover the host and port where the service is running on by looking at the host 
-           and port in the YARN logs or by writing a discovery client that is co-ordinated using **ZooKeeper**
-         - Run ``curl http://hostname:port/ip/69.181.160.120/count``
+           and port in the **YARN** logs or by writing a discovery client that is co-ordinated using **ZooKeeper**
+         - Run ``curl http://hostname:port/v3/namespaces/default/apps/Wise/services/WiseService/methods/ip/69.181.160.120/count``
          
      * - Using CDAP
        - .. container:: highlight
@@ -1623,7 +1623,7 @@ Building Real World Applications
      :stub-columns: 1
 
      * - Without CDAP
-       - - Run a command in HBase shell
+       - - Run a command in **HBase shell** 
          - ``hbase shell> list "cdap.user.*"``
          
      * - Using CDAP
@@ -1661,7 +1661,7 @@ Building Real World Applications
      :stub-columns: 1
 
      * - Without CDAP
-       - - Run a command in the Hive CLI
+       - - Run a command in the **Hive CLI**
          - ``"SELECT * FROM dataset_bouncecountstore LIMIT 5"``
          
      * - Using CDAP
@@ -1716,9 +1716,9 @@ Building Real World Applications
      :stub-columns: 1
 
      * - Without CDAP
-       - - Find the yarn application ID from the following command
+       - - Find the **YARN** application ID from the command
          - ``yarn application -list | grep "Wise.WiseService"``
-         - Stop the application by running the following command
+         - Stop the application by running the command
          - ``yarn application -kill <application ID>``
          
      * - Using CDAP
@@ -1745,9 +1745,9 @@ Building Real World Applications
      :stub-columns: 1
 
      * - Without CDAP
-       - - Find the yarn application ID from the following command
+       - - Find the **YARN** application ID from the command
          - ``yarn application -list | grep "Wise.WiseFlow"``
-         - Stop the application by running the following command
+         - Stop the application by running the command
          - ``yarn application -kill <application ID>``
          
      * - Using CDAP
@@ -1774,7 +1774,7 @@ Building Real World Applications
      :stub-columns: 1
 
      * - Without CDAP
-       - - Delete the workflow from oozie
+       - - Delete the workflow from **Oozie**
          - Remove the service jars and flow jars
          
      * - Using CDAP
@@ -1804,5 +1804,5 @@ Summary
      - - Learn a single framework that works with multiple technologies
        - Abstraction of data in the Hadoop environment through logical representations of underlying data
        - Portability of applications through decoupling underlying infrastructures
-       - Services and tools that enable faster application creation in development
+       - Services and tools that enable faster application development
        - Higher degrees of operational control in production through enterprise best practices

--- a/cdap-docs/reference-manual/source/cli-api.rst
+++ b/cdap-docs/reference-manual/source/cli-api.rst
@@ -24,7 +24,7 @@ Interactive Mode
 
 To run the CLI in interactive mode, run the ``cdap-cli.sh`` executable with no arguments from the terminal::
 
-  $ /bin/cdap-cli.sh
+  $ ./bin/cdap-cli.sh
 
 or, on Windows::
 
@@ -56,7 +56,7 @@ Non-Interactive Mode
 To run the CLI in non-interactive mode, run the ``cdap-cli.sh`` executable, passing the command you want executed
 as the argument. For example, to list all applications currently deployed to CDAP, execute::
 
-  cdap-cli.sh list apps
+  $ cdap-cli.sh list apps
 
 Connecting to Secure CDAP Instances
 -----------------------------------


### PR DESCRIPTION
Fixes numerous problems with references to "Application Templates" and "Adapters" in the documentation.

**Revises the "Introduction to CDAP" exercise.**
- Updates it for 3.2.0. 
- Corrects a number of mistakes in the commands and the output. 
- Changes the formatting to make it easier to see the commands by putting in a **"cdap >"** prompt before each CLI command.
- Commands have been run manually against the 3.2.0 SDK.
- There are so many changes, GitHub is not providing a diff. Sorry.
- [Rendered revised "Introduction to CDAP"](http://builds.cask.co/artifact/CDAP-DOB4/shared/build-1/Docs-HTML/3.2.0/en/introduction/index.html)

Documentation has passed the [Quick Build](http://builds.cask.co/browse/CDAP-DOB4-1).
Full documentation building: http://builds.cask.co/browse/CDAP-DDB25-1

Partial Fix for https://issues.cask.co/browse/CDAP-3891