### PR TITLE
Docs/3.2 cleanup2

### DIFF
--- a/cdap-docs/developers-manual/source/getting-started/building-apps.rst
+++ b/cdap-docs/developers-manual/source/getting-started/building-apps.rst
@@ -145,11 +145,11 @@ Once an application is deployed, there are multiple methods for starting an appl
     * - Parameter
       - Description
     * - ``<program-type>``
-      - One of ``adapter``, ``flow``, ``mapreduce``, ``service``, ``spark``, ``worker``, or ``workflow``
+      - One of ``flow``, ``mapreduce``, ``service``, ``spark``, ``worker``, or ``workflow``
     * - ``<app-id>``
       - Name of the application being called
     * - ``<program-id>``
-      - Name of the *adapter*, *flow*, *MapReduce*, *service*, *spark*, *worker* or *workflow* being called
+      - Name of the *flow*, *MapReduce*, *service*, *spark*, *worker* or *workflow* being called
       
 
 .. _cdap-building-running-stopping:

--- a/cdap-docs/developers-manual/source/getting-started/index.rst
+++ b/cdap-docs/developers-manual/source/getting-started/index.rst
@@ -34,7 +34,7 @@ or a workstation. It has:
 - Tools for :ref:`ingesting data <ingesting-data>` and :ref:`authenticating
   clients <authentication-clients>`, :ref:`datasets, <datasets-index>` and :ref:`example
   applications <examples-index>` to help you become familiar with CDAP, perform common
-  tasks, and serve as templates for developing your own applications.
+  tasks, and serve as the basis for developing your own applications.
 
 Follow these steps:
 

--- a/cdap-docs/examples-manual/source/how-to-guides/index.rst
+++ b/cdap-docs/examples-manual/source/how-to-guides/index.rst
@@ -43,10 +43,10 @@ instructions for building the “Hello World” of any development task with CDA
 - |cube-guide|_ Use a **Cube Dataset** to perform **online analytical processing** of weblogs with CDAP.
 
 
-.. |etl-adapter-guide| replace:: **Creating ETL Pipelines:**
+.. |etl-adapter-guide| replace:: **Creating ETL Applications:**
 .. _etl-adapter-guide: cdap-etl-adapter-guide.html
 
-- |etl-adapter-guide|_ Using CDAP **ETL Application Templates and Adapters**.
+- |etl-adapter-guide|_ Using CDAP **System Artifacts** to create **ETL pipelines** and applications.
 
 
 .. |flow-guide| replace:: **Real-time Data Processing With a Flow:**

--- a/cdap-docs/included-applications/source/etl/custom.rst
+++ b/cdap-docs/included-applications/source/etl/custom.rst
@@ -19,7 +19,7 @@ transformations to extend the existing ``cdap-etl-batch`` and ``cdap-etl-realtim
 
 Plugin Types and Maven Archetypes
 =================================
-In ETL templates, there are five plugin types:
+In ETL applications, there are five plugin types:
 
 - Batch Source (*batchsource*)
 - Batch Sink (*batchsink*)

--- a/cdap-docs/included-applications/source/etl/index.rst
+++ b/cdap-docs/included-applications/source/etl/index.rst
@@ -29,8 +29,7 @@ an *ETL pipeline:*
 
 .. rubric:: System Artifacts, ETL Applications, and ETL Plugins 
 
-An *Application Template* is a blueprint that is used to create an *Adapter*, an instantiation of
-a template in CDAP.
+An *Artifact* is a blueprint that |---| with a configuration file |---| is used to create an *Application*.
 
 CDAP provides system artifacts |---| ``cdap-etl-batch`` and ``cdap-etl-realtime`` |---|
 which are used to create applications that perform ETL in either batch or real time, and
@@ -110,20 +109,18 @@ This lists the available sources, sinks, and transformations (transforms):
 
 .. rubric:: ETL Applications
 
-An *ETL Adapter* is an instantiation of an ETL template that has been given a specific
-configuration on creation.
-
-**Batch adapters** can be scheduled to run periodically using a cron expression and can read
-data from batch sources using a MapReduce job. The batch adapter then performs any
-optional transformations before writing to a batch sink.
-
-**Real time adapters** are designed to poll sources periodically to fetch the data, perform any
-optional transformations, and then write to a real-time sink.
-
-ETL adapters are created by preparing a configuration that specifies the ETL template and
-which source, transformations (transforms), and sinks are used to create the adapter. The
+ETL applications are created by preparing a configuration that specifies the ETL artifact and
+which source, transformations (transforms), and sinks are used to create the application. The
 configuration can either be written as a JSON file or, in the case of the CDAP UI,
 specified in-memory.
+
+**Batch applications** can be scheduled to run periodically using a cron expression and can read
+data from batch sources using a MapReduce job. The batch application then performs any
+optional transformations before writing to one or more batch sinks.
+
+**Real time applications** are designed to poll sources periodically to fetch the data, perform any
+optional transformations, and then write to one or more real-time sinks.
+
 
 .. rubric:: ETL Plugins
 

--- a/cdap-docs/integrations/source/partners/cloudera/configuring.rst
+++ b/cdap-docs/integrations/source/partners/cloudera/configuring.rst
@@ -114,23 +114,23 @@ Run the Cloudera Manager Admin Console *Add Service* Wizard and select *CDAP*.
 When completing the Wizard, these notes may help:
 
 - *Add Service* Wizard, Page 2: **Optional Hive dependency** is for the optional CDAP
- "Explore" component which can be enabled later.
+  "Explore" component which can be enabled later.
  
 - *Add Service* Wizard, Page 3: **Choosing Role Assignments**. Ensure CDAP roles are assigned to hosts colocated
- with service or gateway roles for HBase, HDFS, Yarn, and optionally Hive.
+  with service or gateway roles for HBase, HDFS, Yarn, and optionally Hive.
 
 - *Add Service* Wizard, Page 3: CDAP **Security Auth** service is an optional service
- for CDAP perimeter security; it can be configured and enabled post-wizard.
+  for CDAP perimeter security; it can be configured and enabled post-wizard.
  
 - *Add Service* Wizard, Pages 4 & 5: **Kerberos Auth Enabled** is needed if running against a
- secure Hadoop cluster.
+  secure Hadoop cluster.
 
 - *Add Service* Wizard, Pages 4 & 5: **Router Server Port:** This should match the "Router Bind
- Port"; it’s used by the CDAP UI to connect to the Router service.
+  Port"; it’s used by the CDAP UI to connect to the Router service.
 
 - *Add Service* Wizard, Page 4 & 5: **App Artifact Dir:** This should initially point to the bundled system artifacts included in
- the CDAP parcel directory. If you have modified ``${PARCELS_ROOT}``, please update this setting to match.
- Users will want to customize this directory to a location outside of the CDAP Parcel.
+  the CDAP parcel directory. If you have modified ``${PARCELS_ROOT}``, please update this setting to match.
+  Users will want to customize this directory to a location outside of the CDAP Parcel.
 
 Complete instructions, step-by-step, for using the Admin Console *Add Service* Wizard to install CDAP
 :ref:`are available <step-by-step-cloudera-add-service>`.

--- a/cdap-docs/integrations/source/partners/cloudera/configuring.rst
+++ b/cdap-docs/integrations/source/partners/cloudera/configuring.rst
@@ -113,24 +113,24 @@ Install, Setup, and Startup
 Run the Cloudera Manager Admin Console *Add Service* Wizard and select *CDAP*.
 When completing the Wizard, these notes may help:
 
-   - *Add Service* Wizard, Page 2: **Optional Hive dependency** is for the optional CDAP
-     "Explore" component which can be enabled later.
-     
-   - *Add Service* Wizard, Page 3: **Choosing Role Assignments**. Ensure CDAP roles are assigned to hosts colocated
-     with service or gateway roles for HBase, HDFS, Yarn, and optionally Hive.
+- *Add Service* Wizard, Page 2: **Optional Hive dependency** is for the optional CDAP
+ "Explore" component which can be enabled later.
+ 
+- *Add Service* Wizard, Page 3: **Choosing Role Assignments**. Ensure CDAP roles are assigned to hosts colocated
+ with service or gateway roles for HBase, HDFS, Yarn, and optionally Hive.
 
-   - *Add Service* Wizard, Page 3: CDAP **Security Auth** service is an optional service
-     for CDAP perimeter security; it can be configured and enabled post-wizard.
-     
-   - *Add Service* Wizard, Page 5: **Kerberos Auth Enabled** is needed if running against a
-     secure Hadoop cluster.
+- *Add Service* Wizard, Page 3: CDAP **Security Auth** service is an optional service
+ for CDAP perimeter security; it can be configured and enabled post-wizard.
+ 
+- *Add Service* Wizard, Pages 4 & 5: **Kerberos Auth Enabled** is needed if running against a
+ secure Hadoop cluster.
 
-   - *Add Service* Wizard, Page 5: **Router Server Port:** This should match the "Router Bind
-     Port"; it’s used by the CDAP UI to connect to the Router service.
+- *Add Service* Wizard, Pages 4 & 5: **Router Server Port:** This should match the "Router Bind
+ Port"; it’s used by the CDAP UI to connect to the Router service.
 
-   - *Add Service* Wizard, Page 5: **App Template Dir:** This should initially point to the bundled templates included in
-     the CDAP parcel directory. If you have modified ``${PARCELS_ROOT}``, please update this setting to match.  Advanced
-     users will want to customize this directory to a location outside of the CDAP Parcel.
+- *Add Service* Wizard, Page 4 & 5: **App Artifact Dir:** This should initially point to the bundled system artifacts included in
+ the CDAP parcel directory. If you have modified ``${PARCELS_ROOT}``, please update this setting to match.
+ Users will want to customize this directory to a location outside of the CDAP Parcel.
 
 Complete instructions, step-by-step, for using the Admin Console *Add Service* Wizard to install CDAP
 :ref:`are available <step-by-step-cloudera-add-service>`.

--- a/cdap-docs/integrations/source/partners/cloudera/step-by-step-cloudera.rst
+++ b/cdap-docs/integrations/source/partners/cloudera/step-by-step-cloudera.rst
@@ -73,7 +73,7 @@ The "Add Service" Wizard
    :align: center
    :class: bordered-image
 
-   **Add Service Wizard, Page 4:** Reviewing configurations; as Hive was included, CDAP Explore can be enabled.
+   **Add Service Wizard, Pages 4 & 5:** Reviewing configurations; as Hive was included, CDAP Explore can be enabled.
 
 
 .. figure:: ../../_images/integration-cloudera/cloudera-csd-07.png
@@ -83,7 +83,7 @@ The "Add Service" Wizard
    :align: center
    :class: bordered-image
 
-   **Add Service Wizard, Page 5:** Finishing first run of commands to install CDAP.
+   **Add Service Wizard, Page 6:** Finishing first run of commands to install CDAP.
    
 
 .. figure:: ../../_images/integration-cloudera/cloudera-csd-08.png
@@ -93,7 +93,7 @@ The "Add Service" Wizard
    :align: center
    :class: bordered-image
 
-   **Add Service Wizard, Page 6:** Congratulations screen, though there is still work to be done.
+   **Add Service Wizard, Page 7:** Congratulations screen, though there is still work to be done.
    
 
 Startup

--- a/cdap-docs/reference-manual/source/http-restful-api/artifact.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/artifact.rst
@@ -372,9 +372,9 @@ To delete an artifact, submit an HTTP DELETE request::
    * - ``<namespace>``
      - Namespace ID
    * - ``<artifact-name>``
-     - Name of the artifact.
+     - Name of the artifact
    * - ``<artifact-version>``
-     - Version of the artifact.
+     - Version of the artifact
 
 Deleting an artifact is an advanced feature. If there are programs that use the artifact, those
 programs will not be able to start unless the artifact is added again, or the program application
@@ -399,6 +399,17 @@ To delete a system artifact, submit an HTTP DELETE request::
 
   DELETE <base-url>/namespaces/system/artifacts/<artifact-name>/versions/<artifact-version>
 
+.. list-table::
+   :widths: 20 80
+   :header-rows: 1
+
+   * - Parameter
+     - Description
+   * - ``<artifact-name>``
+     - Name of the artifact
+   * - ``<artifact-version>``
+     - Version of the artifact
+
 Deleting an artifact is an advanced feature. If there are programs that use the artifact, those
 programs will not be able to start unless the artifact is added again, or the program application
 is updated to use a different artifact. 
@@ -409,7 +420,7 @@ List Application Classes
 ========================
 To list application classes, submit an HTTP GET request::
 
-  GET <base-url>/namespaces/<namespace>/classes/apps[scope=<scope>]
+  GET <base-url>/namespaces/<namespace>/classes/apps[?scope=<scope>]
 
 .. list-table::
    :widths: 20 80
@@ -419,10 +430,6 @@ To list application classes, submit an HTTP GET request::
      - Description
    * - ``<namespace>``
      - Namespace ID
-   * - ``<adapter-id>``
-     - Name of the adapter
-   * - ``<config-path>``
-     - Path to the configuration file
    * - ``<scope>``
      - Optional scope filter. If not specified, classes from artifacts in the ``user`` and
        ``system`` scopes are returned. Otherwise, only classes from artifacts in the specified scope are returned.

--- a/cdap-docs/reference-manual/source/http-restful-api/dataset.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/dataset.rst
@@ -332,34 +332,6 @@ You can retrieve a list of datasets used by a program by issuing a HTTP GET requ
    * - ``200 OK``
      - Request was successful
 
-Datasets used by an Adapter
----------------------------
-
-You can retrieve a list of datasets used by an adapter by issuing a HTTP GET request to the URL::
-
-  GET <base-url>/namespaces/<namespace>/adapters/<adapter-id>/datasets
-
-.. list-table::
-   :widths: 20 80
-   :header-rows: 1
-
-   * - Parameter
-     - Description
-   * - ``<namespace>``
-     - Namespace ID
-   * - ``<adapter-id>``
-     - Adapter ID
-
-.. rubric:: HTTP Responses
-.. list-table::
-   :widths: 20 80
-   :header-rows: 1
-
-   * - Status Codes
-     - Description
-   * - ``200 OK``
-     - Request was successful
-
 Programs using a Dataset
 ------------------------
 

--- a/cdap-docs/reference-manual/source/http-restful-api/stream.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/stream.rst
@@ -548,34 +548,6 @@ You can retrieve a list of streams used by a program by issuing a HTTP GET reque
    * - ``200 OK``
      - Request was successful
 
-Streams used by an Adapter
---------------------------
-
-You can retrieve a list of streams used by an adapter by issuing a HTTP GET request to the URL::
-
-  GET <base-url>/namespaces/<namespace>/adapters/<adapter-id>/streams 
-
-.. list-table::
-   :widths: 20 80
-   :header-rows: 1
-
-   * - Parameter
-     - Description
-   * - ``<namespace>``
-     - Namespace ID
-   * - ``<adapter-id>``
-     - Adapter ID
-
-.. rubric:: HTTP Responses
-.. list-table::
-   :widths: 20 80
-   :header-rows: 1
-
-   * - Status Codes
-     - Description
-   * - ``200 OK``
-     - Request was successful
-
 Programs using a Stream 
 -----------------------
 

--- a/cdap-examples/resources/weblog-analytics-config.json
+++ b/cdap-examples/resources/weblog-analytics-config.json
@@ -38,8 +38,8 @@
         ],
         "schedule": "* * * * *"
     },
-    "description": "Batch Extract-Transform-Load (ETL) Template",
-    "name": "webadapter",
+    "description": "Extract-Transform-Load (ETL) Batch Application",
+    "name": "weblog-analytics-app",
     "ui": {
         "nodes": {
             "Stream-source-1": {

--- a/cdap-examples/resources/weblog-stop-all.txt
+++ b/cdap-examples/resources/weblog-stop-all.txt
@@ -1,2 +1,1 @@
-stop service CubeServiceApp.CubeService 
-stop adapter cubeAnalytics
+stop service CubeServiceApp.CubeService


### PR DESCRIPTION
A follow-up to https://github.com/caskdata/cdap/pull/4212.

Fixes more references to "Application Templates" and "Adapters" in the documentation.

Documentation has passed the [Quick Build](http://builds.cask.co/browse/CDAP-DOB5-1).
Full documentation building: http://builds.cask.co/browse/CDAP-DDB26-1

Fix for https://issues.cask.co/browse/CDAP-3891