### PR TITLE
CDAP-3696 Disabling the flaky test till its fixed.

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowHttpHandlerTest.java
@@ -59,6 +59,7 @@ import com.google.gson.reflect.TypeToken;
 import org.apache.http.HttpResponse;
 import org.apache.http.util.EntityUtils;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -1293,6 +1294,7 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
     Assert.assertEquals(1, sparkProgramRuns.size());
   }
 
+  @Ignore
   @Test
   public void testWorkflowForkFailure() throws Exception {
     // Deploy an application containing workflow with fork. Fork executes MapReduce programs


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-3696

This test case tests that the failure of one MapReduce program in the Workflow fork should cause the MapReduce program running in other branch to get marked as killed by interrupting it. However the test case is flaky and the outcome depends on the timing of when the interrupt is generated. Disabling the test till we have the robust way of verification.