### PR TITLE
Increase the startup memory of the SDK

### DIFF
--- a/cdap-standalone/bin/cdap.sh
+++ b/cdap-standalone/bin/cdap.sh
@@ -22,7 +22,7 @@ if [ -d /opt/cdap ]; then
  CDAP_HOME=/opt/cdap; export CDAP_HOME
  DEFAULT_JVM_OPTS="-Xmx3072m -XX:MaxPermSize=128m"
 else
- DEFAULT_JVM_OPTS="-Xmx1024m -XX:MaxPermSize=128m"
+ DEFAULT_JVM_OPTS="-Xmx2048m -XX:MaxPermSize=128m"
 fi
 
 # Add default JVM options here. You can also use JAVA_OPTS and CDAP_OPTS to pass JVM options to this script.


### PR DESCRIPTION
Increase the startup memory for the SDK to allow the WikipediaPipeline Example (and others) to run.

Fixes: https://issues.cask.co/browse/CDAP-3949