### PR TITLE
CDAP-3961 Update dependencies to include cdap-hbase-compat-1.1

### DIFF
--- a/cdap-master/pom.xml
+++ b/cdap-master/pom.xml
@@ -163,7 +163,8 @@
       <id>dist</id>
       <properties>
         <package.depends>--depends cdap --depends cdap-hbase-compat-0.96 --depends cdap-hbase-compat-0.98
-        --depends cdap-hbase-compat-1.0 --depends cdap-hbase-compat-1.0-cdh</package.depends>
+        --depends cdap-hbase-compat-1.0 --depends cdap-hbase-compat-1.0-cdh
+        --depends cdap-hbase-compat-1.1</package.depends>
       </properties>
       <build>
         <plugins>


### PR DESCRIPTION
This is #4268 back-ported to release/3.2 branch