### PR TITLE
Add project versioning to READMEs

### DIFF
--- a/cdap-examples/README.rst
+++ b/cdap-examples/README.rst
@@ -49,9 +49,9 @@ HelloWorld
 ----------
 - This is a simple HelloWorld example that uses a stream, a dataset, a flow, and a
   service.
-- A dataset, a KeyValueTable.
-- A flow, with a single flowlet that reads from the stream and stores each name in the KeyValueTable.
-- A service, that reads the name from the KeyValueTable and responds with "Hello [Name]!"
+- A dataset created using a KeyValueTable.
+- A flow with a single flowlet that reads from the stream and stores each name in the KeyValueTable.
+- A service that reads the name from the KeyValueTable and responds with "Hello [Name]!"
 
 LogAnalysis
 -----------

--- a/cdap-examples/README.rst
+++ b/cdap-examples/README.rst
@@ -9,7 +9,7 @@ compiled forms as JAR files in a release.
 
 Additional information about these examples is available at the Cask documentation website:
 
-http://docs.cask.co/cdap/current/en/examples-manual/examples/index.html
+http://docs.cask.co/cdap/${project.version}/en/examples-manual/examples/index.html
 
 
 Building
@@ -29,85 +29,106 @@ CountRandom
 - Generates random numbers between 0 and 9999.
 - For each number *i*, generates i%10000, i%1000, i%100, i%10.
 - Increments the counter for each number.
+- Demonstrates the ``@Tick`` feature of flows.
 
+.. CubeService
+.. -----------
+
+DataCleansing
+-------------
+- Demonstrates incrementally consuming partitions of a partitioned fileset using MapReduce.
+      
 FileSetExample
 --------------
 - Illustrates how to use the FileSet dataset in applications.
 - Uses a Service that uploads files in—or downloads files to—a FileSet.
-- Includes a MapReduce that implements the classic word count example. The input and
+- Includes a MapReduce that implements the classic WordCount example. The input and
   output paths of the MapReduce can be configured through runtime arguments.
 
 HelloWorld
 ----------
-- This is a simple HelloWorld example that uses one Stream, one Dataset, one Flow and one
-  Service.
-- A Dataset, a KeyValueTable.
-- A Flow, with a single Flowlet that reads from the Stream and stores each name in the KeyValueTable.
-- A Service, that reads the name from the KeyValueTable and responds with "Hello [Name]!"
+- This is a simple HelloWorld example that uses a stream, a dataset, a flow, and a
+  service.
+- A dataset, a KeyValueTable.
+- A flow, with a single flowlet that reads from the stream and stores each name in the KeyValueTable.
+- A service, that reads the name from the KeyValueTable and responds with "Hello [Name]!"
+
+LogAnalysis
+-----------
+- Demonstrates Spark and MapReduce running in parallel inside a workflow.
+- Shows the use of forks within workflows.
 
 Purchase
 --------
 - An example application that reads purchase data from a stream, processes the data via a workflow,
   and makes it available via ad-hoc querying and the RESTful interface of a service. It
-  uses a scheduled Workflow to start a MapReduce that reads from one ObjectStore dataset
+  uses a scheduled workflow to start a MapReduce program that reads from one ObjectStore dataset
   and writes to another. The app demonstrates using custom datasets and ad-hoc SQL queries.
 
-  - Send sentences of the form "Tom bought 5 apples for $10" to the purchaseStream.
-  - The PurchaseFlow reads the purchaseStream and converts every input String into a
-    Purchase object and stores the object in the purchases Dataset.
-  - When scheduled by the PurchaseHistoryWorkFlow, the PurchaseHistoryBuilder MapReduce
-    program reads the purchases Dataset, creates a purchase history, and stores the purchase
-    history in the history Dataset every morning at 4:00 A.M. You can manually (in the
-    Process screen in the CDAP Console) or programmatically execute the 
-    PurchaseHistoryBuilder MapReduce to store customers' purchase history in the
-    history Dataset.
-  - Request the ``PurchaseHistoryService`` retrieve from the *history* Dataset the
+  - Send sentences of the form "Tom bought 5 apples for $10" to the *purchaseStream*.
+  - The ``PurchaseFlow`` reads the *purchaseStream* and converts every input String into a
+    ``Purchase`` object and stores the object in the *purchases* dataset.
+  - When scheduled by the *PurchaseHistoryWorkFlow*, the *PurchaseHistoryBuilder* MapReduce
+    program reads the *purchases* dataset, creates a purchase history, and stores the purchase
+    history in the *history* dataset every morning at 4:00 A.M. You can manually (in the
+    application's pages in the CDAP-UI) or programmatically execute the 
+    *PurchaseHistoryBuilder* MapReduce to store customers' purchase history in the
+    *history* dataset.
+  - Request the ``PurchaseHistoryService`` retrieve from the *history* dataset the
     purchase history of a user.
-  - You can use SQL to formulate ad-hoc queries over the history Dataset. This is done by
+  - You can use SQL to formulate ad-hoc queries over the *history* dataset. This is done by
     a series of ``curl`` calls, as described in the RESTful API section of the Developer Guide.
 
-  - Note: Because by default the PurchaseHistoryWorkFlow process doesn't run until 4:00 A.M.,
+  - Note: Because the *PurchaseHistoryWorkFlow* process is scheduled to run at 4:00 A.M.,
     you'll have to wait until the next day (or manually or programmatically execute the
-    PurcaseHistoryBuilder) after entering the first customers' purchases or the PurchaseQuery
+    *PurcaseHistoryBuilder*) after entering the first customers' purchases or the *PurchaseQuery*
     will return a "not found" error.
 
 SparkKMeans
 -----------
 - An application that demonstrates streaming text analysis using a Spark program.
-- It calculates the centers of points from an input stream using the KMeans Clustering method.
+- It calculates the centers of points from an input stream using the KMeans Clustering
+  method.
 
 SparkPageRank
 -------------
 - An application that demonstrates text analysis using Spark and MapReduce programs.
 - It computes the page rank of URLs from an input stream.
 
-Sports
-------
-- An application that illustrates the use of partitioned file sets.
-- It loads game results into a file set partitioned by league and season, and processes
+SportResults
+------------
+- An application that illustrates the use of partitioned File sets.
+- It loads game results into a File set partitioned by league and season, and processes
   them with MapReduce.
 
 StreamConversion
 ----------------
-- An application that illustrates the use of time-partitioned file sets.
-- It periodically converts a stream into partitions of a file set, which can be read by
+- An application that illustrates the use of time-partitioned File sets.
+- It periodically converts a stream into partitions of a File set, which can be read by
   SQL queries.
 
 UserProfiles
 ------------
-- An application that demonstrates column-level conflict detection.
+- An application that demonstrates column-level conflict detection using the example of
+  updating of user profiles in a dataset.
 
 WebAnalytics
 ------------
-- An application to generate statistics and to provide insights about web usage through 
+- An application to generate statistics and to provide insights about web usage through
   the analysis of web traffic.
 
+WikipediaPipeline
+-----------------
+- An application that performs analysis on Wikipedia data using MapReduce and Spark programs
+  running within a CDAP workflow: *WikipediaPipelineWorkflow*.
+      
 WordCount
 ---------
 - A simple application that counts words and tracks word associations and unique words
-  seen on the Stream. It demonstrates the power of using Datasets and how they can be used
-  to simplify storing complex data.
-
+  seen on the stream. 
+- It demonstrates the power of using datasets and how they can be used to simplify storing
+  complex data.
+- It uses a configuration class to configure the application at deployment time.
 
 License and Trademarks
 ======================

--- a/cdap-standalone/pom.xml
+++ b/cdap-standalone/pom.xml
@@ -314,6 +314,13 @@
                       <targetPath>examples</targetPath>
                       <includes>
                         <include>README*</include>
+                      </includes>
+                      <filtering>true</filtering>
+                    </resource>
+                    <resource>
+                      <directory>${project.parent.basedir}/cdap-examples</directory>
+                      <targetPath>examples</targetPath>
+                      <includes>
                         <include>resources/**</include>
                         <include>**/src/**</include>
                         <include>**/bin/**</include>

--- a/cdap-standalone/src/dist/README
+++ b/cdap-standalone/src/dist/README
@@ -14,7 +14,7 @@ To install and use CDAP and the included examples, there are a few simple
 prerequisites:
 
   1. JDK 7 (required to run CDAP, note: $JAVA_HOME should be set)
-  2. Node.js v0.10.* through v0.12.* (required to run the CDAP UI)
+  2. Node.js v0.10.* through v0.12.* (required to run the CDAP-UI)
   3. Apache Maven 3.0+ (required to build the example applications)
 
 Once you have installed the prerequisites, unzip the SDK to a suitable directory:
@@ -41,17 +41,17 @@ or on Windows:
 Using CDAP
 ==========
 
-Open a browser window to http://localhost:9999 to view the CDAP UI.
+Open a browser window to http://localhost:9999 to view the CDAP-UI.
 
 To get started with CDAP, see our online introduction:
  
-  http://docs.cask.co/cdap/current/en/introduction/index.html
+  http://docs.cask.co/cdap/${project.version}/en/introduction/index.html
 
 Documentation for CDAP can be found at our documentation website:
 
-  http://docs.cask.co/cdap/current/en/index.html
+  http://docs.cask.co/cdap/${project.version}/en/index.html
 
-Contacts for support, sales and general information can be found on our website at:
+Contacts for support, sales, and general information can be found on our website at:
 
   http://cask.co/company/#company-contact
   


### PR DESCRIPTION
This adds project version and filtering to the CDAP SDK /examples README.

To the main SDK README, it adds some additional instances of using the versioning to set correct paths to the website based on the version. This will help people end up at the correct version of the examples and the documentation for the version of the SDK that they are using.

It adds additional and updated descriptions of the examples to reflect recent changes, and includes a description for all but the CubeService (which is not a complete example; it will be dealt with in another PR.)

Building at: http://builds.cask.co/browse/CDAP-RBT498-1