### PR TITLE
CDAP-3345, dataset TTL inconsistency fix.

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/Tables.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/Tables.java
@@ -43,7 +43,7 @@ public final class Tables {
    * Adds {@link Table} data set to be created at application deploy if not exists.
    * @param configurer application configurer
    * @param datasetName data set name
-   * @param ttl time to live for data written into a table, in ms. {@link #NO_TTL} means unlimited
+   * @param ttl time to live for data written into a table, in seconds. {@link #NO_TTL} means unlimited
    */
   public static void createTable(ApplicationConfigurer configurer, String datasetName, int ttl) {
     createTable(configurer, datasetName, ConflictDetection.ROW, ttl, DatasetProperties.EMPTY);
@@ -64,7 +64,7 @@ public final class Tables {
    * @param configurer application configurer
    * @param datasetName data set name
    * @param level level on which to detect conflicts in changes made by different transactions
-   * @param ttl time to live for data written into a table, in ms. {@link #NO_TTL} means unlimited
+   * @param ttl time to live for data written into a table, in seconds. {@link #NO_TTL} means unlimited
    */
   public static void createTable(ApplicationConfigurer configurer, String datasetName,
                                  ConflictDetection level, int ttl) {
@@ -76,7 +76,7 @@ public final class Tables {
    * @param configurer application configurer
    * @param datasetName data set name
    * @param level level on which to detect conflicts in changes made by different transactions
-   * @param ttl time to live for data written into a table, in ms. {@link #NO_TTL} means unlimited
+   * @param ttl time to live for data written into a table, in seconds. {@link #NO_TTL} means unlimited
    * @param props any additional data set properties
    */
   public static void createTable(ApplicationConfigurer configurer, String datasetName,
@@ -89,7 +89,7 @@ public final class Tables {
   /**
    * Creates properties for {@link Table} or {@link Table} data set instance.
    * @param level level on which to detect conflicts in changes made by different transactions
-   * @param ttl time to live for data written into a table, in ms. {@link #NO_TTL} means unlimited
+   * @param ttl time to live for data written into a table, in seconds. {@link #NO_TTL} means unlimited
    * @return {@link DatasetProperties} for the data set
    */
   public static DatasetProperties tableProperties(ConflictDetection level, int ttl, DatasetProperties props) {

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableTest.java
@@ -134,7 +134,7 @@ public class HBaseTableTest extends BufferingTableTest<BufferingTable> {
   public void testTTL() throws Exception {
     // for the purpose of this test it is fine not to configure ttl when creating table: we want to see if it
     // applies on reading
-    int ttl = 1000;
+    int ttl = 1;
     String ttlTable = "ttl";
     String noTtlTable = "nottl";
     DatasetProperties props = DatasetProperties.builder().add(Table.PROPERTY_TTL, String.valueOf(ttl)).build();
@@ -150,7 +150,7 @@ public class HBaseTableTest extends BufferingTableTest<BufferingTable> {
     table.put(b("row1"), b("col1"), b("val1"));
     table.commitTx();
 
-    TimeUnit.SECONDS.sleep(2);
+    TimeUnit.MILLISECONDS.sleep(1010);
 
     tx = txSystemClient.startShort();
     table.startTx(tx);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandler.java
@@ -17,11 +17,9 @@
 package co.cask.cdap.data2.datafabric.dataset.service;
 
 import co.cask.cdap.api.dataset.DatasetSpecification;
-import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.common.DatasetAlreadyExistsException;
 import co.cask.cdap.common.DatasetTypeNotFoundException;
 import co.cask.cdap.common.HandlerException;
-import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetAdminOpResponse;
 import co.cask.cdap.data2.transaction.queue.QueueConstants;
@@ -34,7 +32,6 @@ import co.cask.http.HttpResponder;
 import com.google.common.base.Charsets;
 import com.google.common.base.Function;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -56,7 +53,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
-import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -73,9 +69,7 @@ import javax.ws.rs.QueryParam;
 @Path(Constants.Gateway.API_VERSION_3 + "/namespaces/{namespace-id}")
 public class DatasetInstanceHandler extends AbstractHttpHandler {
   private static final Logger LOG = LoggerFactory.getLogger(DatasetInstanceHandler.class);
-  private static final Gson GSON = new GsonBuilder()
-    .registerTypeAdapter(DatasetSpecification.class, new DatasetSpecificationAdapter())
-    .create();
+  private static final Gson GSON = new Gson();
 
   private final DatasetInstanceService instanceService;
 
@@ -98,7 +92,7 @@ public class DatasetInstanceHandler extends AbstractHttpHandler {
    * @param name name of the dataset instance
    * @param owners a list of owners of the dataset instance, in the form @{code <type>::<id>}
    *               (e.g. "program::namespace:default/application:PurchaseHistory/program:flow:PurchaseFlow")
-   * @throws NotFoundException if the dataset instance was not found
+   * @throws Exception if the dataset instance was not found
    */
   @GET
   @Path("/data/datasets/{name}")
@@ -241,55 +235,15 @@ public class DatasetInstanceHandler extends AbstractHttpHandler {
     return datasetSummaries;
   }
 
-  private DatasetInstanceConfiguration  getInstanceConfiguration(HttpRequest request) {
+  private DatasetInstanceConfiguration getInstanceConfiguration(HttpRequest request) {
     Reader reader = new InputStreamReader(new ChannelBufferInputStream(request.getContent()), Charsets.UTF_8);
     DatasetInstanceConfiguration creationProperties = GSON.fromJson(reader, DatasetInstanceConfiguration.class);
-    fixProperties(creationProperties.getProperties());
     return creationProperties;
   }
 
   private Map<String, String> getProperties(HttpRequest request) {
     Reader reader = new InputStreamReader(new ChannelBufferInputStream(request.getContent()), Charsets.UTF_8);
     Map<String, String> properties = GSON.fromJson(reader, new TypeToken<Map<String, String>>() { }.getType());
-    fixProperties(properties);
     return properties;
-  }
-
-  private void fixProperties(Map<String, String> properties) {
-    if (properties.containsKey(Table.PROPERTY_TTL)) {
-      long ttl = TimeUnit.SECONDS.toMillis(Long.parseLong(properties.get(Table.PROPERTY_TTL)));
-      properties.put(Table.PROPERTY_TTL, String.valueOf(ttl));
-    }
-  }
-
-  /**
-   * Adapter for {@link DatasetSpecification}
-   */
-  private static final class DatasetSpecificationAdapter implements JsonSerializer<DatasetSpecification> {
-
-    private static final Type MAP_STRING_STRING_TYPE = new TypeToken<SortedMap<String, String>>() { }.getType();
-    private static final Maps.EntryTransformer<String, String, String> TRANSFORM_DATASET_PROPERTIES =
-      new Maps.EntryTransformer<String, String, String>() {
-        @Override
-        public String transformEntry(String key, String value) {
-          if (key.equals(Table.PROPERTY_TTL)) {
-            return String.valueOf(TimeUnit.MILLISECONDS.toSeconds(Long.parseLong(value)));
-          } else {
-            return value;
-          }
-        }
-      };
-
-    @Override
-    public JsonElement serialize(DatasetSpecification src, Type typeOfSrc, JsonSerializationContext context) {
-      JsonObject jsonObject = new JsonObject();
-      jsonObject.addProperty("name", src.getName());
-      jsonObject.addProperty("type", src.getType());
-      jsonObject.add("properties", context.serialize(Maps.transformEntries(src.getProperties(),
-                                                     TRANSFORM_DATASET_PROPERTIES), MAP_STRING_STRING_TYPE));
-      Type specsType = new TypeToken<SortedMap<String, DatasetSpecification>>() { }.getType();
-      jsonObject.add("datasetSpecs", context.serialize(src.getSpecifications(), specsType));
-      return jsonObject;
-    }
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableAdmin.java
@@ -37,6 +37,7 @@ import org.apache.twill.filesystem.Location;
 import org.apache.twill.filesystem.LocationFactory;
 
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 /**
  *
@@ -84,6 +85,8 @@ public class HBaseTableAdmin extends AbstractHBaseDataSetAdmin {
     if (ttlProp != null) {
       long ttl = Long.parseLong(ttlProp);
       if (ttl > 0) {
+        // convert ttl from seconds to milli-seconds
+        ttl = TimeUnit.SECONDS.toMillis(ttl);
         columnDescriptor.setValue(TxConstants.PROPERTY_TTL, String.valueOf(ttl));
       }
     }
@@ -132,14 +135,19 @@ public class HBaseTableAdmin extends AbstractHBaseDataSetAdmin {
       tableUtil.setBloomFilter(columnDescriptor, HBaseTableUtil.BloomType.ROW);
       needUpgrade = true;
     }
+    String ttlInMillis = null;
+    if (spec.getProperty(Table.PROPERTY_TTL) != null) {
+      // ttl not null, convert to millis
+      ttlInMillis = String.valueOf(TimeUnit.SECONDS.toMillis(Long.valueOf(spec.getProperty(Table.PROPERTY_TTL))));
+    }
+
     if (spec.getProperty(Table.PROPERTY_TTL) == null &&
         columnDescriptor.getValue(TxConstants.PROPERTY_TTL) != null) {
       columnDescriptor.remove(TxConstants.PROPERTY_TTL.getBytes());
       needUpgrade = true;
     } else if (spec.getProperty(Table.PROPERTY_TTL) != null &&
-               !spec.getProperty(Table.PROPERTY_TTL).equals
-                  (columnDescriptor.getValue(TxConstants.PROPERTY_TTL))) {
-      columnDescriptor.setValue(TxConstants.PROPERTY_TTL, spec.getProperty(TxConstants.PROPERTY_TTL));
+               !ttlInMillis.equals(columnDescriptor.getValue(TxConstants.PROPERTY_TTL))) {
+      columnDescriptor.setValue(TxConstants.PROPERTY_TTL, ttlInMillis);
       needUpgrade = true;
     }
 

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/DatasetSpecificationUpgrader.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/DatasetSpecificationUpgrader.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data.tools;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.dataset.DatasetSpecification;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.data2.datafabric.dataset.DatasetMetaTableUtil;
+import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
+import co.cask.cdap.data2.util.hbase.ScanBuilder;
+import co.cask.cdap.proto.Id;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.gson.Gson;
+import com.google.inject.Inject;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.client.HBaseAdmin;
+import org.apache.hadoop.hbase.client.HTable;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.ResultScanner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+
+/**
+ * Upgrading from CDAP version < 3.3 to CDAP version 3.3.
+ * This requires updating the TTL property for DatasetSpecification in the DatasetInstanceMDS table.
+ */
+public class DatasetSpecificationUpgrader {
+  private static final Logger LOG = LoggerFactory.getLogger(DatasetSpecificationUpgrader.class);
+  private static final Gson GSON = new Gson();
+  private static final String TTL_UPDATED = "table.ttl.migrated.to.seconds";
+
+  private final HBaseTableUtil tableUtil;
+  private final Configuration conf;
+
+  @Inject
+  public DatasetSpecificationUpgrader(HBaseTableUtil tableUtil, Configuration conf) {
+    this.tableUtil = tableUtil;
+    this.conf = conf;
+  }
+
+  /**
+   * Updates the TTL in the {@link co.cask.cdap.data2.datafabric.dataset.service.mds.DatasetInstanceMDS}
+   * table for CDAP versions prior to 3.3.
+   * <p>
+   * The TTL for {@link DatasetSpecification} was stored in milliseconds.
+   * Since the spec (as of CDAP version 3.3) is in seconds, the instance MDS entries must be updated.
+   * This is to be called only if the current CDAP version is < 3.3.
+   * </p>
+   * @throws Exception
+   */
+  public void upgrade() throws Exception {
+    TableId datasetSpecId = TableId.from(Id.Namespace.SYSTEM.getId(), DatasetMetaTableUtil.INSTANCE_TABLE_NAME);
+    HBaseAdmin hBaseAdmin = new HBaseAdmin(conf);
+    if (!tableUtil.tableExists(hBaseAdmin, datasetSpecId)) {
+      LOG.error("Dataset instance table does not exist: {}. Should not happen", datasetSpecId);
+      return;
+    }
+
+    HTable specTable = tableUtil.createHTable(conf, datasetSpecId);
+
+    try {
+      ScanBuilder scanBuilder = tableUtil.buildScan();
+      scanBuilder.setTimeRange(0, HConstants.LATEST_TIMESTAMP);
+      scanBuilder.setMaxVersions();
+      try (ResultScanner resultScanner = specTable.getScanner(scanBuilder.build())) {
+        Result result;
+        while ((result = resultScanner.next()) != null) {
+          Put put = new Put(result.getRow());
+          for (Map.Entry<byte[], NavigableMap<byte[], NavigableMap<Long, byte[]>>> familyMap :
+            result.getMap().entrySet()) {
+            for (Map.Entry<byte[], NavigableMap<Long, byte[]>> columnMap : familyMap.getValue().entrySet()) {
+              for (Map.Entry<Long, byte[]> columnEntry : columnMap.getValue().entrySet()) {
+                Long timeStamp = columnEntry.getKey();
+                byte[] colVal = columnEntry.getValue();
+                String specEntry = Bytes.toString(colVal);
+                DatasetSpecification specification = GSON.fromJson(specEntry, DatasetSpecification.class);
+                DatasetSpecification updatedSpec = updateTTLInSpecification(specification, null);
+                colVal = Bytes.toBytes(GSON.toJson(updatedSpec));
+                put.add(familyMap.getKey(), columnMap.getKey(), timeStamp, colVal);
+              }
+            }
+          }
+          specTable.put(put);
+        }
+      }
+    } finally {
+      specTable.flushCommits();
+      specTable.close();
+    }
+  }
+
+  private Map<String, String> updatedProperties(Map<String, String> properties) {
+    if (properties.containsKey(Table.PROPERTY_TTL) && !properties.containsKey(TTL_UPDATED)) {
+      SortedMap<String, String> updatedProperties = new TreeMap<>(properties);
+      long updatedValue = TimeUnit.MILLISECONDS.toSeconds(Long.valueOf(updatedProperties.get(Table.PROPERTY_TTL)));
+      updatedProperties.put(Table.PROPERTY_TTL, String.valueOf(updatedValue));
+      updatedProperties.put(TTL_UPDATED, "true");
+      return updatedProperties;
+    }
+    return properties;
+  }
+
+  @VisibleForTesting
+  DatasetSpecification updateTTLInSpecification(DatasetSpecification specification, @Nullable String parentName) {
+    Map<String, String> properties = updatedProperties(specification.getProperties());
+    List<DatasetSpecification> updatedSpecs = new ArrayList<>();
+    for (DatasetSpecification datasetSpecification : specification.getSpecifications().values()) {
+      updatedSpecs.add(updateTTLInSpecification(datasetSpecification, specification.getName()));
+    }
+
+    String specName = specification.getName();
+    if (parentName != null && specification.getName().startsWith(parentName)) {
+      specName = specification.getName().substring(parentName.length() + 1);
+    }
+    return DatasetSpecification.builder(specName,
+                                        specification.getType()).properties(properties).datasets(updatedSpecs).build();
+  }
+}

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
@@ -366,6 +366,10 @@ public class UpgradeTool {
     LOG.info("Upgrading QueueAdmin ...");
     QueueAdmin queueAdmin = injector.getInstance(QueueAdmin.class);
     queueAdmin.upgrade();
+
+    LOG.info("Upgrading Dataset Specification...");
+    DatasetSpecificationUpgrader dsUpgrader = injector.getInstance(DatasetSpecificationUpgrader.class);
+    dsUpgrader.upgrade();
   }
 
   public static void main(String[] args) {

--- a/cdap-master/src/test/java/co/cask/cdap/data/tools/DatasetSpecificationUpgradeTest.java
+++ b/cdap-master/src/test/java/co/cask/cdap/data/tools/DatasetSpecificationUpgradeTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data.tools;
+
+import co.cask.cdap.api.dataset.DatasetSpecification;
+import co.cask.cdap.api.dataset.table.Table;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test {@link co.cask.cdap.data.tools.DatasetSpecificationUpgrader}
+ */
+public class DatasetSpecificationUpgradeTest {
+  private static final String TTL_UPDATED = "table.ttl.migrated.to.seconds";
+
+  @Test
+  public void testDatasetSpecificationUpgrade() throws Exception {
+    // we can pass null for these parameters as those are not used
+    DatasetSpecificationUpgrader datasetSpecificationUpgrader = new DatasetSpecificationUpgrader(null, null);
+
+    DatasetSpecification specification = DatasetSpecification.builder("dataset1", "Table").
+      properties(ImmutableMap.of(Table.PROPERTY_TTL, "3600000")).
+      datasets(ImmutableList.<DatasetSpecification>of()).build();
+
+    // TTL should be converted to seconds
+    DatasetSpecification expected = DatasetSpecification.builder("dataset1", "Table").
+      properties(ImmutableMap.of(Table.PROPERTY_TTL, "3600", TTL_UPDATED, "true")).
+      datasets(ImmutableList.<DatasetSpecification>of()).build();
+
+    Assert.assertEquals(expected, datasetSpecificationUpgrader.updateTTLInSpecification(specification, null));
+    // calling it again to test idempotence
+    Assert.assertEquals(expected, datasetSpecificationUpgrader.updateTTLInSpecification(specification, null));
+
+    DatasetSpecification nestedSpec = DatasetSpecification.builder("dataset2", "Table").
+      properties(ImmutableMap.of(Table.PROPERTY_TTL, "7200000")).datasets(specification).build();
+
+    // TTL should be converted to seconds for both parent and nested specs
+    DatasetSpecification expected2 = DatasetSpecification.builder("dataset2", "Table").
+      properties(ImmutableMap.of(Table.PROPERTY_TTL, "7200", TTL_UPDATED, "true")).
+      datasets(DatasetSpecification.builder("dataset1", "Table").
+        properties(ImmutableMap.of(Table.PROPERTY_TTL, "3600", TTL_UPDATED, "true")).
+        datasets(ImmutableList.<DatasetSpecification>of()).
+        build()).
+      build();
+    Assert.assertEquals(expected2, datasetSpecificationUpgrader.updateTTLInSpecification(nestedSpec, null));
+
+    // calling it again to test idempotence
+    Assert.assertEquals(expected2, datasetSpecificationUpgrader.updateTTLInSpecification(nestedSpec, null));
+
+    specification = DatasetSpecification.builder("dataset3", "Table").build();
+    Assert.assertEquals(specification, datasetSpecificationUpgrader.updateTTLInSpecification(specification, null));
+
+    // calling it again to test idempotence
+    Assert.assertEquals(specification, datasetSpecificationUpgrader.updateTTLInSpecification(specification, null));
+  }
+}


### PR DESCRIPTION
use seconds in Dataset Specification, conversion to milliseconds only happens in HBaseTableAdmin implementation, all REST API's and  dataset specs uses seconds.

UpgradeTool has been updated to update DatasetSpecification Entries (from milli-seconds to seconds) in Dataset Instance MDS Table.

JIRA: https://issues.cask.co/browse/CDAP-3345
