### PR TITLE
CDAP-3677: implement storeJobsandTriggers

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/store/DatasetBasedTimeScheduleStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/store/DatasetBasedTimeScheduleStore.java
@@ -95,7 +95,12 @@ public class DatasetBasedTimeScheduleStore extends RAMJobStore {
   public void storeJobsAndTriggers(Map<JobDetail, Set<? extends Trigger>> triggersAndJobs,
                                    boolean replace) throws JobPersistenceException {
     super.storeJobsAndTriggers(triggersAndJobs, replace);
-    // TODO (sree): Add persisting job and triggers
+    for (Map.Entry<JobDetail, Set<? extends Trigger>> e: triggersAndJobs.entrySet()) {
+      storeJob(e.getKey(), replace);
+      for (Trigger trigger: e.getValue()) {
+        storeTrigger((OperableTrigger) trigger, replace);
+      }
+    }
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/store/DatasetBasedTimeScheduleStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/store/DatasetBasedTimeScheduleStore.java
@@ -303,7 +303,7 @@ public class DatasetBasedTimeScheduleStore extends RAMJobStore {
                 LOG.debug("Schedule: trigger with key {} added", trigger.trigger.getKey());
               } else {
                 LOG.debug("Schedule: trigger with key {} and state {} skipped", trigger.trigger.getKey(),
-                          trigger.state.toString());
+                          trigger.state);
               }
             }
           } else {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/store/DatasetBasedTimeScheduleStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/store/DatasetBasedTimeScheduleStore.java
@@ -95,10 +95,10 @@ public class DatasetBasedTimeScheduleStore extends RAMJobStore {
   public void storeJobsAndTriggers(Map<JobDetail, Set<? extends Trigger>> triggersAndJobs,
                                    boolean replace) throws JobPersistenceException {
     super.storeJobsAndTriggers(triggersAndJobs, replace);
-    for (Map.Entry<JobDetail, Set<? extends Trigger>> e: triggersAndJobs.entrySet()) {
-      storeJob(e.getKey(), replace);
-      for (Trigger trigger: e.getValue()) {
-        storeTrigger((OperableTrigger) trigger, replace);
+    for (Map.Entry<JobDetail, Set<? extends Trigger>> e : triggersAndJobs.entrySet()) {
+      persistJobAndTrigger(e.getKey(), null);
+      for (Trigger trigger : e.getValue()) {
+        persistJobAndTrigger(null, (OperableTrigger) trigger);
       }
     }
   }
@@ -303,7 +303,7 @@ public class DatasetBasedTimeScheduleStore extends RAMJobStore {
                 LOG.debug("Schedule: trigger with key {} added", trigger.trigger.getKey());
               } else {
                 LOG.debug("Schedule: trigger with key {} and state {} skipped", trigger.trigger.getKey(),
-                                                                                trigger.state.toString());
+                          trigger.state.toString());
               }
             }
           } else {


### PR DESCRIPTION
Issue: https://issues.cask.co/browse/CDAP-3677
Build: http://builds.cask.co/browse/CDAP-DUT2947-1

- implementing overriding method storeJobsAndTriggers in DatasetBasedTimeScheduleStore which will support storing multiple jobs and triggers as one operation. This does not had any implementation before.
- This will help to solve the issue in which while deploying multiple triggers of a job the failure of one trigger will fail the deployment of all as the sanity check is done before hand. 
- The bulk deployment will be done during the refactoring of the Scheduler: https://issues.cask.co/browse/CDAP-3598
- It will also allow us to add all the triggers with a job in one go rather than iterating over all schedules and adding them one by one. 

