### PR TITLE
Change the RESTful APIs Index page

### DIFF
--- a/cdap-docs/reference-manual/source/http-restful-api/index.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/index.rst
@@ -42,6 +42,38 @@ API includes the namespacing of applications, data, and metadata to achieve appl
 data isolation. This is an inital step towards introducing `multi-tenancy
 <http://en.wikipedia.org/wiki/Multitenancy>`__ into CDAP.
 
+**Introduction**
+
+- :doc:`Introduction: <introduction>` conventions, converting from HTTP RESTful API v2, naming restrictions, status codes, and working with CDAP security
+
+**General APIs**
+
+- :doc:`Namespace: <namespace>` creating and managing namespaces
+- :doc:`Metadata: <metadata>` setting, retrieving, and deleting user metadata annotations
+- :doc:`Preferences: <preferences>` setting, retrieving, and deleting preferences
+- :doc:`Configuration: <configuration>` retrieving the CDAP and HBase configurations
+- :doc:`Transactions: <transactions>` interacting with the transaction service
+
+**Major CDAP Entities APIs**
+
+- :doc:`Artifact: <artifact>` deploying artifacts and retrieving details about plugins available to artifacts and classes contained within artifacts
+- :doc:`Lifecycle: <lifecycle>` deploying and managing applications, and managing the lifecycle of flows, MapReduce programs, Spark programs, workflows, and custom services
+- :doc:`Stream: <stream>` sending data events to a stream or to inspect the contents of a stream
+- :doc:`Dataset: <dataset>` interacting with datasets, dataset modules, and dataset types
+- :doc:`Service: <service>` supports making requests to the methods of an application’s services
+- :doc:`Workflow: <workflow>` retrieving values from workflow tokens and statistics on workflow runs
+
+**Querying and Viewing APIs**
+
+- :doc:`Query: <query>` sending ad-hoc queries to CDAP datasets
+- :doc:`Views: <views>` a read-only view of a stream, with a specific read format
+
+**Logging, Metrics, and Monitoring APIs**
+
+- :doc:`Logging: <logging>` retrieving application logs
+- :doc:`Metrics: <metrics>` retrieving metrics for system and user applications (user-defined metrics)
+- :doc:`Monitor: <monitor>` checking the status of various system and custom CDAP services
+
 
 .. rubric:: Alphabetical List of APIs
 
@@ -65,37 +97,3 @@ data isolation. This is an inital step towards introducing `multi-tenancy
 - :doc:`Transactions: <transactions>` interacting with the transaction service
 - :doc:`Views: <views>` a read-only view of a stream, with a specific read format
 - :doc:`Workflow: <workflow>` retrieving values from workflow tokens and statistics on workflow runs
-
-
-.. rubric:: Thematic Grouping of APIs
-
-- :doc:`Introduction: <introduction>` conventions, converting from HTTP RESTful API v2, naming restrictions, status codes, and working with CDAP security
-
-**General**
-
-- :doc:`Namespace: <namespace>` creating and managing namespaces
-- :doc:`Metadata: <metadata>` setting, retrieving, and deleting user metadata annotations
-- :doc:`Preferences: <preferences>` setting, retrieving, and deleting preferences
-- :doc:`Configuration: <configuration>` retrieving the CDAP and HBase configurations
-- :doc:`Transactions: <transactions>` interacting with the transaction service
-
-**Major CDAP Entities**
-
-- :doc:`Artifact: <artifact>` deploying artifacts and retrieving details about plugins available to artifacts and classes contained within artifacts
-- :doc:`Lifecycle: <lifecycle>` deploying and managing applications, and managing the lifecycle of flows, MapReduce programs, Spark programs, workflows, and custom services
-- :doc:`Stream: <stream>` sending data events to a stream or to inspect the contents of a stream
-- :doc:`Dataset: <dataset>` interacting with datasets, dataset modules, and dataset types
-- :doc:`Service: <service>` supports making requests to the methods of an application’s services
-- :doc:`Workflow: <workflow>` retrieving values from workflow tokens and statistics on workflow runs
-
-**Querying and Viewing**
-
-- :doc:`Query: <query>` sending ad-hoc queries to CDAP datasets
-- :doc:`Views: <views>` a read-only view of a stream, with a specific read format
-
-**Logging, Metrics, and Monitoring**
-
-- :doc:`Logging: <logging>` retrieving application logs
-- :doc:`Metrics: <metrics>` retrieving metrics for system and user applications (user-defined metrics)
-- :doc:`Monitor: <monitor>` checking the status of various system and custom CDAP services
-

--- a/cdap-docs/reference-manual/source/http-restful-api/index.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/index.rst
@@ -16,19 +16,19 @@ CDAP HTTP RESTful API v3
 .. toctree::
    
     Introduction <introduction>
-    Namespace <namespace>
-    Lifecycle <lifecycle>
-    Configuration <configuration>
-    Metadata <metadata>
-    Preferences <preferences>
     Artifact <artifact>
-    Stream <stream>
+    Configuration <configuration>
     Dataset <dataset>
-    Query <query>
-    Service <service>
+    Lifecycle <lifecycle>
     Logging <logging>
+    Metadata <metadata>
     Metrics <metrics>
     Monitor <monitor>
+    Namespace <namespace>
+    Preferences <preferences>
+    Query <query>
+    Service <service>
+    Stream <stream>
     Transactions <transactions>
     Views <views>
     Workflow <workflow>
@@ -38,27 +38,64 @@ CDAP HTTP RESTful API v3
 The Cask Data Application Platform (CDAP) has an HTTP interface for a multitude of
 purposes: everything from sending data events to a stream or to inspect the contents of a
 stream through checking the status of various system and custom CDAP services. V3 of the
-API includes the namespacing of applications, data and metadata to achieve application and
+API includes the namespacing of applications, data, and metadata to achieve application and
 data isolation. This is an inital step towards introducing `multi-tenancy
 <http://en.wikipedia.org/wiki/Multitenancy>`__ into CDAP.
 
-- :doc:`Introduction: <introduction>` conventions, converting from HTTP RESTful API v2, 
-  naming restrictions, status codes, and working with CDAP security
-- :doc:`Namespace: <namespace>` creating and managing namespaces
-- :doc:`Lifecycle: <lifecycle>` deploying and managing applications, and managing the lifecycle of flows,
-  MapReduce programs, Spark programs, workflows, and custom services
+
+.. rubric:: Alphabetical List of APIs
+
+- :doc:`Introduction: <introduction>` conventions, converting from HTTP RESTful API v2, naming restrictions, status codes, and working with CDAP security
+
+..
+
+- :doc:`Artifact: <artifact>` deploying artifacts and retrieving details about plugins available to artifacts and classes contained within artifacts
 - :doc:`Configuration: <configuration>` retrieving the CDAP and HBase configurations
-- :doc:`Metadata: <metadata>` setting, retrieving, and deleting user metadata annotations
-- :doc:`Preferences: <preferences>` setting, retrieving, and deleting preferences
-- :doc:`Artifact: <artifact>` deploying artifacts and retrieving details about plugins available to artifacts
-  and classes contained within artifacts
-- :doc:`Stream: <stream>` sending data events to a stream or to inspect the contents of a stream
 - :doc:`Dataset: <dataset>` interacting with datasets, dataset modules, and dataset types
+- :doc:`Lifecycle: <lifecycle>` deploying and managing applications, and managing the lifecycle of flows, MapReduce programs, Spark programs, workflows, and custom services
+- :doc:`Logging: <logging>` retrieving application logs
+- :doc:`Metadata: <metadata>` setting, retrieving, and deleting user metadata annotations
+- :doc:`Metrics: <metrics>` retrieving metrics for system and user applications (user-defined metrics)
+- :doc:`Monitor: <monitor>` checking the status of various system and custom CDAP services
+- :doc:`Namespace: <namespace>` creating and managing namespaces
+- :doc:`Preferences: <preferences>` setting, retrieving, and deleting preferences
 - :doc:`Query: <query>` sending ad-hoc queries to CDAP datasets
 - :doc:`Service: <service>` supports making requests to the methods of an application’s services
+- :doc:`Stream: <stream>` sending data events to a stream or to inspect the contents of a stream
+- :doc:`Transactions: <transactions>` interacting with the transaction service
+- :doc:`Views: <views>` a read-only view of a stream, with a specific read format
+- :doc:`Workflow: <workflow>` retrieving values from workflow tokens and statistics on workflow runs
+
+
+.. rubric:: Thematic Grouping of APIs
+
+- :doc:`Introduction: <introduction>` conventions, converting from HTTP RESTful API v2, naming restrictions, status codes, and working with CDAP security
+
+**General**
+
+- :doc:`Namespace: <namespace>` creating and managing namespaces
+- :doc:`Metadata: <metadata>` setting, retrieving, and deleting user metadata annotations
+- :doc:`Preferences: <preferences>` setting, retrieving, and deleting preferences
+- :doc:`Configuration: <configuration>` retrieving the CDAP and HBase configurations
+- :doc:`Transactions: <transactions>` interacting with the transaction service
+
+**Major CDAP Entities**
+
+- :doc:`Artifact: <artifact>` deploying artifacts and retrieving details about plugins available to artifacts and classes contained within artifacts
+- :doc:`Lifecycle: <lifecycle>` deploying and managing applications, and managing the lifecycle of flows, MapReduce programs, Spark programs, workflows, and custom services
+- :doc:`Stream: <stream>` sending data events to a stream or to inspect the contents of a stream
+- :doc:`Dataset: <dataset>` interacting with datasets, dataset modules, and dataset types
+- :doc:`Service: <service>` supports making requests to the methods of an application’s services
+- :doc:`Workflow: <workflow>` retrieving values from workflow tokens and statistics on workflow runs
+
+**Querying and Viewing**
+
+- :doc:`Query: <query>` sending ad-hoc queries to CDAP datasets
+- :doc:`Views: <views>` a read-only view of a stream, with a specific read format
+
+**Logging, Metrics, and Monitoring**
+
 - :doc:`Logging: <logging>` retrieving application logs
 - :doc:`Metrics: <metrics>` retrieving metrics for system and user applications (user-defined metrics)
 - :doc:`Monitor: <monitor>` checking the status of various system and custom CDAP services
-- :doc:`Views: <views>` a read-only view of a stream, with a specific read format
-- :doc:`Transactions: <transactions>` interacting with the transaction service
-- :doc:`Workflow: <workflow>` retrieving values from workflow tokens and statistics on workflow runs
+


### PR DESCRIPTION
Corrects the order of the RESTful APIs on the index page and left sidebar, and adds a thematic index in addition to the alphabetical one.

Passed [Quick Build](http://builds.cask.co/browse/CDAP-DOB7-2): Here's the [revised index page](http://builds.cask.co/artifact/CDAP-DOB7/shared/build-2/Docs-HTML/3.2.0/en/reference-manual/http-restful-api/index.html).

Fix for https://issues.cask.co/browse/CDAP-3892 (the order of the left sidebar did not match the index page)