### PR TITLE
Remove usage of 'adapter'.

### DIFF
--- a/cdap-ui/app/features/adapters/controllers/create/toppanel-ctrl.js
+++ b/cdap-ui/app/features/adapters/controllers/create/toppanel-ctrl.js
@@ -110,7 +110,7 @@ angular.module(PKG.name + '.feature.adapters')
                       });
                     }.bind(this),
                     function error() {
-                      console.log('ERROR: Exporting adapter ' + MyAppDAGService.metadata.name + ' failed.');
+                      console.log('ERROR: Exporting ' + MyAppDAGService.metadata.name + ' failed.');
                     }
                   );
               };


### PR DESCRIPTION
This fix is in response to [a comment](https://github.com/caskdata/cdap/pull/4215/files#r40985750) in a previous PR (https://github.com/caskdata/cdap/pull/4215).