### PR TITLE
CDAP-3924 ExploreHttpClient, ExploreDriver, and QueryClient to now wo…

### DIFF
--- a/cdap-cli/src/main/java/co/cask/cdap/cli/ArgumentName.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/ArgumentName.java
@@ -94,7 +94,10 @@ public enum ArgumentName {
   ARTIFACT_CONFIG_FILE("artifact-config"),
   SCOPE("scope"),
   PLUGIN_TYPE("plugin-type"),
-  PLUGIN_NAME("plugin-name");
+  PLUGIN_NAME("plugin-name"),
+
+  INSTANCE_URI("cdap-instance-uri"),
+  VERIFY_SSL_CERT("verify-ssl-cert");
 
   private final String name;
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/CLIConfig.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/CLIConfig.java
@@ -144,9 +144,10 @@ public class CLIConfig implements TableRendererConfig {
     notifyConnectionChanged();
   }
 
-  public void tryConnect(CLIConnectionConfig connectionConfig,
+  public void tryConnect(CLIConnectionConfig connectionConfig, boolean verifySSLCert,
                          PrintStream output, boolean debug) throws Exception {
     try {
+      clientConfig.setVerifySSLCert(verifySSLCert);
       UserAccessToken userToken = acquireAccessToken(clientConfig, connectionConfig, output, debug);
       AccessToken accessToken = null;
       if (userToken != null) {
@@ -252,6 +253,7 @@ public class CLIConfig implements TableRendererConfig {
                                            connectionInfo.isSSLEnabled());
     return authenticationClient;
   }
+
   @Nullable
   private UserAccessToken getSavedAccessToken(String hostname) {
     File file = getAccessTokenFile(hostname);

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/CLIMain.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/CLIMain.java
@@ -115,7 +115,6 @@ public class CLIMain {
     this.options = options;
     this.cliConfig = cliConfig;
 
-    cliConfig.getClientConfig().setVerifySSLCert(options.isVerifySSL());
     injector = Guice.createInjector(
       new AbstractModule() {
         @Override
@@ -182,7 +181,7 @@ public class CLIMain {
     InstanceURIParser instanceURIParser = injector.getInstance(InstanceURIParser.class);
     try {
       CLIConnectionConfig connection = instanceURIParser.parse(options.getUri());
-      cliConfig.tryConnect(connection, cliConfig.getOutput(), options.isDebug());
+      cliConfig.tryConnect(connection, options.isVerifySSL(), cliConfig.getOutput(), options.isDebug());
       return true;
     } catch (Exception e) {
       if (options.isDebug()) {

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/ConnectCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/ConnectCommand.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.cli.command;
 
+import co.cask.cdap.cli.ArgumentName;
 import co.cask.cdap.cli.CLIConfig;
 import co.cask.cdap.cli.CLIConnectionConfig;
 import co.cask.cdap.cli.LaunchOptions;
@@ -45,10 +46,13 @@ public class ConnectCommand implements Command {
 
   @Override
   public void execute(Arguments arguments, PrintStream output) throws Exception {
-    String instanceURI = arguments.get("cdap-instance-uri");
+    String instanceURI = arguments.get(ArgumentName.INSTANCE_URI.toString());
+    String verifySSLCertString = arguments.getOptional(ArgumentName.VERIFY_SSL_CERT.toString());
+    boolean verifySSLCert = verifySSLCertString != null ? Boolean.valueOf(verifySSLCertString) : true;
+
     CLIConnectionConfig connection = instanceURIParser.parse(instanceURI);
     try {
-      cliConfig.tryConnect(connection, output, debug);
+      cliConfig.tryConnect(connection, verifySSLCert, output, debug);
     } catch (Exception e) {
       output.println("Failed to connect to " + instanceURI + ": " + e.getMessage());
       if (debug) {
@@ -59,7 +63,8 @@ public class ConnectCommand implements Command {
 
   @Override
   public String getPattern() {
-    return "connect <cdap-instance-uri>";
+    return String.format("connect <%s> [<%s>]",
+                         ArgumentName.INSTANCE_URI, ArgumentName.VERIFY_SSL_CERT);
   }
 
   @Override

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/QueryClientTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/QueryClientTestRun.java
@@ -20,13 +20,16 @@ import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.client.app.FakeApp;
 import co.cask.cdap.client.app.FakeFlow;
 import co.cask.cdap.client.common.ClientTestBase;
+import co.cask.cdap.client.config.ClientConfig;
 import co.cask.cdap.client.config.ConnectionConfig;
+import co.cask.cdap.common.UnauthorizedException;
 import co.cask.cdap.explore.client.ExploreClient;
 import co.cask.cdap.explore.client.ExploreExecutionResult;
 import co.cask.cdap.explore.client.FixedAddressExploreClient;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.QueryResult;
+import co.cask.cdap.security.authentication.client.AccessToken;
 import co.cask.cdap.test.XSlowTests;
 import com.google.common.collect.Lists;
 import org.junit.Assert;
@@ -34,6 +37,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
@@ -58,9 +62,9 @@ public class QueryClientTestRun extends ClientTestBase {
     streamClient = new StreamClient(clientConfig);
     String accessToken = (clientConfig.getAccessToken() == null) ? null : clientConfig.getAccessToken().getValue();
     ConnectionConfig connectionConfig = clientConfig.getConnectionConfig();
-    exploreClient = new FixedAddressExploreClient(connectionConfig.getHostname(),
-                                                  connectionConfig.getPort(),
-                                                  accessToken);
+    exploreClient = new FixedAddressExploreClient(connectionConfig.getHostname(), connectionConfig.getPort(),
+                                                  accessToken, connectionConfig.isSSLEnabled(),
+                                                  clientConfig.isVerifySSLCert());
     namespaceClient = new NamespaceClient(clientConfig);
   }
 

--- a/cdap-client/src/main/java/co/cask/cdap/client/QueryClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/QueryClient.java
@@ -37,7 +37,6 @@ public class QueryClient {
 
   @Inject
   public QueryClient(final ClientConfig config) {
-
     Supplier<String> hostname = new Supplier<String>() {
       @Override
       public String get() {
@@ -58,12 +57,25 @@ public class QueryClient {
         if (config.getAccessToken() != null) {
           return config.getAccessToken().getValue();
         }
-
         return null;
       }
     };
 
-    exploreClient = new SuppliedAddressExploreClient(hostname, port, accessToken);
+    Supplier<Boolean> sslEnabled = new Supplier<Boolean>() {
+      @Override
+      public Boolean get() {
+        return config.getConnectionConfig().isSSLEnabled();
+      }
+    };
+
+    Supplier<Boolean> verifySSLCert = new Supplier<Boolean>() {
+      @Override
+      public Boolean get() {
+        return config.isVerifySSLCert();
+      }
+    };
+
+    exploreClient = new SuppliedAddressExploreClient(hostname, port, accessToken, sslEnabled, verifySSLCert);
   }
 
   /**

--- a/cdap-docs/integrations/source/jdbc.rst
+++ b/cdap-docs/integrations/source/jdbc.rst
@@ -48,20 +48,24 @@ and executes a query over a CDAP dataset ``mydataset``::
   // First, register the driver once in your application
   Class.forName("co.cask.cdap.explore.jdbc.ExploreDriver");
 
-  // If your CDAP instance requires a authentication token for connection,
-  // you have to specify it here.
+  // If your CDAP instance requires an authentication token for connection, specify it here.
   // Replace <cdap-host> and <authentication_token> as appropriate to your installation.
   String connectionUrl = "jdbc:cdap://<cdap-host>:10000" +
     "?auth.token=<authentication_token>";
 
-  // Connect to CDAP instance
+  // Connect to the CDAP instance
   Connection connection = DriverManager.getConnection(connectionUrl);
 
   // Execute a query over CDAP datasets and retrieve the results
   ResultSet resultSet = connection.prepareStatement("select * from dataset_mydataset").executeQuery();
   ...
 
+Here are the parameters that can be used in the connection URL:
+  
+- ``namespace``: CDAP namespace to run in
+- ``auth.token``: authentication token for the connection
+- ``ssl.enabled``: boolean; whether SSL is enabled or not
+- ``verify.ssl.cert``: boolean; false to suspend certificate checks and allow self-signed certificates
+
 JDBC drivers are a standard in the Java ecosystem, with many `resources about them available
 <http://docs.oracle.com/javase/tutorial/jdbc/>`__.
-
-

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/AbstractExploreClient.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/AbstractExploreClient.java
@@ -55,7 +55,7 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
 /**
- * A base for an Explore Client that talks to a server implementing {@link Explore} over HTTP.
+ * A base for an Explore Client that talks to a server implementing {@link Explore} over HTTP/HTTPS.
  */
 public abstract class AbstractExploreClient extends ExploreHttpClient implements ExploreClient {
   private static final Gson GSON = new Gson();
@@ -539,12 +539,12 @@ public abstract class AbstractExploreClient extends ExploreHttpClient implements
           try {
             exploreClient.close(handle);
           } catch (ExploreException e) {
-            LOG.error("Caught exception during cancel operation", e);
+            LOG.error("Caught exception during close operation", e);
             throw Throwables.propagate(e);
           } catch (HandleNotFoundException e) {
             // Don't need to throw an exception in that case -
             // if the handle is not found, the query is already closed
-            LOG.warn("Caught exception when closing execution", e);
+            LOG.warn("Caught exception during close operation", e);
           }
         }
 

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/DiscoveryExploreClient.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/DiscoveryExploreClient.java
@@ -57,8 +57,22 @@ public class DiscoveryExploreClient extends AbstractExploreClient {
       String.format("Cannot discover service %s", Service.EXPLORE_HTTP_USER_SERVICE));
   }
 
+  // This class is only used internally.
+  // It does not go through router, so it doesn't ever need an auth token, sslEnabled, or verifySSLCert.
+
   @Override
-  protected String getAuthorizationToken() {
+  protected String getAuthToken() {
     return null;
+  }
+
+
+  @Override
+  protected boolean isSSLEnabled() {
+    return false;
+  }
+
+  @Override
+  protected boolean verifySSLCert() {
+    return false;
   }
 }

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/ExploreHttpClient.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/ExploreHttpClient.java
@@ -41,6 +41,7 @@ import co.cask.cdap.proto.TableInfo;
 import co.cask.cdap.proto.TableNameInfo;
 import co.cask.common.http.HttpMethod;
 import co.cask.common.http.HttpRequest;
+import co.cask.common.http.HttpRequestConfig;
 import co.cask.common.http.HttpRequests;
 import co.cask.common.http.HttpResponse;
 import com.google.common.base.Charsets;
@@ -50,7 +51,6 @@ import com.google.common.collect.Maps;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonParseException;
-import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -84,7 +84,11 @@ abstract class ExploreHttpClient implements Explore {
 
   protected abstract InetSocketAddress getExploreServiceAddress();
 
-  protected abstract String getAuthorizationToken();
+  protected abstract String getAuthToken();
+
+  protected abstract boolean isSSLEnabled();
+
+  protected abstract boolean verifySSLCert();
 
   protected boolean isAvailable() {
     try {
@@ -400,12 +404,8 @@ abstract class ExploreHttpClient implements Explore {
     String responseString = response.getResponseBodyAsString();
     try {
       return GSON.fromJson(responseString, type);
-    } catch (JsonSyntaxException e) {
-      String message = String.format("Cannot parse server response: %s", responseString);
-      LOG.error(message, e);
-      throw new ExploreException(message, e);
     } catch (JsonParseException e) {
-      String message = String.format("Cannot parse server response as map: %s", responseString);
+      String message = String.format("Cannot parse server response: %s", responseString);
       LOG.error(message, e);
       throw new ExploreException(message, e);
     }
@@ -431,20 +431,18 @@ abstract class ExploreHttpClient implements Explore {
                                  @Nullable Map<String, String> headers,
                                  @Nullable String body) throws ExploreException {
     Map<String, String> newHeaders = headers;
-    if (getAuthorizationToken() != null && !getAuthorizationToken().isEmpty()) {
+    if (getAuthToken() != null && !getAuthToken().isEmpty()) {
       newHeaders = (headers != null) ? Maps.newHashMap(headers) : Maps.<String, String>newHashMap();
-      newHeaders.put("Authorization", "Bearer " + getAuthorizationToken());
+      newHeaders.put("Authorization", "Bearer " + getAuthToken());
     }
     String resolvedUrl = resolve(resource);
     try {
       URL url = new URL(resolvedUrl);
+      HttpRequest.Builder builder = HttpRequest.builder(HttpMethod.valueOf(requestMethod), url).addHeaders(newHeaders);
       if (body != null) {
-        return HttpRequests.execute(HttpRequest.builder(HttpMethod.valueOf(requestMethod), url)
-                                      .addHeaders(newHeaders).withBody(body).build());
-      } else {
-        return HttpRequests.execute(HttpRequest.builder(HttpMethod.valueOf(requestMethod), url)
-                                      .addHeaders(newHeaders).build());
+        builder.withBody(body);
       }
+      return HttpRequests.execute(builder.build(), createRequestConfig());
     } catch (IOException e) {
       throw new ExploreException(
         String.format("Error connecting to Explore Service at %s while doing %s with headers %s and body %s",
@@ -454,9 +452,16 @@ abstract class ExploreHttpClient implements Explore {
     }
   }
 
+  private HttpRequestConfig createRequestConfig() {
+    return new HttpRequestConfig(HttpRequestConfig.DEFAULT.getConnectTimeout(),
+                                 HttpRequestConfig.DEFAULT.getReadTimeout(),
+                                 verifySSLCert());
+  }
+
   private String resolve(String resource) {
     InetSocketAddress addr = getExploreServiceAddress();
-    String url = String.format("http://%s:%s%s/%s", addr.getHostName(), addr.getPort(),
+    String url = String.format("%s://%s:%s%s/%s", isSSLEnabled() ? "https" : "http",
+                               addr.getHostName(), addr.getPort(),
                                Constants.Gateway.API_VERSION_3, resource);
     LOG.trace("Explore URL = {}", url);
     return url;

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/FixedAddressExploreClient.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/FixedAddressExploreClient.java
@@ -21,15 +21,20 @@ import javax.annotation.Nullable;
 
 /**
  * An Explore Client that uses the provided host and port to talk to a server
- * implementing {@link co.cask.cdap.explore.service.Explore} over HTTP.
+ * implementing {@link co.cask.cdap.explore.service.Explore} over HTTP/HTTPS.
  */
 public class FixedAddressExploreClient extends AbstractExploreClient {
   private final InetSocketAddress addr;
   private final String authToken;
+  private final boolean sslEnabled;
+  private final boolean verifySSLCert;
 
-  public FixedAddressExploreClient(String host, int port, @Nullable String authToken) {
+  public FixedAddressExploreClient(String host, int port, @Nullable String authToken,
+                                   boolean sslEnabled, boolean verifySSLCert) {
     this.addr = InetSocketAddress.createUnresolved(host, port);
     this.authToken = authToken;
+    this.sslEnabled = sslEnabled;
+    this.verifySSLCert = verifySSLCert;
   }
 
   @Override
@@ -37,7 +42,17 @@ public class FixedAddressExploreClient extends AbstractExploreClient {
     return addr;
   }
 
-  protected String getAuthorizationToken() {
+  protected String getAuthToken() {
     return authToken;
+  }
+
+  @Override
+  protected boolean isSSLEnabled() {
+    return sslEnabled;
+  }
+
+  @Override
+  protected boolean verifySSLCert() {
+    return verifySSLCert;
   }
 }

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/SuppliedAddressExploreClient.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/SuppliedAddressExploreClient.java
@@ -21,7 +21,7 @@ import com.google.common.base.Supplier;
 import java.net.InetSocketAddress;
 
 /**
- * An Explore Client that uses the supplied host and port to talk to a server
+ * An Explore Client that uses the supplied parameters to talk to a server
  * implementing {@link co.cask.cdap.explore.service.Explore} over HTTP.
  */
 public class SuppliedAddressExploreClient extends AbstractExploreClient {
@@ -29,11 +29,16 @@ public class SuppliedAddressExploreClient extends AbstractExploreClient {
   private final Supplier<String> host;
   private final Supplier<Integer> port;
   private final Supplier<String> authToken;
+  private final Supplier<Boolean> sslEnabled;
+  private final Supplier<Boolean> verifySSLCert;
 
-  public SuppliedAddressExploreClient(Supplier<String> host, Supplier<Integer> port, Supplier<String> authToken) {
+  public SuppliedAddressExploreClient(Supplier<String> host, Supplier<Integer> port, Supplier<String> authToken,
+                                      Supplier<Boolean> sslEnabled, Supplier<Boolean> verifySSLCert) {
     this.host = host;
     this.port = port;
     this.authToken = authToken;
+    this.sslEnabled = sslEnabled;
+    this.verifySSLCert = verifySSLCert;
   }
 
   @Override
@@ -41,7 +46,17 @@ public class SuppliedAddressExploreClient extends AbstractExploreClient {
     return InetSocketAddress.createUnresolved(host.get(), port.get());
   }
 
-  protected String getAuthorizationToken() {
+  protected String getAuthToken() {
     return authToken.get();
+  }
+
+  @Override
+  protected boolean isSSLEnabled() {
+    return sslEnabled.get();
+  }
+
+  @Override
+  protected boolean verifySSLCert() {
+    return verifySSLCert.get();
   }
 }

--- a/cdap-explore-jdbc/src/main/java/co/cask/cdap/explore/jdbc/ExploreDatabaseMetaData.java
+++ b/cdap-explore-jdbc/src/main/java/co/cask/cdap/explore/jdbc/ExploreDatabaseMetaData.java
@@ -137,7 +137,8 @@ public class ExploreDatabaseMetaData implements DatabaseMetaData {
 
   @Override
   public String getDriverVersion() throws SQLException {
-    return String.format("%d.%d.0", ExploreDriver.getMajorDriverVersion(), ExploreDriver.getMinorDriverVersion());
+    return String.format("%d.%d.%d", ExploreDriver.getMajorDriverVersion(), ExploreDriver.getMinorDriverVersion(),
+                         ExploreDriver.getFixDriverVersion());
   }
 
   @Override


### PR DESCRIPTION
CDAP-3924 ExploreHttpClient, ExploreDriver, and QueryClient to now work over HTTPS.

Tested both the ExploreDriver and QueryClient against ssl-enabled cdap cluster.


https://issues.cask.co/browse/CDAP-3924
http://builds.cask.co/browse/CDAP-DUT2953-2

Also resolves:
https://issues.cask.co/browse/CDAP-13