### PR TITLE
Feature/hdinsight install

### DIFF
--- a/cdap-distributions/src/hdinsight/cdap-site.xml.template
+++ b/cdap-distributions/src/hdinsight/cdap-site.xml.template
@@ -1,0 +1,13 @@
+{
+  "cdap": {
+    "cdap_site": {
+      "zookeeper.quorum": "ZK_QUORUM",
+      "kafka.log.dir": "/var/cdap/kafka-logs"
+    },
+    "skip_prerequisites": "true"
+  },
+  "hadoop": {
+    "distribution": "hdp",
+    "distribution_version": "HDP_VERSION"
+  }
+}

--- a/cdap-distributions/src/hdinsight/install.sh
+++ b/cdap-distributions/src/hdinsight/install.sh
@@ -35,11 +35,11 @@ apt-get install --yes git || die "Failed to install git"
 # Install chef
 curl -L https://www.chef.io/chef/install.sh | sudo bash || die "Failed to install chef"
 
-# Clone cdap repo
+# Clone CDAP repo
 __create_tmpdir
 git clone --depth 1 https://github.com/caskdata/cdap.git ${__gitdir}
 
-# Setup cookbook repo using packer scripts
+# Setup cookbook repo
 test -d /var/chef/cookbooks && rm -rf /var/chef/cookbooks
 ${__packerdir}/cookbook-dir.sh || die "Failed to setup cookbook dir"
 
@@ -50,7 +50,7 @@ ${__packerdir}/cookbook-setup.sh || die "Failed to install cookbooks"
 chef-solo -o 'recipe[cdap::cli]'
 
 # Read zookeeper quorum from hbase-site.xml, using sourced init script function
-source ${__gitdir}/cdap-common/bin/common.sh || die "Cannot source cdap common script"
+source ${__gitdir}/cdap-common/bin/common.sh || die "Cannot source CDAP common script"
 __zk_quorum=$(get_conf 'hbase.zookeeper.quorum' '/etc/hbase/conf/hbase-site.xml') || die "Cannot determine zookeeper quorum"
 
 # Get HDP version, allow for the future addition hdp-select "current" directory

--- a/cdap-distributions/src/hdinsight/install.sh
+++ b/cdap-distributions/src/hdinsight/install.sh
@@ -20,7 +20,7 @@
 
 die() { echo "ERROR: ${*}"; exit 1; };
 
-# Fetch repo file for YUM
+# Fetch repo file for Apt
 curl http://repository.cask.co/ubuntu/precise/amd64/cdap/3.2/cask.list > /etc/apt/sources.list.d/cask.list || die "Cannot fetch repo"
 curl -s http://repository.cask.co/ubuntu/precise/amd64/cdap/3.2/pubkey.gpg | sudo apt-key add - || die "Cannot import GPG key from repo"
 # install node.js

--- a/cdap-distributions/src/hdinsight/install.sh
+++ b/cdap-distributions/src/hdinsight/install.sh
@@ -47,7 +47,7 @@ ${__packerdir}/cookbook-dir.sh || die "Failed to setup cookbook dir"
 ${__packerdir}/cookbook-setup.sh || die "Failed to install cookbooks"
 
 # CDAP base install, ensures package dependencies are present
-chef-solo -o 'recipe[default]'
+chef-solo -o 'recipe[cdap::default]'
 
 # Read zookeeper quorum from hbase-site.xml, using sourced init script function
 source ${__gitdir}/cdap-common/bin/common.sh || die "Cannot source cdap common script"

--- a/cdap-distributions/src/hdinsight/install.sh
+++ b/cdap-distributions/src/hdinsight/install.sh
@@ -24,7 +24,7 @@ __tmpdir="/tmp/cdap_install.$$.$(date +%s)"
 __gitdir="${__tmpdir}/cdap"
 
 __packerdir="${__gitdir}/cdap-distributions/src/packer/scripts"
-__cdap_site_template="${__gitdir}/cdap-distribution/src/hdinsight/cdap-site.xml.template"
+__cdap_site_template="${__gitdir}/cdap-distributions/src/hdinsight/cdap-site.xml.template"
 
 __cleanup_tmpdir() { test -d ${__tmpdir} && rm -rf ${__tmpdir}; };
 __create_tmpdir() { mkdir -p ${__tmpdir}; };
@@ -46,8 +46,8 @@ ${__packerdir}/cookbook-dir.sh || die "Failed to setup cookbook dir"
 # Install cookbooks via knife
 ${__packerdir}/cookbook-setup.sh || die "Failed to install cookbooks"
 
-# CDAP base install, ensures package dependencies are present
-chef-solo -o 'recipe[cdap::default]'
+# CDAP cli install, ensures package dependencies are present
+chef-solo -o 'recipe[cdap::cli]'
 
 # Read zookeeper quorum from hbase-site.xml, using sourced init script function
 source ${__gitdir}/cdap-common/bin/common.sh || die "Cannot source cdap common script"

--- a/cdap-distributions/src/hdinsight/install.sh
+++ b/cdap-distributions/src/hdinsight/install.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+#
+# Copyright © 2015 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+#
+# Install CDAP under hadoop user for EMR
+#
+
+die() { echo "ERROR: ${*}"; exit 1; };
+
+# Fetch repo file for YUM
+curl http://repository.cask.co/ubuntu/precise/amd64/cdap/3.2/cask.list > /etc/apt/sources.list.d/cask.list || die "Cannot fetch repo"
+curl -s http://repository.cask.co/ubuntu/precise/amd64/cdap/3.2/pubkey.gpg | sudo apt-key add - || die "Cannot import GPG key from repo"
+# install node.js
+curl --silent --location https://deb.nodesource.com/setup | sudo bash - || die "Failed to configure nodejs repo"
+sudo apt-get install --yes nodejs || die "Failed to install nodejs"
+
+# Redundant - nodejs install does an apt-get update
+# apt-get update
+
+# Install CDAP packages
+apt-get install cdap-{gateway,kafka,master,ui} --yes || die "Failed installing CDAP packages"
+
+# Setup kafka storage dir
+mkdir -p /var/cdap/kafka-logs
+chown -R cdap:cdap /var/cdap/kafka-logs
+
+# We need to get the zookeeper quorum
+# Read it from hbase-site.xml
+
+. /opt/cdap/master/bin/common.sh || die "Cannot source cdap-master common script"
+__zk_quorum=$(get_conf 'hbase.zookeeper.quorum' '/usr/hdp/current/hbase-client/conf/hbase-site.xml')
+
+# Configure CDAP
+__ipaddr=`ifconfig eth0 | grep addr: | cut -d: -f2 | head -n 1 | awk '{print $1}'`
+sed \
+  -e "s/FQDN1:2181,FQDN2/${__zk_quorum}/" \
+  -e 's:/data/cdap/kafka-logs:/var/cdap/kafka-logs:' \
+  -e "s/FQDN1:9092,FQDN2:9092/${__ipaddr}:9092/" \
+  -e "s/LOCAL-ROUTER-IP/${__ipaddr}/" \
+  -e 's/LOCAL-APP-FABRIC-IP//' \
+  -e 's/LOCAL-DATA-FABRIC-IP//' \
+  -e 's/LOCAL-WATCHDOG-IP//' \
+  -e "s/ROUTER-HOST-IP/${__ipaddr}/" \
+  -e 's/router.server.port/router.bind.port/' \
+  /etc/cdap/conf/cdap-site.xml.example > /etc/cdap/conf/cdap-site.xml
+
+__hdp_version=$(basename $(dirname $(readlink /usr/hdp/current/hadoop-client)))
+
+sed -i \
+  -e "s/# export OPTS=\"\${OPTS} -Dhdp.version=2.2.6.0-2800\"/export \"OPTS=\${OPTS} -Dhdp.version=${__hdp_version}\"/" \
+  /etc/cdap/conf/cdap-env.sh
+
+# Start services
+for i in /etc/init.d/cdap-*
+do
+  $i start || die "Failed to start $i"
+done
+exit 0

--- a/cdap-distributions/src/hdinsight/install.sh
+++ b/cdap-distributions/src/hdinsight/install.sh
@@ -15,7 +15,7 @@
 # the License.
 
 #
-# Install CDAP under hadoop user for EMR
+# Install CDAP for Azure HDInsight cluster
 #
 
 die() { echo "ERROR: ${*}"; exit 1; };

--- a/cdap-distributions/src/hdinsight/install.sh
+++ b/cdap-distributions/src/hdinsight/install.sh
@@ -73,4 +73,3 @@ done
 
 __cleanup_tmpdir
 exit 0
-


### PR DESCRIPTION
Script to install cdap on an hdinsight edgenode.

   - [x] clones cdap repo & uses the packer script to setup cookbooks
   - [x] sources our init scripts to get zookeeper quorum from hbase-site.xml
      - [x] a little bit of an ugly catch 22 here since our init scripts require xmllint, so it installs cdap-cli pkg first
   - [x] installs ntp (since it is missing) and installs/configures/starts CDAP
