### PR TITLE
CDAP-3939 improve error handling with artifact and app deployment

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppLifecycleHttpHandler.java
@@ -396,7 +396,9 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
         } catch (InvalidArtifactException e) {
           responder.sendString(HttpResponseStatus.BAD_REQUEST, e.getMessage());
         } catch (ArtifactAlreadyExistsException e) {
-          responder.sendString(HttpResponseStatus.CONFLICT, e.getMessage());
+          responder.sendString(HttpResponseStatus.CONFLICT, String.format(
+            "Artifact '%s' already exists. Please use the API that creates an application from an existing artifact. " +
+            "If you are trying to replace the artifact, please delete it and then try again.", artifactId));
         } catch (WriteConflictException e) {
           // don't really expect this to happen. It means after multiple retries there were still write conflicts.
           LOG.warn("Write conflict while trying to add artifact {}.", artifactId, e);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ApplicationLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ApplicationLifecycleService.java
@@ -313,6 +313,7 @@ public class ApplicationLifecycleService extends AbstractIdleService {
       } catch (IOException e2) {
         // if the delete fails, nothing we can do, just log it and continue on
         LOG.warn("Failed to delete artifact {} after deployment of artifact and application failed.", artifactId, e2);
+        e.addSuppressed(e2);
       }
       throw e;
     }


### PR DESCRIPTION
Improving the failure handling for the API call that creates an
artifact and application in the same call. If the artifact was
added successfully, but the application failed to deploy,
remove the newly added artifact so that deployment can be
re-tried. If the artifact already exists, give a more detailed
error message explaining how to deploy the app.