### PR TITLE
Fix docs for new "app.program.extra.classpath"

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -210,18 +210,18 @@
   </property>
 
   <property>
-    <name>app.program.jvm.opts</name>
-    <value>-XX:MaxPermSize=128M ${twill.jvm.gc.opts}</value>
+    <name>app.program.extra.classpath</name>
+    <value/>
     <description>
-      Java options for all program containers
+      Extra Java classpath for CDAP programs
     </description>
   </property>
 
   <property>
-    <name>app.program.extra.classpath</name>
-    <value/>
+    <name>app.program.jvm.opts</name>
+    <value>-XX:MaxPermSize=128M ${twill.jvm.gc.opts}</value>
     <description>
-      Extra Java classpath for CDAP program.
+      Java options for all program containers
     </description>
   </property>
 

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -25,7 +25,7 @@ CHECK_INCLUDES=${TRUE}
 
 function download_includes() {
   echo_red_bold "Check guarded files for changes"
-  test_an_include a5eb7a76573485b048d358b3d23521fa "${DEFAULT_XML}"
+  test_an_include 3f478918035c7ea6e4e5eccea246b3d0 "${DEFAULT_XML}"
 
   echo "Building rst file from cdap-default.xml..."
   local includes_dir=${1}

--- a/cdap-docs/developers-manual/build.sh
+++ b/cdap-docs/developers-manual/build.sh
@@ -66,7 +66,7 @@ function download_includes() {
 # https://raw.githubusercontent.com/caskdata/cdap-clients/develop/cdap-authentication-clients/java/README.rst
   local clients_url="${github_url}/cdap-clients/${clients_branch}"
 
-  download_readme_file_and_test ${includes_dir} ${clients_url} bf10a586e605be8191b3b554c425c3aa cdap-authentication-clients/java
+  download_readme_file_and_test ${includes_dir} ${clients_url} f99720412e7085fdc3e350205ce21bcc cdap-authentication-clients/java
   download_readme_file_and_test ${includes_dir} ${clients_url} f075935545e48a132d014c6a8d32122a cdap-authentication-clients/javascript
   download_readme_file_and_test ${includes_dir} ${clients_url} 1f8330e0370b3895c38452f9af72506a cdap-authentication-clients/python
   download_readme_file_and_test ${includes_dir} ${clients_url} 33b06b7ca1e423e93f2bb2c6f7d00e21 cdap-authentication-clients/ruby


### PR DESCRIPTION
Move new "app.program.extra.classpath" to the correct alphabetical location.

Update hashes.

Quick Build: [Results](http://builds.cask.co/browse/CDAP-DOB10-1) passed.