### PR TITLE
CDAP-3695 Synchronize the store updates for the last schedule run.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/store/DatasetBasedStreamSizeScheduleStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/store/DatasetBasedStreamSizeScheduleStore.java
@@ -79,7 +79,7 @@ public class DatasetBasedStreamSizeScheduleStore {
   /**
    * Initialize this persistent store.
    */
-  public void initialize() throws IOException, DatasetManagementException {
+  public synchronized void initialize() throws IOException, DatasetManagementException {
     table = tableUtil.getMetaTable();
     Preconditions.checkNotNull(table, "Could not get dataset client for data set: %s",
                                ScheduleStoreTableUtil.SCHEDULE_STORE_DATASET_NAME);
@@ -207,8 +207,8 @@ public class DatasetBasedStreamSizeScheduleStore {
    * @param programType program type the schedule is running for
    * @param scheduleName name of the schedule
    */
-  public void delete(final Id.Program programId, final SchedulableProgramType programType, final String scheduleName)
-    throws InterruptedException, TransactionFailureException {
+  public synchronized void delete(final Id.Program programId, final SchedulableProgramType programType,
+                                  final String scheduleName) throws InterruptedException, TransactionFailureException {
     factory.createExecutor(ImmutableList.of((TransactionAware) table))
       .execute(new TransactionExecutor.Subroutine() {
         @Override
@@ -224,7 +224,7 @@ public class DatasetBasedStreamSizeScheduleStore {
   /**
    * @return a list of all the schedules and their states present in the store
    */
-  public List<StreamSizeScheduleState> list() throws InterruptedException, TransactionFailureException {
+  public synchronized List<StreamSizeScheduleState> list() throws InterruptedException, TransactionFailureException {
     final List<StreamSizeScheduleState> scheduleStates = Lists.newArrayList();
     factory.createExecutor(ImmutableList.of((TransactionAware) table))
       .execute(new TransactionExecutor.Subroutine() {
@@ -276,7 +276,7 @@ public class DatasetBasedStreamSizeScheduleStore {
     return scheduleStates;
   }
 
-  private void updateTable(final Id.Program programId, final SchedulableProgramType programType,
+  private synchronized void updateTable(final Id.Program programId, final SchedulableProgramType programType,
                            final String scheduleName, final byte[][] columns, final byte[][] values,
                            @Nullable final TransactionMethod txMethod)
     throws InterruptedException, TransactionFailureException {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/store/DatasetBasedStreamSizeScheduleStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/store/DatasetBasedStreamSizeScheduleStore.java
@@ -277,8 +277,8 @@ public class DatasetBasedStreamSizeScheduleStore {
   }
 
   private synchronized void updateTable(final Id.Program programId, final SchedulableProgramType programType,
-                           final String scheduleName, final byte[][] columns, final byte[][] values,
-                           @Nullable final TransactionMethod txMethod)
+                                        final String scheduleName, final byte[][] columns, final byte[][] values,
+                                        @Nullable final TransactionMethod txMethod)
     throws InterruptedException, TransactionFailureException {
     factory.createExecutor(ImmutableList.of((TransactionAware) table))
       .execute(new TransactionExecutor.Subroutine() {


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-3695

`StreamSizeSchedulerTest.testStreamSizeSchedule` fails on the bamboo.

Following execution sequence leads to the failure:

1. Assume two threads, Thread1 (corresponding to the "SampleSchedule1") and Thread2 (corresponding to the "SampleSchedule2"), start executing the `StreamSizeScheduleTask.receivedPollingInformation` method concurrently. 

2. Thread1 updates the store with base run for the SampleSchedule1. Since this is inside the `synchronized` block, Thread2 will be blocked till the updates by Thread1 happens. 

3. Thread2 now acquires the lock and try to update the base run for the SampleSchedule2.

4. Meanwhile Thread1 runs the program and try to update the last run outside the synchronization block. For this the new transaction is started which sets `BufferingTable.toUndo` to `null`.

5. Thread2 now try to persist the `BufferingTable.toUndo`. However it is set to `null` by Thread1 already, so we get `NullPointerException`.

Fix is to synchronize the last schedule run updates to the store as well.